### PR TITLE
Fix continuous integration builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM gcr.io/asylo-framework/asylo:buildenv-v0.3.4
 
 RUN apt-get -y update && apt-get install -y git curl clang-format shellcheck
-# TODO: remove this when asylo updates their bazel version
-RUN apt-get install --only-upgrade bazel
 
 RUN git --version
 RUN clang-format -version


### PR DESCRIPTION
Bazel has updated to 0.27 and is breaking a bunch of stuff in asylo bzl
files. This is the fastest fix to unblock CI - it will cause remote
cache to stop working. We will add a proper fix in the next days.