### PR TITLE
Add license information to BUILD files

### DIFF
--- a/examples/hello_world/client/BUILD
+++ b/examples/hello_world/client/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 cc_binary(
     name = "client",
     srcs = ["hello_world.cc"],

--- a/examples/hello_world/module/cpp/BUILD
+++ b/examples/hello_world/module/cpp/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 cc_binary(
     name = "hello_world.wasm",
     srcs = ["hello_world.cc"],

--- a/examples/hello_world/proto/BUILD
+++ b/examples/hello_world/proto/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
 )
 
 load(

--- a/examples/machine_learning/client/BUILD
+++ b/examples/machine_learning/client/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 cc_binary(
     name = "client",
     srcs = ["machine_learning.cc"],

--- a/examples/machine_learning/proto/BUILD
+++ b/examples/machine_learning/proto/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
 )
 
 load(

--- a/examples/private_set_intersection/client/BUILD
+++ b/examples/private_set_intersection/client/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 cc_binary(
     name = "client",
     srcs = ["private_set_intersection.cc"],

--- a/examples/private_set_intersection/proto/BUILD
+++ b/examples/private_set_intersection/proto/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
 )
 
 load(

--- a/examples/running_average/client/BUILD
+++ b/examples/running_average/client/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 cc_binary(
     name = "client",
     srcs = ["running_average.cc"],

--- a/examples/running_average/proto/BUILD
+++ b/examples/running_average/proto/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
 )
 
 load(

--- a/examples/rustfmt/client/BUILD
+++ b/examples/rustfmt/client/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 cc_binary(
     name = "client",
     srcs = ["rustfmt.cc"],

--- a/examples/rustfmt/proto/BUILD
+++ b/examples/rustfmt/proto/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
 )
 
 load(

--- a/examples/utils/BUILD
+++ b/examples/utils/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 cc_library(
     name = "utils",
     hdrs = ["utils.h"],

--- a/oak/client/BUILD
+++ b/oak/client/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 cc_library(
     name = "manager_client",
     hdrs = ["manager_client.h"],

--- a/oak/common/BUILD
+++ b/oak/common/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 # Mark tests that can be run on the host system (i.e. with a normal
 # compiler, not the Asylo toolchain) with 'host' tag.
 test_suite(

--- a/oak/module/BUILD
+++ b/oak/module/BUILD
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+package(
+    licenses = ["notice"],
+)
+
 cc_library(
     name = "defines",
     hdrs = ["defines.h"],

--- a/oak/proto/BUILD
+++ b/oak/proto/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
 )
 
 load(

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//oak/server:__subpackages__"],
+    licenses = ["notice"],
 )
 
 load("//oak/server:wabt.bzl", "wasm_group")

--- a/oak/server/asylo/BUILD
+++ b/oak/server/asylo/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//oak/server:__subpackages__"],
+    licenses = ["notice"],
 )
 
 load(

--- a/oak/server/dev/BUILD
+++ b/oak/server/dev/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//oak/server:__subpackages__"],
+    licenses = ["notice"],
 )
 
 cc_library(

--- a/oak/server/storage/BUILD
+++ b/oak/server/storage/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//oak/server:__pkg__"],
+    licenses = ["notice"],
 )
 
 # Mark tests that can be run on the host system (i.e. with a normal

--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -6,6 +6,7 @@ set -o xtrace
 
 # Check which BUILD and .bzl files need to be reformatted.
 find oak examples toolchain \( -type f -name BUILD -o -name '*bzl' \) -exec buildifier -lint=warn -mode=check {} +
+find oak examples toolchain \( -type f -name BUILD \) -exec grep --files-without-match '^    licenses = \["notice"\],$' {} + && (echo 'missing license directive in BUILD file'; exit 1)
 
 # Check shell scripts for common mistakes.
 find scripts -type f -exec shellcheck {} +

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-package(default_visibility = ["//visibility:public"])
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
 
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 


### PR DESCRIPTION
This is needed in order to import the code in //google3/third_party, see
http://go/thirdpartylicenses (internal link).

Add presubmit to ensure we don't forget in the future.