### PR TITLE
Add explicit PointerAlignment for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,4 @@
 BasedOnStyle: Google
 ColumnLimit: 100
+DerivePointerAlignment: false
+PointerAlignment: Left


### PR DESCRIPTION
The default derives alignment from the file, allowing inconsistency
between files.