### PR TITLE
Implement code generation for Oak nodes

### DIFF
--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 oak = { path = "../../rust/oak" }
+oak_derive = { path = "../../rust/oak_derive" }
 protobuf = "*"
 
 [build-dependencies]

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -15,12 +15,15 @@
 //
 
 extern crate oak;
+extern crate oak_derive;
 extern crate protobuf;
 
 mod proto;
 
+use oak_derive::OakNode;
 use protobuf::Message;
 
+#[derive(OakNode)]
 struct Node;
 
 impl oak::Node for Node {
@@ -48,5 +51,3 @@ impl oak::Node for Node {
         };
     }
 }
-
-oak::oak_node!(Node);

--- a/examples/machine_learning/Cargo.toml
+++ b/examples/machine_learning/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ["cdylib"]
 rusty-machine = "*"
 rand = "*"
 oak = { path = "../../rust/oak" }
+oak_derive = { path = "../../rust/oak_derive" }

--- a/examples/machine_learning/src/lib.rs
+++ b/examples/machine_learning/src/lib.rs
@@ -18,9 +18,11 @@
 // https://github.com/AtheMathmo/rusty-machine/blob/master/examples/naive_bayes_dogs.rs .
 
 extern crate oak;
+extern crate oak_derive;
 extern crate rand;
 extern crate rusty_machine;
 
+use oak_derive::OakNode;
 use rand::distributions::Distribution;
 use rand::distributions::Normal;
 use rand::distributions::Standard;
@@ -146,6 +148,7 @@ struct Config {
     test_animals: Vec<Animal>,
 }
 
+#[derive(OakNode)]
 struct Node {
     training_set_size: usize,
     test_set_size: usize,

--- a/examples/private_set_intersection/Cargo.toml
+++ b/examples/private_set_intersection/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 oak = { path = "../../rust/oak" }
+oak_derive = { path = "../../rust/oak_derive" }
 protobuf = "*"
 
 [build-dependencies]

--- a/examples/private_set_intersection/src/lib.rs
+++ b/examples/private_set_intersection/src/lib.rs
@@ -26,14 +26,16 @@
 //! intersection.
 
 extern crate oak;
+extern crate oak_derive;
 extern crate protobuf;
 
 mod proto;
 
+use oak_derive::OakNode;
 use protobuf::Message;
 use std::collections::HashSet;
 
-#[derive(Default)]
+#[derive(Default, OakNode)]
 struct Node {
     values: Option<HashSet<String>>,
 }
@@ -73,5 +75,3 @@ impl oak::Node for Node {
         };
     }
 }
-
-oak::oak_node!(Node);

--- a/examples/running_average/Cargo.toml
+++ b/examples/running_average/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 oak = { path = "../../rust/oak" }
+oak_derive = { path = "../../rust/oak_derive" }
 protobuf = "*"
 
 [build-dependencies]

--- a/examples/running_average/src/lib.rs
+++ b/examples/running_average/src/lib.rs
@@ -23,13 +23,15 @@
 //! to and including the value provided in the request.
 
 extern crate oak;
+extern crate oak_derive;
 extern crate protobuf;
 
 mod proto;
 
+use oak_derive::OakNode;
 use protobuf::Message;
 
-#[derive(Default)]
+#[derive(Default, OakNode)]
 struct Node {
     sum: u64,
     count: u64,
@@ -64,5 +66,3 @@ impl oak::Node for Node {
         };
     }
 }
-
-oak::oak_node!(Node);

--- a/rust/oak/Cargo.toml
+++ b/rust/oak/Cargo.toml
@@ -2,5 +2,3 @@
 name = "oak"
 version = "0.1.0"
 authors = ["Tiziano Santoro <tzn@google.com>"]
-
-[dependencies]

--- a/rust/oak/src/lib.rs
+++ b/rust/oak/src/lib.rs
@@ -105,7 +105,7 @@ thread_local! {
 ///
 /// impl oak::Node for Node {
 ///     fn new() -> Self { Node }
-///     fn invoke(&mut self, request: &mut oak::Reader, response: &mut oak::Writer) { /* ... */ }
+///     fn invoke(&mut self, grpc_method_name: &str, request: &mut oak::Reader, response: &mut oak::Writer) { /* ... */ }
 /// }
 ///
 /// #[no_mangle]
@@ -130,14 +130,4 @@ pub extern "C" fn oak_handle_grpc_call() {
             &mut Writer { _private: () },
         );
     });
-}
-
-#[macro_export]
-macro_rules! oak_node {
-    ($node_type: ty) => {
-        #[no_mangle]
-        pub extern "C" fn oak_initialize() {
-            $crate::set_node::<$node_type>();
-        }
-    };
 }

--- a/rust/oak_derive/Cargo.toml
+++ b/rust/oak_derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "oak_derive"
+version = "0.1.0"
+authors = ["Tiziano Santoro <tzn@google.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "*"
+syn = { version = "*", features = ["extra-traits"]}
+
+[dev-dependencies]
+oak = { path = "../oak" }

--- a/rust/oak_derive/src/lib.rs
+++ b/rust/oak_derive/src/lib.rs
@@ -1,0 +1,42 @@
+extern crate proc_macro;
+extern crate syn;
+
+use proc_macro::TokenStream;
+use quote::quote;
+
+/// Implements the necessary bindings to make the annotated struct act as an Oak Node.
+///
+/// May only be used on struct objects.
+///
+/// At most one struct may be annotated with this, as it produces global symbols that would
+/// otherwise conflict if implemented multiple times.
+///
+/// ```rust
+/// extern crate oak;
+///
+/// #[derive(oak_derive::OakNode)]
+/// struct Node;
+///
+/// impl oak::Node for Node {
+///     fn new() -> Self { Node }
+///     fn invoke(&mut self, grpc_method_name: &str, request: &mut oak::Reader, response: &mut oak::Writer) { /* ... */ }
+/// }
+/// ```
+#[proc_macro_derive(OakNode)]
+pub fn derive_oak_node(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let name = input.ident;
+    match input.data {
+        syn::Data::Struct(_) => (),
+        _ => panic!("#[derive(OakNode)] is only defined for structs"),
+    };
+
+    let expanded = quote! {
+        #[no_mangle]
+        pub extern "C" fn oak_initialize() {
+            oak::set_node::<#name>();
+        }
+    };
+
+    TokenStream::from(expanded)
+}


### PR DESCRIPTION
Rely on procedural macros to support the `#[derive]` annotations instead
of the previous approach.