### PR TITLE
Always emit a status along with a proto response

### DIFF
--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -23,6 +23,7 @@ extern crate protobuf;
 
 mod proto;
 
+use oak::GrpcResult;
 use oak_derive::OakNode;
 use proto::hello_world::{HelloRequest, HelloResponse};
 use proto::hello_world_grpc::{dispatch, HelloWorldNode};
@@ -41,40 +42,40 @@ impl oak::Node for Node {
 }
 
 impl HelloWorldNode for Node {
-    fn say_hello(&mut self, req: HelloRequest) -> HelloResponse {
+    fn say_hello(&mut self, req: HelloRequest) -> GrpcResult<HelloResponse> {
         info!("Say hello to {}", req.greeting);
         let mut res = HelloResponse::new();
         res.reply = format!("HELLO {}!", req.greeting);
-        res
+        Ok(res)
     }
 
-    fn lots_of_replies(&mut self, req: HelloRequest) -> Vec<HelloResponse> {
+    fn lots_of_replies(&mut self, req: HelloRequest) -> GrpcResult<Vec<HelloResponse>> {
         info!("Say hello to {}", req.greeting);
         let mut res1 = HelloResponse::new();
         res1.reply = format!("HELLO {}!", req.greeting);
         let mut res2 = HelloResponse::new();
         res2.reply = format!("BONJOUR {}!", req.greeting);
-        vec![res1, res2]
+        Ok(vec![res1, res2])
     }
 
-    fn lots_of_greetings(&mut self, reqs: Vec<HelloRequest>) -> HelloResponse {
+    fn lots_of_greetings(&mut self, reqs: Vec<HelloRequest>) -> GrpcResult<HelloResponse> {
         info!("Say hello");
         let mut msg = String::new();
         msg.push_str("Hello ");
         msg.push_str(&recipients(&reqs));
         let mut res = HelloResponse::new();
         res.reply = msg;
-        res
+        Ok(res)
     }
 
-    fn bidi_hello(&mut self, reqs: Vec<HelloRequest>) -> Vec<HelloResponse> {
+    fn bidi_hello(&mut self, reqs: Vec<HelloRequest>) -> GrpcResult<Vec<HelloResponse>> {
         info!("Say hello");
         let msg = recipients(&reqs);
         let mut res1 = HelloResponse::new();
         res1.reply = format!("HELLO {}!", msg);
         let mut res2 = HelloResponse::new();
         res2.reply = format!("BONJOUR {}!", msg);
-        vec![res1, res2]
+        Ok(vec![res1, res2])
     }
 }
 

--- a/examples/hello_world/src/proto/hello_world_grpc.rs
+++ b/examples/hello_world/src/proto/hello_world_grpc.rs
@@ -19,18 +19,19 @@
 #![allow(unused_results)]
 
 
+use oak::GrpcResult;
 use protobuf::Message;
 use std::io::Write;
 
 // Oak node server interface
 pub trait HelloWorldNode {
-    fn say_hello(&mut self, req: super::hello_world::HelloRequest) -> super::hello_world::HelloResponse;
+    fn say_hello(&mut self, req: super::hello_world::HelloRequest) -> GrpcResult<super::hello_world::HelloResponse>;
 
-    fn lots_of_replies(&mut self, req: super::hello_world::HelloRequest) -> Vec<super::hello_world::HelloResponse>;
+    fn lots_of_replies(&mut self, req: super::hello_world::HelloRequest) -> GrpcResult<Vec<super::hello_world::HelloResponse>>;
 
-    fn lots_of_greetings(&mut self, reqs: Vec<super::hello_world::HelloRequest>) -> super::hello_world::HelloResponse;
+    fn lots_of_greetings(&mut self, reqs: Vec<super::hello_world::HelloRequest>) -> GrpcResult<super::hello_world::HelloResponse>;
 
-    fn bidi_hello(&mut self, reqs: Vec<super::hello_world::HelloRequest>) -> Vec<super::hello_world::HelloResponse>;
+    fn bidi_hello(&mut self, reqs: Vec<super::hello_world::HelloRequest>) -> GrpcResult<Vec<super::hello_world::HelloResponse>>;
 }
 
 // Oak node gRPC method dispatcher
@@ -38,12 +39,12 @@ pub fn dispatch(node: &mut HelloWorldNode, grpc_method_name: &str, grpc_pair: &m
     match grpc_method_name {
         "/oak.examples.hello_world.HelloWorld/SayHello" => {
             let req = protobuf::parse_from_reader(&mut grpc_pair.receive).unwrap();
-            let rsp = node.say_hello(req);
+            let rsp = node.say_hello(req).unwrap();
             rsp.write_to_writer(&mut grpc_pair.send).unwrap();
         }
         "/oak.examples.hello_world.HelloWorld/LotsOfReplies" => {
             let req = protobuf::parse_from_reader(&mut grpc_pair.receive).unwrap();
-            let rsps = node.lots_of_replies(req);
+            let rsps = node.lots_of_replies(req).unwrap();
             for rsp in rsps {
                 rsp.write_to_writer(&mut grpc_pair.send).unwrap();
             }
@@ -56,7 +57,7 @@ pub fn dispatch(node: &mut HelloWorldNode, grpc_method_name: &str, grpc_pair: &m
                     Ok(req) => reqs.push(req),
                 }
             }
-            let rsp = node.lots_of_greetings(reqs);
+            let rsp = node.lots_of_greetings(reqs).unwrap();
             rsp.write_to_writer(&mut grpc_pair.send).unwrap();
         }
         "/oak.examples.hello_world.HelloWorld/BidiHello" => {
@@ -67,7 +68,7 @@ pub fn dispatch(node: &mut HelloWorldNode, grpc_method_name: &str, grpc_pair: &m
                     Ok(req) => reqs.push(req),
                 }
             }
-            let rsps = node.bidi_hello(reqs);
+            let rsps = node.bidi_hello(reqs).unwrap();
             for rsp in rsps {
                 rsp.write_to_writer(&mut grpc_pair.send).unwrap();
             }

--- a/examples/private_set_intersection/src/lib.rs
+++ b/examples/private_set_intersection/src/lib.rs
@@ -31,6 +31,7 @@ extern crate protobuf;
 
 mod proto;
 
+use oak::GrpcResult;
 use oak_derive::OakNode;
 use proto::private_set_intersection::{GetIntersectionResponse, SubmitSetRequest};
 use proto::private_set_intersection_grpc::{dispatch, PrivateSetIntersectionNode};
@@ -51,20 +52,21 @@ impl oak::Node for Node {
 }
 
 impl PrivateSetIntersectionNode for Node {
-    fn submit_set(&mut self, req: SubmitSetRequest) {
+    fn submit_set(&mut self, req: SubmitSetRequest) -> GrpcResult<()> {
         let set = req.values.iter().cloned().collect::<HashSet<_>>();
         let next = match self.values {
             Some(ref previous) => previous.intersection(&set).cloned().collect(),
             None => set,
         };
         self.values = Some(next);
+        Ok(())
     }
 
-    fn get_intersection(&mut self) -> GetIntersectionResponse {
+    fn get_intersection(&mut self) -> GrpcResult<GetIntersectionResponse> {
         let mut res = GetIntersectionResponse::new();
         if let Some(ref set) = self.values {
             res.values = set.iter().cloned().collect();
         };
-        res
+        Ok(res)
     }
 }

--- a/examples/private_set_intersection/src/proto/private_set_intersection_grpc.rs
+++ b/examples/private_set_intersection/src/proto/private_set_intersection_grpc.rs
@@ -19,14 +19,15 @@
 #![allow(unused_results)]
 
 
+use oak::GrpcResult;
 use protobuf::Message;
 use std::io::Write;
 
 // Oak node server interface
 pub trait PrivateSetIntersectionNode {
-    fn submit_set(&mut self, req: super::private_set_intersection::SubmitSetRequest);
+    fn submit_set(&mut self, req: super::private_set_intersection::SubmitSetRequest) -> GrpcResult<()>;
 
-    fn get_intersection(&mut self) -> super::private_set_intersection::GetIntersectionResponse;
+    fn get_intersection(&mut self) -> GrpcResult<super::private_set_intersection::GetIntersectionResponse>;
 }
 
 // Oak node gRPC method dispatcher
@@ -34,10 +35,10 @@ pub fn dispatch(node: &mut PrivateSetIntersectionNode, grpc_method_name: &str, g
     match grpc_method_name {
         "/oak.examples.private_set_intersection.PrivateSetIntersection/SubmitSet" => {
             let req = protobuf::parse_from_reader(&mut grpc_pair.receive).unwrap();
-            node.submit_set(req);
+            node.submit_set(req).unwrap();
         }
         "/oak.examples.private_set_intersection.PrivateSetIntersection/GetIntersection" => {
-            let rsp = node.get_intersection();
+            let rsp = node.get_intersection().unwrap();
             rsp.write_to_writer(&mut grpc_pair.send).unwrap();
         }
         _ => {

--- a/examples/running_average/src/lib.rs
+++ b/examples/running_average/src/lib.rs
@@ -28,6 +28,7 @@ extern crate protobuf;
 
 mod proto;
 
+use oak::GrpcResult;
 use oak_derive::OakNode;
 use proto::running_average::{GetAverageResponse, SubmitSampleRequest};
 use proto::running_average_grpc::{dispatch, RunningAverageNode};
@@ -48,14 +49,15 @@ impl oak::Node for Node {
 }
 
 impl RunningAverageNode for Node {
-    fn submit_sample(&mut self, req: SubmitSampleRequest) {
+    fn submit_sample(&mut self, req: SubmitSampleRequest) -> GrpcResult<()> {
         self.sum += req.value;
         self.count += 1;
+        Ok(())
     }
 
-    fn get_average(&mut self) -> GetAverageResponse {
+    fn get_average(&mut self) -> GrpcResult<GetAverageResponse> {
         let mut res = GetAverageResponse::new();
         res.average = self.sum / self.count;
-        res
+        Ok(res)
     }
 }

--- a/examples/running_average/src/proto/running_average_grpc.rs
+++ b/examples/running_average/src/proto/running_average_grpc.rs
@@ -19,14 +19,15 @@
 #![allow(unused_results)]
 
 
+use oak::GrpcResult;
 use protobuf::Message;
 use std::io::Write;
 
 // Oak node server interface
 pub trait RunningAverageNode {
-    fn submit_sample(&mut self, req: super::running_average::SubmitSampleRequest);
+    fn submit_sample(&mut self, req: super::running_average::SubmitSampleRequest) -> GrpcResult<()>;
 
-    fn get_average(&mut self) -> super::running_average::GetAverageResponse;
+    fn get_average(&mut self) -> GrpcResult<super::running_average::GetAverageResponse>;
 }
 
 // Oak node gRPC method dispatcher
@@ -34,10 +35,10 @@ pub fn dispatch(node: &mut RunningAverageNode, grpc_method_name: &str, grpc_pair
     match grpc_method_name {
         "/oak.examples.running_average.RunningAverage/SubmitSample" => {
             let req = protobuf::parse_from_reader(&mut grpc_pair.receive).unwrap();
-            node.submit_sample(req);
+            node.submit_sample(req).unwrap();
         }
         "/oak.examples.running_average.RunningAverage/GetAverage" => {
-            let rsp = node.get_average();
+            let rsp = node.get_average().unwrap();
             rsp.write_to_writer(&mut grpc_pair.send).unwrap();
         }
         _ => {

--- a/rust/oak/src/lib.rs
+++ b/rust/oak/src/lib.rs
@@ -21,6 +21,8 @@ use std::io::{Read, Write};
 
 mod proto;
 
+pub type GrpcResult<T> = Result<T, proto::status::Status>;
+
 type Handle = u64;
 
 // Keep in sync with /oak/server/oak_node.h.

--- a/rust/oak/src/proto/mod.rs
+++ b/rust/oak/src/proto/mod.rs
@@ -1,2 +1,2 @@
-mod status;
+pub mod status;
 mod storage;


### PR DESCRIPTION
This is a better match to normal gRPC behaviour; however, note that
the status does not (yet) go anywhere, it just gets dropped in the
generated dispatcher code.