### PR TITLE
Upgrade protobuf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH "$BUILDIFIER_DIR/bin:$PATH"
 RUN chmod +x $BUILDIFIER_DIR/bin/buildifier
 
 # Install Protobuf compiler.
-ARG PROTOBUF_VERSION=3.7.1
+ARG PROTOBUF_VERSION=3.9.1
 ARG PROTOBUF_DIR=/usr/local/protobuf
 RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip > /tmp/protobuf.zip
 RUN unzip /tmp/protobuf.zip -d $PROTOBUF_DIR

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,9 +31,9 @@ http_archive(
 # Asylo Framework.
 http_archive(
     name = "com_google_asylo",
-    urls = ["https://github.com/google/asylo/archive/v0.4.0.tar.gz"],
-    strip_prefix = "asylo-0.4.0",
-    sha256 = "9dd8063d1a8002f6cc729f0115e2140a2eb1b14a10c111411f6b554e14ee739c",
+    urls = ["https://github.com/google/asylo/archive/dfdc44744e3b18531830deb37c5633f648e6cdbd.tar.gz"],
+    strip_prefix = "asylo-dfdc44744e3b18531830deb37c5633f648e6cdbd",
+    sha256 = "b622044f967da3b8a8e2c76a18afe0014baab3226a902db0b87255f3ffc31c2c",
 )
 
 # Google Test
@@ -47,11 +47,13 @@ git_repository(
 http_archive(
     name = "com_google_protobuf",
     urls = [
-        "https://github.com/protocolbuffers/protobuf/archive/v3.7.1.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v3.9.1.tar.gz",
     ],
-    strip_prefix = "protobuf-3.7.1",
-    sha256 = "f1748989842b46fa208b2a6e4e2785133cfcc3e4d43c17fecb023733f0f5443f",
+    strip_prefix = "protobuf-3.9.1",
+    sha256 = "98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357",
 )
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
 
 # Google APIs for Cloud Spanner protos.
 # TODO: Switch from fork after https://github.com/googleapis/googleapis/pull/553 is merged.

--- a/oak/proto/BUILD
+++ b/oak/proto/BUILD
@@ -40,9 +40,7 @@ cc_proto_library(
 proto_library(
     name = "application_proto",
     srcs = ["application.proto"],
-    deps = [
-        ":manager_proto",
-    ],
+    deps = [],
 )
 
 cc_proto_library(

--- a/oak/proto/application.proto
+++ b/oak/proto/application.proto
@@ -18,8 +18,6 @@ syntax = "proto3";
 
 package oak;
 
-import "oak/proto/manager.proto";
-
 message GetAttestationRequest {
   // TODO: Specify this message.
 }


### PR DESCRIPTION
Temporarily depend on a version of Asylo that includes https://github.com/google/asylo/commit/efcc507e6c028412a0e612256e493341628b1fdb .

Also remove unnecessary proto import.

Fixes #111 .