### PR TITLE
Police Oak module exported function requirements

### DIFF
--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -52,9 +52,11 @@ cc_library(
     name = "oak_node",
     srcs = [
         "oak_node.cc",
+        "wabt_output.cc",
     ],
     hdrs = [
         "oak_node.h",
+        "wabt_output.h",
     ],
     deps = [
         ":buffer_channel",

--- a/oak/server/enclave_server.cc
+++ b/oak/server/enclave_server.cc
@@ -45,8 +45,11 @@ EnclaveServer::EnclaveServer()
 asylo::Status EnclaveServer::Initialize(const asylo::EnclaveConfig& config) {
   LOG(INFO) << "Initializing Oak Instance";
   const InitializeInput& initialize_input_message = config.GetExtension(initialize_input);
-  node_ = absl::make_unique<OakNode>(initialize_input_message.node_id(),
-                                     initialize_input_message.module());
+  node_ = OakNode::Create(initialize_input_message.node_id(), initialize_input_message.module());
+  if (node_ == nullptr) {
+    return asylo::Status(asylo::error::GoogleError::INVALID_ARGUMENT, "Failed to create Oak Node");
+  }
+
   return InitializeServer();
 }
 

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -17,6 +17,7 @@
 #ifndef OAK_SERVER_OAK_NODE_H_
 #define OAK_SERVER_OAK_NODE_H_
 
+#include <memory>
 #include <unordered_map>
 
 #include "absl/base/thread_annotations.h"
@@ -36,7 +37,9 @@ const Handle GRPC_METHOD_NAME_CHANNEL_HANDLE = 3;
 
 class OakNode final : public Node::Service {
  public:
-  OakNode(const std::string& node_id, const std::string& module);
+  // Creates an Oak node with the given node_id by loading the Wasm
+  // module code.
+  static std::unique_ptr<OakNode> Create(const std::string& node_id, const std::string& module);
 
   // Performs an Oak Module invocation.
   grpc::Status ProcessModuleInvocation(grpc::GenericServerContext* context,
@@ -44,6 +47,10 @@ class OakNode final : public Node::Service {
                                        std::vector<char>* response_data);
 
  private:
+  // Clients should construct OakNode instances with Create() (which
+  // can fail).
+  OakNode(const std::string& node_id, const std::string& module);
+
   grpc::Status GetAttestation(grpc::ServerContext* context, const GetAttestationRequest* request,
                               GetAttestationResponse* response) override;
 

--- a/oak/server/wabt_output.cc
+++ b/oak/server/wabt_output.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/server/wabt_output.h"
+
+std::ostream& operator<<(std::ostream& os, const wabt::ExternalKind& k) {
+  return os << wabt::GetKindName(k);
+}
+
+std::ostream& operator<<(std::ostream& os, const wabt::Type& t) {
+  return os << wabt::GetTypeName(t);
+}
+
+std::ostream& operator<<(std::ostream& os, const std::vector<wabt::Type>& vt) {
+  os << "(";
+  for (int ii = 0; ii < vt.size(); ii++) {
+    if (ii > 0) {
+      os << ", ";
+    }
+    os << vt[ii];
+  }
+  return os << ")";
+}
+
+std::ostream& operator<<(std::ostream& os, const wabt::interp::FuncSignature& sig) {
+  return os << sig.param_types << " -> " << sig.result_types;
+}

--- a/oak/server/wabt_output.h
+++ b/oak/server/wabt_output.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_SERVER_WABT_OUTPUT_H_
+#define OAK_SERVER_WABT_OUTPUT_H_
+
+#include <iostream>
+
+#include "src/interp/interp.h"
+
+/* Output helpers for wabt:: types */
+
+std::ostream& operator<<(std::ostream& os, const wabt::ExternalKind& k);
+std::ostream& operator<<(std::ostream& os, const wabt::Type& t);
+std::ostream& operator<<(std::ostream& os, const std::vector<wabt::Type>& vt);
+std::ostream& operator<<(std::ostream& os, const wabt::interp::FuncSignature& sig);
+
+#endif  // OAK_SERVER_WABT_OUTPUT_H_


### PR DESCRIPTION
Check that an Oak module exports the required entrypoints, and that they have the correct signature.
Move Oak Node creation to a factory method to allow early detection of an invalid Node.

Best reviewed commit-by-commit.