### PR TITLE
Add assertion authority configuration to OakManager

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,12 +19,12 @@ workspace(name = "oak")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-# Asylo Framework v0.3.4
+# Asylo Framework v0.3.4.1
 http_archive(
     name = "com_google_asylo",
-    urls = ["https://github.com/google/asylo/archive/v0.3.4.tar.gz"],
-    strip_prefix = "asylo-0.3.4",
-    sha256 = "e408c614ad129dd7dff0dc7a816f77aae81f22eb851f63fc0bba7de61a467b62",
+    urls = ["https://github.com/google/asylo/archive/v0.3.4.1.tar.gz"],
+    strip_prefix = "asylo-0.3.4.1",
+    sha256 = "5001ff28b03b9a604d77b393deedfa75ed7c553cd7d75332fe52ef147bedbbba",
 )
 
 # Google Protocol Buffers v3.6.1.2

--- a/oak/client/node_client.h
+++ b/oak/client/node_client.h
@@ -16,6 +16,7 @@
 
 #include "asylo/grpc/auth/enclave_channel_credentials.h"
 #include "asylo/grpc/auth/null_credentials_options.h"
+#include "asylo/identity/descriptions.h"
 #include "asylo/identity/init.h"
 #include "asylo/util/logging.h"
 #include "oak/proto/node.grpc.pb.h"
@@ -49,13 +50,21 @@ class NodeClient {
     return response;
   }
 
+  static asylo::EnclaveAssertionAuthorityConfig GetNullAssertionAuthorityConfig() {
+    asylo::EnclaveAssertionAuthorityConfig test_config;
+    asylo::SetNullAssertionDescription(test_config.mutable_description());
+    return test_config;
+  }
+
   // This method sets up the necessary global state for Asylo to be able to validate authorities
   // (e.g. root CAs, remote attestation endpoints, etc.).
   static void InitializeAssertionAuthorities() {
     LOG(INFO) << "Initializing assertion authorities";
 
-    // TODO: Provide a list of Assertion Authorities when available.
-    std::vector<asylo::EnclaveAssertionAuthorityConfig> configs;
+    // TODO: Provide a list of non-null Assertion Authorities when available.
+    std::vector<asylo::EnclaveAssertionAuthorityConfig> configs = {
+        GetNullAssertionAuthorityConfig(),
+    };
 
     asylo::Status status =
         asylo::InitializeEnclaveAssertionAuthorities(configs.begin(), configs.end());

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -38,6 +38,8 @@ cc_library(
         "@com_google_absl//absl/memory",
         "@com_google_asylo//asylo:enclave_client",
         "@com_google_asylo//asylo/grpc/util:enclave_server_proto_cc",
+        "@com_google_asylo//asylo/identity:descriptions",
+        "@com_google_asylo//asylo/identity:enclave_assertion_authority_config_proto_cc",
         "@com_google_asylo//asylo/util:logging",
     ],
 )

--- a/oak/server/enclave_server.h
+++ b/oak/server/enclave_server.h
@@ -29,8 +29,6 @@
 #include "asylo/grpc/auth/enclave_server_credentials.h"
 #include "asylo/grpc/auth/null_credentials_options.h"
 #include "asylo/grpc/util/enclave_server.pb.h"
-#include "asylo/identity/descriptions.h"
-#include "asylo/identity/init.h"
 #include "asylo/trusted_application.h"
 #include "asylo/util/logging.h"
 #include "asylo/util/status.h"
@@ -85,28 +83,12 @@ class EnclaveServer final : public asylo::TrustedApplication {
   }
 
  private:
-  static asylo::EnclaveAssertionAuthorityConfig GetNullAssertionAuthorityConfig() {
-    asylo::EnclaveAssertionAuthorityConfig test_config;
-    asylo::SetNullAssertionDescription(test_config.mutable_description());
-    return test_config;
-  }
-
   // Initializes a gRPC server. If the server is already initialized, does nothing.
   asylo::Status InitializeServer() LOCKS_EXCLUDED(server_mutex_) {
     // Ensure that the server is only created and initialized once.
     absl::MutexLock lock(&server_mutex_);
     if (server_) {
       return asylo::Status::OkStatus();
-    }
-
-    std::vector<asylo::EnclaveAssertionAuthorityConfig> configs = {
-        GetNullAssertionAuthorityConfig(),
-    };
-
-    asylo::Status status =
-        asylo::InitializeEnclaveAssertionAuthorities(configs.begin(), configs.end());
-    if (!status.ok()) {
-      LOG(QFATAL) << "Could not initialize assertion authorities";
     }
 
     ASYLO_ASSIGN_OR_RETURN(server_, CreateServer());

--- a/oak/server/oak_manager.cc
+++ b/oak/server/oak_manager.cc
@@ -17,6 +17,8 @@
 #include "oak_manager.h"
 
 #include "absl/memory/memory.h"
+#include "asylo/identity/descriptions.h"
+#include "asylo/identity/enclave_assertion_authority_config.pb.h"
 #include "asylo/util/logging.h"
 #include "gflags/gflags.h"
 
@@ -54,6 +56,10 @@ void OakManager::InitializeEnclaveManager() {
 void OakManager::CreateEnclave(const std::string& node_id, const std::string& module) {
   LOG(INFO) << "Creating enclave";
   asylo::EnclaveConfig config;
+  // Explicitly initialize the null assertion authority in the enclave.
+  asylo::EnclaveAssertionAuthorityConfig* authority_config =
+      config.add_enclave_assertion_authority_configs();
+  asylo::SetNullAssertionDescription(authority_config->mutable_description());
   oak::InitializeInput* initialize_input = config.MutableExtension(oak::initialize_input);
   initialize_input->set_node_id(node_id);
   initialize_input->set_module(module);


### PR DESCRIPTION
This further fixes #58 by moving the authority configuration out of the EnclaveServer and into the OakManager.