### PR TITLE
Fix references to Oak Scheduler client in examples

### DIFF
--- a/examples/hello_world/client/BUILD
+++ b/examples/hello_world/client/BUILD
@@ -20,8 +20,8 @@ cc_binary(
     deps = [
         "//examples/hello_world/proto:hello_world_proto_grpc",
         "//examples/utils",
+        "//oak/client:manager_client",
         "//oak/client:node_client",
-        "//oak/client:scheduler_client",
         "@com_google_absl//absl/memory",
         "@com_google_asylo//asylo/util:logging",
         "@com_github_gflags_gflags//:gflags_nothreads",

--- a/examples/hello_world/client/hello_world.cc
+++ b/examples/hello_world/client/hello_world.cc
@@ -22,10 +22,10 @@
 #include "examples/hello_world/proto/hello_world.grpc.pb.h"
 #include "examples/hello_world/proto/hello_world.pb.h"
 #include "examples/utils/utils.h"
+#include "oak/client/manager_client.h"
 #include "oak/client/node_client.h"
-#include "oak/client/scheduler_client.h"
 
-DEFINE_string(scheduler_address, "127.0.0.1:8888", "Address of the Oak Scheduler to connect to");
+DEFINE_string(manager_address, "127.0.0.1:8888", "Address of the Oak Manager to connect to");
 DEFINE_string(module, "", "File containing the compiled WebAssembly module");
 
 using ::oak::examples::hello_world::HelloWorld;
@@ -48,14 +48,13 @@ std::string say_hello(HelloWorld::Stub* stub, std::string name) {
 int main(int argc, char** argv) {
   ::google::ParseCommandLineFlags(&argc, &argv, /*remove_flags=*/true);
 
-  // Connect to the Oak Scheduler.
-  std::unique_ptr<::oak::SchedulerClient> scheduler_client =
-      ::absl::make_unique<::oak::SchedulerClient>(
-          ::grpc::CreateChannel(FLAGS_scheduler_address, ::grpc::InsecureChannelCredentials()));
+  // Connect to the Oak Manager.
+  std::unique_ptr<::oak::ManagerClient> manager_client = ::absl::make_unique<::oak::ManagerClient>(
+      ::grpc::CreateChannel(FLAGS_manager_address, ::grpc::InsecureChannelCredentials()));
 
   // Load the Oak Module to execute. This needs to be compiled from Rust to WebAssembly separately.
   std::string module_bytes = ::oak::utils::read_file(FLAGS_module);
-  ::oak::CreateNodeResponse create_node_response = scheduler_client->CreateNode(module_bytes);
+  ::oak::CreateNodeResponse create_node_response = manager_client->CreateNode(module_bytes);
 
   std::stringstream addr;
   addr << "127.0.0.1:" << create_node_response.port();

--- a/examples/running_average/client/BUILD
+++ b/examples/running_average/client/BUILD
@@ -20,8 +20,8 @@ cc_binary(
     deps = [
         "//examples/running_average/proto:running_average_proto_grpc",
         "//examples/utils",
+        "//oak/client:manager_client",
         "//oak/client:node_client",
-        "//oak/client:scheduler_client",
         "@com_google_absl//absl/memory",
         "@com_google_asylo//asylo/util:logging",
         "@com_github_gflags_gflags//:gflags_nothreads",

--- a/examples/running_average/client/running_average.cc
+++ b/examples/running_average/client/running_average.cc
@@ -22,10 +22,10 @@
 #include "examples/running_average/proto/running_average.grpc.pb.h"
 #include "examples/running_average/proto/running_average.pb.h"
 #include "examples/utils/utils.h"
+#include "oak/client/manager_client.h"
 #include "oak/client/node_client.h"
-#include "oak/client/scheduler_client.h"
 
-DEFINE_string(scheduler_address, "127.0.0.1:8888", "Address of the Oak Scheduler to connect to");
+DEFINE_string(manager_address, "127.0.0.1:8888", "Address of the Oak Manager to connect to");
 DEFINE_string(module, "", "File containing the compiled WebAssembly module");
 
 using ::oak::examples::running_average::GetAverageResponse;
@@ -59,14 +59,13 @@ int retrieve_average(RunningAverage::Stub* stub) {
 int main(int argc, char** argv) {
   ::google::ParseCommandLineFlags(&argc, &argv, /*remove_flags=*/true);
 
-  // Connect to the Oak Scheduler.
-  std::unique_ptr<::oak::SchedulerClient> scheduler_client =
-      ::absl::make_unique<::oak::SchedulerClient>(
-          ::grpc::CreateChannel(FLAGS_scheduler_address, ::grpc::InsecureChannelCredentials()));
+  // Connect to the Oak Manager.
+  std::unique_ptr<::oak::ManagerClient> manager_client = ::absl::make_unique<::oak::ManagerClient>(
+      ::grpc::CreateChannel(FLAGS_manager_address, ::grpc::InsecureChannelCredentials()));
 
   // Load the Oak Module to execute. This needs to be compiled from Rust to WebAssembly separately.
   std::string module_bytes = ::oak::utils::read_file(FLAGS_module);
-  ::oak::CreateNodeResponse create_node_response = scheduler_client->CreateNode(module_bytes);
+  ::oak::CreateNodeResponse create_node_response = manager_client->CreateNode(module_bytes);
 
   std::stringstream addr;
   addr << "127.0.0.1:" << create_node_response.port();

--- a/oak/client/BUILD
+++ b/oak/client/BUILD
@@ -15,10 +15,10 @@
 #
 
 cc_library(
-    name = "scheduler_client",
-    hdrs = ["scheduler_client.h"],
+    name = "manager_client",
+    hdrs = ["manager_client.h"],
     deps = [
-        "//oak/proto:scheduler_grpc_proto",
+        "//oak/proto:manager_grpc_proto",
         "@com_github_grpc_grpc//:grpc++",
     ],
     visibility = ["//visibility:public"],

--- a/oak/client/manager_client.h
+++ b/oak/client/manager_client.h
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-#include "oak/proto/scheduler.grpc.pb.h"
+#include "oak/proto/manager.grpc.pb.h"
 
 namespace oak {
 
-// A client connected to an Oak Scheduler instance.
+// A client connected to an Oak Manager instance.
 //
 // It allows creating new Oak Node instances based on the Oak Module provided.
 //
 // TODO: Allow specifying policy configuration in the CreateNode request.
-class SchedulerClient {
+class ManagerClient {
  public:
-  SchedulerClient(const std::shared_ptr<::grpc::ChannelInterface>& channel)
-      : stub_(::oak::Scheduler::NewStub(channel, ::grpc::StubOptions())) {}
+  ManagerClient(const std::shared_ptr<::grpc::ChannelInterface>& channel)
+      : stub_(::oak::Manager::NewStub(channel, ::grpc::StubOptions())) {}
 
   // TODO: Return StatusOr<::oak::CreateNodeResponse>.
   ::oak::CreateNodeResponse CreateNode(const std::string& module_bytes) {
@@ -48,7 +48,7 @@ class SchedulerClient {
   }
 
  private:
-  std::unique_ptr<::oak::Scheduler::Stub> stub_;
+  std::unique_ptr<::oak::Manager::Stub> stub_;
 };
 
 }  // namespace oak


### PR DESCRIPTION
Some of the classes were renamed in #14, but the examples were missed.

ref #7