### PR TITLE
Make build scripts more robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG UID
 ARG USERNAME=docker
 ARG GROUPNAME=docker
 
-RUN groupadd --gid $GID $GROUPNAME
+RUN groupadd --force --gid $GID $GROUPNAME
 RUN useradd --create-home --uid $UID --gid $GID $USERNAME
 USER $USERNAME
 

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -3,7 +3,7 @@
 set -o errexit
 set -o xtrace
 
-readonly USERNAME="$(id --user --name)"
+readonly USERNAME="$(id -u -n)"
 
 mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
@@ -11,9 +11,10 @@ mkdir -p './cargo-cache'
 docker build \
   --tag=oak \
   --build-arg="USERNAME=$USERNAME" \
-  --build-arg="UID=$(id --user)" \
-  --build-arg="GID=$(id --group)" \
+  --build-arg="UID=$(id -u)" \
+  --build-arg="GID=$(id -g)" \
   .
+
 docker run \
   --interactive \
   --tty \

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-readonly USERNAME="$(id --user --name)"
+readonly USERNAME="$(id -u -n)"
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
 # Run oak server


### PR DESCRIPTION
 - Use short `id` options that work on OSX too
 - Cope with an already-existing group