### PR TITLE
Speed up Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ language: shell
 services:
   - docker
 
+cache:
+  timeout: 600
+  directories:
+    - bazel-cache  # explicit cache directory for Docker builds (scripts/docker_run)
+    - cargo-cache  # default cache directory for Rust builds, shared with Docker builds
+    - .cache/bazel  # default cache directory for local Bazel builds
+
 env:
   - FORMAT_CHECKS=true
   - BUILD_SERVER=true

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -5,7 +5,7 @@ set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
-COMPILATION_MODE='opt'
+COMPILATION_MODE='fastbuild'
 
 while getopts "hd" opt; do
     case "$opt" in
@@ -15,10 +15,10 @@ while getopts "hd" opt; do
   -h    Print this message"
         exit 0
         ;;
-    d)  
+    d)
         COMPILATION_MODE='dbg'
         ;;
-    *) 
+    *)
         exit 1
         ;;
     esac


### PR DESCRIPTION
Looks like the Travis cache works better now than for #88 / #53, but there's still a "could not download cache" error for the [largest build](https://travis-ci.org/daviddrysdale/oak/jobs/561113337)