### PR TITLE
Move logging channel from OakNode to OakRuntime

### DIFF
--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -38,6 +38,8 @@ class OakNode final : public Application::Service {
   // Creates an Oak node by loading the Wasm module code.
   static std::unique_ptr<OakNode> Create(const std::string& module);
 
+  void SetChannel(Handle handle, std::unique_ptr<ChannelHalf> channel_half);
+
   // The destructor for a running OakNode instance will block until the thread
   // running the instance completes.
   virtual ~OakNode();

--- a/oak/server/oak_runtime.h
+++ b/oak/server/oak_runtime.h
@@ -25,6 +25,7 @@
 #include "include/grpcpp/security/server_credentials.h"
 #include "include/grpcpp/server.h"
 #include "oak/proto/enclave.pb.h"
+#include "oak/proto/oak_api.pb.h"
 #include "oak/server/oak_node.h"
 
 namespace oak {
@@ -56,6 +57,8 @@ class OakRuntime {
   // Creates a gRPC server that hosts node_ on a free port with credentials_.
   asylo::StatusOr<std::unique_ptr<::grpc::Server>> CreateServer(
       const std::shared_ptr<grpc::ServerCredentials> credentials);
+
+  void SetUpChannels();
 
   // Consumes gRPC events from the completion queue in an infinite loop.
   void CompletionQueueLoop();


### PR DESCRIPTION
This is a step towards #176 , as we need OakRuntime to manage Channels,
as opposed to the OakNode creating them directly.