### PR TITLE
Attach policy labels to Messages

### DIFF
--- a/oak/client/BUILD
+++ b/oak/client/BUILD
@@ -50,8 +50,8 @@ cc_library(
     hdrs = ["policy_metadata.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//oak/common:policy",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/base",
-        "@com_google_absl//absl/strings",
     ],
 )

--- a/oak/client/policy_metadata.cc
+++ b/oak/client/policy_metadata.cc
@@ -21,7 +21,7 @@
 
 namespace oak {
 
-const absl::string_view kOakPolicyMetadataKey = "x-oak-policy";
+const char kOakLabelMetadataKey[] = "x-oak-label";
 
 PolicyMetadata::PolicyMetadata() {}
 
@@ -30,7 +30,7 @@ grpc::Status PolicyMetadata::GetMetadata(grpc::string_ref service_url, grpc::str
                                          std::multimap<grpc::string, grpc::string>* metadata) {
   // TODO: Make actual policy configurable. For now we are injecting a nonsense policy, which the
   // server is not even checking yet.
-  metadata->insert(std::make_pair(kOakPolicyMetadataKey, "test-oak-policy"));
+  metadata->insert(std::make_pair(kOakLabelMetadataKey, "test-oak-label"));
   return grpc::Status::OK;
 }
 

--- a/oak/client/policy_metadata.cc
+++ b/oak/client/policy_metadata.cc
@@ -19,9 +19,9 @@
 #include <map>
 #include <utility>
 
-namespace oak {
+#include "oak/common/policy.h"
 
-const char kOakLabelMetadataKey[] = "x-oak-label";
+namespace oak {
 
 PolicyMetadata::PolicyMetadata() {}
 
@@ -30,7 +30,7 @@ grpc::Status PolicyMetadata::GetMetadata(grpc::string_ref service_url, grpc::str
                                          std::multimap<grpc::string, grpc::string>* metadata) {
   // TODO: Make actual policy configurable. For now we are injecting a nonsense policy, which the
   // server is not even checking yet.
-  metadata->insert(std::make_pair(kOakLabelMetadataKey, "test-oak-label"));
+  metadata->insert(std::make_pair(kOakLabelGrpcMetadataKey, "test-oak-label"));
   return grpc::Status::OK;
 }
 

--- a/oak/client/policy_metadata.h
+++ b/oak/client/policy_metadata.h
@@ -25,7 +25,7 @@ namespace oak {
 
 // Metadata key used to refer to Oak Policies associated with the gRPC request. This is effectively
 // treated as the name of a custom HTTP header.
-ABSL_CONST_INIT extern const absl::string_view kOakPolicyMetadataKey;
+ABSL_CONST_INIT extern const char kOakLabelMetadataKey[];
 
 // This class injects a pre-determined Oak Policy to each outgoing gRPC call.
 // In real-world use cases it should be combined to channel credentials, providing enclave

--- a/oak/client/policy_metadata.h
+++ b/oak/client/policy_metadata.h
@@ -17,15 +17,9 @@
 #ifndef OAK_CLIENT_POLICY_METADATA_H_
 #define OAK_CLIENT_POLICY_METADATA_H_
 
-#include "absl/base/attributes.h"
-#include "absl/strings/string_view.h"
 #include "include/grpcpp/grpcpp.h"
 
 namespace oak {
-
-// Metadata key used to refer to Oak Policies associated with the gRPC request. This is effectively
-// treated as the name of a custom HTTP header.
-ABSL_CONST_INIT extern const char kOakLabelMetadataKey[];
 
 // This class injects a pre-determined Oak Policy to each outgoing gRPC call.
 // In real-world use cases it should be combined to channel credentials, providing enclave

--- a/oak/common/BUILD
+++ b/oak/common/BUILD
@@ -61,3 +61,13 @@ filegroup(
         "testdata/*.textproto",
     ]),
 )
+
+cc_library(
+    name = "policy",
+    srcs = ["policy.cc"],
+    hdrs = ["policy.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_absl//absl/base",
+    ],
+)

--- a/oak/common/policy.cc
+++ b/oak/common/policy.cc
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/common/policy.h"
+
+namespace oak {
+
+const char kOakLabelGrpcMetadataKey[] = "x-oak-label";
+}

--- a/oak/common/policy.h
+++ b/oak/common/policy.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_COMMON_POLICIES_H_
+#define OAK_COMMON_POLICIES_H_
+
+#include "absl/base/attributes.h"
+
+namespace oak {
+
+// Metadata key used to refer to Oak Policies associated with the gRPC request. This is effectively
+// treated as the name of a custom HTTP header.
+ABSL_CONST_INIT extern const char kOakLabelGrpcMetadataKey[];
+
+}  // namespace oak
+
+#endif

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -116,6 +116,7 @@ cc_library(
         ":channel",
         ":oak_node",
         "//oak/common:app_config",
+        "//oak/common:policy",
         "//oak/proto:application_cc_grpc",
         "//oak/proto:enclave_cc_proto",
         "//oak/proto:grpc_encap_cc_proto",

--- a/oak/server/channel.h
+++ b/oak/server/channel.h
@@ -39,9 +39,11 @@ using ChannelHalf = absl::variant<std::unique_ptr<MessageChannelReadHalf>,
 
 // Each message transferred over a channel includes data and potentially
 // also references to halves of channels.
+// It also has a set of labels attached to it, which are used for information flow.
 struct Message {
   std::vector<char> data;
   std::vector<std::unique_ptr<ChannelHalf>> channels;
+  std::vector<std::string> labels;
 };
 
 // Result of a read operation. If the operation would have produced a message

--- a/oak/server/module_invocation.cc
+++ b/oak/server/module_invocation.cc
@@ -77,11 +77,11 @@ void ModuleInvocation::ProcessRequest(bool ok) {
   std::string encap_req;
   grpc_request.SerializeToString(&encap_req);
   // TODO: figure out a way to avoid the extra copy (into then out of std::string)
-  std::unique_ptr<Message> rsp_msg = absl::make_unique<Message>();
-  rsp_msg->data.insert(rsp_msg->data.end(), encap_req.begin(), encap_req.end());
+  std::unique_ptr<Message> req_msg = absl::make_unique<Message>();
+  req_msg->data.insert(req_msg->data.end(), encap_req.begin(), encap_req.end());
   // Write data to the gRPC input channel, which the runtime connected to the
   // Node.
-  req_half_->Write(std::move(rsp_msg));
+  req_half_->Write(std::move(req_msg));
   LOG(INFO) << "Wrote encapsulated request to gRPC input channel";
 
   // Move straight onto sending first response.

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -50,7 +50,9 @@ bazel_build_flags+=(
     "--compilation_mode=$COMPILATION_MODE"
 )
 
-bazel build "${bazel_build_flags[@]}" "//examples/$TARGET/client"
+# Use a different output_base so that we don't lose incremental state.
+# See https://docs.bazel.build/versions/master/command-line-reference.html#flag--output_base.
+bazel --output_base="$CACHE_DIR/client" build "${bazel_build_flags[@]}" "//examples/$TARGET/client"
 
 readonly CPP_FOLDER="$(find examples/"$TARGET" -type d -name cpp)"
 if [[ -n "$CPP_FOLDER" ]]; then

--- a/scripts/build_server_dev
+++ b/scripts/build_server_dev
@@ -8,5 +8,6 @@ bazel_build_flags+=(
     '--config=clang'
 )
 
-# We set a different output_base so that caches do not interfere with each other.
+# Use a different output_base so that we don't lose incremental state.
+# See https://docs.bazel.build/versions/master/command-line-reference.html#flag--output_base.
 bazel --output_base="$CACHE_DIR/clang" build "${bazel_build_flags[@]}" //oak/server/dev:oak


### PR DESCRIPTION
Currently those labels are not used for anything, but in the future they
will be used for information flow.

Convert constant from absl::string_view back to char*, it does not seem
to work with std::multimap otherwise.

Rename _policy_ to _label_. This may still not be the final terminology,
but seems more appropriate.

Reintroduce `--output_base` flag to `build_example` to avoid losing
incremental state.

Ref #212