### PR TITLE
Add script to build a single example

### DIFF
--- a/scripts/build_example
+++ b/scripts/build_example
@@ -23,13 +23,13 @@ while getopts "hd" opt; do
     esac
 done
 
-readonly NAME="${@:$OPTIND:1}"
+readonly NAME="${*:$OPTIND:1}"
 
 if [[ -z "${NAME}" ]]; then
     readonly EXAMPLES="$(find examples -mindepth 2 -maxdepth 2 -type f -name Cargo.toml | cut -d'/' -f2)"
     PS3='Choose example to build: '
 
-    options=($EXAMPLES)
+    readarray -t options <<< "$EXAMPLES"
     select opt in "${options[@]}";
     do
         echo "Building $opt"

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -4,18 +4,18 @@ set -o errexit
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
-COMPILATION_MODE="opt"
+COMPILATION_MODE='opt'
 
 while getopts "hd" opt; do
     case "$opt" in
     h)
-        echo -e "Usage: ./scripts/build_example [-d] [example_name]
+        echo -e "Usage: $0 [-d] [example_name]
   -d    Build using debug mode
-  -h    Pritn this message"
+  -h    Print this message"
         exit 0
         ;;
     d)  
-        COMPILATION_MODE="dbg" 
+        COMPILATION_MODE='dbg'
         ;;
     *) 
         exit 1

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+readonly SCRIPTS_DIR="$(dirname "$0")"
+
+COMPILATION_MODE="opt"
+
+while getopts "hd" opt; do
+    case "$opt" in
+    h)
+        echo -e "Usage: ./scripts/build_example [-d] [example_name]
+  -d    Build using debug mode
+  -h    Pritn this message"
+        exit 0
+        ;;
+    d)  
+        COMPILATION_MODE="dbg" 
+        ;;
+    *) 
+        exit 1
+        ;;
+    esac
+done
+
+readonly NAME="${@:$OPTIND:1}"
+
+if [[ -z "${NAME}" ]]; then
+    readonly EXAMPLES="$(find examples -mindepth 2 -maxdepth 2 -type f -name Cargo.toml | cut -d'/' -f2)"
+    PS3='Choose example to build: '
+
+    options=($EXAMPLES)
+    select opt in "${options[@]}";
+    do
+        echo "Building $opt"
+        cargo build --release --target=wasm32-unknown-unknown --manifest-path="examples/$opt/Cargo.toml"
+        bazel build --compilation_mode="$COMPILATION_MODE" "//examples/$opt/client"
+        break
+    done
+else
+    cargo build --release --target=wasm32-unknown-unknown --manifest-path="examples/$NAME/Cargo.toml"
+    bazel build --compilation_mode="$COMPILATION_MODE" "//examples/$NAME/client"
+fi

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -10,8 +10,9 @@ if [[ -z "${NAME}" ]]; then
 fi
 
 readonly OAK_MANAGER_ADDRESS="${OAK_MANAGER_ADDRESS:-127.0.0.1:8888}"
+readonly SCRIPTS_DIR="$(dirname "$0")"
 
-cargo build --release --target=wasm32-unknown-unknown --manifest-path="examples/${NAME}/Cargo.toml"
+"$SCRIPTS_DIR/build_example" "$NAME"
 bazel run "//examples/${NAME}/client" \
   -- \
   --manager_address="${OAK_MANAGER_ADDRESS}" \


### PR DESCRIPTION
This is a small script that allows to build only one of the examples,
either by entering it as an arg or selecting it from a list.
Additionally, it allows us to build the C++ code in debug mode, if
needed.