### PR TITLE
Make channels message-oriented

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -33,6 +33,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +152,8 @@ dependencies = [
 name = "oak"
 version = "0.1.0"
 dependencies = [
+ "fmt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -526,6 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum fmt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09904adae26440d46daeacb5ed7922fee69d43ebf84d31e078cd49652cecd718"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -62,6 +62,7 @@ cc_library(
         ":buffer_channel",
         ":channel",
         ":logging_channel",
+        ":status",
         "//oak/proto:application_cc_grpc",
         "@boringssl//:crypto",
         "@com_github_grpc_grpc//:grpc++",
@@ -102,6 +103,12 @@ cc_library(
     deps = [
         ":channel",
     ],
+)
+
+cc_library(
+    name = "status",
+    hdrs = ["status.h"],
+    deps = [],
 )
 
 cc_library(

--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -57,10 +57,14 @@ static wabt::interp::TypedValue MakeI64(uint64_t v) {
 
 static void LogHostFunctionCall(const wabt::interp::HostFunc* func,
                                 const wabt::interp::TypedValues& args) {
-  LOG(INFO) << "Called host function: " << func->module_name << "." << func->field_name;
+  std::stringstream params;
+  bool first = true;
   for (auto const& arg : args) {
-    LOG(INFO) << "Arg: " << wabt::interp::TypedValueToString(arg);
+    params << std::string(first ? "" : ", ") << wabt::interp::TypedValueToString(arg);
+    first = false;
   }
+  LOG(INFO) << "Called host function: " << func->module_name << "." << func->field_name << "("
+            << params.str() << ")";
 }
 
 static wabt::Result ReadModule(const std::string module_bytes, wabt::interp::Environment* env,

--- a/oak/server/status.h
+++ b/oak/server/status.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_SERVER_STATUS_H_
+#define OAK_SERVER_STATUS_H_
+
+namespace oak {
+
+using OakStatus = int32_t;
+
+// The following status values are returned from Oak host functions.
+// Keep in sync with /rust/oak/src/lib.rs.
+
+// Success.
+const OakStatus STATUS_OK = 0;
+// Invalid handle provided.
+const OakStatus STATUS_ERR_BAD_HANDLE = 1;
+// Arguments invalid.
+const OakStatus STATUS_ERR_INVALID_ARGS = 2;
+// Channel has been closed.
+const OakStatus STATUS_ERR_CHANNEL_CLOSED = 3;
+// Provided buffer was too small for operation (an output value will indicate required size).
+const OakStatus STATUS_ERR_BUFFER_TOO_SMALL = 4;
+// Argument out of valid range.
+const OakStatus STATUS_ERR_OUT_OF_RANGE = 5;
+
+}  // namespace oak
+
+#endif  // OAK_SERVER_STATUS_H_

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -24,6 +24,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +50,8 @@ dependencies = [
 name = "oak"
 version = "0.1.0"
 dependencies = [
+ "fmt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -283,6 +290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum fmt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09904adae26440d46daeacb5ed7922fee69d43ebf84d31e078cd49652cecd718"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"

--- a/rust/oak/Cargo.toml
+++ b/rust/oak/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Tiziano Santoro <tzn@google.com>"]
 
 [dependencies]
 protobuf = "*"
+fmt = "*"
+log = "*"
 
 [build-dependencies]
 protoc-rust = "*"


### PR DESCRIPTION
To guarantee that a read only ever produces a complete message, we need
to cope with the case where the provided buffer for channel_read is not
large enough.  In this case, no data is returned but the required size
needs to be, so the caller can re-allocate and call again.

Wasm only currently allows a single return value in function signatures,
so hackily overload the returned size i32 so that negative values
indicate that nothing was returned, and what the required size is.

In turn, this means that the Rust code for a ReadChannelHalf cannot
implement the Read trait any more, because that trait is fundamentally
stream-oriented not message-oriented (i.e. it assumes partial reads are
just fine, and just repeats until EOF).