### PR TITLE
Add shim bazel rule for fuzzer

### DIFF
--- a/oak/common/fuzzer.bzl
+++ b/oak/common/fuzzer.bzl
@@ -1,0 +1,26 @@
+#
+# Copyright 2019 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Fuzz-related definitions for Oak testing."""
+
+# Inspired by https://github.com/grpc/grpc/blob/618a3f561d4a93f263cca23abad086ed8f4d5e86/test/core/util/grpc_fuzzer.bzl.
+def oak_fuzzer(name, srcs = [], deps = [], **kwargs):
+    native.cc_binary(
+        name = name,
+        srcs = srcs,
+        deps = deps,
+        **kwargs
+    )

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -19,6 +19,7 @@ package(
     licenses = ["notice"],
 )
 
+load("//oak/common:fuzzer.bzl", "oak_fuzzer")
 load("//oak/server:wabt.bzl", "wasm_group")
 
 # Mark tests that can be run on the host system (i.e. with a normal
@@ -65,7 +66,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+oak_fuzzer(
     name = "wasm_node_fuzz",
     srcs = [
         "wasm_node_fuzzer.cc",


### PR DESCRIPTION
This will be replaced in actual fuzzing with something like
https://github.com/google/oss-fuzz/blob/7f8013db108e62727fba1c3cbcccac07d543682b/projects/grpc/build.sh#L33
so that it can depend on a provided fuzzer library.

Ref #261