### PR TITLE
Introduce policy as gRPC metadata

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -272,13 +272,12 @@ The client can now connect to this separate gRPC service, and send
 encryption into the enclave:
 
 <!-- prettier-ignore-start -->
-[embedmd]:# (../examples/rustfmt/client/rustfmt.cc C++ /.*InitializeAssertionAuthorities/ /CredentialsOption/)
+[embedmd]:# (../examples/rustfmt/client/rustfmt.cc C++ /.*InitializeAssertionAuthorities/ /CreateChannel.*/)
 ```C++
   oak::ApplicationClient::InitializeAssertionAuthorities();
 
   // Connect to the newly created Oak Application.
-  auto stub = FormatService::NewStub(grpc::CreateChannel(
-      addr.str(), asylo::EnclaveChannelCredentials(asylo::BidirectionalNullCredentialsOption
+  auto stub = FormatService::NewStub(oak::ApplicationClient::CreateChannel(addr.str()));
 ```
 <!-- prettier-ignore-end -->
 

--- a/examples/abitest/client/abitest.cc
+++ b/examples/abitest/client/abitest.cc
@@ -348,8 +348,7 @@ int main(int argc, char** argv) {
   oak::ApplicationClient::InitializeAssertionAuthorities();
 
   // Connect to the newly created Oak Application.
-  auto stub = OakABITestService::NewStub(grpc::CreateChannel(
-      addr.str(), asylo::EnclaveChannelCredentials(asylo::BidirectionalNullCredentialsOptions())));
+  auto stub = OakABITestService::NewStub(oak::ApplicationClient::CreateChannel(addr.str()));
 
   // Invoke the application.
   if (!run_tests(stub.get(), absl::GetFlag(FLAGS_test_filter))) {

--- a/examples/hello_world/client/hello_world.cc
+++ b/examples/hello_world/client/hello_world.cc
@@ -90,8 +90,7 @@ int main(int argc, char** argv) {
   oak::ApplicationClient::InitializeAssertionAuthorities();
 
   // Connect to the newly created Oak Application.
-  auto stub = HelloWorld::NewStub(grpc::CreateChannel(
-      addr.str(), asylo::EnclaveChannelCredentials(asylo::BidirectionalNullCredentialsOptions())));
+  auto stub = HelloWorld::NewStub(oak::ApplicationClient::CreateChannel(addr.str()));
 
   // Perform multiple invocations of the same Oak Application, with different parameters.
   say_hello(stub.get(), "WORLD");

--- a/examples/machine_learning/client/machine_learning.cc
+++ b/examples/machine_learning/client/machine_learning.cc
@@ -93,8 +93,7 @@ int main(int argc, char** argv) {
   ::oak::ApplicationClient::InitializeAssertionAuthorities();
 
   // Connect to the newly created Oak Application.
-  auto stub = MachineLearning::NewStub(grpc::CreateChannel(
-      addr.str(), asylo::EnclaveChannelCredentials(asylo::BidirectionalNullCredentialsOptions())));
+  auto stub = MachineLearning::NewStub(oak::ApplicationClient::CreateChannel(addr.str()));
 
   // Perform multiple invocations of the same Oak Application, with different parameters.
   auto message_0 = send_data(stub.get());

--- a/examples/private_set_intersection/client/private_set_intersection.cc
+++ b/examples/private_set_intersection/client/private_set_intersection.cc
@@ -86,15 +86,13 @@ int main(int argc, char** argv) {
   oak::ApplicationClient::InitializeAssertionAuthorities();
 
   // Connect to the newly created Oak Application from different clients.
-  auto channel_0 = grpc::CreateChannel(
-      addr.str(), asylo::EnclaveChannelCredentials(asylo::BidirectionalNullCredentialsOptions()));
+  auto channel_0 = oak::ApplicationClient::CreateChannel(addr.str());
   oak::ApplicationClient client_0(channel_0);
   oak::GetAttestationResponse attestation = client_0.GetAttestation();
   LOG(INFO) << "Oak Application attestation: " << attestation.DebugString();
   auto stub_0 = PrivateSetIntersection::NewStub(channel_0);
 
-  auto stub_1 = PrivateSetIntersection::NewStub(grpc::CreateChannel(
-      addr.str(), asylo::EnclaveChannelCredentials(asylo::BidirectionalNullCredentialsOptions())));
+  auto stub_1 = PrivateSetIntersection::NewStub(oak::ApplicationClient::CreateChannel(addr.str()));
 
   // Submit sets from different clients.
   std::vector<std::string> set_0{"a", "b", "c"};

--- a/examples/running_average/client/running_average.cc
+++ b/examples/running_average/client/running_average.cc
@@ -80,11 +80,9 @@ int main(int argc, char** argv) {
   oak::ApplicationClient::InitializeAssertionAuthorities();
 
   // Connect to the newly created Oak Application from different clients.
-  auto stub_0 = RunningAverage::NewStub(grpc::CreateChannel(
-      addr.str(), asylo::EnclaveChannelCredentials(asylo::BidirectionalNullCredentialsOptions())));
+  auto stub_0 = RunningAverage::NewStub(oak::ApplicationClient::CreateChannel(addr.str()));
 
-  auto stub_1 = RunningAverage::NewStub(grpc::CreateChannel(
-      addr.str(), asylo::EnclaveChannelCredentials(asylo::BidirectionalNullCredentialsOptions())));
+  auto stub_1 = RunningAverage::NewStub(oak::ApplicationClient::CreateChannel(addr.str()));
 
   // Submit samples from different clients.
   submit_sample(stub_0.get(), 100);

--- a/examples/rustfmt/client/rustfmt.cc
+++ b/examples/rustfmt/client/rustfmt.cc
@@ -70,8 +70,7 @@ int main(int argc, char** argv) {
   oak::ApplicationClient::InitializeAssertionAuthorities();
 
   // Connect to the newly created Oak Application.
-  auto stub = FormatService::NewStub(grpc::CreateChannel(
-      addr.str(), asylo::EnclaveChannelCredentials(asylo::BidirectionalNullCredentialsOptions())));
+  auto stub = FormatService::NewStub(oak::ApplicationClient::CreateChannel(addr.str()));
 
   // Perform multiple invocations of the same Oak Application, with different parameters.
   format(stub.get(), "fn     main    ()     {     }");

--- a/oak/client/BUILD
+++ b/oak/client/BUILD
@@ -34,11 +34,24 @@ cc_library(
     hdrs = ["application_client.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":policy_metadata",
         "//oak/common:app_config",
         "//oak/proto:application_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_asylo//asylo/grpc/auth:null_credentials_options",
         "@com_google_asylo//asylo/identity:init",
         "@com_google_asylo//asylo/util:logging",
+    ],
+)
+
+cc_library(
+    name = "policy_metadata",
+    srcs = ["policy_metadata.cc"],
+    hdrs = ["policy_metadata.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/strings",
     ],
 )

--- a/oak/client/manager_client.h
+++ b/oak/client/manager_client.h
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+#ifndef OAK_CLIENT_MANAGER_CLIENT_H_
+#define OAK_CLIENT_MANAGER_CLIENT_H_
+
 #include <memory>
 
 #include "absl/memory/memory.h"
+#include "include/grpcpp/grpcpp.h"
 #include "oak/common/app_config.h"
 #include "oak/proto/manager.grpc.pb.h"
 
@@ -91,3 +95,5 @@ class ManagerClient {
 };
 
 }  // namespace oak
+
+#endif  // OAK_CLIENT_MANAGER_CLIENT_H_

--- a/oak/client/policy_metadata.cc
+++ b/oak/client/policy_metadata.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/client/policy_metadata.h"
+
+#include <map>
+#include <utility>
+
+namespace oak {
+
+const absl::string_view kOakPolicyMetadataKey = "x-oak-policy";
+
+PolicyMetadata::PolicyMetadata() {}
+
+grpc::Status PolicyMetadata::GetMetadata(grpc::string_ref service_url, grpc::string_ref method_name,
+                                         const grpc::AuthContext& channel_auth_context,
+                                         std::multimap<grpc::string, grpc::string>* metadata) {
+  // TODO: Make actual policy configurable. For now we are injecting a nonsense policy, which the
+  // server is not even checking yet.
+  metadata->insert(std::make_pair(kOakPolicyMetadataKey, "test-oak-policy"));
+  return grpc::Status::OK;
+}
+
+}  // namespace oak

--- a/oak/client/policy_metadata.h
+++ b/oak/client/policy_metadata.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_CLIENT_POLICY_METADATA_H_
+#define OAK_CLIENT_POLICY_METADATA_H_
+
+#include "absl/base/attributes.h"
+#include "absl/strings/string_view.h"
+#include "include/grpcpp/grpcpp.h"
+
+namespace oak {
+
+// Metadata key used to refer to Oak Policies associated with the gRPC request. This is effectively
+// treated as the name of a custom HTTP header.
+ABSL_CONST_INIT extern const absl::string_view kOakPolicyMetadataKey;
+
+// This class injects a pre-determined Oak Policy to each outgoing gRPC call.
+// In real-world use cases it should be combined to channel credentials, providing enclave
+// attestation.
+// See https://grpc.io/docs/guides/auth/.
+class PolicyMetadata : public grpc::MetadataCredentialsPlugin {
+ public:
+  PolicyMetadata();
+
+  grpc::Status GetMetadata(grpc::string_ref service_url, grpc::string_ref method_name,
+                           const grpc::AuthContext& channel_auth_context,
+                           std::multimap<grpc::string, grpc::string>* metadata) override;
+};
+
+}  // namespace oak
+
+#endif  // OAK_CLIENT_POLICY_METADATA_H_


### PR DESCRIPTION
Create PolicyMetadata client class to be used by clients to attach
policies to gRPC requests.

Refactor gRPC channel creation so it is encapsulated by
ApplicationClient.

Ref #212