### PR TITLE
Don't use an invalid channel handle

### DIFF
--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -260,6 +260,7 @@ wabt::interp::HostFunc::Callback OakNode::OakChannelRead(wabt::interp::Environme
 
     if (channels_.count(channel_handle) == 0) {
       LOG(WARNING) << "Invalid channel handle: " << channel_handle;
+      return wabt::interp::Result::Ok;
     }
     std::unique_ptr<Channel>& channel = channels_.at(channel_handle);
 
@@ -282,6 +283,7 @@ wabt::interp::HostFunc::Callback OakNode::OakChannelWrite(wabt::interp::Environm
 
     if (channels_.count(channel_handle) == 0) {
       LOG(WARNING) << "Invalid channel handle: " << channel_handle;
+      return wabt::interp::Result::Ok;
     }
     std::unique_ptr<Channel>& channel = channels_.at(channel_handle);
 


### PR DESCRIPTION
If the channel handle is not in the channel map, don't
attempt to use it.