### PR TITLE
Fix and run format script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,15 +26,15 @@ During a review, the author of the change addresses review comments by adding
 new commits to the same branch / PR and then pushing again (note: we discourage
 force-pushing to any branch, even during review).
 
-Once approved, each PR is merged via the ["Squash and
-merge"](https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits)
+Once approved, each PR is merged via the
+["Squash and merge"](https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits)
 button in the GitHub UI. The final commit message is taken from the PR
 description, and individual commit messages are discarded; for this reason, we
 do not expect commits to have meaningful messages during a review; the PR
-description should follow [standard git commit
-conventions](https://chris.beams.io/posts/git-commit/).
+description should follow
+[standard git commit conventions](https://chris.beams.io/posts/git-commit/).
 
 ## Community Guidelines
 
-This project follows [Google's Open Source Community
-Guidelines](https://opensource.google.com/conduct/).
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google.com/conduct/).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 # Step by step instructions for installing Oak on Ubuntu 18.04
 
-This is starting with a clean Ubuntu install. I needed 4 GB of RAM for
-enclave creation to work.
+This is starting with a clean Ubuntu install. I needed 4 GB of RAM for enclave
+creation to work.
 
 ```
 # apt install git
@@ -17,12 +17,11 @@ enclave creation to work.
 # usermod -a -G docker $USER
 ```
 
-If `$USER` is logged in, you'll need to Log out and log in again (so the
-group change takes effect).
+If `$USER` is logged in, you'll need to Log out and log in again (so the group
+change takes effect).
 
-We use `rustup` rather than `apt install rustc` because we need `rustup` to
-add the webassembly target and it seems that is not in the rustc
-package.
+We use `rustup` rather than `apt install rustc` because we need `rustup` to add
+the webassembly target and it seems that is not in the rustc package.
 
 ```
 $ curl https://sh.rustup.rs -sSf > /tmp/rustup  # make sure you're happy to run
@@ -36,8 +35,8 @@ $ scripts/run_server_docker  # this may take some time
 
 add source $HOME/.cargo/env to your shell init script (e.g. .bashrc or .zshrc)
 
-While you're waiting for docker, you might want to take a look at what that script does.
-The one mystery you might run into is: what does Bazel build?
+While you're waiting for docker, you might want to take a look at what that
+script does. The one mystery you might run into is: what does Bazel build?
 
 This: `oak/server/BUILD`
 

--- a/examples/hello_world/client/hello_world.cc
+++ b/examples/hello_world/client/hello_world.cc
@@ -16,12 +16,11 @@
 
 #include "absl/memory/memory.h"
 #include "asylo/util/logging.h"
-#include "gflags/gflags.h"
-#include "include/grpcpp/grpcpp.h"
-
 #include "examples/hello_world/proto/hello_world.grpc.pb.h"
 #include "examples/hello_world/proto/hello_world.pb.h"
 #include "examples/utils/utils.h"
+#include "gflags/gflags.h"
+#include "include/grpcpp/grpcpp.h"
 #include "oak/client/manager_client.h"
 #include "oak/client/node_client.h"
 

--- a/examples/private_set_intersection/client/private_set_intersection.cc
+++ b/examples/private_set_intersection/client/private_set_intersection.cc
@@ -16,12 +16,11 @@
 
 #include "absl/memory/memory.h"
 #include "asylo/util/logging.h"
-#include "gflags/gflags.h"
-#include "include/grpcpp/grpcpp.h"
-
 #include "examples/private_set_intersection/proto/private_set_intersection.grpc.pb.h"
 #include "examples/private_set_intersection/proto/private_set_intersection.pb.h"
 #include "examples/utils/utils.h"
+#include "gflags/gflags.h"
+#include "include/grpcpp/grpcpp.h"
 #include "oak/client/manager_client.h"
 #include "oak/client/node_client.h"
 

--- a/examples/private_set_intersection/src/lib.rs
+++ b/examples/private_set_intersection/src/lib.rs
@@ -54,7 +54,6 @@ impl oak::Node for Node {
                 let next = match self.values {
                     Some(ref previous) => previous.intersection(&set).cloned().collect(),
                     None => set,
-
                 };
                 self.values = Some(next);
             }

--- a/examples/running_average/client/running_average.cc
+++ b/examples/running_average/client/running_average.cc
@@ -16,12 +16,11 @@
 
 #include "absl/memory/memory.h"
 #include "asylo/util/logging.h"
-#include "gflags/gflags.h"
-#include "include/grpcpp/grpcpp.h"
-
 #include "examples/running_average/proto/running_average.grpc.pb.h"
 #include "examples/running_average/proto/running_average.pb.h"
 #include "examples/utils/utils.h"
+#include "gflags/gflags.h"
+#include "include/grpcpp/grpcpp.h"
 #include "oak/client/manager_client.h"
 #include "oak/client/node_client.h"
 

--- a/examples/utils/utils.h
+++ b/examples/utils/utils.h
@@ -1,12 +1,12 @@
-#include "asylo/util/logging.h"
-
 #include <fstream>
+
+#include "asylo/util/logging.h"
 
 namespace oak {
 namespace utils {
 
 // Reads a binary file and returns its contents as a std::string.
-std::string read_file(const std::string &module_path) {
+std::string read_file(const std::string& module_path) {
   std::ifstream t(module_path, std::ifstream::in);
   if (!t.is_open()) {
     LOG(QFATAL) << "Could not open module " << module_path;

--- a/scripts/format
+++ b/scripts/format
@@ -1,8 +1,10 @@
 #!/bin/sh
 set -x
 
-/google/data/ro/teams/g3doc/mdformat --in_place README.md
+/google/data/ro/teams/g3doc/mdformat --in_place $(find -name "*.md")
 
-clang-format -i ./oak/**/*.cc
-clang-format -i ./oak/**/*.h
-clang-format -i ./oak/**/*.proto
+rustfmt $(find -name "*.rs")
+
+clang-format -i $(find -name "*.cc")
+clang-format -i $(find -name "*.h")
+clang-format -i $(find -name "*.proto")


### PR DESCRIPTION
For some reason just using shell globs was not working for Rust files,
so I switched to using `find` instead to enumerate the various
categories of files.