### PR TITLE
Fix docker_run script

### DIFF
--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -10,5 +10,6 @@ docker run \
   --volume=$PWD:/opt/my-project \
   --workdir=/opt/my-project \
   --publish=8888:8888 \
+  --publish=30000:30000 \
   oak:latest \
   "$@"


### PR DESCRIPTION
Accidentally missed the flag to expose the port on which Oak Nodes are
listening.