### PR TITLE
Made all scripts have proper shebang

### DIFF
--- a/scripts/build_examples_docker
+++ b/scripts/build_examples_docker
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
-set -x
+set -o errexit
+set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 

--- a/scripts/build_examples_docker
+++ b/scripts/build_examples_docker
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 set -e
 set -x
 

--- a/scripts/build_server_docker
+++ b/scripts/build_server_docker
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
-set -x
+set -o errexit
+set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 

--- a/scripts/build_server_docker
+++ b/scripts/build_server_docker
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 set -e
 set -x
 

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 set -e
 set -x
 

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
-set -x
+set -o errexit
+set -o xtrace
 
 docker build --tag=oak .
 docker run \

--- a/scripts/docker_sh
+++ b/scripts/docker_sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
-set -x
+set -o errexit
+set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 

--- a/scripts/docker_sh
+++ b/scripts/docker_sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 set -e
 set -x
 

--- a/scripts/format
+++ b/scripts/format
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 set -x
 
 /google/data/ro/teams/g3doc/mdformat --in_place $(find -name "*.md")

--- a/scripts/format
+++ b/scripts/format
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set -o xtrace
 
 /google/data/ro/teams/g3doc/mdformat --in_place $(find -name "*.md")
 

--- a/scripts/run_server_docker
+++ b/scripts/run_server_docker
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
-set -x
+set -o errexit
+set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 

--- a/scripts/run_server_docker
+++ b/scripts/run_server_docker
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 set -e
 set -x
 


### PR DESCRIPTION
The new shebang is preferable both because of portability, and because bash is more rich in features than sh.