### PR TITLE
Add support for writing wasm modules in C++

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,11 @@ build:sgx-sim --define=SGX_SIM=1
 # make assumptions about it being related to SGX.
 build:enc-sim --config=sgx-sim
 
+# Toolchain for compiling C++ code to wasm32
+build:wasm32 --crosstool_top=//toolchain:clang_llvm
+build:wasm32 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build:wasm32 --cpu=wasm32
+
 # Bazel 0.27.0 deprecates features that our dependencies (gRPC, protobuf) rely on, so disable
 # the checks until all dependencies have been updated to cope with a later Bazel.
 # TODO: remove these options when possible

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,3 +102,12 @@ sgx_deps()
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 grpc_deps()
+
+
+# clang + llvm 8.0
+http_archive(
+    name = "clang_llvm",
+    build_file = "//toolchain:clang_llvm.BUILD",
+    strip_prefix = "clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04",
+    url = "http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -110,4 +110,5 @@ http_archive(
     build_file = "//toolchain:clang_llvm.BUILD",
     strip_prefix = "clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04",
     url = "http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
+    sha256 = "0f5c314f375ebd5c35b8c1d5e5b161d9efaeff0523bac287f8b4e5b751272f51"
 )

--- a/examples/hello_world/module/cpp/BUILD
+++ b/examples/hello_world/module/cpp/BUILD
@@ -1,0 +1,24 @@
+#
+# Copyright 2019 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cc_binary(
+    name = "hello_world.wasm",
+    srcs = ["hello_world.cc"],
+    deps = [
+        "//oak/common:handles",
+        "//oak/module:defines",
+    ],
+)

--- a/examples/hello_world/module/cpp/hello_world.cc
+++ b/examples/hello_world/module/cpp/hello_world.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "oak/common/handles.h"
+#include "oak/module/defines.h"  // for imports and exports
+
+import_from_module("oak") int channel_read(uint64_t handle, uint8_t* buff, size_t usize,
+                                           uint32_t* actual_size);
+import_from_module("oak") int channel_write(uint64_t handle, uint8_t* buff, size_t usize);
+
+export_to_wasm void oak_initialize() {}
+
+export_to_wasm void oak_handle_grpc_call() {
+  uint8_t _buf[256];
+  uint32_t actual_size;
+  channel_read(oak::GRPC_IN_CHANNEL_HANDLE, _buf, sizeof(_buf), &actual_size);
+
+  // Hard-coded serialized HelloResponse protobuf that says testing.
+  // TODO: replace with use of message type and serialization.
+  uint8_t buf[] = "\x0A\x07\x74\x65\x73\x74\x69\x6e\x67";
+  channel_write(oak::GRPC_OUT_CHANNEL_HANDLE, buf, sizeof(buf) - 1);
+}

--- a/examples/hello_world/module/cpp/hello_world.cc
+++ b/examples/hello_world/module/cpp/hello_world.cc
@@ -20,13 +20,13 @@
 #include "oak/common/handles.h"
 #include "oak/module/defines.h"  // for imports and exports
 
-import_from_module("oak") int channel_read(uint64_t handle, uint8_t* buff, size_t usize,
-                                           uint32_t* actual_size);
-import_from_module("oak") int channel_write(uint64_t handle, uint8_t* buff, size_t usize);
+WASM_IMPORT("oak")
+int channel_read(uint64_t handle, uint8_t* buff, size_t usize, uint32_t* actual_size);
+WASM_IMPORT("oak") int channel_write(uint64_t handle, uint8_t* buff, size_t usize);
 
-export_to_wasm void oak_initialize() {}
+WASM_EXPORT void oak_initialize() {}
 
-export_to_wasm void oak_handle_grpc_call() {
+WASM_EXPORT void oak_handle_grpc_call() {
   uint8_t _buf[256];
   uint32_t actual_size;
   channel_read(oak::GRPC_IN_CHANNEL_HANDLE, _buf, sizeof(_buf), &actual_size);

--- a/oak/common/BUILD
+++ b/oak/common/BUILD
@@ -1,0 +1,21 @@
+#
+# Copyright 2018 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cc_library(
+    name = "handles",
+    hdrs = ["handles.h"],
+    visibility = ["//visibility:public"],
+)

--- a/oak/common/handles.h
+++ b/oak/common/handles.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_HANDLES_H_
+#define OAK_HANDLES_H_
+
+#include <stdint.h>
+
+namespace oak {
+using Handle = uint64_t;
+
+// Keep in sync with /rust/oak/src/lib.rs.
+const Handle LOGGING_CHANNEL_HANDLE = 1;
+const Handle GRPC_METHOD_NAME_CHANNEL_HANDLE = 2;
+const Handle GRPC_IN_CHANNEL_HANDLE = 3;
+const Handle GRPC_OUT_CHANNEL_HANDLE = 4;
+
+}  // namespace oak
+
+#endif  // OAK_HANDLES_H_

--- a/oak/module/BUILD
+++ b/oak/module/BUILD
@@ -1,0 +1,21 @@
+#
+# Copyright 2018 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cc_library(
+    name = "defines",
+    hdrs = ["defines.h"],
+    visibility = ["//visibility:public"],
+)

--- a/oak/module/defines.h
+++ b/oak/module/defines.h
@@ -17,7 +17,7 @@
 #ifndef OAK_MODULE_DEFINES_H_
 #define OAK_MODULE_DEFINES_H_
 
-#define export_to_wasm extern "C" __attribute__((visibility("default")))
-#define import_from_module(name) extern "C" __attribute__((import_module(name)))
+#define WASM_EXPORT extern "C" __attribute__((visibility("default")))
+#define WASM_IMPORT(module_name) extern "C" __attribute__((import_module(module_name)))
 
 #endif  // OAK_MODULE_DEFINES_H_

--- a/oak/module/defines.h
+++ b/oak/module/defines.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_MODULE_DEFINES_H_
+#define OAK_MODULE_DEFINES_H_
+
+#define export_to_wasm extern "C" __attribute__((visibility("default")))
+#define import_from_module(name) extern "C" __attribute__((import_module(name)))
+
+#endif  // OAK_MODULE_DEFINES_H_

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -64,6 +64,7 @@ cc_library(
         ":channel",
         ":logging_channel",
         ":status",
+        "//oak/common:handles",
         "//oak/proto:application_cc_grpc",
         "@boringssl//:crypto",
         "@com_github_grpc_grpc//:grpc++",

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -22,19 +22,12 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/types/span.h"
+#include "oak/common/handles.h"
 #include "oak/proto/application.grpc.pb.h"
 #include "oak/server/channel.h"
 #include "src/interp/interp.h"
 
 namespace oak {
-
-using Handle = uint64_t;
-
-// Keep in sync with /rust/oak/src/lib.rs.
-const Handle LOGGING_CHANNEL_HANDLE = 1;
-const Handle GRPC_METHOD_NAME_CHANNEL_HANDLE = 2;
-const Handle GRPC_IN_CHANNEL_HANDLE = 3;
-const Handle GRPC_OUT_CHANNEL_HANDLE = 4;
 
 typedef std::unordered_map<Handle, std::unique_ptr<ChannelHalf>> ChannelHalfTable;
 

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -45,3 +45,9 @@ fi
 
 cargo build --release --target=wasm32-unknown-unknown --manifest-path="examples/$TARGET/module/rust/Cargo.toml"
 bazel --output_base="$CACHE_DIR/client" build --symlink_prefix='client-' --compilation_mode="$COMPILATION_MODE" "//examples/$TARGET/client"
+
+readonly CPP_FOLDER="$(find examples/"$TARGET" -type d -name cpp)"
+if [[ ! -z "$CPP_FOLDER" ]]; then
+    #TODO: support compilation mode wasm.
+    bazel --output_base="$CACHE_DIR/module" build --symlink_prefix='module-' --config=wasm32 "//examples/$TARGET/module/cpp:all"
+fi

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -1,11 +1,29 @@
 #!/usr/bin/env bash
-set -e
-set -x
+set -o errexit
+set -o xtrace
 
-readonly NAME="${1}"
+IS_CPP=false
 
+while getopts "hc" opt; do
+    case "$opt" in
+    h)
+        echo -e "Usage: $0 [-c] example_name
+  -c    Build the cc version of the example
+  -h    Print this message"
+        exit 0
+        ;;
+    c)  
+        IS_CPP=true
+        ;;
+    *) 
+        exit 1
+        ;;
+    esac
+done
+
+readonly NAME="${*:$OPTIND:1}"
 if [[ -z "${NAME}" ]]; then
-  echo "Missing example name, usage: run_example <name>"
+  echo "Missing example name, use -h for help"
   exit 1
 fi
 
@@ -13,6 +31,13 @@ readonly OAK_MANAGER_ADDRESS="${OAK_MANAGER_ADDRESS:-127.0.0.1:8888}"
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
 "$SCRIPTS_DIR/build_example" "$NAME"
+
+if [ "$IS_CPP" = true ]; then
+  readonly MODULE_PATH="$PWD/module-bin/examples/${NAME}/module/cpp/${NAME}.wasm"
+else
+  readonly MODULE_PATH="$PWD/examples/target/wasm32-unknown-unknown/release/${NAME}.wasm"
+fi
+
 "./client-bin/examples/${NAME}/client/client" \
   --manager_address="${OAK_MANAGER_ADDRESS}" \
-  --module="$PWD/examples/target/wasm32-unknown-unknown/release/${NAME}.wasm"
+  --module="${MODULE_PATH}"

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -1,0 +1,48 @@
+#
+# Copyright 2019 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#c
+package(default_visibility = ["//visibility:public"])
+
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+
+cc_toolchain_config(name = "clang_llvm_toolchain_config")
+
+cc_toolchain_suite(
+    name = "clang_llvm",
+    toolchains = {
+        "wasm32": ":clang_llvm_toolchain",
+    },
+)
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        "clang.sh",
+        "@clang_llvm//:all_files",
+    ],
+)
+
+cc_toolchain(
+    name = "clang_llvm_toolchain",
+    all_files = ":all_files",
+    compiler_files = ":all_files",
+    dwp_files = ":empty",
+    linker_files = ":all_files",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+    toolchain_config = ":clang_llvm_toolchain_config",
+    toolchain_identifier = "clang_llvm-toolchain",
+)

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -1,0 +1,169 @@
+#
+# Copyright 2019 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file is configuring the toolchain to use for wasm32, which is clang and llvm.
+# It overwrites the tool paths to point to clang and sets the needed flags for different
+# types of actions.
+
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "action_config",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool",
+    "tool_path",
+)
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+    ACTION_NAMES.cpp_link_static_library,
+]
+
+lto_index_actions = [
+    ACTION_NAMES.lto_index_for_executable,
+    ACTION_NAMES.lto_index_for_dynamic_library,
+    ACTION_NAMES.lto_index_for_nodeps_dynamic_library,
+]
+
+all_cpp_compile_actions = [
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+]
+
+def _impl(ctx):
+    # Overwrite the paths to point to clang.
+    # TODO: Bazel has a limitation as these paths can be only relative to the toolchain folder.
+    # The hack around this is to have a script file that just redirects to the correct binary.
+    # We need to fix this once Bazel does this properly.
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "clang.sh",
+        ),
+        tool_path(
+            name = "ld",
+            path = "clang.sh",
+        ),
+        tool_path(
+            name = "ar",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "nm",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "strip",
+            path = "/bin/false",
+        ),
+    ]
+
+    # Setup the correct flags for compile + link + lto
+    wasm_flags = feature(
+        name = "wasm_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_cpp_compile_actions + all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-ffreestanding",
+                            # Bazel require explicit include paths for system headers
+                            "-isystem",
+                            "external/clang_llvm/lib/clang/8.0.0/include",
+                            "-isystem",
+                            "external/clang_llvm/include/c++/v1/",
+                            "--target=wasm32-unknown-unknown",
+                            # Make sure we don't link stdlib
+                            "-nostdlib",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Flags to pass to lld.
+    link_flags = feature(
+        name = "link_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            # No main file for wasm.
+                            "--for-linker",
+                            "-no-entry",
+                            # Export symbol in the executable which are marked as
+                            # visibility=default.
+                            "--for-linker",
+                            "--export-dynamic",
+                            # Allow undefined symbols. These will be defined by the wasm vm.
+                            "--for-linker",
+                            "--allow-undefined",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Put everythign together and return a config_info.
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        toolchain_identifier = "clang_llvm-toolchain",
+        host_system_name = "i686-unknown-linux-gnu",
+        target_system_name = "wasm32-unknown-unknown",
+        target_cpu = "wasm32",
+        target_libc = "unknown",
+        compiler = "clang",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+        features = [
+            wasm_flags,
+            link_flags,
+        ],
+    )
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/toolchain/clang.sh
+++ b/toolchain/clang.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -o errexit
+set -o xtrace
+
+external/clang_llvm/bin/clang "$@"

--- a/toolchain/clang_llvm.BUILD
+++ b/toolchain/clang_llvm.BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**/*"]),
+)


### PR DESCRIPTION
Please see commits separately.
The compilation becomes difficult due to 3 toolchains now and bazel is not great at handling this. We've already had problems when compiling server - client combinations, as it invalidated the cache. This, hopefully, fixes most of this, even if it goes in circles for it.

First step towards building #10 
