### PR TITLE
Support hash-based remote attestation in Oak Nodes

### DIFF
--- a/examples/private_set_intersection/client/private_set_intersection.cc
+++ b/examples/private_set_intersection/client/private_set_intersection.cc
@@ -80,9 +80,13 @@ int main(int argc, char** argv) {
   ::oak::NodeClient::InitializeAssertionAuthorities();
 
   // Connect to the newly created Oak Node from different clients.
-  auto stub_0 = PrivateSetIntersection::NewStub(::grpc::CreateChannel(
+  auto channel_0 = ::grpc::CreateChannel(
       addr.str(),
-      ::asylo::EnclaveChannelCredentials(::asylo::BidirectionalNullCredentialsOptions())));
+      ::asylo::EnclaveChannelCredentials(::asylo::BidirectionalNullCredentialsOptions()));
+  auto node_client_0 = ::oak::NodeClient(channel_0);
+  auto attestation = node_client_0.GetAttestation();
+  LOG(INFO) << "Oak Node attestation: " << attestation.DebugString();
+  auto stub_0 = PrivateSetIntersection::NewStub(channel_0);
 
   auto stub_1 = PrivateSetIntersection::NewStub(::grpc::CreateChannel(
       addr.str(),

--- a/examples/private_set_intersection/client/private_set_intersection.cc
+++ b/examples/private_set_intersection/client/private_set_intersection.cc
@@ -83,8 +83,8 @@ int main(int argc, char** argv) {
   auto channel_0 = ::grpc::CreateChannel(
       addr.str(),
       ::asylo::EnclaveChannelCredentials(::asylo::BidirectionalNullCredentialsOptions()));
-  auto node_client_0 = ::oak::NodeClient(channel_0);
-  auto attestation = node_client_0.GetAttestation();
+  ::oak::NodeClient node_client_0(channel_0);
+  ::oak::GetAttestationResponse attestation = node_client_0.GetAttestation();
   LOG(INFO) << "Oak Node attestation: " << attestation.DebugString();
   auto stub_0 = PrivateSetIntersection::NewStub(channel_0);
 

--- a/oak/client/node_client.h
+++ b/oak/client/node_client.h
@@ -28,6 +28,9 @@ namespace oak {
 // It allows invoking the Oak Node as specified by the Oak Node policies.
 //
 // TODO: Verify remote attestations.
+// TODO: Make this class take ownership of the gRPC channel (e.g. via a unique_ptr), and force
+// clients to instantiate gRPC stubs via it, or parametrize this class with the type of the stub to
+// instantiate.
 class NodeClient {
  public:
   NodeClient(const std::shared_ptr<::grpc::ChannelInterface>& channel)
@@ -35,8 +38,16 @@ class NodeClient {
     InitializeAssertionAuthorities();
   }
 
-  void GetAttestation() {
-    // TODO: Implement this method.
+  ::oak::GetAttestationResponse GetAttestation() {
+    ::grpc::ClientContext context;
+    ::oak::GetAttestationRequest request;
+    ::oak::GetAttestationResponse response;
+    auto status = stub_->GetAttestation(&context, request, &response);
+    if (!status.ok()) {
+      LOG(QFATAL) << "Could not get attestation: " << status.error_code() << ": "
+                  << status.error_message();
+    }
+    return response;
   }
 
   // This method sets up the necessary global state for Asylo to be able to validate authorities

--- a/oak/proto/node.proto
+++ b/oak/proto/node.proto
@@ -23,8 +23,8 @@ message GetAttestationRequest {
 }
 
 message GetAttestationResponse {
-  // SHA256 hash of the WebAssembly bytecode of the Oak Module loaded by the Oak
-  // Node.
+  // SHA256 hash of the WebAssembly bytecode for the Oak Module loaded by the
+  // Oak Node.
   // May be used by client to determine whether the Oak Node is running a
   // particular expected / whitelisted version of an Oak Module.
   bytes module_hash_sha_256 = 1;

--- a/oak/proto/node.proto
+++ b/oak/proto/node.proto
@@ -23,7 +23,11 @@ message GetAttestationRequest {
 }
 
 message GetAttestationResponse {
-  // TODO: Specify this message.
+  // SHA256 hash of the WebAssembly bytecode of the Oak Module loaded by the Oak
+  // Node.
+  // May be used by client to determine whether the Oak Node is running a
+  // particular expected / whitelisted version of an Oak Module.
+  bytes module_hash_sha_256 = 1;
 }
 
 // An Oak Node is an instance of an Oak Module an Oak VM, usually running within

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -52,6 +52,7 @@ cc_library(
     ],
     deps = [
         "//oak/proto:node_grpc_proto",
+        "@boringssl//:crypto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/types:span",

--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -27,6 +27,8 @@
 #include "absl/memory/memory.h"
 #include "absl/types/span.h"
 
+#include <openssl/sha.h>
+
 namespace oak {
 namespace grpc_server {
 
@@ -138,8 +140,17 @@ static wabt::Result ReadModule(const std::string module_bytes, wabt::interp::Env
   return result;
 }
 
+const std::string Sha256Hash(const std::string& data) {
+  std::vector<uint8_t> digest(SHA256_DIGEST_LENGTH);
+  SHA256_CTX context;
+  SHA256_Init(&context);
+  SHA256_Update(&context, data.data(), data.size());
+  SHA256_Final(digest.data(), &context);
+  return std::string(digest.cbegin(), digest.cend());
+}
+
 OakNode::OakNode(const std::string& node_id, const std::string& module)
-    : Service(), node_id_(node_id) {
+    : Service(), node_id_(node_id), module_hash_sha_256_(Sha256Hash(module)) {
   LOG(INFO) << "Creating Oak Node";
   wabt::Result result;
   InitEnvironment(&env_);
@@ -349,7 +360,8 @@ static const ::grpc::ByteBuffer Wrap(const std::vector<char>* bytes) {
 ::grpc::Status OakNode::GetAttestation(::grpc::ServerContext* context,
                                        const ::oak::GetAttestationRequest* request,
                                        ::oak::GetAttestationResponse* response) {
-  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "TODO");
+  response->set_module_hash_sha_256(module_hash_sha_256_);
+  return ::grpc::Status::OK;
 }
 
 }  // namespace grpc_server

--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -140,13 +140,13 @@ static wabt::Result ReadModule(const std::string module_bytes, wabt::interp::Env
   return result;
 }
 
-const std::string Sha256Hash(const std::string& data) {
-  std::vector<uint8_t> digest(SHA256_DIGEST_LENGTH);
+std::string Sha256Hash(const std::string& data) {
   SHA256_CTX context;
   SHA256_Init(&context);
   SHA256_Update(&context, data.data(), data.size());
-  SHA256_Final(digest.data(), &context);
-  return std::string(digest.cbegin(), digest.cend());
+  std::vector<uint8_t> hash(SHA256_DIGEST_LENGTH);
+  SHA256_Final(hash.data(), &context);
+  return std::string(hash.cbegin(), hash.cend());
 }
 
 OakNode::OakNode(const std::string& node_id, const std::string& module)

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -67,7 +67,7 @@ class OakNode final : public ::oak::Node::Service {
   // configuration will result in Oak Node instances with distinct node_id_.
   const std::string node_id_;
 
-  // Hash (measurement) of the Oak Module with which this Oak Node was initialized.
+  // Hash of the Oak Module with which this Oak Node was initialized.
   // To be used as the basis for remote attestation based on code identity.
   const std::string module_hash_sha_256_;
 };

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -63,7 +63,13 @@ class OakNode final : public ::oak::Node::Service {
   // Outgoing gRPC data for the current invocation.
   std::unique_ptr<std::vector<char>> response_data_;
 
+  // Unique ID of the Oak Node instance. Creating multiple Oak Nodes with the same module and policy
+  // configuration will result in Oak Node instances with distinct node_id_.
   const std::string node_id_;
+
+  // Hash (measurement) of the Oak Module with which this Oak Node was initialized.
+  // To be used as the basis for remote attestation based on code identity.
+  const std::string module_hash_sha_256_;
 };
 
 }  // namespace grpc_server


### PR DESCRIPTION
Add support for the Oak Node reporting the SHA256 hash of the Oak Module
with which it was initialized.

Modify one of the examples to print out the remote attestation received
from the Oak Node.

ref. #6