### PR TITLE
Check bounds of all linear memory references

### DIFF
--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -39,8 +39,9 @@ namespace oak {
 static std::unique_ptr<wabt::FileStream> s_log_stream = wabt::FileStream::CreateStdout();
 static std::unique_ptr<wabt::FileStream> s_stdout_stream = wabt::FileStream::CreateStdout();
 
-static bool MemoryAvailable(wabt::interp::Environment* env, const uint32_t offset, const uint32_t size) {
-  return ((offset + size) <=  env->GetMemory(0)->data.size());
+static bool MemoryAvailable(wabt::interp::Environment* env, const uint32_t offset,
+                            const uint32_t size) {
+  return ((offset + size) <= env->GetMemory(0)->data.size());
 }
 
 static absl::Span<const char> ReadMemory(wabt::interp::Environment* env, const uint32_t offset,

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -454,7 +454,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakChannelCreate(wabt::interp::Enviro
 
     uint32_t write_half_offset = args[0].get_i32();
     uint32_t read_half_offset = args[1].get_i32();
-    if (!MemoryAvailable(env, write_half_offset, 4) || !MemoryAvailable(env, read_half_offset, 4)) {
+    if (!MemoryAvailable(env, write_half_offset, 8) || !MemoryAvailable(env, read_half_offset, 8)) {
       LOG(WARNING) << "Node provided invalid memory offset+size";
       results[0].set_i32(OakStatus::ERR_INVALID_ARGS);
       return wabt::interp::Result::Ok;


### PR DESCRIPTION
For any offset+size parameters passed to Oak host functions, check
that the corresponding linear memory range is actually available
before using it.  Fixes #219.