### PR TITLE
Nodes, channels and termination

### DIFF
--- a/examples/hello_world/client/hello_world.cc
+++ b/examples/hello_world/client/hello_world.cc
@@ -80,7 +80,8 @@ int main(int argc, char** argv) {
 
   std::stringstream addr;
   addr << "127.0.0.1:" << create_application_response.grpc_port();
-  LOG(INFO) << "Connecting to Oak Application: " << addr.str();
+  std::string application_id(create_application_response.application_id());
+  LOG(INFO) << "Connecting to Oak Application id=" << application_id << ": " << addr.str();
 
   oak::ApplicationClient::InitializeAssertionAuthorities();
 
@@ -96,6 +97,10 @@ int main(int argc, char** argv) {
   say_hello(stub.get(), "MONDE");
 
   lots_of_replies(stub.get(), "WORLDS");
+
+  // Request termination of the Oak Application.
+  LOG(INFO) << "Terminating application id=" << application_id;
+  manager_client->TerminateApplication(application_id);
 
   return 0;
 }

--- a/examples/hello_world/module/cpp/hello_world.cc
+++ b/examples/hello_world/module/cpp/hello_world.cc
@@ -67,7 +67,10 @@ WASM_EXPORT int32_t oak_main() {
   handle_space[8] = 0x00;  // read ready?
 
   while (true) {
-    wait_on_channels(handle_space, 1);
+    int32_t result = wait_on_channels(handle_space, 1);
+    if (result != oak::OakStatus::OK) {
+      return result;
+    }
 
     channel_read(grpc_in_handle, _buf, sizeof(_buf), &actual_size);
 

--- a/oak/client/manager_client.h
+++ b/oak/client/manager_client.h
@@ -64,6 +64,23 @@ class ManagerClient {
     return response;
   }
 
+  void TerminateApplication(const std::string& application_id) {
+    grpc::ClientContext context;
+
+    TerminateApplicationRequest request;
+    TerminateApplicationResponse response;
+    request.set_application_id(application_id);
+
+    LOG(INFO) << "Terminating Oak Application";
+    grpc::Status status = stub_->TerminateApplication(&context, request, &response);
+    if (!status.ok()) {
+      LOG(ERROR) << "Failed: " << status.error_code() << '/' << status.error_message() << '/'
+                 << status.error_details();
+    }
+
+    LOG(INFO) << "Termination response: " << response.DebugString();
+  }
+
  private:
   std::unique_ptr<Manager::Stub> stub_;
 };

--- a/oak/common/app_config.cc
+++ b/oak/common/app_config.cc
@@ -24,15 +24,15 @@
 
 namespace oak {
 
-namespace {
-
 // Names of ports that are implicitly defined for pseudo-Node instances,
 // as described in //oak/proto/manager.proto.
-constexpr char kGrpcNodeRequestPortName[] = "request";
-constexpr char kGrpcNodeResponsePortName[] = "response";
-constexpr char kLoggingNodePortName[] = "in";
-constexpr char kStorageNodeRequestPortName[] = "request";
-constexpr char kStorageNodeResponsePortName[] = "response";
+const char kGrpcNodeRequestPortName[] = "request";
+const char kGrpcNodeResponsePortName[] = "response";
+const char kLoggingNodePortName[] = "in";
+const char kStorageNodeRequestPortName[] = "request";
+const char kStorageNodeResponsePortName[] = "response";
+
+namespace {
 
 // Conventional names for pseudo-node instances (not specified in the proto
 // definition).

--- a/oak/common/app_config.h
+++ b/oak/common/app_config.h
@@ -23,6 +23,12 @@
 
 namespace oak {
 
+extern const char kGrpcNodeRequestPortName[];
+extern const char kGrpcNodeResponsePortName[];
+extern const char kLoggingNodePortName[];
+extern const char kStorageNodeRequestPortName[];
+extern const char kStorageNodeResponsePortName[];
+
 // Build a default application configuration with a single Wasm node of the given
 // name and contents, accessible via gRPC.
 std::unique_ptr<ApplicationConfiguration> DefaultConfig(const std::string& name,

--- a/oak/proto/manager.proto
+++ b/oak/proto/manager.proto
@@ -145,6 +145,13 @@ message CreateApplicationResponse {
   int32 grpc_port = 2;
 }
 
+message TerminateApplicationRequest {
+  string application_id = 1;
+}
+
+message TerminateApplicationResponse {
+}
+
 // Untrusted service in charge of creating Oak Applications on demand.
 service Manager {
   // Request the creation of a new Oak Application with the specified configuration.
@@ -153,4 +160,7 @@ service Manager {
   // endpoint via gRPC and perform a direct attestation against the Node itself,
   // to verify that its configuration corresponds to what the client expects.
   rpc CreateApplication(CreateApplicationRequest) returns (CreateApplicationResponse);
+
+  // Request that an Oak Application terminate.
+  rpc TerminateApplication(TerminateApplicationRequest) returns (TerminateApplicationResponse);
 }

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -29,11 +29,13 @@ test_suite(
 
 cc_library(
     name = "oak_node",
+    srcs = ["oak_node.cc"],
     hdrs = ["oak_node.h"],
     deps = [
         ":channel",
         "//oak/common:handles",
         "@com_google_absl//absl/synchronization",
+        "@com_google_asylo//asylo/util:logging",
     ],
 )
 

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -100,7 +100,7 @@ cc_library(
     srcs = ["module_invocation.cc"],
     hdrs = ["module_invocation.h"],
     deps = [
-        ":oak_node",
+        ":channel",
         "//oak/proto:grpc_encap_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_asylo//asylo/util:logging",

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -28,6 +28,16 @@ test_suite(
 )
 
 cc_library(
+    name = "oak_node",
+    hdrs = ["oak_node.h"],
+    deps = [
+        ":channel",
+        "//oak/common:handles",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+cc_library(
     name = "wasm_node",
     srcs = [
         "wabt_output.cc",
@@ -87,6 +97,7 @@ cc_library(
     deps = [
         ":channel",
         ":module_invocation",
+        ":oak_node",
         "//oak/proto:application_cc_grpc",
         "//oak/proto:enclave_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
@@ -153,6 +164,7 @@ cc_library(
     srcs = ["node_thread.cc"],
     hdrs = ["node_thread.h"],
     deps = [
+        ":oak_node",
         "@com_google_asylo//asylo/util:logging",
     ],
 )

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -100,6 +100,7 @@ cc_library(
         ":channel",
         ":module_invocation",
         ":oak_node",
+        "//oak/common:app_config",
         "//oak/proto:application_cc_grpc",
         "//oak/proto:enclave_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
@@ -178,6 +179,7 @@ cc_library(
     deps = [
         ":channel",
         ":node_thread",
+        "//oak/common:app_config",
         "//oak/common:handles",
         "@com_google_absl//absl/memory",
         "@com_google_asylo//asylo/util:logging",

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -178,6 +178,8 @@ cc_library(
     deps = [
         ":channel",
         ":node_thread",
+        "//oak/common:handles",
+        "@com_google_absl//absl/memory",
         "@com_google_asylo//asylo/util:logging",
     ],
 )

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -28,14 +28,14 @@ test_suite(
 )
 
 cc_library(
-    name = "oak_node",
+    name = "wasm_node",
     srcs = [
-        "oak_node.cc",
         "wabt_output.cc",
+        "wasm_node.cc",
     ],
     hdrs = [
-        "oak_node.h",
         "wabt_output.h",
+        "wasm_node.h",
     ],
     deps = [
         ":channel",
@@ -55,17 +55,17 @@ cc_library(
 )
 
 cc_test(
-    name = "oak_node_test",
+    name = "wasm_node_test",
     srcs = [
-        "oak_node_test.cc",
         "wabt_output_test.cc",
+        "wasm_node_test.cc",
     ],
     data = [
         ":testdata",
     ],
     tags = ["host"],
     deps = [
-        ":oak_node",
+        ":wasm_node",
         "@gtest//:gtest_main",
     ],
 )
@@ -114,7 +114,7 @@ cc_library(
     deps = [
         ":module_invocation",
         ":oak_grpc_node",
-        ":oak_node",
+        ":wasm_node",
         "//oak/common:app_config",
         "//oak/proto:enclave_cc_proto",
         "//oak/server:logging_node",

--- a/oak/server/asylo/asylo_oak_manager.cc
+++ b/oak/server/asylo/asylo_oak_manager.cc
@@ -49,6 +49,15 @@ grpc::Status AsyloOakManager::CreateApplication(grpc::ServerContext* context,
   return grpc::Status::OK;
 }
 
+grpc::Status AsyloOakManager::TerminateApplication(grpc::ServerContext* context,
+                                                   const oak::TerminateApplicationRequest* request,
+                                                   oak::TerminateApplicationResponse* response) {
+  LOG(INFO) << "Terminating application with ID " << request->application_id();
+
+  DestroyEnclave(request->application_id());
+  return grpc::Status::OK;
+}
+
 void AsyloOakManager::InitializeEnclaveManager() {
   LOG(INFO) << "Initializing enclave manager";
   asylo::EnclaveManager::Configure(asylo::EnclaveManagerOptions());
@@ -86,7 +95,7 @@ grpc::Status AsyloOakManager::CreateEnclave(
 
 asylo::StatusOr<oak::InitializeOutput> AsyloOakManager::GetEnclaveOutput(
     const std::string& node_id) {
-  LOG(INFO) << "Initializing enclave";
+  LOG(INFO) << "Initializing enclave " << node_id;
   asylo::EnclaveClient* client = enclave_manager_->GetClient(node_id);
   asylo::EnclaveInput input;
   asylo::EnclaveOutput output;
@@ -108,7 +117,7 @@ std::string AsyloOakManager::NewApplicationId() {
 }
 
 void AsyloOakManager::DestroyEnclave(const std::string& node_id) {
-  LOG(INFO) << "Destroying enclave";
+  LOG(INFO) << "Destroying enclave " << node_id;
   asylo::EnclaveClient* client = enclave_manager_->GetClient(node_id);
   asylo::EnclaveFinal final_input;
   asylo::Status status = enclave_manager_->DestroyEnclave(client, final_input);

--- a/oak/server/asylo/asylo_oak_manager.h
+++ b/oak/server/asylo/asylo_oak_manager.h
@@ -36,6 +36,10 @@ class AsyloOakManager final : public Manager::Service {
                                  const CreateApplicationRequest* request,
                                  CreateApplicationResponse* response) override;
 
+  grpc::Status TerminateApplication(grpc::ServerContext* context,
+                                    const TerminateApplicationRequest* request,
+                                    TerminateApplicationResponse* response) override;
+
  private:
   void InitializeEnclaveManager();
 

--- a/oak/server/asylo/enclave_server.cc
+++ b/oak/server/asylo/enclave_server.cc
@@ -35,7 +35,6 @@
 #include "include/grpcpp/server_builder.h"
 #include "oak/proto/enclave.pb.h"
 #include "oak/server/module_invocation.h"
-#include "oak/server/oak_node.h"
 #include "oak/server/oak_runtime.h"
 
 namespace oak {

--- a/oak/server/asylo/enclave_server.h
+++ b/oak/server/asylo/enclave_server.h
@@ -34,7 +34,6 @@
 #include "include/grpcpp/security/server_credentials.h"
 #include "include/grpcpp/server.h"
 #include "oak/proto/enclave.pb.h"
-#include "oak/server/oak_node.h"
 #include "oak/server/oak_runtime.h"
 
 namespace oak {

--- a/oak/server/channel.h
+++ b/oak/server/channel.h
@@ -73,6 +73,9 @@ class ChannelHalf {
     return nothing;
   }
 
+  // BlockingRead behaves like Read but blocks until a message is available.
+  virtual ReadResult BlockingRead(uint32_t size) { return Read(size); }
+
   // Indicate whether a Read operation would return a message.
   virtual bool CanRead() { return false; }
 
@@ -100,7 +103,7 @@ class MessageChannel final : public ChannelHalf {
   ReadResult Read(uint32_t size) override LOCKS_EXCLUDED(mu_);
 
   // BlockingRead behaves like Read but blocks until a message is available.
-  ReadResult BlockingRead(uint32_t size) LOCKS_EXCLUDED(mu_);
+  ReadResult BlockingRead(uint32_t size) override LOCKS_EXCLUDED(mu_);
 
   // Write passes ownership of a message to the channel.
   void Write(std::unique_ptr<Message> data) override LOCKS_EXCLUDED(mu_);
@@ -120,7 +123,7 @@ class MessageChannelReadHalf final : public ChannelHalf {
   MessageChannelReadHalf(std::shared_ptr<MessageChannel> channel) : channel_(channel) {}
   ReadResult Read(uint32_t size) override { return channel_->Read(size); }
   bool CanRead() override { return channel_->Count() > 0; }
-  ReadResult BlockingRead(uint32_t size) { return channel_->BlockingRead(size); }
+  ReadResult BlockingRead(uint32_t size) override { return channel_->BlockingRead(size); }
   void Await() override { return channel_->Await(); }
 
  private:

--- a/oak/server/channel.h
+++ b/oak/server/channel.h
@@ -137,6 +137,13 @@ class MessageChannelWriteHalf final : public ChannelHalf {
   std::shared_ptr<MessageChannel> channel_;
 };
 
+// Current readable status of a channel.
+struct ChannelStatus {
+  explicit ChannelStatus(uint64_t h) : handle(h) {}
+  uint64_t handle;
+  bool ready;
+};
+
 }  // namespace oak
 
 #endif  // OAK_SERVER_CHANNEL_H_

--- a/oak/server/dev/dev_oak_manager.cc
+++ b/oak/server/dev/dev_oak_manager.cc
@@ -57,6 +57,22 @@ grpc::Status DevOakManager::CreateApplication(grpc::ServerContext* context,
   return grpc::Status::OK;
 }
 
+grpc::Status DevOakManager::TerminateApplication(grpc::ServerContext* context,
+                                                 const oak::TerminateApplicationRequest* request,
+                                                 oak::TerminateApplicationResponse* response) {
+  LOG(INFO) << "Terminating application with ID " << request->application_id();
+
+  OakRuntime* runtime = runtimes_[request->application_id()].get();
+  if (runtime == nullptr) {
+    LOG(ERROR) << "Unrecognized application ID";
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Unknown application ID");
+  }
+  runtime->Stop();
+  LOG(INFO) << "Application with ID " << request->application_id() << " stopped";
+  runtimes_.erase(request->application_id());
+  return grpc::Status::OK;
+}
+
 // Even if we are not running in an enclave, we are still relying on Asylo assertion authorities
 // This allows us to use the same client code to connect to the runtime, and it will potentially
 // allow us to use non-enclave identities in the future.

--- a/oak/server/dev/dev_oak_manager.h
+++ b/oak/server/dev/dev_oak_manager.h
@@ -34,6 +34,10 @@ class DevOakManager final : public Manager::Service {
                                  const CreateApplicationRequest* request,
                                  CreateApplicationResponse* response) override;
 
+  grpc::Status TerminateApplication(grpc::ServerContext* context,
+                                    const TerminateApplicationRequest* request,
+                                    TerminateApplicationResponse* response) override;
+
  private:
   void CreateServer();
   void InitializeAssertionAuthorities();

--- a/oak/server/logging_node.cc
+++ b/oak/server/logging_node.cc
@@ -18,22 +18,20 @@
 
 #include "absl/memory/memory.h"
 #include "asylo/util/logging.h"
+#include "oak/common/app_config.h"
 
 namespace oak {
 
-void LoggingNode::AddChannel(std::unique_ptr<MessageChannelReadHalf> half) {
-  handle_ = OakNode::AddChannel(std::move(half));
-}
-
 void LoggingNode::Run() {
   // Borrow pointer to the channel half.
-  ChannelHalf* channel = BorrowChannel(handle_);
+  Handle handle = FindChannel(kLoggingNodePortName);
+  ChannelHalf* channel = BorrowChannel(handle);
   if (channel == nullptr) {
     LOG(ERROR) << "No channel available!";
     return;
   }
   std::vector<std::unique_ptr<ChannelStatus>> status;
-  status.push_back(absl::make_unique<ChannelStatus>(handle_));
+  status.push_back(absl::make_unique<ChannelStatus>(handle));
   while (true) {
     if (!WaitOnChannels(&status)) {
       LOG(WARNING) << "Node termination requested";

--- a/oak/server/logging_node.cc
+++ b/oak/server/logging_node.cc
@@ -16,13 +16,30 @@
 
 #include "oak/server/logging_node.h"
 
+#include "absl/memory/memory.h"
 #include "asylo/util/logging.h"
 
 namespace oak {
 
+void LoggingNode::AddChannel(std::unique_ptr<MessageChannelReadHalf> half) {
+  handle_ = OakNode::AddChannel(std::move(half));
+}
+
 void LoggingNode::Run() {
+  // Borrow pointer to the channel half.
+  ChannelHalf* channel = BorrowChannel(handle_);
+  if (channel == nullptr) {
+    LOG(ERROR) << "No channel available!";
+    return;
+  }
+  std::vector<std::unique_ptr<ChannelStatus>> status;
+  status.push_back(absl::make_unique<ChannelStatus>(handle_));
   while (true) {
-    ReadResult result = half_->BlockingRead(INT_MAX);
+    if (!WaitOnChannels(&status)) {
+      LOG(WARNING) << "Node termination requested";
+      return;
+    }
+    ReadResult result = channel->Read(INT_MAX);
     if (result.required_size > 0) {
       LOG(ERROR) << "Message size too large: " << result.required_size;
       return;

--- a/oak/server/logging_node.h
+++ b/oak/server/logging_node.h
@@ -29,15 +29,10 @@ namespace oak {
 // Pseudo-node to perform logging.
 class LoggingNode final : public NodeThread {
  public:
-  LoggingNode() : NodeThread("logging"), handle_(0) {}
-
-  // Add the inbound channel (with implicit port name "in").
-  void AddChannel(std::unique_ptr<MessageChannelReadHalf> half);
+  explicit LoggingNode(const std::string& name) : NodeThread(name) {}
 
  private:
   void Run() override;
-
-  Handle handle_;
 };
 
 }  // namespace oak

--- a/oak/server/logging_node.h
+++ b/oak/server/logging_node.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <thread>
 
+#include "oak/common/handles.h"
 #include "oak/server/channel.h"
 #include "oak/server/node_thread.h"
 
@@ -28,15 +29,15 @@ namespace oak {
 // Pseudo-node to perform logging.
 class LoggingNode final : public NodeThread {
  public:
-  LoggingNode() : NodeThread("logging"), half_(nullptr) {}
+  LoggingNode() : NodeThread("logging"), handle_(0) {}
 
   // Add the inbound channel (with implicit port name "in").
-  void AddChannel(std::unique_ptr<MessageChannelReadHalf> half) { half_ = std::move(half); }
+  void AddChannel(std::unique_ptr<MessageChannelReadHalf> half);
 
  private:
   void Run() override;
 
-  std::unique_ptr<MessageChannelReadHalf> half_;
+  Handle handle_;
 };
 
 }  // namespace oak

--- a/oak/server/module_invocation.h
+++ b/oak/server/module_invocation.h
@@ -30,7 +30,7 @@ class ModuleInvocation {
   // All constructor arguments must outlive this object.  It manages its own
   // lifetime after RequestNext is called.
   ModuleInvocation(grpc::AsyncGenericService* service, grpc::ServerCompletionQueue* queue,
-                   MessageChannelWriteHalf* req_half, MessageChannelReadHalf* rsp_half)
+                   ChannelHalf* req_half, ChannelHalf* rsp_half)
       : service_(service),
         queue_(queue),
         req_half_(req_half),
@@ -69,8 +69,8 @@ class ModuleInvocation {
   grpc::ServerCompletionQueue* const queue_;
 
   // Borrowed references to the channels used to communication for invocation.
-  MessageChannelWriteHalf* req_half_;
-  MessageChannelReadHalf* rsp_half_;
+  ChannelHalf* req_half_;
+  ChannelHalf* rsp_half_;
 
   grpc::GenericServerContext context_;
   grpc::GenericServerAsyncReaderWriter stream_;

--- a/oak/server/module_invocation.h
+++ b/oak/server/module_invocation.h
@@ -18,7 +18,8 @@
 #define OAK_SERVER_MODULE_INVOCATION_H_
 
 #include "include/grpcpp/generic/async_generic_service.h"
-#include "oak/server/oak_node.h"
+#include "include/grpcpp/grpcpp.h"
+#include "oak/server/channel.h"
 
 namespace oak {
 

--- a/oak/server/node_thread.h
+++ b/oak/server/node_thread.h
@@ -17,33 +17,31 @@
 #ifndef OAK_SERVER_NODE_THREAD_H_
 #define OAK_SERVER_NODE_THREAD_H_
 
-#include <atomic>
 #include <memory>
 #include <thread>
+
+#include "oak/server/oak_node.h"
 
 namespace oak {
 
 // This class represents a node or pseudo-node that executes as a distinct
 // thread.
-class NodeThread {
+class NodeThread : public OakNode {
  public:
   // Construct a thread, identified by the given name in diagnostic messages.
-  NodeThread(const std::string& name) : name_(name), termination_pending_(false) {}
+  NodeThread(const std::string& name) : OakNode(name) {}
   virtual ~NodeThread();
 
   // Start kicks off a separate thread that invokes the Run() method.
-  void Start();
+  void Start() override;
 
   // Stop terminates the thread associated with the pseudo-node.
-  void Stop();
+  void Stop() override;
 
  protected:
   // The Run() method is run on a new thread, and should respond to termination requests
   // (indicated by termination_pending_.load()) in a timely manner.
   virtual void Run() = 0;
-
-  const std::string name_;
-  std::atomic_bool termination_pending_;
 
  private:
   std::thread thread_;

--- a/oak/server/oak_grpc_node.cc
+++ b/oak/server/oak_grpc_node.cc
@@ -16,6 +16,8 @@
 
 #include "oak/server/oak_grpc_node.h"
 
+#include <thread>
+
 #include "absl/memory/memory.h"
 #include "asylo/grpc/auth/enclave_server_credentials.h"
 #include "asylo/grpc/auth/null_credentials_options.h"

--- a/oak/server/oak_grpc_node.cc
+++ b/oak/server/oak_grpc_node.cc
@@ -55,12 +55,11 @@ std::unique_ptr<OakGrpcNode> OakGrpcNode::Create() {
   return node;
 }
 
-grpc::Status OakGrpcNode::Start() {
+void OakGrpcNode::Start() {
   // Start a new thread to process the gRPC completion queue.
   std::thread thread(&OakGrpcNode::CompletionQueueLoop, this);
   thread.detach();
   // TODO: This thread will need to be joined once we sort out termination.
-  return grpc::Status::OK;
 }
 
 void OakGrpcNode::CompletionQueueLoop() {
@@ -98,13 +97,12 @@ grpc::Status OakGrpcNode::GetAttestation(grpc::ServerContext* context,
   return ::grpc::Status::OK;
 }
 
-grpc::Status OakGrpcNode::Stop() {
+void OakGrpcNode::Stop() {
   if (server_) {
     LOG(INFO) << "Shutting down...";
     server_->Shutdown();
     server_ = nullptr;
   }
-  return grpc::Status::OK;
 }
 
 }  // namespace oak

--- a/oak/server/oak_grpc_node.h
+++ b/oak/server/oak_grpc_node.h
@@ -26,22 +26,16 @@ namespace oak {
 
 class OakGrpcNode final : public Application::Service, public OakNode {
  public:
-  static std::unique_ptr<OakGrpcNode> Create();
+  static std::unique_ptr<OakGrpcNode> Create(const std::string& name);
   virtual ~OakGrpcNode(){};
 
   void Start() override;
   void Stop() override;
 
-  // Add the inbound channel (with implicit port name "response").
-  void AddReadChannel(std::unique_ptr<MessageChannelReadHalf> rsp_half);
-
-  // Add the outbound channel (with implicit port name "request").
-  void AddWriteChannel(std::unique_ptr<MessageChannelWriteHalf> req_half);
-
   int GetPort() { return port_; };
 
  private:
-  OakGrpcNode() : OakNode("grpc") {}
+  OakGrpcNode(const std::string& name) : OakNode(name) {}
   OakGrpcNode(const OakGrpcNode&) = delete;
   OakGrpcNode& operator=(const OakGrpcNode&) = delete;
 
@@ -52,9 +46,6 @@ class OakGrpcNode final : public Application::Service, public OakNode {
   void CompletionQueueLoop();
 
   int port_;
-
-  std::unique_ptr<MessageChannelWriteHalf> req_half_;
-  std::unique_ptr<MessageChannelReadHalf> rsp_half_;
 
   std::unique_ptr<::grpc::Server> server_;
 

--- a/oak/server/oak_grpc_node.h
+++ b/oak/server/oak_grpc_node.h
@@ -17,6 +17,8 @@
 #ifndef OAK_SERVER_OAK_GRPC_NODE_H_
 #define OAK_SERVER_OAK_GRPC_NODE_H_
 
+#include <thread>
+
 #include "include/grpcpp/grpcpp.h"
 #include "oak/proto/application.grpc.pb.h"
 #include "oak/server/channel.h"
@@ -53,6 +55,7 @@ class OakGrpcNode final : public Application::Service, public OakNode {
   std::unique_ptr<grpc::AsyncGenericService> module_service_;
   // The queue expects to deal with void* tag values that are always function pointers to
   // void(bool) functions.
+  std::thread queue_thread_;
   std::unique_ptr<grpc::ServerCompletionQueue> completion_queue_;
 };
 

--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/server/oak_node.h"
+
+#include "asylo/util/logging.h"
+
+namespace oak {
+
+Handle OakNode::AddNamedChannel(const std::string& port_name, std::unique_ptr<ChannelHalf> half) {
+  absl::MutexLock lock(&mu_);
+  Handle handle = ++next_handle_;
+  LOG(INFO) << "port name '" << port_name << "' maps to handle " << handle;
+  named_channels_[port_name] = handle;
+  channel_halves_[handle] = std::move(half);
+  return handle;
+}
+
+Handle OakNode::AddChannel(std::unique_ptr<ChannelHalf> half) {
+  absl::MutexLock lock(&mu_);
+  Handle handle = ++next_handle_;
+  channel_halves_[handle] = std::move(half);
+  return handle;
+}
+
+ChannelHalf* OakNode::BorrowChannel(Handle handle) {
+  absl::ReaderMutexLock lock(&mu_);
+  return channel_halves_[handle].get();
+}
+
+Handle OakNode::FindChannel(const std::string& port_name) {
+  absl::ReaderMutexLock lock(&mu_);
+  auto it = named_channels_.find(port_name);
+  if (it == named_channels_.end()) {
+    return 0;
+  }
+  return it->second;
+}
+
+}  // namespace oak

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -18,19 +18,55 @@
 #define OAK_SERVER_NODE_H_
 
 #include <atomic>
+#include <memory>
+#include <unordered_map>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "oak/common/handles.h"
+#include "oak/server/channel.h"
 
 namespace oak {
 
 class OakNode {
  public:
-  OakNode(const std::string& name) : name_(name), termination_pending_(false) {}
+  OakNode(const std::string& name) : name_(name), termination_pending_(false), next_handle_(0) {}
   virtual ~OakNode() {}
+
   virtual void Start() = 0;
   virtual void Stop() = 0;
+
+  // Add channel identified by the given port name to the node.  This must
+  // only be called before the node is started (with Start()).
+  Handle AddNamedChannel(const std::string& port_name, std::unique_ptr<ChannelHalf> half)
+      LOCKS_EXCLUDED(mu_);
+
+  // Take ownership of the given channel half, returning a channel handle that
+  // the node can use to refer to it in future.
+  Handle AddChannel(std::unique_ptr<ChannelHalf> half) LOCKS_EXCLUDED(mu_);
+
+  // Return a borrowed reference to the channel half identified by the given
+  // handle (or nullptr if the handle is not recognized).
+  ChannelHalf* BorrowChannel(Handle handle) LOCKS_EXCLUDED(mu_);
+
+  // Find the channel handle identified by the given port name.
+  Handle FindChannel(const std::string& port_name) LOCKS_EXCLUDED(mu_);
 
  protected:
   const std::string name_;
   std::atomic_bool termination_pending_;
+
+ private:
+  using ChannelHalfTable = std::unordered_map<Handle, std::unique_ptr<ChannelHalf>>;
+
+  mutable absl::Mutex mu_;  // protects next_handle_, named_channels_, channel_halves_
+
+  // Map from pre-configured port names to channel handles.
+  Handle next_handle_ GUARDED_BY(mu_);
+  std::unordered_map<std::string, Handle> named_channels_ GUARDED_BY(mu_);
+
+  // Map from channel handles to channel half instances.
+  ChannelHalfTable channel_halves_ GUARDED_BY(mu_);
 };
 
 }  // namespace oak

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_SERVER_NODE_H_
+#define OAK_SERVER_NODE_H_
+
+#include <atomic>
+
+namespace oak {
+
+class OakNode {
+ public:
+  OakNode(const std::string& name) : name_(name), termination_pending_(false) {}
+  virtual ~OakNode() {}
+  virtual void Start() = 0;
+  virtual void Stop() = 0;
+
+ protected:
+  const std::string name_;
+  std::atomic_bool termination_pending_;
+};
+
+}  // namespace oak
+
+#endif  // OAK_SERVER_NODE_H_

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
@@ -51,6 +52,11 @@ class OakNode {
 
   // Find the channel handle identified by the given port name.
   Handle FindChannel(const std::string& port_name) LOCKS_EXCLUDED(mu_);
+
+  // Wait on the given channel handles, modifying the contents of the passed-in
+  // vector.  Returns a boolean indicating whether the wait finished due to node
+  // termination.
+  bool WaitOnChannels(std::vector<std::unique_ptr<ChannelStatus>>* statuses);
 
  protected:
   const std::string name_;

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -102,6 +102,7 @@ int32_t OakRuntime::GetPort() { return grpc_node_->GetPort(); }
 
 asylo::Status OakRuntime::Stop() {
   LOG(INFO) << "Stopping runtime...";
+  grpc_node_ = nullptr;
   for (auto& named_node : nodes_) {
     LOG(INFO) << "Stopping node " << named_node.first;
     named_node.second->Stop();

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -25,7 +25,6 @@
 #include "asylo/util/status_macros.h"
 #include "oak/common/app_config.h"
 #include "oak/server/module_invocation.h"
-#include "oak/server/oak_node.h"
 
 namespace oak {
 
@@ -43,8 +42,8 @@ asylo::Status OakRuntime::Initialize(const ApplicationConfiguration& config) {
   for (const auto& node_config : config.nodes()) {
     if (node_config.has_web_assembly_node()) {
       LOG(INFO) << "Create Wasm node named " << node_config.node_name();
-      std::unique_ptr<OakNode> node =
-          OakNode::Create(node_config.node_name(), node_config.web_assembly_node().module_bytes());
+      std::unique_ptr<WasmNode> node =
+          WasmNode::Create(node_config.node_name(), node_config.web_assembly_node().module_bytes());
       if (node == nullptr) {
         return asylo::Status(asylo::error::GoogleError::INVALID_ARGUMENT,
                              "Failed to create Oak Node");

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -151,7 +151,14 @@ asylo::Status OakRuntime::Stop() {
     grpc_node_->Stop();
     grpc_node_ = nullptr;
   }
-  // TODO: stop other pseudo-Nodes if present
+  if (logging_node_) {
+    logging_node_->Stop();
+    logging_node_ = nullptr;
+  }
+  if (storage_node_) {
+    storage_node_->Stop();
+    storage_node_ = nullptr;
+  }
 
   return asylo::Status::OkStatus();
 }

--- a/oak/server/oak_runtime.h
+++ b/oak/server/oak_runtime.h
@@ -41,7 +41,7 @@ namespace oak {
 
 class OakRuntime {
  public:
-  OakRuntime() = default;
+  OakRuntime() : grpc_node_(nullptr) {}
   virtual ~OakRuntime() = default;
 
   // Initializes a gRPC server. If the server is already initialized, does nothing.
@@ -52,14 +52,12 @@ class OakRuntime {
   int32_t GetPort();
 
  private:
-  // Collection of Wasm nodes indexed by node name.
-  std::map<std::string, std::unique_ptr<WasmNode>> wasm_nodes_;
+  OakRuntime& operator=(const OakRuntime& other) = delete;
 
-  // TODO: These are hardcoded now. Make them generic nodes and channels and use config.
-  // Pseudo-nodes.
-  std::unique_ptr<OakGrpcNode> grpc_node_;
-  std::unique_ptr<LoggingNode> logging_node_;
-  std::unique_ptr<StorageNode> storage_node_;
+  // Collection of nodes indexed by node name.
+  std::map<std::string, std::unique_ptr<OakNode>> nodes_;
+  // Convenience (non-owning) reference to gRPC pseudo-node
+  OakGrpcNode* grpc_node_;
 };  // class OakRuntime
 
 }  // namespace oak

--- a/oak/server/oak_runtime.h
+++ b/oak/server/oak_runtime.h
@@ -28,8 +28,8 @@
 #include "oak/proto/oak_api.pb.h"
 #include "oak/server/logging_node.h"
 #include "oak/server/oak_grpc_node.h"
-#include "oak/server/oak_node.h"
 #include "oak/server/storage/storage_node.h"
+#include "oak/server/wasm_node.h"
 
 namespace oak {
 // OakRuntime contains the common runtime needed for an Oak System. The Runtime is responsible for
@@ -53,7 +53,7 @@ class OakRuntime {
 
  private:
   // Collection of Wasm nodes indexed by node name.
-  std::map<std::string, std::unique_ptr<OakNode> > wasm_nodes_;
+  std::map<std::string, std::unique_ptr<WasmNode>> wasm_nodes_;
 
   // TODO: These are hardcoded now. Make them generic nodes and channels and use config.
   // Pseudo-nodes.

--- a/oak/server/storage/BUILD
+++ b/oak/server/storage/BUILD
@@ -46,6 +46,7 @@ cc_library(
     srcs = ["storage_node.cc"],
     hdrs = ["storage_node.h"],
     deps = [
+        "//oak/common:app_config",
         "//oak/common:handles",
         "//oak/proto:storage_cc_grpc",
         "//oak/proto:storage_channel_cc_proto",

--- a/oak/server/storage/BUILD
+++ b/oak/server/storage/BUILD
@@ -46,6 +46,7 @@ cc_library(
     srcs = ["storage_node.cc"],
     hdrs = ["storage_node.h"],
     deps = [
+        "//oak/common:handles",
         "//oak/proto:storage_cc_grpc",
         "//oak/proto:storage_channel_cc_proto",
         "//oak/server:channel",

--- a/oak/server/storage/storage_node.h
+++ b/oak/server/storage/storage_node.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <thread>
 
+#include "oak/common/handles.h"
 #include "oak/proto/storage.grpc.pb.h"
 #include "oak/server/channel.h"
 #include "oak/server/node_thread.h"
@@ -39,8 +40,8 @@ class StorageNode final : public NodeThread {
  private:
   void Run() override;
 
-  std::unique_ptr<MessageChannelReadHalf> req_half_;
-  std::unique_ptr<MessageChannelWriteHalf> rsp_half_;
+  Handle req_handle_;
+  Handle rsp_handle_;
 
   std::unique_ptr<oak::Storage::Stub> storage_service_;
 };

--- a/oak/server/storage/storage_node.h
+++ b/oak/server/storage/storage_node.h
@@ -29,19 +29,10 @@ namespace oak {
 
 class StorageNode final : public NodeThread {
  public:
-  StorageNode(const std::string& storage_address);
-
-  // Add the inbound channel (with implicit port name "request").
-  void AddReadChannel(std::unique_ptr<MessageChannelReadHalf> req_half);
-
-  // Add the outbound channel (with implicit port name "response").
-  void AddWriteChannel(std::unique_ptr<MessageChannelWriteHalf> rsp_half);
+  StorageNode(const std::string& name, const std::string& storage_address);
 
  private:
   void Run() override;
-
-  Handle req_handle_;
-  Handle rsp_handle_;
 
   std::unique_ptr<oak::Storage::Stub> storage_service_;
 };

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef OAK_SERVER_OAK_NODE_H_
-#define OAK_SERVER_OAK_NODE_H_
+#ifndef OAK_SERVER_WASM_NODE_H_
+#define OAK_SERVER_WASM_NODE_H_
 
 #include <memory>
 #include <thread>
@@ -33,19 +33,18 @@ namespace oak {
 
 using ChannelHalfTable = std::unordered_map<Handle, std::unique_ptr<ChannelHalf>>;
 
-class OakNode final : public NodeThread {
+class WasmNode final : public NodeThread {
  public:
-  // Creates an Oak node by loading the Wasm module code.
-  static std::unique_ptr<OakNode> Create(const std::string& name, const std::string& module);
+  // Creates a Wasm Node by loading the Wasm module code.
+  static std::unique_ptr<WasmNode> Create(const std::string& name, const std::string& module);
 
   // Add channel identified by the given port name to the node.  This should
   // only be called before the node is started (with Start());
   Handle AddNamedChannel(const std::string& port_name, std::unique_ptr<ChannelHalf> channel_half);
 
  private:
-  // Clients should construct OakNode instances with Create() (which
-  // can fail).
-  OakNode(const std::string& name);
+  // Clients should construct WasmNode instances with Create() (which can fail).
+  WasmNode(const std::string& name);
 
   void InitEnvironment(wabt::interp::Environment* env);
 
@@ -77,4 +76,4 @@ class OakNode final : public NodeThread {
 
 }  // namespace oak
 
-#endif  // OAK_SERVER_OAK_NODE_H_
+#endif  // OAK_SERVER_WASM_NODE_H_

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -18,29 +18,16 @@
 #define OAK_SERVER_WASM_NODE_H_
 
 #include <memory>
-#include <thread>
-#include <unordered_map>
 
-#include "absl/base/thread_annotations.h"
-#include "absl/types/span.h"
-#include "oak/common/handles.h"
-#include "oak/proto/application.grpc.pb.h"
-#include "oak/server/channel.h"
 #include "oak/server/node_thread.h"
 #include "src/interp/interp.h"
 
 namespace oak {
 
-using ChannelHalfTable = std::unordered_map<Handle, std::unique_ptr<ChannelHalf>>;
-
 class WasmNode final : public NodeThread {
  public:
   // Creates a Wasm Node by loading the Wasm module code.
   static std::unique_ptr<WasmNode> Create(const std::string& name, const std::string& module);
-
-  // Add channel identified by the given port name to the node.  This should
-  // only be called before the node is started (with Start());
-  Handle AddNamedChannel(const std::string& port_name, std::unique_ptr<ChannelHalf> channel_half);
 
  private:
   // Clients should construct WasmNode instances with Create() (which can fail).
@@ -65,13 +52,6 @@ class WasmNode final : public NodeThread {
   wabt::interp::Environment env_;
   // TODO: Use smart pointers.
   wabt::interp::DefinedModule* module_;
-
-  // Map from pre-configured port names to channel handles.
-  Handle next_handle_;
-  std::unordered_map<std::string, Handle> named_channels_;
-
-  // Map from channel handles to channel half instances.
-  ChannelHalfTable channel_halves_;
 };
 
 }  // namespace oak

--- a/oak/server/wasm_node_test.cc
+++ b/oak/server/wasm_node_test.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "oak/server/oak_node.h"
+#include "oak/server/wasm_node.h"
 
 #include <fstream>
 
@@ -35,29 +35,29 @@ std::string DataFrom(const std::string& filename) {
 
 }  // namespace
 
-TEST(OakNode, MalformedFailure) {
+TEST(WasmNode, MalformedFailure) {
   // No magic.
-  ASSERT_EQ(nullptr, OakNode::Create("test", ""));
+  ASSERT_EQ(nullptr, WasmNode::Create("test", ""));
   // Wrong magic.
-  ASSERT_EQ(nullptr, OakNode::Create("test", std::string("\x00\x61\x73\x6b\x01\x00\x00\x00", 8)));
+  ASSERT_EQ(nullptr, WasmNode::Create("test", std::string("\x00\x61\x73\x6b\x01\x00\x00\x00", 8)));
   // Wrong version.
-  ASSERT_EQ(nullptr, OakNode::Create("test", std::string("\x00\x61\x73\x6d\x09\x00\x00\x00", 8)));
+  ASSERT_EQ(nullptr, WasmNode::Create("test", std::string("\x00\x61\x73\x6d\x09\x00\x00\x00", 8)));
   // Right magic+version, no contents.
-  ASSERT_EQ(nullptr, OakNode::Create("test", DataFrom("oak/server/testdata/empty.wasm")));
+  ASSERT_EQ(nullptr, WasmNode::Create("test", DataFrom("oak/server/testdata/empty.wasm")));
 }
 
-TEST(OakNode, MinimalSuccess) {
-  std::unique_ptr<OakNode> node =
-      OakNode::Create("test", DataFrom("oak/server/testdata/minimal.wasm"));
+TEST(WasmNode, MinimalSuccess) {
+  std::unique_ptr<WasmNode> node =
+      WasmNode::Create("test", DataFrom("oak/server/testdata/minimal.wasm"));
   EXPECT_NE(nullptr, node);
 }
 
-TEST(OakNode, MissingExports) {
-  ASSERT_EQ(nullptr, OakNode::Create("test", DataFrom("oak/server/testdata/missing.wasm")));
+TEST(WasmNode, MissingExports) {
+  ASSERT_EQ(nullptr, WasmNode::Create("test", DataFrom("oak/server/testdata/missing.wasm")));
 }
 
-TEST(OakNode, WrongSignature) {
-  ASSERT_EQ(nullptr, OakNode::Create("test", DataFrom("oak/server/testdata/wrong.wasm")));
+TEST(WasmNode, WrongSignature) {
+  ASSERT_EQ(nullptr, WasmNode::Create("test", DataFrom("oak/server/testdata/wrong.wasm")));
 }
 
 }  // namespace oak


### PR DESCRIPTION
Evolving node processing to a common base `OakNode` class, with all node types deriving from it, some via `NodeThread`.

Along the way, add an initial chunk of code for termination processing.

 Probably easiest to review commit-by-commit, particularly given the rename of `OakNode` to `WasmNode` and subsequent re-use of the `OakNode` name.