### PR TITLE
Fix TODO on Wasm object ownership

### DIFF
--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -80,11 +80,9 @@ static void LogHostFunctionCall(const wabt::interp::HostFunc* func,
 }
 
 static wabt::Result ReadModule(const std::string& module_bytes, wabt::interp::Environment* env,
-                               wabt::Errors* errors, wabt::interp::DefinedModule** out_module) {
+                               wabt::Errors* errors) {
   LOG(INFO) << "Reading module";
   wabt::Result result;
-
-  *out_module = nullptr;
 
   wabt::Features s_features;
   const bool kReadDebugNames = true;
@@ -94,8 +92,9 @@ static wabt::Result ReadModule(const std::string& module_bytes, wabt::interp::En
   wabt::ReadBinaryOptions options(s_features, log_stream, kReadDebugNames, kStopOnFirstError,
                                   kFailOnCustomSectionError);
 
+  wabt::interp::DefinedModule* module = nullptr;
   return wabt::ReadBinaryInterp(env, module_bytes.data(), module_bytes.size(), options, errors,
-                                out_module);
+                                &module);
 }
 
 // Describes an expected export from an Oak module.
@@ -125,7 +124,7 @@ const std::vector<RequiredExport> kRequiredExports({
 
 // Check module exports all required functions with the correct signatures,
 // returning true if so.
-static bool CheckModuleExport(wabt::interp::Environment* env, wabt::interp::DefinedModule* module,
+static bool CheckModuleExport(wabt::interp::Environment* env, wabt::interp::Module* module,
                               const RequiredExport& req) {
   LOG(INFO) << "check for " << req;
   wabt::interp::Export* exp = module->GetExport(req.name_);
@@ -165,8 +164,7 @@ static bool CheckModuleExport(wabt::interp::Environment* env, wabt::interp::Defi
   }
   return true;
 }
-static bool CheckModuleExports(wabt::interp::Environment* env,
-                               wabt::interp::DefinedModule* module) {
+static bool CheckModuleExports(wabt::interp::Environment* env, wabt::interp::Module* module) {
   return std::all_of(
       kRequiredExports.begin(), kRequiredExports.end(),
       [env, module](const RequiredExport& req) { return CheckModuleExport(env, module, req); });
@@ -183,7 +181,7 @@ std::unique_ptr<WasmNode> WasmNode::Create(const std::string& name, const std::s
 
   wabt::Errors errors;
   LOG(INFO) << "Reading module";
-  wabt::Result result = ReadModule(module, &node->env_, &errors, &node->module_);
+  wabt::Result result = ReadModule(module, &node->env_, &errors);
   if (!wabt::Succeeded(result)) {
     LOG(WARNING) << "Could not read module: " << result;
     LOG(WARNING) << "Errors: " << wabt::FormatErrorsToString(errors, wabt::Location::Type::Binary);
@@ -191,7 +189,7 @@ std::unique_ptr<WasmNode> WasmNode::Create(const std::string& name, const std::s
   }
 
   LOG(INFO) << "Reading module done";
-  if (!CheckModuleExports(&node->env_, node->module_)) {
+  if (!CheckModuleExports(&node->env_, node->env_.GetLastModule())) {
     LOG(WARNING) << "Failed to validate module";
     return nullptr;
   }
@@ -234,7 +232,8 @@ void WasmNode::Run() {
 
   LOG(INFO) << "module execution thread: run oak_main";
   wabt::interp::TypedValues args;
-  wabt::interp::ExecResult exec_result = executor.RunExportByName(module_, "oak_main", args);
+  wabt::interp::ExecResult exec_result =
+      executor.RunExportByName(env_.GetLastModule(), "oak_main", args);
 
   if (exec_result.result != wabt::interp::Result::Ok) {
     LOG(ERROR) << "execution failure: " << wabt::interp::ResultToString(exec_result.result);

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -189,7 +189,7 @@ std::unique_ptr<WasmNode> WasmNode::Create(const std::string& name, const std::s
   }
 
   LOG(INFO) << "Reading module done";
-  if (!CheckModuleExports(&node->env_, node->env_.GetLastModule())) {
+  if (!CheckModuleExports(&node->env_, node->Module())) {
     LOG(WARNING) << "Failed to validate module";
     return nullptr;
   }
@@ -232,8 +232,7 @@ void WasmNode::Run() {
 
   LOG(INFO) << "module execution thread: run oak_main";
   wabt::interp::TypedValues args;
-  wabt::interp::ExecResult exec_result =
-      executor.RunExportByName(env_.GetLastModule(), "oak_main", args);
+  wabt::interp::ExecResult exec_result = executor.RunExportByName(Module(), "oak_main", args);
 
   if (exec_result.result != wabt::interp::Result::Ok) {
     LOG(ERROR) << "execution failure: " << wabt::interp::ResultToString(exec_result.result);

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -35,6 +35,9 @@ class WasmNode final : public NodeThread {
 
   void InitEnvironment(wabt::interp::Environment* env);
 
+  // Return a (borrowed) pointer to the Web Assembly module for the Node.
+  wabt::interp::Module* Module() { return env_.GetLastModule(); }
+
   void Run() override;
 
   // Native implementation of the `oak.channel_read` host function.

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -50,7 +50,9 @@ class WasmNode final : public NodeThread {
   wabt::interp::HostFunc::Callback OakChannelFind(wabt::interp::Environment* env);
 
   wabt::interp::Environment env_;
-  // TODO: Use smart pointers.
+  // Non-owning reference to (sole) Wasm module for convenience (the owning
+  // reference is held in env_); basically equivalent to:
+  //   dynamic_cast<DefinedModule>(env_->GetLastModule()).
   wabt::interp::DefinedModule* module_;
 };
 

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -50,10 +50,6 @@ class WasmNode final : public NodeThread {
   wabt::interp::HostFunc::Callback OakChannelFind(wabt::interp::Environment* env);
 
   wabt::interp::Environment env_;
-  // Non-owning reference to (sole) Wasm module for convenience (the owning
-  // reference is held in env_); basically equivalent to:
-  //   dynamic_cast<DefinedModule>(env_->GetLastModule()).
-  wabt::interp::DefinedModule* module_;
 };
 
 }  // namespace oak


### PR DESCRIPTION
Multiple choice PR:
 - [ ] Take just the first commit, which documents current ownership setup.
 - [ ] Take the second commit (squashed), which drops the extra reference.
 - [ ] Take the third commit (squashed), which uses an accessor to wrap `GetLastModule`
