### PR TITLE
Fix gRPC encapsulated storage operations

### DIFF
--- a/rust/oak/src/storage/mod.rs
+++ b/rust/oak/src/storage/mod.rs
@@ -76,6 +76,9 @@ impl Storage {
         );
 
         let mut request_any = protobuf::well_known_types::Any::new();
+        request_any.set_type_url(
+            String::from("type.googleapis.com/") + operation_request.descriptor().full_name(),
+        );
         operation_request
             .write_to_writer(&mut request_any.value)
             .unwrap();

--- a/rust/oak/src/storage/mod.rs
+++ b/rust/oak/src/storage/mod.rs
@@ -76,6 +76,8 @@ impl Storage {
         );
 
         let mut request_any = protobuf::well_known_types::Any::new();
+        // TODO: rust-protobuf does not provide pack_from/unpack_to functions.
+        // https://github.com/stepancheg/rust-protobuf/issues/455
         request_any.set_type_url(
             String::from("type.googleapis.com/") + operation_request.descriptor().full_name(),
         );


### PR DESCRIPTION
The rust-protobuf implementation does not automatically set
Any::type_url.