### PR TITLE
Format all code with clang-format

### DIFF
--- a/oak/client/manager_client.h
+++ b/oak/client/manager_client.h
@@ -40,8 +40,8 @@ class ManagerClient {
     LOG(INFO) << "Creating Oak Node";
     ::grpc::Status status = stub_->CreateNode(&context, request, &response);
     if (!status.ok()) {
-      LOG(QFATAL) << "Failed: " << status.error_code() << '/'
-		  << status.error_message() << '/' << status.error_details();
+      LOG(QFATAL) << "Failed: " << status.error_code() << '/' << status.error_message() << '/'
+                  << status.error_details();
     }
 
     LOG(INFO) << "Oak Node created: " << response.DebugString();

--- a/oak/server/enclave_server.h
+++ b/oak/server/enclave_server.h
@@ -65,20 +65,20 @@ class EnclaveServer final : public asylo::TrustedApplication {
 
   ~EnclaveServer() = default;
 
-  asylo::Status Initialize(const asylo::EnclaveConfig &config) override {
+  asylo::Status Initialize(const asylo::EnclaveConfig& config) override {
     LOG(INFO) << "Initializing Oak Instance";
-    const oak::InitializeInput &initialize_input = config.GetExtension(oak::initialize_input);
+    const oak::InitializeInput& initialize_input = config.GetExtension(oak::initialize_input);
     node_ = absl::make_unique<oak::grpc_server::OakNode>(initialize_input.node_id(),
                                                          initialize_input.module());
     return InitializeServer();
   }
 
-  asylo::Status Run(const asylo::EnclaveInput &input, asylo::EnclaveOutput *output) override {
+  asylo::Status Run(const asylo::EnclaveInput& input, asylo::EnclaveOutput* output) override {
     GetServerAddress(output);
     return asylo::Status::OkStatus();
   }
 
-  asylo::Status Finalize(const asylo::EnclaveFinal &enclave_final) override {
+  asylo::Status Finalize(const asylo::EnclaveFinal& enclave_final) override {
     FinalizeServer();
     return asylo::Status::OkStatus();
   }
@@ -126,8 +126,8 @@ class EnclaveServer final : public asylo::TrustedApplication {
 
   // Gets the address of the hosted gRPC server and writes it to
   // server_output_config extension of |output|.
-  void GetServerAddress(asylo::EnclaveOutput *output) EXCLUSIVE_LOCKS_REQUIRED(server_mutex_) {
-    oak::InitializeOutput *initialize_output = output->MutableExtension(oak::initialize_output);
+  void GetServerAddress(asylo::EnclaveOutput* output) EXCLUSIVE_LOCKS_REQUIRED(server_mutex_) {
+    oak::InitializeOutput* initialize_output = output->MutableExtension(oak::initialize_output);
     initialize_output->set_port(port_);
   }
 
@@ -155,9 +155,9 @@ class EnclaveServer final : public asylo::TrustedApplication {
     while (true) {
       RequestNextCall();
 
-      grpc_server::BaseGrpcEventHandler *eventHandler = nullptr;
+      grpc_server::BaseGrpcEventHandler* eventHandler = nullptr;
       bool ok = false;
-      if (!completion_queue_->Next(reinterpret_cast<void **>(&eventHandler), &ok)) {
+      if (!completion_queue_->Next(reinterpret_cast<void**>(&eventHandler), &ok)) {
         LOG(FATAL) << "Failure reading from completion queue";
         return;
       }

--- a/oak/server/oak_enclave.cc
+++ b/oak/server/oak_enclave.cc
@@ -26,6 +26,6 @@
 
 namespace asylo {
 
-TrustedApplication *BuildTrustedApplication() { return new oak::EnclaveServer(); }
+TrustedApplication* BuildTrustedApplication() { return new oak::EnclaveServer(); }
 
 }  // namespace asylo

--- a/oak/server/oak_main.cc
+++ b/oak/server/oak_main.cc
@@ -34,7 +34,7 @@ void sigint_handler(int param) {
   exit(1);
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   // Setup.
   ::google::ParseCommandLineFlags(&argc, &argv, /*remove_flags=*/true);
 

--- a/oak/server/oak_manager.cc
+++ b/oak/server/oak_manager.cc
@@ -24,9 +24,9 @@ DEFINE_string(enclave_path, "", "Path to enclave to load");
 
 OakManager::OakManager() : Service(), node_id_(0) { InitializeEnclaveManager(); }
 
-::grpc::Status OakManager::CreateNode(::grpc::ServerContext *context,
-                                      const ::oak::CreateNodeRequest *request,
-                                      ::oak::CreateNodeResponse *response) {
+::grpc::Status OakManager::CreateNode(::grpc::ServerContext* context,
+                                      const ::oak::CreateNodeRequest* request,
+                                      ::oak::CreateNodeResponse* response) {
   std::string node_id = NewNodeId();
   CreateEnclave(node_id, request->module());
   ::oak::InitializeOutput out = GetEnclaveOutput(node_id);
@@ -49,10 +49,10 @@ void OakManager::InitializeEnclaveManager() {
                                                             /*debug=*/true);
 }
 
-void OakManager::CreateEnclave(const std::string &node_id, const std::string &module) {
+void OakManager::CreateEnclave(const std::string& node_id, const std::string& module) {
   LOG(INFO) << "Creating enclave";
   ::asylo::EnclaveConfig config;
-  ::oak::InitializeInput *initialize_input = config.MutableExtension(::oak::initialize_input);
+  ::oak::InitializeInput* initialize_input = config.MutableExtension(::oak::initialize_input);
   initialize_input->set_node_id(node_id);
   initialize_input->set_module(module);
   ::asylo::Status status = enclave_manager_->LoadEnclave(node_id, *enclave_loader_, config);
@@ -62,9 +62,9 @@ void OakManager::CreateEnclave(const std::string &node_id, const std::string &mo
   LOG(INFO) << "Enclave created";
 }
 
-::oak::InitializeOutput OakManager::GetEnclaveOutput(const std::string &node_id) {
+::oak::InitializeOutput OakManager::GetEnclaveOutput(const std::string& node_id) {
   LOG(INFO) << "Initializing enclave";
-  ::asylo::EnclaveClient *client = enclave_manager_->GetClient(node_id);
+  ::asylo::EnclaveClient* client = enclave_manager_->GetClient(node_id);
   ::asylo::EnclaveInput input;
   ::asylo::EnclaveOutput output;
   ::asylo::Status status = client->EnterAndRun(input, &output);
@@ -83,9 +83,9 @@ std::string OakManager::NewNodeId() {
   return id_str.str();
 }
 
-void OakManager::DestroyEnclave(const std::string &node_id) {
+void OakManager::DestroyEnclave(const std::string& node_id) {
   LOG(INFO) << "Destroying enclave";
-  ::asylo::EnclaveClient *client = enclave_manager_->GetClient(node_id);
+  ::asylo::EnclaveClient* client = enclave_manager_->GetClient(node_id);
   ::asylo::EnclaveFinal final_input;
   ::asylo::Status status = enclave_manager_->DestroyEnclave(client, final_input);
   if (!status.ok()) {

--- a/oak/server/oak_manager.h
+++ b/oak/server/oak_manager.h
@@ -24,21 +24,21 @@ class OakManager final : public ::oak::Manager::Service {
  public:
   OakManager();
 
-  ::grpc::Status CreateNode(::grpc::ServerContext *context, const ::oak::CreateNodeRequest *request,
-                            ::oak::CreateNodeResponse *response) override;
+  ::grpc::Status CreateNode(::grpc::ServerContext* context, const ::oak::CreateNodeRequest* request,
+                            ::oak::CreateNodeResponse* response) override;
 
  private:
   void InitializeEnclaveManager();
 
-  void CreateEnclave(const std::string &node_id, const std::string &module);
+  void CreateEnclave(const std::string& node_id, const std::string& module);
 
-  oak::InitializeOutput GetEnclaveOutput(const std::string &node_id);
+  oak::InitializeOutput GetEnclaveOutput(const std::string& node_id);
 
   std::string NewNodeId();
 
-  void DestroyEnclave(const std::string &node_id);
+  void DestroyEnclave(const std::string& node_id);
 
-  asylo::EnclaveManager *enclave_manager_;
+  asylo::EnclaveManager* enclave_manager_;
   std::unique_ptr<asylo::SimLoader> enclave_loader_;
 
   uint64_t node_id_;

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -26,34 +26,34 @@ namespace grpc_server {
 
 class OakNode final : public ::oak::Node::Service {
  public:
-  OakNode(const std::string &node_id, const std::string &module);
+  OakNode(const std::string& node_id, const std::string& module);
 
-  ::grpc::Status HandleGrpcCall(const ::grpc::GenericServerContext *context,
-                                const ::grpc::ByteBuffer *request_data,
-                                ::grpc::ByteBuffer *response_data);
+  ::grpc::Status HandleGrpcCall(const ::grpc::GenericServerContext* context,
+                                const ::grpc::ByteBuffer* request_data,
+                                ::grpc::ByteBuffer* response_data);
 
  private:
-  ::grpc::Status GetAttestation(::grpc::ServerContext *context,
-                                const ::oak::GetAttestationRequest *request,
-                                ::oak::GetAttestationResponse *response) override;
+  ::grpc::Status GetAttestation(::grpc::ServerContext* context,
+                                const ::oak::GetAttestationRequest* request,
+                                ::oak::GetAttestationResponse* response) override;
 
-  void InitEnvironment(wabt::interp::Environment *env);
+  void InitEnvironment(wabt::interp::Environment* env);
 
   // Native implementation of the `oak.read_method_name` host function.
-  ::wabt::interp::HostFunc::Callback OakReadMethodName(wabt::interp::Environment *env);
+  ::wabt::interp::HostFunc::Callback OakReadMethodName(wabt::interp::Environment* env);
 
   // Native implementation of the `oak.read` host function.
-  ::wabt::interp::HostFunc::Callback OakRead(wabt::interp::Environment *env);
+  ::wabt::interp::HostFunc::Callback OakRead(wabt::interp::Environment* env);
 
   // Native implementation of the `oak.write` host function.
-  ::wabt::interp::HostFunc::Callback OakWrite(wabt::interp::Environment *env);
+  ::wabt::interp::HostFunc::Callback OakWrite(wabt::interp::Environment* env);
 
   wabt::interp::Environment env_;
   // TODO: Use smart pointers.
-  wabt::interp::DefinedModule *module_;
+  wabt::interp::DefinedModule* module_;
 
   // Incoming gRPC data for the current invocation.
-  const ::grpc::GenericServerContext *server_context_;
+  const ::grpc::GenericServerContext* server_context_;
 
   std::unique_ptr<std::vector<char>> request_data_;
   // Cursor keeping track of how many bytes of request_data_ have been consumed by the Oak Module

--- a/scripts/format
+++ b/scripts/format
@@ -3,6 +3,6 @@ set -x
 
 /google/data/ro/teams/g3doc/mdformat --in_place README.md
 
-clang-format -i ./oak/**.cc
-clang-format -i ./oak/**.h
-clang-format -i ./oak/**.proto
+clang-format -i ./oak/**/*.cc
+clang-format -i ./oak/**/*.h
+clang-format -i ./oak/**/*.proto


### PR DESCRIPTION
It turns out that the glob expression was incorrect, so that is now
fixed, and all the files are now correctly formatted.

In particular #29 affects pointer types, which are now consistent.