### PR TITLE
Use Google Cloud Build to upload artifacts

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,48 @@
+# Reference: https://cloud.google.com/cloud-build/docs/build-config
+
+steps:
+  # Pull pre-existing latest Docker image.
+  - name: 'gcr.io/cloud-builders/docker'
+    id: pull_image
+    waitFor: ['-']
+    timeout: 10m
+    args: ['pull', 'gcr.io/oak-ci/oak:latest']
+  # Build Docker image based on current Dockerfile, if necessary.
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build_image
+    waitFor: ['pull_image']
+    timeout: 10m
+    args: ['build', '--pull', '--cache-from=gcr.io/oak-ci/oak:latest', '--tag=gcr.io/oak-ci/oak:latest', '.']
+  # Run build step inside the newly created Docker image.
+  # See: https://cloud.google.com/cloud-build/docs/create-custom-build-steps
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: build_code
+    waitFor: ['build_image']
+    timeout: 30m
+    entrypoint: 'bash'
+    args: ['./scripts/build_server']
+  # Copy compiled enclave binary to workspace so that it can be uploaded as artifact.
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: copy_artifacts
+    waitFor: ['build_code']
+    timeout: 5m
+    entrypoint: 'cp'
+    args: ['./bazel-bin/oak/server/asylo/oak_enclave_unsigned.so', './oak_enclave_unsigned.so']
+
+# Copy compiled enclave binary to Google Cloud Storage.
+# See:
+# - https://pantheon.corp.google.com/storage/browser/artifacts.oak-ci.appspot.com/test/?project=oak-ci
+# - https://cloud.google.com/cloud-build/docs/configuring-builds/store-images-artifacts#storing_artifacts_in
+# TODO: Finalize artifact location.
+artifacts:
+  objects:
+    location: gs://artifacts.oak-ci.appspot.com/test
+    paths:
+      - ./oak_enclave_unsigned.so
+
+timeout: 2h
+
+options:
+  machineType: 'N1_HIGHCPU_8'
+  requestedVerifyOption: 'VERIFIED'
+  sourceProvenanceHash: [ 'SHA256' ]

--- a/scripts/build_dev_server
+++ b/scripts/build_dev_server
@@ -29,23 +29,21 @@ readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
     fi
 )
 
-# If this variable is set, use the remote cache, assuming it is publicly readable.
+# Use the remote cache, assuming it is publicly readable.
 # See https://pantheon.corp.google.com/storage/browser/oak-bazel-cache?project=oak-ci
-if [[ -n "${BAZEL_REMOTE_CACHE_ENABLED:-}" ]]; then
+bazel_build_flags+=(
+    '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+)
+# If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.
+# Note that this is only needed to write to the cache, not to read from it.
+if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
     bazel_build_flags+=(
-        '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+        "--google_credentials=$OAK_REMOTE_CACHE_KEY"
     )
-    # If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.
-    # Note that this is only needed to write to the cache, not to read from it.
-    if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
-        bazel_build_flags+=(
-            "--google_credentials=$OAK_REMOTE_CACHE_KEY"
-        )
-    else
-        bazel_build_flags+=(
-            '--remote_upload_local_results=false'
-        )
-    fi
+else
+    bazel_build_flags+=(
+        '--remote_upload_local_results=false'
+    )
 fi
 
 bazel build "${bazel_build_flags[@]}" //oak/server/dev:oak

--- a/scripts/build_server
+++ b/scripts/build_server
@@ -28,23 +28,21 @@ readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
     fi
 )
 
-# If this variable is set, use the remote cache, assuming it is publicly readable.
+# Use the remote cache, assuming it is publicly readable.
 # See https://pantheon.corp.google.com/storage/browser/oak-bazel-cache?project=oak-ci
-if [[ -n "${BAZEL_REMOTE_CACHE_ENABLED:-}" ]]; then
+bazel_build_flags+=(
+    '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+)
+# If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.
+# Note that this is only needed to write to the cache, not to read from it.
+if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
     bazel_build_flags+=(
-        '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+        "--google_credentials=$OAK_REMOTE_CACHE_KEY"
     )
-    # If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.
-    # Note that this is only needed to write to the cache, not to read from it.
-    if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
-        bazel_build_flags+=(
-            "--google_credentials=$OAK_REMOTE_CACHE_KEY"
-        )
-    else
-        bazel_build_flags+=(
-            '--remote_upload_local_results=false'
-        )
-    fi
+else
+    bazel_build_flags+=(
+        '--remote_upload_local_results=false'
+    )
 fi
 
 bazel build "${bazel_build_flags[@]}" //oak/server/asylo:oak

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -13,4 +13,14 @@ cargo clippy --all-targets --manifest-path=./rust/Cargo.toml -- --deny=warnings
 cargo test --all-targets --manifest-path=./examples/Cargo.toml
 cargo clippy --all-targets --manifest-path=./examples/Cargo.toml -- --deny=warnings
 
-bazel test --test_output=all //oak/server:host_tests //oak/server/storage:host_tests //oak/common:host_tests
+# Use the remote cache, assuming it is publicly readable.
+# See https://pantheon.corp.google.com/storage/browser/oak-bazel-cache?project=oak-ci
+bazel_test_flags=(
+    '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+    '--test_output=all'
+)
+
+bazel test "${bazel_test_flags[@]}" \
+  //oak/server:host_tests \
+  //oak/server/storage:host_tests \
+  //oak/common:host_tests


### PR DESCRIPTION
Add an additional pipeline running on Google Cloud Build, which builds
the enclave binary and pushes it to Google Cloud Storage. The intention
is for this to be used to build reference binary artifacts to be
deployed on Borg in Google if necessary, once we get full reproducible
builds (#241).

Example run:
https://pantheon.corp.google.com/cloud-build/builds/700d7aea-6799-4822-afa1-ec3758e88faf?project=oak-ci
