### PR TITLE
Fix rust clippy errors and warnings

### DIFF
--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -53,7 +53,7 @@ impl oak::Node for Node {
                 }
             }
             _ => {
-                writeln!(logging_channel, "unknown method name: {}", grpc_method_name);
+                writeln!(logging_channel, "unknown method name: {}", grpc_method_name).unwrap();
                 panic!("unknown method name");
             }
         };

--- a/examples/machine_learning/src/lib.rs
+++ b/examples/machine_learning/src/lib.rs
@@ -255,7 +255,8 @@ impl oak::Node for Node {
                                 logging_channel,
                                 "Predicted: {:?}; Actual: {:?}; Accurate? {:?}",
                                 animal.type_, actual_type, accurate
-                            ).unwrap();
+                            )
+                            .unwrap();
                         }
                     }
                 }
@@ -265,7 +266,8 @@ impl oak::Node for Node {
                     hits,
                     self.test_set_size,
                     (f64::from(hits)) / (f64::from(self.test_set_size as u32)) * 100.
-                ).unwrap();
+                )
+                .unwrap();
             }
             _ => {
                 writeln!(logging_channel, "unknown method name: {}", grpc_method_name).unwrap();

--- a/examples/machine_learning/src/lib.rs
+++ b/examples/machine_learning/src/lib.rs
@@ -85,10 +85,10 @@ fn generate_animal_data(
     training_set_size: usize,
     test_set_size: usize,
 ) -> (Matrix<f64>, Matrix<f64>, Matrix<f64>, Vec<Animal>) {
-    writeln!(logging_channel, "rnd xxx");
+    writeln!(logging_channel, "rnd xxx").unwrap();
     //let mut rng = rand::thread_rng();
     let mut rng = rand::rngs::StdRng::seed_from_u64(123);
-    writeln!(logging_channel, "rnd OK");
+    writeln!(logging_channel, "rnd OK").unwrap();
 
     // We'll train the model on these dogs
     let training_animals = (0..training_set_size)
@@ -131,7 +131,7 @@ fn generate_animal_data(
 
 fn evaluate_prediction(hits: &mut u32, animal: &Animal, prediction: &[f64]) -> (Type, bool) {
     let predicted_type = animal.type_;
-    let actual_type = if prediction[0] == 1. {
+    let actual_type = if (prediction[0] - 1.).abs() < std::f64::EPSILON {
         Type::Cat
     } else {
         Type::Dog
@@ -167,11 +167,11 @@ impl oak::Node for Node {
             model: NaiveBayes::new(),
         }
     }
-    fn invoke(&mut self, grpc_method_name: &str, grpc_channel: &mut oak::Channel) {
+    fn invoke(&mut self, grpc_method_name: &str, _grpc_channel: &mut oak::Channel) {
         let mut logging_channel = oak::logging_channel();
         match grpc_method_name {
             "/oak.examples.machine_learning.MachineLearning/Data" => {
-                writeln!(logging_channel, "Data");
+                writeln!(logging_channel, "Data").unwrap();
                 //(self.training_set_size, self.test_set_size) = (1000, 1000);
                 // Generate all of our train and test data
                 let (training_matrix, target_matrix, test_matrix, test_animals) =
@@ -181,14 +181,14 @@ impl oak::Node for Node {
                         self.test_set_size,
                     );
                 self.config = Some(Config {
-                    training_matrix: training_matrix,
-                    target_matrix: target_matrix,
-                    test_matrix: test_matrix,
-                    test_animals: test_animals,
+                    training_matrix,
+                    target_matrix,
+                    test_matrix,
+                    test_animals,
                 });
             }
             "/oak.examples.machine_learning.MachineLearning/Learn" => {
-                writeln!(logging_channel, "Training model");
+                writeln!(logging_channel, "Training model").unwrap();
                 //self.model = NaiveBayes::<naive_bayes::Gaussian>::new();
                 match self.config {
                     Some(ref c) => self
@@ -196,12 +196,12 @@ impl oak::Node for Node {
                         .train(&c.training_matrix, &c.target_matrix)
                         .expect("failed to train model of dogs"),
                     None => {
-                        writeln!(logging_channel, "config not set");
+                        writeln!(logging_channel, "config not set").unwrap();
                     }
                 }
             }
             "/oak.examples.machine_learning.MachineLearning/Predict" => {
-                writeln!(logging_channel, "Predicting");
+                writeln!(logging_channel, "Predicting").unwrap();
                 let mut predictions = None;
                 match self.config {
                     Some(ref c) => {
@@ -212,7 +212,7 @@ impl oak::Node for Node {
                         )
                     }
                     None => {
-                        writeln!(logging_channel, "config not set");
+                        writeln!(logging_channel, "config not set").unwrap();
                     }
                 }
                 // Score how well we did.
@@ -232,13 +232,13 @@ impl oak::Node for Node {
                         }
                     }
                     None => {
-                        writeln!(logging_channel, "test_animals not set");
+                        writeln!(logging_channel, "test_animals not set").unwrap();
                         return;
                     }
                 }
 
                 if unprinted_total > 0 {
-                    writeln!(logging_channel, "...");
+                    writeln!(logging_channel, "...").unwrap();
                 }
 
                 if let Some(ref c) = self.config {
@@ -255,7 +255,7 @@ impl oak::Node for Node {
                                 logging_channel,
                                 "Predicted: {:?}; Actual: {:?}; Accurate? {:?}",
                                 animal.type_, actual_type, accurate
-                            );
+                            ).unwrap();
                         }
                     }
                 }
@@ -265,10 +265,10 @@ impl oak::Node for Node {
                     hits,
                     self.test_set_size,
                     (f64::from(hits)) / (f64::from(self.test_set_size as u32)) * 100.
-                );
+                ).unwrap();
             }
             _ => {
-                writeln!(logging_channel, "unknown method name: {}", grpc_method_name);
+                writeln!(logging_channel, "unknown method name: {}", grpc_method_name).unwrap();
                 panic!("unknown method name");
             }
         }

--- a/examples/private_set_intersection/src/lib.rs
+++ b/examples/private_set_intersection/src/lib.rs
@@ -72,7 +72,7 @@ impl oak::Node for Node {
                 out_stream.flush().expect("could not flush");
             }
             _ => {
-                writeln!(logging_channel, "unknown method name: {}", grpc_method_name);
+                writeln!(logging_channel, "unknown method name: {}", grpc_method_name).unwrap();
                 panic!("unknown method name");
             }
         };

--- a/examples/running_average/src/lib.rs
+++ b/examples/running_average/src/lib.rs
@@ -63,7 +63,7 @@ impl oak::Node for Node {
                 out_stream.flush().expect("could not flush");
             }
             _ => {
-                writeln!(logging_channel, "unknown method name: {}", grpc_method_name);
+                writeln!(logging_channel, "unknown method name: {}", grpc_method_name).unwrap();
                 panic!("unknown method name");
             }
         };

--- a/rust/oak/src/lib.rs
+++ b/rust/oak/src/lib.rs
@@ -41,12 +41,12 @@ pub struct Channel {
 
 impl Channel {
     pub fn new(handle: Handle) -> Channel {
-        Channel { handle: handle }
+        Channel { handle }
     }
 }
 
 pub fn logging_channel() -> impl Write {
-    let mut logging_channel = Channel::new(LOGGING_CHANNEL_HANDLE);
+    let logging_channel = Channel::new(LOGGING_CHANNEL_HANDLE);
     // Only flush logging channel on newlines.
     std::io::LineWriter::new(logging_channel)
 }
@@ -118,7 +118,7 @@ pub extern "C" fn oak_handle_grpc_call() {
     NODE.with(|node| {
         let mut grpc_method_channel = Channel::new(GRPC_METHOD_NAME_CHANNEL_HANDLE);
         let mut grpc_method_name = String::new();
-        grpc_method_channel.read_to_string(&mut grpc_method_name);
+        grpc_method_channel.read_to_string(&mut grpc_method_name).unwrap();
         let mut grpc_channel = Channel::new(GRPC_CHANNEL_HANDLE);
         node.borrow_mut()
             .invoke(&grpc_method_name, &mut grpc_channel);

--- a/rust/oak/src/lib.rs
+++ b/rust/oak/src/lib.rs
@@ -118,7 +118,9 @@ pub extern "C" fn oak_handle_grpc_call() {
     NODE.with(|node| {
         let mut grpc_method_channel = Channel::new(GRPC_METHOD_NAME_CHANNEL_HANDLE);
         let mut grpc_method_name = String::new();
-        grpc_method_channel.read_to_string(&mut grpc_method_name).unwrap();
+        grpc_method_channel
+            .read_to_string(&mut grpc_method_name)
+            .unwrap();
         let mut grpc_channel = Channel::new(GRPC_CHANNEL_HANDLE);
         node.borrow_mut()
             .invoke(&grpc_method_name, &mut grpc_channel);


### PR DESCRIPTION
This fixes most of the issues raised by running clippy. A following diff
will enable clippy as a default check, but this prevents CI from
failing.

There still are issues with automatic generated protobuf code, which is
being fixed here: https://github.com/stepancheg/rust-protobuf/pull/332

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/project-oak/oak/87)
<!-- Reviewable:end -->
