### PR TITLE
Clarify sign/size of ABI types

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -20,12 +20,40 @@ involve manual management of linear memory. Oak Applications will typically use
 the higher-level [Oak SDK](sdk.md) which provides more convenient (and safer)
 wrappers around this functionality.
 
+## Integer Types
+
+WebAssembly has two integer types (`i32` and `i64`) which are treated as
+[signed or unsigned values depending on the context](https://webassembly.github.io/spec/core/syntax/types.html#value-types).
+
+Integer types that are passed across the Wasm boundary that forms the Oak ABI
+are written as `u32` or `u64` in this document, to make clear that the
+corresponding Wasm `i32` or `i64` values are always treated as unsigned values.
+(There are currently no uses of signed values in the ABI.)
+
+Integer types that refer to:
+
+- offsets in linear memory
+- sizes of regions in linear memory
+
+are written as the `usize` type, which is an alias for the `u32` type in the
+current WebAsssembly implementation(s). However, in any future
+[64-bit](https://github.com/WebAssembly/design/blob/master/FutureFeatures.md#linear-memory-bigger-than-4-gib)
+version of WebAssembly this `usize` type would instead be an alias for the `u64`
+type.
+
+Two specific sets of integer values are used in multiple places in the ABI:
+
+- Many ABI operations return a `u32` **status** value, indicating the result of
+  the operation.
+- Many operations take a `u64` **handle** value; these values are Node-specific
+  and non-zero (zero is reserved to indicate an invalid handle).
+
 ## Exported Function
 
 Each Oak Module must expose the following **exported function** as a
 [WebAssembly export](https://webassembly.github.io/spec/core/syntax/modules.html#exports):
 
-- `oak_main: () -> i32`: Invoked when the Oak Manager executes the Oak Node.
+- `oak_main: () -> u32`: Invoked when the Oak Manager executes the Oak Node.
   This function should perform its own event loop, reading incoming messages
   that arrive on the read halves of its channels, sending outgoing messages over
   the write halves of channels. This function is generally expected to run
@@ -39,7 +67,7 @@ functions** as
 [WebAssembly imports](https://webassembly.github.io/spec/core/syntax/modules.html#imports)
 (all of them defined in the `oak` module):
 
-- `wait_on_channels: (i32, i32) -> i32`: Blocks until data is available for
+- `wait_on_channels: (usize, u32) -> u32`: Blocks until data is available for
   reading from one of the specified channel handles. The channel handles are
   encoded in a buffer that holds N contiguous 9-byte chunks, each of which is
   made up of an 8-byte channel handle value (little-endian u64) followed by a
@@ -49,12 +77,12 @@ functions** as
   - arg1: Count N of handles provided
   - return 0: Status of operation
 
-- `channel_read: (i64, i32, i32, i32, i32, i32, i32) -> i32`: Reads a single
-  message and associated channel handles from the specified channel, setting the
-  size of the data in the location provided by arg 3, and the count of returned
-  handles in the location provided by arg 6. If the provided spaces for data
-  (args 1 and 2) or handles (args 4 and 5) are not large enough for the read
-  operation, then no data will be returned and either `BUFFER_TOO_SMALL` or
+- `channel_read: (u64, usize, usize, usize, usize, u32, usize) -> u32`: Reads a
+  single message and associated channel handles from the specified channel,
+  setting the size of the data in the location provided by arg 3, and the count
+  of returned handles in the location provided by arg 6. If the provided spaces
+  for data (args 1 and 2) or handles (args 4 and 5) are not large enough for the
+  read operation, then no data will be returned and either `BUFFER_TOO_SMALL` or
   `HANDLE_SPACE_TOO_SMALL` will be returned; in either case, the required sizes
   will be returned in the spaces provided by args 3 and 6.
 
@@ -63,7 +91,7 @@ functions** as
   - arg 2: Destination buffer size in bytes
   - arg 3: Address of a 4-byte location that will receive the number of bytes in
     the message (as a little-endian u32).
-  - arg 4: Destination handle array buffer (to receive little-endian i64 values)
+  - arg 4: Destination handle array buffer (to receive little-endian u64 values)
   - arg 5: Destination handle array count
   - arg 6: Address of a 4-byte location that will receive the number of handles
     retrieved with the message (as a little-endian u32)
@@ -73,13 +101,13 @@ functions** as
   [`zx_channel_read`](https://fuchsia.dev/fuchsia-src/zircon/syscalls/channel_read)
   in Fuchsia.
 
-- `channel_write: (i64, i32, i32, i32, i32) -> i32`: Writes a single message to
-  the specified channel, together with any associated handles.
+- `channel_write: (u64, usize, usize, usize, u32) -> u32`: Writes a single
+  message to the specified channel, together with any associated handles.
 
   - arg 0: Handle to channel send half
   - arg 1: Source buffer address holding message
   - arg 2: Source buffer size in bytes
-  - arg 3: Source handle array (of little-endian i64 values)
+  - arg 3: Source handle array (of little-endian u64 values)
   - arg 4: Source handle array count
   - return 0: Status of operation
 
@@ -87,8 +115,8 @@ functions** as
   [`zx_channel_write`](https://fuchsia.dev/fuchsia-src/zircon/syscalls/channel_write)
   in Fuchsia.
 
-- `channel_create: (i32, i32) -> i64`: Create a new unidirectional channel and
-  return the channel handles for its read and write halves.
+- `channel_create: (usize, usize) -> u32`: Create a new unidirectional channel
+  and return the channel handles for its read and write halves.
 
   - arg 0: Address of an 8-byte location that will receive the handle for the
     write half of the channel (as a little-endian u64).
@@ -96,19 +124,19 @@ functions** as
     read half of the channel (as a little-endian u64).
   - return 0: Status of operation
 
-- `channel_close: (i64) -> i32`: Closes the channel identified by arg 0.
+- `channel_close: (u64) -> u32`: Closes the channel identified by arg 0.
 
   - arg 0: Handle to channel
   - return 0: Status of operation
 
-- `channel_find: (i32, i32) -> i64`: Return the channel handle that corresponds
-  to a provided port name, or zero if not found.
+- `channel_find: (usize, usize) -> u64`: Return the channel handle that
+  corresponds to a provided port name, or zero if not found.
 
   - arg 0: Source buffer holding port name
   - arg 1: Source buffer size in bytes
   - return 0: Channel handle, or zero if not found.
 
-- `random_get: (i32, i32) -> i32`: Fill a buffer with random bytes.
+- `random_get: (usize, usize) -> u32`: Fill a buffer with random bytes.
 
   - arg 0: Destination buffer
   - arg 1: Destination buffer size in bytes

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -44,6 +44,10 @@ The lowest level of access to the [Oak ABI](abi.md) is provided by the
 This module simply provides the Rust `extern "C"` declarations of the
 [host functions](abi.md#host-functions) provided by the ABI.
 
+The `u32`, `u64` and `usize` integer types described in the
+[Oak ABI](abi.md#integer-types) definition are mapped to the Rust integer types
+with the same names.
+
 ### `oak::io` Module
 
 The [`oak::io`](https://project-oak.github.io/oak/sdk/oak/io/index.html) module

--- a/examples/abitest/module/rust/src/lib.rs
+++ b/examples/abitest/module/rust/src/lib.rs
@@ -214,14 +214,14 @@ impl FrontendNode {
         let mut read = oak::ReadHandle { handle: 0 };
         unsafe {
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::channel_create(
                     invalid_raw_offset() as *mut u64,
                     &mut read.handle as *mut u64
                 )
             );
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::channel_create(
                     &mut write.handle as *mut u64,
                     invalid_raw_offset() as *mut u64
@@ -254,14 +254,20 @@ impl FrontendNode {
     fn test_channel_close_raw(&self) -> std::io::Result<()> {
         let (w, r) = oak::channel_create().unwrap();
         unsafe {
-            expect_eq!(OakStatus::OK.value(), oak::wasm::channel_close(w.handle));
-            expect_eq!(OakStatus::OK.value(), oak::wasm::channel_close(r.handle));
             expect_eq!(
-                OakStatus::ERR_BAD_HANDLE.value(),
+                OakStatus::OK.value() as u32,
                 oak::wasm::channel_close(w.handle)
             );
             expect_eq!(
-                OakStatus::ERR_BAD_HANDLE.value(),
+                OakStatus::OK.value() as u32,
+                oak::wasm::channel_close(r.handle)
+            );
+            expect_eq!(
+                OakStatus::ERR_BAD_HANDLE.value() as u32,
+                oak::wasm::channel_close(w.handle)
+            );
+            expect_eq!(
+                OakStatus::ERR_BAD_HANDLE.value() as u32,
                 oak::wasm::channel_close(9_999_999)
             );
         }
@@ -291,31 +297,31 @@ impl FrontendNode {
         unsafe {
             // Try invalid values for the 4 linear memory offset arguments.
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::channel_read(
                     in_channel.handle,
                     invalid_raw_offset() as *mut u8,
                     1,
                     &mut actual_size,
                     handles.as_mut_ptr() as *mut u8,
-                    handles.capacity(),
+                    handles.capacity() as u32,
                     &mut actual_handle_count
                 )
             );
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::channel_read(
                     in_channel.handle,
                     buf.as_mut_ptr(),
                     buf.capacity(),
                     invalid_raw_offset() as *mut u32,
                     handles.as_mut_ptr() as *mut u8,
-                    handles.capacity(),
+                    handles.capacity() as u32,
                     &mut actual_handle_count
                 )
             );
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::channel_read(
                     in_channel.handle,
                     buf.as_mut_ptr(),
@@ -327,28 +333,28 @@ impl FrontendNode {
                 )
             );
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::channel_read(
                     in_channel.handle,
                     buf.as_mut_ptr(),
                     buf.capacity(),
                     &mut actual_size,
                     handles.as_mut_ptr() as *mut u8,
-                    handles.capacity(),
+                    handles.capacity() as u32,
                     invalid_raw_offset() as *mut u32
                 )
             );
 
             // Valid case.
             expect_eq!(
-                OakStatus::OK.value(),
+                OakStatus::OK.value() as u32,
                 oak::wasm::channel_read(
                     in_channel.handle,
                     buf.as_mut_ptr(),
                     buf.capacity(),
                     &mut actual_size,
                     handles.as_mut_ptr() as *mut u8,
-                    handles.capacity(),
+                    handles.capacity() as u32,
                     &mut actual_handle_count
                 )
             );
@@ -421,17 +427,17 @@ impl FrontendNode {
         let handles = vec![in_channel.handle];
         unsafe {
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::channel_write(
                     out_channel.handle,
                     invalid_raw_offset() as *const u8,
                     1,
                     handles.as_ptr() as *const u8,
-                    handles.len(),
+                    handles.len() as u32,
                 )
             );
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::channel_write(
                     out_channel.handle,
                     buf.as_ptr(),
@@ -491,7 +497,7 @@ impl FrontendNode {
 
         unsafe {
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::wait_on_channels(invalid_raw_offset() as *mut u8, 1)
             );
         }
@@ -513,7 +519,7 @@ impl FrontendNode {
                 .unwrap();
             space.push(0x99); // deliberate nonsense status value
             expect_eq!(
-                OakStatus::OK.value(),
+                OakStatus::OK.value() as u32,
                 oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as u32)
             );
             expect_eq!(
@@ -543,7 +549,7 @@ impl FrontendNode {
                 .unwrap();
             space.push(0x00);
             expect_eq!(
-                OakStatus::OK.value(),
+                OakStatus::OK.value() as u32,
                 oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as u32)
             );
             expect_eq!(
@@ -568,7 +574,7 @@ impl FrontendNode {
                 .unwrap();
             space.push(0x00);
             expect_eq!(
-                OakStatus::OK.value(),
+                OakStatus::OK.value() as u32,
                 oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as u32)
             );
             expect_eq!(
@@ -595,7 +601,7 @@ impl FrontendNode {
                 .unwrap();
             space.push(0x00);
             expect_eq!(
-                OakStatus::ERR_BAD_HANDLE.value(),
+                OakStatus::ERR_BAD_HANDLE.value() as u32,
                 oak::wasm::wait_on_channels(space.as_mut_ptr(), COUNT as u32)
             );
             expect_eq!(
@@ -707,7 +713,7 @@ impl FrontendNode {
     fn test_random_get_raw(&self) -> std::io::Result<()> {
         unsafe {
             expect_eq!(
-                OakStatus::ERR_INVALID_ARGS.value(),
+                OakStatus::ERR_INVALID_ARGS.value() as u32,
                 oak::wasm::random_get(invalid_raw_offset() as *mut u8, 1)
             );
         }

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -36,6 +36,10 @@
 
 namespace oak {
 
+// Alias for types used for linear memory addressing.  This should be the only
+// thing that needs changing for any future 64-bit version of Wasm.
+static wabt::Type wabtUsizeType = wabt::Type::I32;
+
 // From https://github.com/WebAssembly/wabt/blob/master/src/tools/wasm-interp.cc .
 
 static std::unique_ptr<wabt::FileStream> s_log_stream = wabt::FileStream::CreateStdout();
@@ -204,27 +208,26 @@ void WasmNode::InitEnvironment(wabt::interp::Environment* env) {
   oak_module->AppendFuncExport(
       "channel_read",
       wabt::interp::FuncSignature(
-          std::vector<wabt::Type>{wabt::Type::I64, wabt::Type::I32, wabt::Type::I32,
-                                  wabt::Type::I32, wabt::Type::I32, wabt::Type::I32,
-                                  wabt::Type::I32},
+          std::vector<wabt::Type>{wabt::Type::I64, wabtUsizeType, wabtUsizeType, wabtUsizeType,
+                                  wabtUsizeType, wabt::Type::I32, wabtUsizeType},
           std::vector<wabt::Type>{wabt::Type::I32}),
       this->OakChannelRead(env));
   oak_module->AppendFuncExport(
       "channel_write",
       wabt::interp::FuncSignature(
-          std::vector<wabt::Type>{wabt::Type::I64, wabt::Type::I32, wabt::Type::I32,
-                                  wabt::Type::I32, wabt::Type::I32},
+          std::vector<wabt::Type>{wabt::Type::I64, wabtUsizeType, wabtUsizeType, wabtUsizeType,
+                                  wabt::Type::I32},
           std::vector<wabt::Type>{wabt::Type::I32}),
       this->OakChannelWrite(env));
 
   oak_module->AppendFuncExport(
       "wait_on_channels",
-      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabtUsizeType, wabt::Type::I32},
                                   std::vector<wabt::Type>{wabt::Type::I32}),
       this->OakWaitOnChannels(env));
   oak_module->AppendFuncExport(
       "channel_create",
-      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabtUsizeType, wabtUsizeType},
                                   std::vector<wabt::Type>{wabt::Type::I32}),
       this->OakChannelCreate(env));
   oak_module->AppendFuncExport(
@@ -234,12 +237,12 @@ void WasmNode::InitEnvironment(wabt::interp::Environment* env) {
       this->OakChannelClose(env));
   oak_module->AppendFuncExport(
       "channel_find",
-      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabtUsizeType, wabtUsizeType},
                                   std::vector<wabt::Type>{wabt::Type::I64}),
       this->OakChannelFind(env));
   oak_module->AppendFuncExport(
       "random_get",
-      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabtUsizeType, wabtUsizeType},
                                   std::vector<wabt::Type>{wabt::Type::I32}),
       this->OakRandomGet(env));
 }

--- a/rust/oak/src/grpc/mod.rs
+++ b/rust/oak/src/grpc/mod.rs
@@ -106,7 +106,7 @@ pub fn event_loop<T: OakNode>(
         crate::prep_handle_space(&mut space);
         unsafe {
             let status = wasm::wait_on_channels(space.as_mut_ptr(), read_handles.len() as u32);
-            match OakStatus::from_i32(status) {
+            match OakStatus::from_i32(status as i32) {
                 Some(OakStatus::OK) => (),
                 Some(err) => return err as i32,
                 None => return OakStatus::OAK_STATUS_UNSPECIFIED.value(),

--- a/rust/oak/src/lib.rs
+++ b/rust/oak/src/lib.rs
@@ -93,7 +93,7 @@ pub fn wait_on_channels(handles: &[ReadHandle]) -> Result<Vec<ChannelReadStatus>
     let mut space = new_handle_space(handles);
     unsafe {
         let status = wasm::wait_on_channels(space.as_mut_ptr(), handles.len() as u32);
-        match OakStatus::from_i32(status) {
+        match OakStatus::from_i32(status as i32) {
             Some(OakStatus::OK) => (),
             Some(err) => return Err(err),
             None => return Err(OakStatus::OAK_STATUS_UNSPECIFIED),
@@ -131,9 +131,9 @@ pub fn channel_read(half: ReadHandle, buf: &mut Vec<u8>, handles: &mut Vec<Handl
                 buf.capacity(),
                 &mut actual_size,
                 handles.as_mut_ptr() as *mut u8,
-                handles.capacity(),
+                handles.capacity() as u32,
                 &mut actual_handle_count,
-            )
+            ) as i32
         });
         match status {
             Some(OakStatus::OK) => {
@@ -183,8 +183,8 @@ pub fn channel_write(half: WriteHandle, buf: &[u8], handles: &[Handle]) -> OakSt
             buf.as_ptr(),
             buf.len(),
             handles.as_ptr() as *const u8, // Wasm spec defines this as little-endian
-            handles.len(),
-        )
+            handles.len() as u32,
+        ) as i32
     }) {
         Some(s) => s,
         None => OakStatus::ERR_INTERNAL,
@@ -199,7 +199,7 @@ pub fn channel_create() -> Result<(WriteHandle, ReadHandle), OakStatus> {
     let mut write = WriteHandle { handle: 0 };
     let mut read = ReadHandle { handle: 0 };
     match OakStatus::from_i32(unsafe {
-        wasm::channel_create(&mut write.handle as *mut u64, &mut read.handle as *mut u64)
+        wasm::channel_create(&mut write.handle as *mut u64, &mut read.handle as *mut u64) as i32
     }) {
         Some(OakStatus::OK) => Ok((write, read)),
         Some(err) => Err(err),
@@ -209,7 +209,7 @@ pub fn channel_create() -> Result<(WriteHandle, ReadHandle), OakStatus> {
 
 /// Close the specified channel [`Handle`].
 pub fn channel_close(handle: Handle) -> OakStatus {
-    match OakStatus::from_i32(unsafe { wasm::channel_close(handle) }) {
+    match OakStatus::from_i32(unsafe { wasm::channel_close(handle) as i32 }) {
         Some(s) => s,
         None => OakStatus::OAK_STATUS_UNSPECIFIED,
     }
@@ -223,7 +223,7 @@ pub fn channel_find(port_name: &str) -> Handle {
 
 /// Fill a buffer with random data.
 pub fn random_get(buf: &mut [u8]) -> OakStatus {
-    match OakStatus::from_i32(unsafe { wasm::random_get(buf.as_mut_ptr(), buf.len()) }) {
+    match OakStatus::from_i32(unsafe { wasm::random_get(buf.as_mut_ptr(), buf.len()) as i32 }) {
         Some(s) => s,
         None => OakStatus::OAK_STATUS_UNSPECIFIED,
     }

--- a/rust/oak/src/tests.rs
+++ b/rust/oak/src/tests.rs
@@ -33,7 +33,7 @@ fn test_write_message_failure() {
     oak_tests::reset_channels();
     let send_channel = WriteHandle { handle: 123 };
     let data = [0x44, 0x4d, 0x44];
-    oak_tests::set_write_status(Some(OakStatus::ERR_INVALID_ARGS.value()));
+    oak_tests::set_write_status(Some(OakStatus::ERR_INVALID_ARGS.value() as u32));
     assert_eq!(
         OakStatus::ERR_INVALID_ARGS,
         channel_write(send_channel, &data, &[])
@@ -73,7 +73,7 @@ fn test_read_message_failure() {
     let rcv = ReadHandle { handle: 123 };
     let mut buf = Vec::with_capacity(100);
     let mut handles = Vec::with_capacity(1);
-    oak_tests::set_read_status(Some(OakStatus::ERR_INVALID_ARGS.value()));
+    oak_tests::set_read_status(Some(OakStatus::ERR_INVALID_ARGS.value() as u32));
     assert_eq!(
         channel_read(rcv, &mut buf, &mut handles),
         OakStatus::ERR_INVALID_ARGS
@@ -88,7 +88,7 @@ fn test_read_message_internal_failure() {
     let mut handles = Vec::with_capacity(1);
 
     // Set buffer too small but don't set actual size, so the retry gets confused.
-    oak_tests::set_read_status(Some(OakStatus::ERR_BUFFER_TOO_SMALL.value()));
+    oak_tests::set_read_status(Some(OakStatus::ERR_BUFFER_TOO_SMALL.value() as u32));
     assert_matches!(
         channel_read(rcv, &mut buf, &mut handles),
         OakStatus::ERR_BUFFER_TOO_SMALL

--- a/rust/oak/src/wasm/mod.rs
+++ b/rust/oak/src/wasm/mod.rs
@@ -28,7 +28,7 @@ extern "C" {
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///
     /// [`OakStatus`]: crate::OakStatus
-    pub fn wait_on_channels(buf: *mut u8, count: u32) -> i32;
+    pub fn wait_on_channels(buf: *mut u8, count: u32) -> u32;
 
     /// Read a message from a channel.
     ///
@@ -55,9 +55,9 @@ extern "C" {
         size: usize,
         actual_size: *mut u32,
         handle_buf: *mut u8,
-        handle_count: usize,
+        handle_count: u32,
         actual_handle_count: *mut u32,
-    ) -> i32;
+    ) -> u32;
 
     /// Write a message to a channel.
     ///
@@ -72,8 +72,8 @@ extern "C" {
         buf: *const u8,
         size: usize,
         handle_buf: *const u8,
-        handle_count: usize,
-    ) -> i32;
+        handle_count: u32,
+    ) -> u32;
 
     /// Create a new unidirectional channel.
     ///
@@ -83,7 +83,7 @@ extern "C" {
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///
     /// [`OakStatus`]: crate::OakStatus
-    pub fn channel_create(write: *mut u64, read: *mut u64) -> i32;
+    pub fn channel_create(write: *mut u64, read: *mut u64) -> u32;
 
     /// Close a channel.
     ///
@@ -92,7 +92,7 @@ extern "C" {
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///
     /// [`OakStatus`]: crate::OakStatus
-    pub fn channel_close(handle: u64) -> i32;
+    pub fn channel_close(handle: u64) -> u32;
 
     /// Find a pre-defined channel identified by port name.
     ///
@@ -106,7 +106,7 @@ extern "C" {
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///
     /// [`OakStatus`]: crate::OakStatus
-    pub fn random_get(buf: *mut u8, len: usize) -> i32;
+    pub fn random_get(buf: *mut u8, len: usize) -> u32;
 }
 
 /// Number of bytes needed per-handle for channel readiness notifications.


### PR DESCRIPTION
Use u32/u64/usize everywhere (all ABI values are treated as unsigned),
with usize specifically indicating a linear memory address or size
(so any future Wasm64 port would map usize->u64 instead of u32).