### PR TITLE
Create skeleton for fuzz target

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -78,6 +78,16 @@ build:ubsan --copt -fno-omit-frame-pointer
 build:ubsan --linkopt -fsanitize=undefined
 build:ubsan --linkopt -lubsan
 
+# --config fuzzer: Fuzzer
+build:fuzzer --crosstool_top=//toolchain:clang
+build:fuzzer --cpu=k8
+build:fuzzer --strip=never
+build:fuzzer --copt -fsanitize=fuzzer,address
+build:fuzzer --copt -O1
+build:fuzzer --copt -g
+build:fuzzer --copt -fno-omit-frame-pointer
+build:fuzzer --linkopt -fsanitize=fuzzer,address
+
 # Bazel 0.27.0 deprecates features that our dependencies (gRPC, protobuf) rely on, so disable
 # the checks until all dependencies have been updated to cope with a later Bazel.
 # TODO: remove these options when possible

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -65,6 +65,16 @@ cc_library(
     ],
 )
 
+cc_binary(
+    name = "wasm_node_fuzz",
+    srcs = [
+        "wasm_node_fuzzer.cc",
+    ],
+    deps = [
+        ":wasm_node",
+    ],
+)
+
 cc_test(
     name = "wasm_node_test",
     srcs = [

--- a/oak/server/wasm_node_fuzzer.cc
+++ b/oak/server/wasm_node_fuzzer.cc
@@ -1,0 +1,10 @@
+#include <memory>
+
+#include "oak/server/wasm_node.h"
+
+// See https://llvm.org/docs/LibFuzzer.html#fuzz-target.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  std::string module(reinterpret_cast<char const*>(data), size);
+  std::unique_ptr<oak::WasmNode> node = oak::WasmNode::Create("test", module);
+  return 0;
+}

--- a/scripts/build_dev_server
+++ b/scripts/build_dev_server
@@ -13,6 +13,7 @@ bazel_build_flags=(
 # - /scripts/build_example
 # - /scripts/build_server
 # - /scripts/build_dev_server
+# - /scripts/fuzz
 
 readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
 

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -57,6 +57,7 @@ bazel_build_flags=(
 # - /scripts/build_example
 # - /scripts/build_server
 # - /scripts/build_dev_server
+# - /scripts/fuzz
 
 readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
 

--- a/scripts/build_server
+++ b/scripts/build_server
@@ -12,6 +12,7 @@ bazel_build_flags=(
 # - /scripts/build_example
 # - /scripts/build_server
 # - /scripts/build_dev_server
+# - /scripts/fuzz
 
 readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
 

--- a/scripts/fuzz
+++ b/scripts/fuzz
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+readonly OAK_REMOTE_CACHE_KEY='./.oak_remote_cache_key.json'
+
+# Use the remote cache, assuming it is publicly readable.
+# See https://pantheon.corp.google.com/storage/browser/oak-bazel-cache?project=oak-ci
+bazel_build_flags=(
+    '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+    '--config=fuzzer'
+)
+# If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.
+# Note that this is only needed to write to the cache, not to read from it.
+if [[ -f "$OAK_REMOTE_CACHE_KEY" ]]; then
+    bazel_build_flags+=(
+        "--google_credentials=$OAK_REMOTE_CACHE_KEY"
+    )
+else
+    bazel_build_flags+=(
+        '--remote_upload_local_results=false'
+    )
+fi
+
+bazel build "${bazel_build_flags[@]}" //oak/server:wasm_node_fuzz
+./bazel-bin/oak/server/wasm_node_fuzz


### PR DESCRIPTION
Add fuzz configuration to `.bazelrc`.
Create fuzz target for `wasm_node`.
Add `./scripts/fuzz` to get things up and running quickly.

Ref #261