### PR TITLE
Improve memory management for Oak Module

### DIFF
--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -55,6 +55,7 @@ cc_library(
         "@boringssl//:crypto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
         "@com_google_asylo//asylo/util:logging",
         "@wabt",
@@ -68,6 +69,7 @@ cc_library(
     deps = [
         ":oak_node",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/memory",
     ],
 )
 

--- a/oak/server/grpc_stream.cc
+++ b/oak/server/grpc_stream.cc
@@ -24,15 +24,15 @@ namespace oak {
 namespace {
 
 // Converts a gRPC ByteBuffer into a vector of bytes.
-std::unique_ptr<std::vector<uint8_t>> Unwrap(const ::grpc::ByteBuffer& buffer) {
-  auto bytes = absl::make_unique<std::vector<uint8_t>>();
+std::vector<uint8_t> Unwrap(const ::grpc::ByteBuffer& buffer) {
+  std::vector<uint8_t> bytes;
   std::vector<::grpc::Slice> slices;
   ::grpc::Status status = buffer.Dump(&slices);
   if (!status.ok()) {
     LOG(QFATAL) << "Could not unwrap buffer";
   }
   for (const auto& slice : slices) {
-    bytes->insert(bytes->end(), slice.begin(), slice.end());
+    bytes.insert(bytes.end(), slice.begin(), slice.end());
   }
   return bytes;
 }
@@ -67,9 +67,9 @@ void GrpcStream::ProcessRequest(bool ok) {
     delete this;
     return;
   }
-  std::unique_ptr<std::vector<uint8_t>> request_data = Unwrap(request_);
+  std::vector<uint8_t> request_data = Unwrap(request_);
   std::vector<uint8_t> response_data;
-  node_->ProcessModuleCall(&context_, *request_data, &response_data);
+  node_->ProcessModuleCall(&context_, request_data, &response_data);
 
   // Restarts the gRPC flow with a new GrpcStream object for the next request
   // after processing this request.  This ensures that processing is serialized.

--- a/oak/server/grpc_stream.cc
+++ b/oak/server/grpc_stream.cc
@@ -16,7 +16,35 @@
 
 #include "oak/server/grpc_stream.h"
 
+#include "absl/memory/memory.h"
+#include "asylo/util/logging.h"
+
 namespace oak {
+
+namespace {
+
+// Converts a gRPC ByteBuffer into a vector of bytes.
+std::unique_ptr<std::vector<uint8_t>> Unwrap(const ::grpc::ByteBuffer& buffer) {
+  auto bytes = absl::make_unique<std::vector<uint8_t>>();
+  std::vector<::grpc::Slice> slices;
+  ::grpc::Status status = buffer.Dump(&slices);
+  if (!status.ok()) {
+    LOG(QFATAL) << "Could not unwrap buffer";
+  }
+  for (const auto& slice : slices) {
+    bytes->insert(bytes->end(), slice.begin(), slice.end());
+  }
+  return bytes;
+}
+
+// Converts a vector of bytes into a gRPC ByteBuffer.
+const ::grpc::ByteBuffer Wrap(const std::vector<uint8_t>& bytes) {
+  ::grpc::Slice slice(bytes.data(), bytes.size());
+  ::grpc::ByteBuffer buffer(&slice, /*nslices=*/1);
+  return buffer;
+}
+
+}  // namespace
 
 void GrpcStream::Start() {
   auto* callback = new std::function<void(bool)>(
@@ -39,13 +67,16 @@ void GrpcStream::ProcessRequest(bool ok) {
     delete this;
     return;
   }
-  node_->ProcessModuleCall(&context_, &request_, &response_);
+  std::unique_ptr<std::vector<uint8_t>> request_data = Unwrap(request_);
+  std::vector<uint8_t> response_data;
+  node_->ProcessModuleCall(&context_, *request_data, &response_data);
 
   // Restarts the gRPC flow with a new GrpcStream object for the next request
   // after processing this request.  This ensures that processing is serialized.
   auto* request = new GrpcStream(service_, queue_, node_);
   request->Start();
 
+  response_ = Wrap(response_data);
   ::grpc::WriteOptions options;
   auto* callback =
       new std::function<void(bool)>(std::bind(&GrpcStream::Finish, this, std::placeholders::_1));

--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -14,20 +14,17 @@
  * limitations under the License.
  */
 
-#include "asylo/util/logging.h"
-
 #include "oak/server/oak_node.h"
 
+#include <openssl/sha.h>
+
+#include "absl/memory/memory.h"
+#include "asylo/util/logging.h"
 #include "src/binary-reader.h"
 #include "src/error-formatter.h"
 #include "src/error.h"
 #include "src/interp/binary-reader-interp.h"
 #include "src/interp/interp.h"
-
-#include "absl/memory/memory.h"
-#include "absl/types/span.h"
-
-#include <openssl/sha.h>
 
 namespace oak {
 
@@ -47,15 +44,15 @@ static wabt::interp::Result PrintCallback(const wabt::interp::HostFunc* func,
   return wabt::interp::Result::Ok;
 }
 
-static const absl::Span<const char> ReadMemory(wabt::interp::Environment* env,
-                                               const uint32_t offset, const uint32_t size) {
+static ::absl::Span<const char> ReadMemory(::wabt::interp::Environment* env, const uint32_t offset,
+                                           const uint32_t size) {
   return absl::MakeConstSpan(env->GetMemory(0)->data).subspan(offset, size);
 }
 
 static const std::string ReadString(wabt::interp::Environment* env, const uint32_t offset,
                                     const uint32_t size) {
-  auto mem = ReadMemory(env, offset, size);
-  return std::string(mem.cbegin(), mem.cend());
+  ::absl::Span<const char> memory = ReadMemory(env, offset, size);
+  return std::string(memory.cbegin(), memory.cend());
 }
 
 template <class Iterator>
@@ -255,23 +252,17 @@ void OakNode::InitEnvironment(wabt::interp::Environment* env) {
     for (auto const& arg : args) {
       LOG(INFO) << "Arg: " << wabt::interp::TypedValueToString(arg);
     }
+    uint32_t offset = args[0].get_i32();
+    uint32_t size = args[1].get_i32();
 
-    // TODO: Synchronise this method.
-
-    uint32_t p = args[0].get_i32();
-    uint32_t len = args[1].get_i32();
-
-    uint32_t start = request_data_cursor_;
-    uint32_t end = start + len;
-    if (end > request_data_->size()) {
-      end = request_data_->size();
+    if (size > module_data_input_.size()) {
+      size = module_data_input_.size();
     }
+    WriteMemory(env, offset, module_data_input_.cbegin(), module_data_input_.cbegin() + size);
+    results[0].set_i32(size);
+    module_data_input_.remove_prefix(size);
 
-    WriteMemory(env, p, request_data_->cbegin() + start, request_data_->cbegin() + end);
-    results[0].set_i32(end - start);
-    request_data_cursor_ = end;
-
-    return wabt::interp::Result::Ok;
+    return ::wabt::interp::Result::Ok;
   };
 }
 
@@ -282,55 +273,26 @@ void OakNode::InitEnvironment(wabt::interp::Environment* env) {
     for (auto const& arg : args) {
       LOG(INFO) << "Arg: " << wabt::interp::TypedValueToString(arg);
     }
+    uint32_t offset = args[0].get_i32();
+    uint32_t size = args[1].get_i32();
 
-    // TODO: Synchronise this method.
-
-    uint32_t p = args[0].get_i32();
-    uint32_t len = args[1].get_i32();
-
-    auto data = ReadMemory(env, p, len);
-    response_data_->insert(response_data_->end(), data.cbegin(), data.cend());
-
-    results[0].set_i32(len);
+    ::absl::Span<const char> memory = ReadMemory(env, offset, size);
+    module_data_output_->insert(module_data_output_->end(), memory.cbegin(), memory.cend());
+    results[0].set_i32(size);
 
     return wabt::interp::Result::Ok;
   };
 }
 
-// Converts a gRPC ByteBuffer into a vector of bytes.
-// TODO: Move to GrpcStream.
-static std::unique_ptr<std::vector<char>> Unwrap(const ::grpc::ByteBuffer* buffer) {
-  auto bytes = absl::make_unique<std::vector<char>>();
-  std::vector<::grpc::Slice> slices;
-  ::grpc::Status status = buffer->Dump(&slices);
-  if (!status.ok()) {
-    LOG(QFATAL) << "Could not unwrap buffer";
-  }
-  for (const auto& slice : slices) {
-    bytes->insert(bytes->end(), slice.begin(), slice.end());
-  }
-  return bytes;
-}
-
-// Converts a vector of bytes into a gRPC ByteBuffer.
-// TODO: Move to GrpcStream.
-static const ::grpc::ByteBuffer Wrap(const std::vector<char>* bytes) {
-  ::grpc::Slice slice(bytes->data(), bytes->size());
-  ::grpc::ByteBuffer buffer(&slice, /*nslices=*/1);
-  return buffer;
-}
-
-// TODO: Refactor Oak Module code into a separate class.
-void OakNode::ProcessModuleCall(::grpc::GenericServerContext* context, ::grpc::ByteBuffer* request,
-                                ::grpc::ByteBuffer* response) {
-  // TODO: Synchronise this method.
+::grpc::Status OakNode::ProcessModuleCall(::grpc::GenericServerContext* context,
+                                          const std::vector<uint8_t>& request_data,
+                                          std::vector<uint8_t>* response_data) {
   LOG(INFO) << "Handling gRPC call: " << context->method();
   server_context_ = context;
 
-  request_data_ = Unwrap(request);
-  request_data_cursor_ = 0;
-
-  response_data_ = absl::make_unique<std::vector<char>>();
+  ::absl::MutexLock lock(&module_data_mutex_);
+  module_data_input_ = ::absl::Span<const uint8_t>(request_data);
+  module_data_output_ = response_data;
 
   wabt::Stream* trace_stream = nullptr;
   wabt::interp::Thread::Options thread_options;
@@ -349,7 +311,7 @@ void OakNode::ProcessModuleCall(::grpc::GenericServerContext* context, ::grpc::B
     LOG(WARNING) << "Could not handle gRPC call: "
                  << wabt::interp::ResultToString(exec_result.result);
   }
-  *response = Wrap(response_data_.get());
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status OakNode::GetAttestation(::grpc::ServerContext* context,

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -63,10 +63,12 @@ class OakNode final : public ::oak::Node::Service {
   // Guards data used by OakRead and OakWrite host methods.
   ::absl::Mutex module_data_mutex_;
 
-  // Span containing the gRPC request data read by the module.
+  // Span containing the gRPC request data passed to ProcessModuleCall.
+  // This is a view of the data which advances each time the OakRead host function is called.
   ::absl::Span<const uint8_t> GUARDED_BY(module_data_mutex_) module_data_input_;
 
-  // Pointer to the gRPC response data written by the module.
+  // Pointer to the gRPC response data passed to ProcessModuleCall.
+  // Data is inserted each time the OakWrite host function is called.
   std::vector<uint8_t>* GUARDED_BY(module_data_mutex_) module_data_output_;
 
   // Unique ID of the Oak Node instance. Creating multiple Oak Nodes with the same module and policy

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -17,8 +17,10 @@
 #ifndef OAK_SERVER_OAK_NODE_H_
 #define OAK_SERVER_OAK_NODE_H_
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/types/span.h"
 #include "oak/proto/node.grpc.pb.h"
-
 #include "src/interp/interp.h"
 
 namespace oak {
@@ -28,8 +30,10 @@ class OakNode final : public ::oak::Node::Service {
   OakNode(const std::string& node_id, const std::string& module);
 
   // Performs an Oak Module invocation.
-  void ProcessModuleCall(::grpc::GenericServerContext* context, ::grpc::ByteBuffer* request,
-                         ::grpc::ByteBuffer* response);
+  ::grpc::Status ProcessModuleCall(::grpc::GenericServerContext* context,
+                                   const std::vector<uint8_t>& request_data,
+                                   std::vector<uint8_t>* response_data)
+      LOCKS_EXCLUDED(module_data_mutex_);
 
  private:
   ::grpc::Status GetAttestation(::grpc::ServerContext* context,
@@ -42,10 +46,12 @@ class OakNode final : public ::oak::Node::Service {
   ::wabt::interp::HostFunc::Callback OakReadMethodName(wabt::interp::Environment* env);
 
   // Native implementation of the `oak.read` host function.
-  ::wabt::interp::HostFunc::Callback OakRead(wabt::interp::Environment* env);
+  ::wabt::interp::HostFunc::Callback OakRead(::wabt::interp::Environment* env)
+      EXCLUSIVE_LOCKS_REQUIRED(module_data_mutex_);
 
   // Native implementation of the `oak.write` host function.
-  ::wabt::interp::HostFunc::Callback OakWrite(wabt::interp::Environment* env);
+  ::wabt::interp::HostFunc::Callback OakWrite(::wabt::interp::Environment* env)
+      EXCLUSIVE_LOCKS_REQUIRED(module_data_mutex_);
 
   wabt::interp::Environment env_;
   // TODO: Use smart pointers.
@@ -54,13 +60,14 @@ class OakNode final : public ::oak::Node::Service {
   // Incoming gRPC data for the current invocation.
   const ::grpc::GenericServerContext* server_context_;
 
-  std::unique_ptr<std::vector<char>> request_data_;
-  // Cursor keeping track of how many bytes of request_data_ have been consumed by the Oak Module
-  // during the current invocation.
-  uint32_t request_data_cursor_;
+  // Guards data used by OakRead and OakWrite host methods.
+  ::absl::Mutex module_data_mutex_;
 
-  // Outgoing gRPC data for the current invocation.
-  std::unique_ptr<std::vector<char>> response_data_;
+  // Span containing the gRPC request data read by the module.
+  ::absl::Span<const uint8_t> GUARDED_BY(module_data_mutex_) module_data_input_;
+
+  // Pointer to the gRPC response data written by the module.
+  std::vector<uint8_t>* GUARDED_BY(module_data_mutex_) module_data_output_;
 
   // Unique ID of the Oak Node instance. Creating multiple Oak Nodes with the same module and policy
   // configuration will result in Oak Node instances with distinct node_id_.


### PR DESCRIPTION
Avoids copying and managing an external cursor by using a Span
for the request data and pushing ::grpc::ByteBuffer conversion
up to the caller.

ref #4