### PR TITLE
Move gRPC channels to runtime

### DIFF
--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -41,7 +41,6 @@ cc_library(
         ":channel",
         "//oak/common:handles",
         "//oak/proto:application_cc_grpc",
-        "//oak/proto:grpc_encap_cc_proto",
         "//oak/proto:oak_api_cc_proto",
         "@boringssl//:crypto",
         "@com_github_grpc_grpc//:grpc++",
@@ -84,6 +83,7 @@ cc_library(
     hdrs = ["module_invocation.h"],
     deps = [
         ":oak_node",
+        "//oak/proto:grpc_encap_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_asylo//asylo/util:logging",
     ],

--- a/oak/server/channel.h
+++ b/oak/server/channel.h
@@ -78,7 +78,7 @@ class ChannelHalf {
     // Fallback implementation that just drops the message.
   }
 
-  // Await blocks until there is a message avaialable to read on the channel.
+  // Await blocks until there is a message available to read on the channel.
   virtual void Await() {}
 };
 
@@ -88,9 +88,9 @@ class ChannelHalf {
 // |MessageChannelWriteHalf|) to interact with it.
 // TODO: Clean up this interface, e.g. hide the Read and Write methods on MessageChannel and expose
 // methods to get access to the read and write halves instead.
-class MessageChannel final : ChannelHalf {
+class MessageChannel final : public ChannelHalf {
  public:
-  virtual ~MessageChannel() override {}
+  ~MessageChannel() override {}
 
   // Count indicates the number of pending messages.
   size_t Count() const LOCKS_EXCLUDED(mu_);
@@ -117,7 +117,7 @@ class MessageChannel final : ChannelHalf {
 class MessageChannelReadHalf final : public ChannelHalf {
  public:
   MessageChannelReadHalf(std::shared_ptr<MessageChannel> channel) : channel_(channel) {}
-  virtual ~MessageChannelReadHalf() override {}
+  ~MessageChannelReadHalf() override {}
   ReadResult Read(uint32_t size) override { return channel_->Read(size); }
   ReadResult BlockingRead(uint32_t size) { return channel_->BlockingRead(size); }
   void Await() override { return channel_->Await(); }
@@ -130,7 +130,7 @@ class MessageChannelReadHalf final : public ChannelHalf {
 class MessageChannelWriteHalf final : public ChannelHalf {
  public:
   MessageChannelWriteHalf(std::shared_ptr<MessageChannel> channel) : channel_(channel) {}
-  virtual ~MessageChannelWriteHalf() override {}
+  ~MessageChannelWriteHalf() override {}
   void Write(std::unique_ptr<Message> msg) override { channel_->Write(std::move(msg)); }
 
  private:

--- a/oak/server/channel.h
+++ b/oak/server/channel.h
@@ -90,8 +90,6 @@ class ChannelHalf {
 // methods to get access to the read and write halves instead.
 class MessageChannel final : public ChannelHalf {
  public:
-  ~MessageChannel() override {}
-
   // Count indicates the number of pending messages.
   size_t Count() const LOCKS_EXCLUDED(mu_);
 
@@ -117,7 +115,6 @@ class MessageChannel final : public ChannelHalf {
 class MessageChannelReadHalf final : public ChannelHalf {
  public:
   MessageChannelReadHalf(std::shared_ptr<MessageChannel> channel) : channel_(channel) {}
-  ~MessageChannelReadHalf() override {}
   ReadResult Read(uint32_t size) override { return channel_->Read(size); }
   ReadResult BlockingRead(uint32_t size) { return channel_->BlockingRead(size); }
   void Await() override { return channel_->Await(); }
@@ -130,7 +127,6 @@ class MessageChannelReadHalf final : public ChannelHalf {
 class MessageChannelWriteHalf final : public ChannelHalf {
  public:
   MessageChannelWriteHalf(std::shared_ptr<MessageChannel> channel) : channel_(channel) {}
-  ~MessageChannelWriteHalf() override {}
   void Write(std::unique_ptr<Message> msg) override { channel_->Write(std::move(msg)); }
 
  private:

--- a/oak/server/channel.h
+++ b/oak/server/channel.h
@@ -102,7 +102,7 @@ class MessageChannel final : public ChannelHalf {
   // Write passes ownership of a message to the channel.
   void Write(std::unique_ptr<Message> data) override LOCKS_EXCLUDED(mu_);
 
-  void Await() LOCKS_EXCLUDED(mu_);
+  void Await() override LOCKS_EXCLUDED(mu_);
 
  private:
   ReadResult ReadLocked(uint32_t size) EXCLUSIVE_LOCKS_REQUIRED(mu_);

--- a/oak/server/module_invocation.cc
+++ b/oak/server/module_invocation.cc
@@ -63,7 +63,26 @@ void ModuleInvocation::ProcessRequest(bool ok) {
     return;
   }
   std::unique_ptr<Message> request_data = Unwrap(request_);
-  node_->ProcessModuleInvocation(&context_, std::move(request_data));
+
+  LOG(INFO) << "Handling gRPC call: " << context_.method();
+
+  // Build an encapsulation of the gRPC request invocation and write its serialized
+  // form to the gRPC input channel.
+  oak::GrpcRequest grpc_in;
+  grpc_in.set_method_name(context_.method());
+  google::protobuf::Any* any = new google::protobuf::Any();
+  any->set_value(request_data->data(), request_data->size());
+  grpc_in.set_allocated_req_msg(any);
+  grpc_in.set_last(true);
+  std::string encap_req;
+  grpc_in.SerializeToString(&encap_req);
+  // TODO: figure out a way to avoid the extra copy (into then out of std::string)
+  std::unique_ptr<Message> encap_data =
+      absl::make_unique<Message>(encap_req.begin(), encap_req.end());
+  // Write data to the gRPC input channel, which the runtime connected to the
+  // Node.
+  grpc_in_->Write(std::move(encap_data));
+  LOG(INFO) << "Wrote encapsulated request to gRPC input channel";
 
   // Move straight onto sending first response.
   SendResponse(true);
@@ -75,14 +94,21 @@ void ModuleInvocation::SendResponse(bool ok) {
     return;
   }
 
-  oak::GrpcResponse grpc_out = node_->NextResponse();
-  if (grpc_out.status().code() != grpc::StatusCode::OK) {
-    LOG(WARNING) << "Encapsulated response has non-OK status: " << grpc_out.status().code();
-    // Assume google::rpc::Status maps directly to grpc::Status.
-    FinishAndRestart(grpc::Status(static_cast<grpc::StatusCode>(grpc_out.status().code()),
-                                  grpc_out.status().message()));
+  oak::GrpcResponse grpc_out;
+  ReadResult rsp_result;
+  // Block until we can read a single queued GrpcResponse message (in serialized form) from the
+  // gRPC output channel.
+  rsp_result = grpc_out_->BlockingRead(INT_MAX);
+  if (rsp_result.required_size > 0) {
+    LOG(ERROR) << "Message size too large: " << rsp_result.required_size;
+    FinishAndRestart(grpc::Status(grpc::StatusCode::INTERNAL, "Message size too large"));
     return;
   }
+
+  LOG(INFO) << "Read encapsulated message of size " << rsp_result.data->size()
+            << " from output channel";
+  // TODO: Check errors.
+  grpc_out.ParseFromString(std::string(rsp_result.data->data(), rsp_result.data->size()));
 
   const grpc::string& inner_msg = grpc_out.rsp_msg().value();
   grpc::Slice slice(inner_msg.data(), inner_msg.size());
@@ -108,7 +134,7 @@ void ModuleInvocation::SendResponse(bool ok) {
 
     // Restart the gRPC flow with a new ModuleInvocation object for the next request
     // after processing this request.  This ensures that processing is serialized.
-    auto* request = new ModuleInvocation(service_, queue_, node_);
+    auto* request = new ModuleInvocation(service_, queue_, grpc_in_, grpc_out_);
     request->Start();
   }
 }
@@ -118,7 +144,7 @@ void ModuleInvocation::Finish(bool ok) { delete this; }
 void ModuleInvocation::FinishAndRestart(const grpc::Status& status) {
   // Restart the gRPC flow with a new ModuleInvocation object for the next request
   // after processing this request.  This ensures that processing is serialized.
-  auto* request = new ModuleInvocation(service_, queue_, node_);
+  auto* request = new ModuleInvocation(service_, queue_, grpc_in_, grpc_out_);
   request->Start();
 
   // Finish the current invocation (which triggers self-destruction).

--- a/oak/server/module_invocation.h
+++ b/oak/server/module_invocation.h
@@ -29,8 +29,13 @@ class ModuleInvocation {
   // All constructor arguments must outlive this object.  It manages its own
   // lifetime after RequestNext is called.
   ModuleInvocation(grpc::AsyncGenericService* service, grpc::ServerCompletionQueue* queue,
-                   OakNode* node)
-      : service_(service), queue_(queue), node_(node), stream_(&context_) {}
+                   std::shared_ptr<MessageChannel> grpc_in,
+                   std::shared_ptr<MessageChannel> grpc_out)
+      : service_(service),
+        queue_(queue),
+        grpc_in_(grpc_in),
+        grpc_out_(grpc_out),
+        stream_(&context_) {}
 
   // This object deletes itself.
   ~ModuleInvocation() = default;
@@ -62,7 +67,9 @@ class ModuleInvocation {
 
   grpc::AsyncGenericService* const service_;
   grpc::ServerCompletionQueue* const queue_;
-  OakNode* const node_;
+
+  std::shared_ptr<MessageChannel> grpc_in_;
+  std::shared_ptr<MessageChannel> grpc_out_;
 
   grpc::GenericServerContext context_;
   grpc::GenericServerAsyncReaderWriter stream_;

--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -349,6 +349,12 @@ wabt::interp::HostFunc::Callback OakNode::OakWaitOnChannels(wabt::interp::Enviro
       return wabt::interp::Result::Ok;
     }
 
+    if (channel_halves_.count(handle0) == 0) {
+      LOG(WARNING) << "Invalid channel handle: " << handle0;
+      results[0].set_i32(OakStatus::ERR_BAD_HANDLE);
+      return wabt::interp::Result::Ok;
+    }
+
     std::unique_ptr<ChannelHalf>& channel = channel_halves_.at(handle0);
     channel->Await();
     // TODO: Mark just the relevant channels as ready to read.

--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -197,17 +197,18 @@ std::unique_ptr<OakNode> OakNode::Create(const std::string& module) {
     return nullptr;
   }
 
+  return node;
+}
+
+void OakNode::Run() {
   // Spin up a per-node Wasm thread to run forever; the Node object must
-  // outlast this thread (which is enforced by ~OakNode).  Also, make sure
+  // outlast this thread (which is enforced by ~OakNode). Also, make sure
   // we pass the DefinedNode* to the thread by value so it doesn't fall out
   // of scope once this function exits.
   LOG(INFO) << "Executing module oak_main on new thread";
-  OakNode* raw_node = node.get();
-  std::thread t([raw_node] { raw_node->RunModule(); });
-  node->main_ = std::move(t);
+  std::thread t([this] { this->RunModule(); });
+  main_ = std::move(t);
   LOG(INFO) << "Started module execution thread";
-
-  return node;
 }
 
 void OakNode::SetChannel(Handle handle, std::unique_ptr<ChannelHalf> channel_half) {

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -37,7 +37,11 @@ class OakNode final : public Application::Service {
   // Creates an Oak node by loading the Wasm module code.
   static std::unique_ptr<OakNode> Create(const std::string& module);
 
-  void Run();
+  // Starts running the node in a background thread.
+  void Start();
+
+  // Stops the background thread if one exists.
+  void Stop();
 
   void SetChannel(Handle handle, std::unique_ptr<ChannelHalf> channel_half);
 

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -37,6 +37,8 @@ class OakNode final : public Application::Service {
   // Creates an Oak node by loading the Wasm module code.
   static std::unique_ptr<OakNode> Create(const std::string& module);
 
+  void Run();
+
   void SetChannel(Handle handle, std::unique_ptr<ChannelHalf> channel_half);
 
   // The destructor for a running OakNode instance will block until the thread

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -44,13 +44,6 @@ class OakNode final : public Application::Service {
   // running the instance completes.
   virtual ~OakNode();
 
-  // Performs an Oak Module gRPC invocation. Takes ownership of the passed in request data.
-  void ProcessModuleInvocation(grpc::GenericServerContext* context,
-                               std::unique_ptr<Message> request_data);
-
-  // Returns the next response from a gRPC invocation.
-  oak::GrpcResponse NextResponse();
-
  private:
   // Clients should construct OakNode instances with Create() (which
   // can fail).
@@ -78,10 +71,6 @@ class OakNode final : public Application::Service {
 
   // Hold the mapping between per-Node channel handles and channel half instances
   ChannelHalfTable channel_halves_;
-
-  // Hold on to the other halves of channels that the node uses to perform gRPC.
-  std::unique_ptr<MessageChannelWriteHalf> req_half_;
-  std::unique_ptr<MessageChannelReadHalf> rsp_half_;
 
   // Thread running the oak_main export.
   std::thread main_;

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -25,7 +25,6 @@
 #include "absl/types/span.h"
 #include "oak/common/handles.h"
 #include "oak/proto/application.grpc.pb.h"
-#include "oak/proto/grpc_encap.pb.h"
 #include "oak/server/channel.h"
 #include "src/interp/interp.h"
 

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -68,6 +68,8 @@ asylo::Status OakRuntime::InitializeServer(
   std::thread thread(&OakRuntime::CompletionQueueLoop, this);
   thread.detach();
 
+  node_->Run();
+
   return asylo::Status::OkStatus();
 }
 

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -68,7 +68,7 @@ asylo::Status OakRuntime::InitializeServer(
   std::thread thread(&OakRuntime::CompletionQueueLoop, this);
   thread.detach();
 
-  node_->Run();
+  node_->Start();
 
   return asylo::Status::OkStatus();
 }

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -144,7 +144,7 @@ void OakRuntime::CompletionQueueLoop() {
   LOG(INFO) << "Starting gRPC completion queue loop";
   // The stream object will delete itself when finished with the request,
   // after creating a new stream object for the next request.
-  auto* stream =
+  auto stream =
       new ModuleInvocation(&module_service_, completion_queue_.get(), grpc_in_, grpc_out_);
   stream->Start();
   while (true) {
@@ -154,7 +154,7 @@ void OakRuntime::CompletionQueueLoop() {
       LOG(FATAL) << "Failure reading from completion queue";
       return;
     }
-    auto* callback = static_cast<std::function<void(bool)>*>(tag);
+    auto callback = static_cast<std::function<void(bool)>*>(tag);
     (*callback)(ok);
     delete callback;
   }

--- a/oak/server/oak_runtime.h
+++ b/oak/server/oak_runtime.h
@@ -58,6 +58,7 @@ class OakRuntime {
   asylo::StatusOr<std::unique_ptr<::grpc::Server>> CreateServer(
       const std::shared_ptr<grpc::ServerCredentials> credentials);
 
+  // Creates all the necessary channels and pass the appropriate halves to |node_|.
   void SetUpChannels();
 
   // Consumes gRPC events from the completion queue in an infinite loop.
@@ -70,9 +71,14 @@ class OakRuntime {
   int port_;
 
   std::unique_ptr<OakNode> node_;
+
+  // TODO: Split gRPC logic and channels to a separate gRPC pseudo-node.
+  std::shared_ptr<MessageChannel> grpc_in_;
+  std::shared_ptr<MessageChannel> grpc_out_;
+
   grpc::AsyncGenericService module_service_;
   std::unique_ptr<grpc::ServerCompletionQueue> completion_queue_;
-};  // namespace oak
+};
 
 }  // namespace oak
 

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -27,6 +27,7 @@ docker build \
 docker_run_flags=(
   "--interactive"
   "--tty"
+  "--rm"
   "--user=$DOCKER_UID:$DOCKER_GID"
   "--env=USER=$DOCKER_USER"
   "--volume=$PWD/bazel-cache:/.cache/bazel"

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -2,6 +2,7 @@
 
 set -o errexit
 set -o nounset
+set -o xtrace
 
 readonly DOCKER_UID="${UID:-0}"
 readonly DOCKER_GID="${GID:-0}"
@@ -16,6 +17,7 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module/rust$' | cut -d'/' -f2)"
 for example in ${RUST_EXAMPLES}; do
   container_id=$("$SCRIPTS_DIR/docker_run" --detach ./bazel-bin/oak/server/asylo/oak)
+  docker logs --follow "$container_id" &
   "${SCRIPTS_DIR}/docker_run" "${SCRIPTS_DIR}/run_example" "${example}"
   docker stop "$container_id"
 done
@@ -24,6 +26,7 @@ done
 readonly CPP_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module/cpp$' | cut -d'/' -f2)"
 for example in ${CPP_EXAMPLES}; do
   container_id=$("$SCRIPTS_DIR/docker_run" --detach ./bazel-bin/oak/server/asylo/oak)
+  docker logs --follow "$container_id" &
   "${SCRIPTS_DIR}/docker_run" "${SCRIPTS_DIR}/run_example" -c "${example}"
   docker stop "$container_id"
 done


### PR DESCRIPTION
Move most of the gRPC logic from OakChannel to OakRuntime, passing
channel halves around as necessary. After this commit, the gRPC channels
are owned by OakRuntime, and only the appropriate halves are passed to
OakNode.

Ref #176