### PR TITLE
Use a per-invocation gRPC response channel

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -152,13 +152,12 @@ are configured by the `oak::DefaultConfig()`
 - `log` (send): Messages sent to this channel will treated as UTF-8 strings to
   be logged.
 - `grpc_in` (receive): This channel will be populated with incoming gRPC request
-  messages, for processing by the Oak Node. Each message is a serialized
-  `GrpcRequest` protocol buffer message (see
-  [/oak/proto/grpc_encap.proto](oak/proto/grpc_encap.proto)).
-- `grpc_out` (send): This channel can be used to send gRPC response messages.
-  Each such message should be encoded as a serialized `GrpcResponse` protocol
-  buffer message (see
-  [/oak/proto/grpc_encap.proto](oak/proto/grpc_encap.proto)).
+  messages, for processing by the Oak Node. Each incoming message is a
+  serialized `GrpcRequest` protocol buffer message (see
+  [/oak/proto/grpc_encap.proto](oak/proto/grpc_encap.proto)), and is accompanied
+  by a handle for the write half of a channel which should be used for sending
+  the associated gRPC response messages (as serialized `GrpcResponse` protocol
+  buffer messages).
 - `storage_in` (receive): This channel will be populated with incoming storage
   response messages, for processing by the Oak Node. Each message is a
   serialized `StorageOperationResponse` protocol buffer message (see

--- a/examples/abitest/client/abitest.cc
+++ b/examples/abitest/client/abitest.cc
@@ -49,10 +49,6 @@ static const char* app_config_textproto = R"raw(nodes {
       type: IN
     }
     ports {
-      name: "gRPC_output"
-      type: OUT
-    }
-    ports {
       name: "logging_port"
       type: OUT
     }
@@ -160,16 +156,6 @@ channels {
   destination_endpoint {
     node_name: "frontend"
     port_name: "gRPC_input"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "frontend"
-    port_name: "gRPC_output"
-  }
-  destination_endpoint {
-    node_name: "grpc_server"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/app_config.h
+++ b/oak/common/app_config.h
@@ -24,7 +24,6 @@
 namespace oak {
 
 extern const char kGrpcNodeRequestPortName[];
-extern const char kGrpcNodeResponsePortName[];
 extern const char kLoggingNodePortName[];
 extern const char kStorageNodeRequestPortName[];
 extern const char kStorageNodeResponsePortName[];

--- a/oak/common/testdata/barenode.textproto
+++ b/oak/common/testdata/barenode.textproto
@@ -14,10 +14,6 @@ nodes {
       name: "grpc_in"
       type: IN
     }
-    ports {
-      name: "grpc_out"
-      type: OUT
-    }
   }
 }
 wasm_contents {
@@ -32,15 +28,5 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }

--- a/oak/common/testdata/channel_dest_missing.textproto
+++ b/oak/common/testdata/channel_dest_missing.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -53,16 +49,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in_wrong"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/channel_inverted.textproto
+++ b/oak/common/testdata/channel_inverted.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -53,16 +49,6 @@ channels {
   source_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/channel_source_missing.textproto
+++ b/oak/common/testdata/channel_source_missing.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -53,16 +49,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/default.textproto
+++ b/oak/common/testdata/default.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -53,16 +49,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/dup_node_name.textproto
+++ b/oak/common/testdata/dup_node_name.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -53,16 +49,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/dup_port.textproto
+++ b/oak/common/testdata/dup_port.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -57,16 +53,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/dup_wasm.textproto
+++ b/oak/common/testdata/dup_wasm.textproto
@@ -14,10 +14,6 @@ nodes {
       name: "grpc_in"
       type: IN
     }
-    ports {
-      name: "grpc_out"
-      type: OUT
-    }
   }
 }
 wasm_contents {
@@ -36,15 +32,5 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }

--- a/oak/common/testdata/in_port_empty.textproto
+++ b/oak/common/testdata/in_port_empty.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -57,16 +53,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/lognode.textproto
+++ b/oak/common/testdata/lognode.textproto
@@ -15,10 +15,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -40,16 +36,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/missing_wasm.textproto
+++ b/oak/common/testdata/missing_wasm.textproto
@@ -14,10 +14,6 @@ nodes {
       name: "grpc_in"
       type: IN
     }
-    ports {
-      name: "grpc_out"
-      type: OUT
-    }
   }
 }
 channels {
@@ -28,15 +24,5 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }

--- a/oak/common/testdata/multinode.textproto
+++ b/oak/common/testdata/multinode.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "gRPC_output"
-      type: OUT
-    }
-    ports {
       name: "logging_port"
       type: OUT
     }
@@ -69,16 +65,6 @@ channels {
   destination_endpoint {
     node_name: "frontend"
     port_name: "gRPC_input"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "frontend"
-    port_name: "gRPC_output"
-  }
-  destination_endpoint {
-    node_name: "grpc_server"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/out_port_empty.textproto
+++ b/oak/common/testdata/out_port_empty.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -57,16 +53,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/out_port_multi.textproto
+++ b/oak/common/testdata/out_port_multi.textproto
@@ -15,7 +15,7 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
+      name: "backend_out"
       type: OUT
     }
   }
@@ -24,6 +24,10 @@ nodes {
   node_name: "backend"
   web_assembly_node {
     wasm_contents_name: "backend-code"
+    ports {
+      name: "main"
+      type: IN
+    }
     ports {
       name: "extra"
       type: IN
@@ -51,17 +55,17 @@ channels {
 channels {
   source_endpoint {
     node_name: "app"
-    port_name: "grpc_out"
+    port_name: "backend_out"
   }
   destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
+    node_name: "backend"
+    port_name: "main"
   }
 }
 channels {
   source_endpoint {
     node_name: "app"
-    port_name: "grpc_out"
+    port_name: "backend_out"
   }
   destination_endpoint {
     node_name: "backend"

--- a/oak/common/testdata/storagenode.textproto
+++ b/oak/common/testdata/storagenode.textproto
@@ -15,10 +15,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "storage_out"
       type: OUT
     }
@@ -46,16 +42,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/two_grpc.textproto
+++ b/oak/common/testdata/two_grpc.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -57,16 +53,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/common/testdata/two_log.textproto
+++ b/oak/common/testdata/two_log.textproto
@@ -10,10 +10,6 @@ nodes {
       type: IN
     }
     ports {
-      name: "grpc_out"
-      type: OUT
-    }
-    ports {
       name: "log"
       type: OUT
     }
@@ -57,16 +53,6 @@ channels {
   destination_endpoint {
     node_name: "app"
     port_name: "grpc_in"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "app"
-    port_name: "grpc_out"
-  }
-  destination_endpoint {
-    node_name: "grpc"
-    port_name: "response"
   }
 }
 channels {

--- a/oak/proto/grpc_encap.proto
+++ b/oak/proto/grpc_encap.proto
@@ -28,15 +28,13 @@ import "third_party/google/rpc/status.proto";
 // simplified envelope format that includes the relevant details.
 
 message GrpcRequest {
-  int32 stream_id = 1;
-  string method_name = 2;
-  google.protobuf.Any req_msg = 3;
-  bool last = 4;
+  string method_name = 1;
+  google.protobuf.Any req_msg = 2;
+  bool last = 3;
 }
 
 message GrpcResponse {
-  int32 stream_id = 1;
-  google.protobuf.Any rsp_msg = 2;
-  google.rpc.Status status = 3;
-  bool last = 4;
+  google.protobuf.Any rsp_msg = 1;
+  google.rpc.Status status = 2;
+  bool last = 3;
 }

--- a/oak/proto/manager.proto
+++ b/oak/proto/manager.proto
@@ -49,15 +49,12 @@ message Node {
 // interact with the Application over gRPC.
 //
 // An Application that exposes an external gRPC server interface should
-// therefore include a single GrpcServerNode, and should configure a pair of
-// Channels (send + receive) between that Node and a WebAssemblyNode that
-// handles the gRPC requests.
+// therefore include a single GrpcServerNode, and should configure a channel
+// from that node to the WebAssemblyNode that handles the gRPC requests.
 //
 // This Node defines the following implicit Ports:
 // - `request`: OUT port on which incoming requests are sent to a WebAssembly
 //   processing Node
-// - `response`: IN port on which outgoing responses are sent back by the
-//   WebAssembly processing Node
 message GrpcServerNode {
 }
 

--- a/oak/server/module_invocation.h
+++ b/oak/server/module_invocation.h
@@ -17,6 +17,8 @@
 #ifndef OAK_SERVER_MODULE_INVOCATION_H_
 #define OAK_SERVER_MODULE_INVOCATION_H_
 
+#include <memory>
+
 #include "include/grpcpp/generic/async_generic_service.h"
 #include "include/grpcpp/grpcpp.h"
 #include "oak/server/channel.h"
@@ -72,6 +74,8 @@ class ModuleInvocation {
 
   // Borrowed references to gRPC Node that this invocation is on behalf of.
   OakGrpcNode* grpc_node_;
+
+  std::unique_ptr<MessageChannelReadHalf> rsp_half_;
 
   grpc::GenericServerContext context_;
   grpc::GenericServerAsyncReaderWriter stream_;

--- a/oak/server/oak_grpc_node.h
+++ b/oak/server/oak_grpc_node.h
@@ -56,9 +56,6 @@ class OakGrpcNode final : public Application::Service, public OakNode {
   MessageChannelWriteHalf* BorrowWriteChannel() const {
     return OakNode::BorrowWriteChannel(FindChannel(kGrpcNodeRequestPortName));
   }
-  MessageChannelReadHalf* BorrowReadChannel() const {
-    return OakNode::BorrowReadChannel(FindChannel(kGrpcNodeResponsePortName));
-  }
 
   // Consumes gRPC events from the completion queue in an infinite loop.
   void CompletionQueueLoop();

--- a/rust/oak/src/io/mod.rs
+++ b/rust/oak/src/io/mod.rs
@@ -16,7 +16,7 @@
 
 //! Wrappers for Oak SDK types to allow their use with [`std::io`].
 
-use crate::{channel_write, OakStatus};
+use crate::{channel_close, channel_write, OakStatus};
 use std::io;
 
 /// Wrapper for a WriteHandle to implement the [`std::io::Write`] trait.
@@ -35,6 +35,10 @@ impl Channel {
     /// Create a new `io::Channel` that uses the given channel handle.
     pub fn new(handle: crate::WriteHandle) -> Self {
         Channel { handle }
+    }
+    /// Close the underlying channel handle.
+    pub fn close(self) -> std::io::Result<()> {
+        result_from_status(Some(channel_close(self.handle.handle)), ())
     }
 }
 

--- a/rust/oak/src/proto/grpc_encap.rs
+++ b/rust/oak/src/proto/grpc_encap.rs
@@ -29,7 +29,6 @@ const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_0;
 #[derive(PartialEq,Clone,Default)]
 pub struct GrpcRequest {
     // message fields
-    pub stream_id: i32,
     pub method_name: ::std::string::String,
     pub req_msg: ::protobuf::SingularPtrField<::protobuf::well_known_types::Any>,
     pub last: bool,
@@ -49,22 +48,7 @@ impl GrpcRequest {
         ::std::default::Default::default()
     }
 
-    // int32 stream_id = 1;
-
-
-    pub fn get_stream_id(&self) -> i32 {
-        self.stream_id
-    }
-    pub fn clear_stream_id(&mut self) {
-        self.stream_id = 0;
-    }
-
-    // Param is passed by value, moved
-    pub fn set_stream_id(&mut self, v: i32) {
-        self.stream_id = v;
-    }
-
-    // string method_name = 2;
+    // string method_name = 1;
 
 
     pub fn get_method_name(&self) -> &str {
@@ -90,7 +74,7 @@ impl GrpcRequest {
         ::std::mem::replace(&mut self.method_name, ::std::string::String::new())
     }
 
-    // .google.protobuf.Any req_msg = 3;
+    // .google.protobuf.Any req_msg = 2;
 
 
     pub fn get_req_msg(&self) -> &::protobuf::well_known_types::Any {
@@ -123,7 +107,7 @@ impl GrpcRequest {
         self.req_msg.take().unwrap_or_else(|| ::protobuf::well_known_types::Any::new())
     }
 
-    // bool last = 4;
+    // bool last = 3;
 
 
     pub fn get_last(&self) -> bool {
@@ -154,19 +138,12 @@ impl ::protobuf::Message for GrpcRequest {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
-                    }
-                    let tmp = is.read_int32()?;
-                    self.stream_id = tmp;
-                },
-                2 => {
                     ::protobuf::rt::read_singular_proto3_string_into(wire_type, is, &mut self.method_name)?;
                 },
-                3 => {
+                2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.req_msg)?;
                 },
-                4 => {
+                3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     }
@@ -185,11 +162,8 @@ impl ::protobuf::Message for GrpcRequest {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        if self.stream_id != 0 {
-            my_size += ::protobuf::rt::value_size(1, self.stream_id, ::protobuf::wire_format::WireTypeVarint);
-        }
         if !self.method_name.is_empty() {
-            my_size += ::protobuf::rt::string_size(2, &self.method_name);
+            my_size += ::protobuf::rt::string_size(1, &self.method_name);
         }
         if let Some(ref v) = self.req_msg.as_ref() {
             let len = v.compute_size();
@@ -204,19 +178,16 @@ impl ::protobuf::Message for GrpcRequest {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
-        if self.stream_id != 0 {
-            os.write_int32(1, self.stream_id)?;
-        }
         if !self.method_name.is_empty() {
-            os.write_string(2, &self.method_name)?;
+            os.write_string(1, &self.method_name)?;
         }
         if let Some(ref v) = self.req_msg.as_ref() {
-            os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
         }
         if self.last != false {
-            os.write_bool(4, self.last)?;
+            os.write_bool(3, self.last)?;
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -260,11 +231,6 @@ impl ::protobuf::Message for GrpcRequest {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
-                    "stream_id",
-                    |m: &GrpcRequest| { &m.stream_id },
-                    |m: &mut GrpcRequest| { &mut m.stream_id },
-                ));
                 fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "method_name",
                     |m: &GrpcRequest| { &m.method_name },
@@ -302,7 +268,6 @@ impl ::protobuf::Message for GrpcRequest {
 
 impl ::protobuf::Clear for GrpcRequest {
     fn clear(&mut self) {
-        self.stream_id = 0;
         self.method_name.clear();
         self.req_msg.clear();
         self.last = false;
@@ -325,7 +290,6 @@ impl ::protobuf::reflect::ProtobufValue for GrpcRequest {
 #[derive(PartialEq,Clone,Default)]
 pub struct GrpcResponse {
     // message fields
-    pub stream_id: i32,
     pub rsp_msg: ::protobuf::SingularPtrField<::protobuf::well_known_types::Any>,
     pub status: ::protobuf::SingularPtrField<super::status::Status>,
     pub last: bool,
@@ -345,22 +309,7 @@ impl GrpcResponse {
         ::std::default::Default::default()
     }
 
-    // int32 stream_id = 1;
-
-
-    pub fn get_stream_id(&self) -> i32 {
-        self.stream_id
-    }
-    pub fn clear_stream_id(&mut self) {
-        self.stream_id = 0;
-    }
-
-    // Param is passed by value, moved
-    pub fn set_stream_id(&mut self, v: i32) {
-        self.stream_id = v;
-    }
-
-    // .google.protobuf.Any rsp_msg = 2;
+    // .google.protobuf.Any rsp_msg = 1;
 
 
     pub fn get_rsp_msg(&self) -> &::protobuf::well_known_types::Any {
@@ -393,7 +342,7 @@ impl GrpcResponse {
         self.rsp_msg.take().unwrap_or_else(|| ::protobuf::well_known_types::Any::new())
     }
 
-    // .google.rpc.Status status = 3;
+    // .google.rpc.Status status = 2;
 
 
     pub fn get_status(&self) -> &super::status::Status {
@@ -426,7 +375,7 @@ impl GrpcResponse {
         self.status.take().unwrap_or_else(|| super::status::Status::new())
     }
 
-    // bool last = 4;
+    // bool last = 3;
 
 
     pub fn get_last(&self) -> bool {
@@ -462,19 +411,12 @@ impl ::protobuf::Message for GrpcResponse {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
-                    }
-                    let tmp = is.read_int32()?;
-                    self.stream_id = tmp;
-                },
-                2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.rsp_msg)?;
                 },
-                3 => {
+                2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.status)?;
                 },
-                4 => {
+                3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     }
@@ -493,9 +435,6 @@ impl ::protobuf::Message for GrpcResponse {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        if self.stream_id != 0 {
-            my_size += ::protobuf::rt::value_size(1, self.stream_id, ::protobuf::wire_format::WireTypeVarint);
-        }
         if let Some(ref v) = self.rsp_msg.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -513,21 +452,18 @@ impl ::protobuf::Message for GrpcResponse {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
-        if self.stream_id != 0 {
-            os.write_int32(1, self.stream_id)?;
-        }
         if let Some(ref v) = self.rsp_msg.as_ref() {
-            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
         }
         if let Some(ref v) = self.status.as_ref() {
-            os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
         }
         if self.last != false {
-            os.write_bool(4, self.last)?;
+            os.write_bool(3, self.last)?;
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -571,11 +507,6 @@ impl ::protobuf::Message for GrpcResponse {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
-                    "stream_id",
-                    |m: &GrpcResponse| { &m.stream_id },
-                    |m: &mut GrpcResponse| { &mut m.stream_id },
-                ));
                 fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<::protobuf::well_known_types::Any>>(
                     "rsp_msg",
                     |m: &GrpcResponse| { &m.rsp_msg },
@@ -613,7 +544,6 @@ impl ::protobuf::Message for GrpcResponse {
 
 impl ::protobuf::Clear for GrpcResponse {
     fn clear(&mut self) {
-        self.stream_id = 0;
         self.rsp_msg.clear();
         self.status.clear();
         self.last = false;
@@ -635,15 +565,13 @@ impl ::protobuf::reflect::ProtobufValue for GrpcResponse {
 
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n\x10grpc_encap.proto\x12\x03oak\x1a\x19google/protobuf/any.proto\x1a#t\
-    hird_party/google/rpc/status.proto\"\x8e\x01\n\x0bGrpcRequest\x12\x1b\n\
-    \tstream_id\x18\x01\x20\x01(\x05R\x08streamId\x12\x1f\n\x0bmethod_name\
-    \x18\x02\x20\x01(\tR\nmethodName\x12-\n\x07req_msg\x18\x03\x20\x01(\x0b2\
-    \x14.google.protobuf.AnyR\x06reqMsg\x12\x12\n\x04last\x18\x04\x20\x01(\
-    \x08R\x04last\"\x9a\x01\n\x0cGrpcResponse\x12\x1b\n\tstream_id\x18\x01\
-    \x20\x01(\x05R\x08streamId\x12-\n\x07rsp_msg\x18\x02\x20\x01(\x0b2\x14.g\
-    oogle.protobuf.AnyR\x06rspMsg\x12*\n\x06status\x18\x03\x20\x01(\x0b2\x12\
-    .google.rpc.StatusR\x06status\x12\x12\n\x04last\x18\x04\x20\x01(\x08R\
-    \x04lastb\x06proto3\
+    hird_party/google/rpc/status.proto\"q\n\x0bGrpcRequest\x12\x1f\n\x0bmeth\
+    od_name\x18\x01\x20\x01(\tR\nmethodName\x12-\n\x07req_msg\x18\x02\x20\
+    \x01(\x0b2\x14.google.protobuf.AnyR\x06reqMsg\x12\x12\n\x04last\x18\x03\
+    \x20\x01(\x08R\x04last\"}\n\x0cGrpcResponse\x12-\n\x07rsp_msg\x18\x01\
+    \x20\x01(\x0b2\x14.google.protobuf.AnyR\x06rspMsg\x12*\n\x06status\x18\
+    \x02\x20\x01(\x0b2\x12.google.rpc.StatusR\x06status\x12\x12\n\x04last\
+    \x18\x03\x20\x01(\x08R\x04lastb\x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/rust/oak_derive/src/lib.rs
+++ b/rust/oak_derive/src/lib.rs
@@ -65,9 +65,7 @@ pub fn derive_oak_exports(input: TokenStream) -> TokenStream {
             // https://doc.rust-lang.org/nomicon/ffi.html#ffi-and-panics
             match std::panic::catch_unwind(||{
                 let mut node = <#name>::new();
-                oak::grpc::event_loop(node,
-                                      oak::ReadHandle{ handle:oak::channel_find("grpc_in")},
-                                      oak::WriteHandle{ handle:oak::channel_find("grpc_out")})
+                oak::grpc::event_loop(node, oak::ReadHandle{ handle: oak::channel_find("grpc_in") })
             }) {
                 Ok(rc) => rc,
                 Err(_) => oak::OakStatus::ERR_INTERNAL.value(),


### PR DESCRIPTION
On each incoming gRPC request, create a new channel for delivery
of the responses, and pass a handle to this channel in with the
request.