### PR TITLE
Convert Bazel rules to use cc_grpc_library

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,21 @@ http_archive(
     sha256 = "2244b0308846bb22b4ff0bcc675e99290ff9f1115553ae9671eba1030af31bc0",
 )
 
+# gRPC
+# TODO: Remove after Asylo upgrades for 0803c79411597f58eae0b12b4eb272c506b8cdbb.
+load(
+    "@com_google_asylo//asylo/bazel:patch_repository.bzl",
+    "patch_repository",
+)
+patch_repository(
+    name = "com_github_grpc_grpc",
+    urls = [
+        "https://github.com/grpc/grpc/archive/cb9b43b9f7291ceb714d92e0a717c6364c1fcc61.zip",
+    ],
+    patches = ["@com_google_asylo//asylo/distrib:grpc_1_19_1.patch"],
+    strip_prefix = "grpc-cb9b43b9f7291ceb714d92e0a717c6364c1fcc61",
+)
+
 # WebAssembly Binary Toolkit (forked by tiziano88).
 git_repository(
     name = "wabt",

--- a/examples/hello_world/client/BUILD
+++ b/examples/hello_world/client/BUILD
@@ -18,13 +18,13 @@ cc_binary(
     name = "client",
     srcs = ["hello_world.cc"],
     deps = [
-        "//examples/hello_world/proto:hello_world_proto_grpc",
+        "//examples/hello_world/proto:hello_world_cc_grpc",
         "//examples/utils",
         "//oak/client:manager_client",
         "//oak/client:node_client",
-        "@com_google_absl//absl/memory",
-        "@com_google_asylo//asylo/util:logging",
         "@com_github_gflags_gflags//:gflags_nothreads",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/memory",
+        "@com_google_asylo//asylo/util:logging",
     ],
 )

--- a/examples/hello_world/proto/BUILD
+++ b/examples/hello_world/proto/BUILD
@@ -19,22 +19,27 @@ package(
 )
 
 load(
-    "@com_github_grpc_grpc//bazel:grpc_build_system.bzl",
-    "grpc_proto_library",
+    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
+    "cc_grpc_library",
 )
 
 proto_library(
-    name = "hello_world",
+    name = "hello_world_proto",
     srcs = ["hello_world.proto"],
     deps = [
         "@com_google_protobuf//:empty_proto",
     ],
 )
 
-grpc_proto_library(
-    name = "hello_world_proto_grpc",
-    srcs = ["hello_world.proto"],
-    has_services = True,
+cc_proto_library(
+    name = "hello_world_cc_proto",
+    deps = [":hello_world_proto"],
+)
+
+cc_grpc_library(
+    name = "hello_world_cc_grpc",
+    srcs = ["hello_world_proto"],
+    grpc_only = True,
     well_known_protos = True,
-    deps = [],
+    deps = ["hello_world_cc_proto"],
 )

--- a/examples/machine_learning/client/BUILD
+++ b/examples/machine_learning/client/BUILD
@@ -18,13 +18,13 @@ cc_binary(
     name = "client",
     srcs = ["machine_learning.cc"],
     deps = [
-        "//examples/machine_learning/proto:machine_learning_proto_grpc",
+        "//examples/machine_learning/proto:machine_learning_cc_grpc",
         "//examples/utils",
         "//oak/client:manager_client",
         "//oak/client:node_client",
-        "@com_google_absl//absl/memory",
-        "@com_google_asylo//asylo/util:logging",
         "@com_github_gflags_gflags//:gflags_nothreads",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/memory",
+        "@com_google_asylo//asylo/util:logging",
     ],
 )

--- a/examples/machine_learning/proto/BUILD
+++ b/examples/machine_learning/proto/BUILD
@@ -19,19 +19,24 @@ package(
 )
 
 load(
-    "@com_github_grpc_grpc//bazel:grpc_build_system.bzl",
-    "grpc_proto_library",
+    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
+    "cc_grpc_library",
 )
 
 proto_library(
-    name = "machine_learning",
+    name = "machine_learning_proto",
     srcs = ["machine_learning.proto"],
 )
 
-grpc_proto_library(
-    name = "machine_learning_proto_grpc",
-    srcs = ["machine_learning.proto"],
-    has_services = True,
+cc_proto_library(
+    name = "machine_learning_cc_proto",
+    deps = [":machine_learning_proto"],
+)
+
+cc_grpc_library(
+    name = "machine_learning_cc_grpc",
+    srcs = [":machine_learning_proto"],
+    grpc_only = True,
     well_known_protos = True,
-    deps = [],
+    deps = [":machine_learning_cc_proto"],
 )

--- a/examples/private_set_intersection/client/BUILD
+++ b/examples/private_set_intersection/client/BUILD
@@ -18,13 +18,14 @@ cc_binary(
     name = "client",
     srcs = ["private_set_intersection.cc"],
     deps = [
-        "//examples/private_set_intersection/proto:private_set_intersection_proto_grpc",
+        "//examples/private_set_intersection/proto:private_set_intersection_cc_grpc",
+        "//examples/private_set_intersection/proto:private_set_intersection_cc_proto",
         "//examples/utils",
         "//oak/client:manager_client",
         "//oak/client:node_client",
-        "@com_google_absl//absl/memory",
-        "@com_google_asylo//asylo/util:logging",
         "@com_github_gflags_gflags//:gflags_nothreads",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/memory",
+        "@com_google_asylo//asylo/util:logging",
     ],
 )

--- a/examples/private_set_intersection/proto/BUILD
+++ b/examples/private_set_intersection/proto/BUILD
@@ -19,22 +19,25 @@ package(
 )
 
 load(
-    "@com_github_grpc_grpc//bazel:grpc_build_system.bzl",
-    "grpc_proto_library",
+    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
+    "cc_grpc_library",
 )
 
 proto_library(
     name = "private_set_intersection_proto",
     srcs = ["private_set_intersection.proto"],
-    deps = [
-        "@com_google_protobuf//:empty_proto",
-    ],
+    deps = ["@com_google_protobuf//:empty_proto"],
 )
 
-grpc_proto_library(
-    name = "private_set_intersection_proto_grpc",
-    srcs = ["private_set_intersection.proto"],
-    has_services = True,
-    well_known_protos = True,
-    deps = [],
+cc_proto_library(
+    name = "private_set_intersection_cc_proto",
+    deps = [":private_set_intersection_proto"],
+)
+
+cc_grpc_library(
+    name = "private_set_intersection_cc_grpc",
+    srcs = [":private_set_intersection_proto"],
+    grpc_only = True,
+    use_external = False,
+    deps = [":private_set_intersection_cc_proto"],
 )

--- a/examples/running_average/client/BUILD
+++ b/examples/running_average/client/BUILD
@@ -18,13 +18,13 @@ cc_binary(
     name = "client",
     srcs = ["running_average.cc"],
     deps = [
-        "//examples/running_average/proto:running_average_proto_grpc",
+        "//examples/running_average/proto:running_average_cc_grpc",
         "//examples/utils",
         "//oak/client:manager_client",
         "//oak/client:node_client",
-        "@com_google_absl//absl/memory",
-        "@com_google_asylo//asylo/util:logging",
         "@com_github_gflags_gflags//:gflags_nothreads",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/memory",
+        "@com_google_asylo//asylo/util:logging",
     ],
 )

--- a/examples/running_average/proto/BUILD
+++ b/examples/running_average/proto/BUILD
@@ -19,22 +19,25 @@ package(
 )
 
 load(
-    "@com_github_grpc_grpc//bazel:grpc_build_system.bzl",
-    "grpc_proto_library",
+    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
+    "cc_grpc_library",
 )
 
 proto_library(
     name = "running_average_proto",
     srcs = ["running_average.proto"],
-    deps = [
-        "@com_google_protobuf//:empty_proto",
-    ],
+    deps = ["@com_google_protobuf//:empty_proto"],
 )
 
-grpc_proto_library(
-    name = "running_average_proto_grpc",
-    srcs = ["running_average.proto"],
-    has_services = True,
+cc_proto_library(
+    name = "running_average_cc_proto",
+    deps = [":running_average_proto"],
+)
+
+cc_grpc_library(
+    name = "running_average_cc_grpc",
+    srcs = [":running_average_proto"],
+    grpc_only = True,
     well_known_protos = True,
-    deps = [],
+    deps = [":running_average_cc_proto"],
 )

--- a/oak/client/BUILD
+++ b/oak/client/BUILD
@@ -17,22 +17,22 @@
 cc_library(
     name = "manager_client",
     hdrs = ["manager_client.h"],
+    visibility = ["//visibility:public"],
     deps = [
-        "//oak/proto:manager_grpc_proto",
+        "//oak/proto:manager_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "node_client",
     hdrs = ["node_client.h"],
+    visibility = ["//visibility:public"],
     deps = [
-        "//oak/proto:node_grpc_proto",
+        "//oak/proto:node_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_asylo//asylo/grpc/auth:null_credentials_options",
         "@com_google_asylo//asylo/identity:init",
         "@com_google_asylo//asylo/util:logging",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/oak/proto/BUILD
+++ b/oak/proto/BUILD
@@ -19,28 +19,53 @@ package(
 )
 
 load(
-    "@com_google_asylo//asylo/bazel:proto.bzl",
-    "asylo_proto_library",
-    "asylo_grpc_proto_library",
+    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
+    "cc_grpc_library",
 )
 
-asylo_proto_library(
+proto_library(
     name = "enclave_proto",
     srcs = ["enclave.proto"],
     deps = ["@com_google_asylo//asylo:enclave_proto"],
 )
 
-asylo_grpc_proto_library(
-    name = "node_grpc_proto",
+cc_proto_library(
+    name = "enclave_cc_proto",
+    deps = [":enclave_proto"],
+)
+
+proto_library(
+    name = "node_proto",
     srcs = ["node.proto"],
 )
 
-load(
-    "@com_github_grpc_grpc//bazel:grpc_build_system.bzl",
-    "grpc_proto_library",
+cc_proto_library(
+    name = "node_cc_proto",
+    deps = [":node_proto"],
 )
 
-grpc_proto_library(
-    name = "manager_grpc_proto",
+cc_grpc_library(
+    name = "node_cc_grpc",
+    srcs = [":node_proto"],
+    grpc_only = True,
+    well_known_protos = True,
+    deps = [":node_cc_proto"],
+)
+
+proto_library(
+    name = "manager_proto",
     srcs = ["manager.proto"],
+)
+
+cc_proto_library(
+    name = "manager_cc_proto",
+    deps = [":manager_proto"],
+)
+
+cc_grpc_library(
+    name = "manager_cc_grpc",
+    srcs = [":manager_proto"],
+    grpc_only = True,
+    well_known_protos = True,
+    deps = [":manager_cc_proto"],
 )

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -30,9 +30,9 @@ cc_library(
         "oak_manager.h",
     ],
     deps = [
-        "//oak/proto:enclave_proto_cc",
-        "//oak/proto:manager_grpc_proto",
-        "//oak/proto:node_grpc_proto",
+        "//oak/proto:enclave_cc_proto",
+        "//oak/proto:manager_cc_grpc",
+        "//oak/proto:node_cc_grpc",
         "@com_github_gflags_gflags//:gflags_nothreads",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/memory",
@@ -53,7 +53,7 @@ cc_library(
         "oak_node.h",
     ],
     deps = [
-        "//oak/proto:node_grpc_proto",
+        "//oak/proto:node_cc_grpc",
         "@boringssl//:crypto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/memory",
@@ -76,16 +76,16 @@ cc_library(
 
 cc_library(
     name = "enclave_server",
-    hdrs = [
-        "enclave_server.h",
-    ],
     srcs = [
         "enclave_server.cc",
+    ],
+    hdrs = [
+        "enclave_server.h",
     ],
     deps = [
         ":module_invocation",
         ":oak_node",
-        "//oak/proto:enclave_proto_cc",
+        "//oak/proto:enclave_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/synchronization",
         "@com_google_asylo//asylo:enclave_runtime",


### PR DESCRIPTION
Updates gRPC rules to allow dependencies on cc_proto_library, which
will facilitate reusing proto rules for services such as Cloud Spanner.

Updates the proto rules to follow Bazel best practices:
https://docs.bazel.build/versions/master/be/protocol-buffer.html#proto_library