### PR TITLE
Improve caching for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ services:
 cache:
   timeout: 600
   directories:
-    - bazel-cache  # explicit cache directory for Docker Bazel builds (scripts/docker_run)
-    - .cache/bazel  # default cache directory for local Bazel builds
     - rust/target  # cached objects for Rust library code
     - examples/target  # cached objects for Rust example code
 

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -45,7 +45,49 @@ else
 fi
 
 cargo build --release --target=wasm32-unknown-unknown --manifest-path="examples/$TARGET/module/rust/Cargo.toml"
-bazel --output_base="$CACHE_DIR/client" build --symlink_prefix='client-' --compilation_mode="$COMPILATION_MODE" "//examples/$TARGET/client"
+
+bazel_build_flags=(
+    "--symlink_prefix=client-"
+    "--compilation_mode=$COMPILATION_MODE"
+)
+
+# Keep this in sync with /scripts/build_server .
+
+readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
+
+(
+    # Disable xtrace to avoid leaking secrets in logs.
+    set +o xtrace;
+    # Do we have a JSON key for the remote cache.
+    # https://docs.bazel.build/versions/master/remote-caching.html#google-cloud-storage
+    if [[ ! -f "$OAK_REMOTE_CACHE_KEY" ]]; then
+        # Check if this exists in the environment and it is not empty.
+        if [[ -n "${BAZEL_GOOGLE_CREDENTIALS:-}" ]]; then
+            echo "$BAZEL_GOOGLE_CREDENTIALS" > "$OAK_REMOTE_CACHE_KEY"
+        fi
+    fi
+)
+
+# If this variable is set, use the remote cache, assuming it is publicly readable.
+# See https://pantheon.corp.google.com/storage/browser/oak-bazel-cache?project=oak-ci
+if [[ -n "${BAZEL_REMOTE_CACHE_ENABLED:-}" ]]; then
+    bazel_build_flags+=(
+        '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+    )
+    # If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.
+    # Note that this is only needed to write to the cache, not to read from it.
+    if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
+        bazel_build_flags+=(
+            "--google_credentials=$OAK_REMOTE_CACHE_KEY"
+        )
+    else
+        bazel_build_flags+=(
+            '--remote_upload_local_results=false'
+        )
+    fi
+fi
+
+bazel --output_base="$CACHE_DIR/client" build "${bazel_build_flags[@]}" "//examples/$TARGET/client"
 
 readonly CPP_FOLDER="$(find examples/"$TARGET" -type d -name cpp)"
 if [[ -n "$CPP_FOLDER" ]]; then

--- a/scripts/build_server
+++ b/scripts/build_server
@@ -4,28 +4,44 @@ set -o errexit
 set -o nounset
 set -o xtrace
 
-readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
-
-(set -o xtrace;
-# Do we have a JSON key for the remote cache.
-# https://docs.bazel.build/versions/master/remote-caching.html#google-cloud-storage
-if [[ ! -f "$OAK_REMOTE_CACHE_KEY" ]]; then
-    # Check if this exists in the environment and it is not empty.
-    if [[ -n "${BAZEL_GOOGLE_CREDENTIALS:-}" ]]; then
-        echo "$BAZEL_GOOGLE_CREDENTIALS" > "$OAK_REMOTE_CACHE_KEY"
-    fi
-fi
+bazel_build_flags=(
+    '--config=enc-sim'
 )
 
-# If we now have a key file, use it. Otherwise build without remote cache.
-if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
-    bazel build \
-        --remote_cache=https://storage.googleapis.com/oak-bazel-cache \
-        --google_credentials="$OAK_REMOTE_CACHE_KEY" \
-        --config=enc-sim \
-        //oak/server/asylo:oak
-else
-    bazel build \
-        --config=enc-sim \
-        //oak/server/asylo:oak
+# Keep this in sync with /scripts/build_example .
+
+readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
+
+(
+    # Disable xtrace to avoid leaking secrets in logs.
+    set +o xtrace;
+    # Do we have a JSON key for the remote cache.
+    # https://docs.bazel.build/versions/master/remote-caching.html#google-cloud-storage
+    if [[ ! -f "$OAK_REMOTE_CACHE_KEY" ]]; then
+        # Check if this exists in the environment and it is not empty.
+        if [[ -n "${BAZEL_GOOGLE_CREDENTIALS:-}" ]]; then
+            echo "$BAZEL_GOOGLE_CREDENTIALS" > "$OAK_REMOTE_CACHE_KEY"
+        fi
+    fi
+)
+
+# If this variable is set, use the remote cache, assuming it is publicly readable.
+# See https://pantheon.corp.google.com/storage/browser/oak-bazel-cache?project=oak-ci
+if [[ -n "${BAZEL_REMOTE_CACHE_ENABLED:-}" ]]; then
+    bazel_build_flags+=(
+        '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+    )
+    # If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.
+    # Note that this is only needed to write to the cache, not to read from it.
+    if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
+        bazel_build_flags+=(
+            "--google_credentials=$OAK_REMOTE_CACHE_KEY"
+        )
+    else
+        bazel_build_flags+=(
+            '--remote_upload_local_results=false'
+        )
+    fi
 fi
+
+bazel build "${bazel_build_flags[@]}" //oak/server/asylo:oak

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -26,20 +26,22 @@ docker build \
   . 1>&2
 
 docker_run_flags=(
-  "--interactive"
-  "--tty"
-  "--rm"
+  '--interactive'
+  '--tty'
+  '--rm'
   "--user=$DOCKER_UID:$DOCKER_GID"
   "--env=USER=$DOCKER_USER"
+  '--env=BAZEL_REMOTE_CACHE_ENABLED'
+  '--env=BAZEL_GOOGLE_CREDENTIALS'
   "--volume=$PWD/bazel-cache:/.cache/bazel"
   "--volume=$PWD/cargo-cache:/usr/local/cargo/registry"
   "--volume=$PWD:/opt/my-project"
-  "--workdir=/opt/my-project"
-  "--network=host"
+  '--workdir=/opt/my-project'
+  '--network=host'
 )
 
-if [[ "$1" == "--detach" ]]; then
-  docker_run_flags+=("--detach")
+if [[ "$1" == '--detach' ]]; then
+  docker_run_flags+=('--detach')
   docker run "${docker_run_flags[@]}" oak:latest "${@:2}"
 else
   docker run "${docker_run_flags[@]}" oak:latest "$@"


### PR DESCRIPTION
I made our cloud storage bucket publicly readable so that we can rely on
bazel remote cache from any branch. Then in the future we should add the
secret key so that it gets passed only to master.

Remove travis cache for bazel (which is often timing out recently).