### PR TITLE
Updated asylo to v0.3.4

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,20 +1,19 @@
-# Copied from https://github.com/google/asylo/blob/master/.bazelrc
+# Copied from https://github.com/google/asylo/blob/v0.3.4/.bazelrc
 
-build:sgx --crosstool_top=@com_google_asylo_sgx_backend//toolchain:crosstool
-build:sgx --dynamic_mode=off
-build:sgx --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
-build:sgx --fission=no
-build:sgx --custom_malloc=@com_google_asylo_sgx_backend//toolchain:malloc
+build:asylo --crosstool_top=@com_google_asylo_toolchain//toolchain:crosstool
+build:asylo --dynamic_mode=off
+build:asylo --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build:asylo --fission=no
+build:asylo --custom_malloc=@com_google_asylo_toolchain//toolchain:malloc
+build:asylo --define=grpc_no_ares=true
+
+build:sgx --config=asylo
+build:sgx --define=ASYLO_SGX=1
 build:sgx --define=SGX_SIM=0
-build:sgx --define=grpc_no_ares=true
 
-build:sgx-sim --crosstool_top=@com_google_asylo_sgx_backend//toolchain:crosstool
-build:sgx-sim --dynamic_mode=off
-build:sgx-sim --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
-build:sgx-sim --fission=no
-build:sgx-sim --custom_malloc=@com_google_asylo_sgx_backend//toolchain:malloc
+build:sgx-sim --config=asylo
+build:sgx-sim --define=ASYLO_SGX=1
 build:sgx-sim --define=SGX_SIM=1
-build:sgx-sim --define=grpc_no_ares=true
 
 # The enclave simulation backend currently makes use of the SGX simulator.
 # However, this is subject to change and users of this config should not

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/asylo-framework/asylo:buildenv-v0.3.3
+FROM gcr.io/asylo-framework/asylo:buildenv-v0.3.4
 
 RUN apt-get -y update && apt-get install -y git curl
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,21 +17,31 @@
 workspace(name = "oak")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+# Asylo Framework v0.3.4
 http_archive(
     name = "com_google_asylo",
-    urls = ["https://github.com/google/asylo/archive/v0.3.3.tar.gz"],
-    strip_prefix = "asylo-0.3.3",
-    sha256 = "55eaf1a2511a3ba5d1f5042a38b1129caaceb41088618454ed68abc8591a75a6",
+    urls = ["https://github.com/google/asylo/archive/v0.3.4.tar.gz"],
+    strip_prefix = "asylo-0.3.4",
+    sha256 = "e408c614ad129dd7dff0dc7a816f77aae81f22eb851f63fc0bba7de61a467b62",
 )
 
+# Google Protocol Buffers v3.6.1.2
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-3.6.1.2",
-    sha256 = "2244b0308846bb22b4ff0bcc675e99290ff9f1115553ae9671eba1030af31bc0",
     urls = [
         "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.2.tar.gz",
     ],
+    strip_prefix = "protobuf-3.6.1.2",
+    sha256 = "2244b0308846bb22b4ff0bcc675e99290ff9f1115553ae9671eba1030af31bc0",
+)
+
+# WebAssembly Binary Toolkit (forked by tiziano88)
+git_repository(
+    name = "wabt",
+    commit = "2d31cda394fc67c7969a9bd44066cb8eafa82e23",
+    remote = "https://github.com/tiziano88/wabt",
 )
 
 load(
@@ -42,22 +52,8 @@ load(
 asylo_deps()
 asylo_go_deps()
 
-load(
-    "@com_google_asylo//asylo/bazel:sgx_deps.bzl",
-    "sgx_deps",
-)
+load("@com_google_asylo//asylo/bazel:sgx_deps.bzl", "sgx_deps")
 sgx_deps()
 
-load(
-    "@com_github_grpc_grpc//bazel:grpc_deps.bzl",
-    "grpc_deps",
-)
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 grpc_deps()
-
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "wabt",
-    commit = "2d31cda394fc67c7969a9bd44066cb8eafa82e23",
-    remote = "https://github.com/tiziano88/wabt",
-)


### PR DESCRIPTION
Changes done
- Updated to asylo-v0.3.4 from v0.3.3
- Replaced http_archive loads with git_repository loads

Remarks:
- Dependency version numbers should really be loaded from a common place, at the moment it's somewhat inconsistent. For example in the [Dockerfile](https://github.com/project-oak/oak/blob/c3a262477df8d843f005ddf9c9e7c000b74de09e/Dockerfile#L6) Protobuf version is explicitly set to v3.7.1 while in the [WORKSPACE](https://github.com/project-oak/oak/blob/c3a262477df8d843f005ddf9c9e7c000b74de09e/WORKSPACE#L30) file it's v3.6.1.2. I'm not sure what would be the right way of doing that, probably injecting a Step 0 that'd generate the Dockerfile and the WORKSPACE file from a version config.
-  Interesting thing is that the project doesn't build with protobuf v3.7+, the problem is similar to [this](https://github.com/protocolbuffers/protobuf/issues/5178).