### PR TITLE
Update Asylo dependency to current HEAD

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,9 +32,9 @@ http_archive(
 # Asylo Framework.
 http_archive(
     name = "com_google_asylo",
-    sha256 = "50c40a832c5ff41bbca695ec9f0235fd13f5917cbcca66bc3fdcd7391672805e",
-    strip_prefix = "asylo-25bd63a9e61df523744ba3299a6a17ae89d2c370",
-    urls = ["https://github.com/google/asylo/archive/25bd63a9e61df523744ba3299a6a17ae89d2c370.tar.gz"],
+    sha256 = "c57507e103b76501d5a8e73147cf6323eedff05fa47912bc1f9182404d3d2cfc",
+    strip_prefix = "asylo-f620292381aae18b5d5fe73dcc63e46f4bd653cc",
+    urls = ["https://github.com/google/asylo/archive/f620292381aae18b5d5fe73dcc63e46f4bd653cc.tar.gz"],
 )
 
 # Google Test

--- a/scripts/check_enclave_reproducibility
+++ b/scripts/check_enclave_reproducibility
@@ -22,7 +22,7 @@ for _ in 0 1
 do
     out="$DIFF_DIR/oak_enclave_unsigned_$(git rev-parse HEAD)_$(date --iso-8601=seconds).so"
     bazel clean
-    bazel build --subcommands --config=enc-sim //oak/server/asylo:oak
+    bazel build --config=enc-sim //oak/server/asylo:oak
     cp -f "$IN" "$out"
 done
 


### PR DESCRIPTION
This finally allows building enclave code reproducibly (#241).

For the record, I got the following output from
`scripts/check_enclave_reproducibility`:

```
5d3b12032df2c95728f2ecf0f646abdc67c46f2f  ./diff/oak_enclave_unsigned_e66a750eaafcaec35b50ba1df0298f342a8aa8f1_2019-10-14T20:05:25+00:00.so
5d3b12032df2c95728f2ecf0f646abdc67c46f2f  ./diff/oak_enclave_unsigned_e66a750eaafcaec35b50ba1df0298f342a8aa8f1_2019-10-14T20:10:46+00:00.so
```