### PR TITLE
Refactoring: Pass `detach` flag to scripts/docker_run

### DIFF
--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Usage: docker_run [--detach] COMMAND
+
 set -o errexit
 set -o xtrace
 
@@ -19,16 +21,23 @@ docker build \
   --tag=oak \
   .
 
-# Keep this in sync with /scripts/run_examples .
-docker run \
-  --interactive \
-  --tty \
-  --user="$DOCKER_UID:$DOCKER_GID" \
-  --env="USER=$DOCKER_USER" \
-  --volume="$PWD/bazel-cache:/.cache/bazel" \
-  --volume="$PWD/cargo-cache:/usr/local/cargo/registry" \
-  --volume="$PWD:/opt/my-project" \
-  --workdir=/opt/my-project \
-  --network=host \
-  oak:latest \
-  "$@"
+docker_run_flags=(
+  "--interactive"
+  "--tty"
+  "--user=$DOCKER_UID:$DOCKER_GID"
+  "--env=USER=$DOCKER_USER"
+  "--volume=$PWD/bazel-cache:/.cache/bazel"
+  "--volume=$PWD/cargo-cache:/usr/local/cargo/registry"
+  "--volume=$PWD:/opt/my-project"
+  "--workdir=/opt/my-project"
+  "--network=host"
+)
+
+if [[ "$1" == "--detach" ]]; then
+  docker_run_flags+=("--detach")
+  docker run "${docker_run_flags[@]}" oak:latest "${@:2}"
+  # Run `docker ps --quiet --latest` in caller to get reference to detached container.
+else
+  docker run "${docker_run_flags[@]}" oak:latest "$@"
+fi
+

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -11,25 +11,11 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 
 # Run Oak server.
 "$SCRIPTS_DIR/build_server_docker"
-
-# Keep this in sync with /scripts/docker_run .
-readonly SERVER_DOCKER_ID="$(\
-  docker run \
-  --detach \
-  --interactive \
-  --tty \
-  --user="$DOCKER_UID" \
-  --env="USER=$DOCKER_USER" \
-  --volume="$PWD/bazel-cache:/.cache/bazel" \
-  --volume="$PWD/cargo-cache:/usr/local/cargo/registry" \
-  --volume="$PWD:/opt/my-project" \
-  --workdir=/opt/my-project \
-  --network=host \
-  oak:latest \
-  ./bazel-bin/oak/server/oak \
-  )"
+"$SCRIPTS_DIR/docker_run" --detach ./bazel-bin/oak/server/oak
+readonly SERVER_CONTAINER_ID="$(docker ps --quiet --latest)"
 
 # Run Oak examples.
 find examples -type f -name run -exec "$SCRIPTS_DIR/docker_run" {} \;
 
-docker stop "$SERVER_DOCKER_ID"
+docker stop "$SERVER_CONTAINER_ID"
+


### PR DESCRIPTION
Avoiding duplicate docker run commands in `scripts/docker_run` and
`scripts/run_examples`.