### PR TITLE
Use different --output_base when building examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.
 /bazel-*
+/client-*
+/module-*
 
 # Cargo cache.
 /cargo-cache/

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -4,6 +4,7 @@ set -o errexit
 set -o xtrace
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
+readonly CACHE_DIR='bazel-cache'
 
 COMPILATION_MODE='fastbuild'
 
@@ -34,11 +35,13 @@ if [[ -z "${NAME}" ]]; then
     select opt in "${options[@]}";
     do
         echo "Building $opt"
-        cargo build --release --target=wasm32-unknown-unknown --manifest-path="examples/$opt/module/rust/Cargo.toml"
-        bazel build --compilation_mode="$COMPILATION_MODE" "//examples/$opt/client"
+        TARGET="$opt"
         break
     done
 else
-    cargo build --release --target=wasm32-unknown-unknown --manifest-path="examples/$NAME/module/rust/Cargo.toml"
-    bazel build --compilation_mode="$COMPILATION_MODE" "//examples/$NAME/client"
+    echo "Building $NAME"
+    TARGET="$NAME"
 fi
+
+cargo build --release --target=wasm32-unknown-unknown --manifest-path="examples/$TARGET/module/rust/Cargo.toml"
+bazel --output_base="$CACHE_DIR/client" build --symlink_prefix='client-' --compilation_mode="$COMPILATION_MODE" "//examples/$TARGET/client"

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -13,7 +13,6 @@ readonly OAK_MANAGER_ADDRESS="${OAK_MANAGER_ADDRESS:-127.0.0.1:8888}"
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
 "$SCRIPTS_DIR/build_example" "$NAME"
-bazel run "//examples/${NAME}/client" \
-  -- \
+"./client-bin/examples/${NAME}/client/client" \
   --manager_address="${OAK_MANAGER_ADDRESS}" \
   --module="$PWD/examples/target/wasm32-unknown-unknown/release/${NAME}.wasm"


### PR DESCRIPTION
Also use distinct names for the symlinks to built code, and avoid
using `bazel run` (as that requires us to be careful that the build
and run steps use exactly the same options).