### PR TITLE
Run cargo clippy by workspace

### DIFF
--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -16,10 +16,6 @@ find scripts -type f -exec shellcheck {} +
 # if formatting has to be applied.
 find examples rust -type f -name '*.rs' -exec rustfmt --check {} +
 
-# Run clippy to lint the rust code
-# First do the examples folder
-(cd "$PWD/examples/" && cargo clippy)
-
-# After this run it on all the subfolders in rust
-# TODO: change this once we have a single workspace
-find rust -type f -name 'Cargo.toml' -execdir cargo clippy \;
+# Run clippy to lint the Rust code.
+cargo clippy --manifest-path="$PWD/examples/Cargo.toml"
+cargo clippy --manifest-path="$PWD/rust/Cargo.toml"


### PR DESCRIPTION
Now that we have two workspaces (one for the main lib and one for the
examples) we can invoke `cargo clippy` in a more idiomatic way.