### PR TITLE
Load [cc_]proto_library targets from Starlark

### DIFF
--- a/examples/hello_world/proto/BUILD
+++ b/examples/hello_world/proto/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/examples/machine_learning/proto/BUILD
+++ b/examples/machine_learning/proto/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/examples/multinode/proto/BUILD
+++ b/examples/multinode/proto/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/examples/private_set_intersection/proto/BUILD
+++ b/examples/private_set_intersection/proto/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/examples/running_average/proto/BUILD
+++ b/examples/running_average/proto/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/examples/rustfmt/proto/BUILD
+++ b/examples/rustfmt/proto/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/oak/proto/BUILD
+++ b/oak/proto/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],


### PR DESCRIPTION
This generates a warning in recent versions of buildifier, cf.
https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#native-proto