### PR TITLE
Decouple scripts from Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ script:
     fi
   - |
     if [[ "${BUILD_SERVER}" == "true" ]]; then
-      ./scripts/build_server_docker
+      ./scripts/docker_run ./scripts/build_server
     fi
   - |
     if [[ "${BUILD_EXAMPLES}" == "true" ]]; then
-      ./scripts/build_examples_docker
+      ./scripts/docker_run ./scripts/build_examples
     fi
   - |
     if [[ "${UNIT_TEST}" == "true" ]]; then

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ This means you might be missing other dependencies like the `protoc` protocol co
 
 The following command builds and runs an Oak Server instance.
 
-`./scripts/run_server_docker`
+`./scripts/docker_run ./scripts/run_server`
 
 ### Run Client
 

--- a/scripts/build_examples
+++ b/scripts/build_examples
@@ -7,5 +7,5 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 readonly EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -name module | cut -d'/' -f2)"
 
 for example in ${EXAMPLES}; do
-  "${SCRIPTS_DIR}/docker_run" "${SCRIPTS_DIR}/build_example" "${example}"
+  "${SCRIPTS_DIR}/build_example" "${example}"
 done

--- a/scripts/build_server
+++ b/scripts/build_server
@@ -3,10 +3,9 @@
 set -o errexit
 set -o xtrace
 
-readonly SCRIPTS_DIR="$(dirname "$0")"
 readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
 
-(set -x; 
+(set -x;
 # Do we have a JSON key for the remote cache.
 # https://docs.bazel.build/versions/master/remote-caching.html#google-cloud-storage
 if [[ ! -f "$OAK_REMOTE_CACHE_KEY" ]]; then
@@ -19,13 +18,13 @@ fi
 
 # If we now have a key file, use it. Otherwise build without remote cache.
 if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
-    "$SCRIPTS_DIR/docker_run" bazel build \
+    bazel build \
         --remote_cache=https://storage.googleapis.com/oak-bazel-cache \
         --google_credentials="$OAK_REMOTE_CACHE_KEY" \
         --config=enc-sim \
         //oak/server/asylo:oak
 else
-    "$SCRIPTS_DIR/docker_run" bazel build \
+    bazel build \
         --config=enc-sim \
         //oak/server/asylo:oak
 fi

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -11,7 +11,7 @@ readonly DOCKER_USER="${USER:-root}"
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
 # Build Oak server.
-"$SCRIPTS_DIR/build_server_docker"
+"$SCRIPTS_DIR/docker_run" "$SCRIPTS_DIR/build_server"
 
 # Run Rust-based Oak examples, each with their own Oak server instance.
 readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module/rust$' | cut -d'/' -f2)"

--- a/scripts/run_server
+++ b/scripts/run_server
@@ -6,5 +6,5 @@ set -o xtrace
 readonly GRPC_PORT="${GRPC_PORT:-8888}"
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
-"$SCRIPTS_DIR/build_server_docker"
-"$SCRIPTS_DIR/docker_run" ./bazel-bin/oak/server/asylo/oak --grpc_port="${GRPC_PORT}"
+"$SCRIPTS_DIR/build_server"
+./bazel-bin/oak/server/asylo/oak --grpc_port="${GRPC_PORT}"


### PR DESCRIPTION
Currently some scripts assume they need to run commands in Docker, while
some others assume they will be run in Docker already. This commit
separates the two things so that most scripts run commands without
knowledge about Docker, but they can easily be run via `docker_run` if
necessary.

Note the new command for starting a server in docker is now longer.