### PR TITLE
Fix clang warning on copy elison

### DIFF
--- a/oak/server/channel.cc
+++ b/oak/server/channel.cc
@@ -55,7 +55,7 @@ ReadResult MessageChannel::ReadLocked(uint32_t size) {
   msgs_.pop_front();
   LOG(INFO) << "Read message of size " << result.data->size() << " from channel, size limit "
             << size;
-  return std::move(result);
+  return result;
 }
 
 ReadResult MessageChannel::BlockingRead(uint32_t size) {


### PR DESCRIPTION
The move is preventing a compiler optimisation. Recommendation is to return by value here.