### PR TITLE
Add indirection between Wasm Node and its code

### DIFF
--- a/examples/abitest/client/abitest.cc
+++ b/examples/abitest/client/abitest.cc
@@ -43,7 +43,7 @@ using ::oak::examples::abitest::OakABITestService;
 static const char* app_config_textproto = R"raw(nodes {
   node_name: "frontend"
   web_assembly_node {
-    module_bytes: "<filled in later>"
+    wasm_contents_name: "frontend-code"
     ports {
       name: "gRPC_input"
       type: IN
@@ -85,7 +85,7 @@ static const char* app_config_textproto = R"raw(nodes {
 nodes {
   node_name: "backend_0"
   web_assembly_node {
-    module_bytes: "<filled in later>"
+    wasm_contents_name: "backend-code"
     ports {
       name: "be_logging_port"
       type: OUT
@@ -103,7 +103,7 @@ nodes {
 nodes {
   node_name: "backend_1"
   web_assembly_node {
-    module_bytes: "<filled in later>"
+    wasm_contents_name: "backend-code"
     ports {
       name: "be_logging_port"
       type: OUT
@@ -121,7 +121,7 @@ nodes {
 nodes {
   node_name: "backend_2"
   web_assembly_node {
-    module_bytes: "<filled in later>"
+    wasm_contents_name: "backend-code"
     ports {
       name: "be_logging_port"
       type: OUT
@@ -143,6 +143,14 @@ nodes {
 nodes {
   node_name: "logging_node"
   log_node {}
+}
+wasm_contents {
+  name: "frontend-code"
+  module_bytes: "<filled in later>"
+}
+wasm_contents {
+  name: "backend-code"
+  module_bytes: "<filled in later>"
 }
 channels {
   source_endpoint {
@@ -313,15 +321,11 @@ int main(int argc, char** argv) {
   google::protobuf::TextFormat::MergeFromString(app_config_textproto, config.get());
 
   // Add the Wasm module bytes to the config.
-  for (auto& node : *config->mutable_nodes()) {
-    if (!node.has_web_assembly_node()) {
-      continue;
-    }
-    if (node.node_name() == "frontend") {
-      node.mutable_web_assembly_node()->set_module_bytes(frontend_module_bytes);
-    } else if (absl::StartsWith(node.node_name(), "backend")) {
-      // All backend nodes share the same code.
-      node.mutable_web_assembly_node()->set_module_bytes(backend_module_bytes);
+  for (auto& contents : *config->mutable_wasm_contents()) {
+    if (contents.name() == "frontend-code") {
+      contents.set_module_bytes(frontend_module_bytes);
+    } else if (contents.name() == "backend-code") {
+      contents.set_module_bytes(backend_module_bytes);
     }
   }
   if (!ValidApplicationConfig(*config)) {

--- a/oak/common/app_config_test.cc
+++ b/oak/common/app_config_test.cc
@@ -111,6 +111,16 @@ TEST(ApplicationConfiguration, NoWasmNode) {
   ASSERT_EQ(false, ValidApplicationConfig(*config));
 }
 
+TEST(ApplicationConfiguration, NoWasmCode) {
+  auto config = ConfigFrom("oak/common/testdata/missing_wasm.textproto");
+  ASSERT_EQ(false, ValidApplicationConfig(*config));
+}
+
+TEST(ApplicationConfiguration, DuplicateWasmName) {
+  auto config = ConfigFrom("oak/common/testdata/dup_wasm.textproto");
+  ASSERT_EQ(false, ValidApplicationConfig(*config));
+}
+
 TEST(ApplicationConfiguration, NoChannelSource) {
   auto config = ConfigFrom("oak/common/testdata/channel_source_missing.textproto");
   ASSERT_EQ(false, ValidApplicationConfig(*config));

--- a/oak/common/testdata/barenode.textproto
+++ b/oak/common/testdata/barenode.textproto
@@ -9,7 +9,7 @@ nodes {
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<bytes>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -19,6 +19,10 @@ nodes {
       type: OUT
     }
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<bytes>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/channel_dest_missing.textproto
+++ b/oak/common/testdata/channel_dest_missing.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -40,6 +40,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/channel_inverted.textproto
+++ b/oak/common/testdata/channel_inverted.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -40,6 +40,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   destination_endpoint {

--- a/oak/common/testdata/channel_source_missing.textproto
+++ b/oak/common/testdata/channel_source_missing.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -40,6 +40,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/default.textproto
+++ b/oak/common/testdata/default.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -40,6 +40,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/dup_node_name.textproto
+++ b/oak/common/testdata/dup_node_name.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -40,6 +40,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/dup_port.textproto
+++ b/oak/common/testdata/dup_port.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -44,6 +44,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/dup_wasm.textproto
+++ b/oak/common/testdata/dup_wasm.textproto
@@ -20,22 +20,12 @@ nodes {
     }
   }
 }
-nodes {
-  node_name: "backend"
-  web_assembly_node {
-    wasm_contents_name: "backend-code"
-    ports {
-      name: "extra"
-      type: IN
-    }
-  }
-}
 wasm_contents {
   name: "app-code"
   module_bytes: "<bytes>"
 }
 wasm_contents {
-  name: "backend-code"
+  name: "app-code"
   module_bytes: "<bytes>"
 }
 channels {
@@ -56,15 +46,5 @@ channels {
   destination_endpoint {
     node_name: "grpc"
     port_name: "response"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "backend"
-    port_name: "extra"
   }
 }

--- a/oak/common/testdata/in_port_empty.textproto
+++ b/oak/common/testdata/in_port_empty.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -44,6 +44,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/lognode.textproto
+++ b/oak/common/testdata/lognode.textproto
@@ -9,7 +9,7 @@ nodes {
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<bytes>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -27,6 +27,10 @@ nodes {
 nodes {
   node_name: "log"
   log_node {}
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<bytes>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/missing_wasm.textproto
+++ b/oak/common/testdata/missing_wasm.textproto
@@ -20,24 +20,6 @@ nodes {
     }
   }
 }
-nodes {
-  node_name: "backend"
-  web_assembly_node {
-    wasm_contents_name: "backend-code"
-    ports {
-      name: "extra"
-      type: IN
-    }
-  }
-}
-wasm_contents {
-  name: "app-code"
-  module_bytes: "<bytes>"
-}
-wasm_contents {
-  name: "backend-code"
-  module_bytes: "<bytes>"
-}
 channels {
   source_endpoint {
     node_name: "grpc"
@@ -56,15 +38,5 @@ channels {
   destination_endpoint {
     node_name: "grpc"
     port_name: "response"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "backend"
-    port_name: "extra"
   }
 }

--- a/oak/common/testdata/multinode.textproto
+++ b/oak/common/testdata/multinode.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "frontend"
   web_assembly_node {
-    module_bytes: "<filled in later>"
+    wasm_contents_name: "frontend-code"
     ports {
       name: "gRPC_input"
       type: IN
@@ -30,7 +30,7 @@ nodes {
 nodes {
   node_name: "backend"
   web_assembly_node {
-    module_bytes: "<filled in later>"
+    wasm_contents_name: "backend-code"
     ports {
       name: "be_logging_port"
       type: OUT
@@ -52,6 +52,14 @@ nodes {
 nodes {
   node_name: "logging_node"
   log_node {}
+}
+wasm_contents {
+  name: "frontend-code"
+  module_bytes: "<filled in later>"
+}
+wasm_contents {
+  name: "backend-code"
+  module_bytes: "<filled in later>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/out_port_empty.textproto
+++ b/oak/common/testdata/out_port_empty.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -44,6 +44,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/storagenode.textproto
+++ b/oak/common/testdata/storagenode.textproto
@@ -9,7 +9,7 @@ nodes {
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<bytes>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -33,6 +33,10 @@ nodes {
   storage_node {
     address: "localhost:8888"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<bytes>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/two_grpc.textproto
+++ b/oak/common/testdata/two_grpc.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -44,6 +44,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   source_endpoint {

--- a/oak/common/testdata/two_log.textproto
+++ b/oak/common/testdata/two_log.textproto
@@ -4,7 +4,7 @@
 nodes {
   node_name: "app"
   web_assembly_node {
-    module_bytes: "<filled in elsewhere>"
+    wasm_contents_name: "app-code"
     ports {
       name: "grpc_in"
       type: IN
@@ -44,6 +44,10 @@ nodes {
   storage_node {
     address: "localhost:7867"
   }
+}
+wasm_contents {
+  name: "app-code"
+  module_bytes: "<filled in elsewhere>"
 }
 channels {
   source_endpoint {

--- a/oak/proto/manager.proto
+++ b/oak/proto/manager.proto
@@ -28,6 +28,7 @@ package oak;
 message ApplicationConfiguration {
   repeated Node nodes = 1;
   repeated Channel channels = 2;
+  repeated WasmContents wasm_contents = 3;
 }
 
 // A Node represents a unit of computation in Oak.
@@ -73,17 +74,28 @@ message LogNode {
 
 // A Node that runs the provided WebAssembly code.
 message WebAssemblyNode {
-  // The compiled code of the Oak Module to instantiate, in WebAssembly binary
-  // format.
-  // See https://webassembly.org/docs/binary-encoding/ .
-  // TODO: Replace this with just a hash of the bytecode to instantiate, and
-  // pass the actual bytecode to the Oak Manager in some other way.
-  bytes module_bytes = 1;
+  // Name of a WasmContents object in the Application configuration that
+  // holds the Wasm code for this Node.
+  string wasm_contents_name = 1;
 
   // The set of Ports available to the Node, which it can use to communicate
   // with other Nodes or with the System.
   // They may be of different types and specified in any order.
   repeated Port ports = 2;
+}
+
+// A mapping from an arbitrary name to a corresponding Wasm binary.
+//
+// The name field must be unique in an Application definition.
+message WasmContents {
+  string name = 1;
+
+  // The compiled code of the Oak Module to instantiate, in WebAssembly binary
+  // format.
+  // See https://webassembly.org/docs/binary-encoding/ .
+  // TODO: Replace this with just a hash of the bytecode to instantiate, and
+  // pass the actual bytecode to the Oak Manager in some other way.
+  bytes module_bytes = 2;
 }
 
 // A pseudo-Node that accepts storage requests and forwards them to an


### PR DESCRIPTION
This allows the Wasm code for a Node to be shared between multiple
instances without duplication.