### PR TITLE
Execute more steps on Google Cloud Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       script:
       - echo "build --show_progress_rate_limit=5.0" >> .bazelrc
       - ./scripts/docker_pull
-      - ./scripts/run_examples
+      - ./scripts/docker_run ./scripts/run_examples
       - ./scripts/docker_run ./scripts/check_generated
     - name: run tests
       script:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,21 +10,41 @@ steps:
   # Build Docker image based on current Dockerfile, if necessary.
   - name: 'gcr.io/cloud-builders/docker'
     id: build_image
-    waitFor: ['pull_image']
     timeout: 10m
     args: ['build', '--pull', '--cache-from=gcr.io/oak-ci/oak:latest', '--tag=gcr.io/oak-ci/oak:latest', '.']
-  # Run build step inside the newly created Docker image.
+  # Run next build steps inside the newly created Docker image.
   # See: https://cloud.google.com/cloud-build/docs/create-custom-build-steps
   - name: 'gcr.io/oak-ci/oak:latest'
-    id: build_code
+    id: check_formatting
+    waitFor: ['build_image']
+    timeout: 30m
+    entrypoint: 'bash'
+    args: ['./scripts/check_formatting']
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: build_server
     waitFor: ['build_image']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/build_server']
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: build_dev_server
+    timeout: 30m
+    entrypoint: 'bash'
+    args: ['./scripts/build_dev_server']
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: run_tests
+    timeout: 30m
+    entrypoint: 'bash'
+    args: ['./scripts/run_tests']
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: run_examples
+    timeout: 30m
+    entrypoint: 'bash'
+    args: ['./scripts/run_examples']
   # Copy compiled enclave binary to workspace so that it can be uploaded as artifact.
   - name: 'gcr.io/oak-ci/oak:latest'
     id: copy_artifacts
-    waitFor: ['build_code']
+    waitFor: ['build_server']
     timeout: 5m
     entrypoint: 'cp'
     args: ['./bazel-bin/oak/server/asylo/oak_enclave_unsigned.so', './oak_enclave_unsigned.so']
@@ -43,6 +63,7 @@ artifacts:
 timeout: 2h
 
 options:
-  machineType: 'N1_HIGHCPU_8'
+  # See: https://cloud.google.com/cloud-build/docs/api/reference/rest/Shared.Types/MachineType
+  machineType: 'N1_HIGHCPU_32'
   requestedVerifyOption: 'VERIFIED'
   sourceProvenanceHash: [ 'SHA256' ]

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -73,23 +73,21 @@ readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
     fi
 )
 
-# If this variable is set, use the remote cache, assuming it is publicly readable.
+# Use the remote cache, assuming it is publicly readable.
 # See https://pantheon.corp.google.com/storage/browser/oak-bazel-cache?project=oak-ci
-if [[ -n "${BAZEL_REMOTE_CACHE_ENABLED:-}" ]]; then
+bazel_build_flags+=(
+    '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+)
+# If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.
+# Note that this is only needed to write to the cache, not to read from it.
+if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
     bazel_build_flags+=(
-        '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+        "--google_credentials=$OAK_REMOTE_CACHE_KEY"
     )
-    # If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.
-    # Note that this is only needed to write to the cache, not to read from it.
-    if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
-        bazel_build_flags+=(
-            "--google_credentials=$OAK_REMOTE_CACHE_KEY"
-        )
-    else
-        bazel_build_flags+=(
-            '--remote_upload_local_results=false'
-        )
-    fi
+else
+    bazel_build_flags+=(
+        '--remote_upload_local_results=false'
+    )
 fi
 
 bazel --output_base="$CACHE_DIR/client" build "${bazel_build_flags[@]}" "//examples/$TARGET/client"

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -11,22 +11,23 @@ readonly DOCKER_USER="${USER:-root}"
 readonly SCRIPTS_DIR="$(dirname "$0")"
 
 # Build Oak server.
-"$SCRIPTS_DIR/docker_run" "$SCRIPTS_DIR/build_server"
+"$SCRIPTS_DIR/build_server"
 
 # Run Rust-based Oak examples, each with their own Oak server instance.
 readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module/rust$' | cut -d'/' -f2)"
 for example in ${RUST_EXAMPLES}; do
-  container_id=$("$SCRIPTS_DIR/docker_run" --detach ./bazel-bin/oak/server/asylo/oak)
-  docker logs --follow "$container_id" &
-  "${SCRIPTS_DIR}/docker_run" "${SCRIPTS_DIR}/run_example" "${example}"
-  docker stop "$container_id"
+  ./bazel-bin/oak/server/asylo/oak &
+  SERVER_PID=$!
+  "${SCRIPTS_DIR}/run_example" "${example}"
+  # TODO: Ensure that background processes are killed with something like `trap cleanup_fn EXIT`.
+  kill -s SIGTERM "$SERVER_PID"
 done
 
 # Run C++-based Oak examples.
 readonly CPP_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module/cpp$' | cut -d'/' -f2)"
 for example in ${CPP_EXAMPLES}; do
-  container_id=$("$SCRIPTS_DIR/docker_run" --detach ./bazel-bin/oak/server/asylo/oak)
-  docker logs --follow "$container_id" &
-  "${SCRIPTS_DIR}/docker_run" "${SCRIPTS_DIR}/run_example" -c "${example}"
-  docker stop "$container_id"
+  ./bazel-bin/oak/server/asylo/oak &
+  SERVER_PID=$!
+  "${SCRIPTS_DIR}/run_example" -c "${example}"
+  kill -s SIGTERM "$SERVER_PID"
 done


### PR DESCRIPTION
Mirror more of the build steps on Google Cloud Build, so that for a
while we can run them in parallel and see whether one is faster / less
  flaky than the other.

Change `run_examples` script so that it runs entirely in Docker (both
server and clients), which should make things more stable in CI.
