### PR TITLE
Stick to i32/i64 integer types for ABI access

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -87,7 +87,7 @@ functions** as
   [`zx_channel_write`](https://fuchsia.dev/fuchsia-src/zircon/syscalls/channel_write)
   in Fuchsia.
 
-- `channel_create: (i32, i32) -> i64`: Create a new unidirectional channel and
+- `channel_create: (i32, i32) -> i32`: Create a new unidirectional channel and
   return the channel handles for its read and write halves.
 
   - arg 0: Address of an 8-byte location that will receive the handle for the

--- a/examples/abitest/module/rust/src/lib.rs
+++ b/examples/abitest/module/rust/src/lib.rs
@@ -216,15 +216,15 @@ impl FrontendNode {
             expect_eq!(
                 OakStatus::ERR_INVALID_ARGS.value(),
                 oak::wasm::channel_create(
-                    invalid_raw_offset() as *mut u64,
-                    &mut read.handle as *mut u64
+                    invalid_raw_offset() as *mut i64,
+                    &mut read.handle as *mut i64
                 )
             );
             expect_eq!(
                 OakStatus::ERR_INVALID_ARGS.value(),
                 oak::wasm::channel_create(
-                    &mut write.handle as *mut u64,
-                    invalid_raw_offset() as *mut u64
+                    &mut write.handle as *mut i64,
+                    invalid_raw_offset() as *mut i64
                 )
             );
         }
@@ -286,8 +286,8 @@ impl FrontendNode {
         let (out_channel, in_channel) = oak::channel_create().unwrap();
         let mut buf = Vec::<u8>::with_capacity(5);
         let mut handles = Vec::with_capacity(5);
-        let mut actual_size: u32 = 99;
-        let mut actual_handle_count: u32 = 99;
+        let mut actual_size: i32 = 99;
+        let mut actual_handle_count: i32 = 99;
         unsafe {
             // Try invalid values for the 4 linear memory offset arguments.
             expect_eq!(
@@ -298,7 +298,7 @@ impl FrontendNode {
                     1,
                     &mut actual_size,
                     handles.as_mut_ptr() as *mut u8,
-                    handles.capacity(),
+                    handles.capacity() as i32,
                     &mut actual_handle_count
                 )
             );
@@ -307,10 +307,10 @@ impl FrontendNode {
                 oak::wasm::channel_read(
                     in_channel.handle,
                     buf.as_mut_ptr(),
-                    buf.capacity(),
-                    invalid_raw_offset() as *mut u32,
+                    buf.capacity() as i32,
+                    invalid_raw_offset() as *mut i32,
                     handles.as_mut_ptr() as *mut u8,
-                    handles.capacity(),
+                    handles.capacity() as i32,
                     &mut actual_handle_count
                 )
             );
@@ -319,7 +319,7 @@ impl FrontendNode {
                 oak::wasm::channel_read(
                     in_channel.handle,
                     buf.as_mut_ptr(),
-                    buf.capacity(),
+                    buf.capacity() as i32,
                     &mut actual_size,
                     invalid_raw_offset() as *mut u8,
                     1,
@@ -331,11 +331,11 @@ impl FrontendNode {
                 oak::wasm::channel_read(
                     in_channel.handle,
                     buf.as_mut_ptr(),
-                    buf.capacity(),
+                    buf.capacity() as i32,
                     &mut actual_size,
                     handles.as_mut_ptr() as *mut u8,
-                    handles.capacity(),
-                    invalid_raw_offset() as *mut u32
+                    handles.capacity() as i32,
+                    invalid_raw_offset() as *mut i32
                 )
             );
 
@@ -345,10 +345,10 @@ impl FrontendNode {
                 oak::wasm::channel_read(
                     in_channel.handle,
                     buf.as_mut_ptr(),
-                    buf.capacity(),
+                    buf.capacity() as i32,
                     &mut actual_size,
                     handles.as_mut_ptr() as *mut u8,
-                    handles.capacity(),
+                    handles.capacity() as i32,
                     &mut actual_handle_count
                 )
             );
@@ -427,7 +427,7 @@ impl FrontendNode {
                     invalid_raw_offset() as *const u8,
                     1,
                     handles.as_ptr() as *const u8,
-                    handles.len(),
+                    handles.len() as i32,
                 )
             );
             expect_eq!(
@@ -435,7 +435,7 @@ impl FrontendNode {
                 oak::wasm::channel_write(
                     out_channel.handle,
                     buf.as_ptr(),
-                    buf.len(),
+                    buf.len() as i32,
                     invalid_raw_offset() as *const u8,
                     1,
                 )
@@ -501,20 +501,20 @@ impl FrontendNode {
             const COUNT: usize = 3;
             let mut space = Vec::with_capacity(COUNT * oak::wasm::SPACE_BYTES_PER_HANDLE);
             space
-                .write_u64::<byteorder::LittleEndian>(out_channel.handle)
+                .write_i64::<byteorder::LittleEndian>(out_channel.handle)
                 .unwrap();
             space.push(0x00);
             space
-                .write_u64::<byteorder::LittleEndian>(in_channel.handle)
+                .write_i64::<byteorder::LittleEndian>(in_channel.handle)
                 .unwrap();
             space.push(0x00);
             space
-                .write_u64::<byteorder::LittleEndian>(self.backend_in[0].handle)
+                .write_i64::<byteorder::LittleEndian>(self.backend_in[0].handle)
                 .unwrap();
             space.push(0x99); // deliberate nonsense status value
             expect_eq!(
                 OakStatus::OK.value(),
-                oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as u32)
+                oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as i32)
             );
             expect_eq!(
                 ChannelReadStatus::INVALID_CHANNEL.value(),
@@ -535,16 +535,16 @@ impl FrontendNode {
             const COUNT: usize = 2;
             let mut space = Vec::with_capacity(COUNT * oak::wasm::SPACE_BYTES_PER_HANDLE);
             space
-                .write_u64::<byteorder::LittleEndian>(9_123_456)
+                .write_i64::<byteorder::LittleEndian>(9_123_456)
                 .unwrap();
             space.push(0x00);
             space
-                .write_u64::<byteorder::LittleEndian>(in_channel.handle)
+                .write_i64::<byteorder::LittleEndian>(in_channel.handle)
                 .unwrap();
             space.push(0x00);
             expect_eq!(
                 OakStatus::OK.value(),
-                oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as u32)
+                oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as i32)
             );
             expect_eq!(
                 oak::proto::oak_api::ChannelReadStatus::INVALID_CHANNEL.value(),
@@ -564,12 +564,12 @@ impl FrontendNode {
             const COUNT: usize = 1;
             let mut space = Vec::with_capacity(COUNT * oak::wasm::SPACE_BYTES_PER_HANDLE);
             space
-                .write_u64::<byteorder::LittleEndian>(in_channel.handle)
+                .write_i64::<byteorder::LittleEndian>(in_channel.handle)
                 .unwrap();
             space.push(0x00);
             expect_eq!(
                 OakStatus::OK.value(),
-                oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as u32)
+                oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as i32)
             );
             expect_eq!(
                 oak::proto::oak_api::ChannelReadStatus::READ_READY.value(),
@@ -591,12 +591,12 @@ impl FrontendNode {
             const COUNT: usize = 1;
             let mut space = Vec::with_capacity(COUNT * oak::wasm::SPACE_BYTES_PER_HANDLE);
             space
-                .write_u64::<byteorder::LittleEndian>(in_channel.handle)
+                .write_i64::<byteorder::LittleEndian>(in_channel.handle)
                 .unwrap();
             space.push(0x00);
             expect_eq!(
                 OakStatus::ERR_BAD_HANDLE.value(),
-                oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as u32)
+                oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as i32)
             );
             expect_eq!(
                 oak::proto::oak_api::ChannelReadStatus::ORPHANED.value(),

--- a/rust/oak/src/grpc/mod.rs
+++ b/rust/oak/src/grpc/mod.rs
@@ -105,7 +105,7 @@ pub fn event_loop<T: OakNode>(
         // Block until there is a message to read on an input channel.
         crate::prep_handle_space(&mut space);
         unsafe {
-            let status = wasm::wait_on_channels(space.as_mut_ptr(), read_handles.len() as u32);
+            let status = wasm::wait_on_channels(space.as_mut_ptr(), read_handles.len() as i32);
             match OakStatus::from_i32(status) {
                 Some(OakStatus::OK) => (),
                 Some(err) => return err as i32,

--- a/rust/oak/src/wasm/mod.rs
+++ b/rust/oak/src/wasm/mod.rs
@@ -28,7 +28,7 @@ extern "C" {
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///
     /// [`OakStatus`]: crate::OakStatus
-    pub fn wait_on_channels(buf: *mut u8, count: u32) -> i32;
+    pub fn wait_on_channels(buf: *mut u8, count: i32) -> i32;
 
     /// Read a message from a channel.
     ///
@@ -50,13 +50,13 @@ extern "C" {
     /// [`ERR_HANDLE_SPACE_TOO_SMALL`]: crate::OakStatus::ERR_HANDLE_SPACE_TOO_SMALL
     /// [`OakStatus`]: crate::OakStatus
     pub fn channel_read(
-        handle: u64,
+        handle: i64,
         buf: *mut u8,
-        size: usize,
-        actual_size: *mut u32,
+        size: i32,
+        actual_size: *mut i32,
         handle_buf: *mut u8,
-        handle_count: usize,
-        actual_handle_count: *mut u32,
+        handle_count: i32,
+        actual_handle_count: *mut i32,
     ) -> i32;
 
     /// Write a message to a channel.
@@ -68,11 +68,11 @@ extern "C" {
     ///
     /// [`OakStatus`]: crate::OakStatus
     pub fn channel_write(
-        handle: u64,
+        handle: i64,
         buf: *const u8,
-        size: usize,
+        size: i32,
         handle_buf: *const u8,
-        handle_count: usize,
+        handle_count: i32,
     ) -> i32;
 
     /// Create a new unidirectional channel.
@@ -83,7 +83,7 @@ extern "C" {
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///
     /// [`OakStatus`]: crate::OakStatus
-    pub fn channel_create(write: *mut u64, read: *mut u64) -> i32;
+    pub fn channel_create(write: *mut i64, read: *mut i64) -> i32;
 
     /// Close a channel.
     ///
@@ -92,26 +92,26 @@ extern "C" {
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///
     /// [`OakStatus`]: crate::OakStatus
-    pub fn channel_close(handle: u64) -> i32;
+    pub fn channel_close(handle: i64) -> i32;
 
     /// Find a pre-defined channel identified by port name.
     ///
     /// The port name is provided in the memory area given by `buf` and `len`.
     ///
     /// Returns the handle value if found, or a zero (invalid) handle if not.
-    pub fn channel_find(buf: *const u8, len: usize) -> u64;
+    pub fn channel_find(buf: *const u8, len: i32) -> i64;
 
     /// Fill a buffer with random data.
     ///
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///
     /// [`OakStatus`]: crate::OakStatus
-    pub fn random_get(buf: *mut u8, len: usize) -> i32;
+    pub fn random_get(buf: *mut u8, len: i32) -> i32;
 }
 
 /// Number of bytes needed per-handle for channel readiness notifications.
 ///
 /// The notification space consists of the channel handle (as a little-endian
-/// u64) followed by a single byte indicating the channel readiness, as
+/// i64) followed by a single byte indicating the channel readiness, as
 /// a `ChannelReadStatus` value.
 pub const SPACE_BYTES_PER_HANDLE: usize = 9;


### PR DESCRIPTION
WebAssembly only has i32/i64 types so ensure that everything in
oak::wasm uses those types:
 - No unsigned types (u32/u64)
 - No pointer-sized types (usize), as linear memory offsets are
   always 32-bit.