### PR TITLE
Add quotes to scripts where appropriate.

### DIFF
--- a/scripts/build_examples_docker
+++ b/scripts/build_examples_docker
@@ -5,7 +5,7 @@ set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
-$SCRIPTS_DIR/docker_run cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/hello_world/Cargo.toml
-$SCRIPTS_DIR/docker_run cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/machine_learning/Cargo.toml
-$SCRIPTS_DIR/docker_run cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/private_set_intersection/Cargo.toml
-$SCRIPTS_DIR/docker_run cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/running_average/Cargo.toml
+"$SCRIPTS_DIR/docker_run" cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/hello_world/Cargo.toml
+"$SCRIPTS_DIR/docker_run" cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/machine_learning/Cargo.toml
+"$SCRIPTS_DIR/docker_run" cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/private_set_intersection/Cargo.toml
+"$SCRIPTS_DIR/docker_run" cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/running_average/Cargo.toml

--- a/scripts/build_server_docker
+++ b/scripts/build_server_docker
@@ -5,4 +5,4 @@ set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
-$SCRIPTS_DIR/docker_run bazel build --config=enc-sim //oak/server:oak
+"$SCRIPTS_DIR/docker_run" bazel build --config=enc-sim //oak/server:oak

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -7,8 +7,8 @@ docker build --tag=oak .
 docker run \
   --interactive \
   --tty \
-  --volume=$PWD/bazel-cache:/root/.cache/bazel \
-  --volume=$PWD:/opt/my-project \
+  --volume="$PWD/bazel-cache":/root/.cache/bazel \
+  --volume="$PWD":/opt/my-project \
   --workdir=/opt/my-project \
   --network=host \
   oak:latest \

--- a/scripts/docker_sh
+++ b/scripts/docker_sh
@@ -5,4 +5,4 @@ set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
-$SCRIPTS_DIR/docker_run bash
+"$SCRIPTS_DIR/docker_run" bash

--- a/scripts/format
+++ b/scripts/format
@@ -2,10 +2,10 @@
 
 set -o xtrace
 
-/google/data/ro/teams/g3doc/mdformat --in_place $(find -name "*.md")
+/google/data/ro/teams/g3doc/mdformat --in_place "$(find . -name "*.md")"
 
-rustfmt $(find -name "*.rs")
+rustfmt "$(find . -name "*.rs")"
 
-clang-format -i $(find -name "*.cc")
-clang-format -i $(find -name "*.h")
-clang-format -i $(find -name "*.proto")
+clang-format -i "$(find . -name "*.cc")"
+clang-format -i "$(find . -name "*.h")"
+clang-format -i "$(find . -name "*.proto")"

--- a/scripts/run_server_docker
+++ b/scripts/run_server_docker
@@ -5,5 +5,5 @@ set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
-$SCRIPTS_DIR/build_server_docker
-$SCRIPTS_DIR/docker_run ./bazel-bin/oak/server/oak
+"$SCRIPTS_DIR/build_server_docker"
+"$SCRIPTS_DIR/docker_run" ./bazel-bin/oak/server/oak


### PR DESCRIPTION
I used [ShellCheck](https://github.com/koalaman/shellcheck) to identify the places where this needed to be done. For portability, they also recommend using `find .` explicitly since it is not implicit in all versions of `find`.