### PR TITLE
Refactor server code outside of the manager

### DIFF
--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -81,6 +81,21 @@ wasm_group(
 )
 
 cc_library(
+    name = "oak_grpc_node",
+    srcs = ["oak_grpc_node.cc"],
+    hdrs = ["oak_grpc_node.h"],
+    deps = [
+        ":channel",
+        ":module_invocation",
+        "//oak/proto:application_cc_grpc",
+        "//oak/proto:enclave_cc_proto",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_asylo//asylo/grpc/auth:null_credentials_options",
+        "@com_google_asylo//asylo/util:logging",
+    ],
+)
+
+cc_library(
     name = "module_invocation",
     srcs = ["module_invocation.cc"],
     hdrs = ["module_invocation.h"],
@@ -98,6 +113,7 @@ cc_library(
     hdrs = ["oak_runtime.h"],
     deps = [
         ":module_invocation",
+        ":oak_grpc_node",
         ":oak_node",
         "//oak/proto:enclave_cc_proto",
         "//oak/server:logging_node",

--- a/oak/server/asylo/enclave_server.cc
+++ b/oak/server/asylo/enclave_server.cc
@@ -49,48 +49,19 @@ asylo::Status EnclaveServer::Initialize(const asylo::EnclaveConfig& config) {
       initialize_input_message.application_configuration();
   runtime_->Initialize(application_configuration);
 
-  grpc::ServerBuilder builder;
-  // Uses ":0" notation so that server listens on a free port.
-  builder.AddListeningPort(
-      "[::]:0", asylo::EnclaveServerCredentials(asylo::BidirectionalNullCredentialsOptions()),
-      &port_);
-  builder.RegisterService(runtime_->GetGrpcService());
-
-  // Add a completion queue and a generic service, in order to proxy incoming RPCs to the Oak Node.
-  auto completion_queue = builder.AddCompletionQueue();
-
-  // Register an async service.
-  auto module_service = absl::make_unique<grpc::AsyncGenericService>();
-  builder.RegisterAsyncGenericService(module_service.get());
-
-  if (server_) {
-    return asylo::Status::OkStatus();
-  }
-
-  // Create a gRPC server. This class owns it.
-  server_ = builder.BuildAndStart();
-  if (!server_) {
-    return asylo::Status(asylo::error::GoogleError::INTERNAL, "Failed to start gRPC server");
-  }
-
-  // Move ownership of unique pointers to the runtime.
-  runtime_->StartCompletionQueue(std::move(module_service), std::move(completion_queue));
+  runtime_->Start();
 
   return asylo::Status::OkStatus();
 }
 
 asylo::Status EnclaveServer::Run(const asylo::EnclaveInput& input, asylo::EnclaveOutput* output) {
   oak::InitializeOutput* initialize_output = output->MutableExtension(oak::initialize_output);
-  initialize_output->set_grpc_port(port_);
+  initialize_output->set_grpc_port(runtime_->GetPort());
   return asylo::Status::OkStatus();
 }
 
 asylo::Status EnclaveServer::Finalize(const asylo::EnclaveFinal& enclave_final) {
-  if (server_) {
-    LOG(INFO) << "Shutting down...";
-    server_->Shutdown();
-    server_ = nullptr;
-  }
+  runtime_->Stop();
   return asylo::Status::OkStatus();
 }
 

--- a/oak/server/asylo/enclave_server.h
+++ b/oak/server/asylo/enclave_server.h
@@ -63,9 +63,7 @@ class EnclaveServer final : public asylo::TrustedApplication {
   asylo::Status Finalize(const asylo::EnclaveFinal& enclave_final) override;
 
  private:
-  int32_t port_;
   std::unique_ptr<OakRuntime> runtime_;
-  std::unique_ptr<::grpc::Server> server_;
 };
 
 }  // namespace oak

--- a/oak/server/dev/dev_oak_manager.h
+++ b/oak/server/dev/dev_oak_manager.h
@@ -39,12 +39,10 @@ class DevOakManager final : public Manager::Service {
   void InitializeAssertionAuthorities();
   std::string NewApplicationId();
 
-  // The port is listening on
-  int32_t port_;
-  // The application id
+  // The application id.
   uint64_t application_id_;
-  std::unordered_map<std::string, std::unique_ptr<OakRuntime>> runtimes;
-  std::unordered_map<std::string, std::unique_ptr<::grpc::Server>> servers;
+  // For each application, identified by it's id as a string we have a runtime
+  std::unordered_map<std::string, std::unique_ptr<OakRuntime>> runtimes_;
 };
 
 }  // namespace oak

--- a/oak/server/oak_grpc_node.cc
+++ b/oak/server/oak_grpc_node.cc
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/server/oak_grpc_node.h"
+#include "absl/memory/memory.h"
+#include "asylo/grpc/auth/enclave_server_credentials.h"
+#include "asylo/grpc/auth/null_credentials_options.h"
+#include "asylo/util/logging.h"
+#include "include/grpcpp/grpcpp.h"
+#include "oak/server/module_invocation.h"
+
+namespace oak {
+
+std::unique_ptr<OakGrpcNode> OakGrpcNode::Create() {
+  std::unique_ptr<OakGrpcNode> node = absl::WrapUnique(new OakGrpcNode());
+  node->grpc_in_ = std::make_shared<MessageChannel>();
+  node->grpc_out_ = std::make_shared<MessageChannel>();
+
+  // Build Server
+  grpc::ServerBuilder builder;
+
+  // Use ":0" notation so that server listens on a free port.
+  builder.AddListeningPort(
+      "[::]:0", asylo::EnclaveServerCredentials(asylo::BidirectionalNullCredentialsOptions()),
+      &node->port_);
+  builder.RegisterService(node.get());
+
+  // Add a completion queue and a generic service, in order to proxy incoming RPCs to the Oak Node.
+  node->completion_queue_ = builder.AddCompletionQueue();
+
+  // Register an async service.
+  node->module_service_ = absl::make_unique<grpc::AsyncGenericService>();
+  builder.RegisterAsyncGenericService(node->module_service_.get());
+
+  node->server_ = builder.BuildAndStart();
+  if (!node->server_) {
+    LOG(QFATAL) << "Failed to start gRPC server";
+    return nullptr;
+  }
+
+  return node;
+}
+
+grpc::Status OakGrpcNode::Start() {
+  // Start a new thread to process the gRPC completion queue.
+  std::thread thread(&OakGrpcNode::CompletionQueueLoop, this);
+  thread.detach();
+  // TODO: This thread will need to be joined once we sort out termination.
+  return grpc::Status::OK;
+}
+
+void OakGrpcNode::CompletionQueueLoop() {
+  LOG(INFO) << "Starting gRPC completion queue loop";
+  // The stream object will delete itself when finished with the request,
+  // after creating a new stream object for the next request.
+  auto stream =
+      new ModuleInvocation(module_service_.get(), completion_queue_.get(), grpc_in_, grpc_out_);
+  stream->Start();
+  while (true) {
+    bool ok;
+    void* tag;
+    if (!completion_queue_->Next(&tag, &ok)) {
+      LOG(FATAL) << "Failure reading from completion queue";
+      return;
+    }
+    auto callback = static_cast<std::function<void(bool)>*>(tag);
+    (*callback)(ok);
+    delete callback;
+  }
+}
+
+void OakGrpcNode::SetUpGrpcChannels(std::shared_ptr<MessageChannel> grpc_in,
+                                    std::shared_ptr<MessageChannel> grpc_out) {
+  grpc_in_ = grpc_in;
+  grpc_out_ = grpc_out;
+}
+
+grpc::Status OakGrpcNode::GetAttestation(grpc::ServerContext* context,
+                                         const GetAttestationRequest* request,
+                                         GetAttestationResponse* response) {
+  // TODO: Move this method to the application and implement it there.
+  return ::grpc::Status::OK;
+}
+
+grpc::Status OakGrpcNode::Stop() {
+  if (server_) {
+    LOG(INFO) << "Shutting down...";
+    server_->Shutdown();
+    server_ = nullptr;
+  }
+  return grpc::Status::OK;
+}
+
+}  // namespace oak

--- a/oak/server/oak_grpc_node.h
+++ b/oak/server/oak_grpc_node.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_SERVER_OAK_GRPC_NODE_H_
+#define OAK_SERVER_OAK_GRPC_NODE_H_
+
+#include "include/grpcpp/grpcpp.h"
+#include "oak/proto/application.grpc.pb.h"
+#include "oak/server/channel.h"
+
+namespace oak {
+
+class OakGrpcNode final : public Application::Service {
+ public:
+  static std::unique_ptr<OakGrpcNode> Create();
+  grpc::Status Start();
+  grpc::Status Stop();
+
+  void SetUpGrpcChannels(std::shared_ptr<MessageChannel> grpc_in,
+                         std::shared_ptr<MessageChannel> grpc_out);
+
+  int GetPort() { return port_; };
+  // The destructor for a running OakGrpcNode instance will block until the thread
+  // running the instance completes.
+  virtual ~OakGrpcNode(){};
+
+ private:
+  OakGrpcNode() = default;
+  OakGrpcNode(const OakGrpcNode&) = delete;
+  OakGrpcNode& operator=(const OakGrpcNode&) = delete;
+
+  int port_;
+
+  grpc::Status GetAttestation(grpc::ServerContext* context, const GetAttestationRequest* request,
+                              GetAttestationResponse* response) override;
+
+  // Consumes gRPC events from the completion queue in an infinite loop.
+  void CompletionQueueLoop();
+
+  // gRPC async service and completion queue.
+  // TODO: remove this once we have a unify way to pass channels around
+  std::shared_ptr<MessageChannel> grpc_in_;
+  std::shared_ptr<MessageChannel> grpc_out_;
+
+  std::unique_ptr<::grpc::Server> server_;
+
+  std::unique_ptr<grpc::AsyncGenericService> module_service_;
+  // The queue expects to deal with void* tag values that are always function pointers to
+  // void(bool) functions.
+  std::unique_ptr<grpc::ServerCompletionQueue> completion_queue_;
+};
+
+}  // namespace oak
+
+#endif  // OAK_SERVER_OAK_GRPC_NODE_H_

--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -172,7 +172,7 @@ static bool CheckModuleExports(wabt::interp::Environment* env,
       [env, module](const RequiredExport& req) { return CheckModuleExport(env, module, req); });
 }
 
-OakNode::OakNode() : Service(), NodeThread("wasm-node") {}
+OakNode::OakNode() : NodeThread("wasm-node") {}
 
 std::unique_ptr<OakNode> OakNode::Create(const std::string& module) {
   LOG(INFO) << "Creating Oak Node";
@@ -357,13 +357,6 @@ wabt::interp::HostFunc::Callback OakNode::OakWaitOnChannels(wabt::interp::Enviro
     }
     return wabt::interp::Result::Ok;
   };
-}
-
-grpc::Status OakNode::GetAttestation(grpc::ServerContext* context,
-                                     const GetAttestationRequest* request,
-                                     GetAttestationResponse* response) {
-  // TODO: Move this method to the application and implement it there.
-  return ::grpc::Status::OK;
 }
 
 }  // namespace oak

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -33,7 +33,7 @@ namespace oak {
 
 typedef std::unordered_map<Handle, std::unique_ptr<ChannelHalf>> ChannelHalfTable;
 
-class OakNode final : public Application::Service, public NodeThread {
+class OakNode final : public NodeThread {
  public:
   // Creates an Oak node by loading the Wasm module code.
   static std::unique_ptr<OakNode> Create(const std::string& module);
@@ -44,9 +44,6 @@ class OakNode final : public Application::Service, public NodeThread {
   // Clients should construct OakNode instances with Create() (which
   // can fail).
   OakNode();
-
-  grpc::Status GetAttestation(grpc::ServerContext* context, const GetAttestationRequest* request,
-                              GetAttestationResponse* response) override;
 
   void InitEnvironment(wabt::interp::Environment* env);
 

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -46,78 +46,71 @@ asylo::Status OakRuntime::Initialize(const ApplicationConfiguration& config) {
 
   // TODO: Support creating multiple Nodes and Channels connecting them.
   const WebAssemblyNode& web_assembly_node = node_configuration.web_assembly_node();
-  node_ = OakNode::Create(web_assembly_node.module_bytes());
-  if (node_ == nullptr) {
+  auto node = OakNode::Create(web_assembly_node.module_bytes());
+  if (node == nullptr) {
     return asylo::Status(asylo::error::GoogleError::INVALID_ARGUMENT, "Failed to create Oak Node");
   }
 
-  SetUpChannels();
+  // Setup the default channels for the node.
+  SetUpChannels(*node.get());
+
+  // TODO: This needs to be configurable
+  // Create the pseudo node required.
+  grpc_node_ = OakGrpcNode::Create();
+  SetUpGrpcChannels(*node.get());
+
+  // Move ownership to vector.
+  wasm_nodes_.push_back(std::move(node));
 
   return asylo::Status::OkStatus();
 }
-grpc::Service* OakRuntime::GetGrpcService() { return node_.get(); }
 
-asylo::Status OakRuntime::StartCompletionQueue(std::unique_ptr<grpc::AsyncGenericService> service,
-                                               std::unique_ptr<grpc::ServerCompletionQueue> queue) {
-  // Use the serivce and queue provided.
-  // TODO: check to see if we already started this.
-  module_service_ = std::move(service);
-  completion_queue_ = std::move(queue);
+asylo::Status OakRuntime::Start() {
+  LOG(INFO) << "Starting runtime";
+
+  // Start the gRPC pseudo-node.
+  grpc_node_->Start();
 
   // Start the logging pseudo-node thread.
   logging_node_->Start();
-
-  // Start a new thread to process the gRPC completion queue.
-  std::thread thread(&OakRuntime::CompletionQueueLoop, this);
-  thread.detach();
 
   // Start a new thread to process storage requests.
   storage_node_->Start();
 
   // Now all dependencies are running, start the thread for the Node itself.
-  node_->Start();
+  for (auto& node : wasm_nodes_) {
+    node->Start();
+  }
 
   return asylo::Status::OkStatus();
 }
 
-void OakRuntime::SetUpChannels() {
+// Create the default set of channels for given node. For now, this means logging and storage
+// TODO: There probably shouldn't be any default list, as all these should come from the config.
+void OakRuntime::SetUpChannels(OakNode& node) {
   // Create logging channel and pass the read half to a new logging pseudo-node.
   auto logging_channel = std::make_shared<MessageChannel>();
-  node_->SetChannel(ChannelHandle::LOGGING,
-                    absl::make_unique<MessageChannelWriteHalf>(logging_channel));
+  node.SetChannel(ChannelHandle::LOGGING,
+                  absl::make_unique<MessageChannelWriteHalf>(logging_channel));
   logging_node_ =
       absl::make_unique<LoggingNode>(absl::make_unique<MessageChannelReadHalf>(logging_channel));
   LOG(INFO) << "Created logging channel " << ChannelHandle::LOGGING << " and pseudo-node";
-
-  // Create the channels needed for gRPC interactions.
-
-  // Incoming request channel: keep the write half in |OakRuntime|, but map
-  // the read half to a well-known channel handle on |node_|.
-  grpc_in_ = std::make_shared<MessageChannel>();
-  node_->SetChannel(ChannelHandle::GRPC_IN, absl::make_unique<MessageChannelReadHalf>(grpc_in_));
-  LOG(INFO) << "Created gRPC input channel: " << ChannelHandle::GRPC_IN;
-
-  // Outgoing response channel: keep the read half in |OakRuntime|, but map
-  // the write half to a well-known channel handle on |node_|.
-  grpc_out_ = std::make_shared<MessageChannel>();
-  node_->SetChannel(ChannelHandle::GRPC_OUT, absl::make_unique<MessageChannelWriteHalf>(grpc_out_));
-  LOG(INFO) << "Created gRPC output channel: " << ChannelHandle::GRPC_IN;
 
   // Create the channels needed for interaction with storage.
 
   // Outgoing storage request channel: keep the read half in C++, but map the write
   // half to a well-known channel handle.
   auto storage_req_channel = std::make_shared<MessageChannel>();
-  node_->SetChannel(ChannelHandle::STORAGE_OUT,
-                    absl::make_unique<MessageChannelWriteHalf>(storage_req_channel));
+  node.SetChannel(ChannelHandle::STORAGE_OUT,
+                  absl::make_unique<MessageChannelWriteHalf>(storage_req_channel));
   auto storage_req_half = absl::make_unique<MessageChannelReadHalf>(storage_req_channel);
   LOG(INFO) << "Created storage output channel: " << ChannelHandle::STORAGE_OUT;
 
   // Inbound storage response channel: keep the write half in C++, but map the read
   // half to a well-known channel handle.
   auto storage_rsp_channel = std::make_shared<MessageChannel>();
-  node_->SetChannel(ChannelHandle::STORAGE_IN,
-                    absl::make_unique<MessageChannelReadHalf>(storage_rsp_channel));
+  node.SetChannel(ChannelHandle::STORAGE_IN,
+                  absl::make_unique<MessageChannelReadHalf>(storage_rsp_channel));
   auto storage_rsp_half = absl::make_unique<MessageChannelWriteHalf>(storage_rsp_channel);
   LOG(INFO) << "Created storage input channel: " << ChannelHandle::STORAGE_IN;
 
@@ -128,24 +121,39 @@ void OakRuntime::SetUpChannels() {
   LOG(INFO) << "Created storage channels";
 }
 
-void OakRuntime::CompletionQueueLoop() {
-  LOG(INFO) << "Starting gRPC completion queue loop";
-  // The stream object will delete itself when finished with the request,
-  // after creating a new stream object for the next request.
-  auto stream =
-      new ModuleInvocation(module_service_.get(), completion_queue_.get(), grpc_in_, grpc_out_);
-  stream->Start();
-  while (true) {
-    bool ok;
-    void* tag;
-    if (!completion_queue_->Next(&tag, &ok)) {
-      LOG(FATAL) << "Failure reading from completion queue";
-      return;
-    }
-    auto callback = static_cast<std::function<void(bool)>*>(tag);
-    (*callback)(ok);
-    delete callback;
+// Create the channels needed for gRPC interactions.
+void OakRuntime::SetUpGrpcChannels(OakNode& node) {
+  // Incoming request channel: keep the write half in |OakRuntime|, but map
+  // the read half to a well-known channel handle on |node_|.
+  grpc_in_ = std::make_shared<MessageChannel>();
+  node.SetChannel(ChannelHandle::GRPC_IN, absl::make_unique<MessageChannelReadHalf>(grpc_in_));
+  LOG(INFO) << "Created gRPC input channel: " << ChannelHandle::GRPC_IN;
+
+  // Outgoing response channel: keep the read half in |OakRuntime|, but map
+  // the write half to a well-known channel handle on |node_|.
+  grpc_out_ = std::make_shared<MessageChannel>();
+  node.SetChannel(ChannelHandle::GRPC_OUT, absl::make_unique<MessageChannelWriteHalf>(grpc_out_));
+  LOG(INFO) << "Created gRPC output channel: " << ChannelHandle::GRPC_IN;
+
+  grpc_node_->SetUpGrpcChannels(grpc_in_, grpc_out_);
+}
+
+int32_t OakRuntime::GetPort() { return grpc_node_->GetPort(); }
+
+asylo::Status OakRuntime::Stop() {
+  LOG(INFO) << "Stopping runtime...";
+  for (auto& node : wasm_nodes_) {
+    node->Stop();
   }
+  wasm_nodes_.clear();
+
+  // TODO: make grpc_node_ generic
+  if (grpc_node_) {
+    grpc_node_->Stop();
+    grpc_node_ = nullptr;
+  }
+
+  return asylo::Status::OkStatus();
 }
 
 }  // namespace oak


### PR DESCRIPTION
This is another step towards having a fully configurable set of channels
and nodes. It introduces a special (for now) new node that is the GRPC
one. It also decouples the manager-server ownership and moves it to the
runtime

This allows the wasm nodes to stop being gRPC servers.

Next, we need to create a base class for all nodes and start migrating
towards a model where all channels and nodes are configurable and owned
by the runtime