### PR TITLE
Cache docker images to Google Container Registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,23 @@ jobs:
   include:
     - name: check formatting
       script:
+      - ./scripts/docker_pull
       - ./scripts/docker_run ./scripts/check_formatting
     - name: build server
       script:
       - echo "build --show_progress_rate_limit=5.0" >> .bazelrc
+      - ./scripts/docker_pull
       - ./scripts/docker_run ./scripts/build_server
       - ./scripts/docker_run ./scripts/build_dev_server
     - name: run examples
       script:
       - echo "build --show_progress_rate_limit=5.0" >> .bazelrc
+      - ./scripts/docker_pull
       - ./scripts/run_examples
       - ./scripts/docker_run ./scripts/check_generated
     - name: run tests
       script:
       - echo "build --show_progress_rate_limit=5.0" >> .bazelrc
+      - ./scripts/docker_pull
       - ./scripts/docker_run ./scripts/run_tests
       - ./scripts/docker_run ./scripts/check_generated

--- a/scripts/docker_pull
+++ b/scripts/docker_pull
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script can be used by anyone, including CI, to pull a version of the image from Google
+# Container Registry, which should allow download public downloads.
+# See https://pantheon.corp.google.com/gcr/settings?project=oak-ci&folder&organizationId=433637338589
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+# See https://pantheon.corp.google.com/gcr/images/oak-ci/GLOBAL/oak
+readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak'
+
+docker pull "$DOCKER_IMAGE_NAME:latest"

--- a/scripts/docker_push
+++ b/scripts/docker_push
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# This script should be used by logged-in users with write access to the Google Container Registry
+# to push a new version of the image.
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+# See https://pantheon.corp.google.com/gcr/images/oak-ci/GLOBAL/oak
+readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak'
+
+docker push "$DOCKER_IMAGE_NAME:latest"

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -18,11 +18,15 @@ readonly DOCKER_UID="${UID:-0}"
 readonly DOCKER_GID="${GID:-0}"
 readonly DOCKER_USER="${USER:-root}"
 
+# See https://pantheon.corp.google.com/gcr/images/oak-ci/GLOBAL/oak
+readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak'
+
 mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 
 docker build \
-  --tag=oak \
+  --cache-from="$DOCKER_IMAGE_NAME:latest" \
+  --tag="$DOCKER_IMAGE_NAME:latest" \
   . 1>&2
 
 docker_run_flags=(
@@ -42,7 +46,7 @@ docker_run_flags=(
 
 if [[ "$1" == '--detach' ]]; then
   docker_run_flags+=('--detach')
-  docker run "${docker_run_flags[@]}" oak:latest "${@:2}"
+  docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_NAME:latest" "${@:2}"
 else
-  docker run "${docker_run_flags[@]}" oak:latest "$@"
+  docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_NAME:latest" "$@"
 fi


### PR DESCRIPTION
For now, we still rely on logged-in users to manually push a new version
of the image when dependencies change, in the future we should automate
that too. CI and other users can already rely on those images to avoid
rebuilding the images locally every time, since the Registry is set to
allow public access.
