### PR TITLE
Fix caching of Rust objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ services:
 cache:
   timeout: 600
   directories:
-    - bazel-cache  # explicit cache directory for Docker builds (scripts/docker_run)
-    - cargo-cache  # default cache directory for Rust builds, shared with Docker builds
+    - bazel-cache  # explicit cache directory for Docker Bazel builds (scripts/docker_run)
     - .cache/bazel  # default cache directory for local Bazel builds
+    - rust/target  # cached objects for Rust library code
+    - examples/target  # cached objects for Rust example code
 
 env:
   - FORMAT_CHECKS=true


### PR DESCRIPTION
The cargo-cache/ directory holds source code rather than built
objects, and so downloading this from Travis cache rather than
crates.io probably won't make much difference.

Instead, cache the two main target/ subdirectories, which hold
built objects and so should prevent some unneeded rebuilding.