### PR TITLE
Add rust-clippy to CI and set docker UID

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+# We don't need anything from docker context when building the image.
 /*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-/bazel-cache
+/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@
 # based on the name of the directory bazel is cloned into.
 /bazel-*
 
+# Cargo cache
+/cargo-cache/
+
 # Generated vscode files
-.vscode/*
+/.vscode/
 
 # emacs stuff
 *~

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,27 @@ RUN git --version
 RUN clang-format -version
 RUN shellcheck --version
 
+# Create an user so we don't run this as root.
+ARG USERID
+ARG USERNAME
+ARG USERGRP
+
+RUN groupadd -g $USERGRP primarygroup
+RUN useradd -mu $USERID -g $USERGRP $USERNAME
+USER $USERNAME
+
 # Install protobuf compiler.
 ARG PROTOBUF_VERSION=3.7.1
 RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip > /tmp/protobuf.zip
-RUN unzip /tmp/protobuf.zip -d /protobuf
-ENV PATH "/protobuf/bin:$PATH"
+RUN unzip /tmp/protobuf.zip -d ~/protobuf
+ENV PATH "/home/$USERNAME/protobuf/bin:$PATH"
 RUN protoc --version
 
 # Install Rust compiler.
 # TODO: We should pint a specific Rust version rather than just installing the current stable.
 RUN curl https://sh.rustup.rs -sSf > /tmp/rustup
 RUN sh /tmp/rustup -y
-ENV PATH "/root/.cargo/bin:$PATH"
+ENV PATH "/home/$USERNAME/.cargo/bin:$PATH"
 RUN rustup --version
 
 # Install rustfmt.
@@ -25,3 +34,6 @@ RUN rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
 
 # Install WebAssembly target for Rust.
 RUN rustup target add wasm32-unknown-unknown
+
+# Install Rust-clippy.
+RUN rustup component add clippy

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ RUN clang-format -version
 RUN shellcheck --version
 
 # Create an user so we don't run this as root.
-ARG USERID
-ARG USERNAME
-ARG USERGRP
+ARG GID
+ARG UID
+ARG USERNAME=docker
+ARG GROUPNAME=docker
 
-RUN groupadd -g $USERGRP primarygroup
-RUN useradd -mu $USERID -g $USERGRP $USERNAME
+RUN groupadd --gid $GID $GROUPNAME
+RUN useradd --create-home --uid $UID --gid $GID $USERNAME
 USER $USERNAME
 
 # Install protobuf compiler.

--- a/scripts/build_examples_docker
+++ b/scripts/build_examples_docker
@@ -5,7 +5,4 @@ set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
-"$SCRIPTS_DIR/docker_run" cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/hello_world/Cargo.toml
-"$SCRIPTS_DIR/docker_run" cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/machine_learning/Cargo.toml
-"$SCRIPTS_DIR/docker_run" cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/private_set_intersection/Cargo.toml
-"$SCRIPTS_DIR/docker_run" cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/running_average/Cargo.toml
+"$SCRIPTS_DIR/docker_run" cargo build --release --target=wasm32-unknown-unknown --manifest-path=examples/Cargo.toml

--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -30,4 +30,10 @@ fi
 
 # Fortunately, rustfmt has the --check option that will make it exit with 1
 # if formatting has to be applied.
-find examples rust -type f -name '*.rs' -exec rustfmt --check {} + > /dev/null
+find examples rust -type f -name '*.rs' -exec rustfmt --check {} +
+
+# Run clippy to lint the rust code
+# First do the examples folder
+find examples -maxdepth 1 -name 'Cargo.toml' -execdir cargo clippy \;
+# After this run it on all the subfolders in rust
+find rust -type f -name 'Cargo.toml' -execdir cargo clippy \;

--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -34,6 +34,8 @@ find examples rust -type f -name '*.rs' -exec rustfmt --check {} +
 
 # Run clippy to lint the rust code
 # First do the examples folder
-find examples -maxdepth 1 -name 'Cargo.toml' -execdir cargo clippy \;
+(cd "$PWD/examples/" && cargo clippy)
+
 # After this run it on all the subfolders in rust
+# TODO: change this once we have a single workspace
 find rust -type f -name 'Cargo.toml' -execdir cargo clippy \;

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -3,11 +3,19 @@
 set -o errexit
 set -o xtrace
 
-docker build --tag=oak .
+USERNAME=$(id -un)
+
+mkdir -p $PWD/bazel-cache
+touch $PWD/bazel-cache/.placeholder
+mkdir -p $PWD/cargo-cache
+touch $PWD/cargo-cache/.placeholder
+
+docker build --tag=oak --build-arg USERNAME="$USERNAME" --build-arg USERID="$(id -u)" --build-arg USERGRP="$(id -g)" .
 docker run \
   --interactive \
   --tty \
-  --volume="$PWD/bazel-cache":/root/.cache/bazel \
+  --volume="$PWD/bazel-cache:/home/$USERNAME/.cache/bazel" \
+  --volume="$PWD/cargo-cache:/home/$USERNAME/.cargo/registry" \
   --volume="$PWD":/opt/my-project \
   --workdir=/opt/my-project \
   --network=host \

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -5,14 +5,14 @@ set -o xtrace
 
 readonly USERNAME="$(id --user --name)"
 
-mkdir -p "./bazel-cache"
-mkdir -p "./cargo-cache"
+mkdir -p './bazel-cache'
+mkdir -p './cargo-cache'
 
 docker build \
   --tag=oak \
-  --build-arg "USERNAME=$USERNAME" \
-  --build-arg "UID=$(id --user)" \
-  --build-arg "GID=$(id --group)" \
+  --build-arg="USERNAME=$USERNAME" \
+  --build-arg="UID=$(id --user)" \
+  --build-arg="GID=$(id --group)" \
   .
 docker run \
   --interactive \

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -3,14 +3,17 @@
 set -o errexit
 set -o xtrace
 
-USERNAME=$(id -un)
+readonly USERNAME="$(id --user --name)"
 
-mkdir -p $PWD/bazel-cache
-touch $PWD/bazel-cache/.placeholder
-mkdir -p $PWD/cargo-cache
-touch $PWD/cargo-cache/.placeholder
+mkdir -p "./bazel-cache"
+mkdir -p "./cargo-cache"
 
-docker build --tag=oak --build-arg USERNAME="$USERNAME" --build-arg USERID="$(id -u)" --build-arg USERGRP="$(id -g)" .
+docker build \
+  --tag=oak \
+  --build-arg "USERNAME=$USERNAME" \
+  --build-arg "UID=$(id --user)" \
+  --build-arg "GID=$(id --group)" \
+  .
 docker run \
   --interactive \
   --tty \


### PR DESCRIPTION
Clippy compiles code and this took a long time since we were not reusing
artefacts. In order to do that, we are running everything in the
container as current user instead of root. This requires mounting both
the bazel cache and the cargo one.

Fixes: #70, #79

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/project-oak/oak/86)
<!-- Reviewable:end -->
