### PR TITLE
Improve Docker user management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,28 +6,22 @@ RUN git --version
 RUN clang-format -version
 RUN shellcheck --version
 
-# Create an user so we don't run this as root.
-ARG GID
-ARG UID
-ARG USERNAME=docker
-ARG GROUPNAME=docker
-
-RUN groupadd --force --gid $GID $GROUPNAME
-RUN useradd --create-home --uid $UID --gid $GID $USERNAME
-USER $USERNAME
-
-# Install protobuf compiler.
+# Install Protobuf compiler.
 ARG PROTOBUF_VERSION=3.7.1
+ARG PROTOBUF_DIR=/usr/local/protobuf
 RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip > /tmp/protobuf.zip
-RUN unzip /tmp/protobuf.zip -d ~/protobuf
-ENV PATH "/home/$USERNAME/protobuf/bin:$PATH"
+RUN unzip /tmp/protobuf.zip -d $PROTOBUF_DIR
+ENV PATH "$PROTOBUF_DIR/bin:$PATH"
 RUN protoc --version
 
 # Install Rust compiler.
 # TODO: We should pin a specific Rust version rather than just installing the current stable.
+ARG RUSTUP_DIR=/usr/local/cargo
+ENV RUSTUP_HOME $RUSTUP_DIR
+ENV CARGO_HOME $RUSTUP_DIR
 RUN curl https://sh.rustup.rs -sSf > /tmp/rustup
 RUN sh /tmp/rustup -y
-ENV PATH "/home/$USERNAME/.cargo/bin:$PATH"
+ENV PATH "$RUSTUP_DIR/bin:$PATH"
 RUN rustup --version
 
 # Install rustfmt.

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -3,24 +3,31 @@
 set -o errexit
 set -o xtrace
 
-readonly USERNAME="$(id -u -n)"
+# The default user for a Docker container has uid 0 (root). To avoid creating
+# root-owned files in the build directory we tell Docker to use the current user
+# ID, if known.
+# See
+# https://github.com/googleapis/google-cloud-cpp/blob/a186208b79d900b4ec71c6f9df3acf7638f01dc6/ci/kokoro/docker/build.sh#L147-L152
+readonly DOCKER_UID="${UID:-0}"
+readonly DOCKER_GID="${GID:-0}"
+readonly DOCKER_USER="${USER:-root}"
 
 mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 
 docker build \
   --tag=oak \
-  --build-arg="USERNAME=$USERNAME" \
-  --build-arg="UID=$(id -u)" \
-  --build-arg="GID=$(id -g)" \
   .
 
+# Keep this in sync with /scripts/run_examples .
 docker run \
   --interactive \
   --tty \
-  --volume="$PWD/bazel-cache:/home/$USERNAME/.cache/bazel" \
-  --volume="$PWD/cargo-cache:/home/$USERNAME/.cargo/registry" \
-  --volume="$PWD":/opt/my-project \
+  --user="$DOCKER_UID:$DOCKER_GID" \
+  --env="USER=$DOCKER_USER" \
+  --volume="$PWD/bazel-cache:/.cache/bazel" \
+  --volume="$PWD/cargo-cache:/usr/local/cargo/registry" \
+  --volume="$PWD:/opt/my-project" \
   --workdir=/opt/my-project \
   --network=host \
   oak:latest \

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -3,26 +3,33 @@
 set -o errexit
 set -o nounset
 
-readonly USERNAME="$(id -u -n)"
+readonly DOCKER_UID="${UID:-0}"
+readonly DOCKER_GID="${GID:-0}"
+readonly DOCKER_USER="${USER:-root}"
+
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
-# Run oak server
+# Run Oak server.
 "$SCRIPTS_DIR/build_server_docker"
 
-# Same command as launched in scripts/docker_run but detached. Keep them in sync
-SERVER_DOCKER_ID=$(docker run \
+# Keep this in sync with /scripts/docker_run .
+readonly SERVER_DOCKER_ID="$(\
+  docker run \
   --detach \
   --interactive \
   --tty \
-  --volume="$PWD/bazel-cache:/home/$USERNAME/.cache/bazel" \
-  --volume="$PWD/cargo-cache:/home/$USERNAME/.cargo/registry" \
-  --volume="$PWD":/opt/my-project \
+  --user="$DOCKER_UID" \
+  --env="USER=$DOCKER_USER" \
+  --volume="$PWD/bazel-cache:/.cache/bazel" \
+  --volume="$PWD/cargo-cache:/usr/local/cargo/registry" \
+  --volume="$PWD:/opt/my-project" \
   --workdir=/opt/my-project \
   --network=host \
   oak:latest \
-  ./bazel-bin/oak/server/oak)
+  ./bazel-bin/oak/server/oak \
+  )"
 
-# Run oak examples
+# Run Oak examples.
 find examples -type f -name run -exec "$SCRIPTS_DIR/docker_run" {} \;
 
 docker stop "$SERVER_DOCKER_ID"


### PR DESCRIPTION
Only set user at runtime, but build Docker image with the default user
(root). This simplifies things because we don't need to switch user
halfway through the build process.

Following @remyabel's suggestion in
https://github.com/project-oak/oak/issues/70#issuecomment-502232945

ref #70