### PR TITLE
Update toolchain config to work with Bazel 1.0.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,6 +29,7 @@ build:wasm32 --cpu=wasm32
 build:wasm32 --symlink_prefix=bazel-wasm-
 
 build:clang --crosstool_top=//toolchain:clang
+build:clang --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 build:clang --cpu=k8
 
 # Use a different symlink prefix for clang-based artifacts.

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -51,6 +51,7 @@ filegroup(
 cc_toolchain(
     name = "clang_toolchain_wasm32",
     all_files = ":all_files",
+    ar_files = ":all_files",
     compiler_files = ":all_files",
     dwp_files = ":empty",
     linker_files = ":all_files",
@@ -64,6 +65,7 @@ cc_toolchain(
 cc_toolchain(
     name = "clang_toolchain_k8",
     all_files = ":all_files",
+    ar_files = ":all_files",
     compiler_files = ":all_files",
     dwp_files = ":empty",
     linker_files = ":all_files",


### PR DESCRIPTION
Latest version of Bazel require explicit attribute for ar files to be included in the sandbox -https://github.com/bazelbuild/bazel/issues/8531

These were introduced before 28.1, which we are using in our Docker file, so it should work - https://docs.bazel.build/versions/0.28.0/be/c-cpp.html