### PR TITLE
Ensure max log level is set in tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -90,6 +90,8 @@ dependencies = [
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak 0.1.0",
  "oak_tests 0.1.0",
+ "serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -205,6 +207,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +298,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+"checksum serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50bfbc39343545618d97869d77f38ed43e48dd77432717dbc7ed39d797f3ecbe"
+"checksum serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89dd85be2e2ad75b041c9df2892ac078fa6e0b90024028b2b9fb4125b7530f01"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"

--- a/rust/oak_log/Cargo.toml
+++ b/rust/oak_log/Cargo.toml
@@ -10,3 +10,5 @@ log = { version = "^0.4.0", features = ["std"] }
 
 [dev-dependencies]
 oak_tests = { path = "../oak_tests" }
+serial_test = "0.2"
+serial_test_derive = "0.2"

--- a/rust/oak_log/src/lib.rs
+++ b/rust/oak_log/src/lib.rs
@@ -21,6 +21,11 @@
 
 extern crate log;
 extern crate oak;
+#[cfg(test)]
+extern crate serial_test;
+#[cfg(test)]
+#[macro_use]
+extern crate serial_test_derive;
 
 #[cfg(test)]
 mod tests;

--- a/rust/oak_log/src/tests.rs
+++ b/rust/oak_log/src/tests.rs
@@ -27,6 +27,7 @@ fn test_logger() -> OakChannelLogger {
 }
 
 #[test]
+#[serial(set_level)]
 fn test_enabled() {
     let x = test_logger();
     struct T {
@@ -59,9 +60,12 @@ fn test_enabled() {
 }
 
 #[test]
+#[serial(set_level)]
 fn test_log() {
     oak_tests::reset_channels();
     let logger = test_logger();
+    log::set_max_level(log::LevelFilter::Info);
+
     let trace = Metadata::builder()
         .level(Level::Trace)
         .target("test")


### PR DESCRIPTION
For some reason, occasionally the log::max_level() is set to Off
and so the oak_log test fails.  Force the level to Info (and check
it).

Fixes #267 (hopefully).