### PR TITLE
Move Rust clippy from formatting to test script

### DIFF
--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -20,7 +20,3 @@ find scripts -type f -exec shellcheck {} +
 # Fortunately, rustfmt has the --check option that will make it exit with 1
 # if formatting has to be applied.
 find examples rust -type f -name '*.rs' -exec rustfmt --check {} +
-
-# Run clippy to lint the Rust code.
-cargo clippy --manifest-path="$PWD/examples/Cargo.toml" --all-targets -- -D warnings
-cargo clippy --manifest-path="$PWD/rust/Cargo.toml" --all-targets -- -D warnings

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -4,6 +4,13 @@ set -o errexit
 set -o nounset
 set -o xtrace
 
-cargo test --manifest-path=./rust/Cargo.toml
-cargo test --manifest-path=./examples/Cargo.toml
+# For each Rust workspace, first run tests, then run clippy, turning warnings into errors.
+# See https://github.com/rust-lang/rust-clippy.
+
+cargo test --all-targets --manifest-path=./rust/Cargo.toml
+cargo clippy --all-targets --manifest-path=./rust/Cargo.toml -- --deny=warnings
+
+cargo test --all-targets --manifest-path=./examples/Cargo.toml
+cargo clippy --all-targets --manifest-path=./examples/Cargo.toml -- --deny=warnings
+
 bazel test --test_output=all //oak/server:host_tests //oak/server/storage:host_tests //oak/common:host_tests


### PR DESCRIPTION
It needs to build the code anyways, and it gets already built in the
testing phase anyways, so running clippy after tests is essentially
instantaneous.

This way the format script does purely syntactic checks and it is much
faster to return errors if there are any.