### PR TITLE
Implement authorization bearer token credentials

### DIFF
--- a/oak/client/BUILD
+++ b/oak/client/BUILD
@@ -34,9 +34,10 @@ cc_library(
     hdrs = ["application_client.h"],
     visibility = ["//visibility:public"],
     deps = [
-        ":per_call_policy",
+        ":authorization_bearer_token_metadata",
         ":policy_metadata",
         "//oak/common:app_config",
+        "//oak/common:nonce_generator",
         "//oak/proto:application_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_asylo//asylo/grpc/auth:null_credentials_options",
@@ -52,18 +53,18 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//oak/common:policy",
+        "//oak/proto:policy_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/base",
     ],
 )
 
 cc_library(
-    name = "per_call_policy",
-    srcs = ["per_call_policy.cc"],
-    hdrs = ["per_call_policy.h"],
+    name = "authorization_bearer_token_metadata",
+    srcs = ["authorization_bearer_token_metadata.cc"],
+    hdrs = ["authorization_bearer_token_metadata.h"],
     visibility = ["//visibility:public"],
     deps = [
-        "//oak/common:nonce_generator",
         "//oak/common:policy",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/base",

--- a/oak/client/authorization_bearer_token_metadata.cc
+++ b/oak/client/authorization_bearer_token_metadata.cc
@@ -14,25 +14,24 @@
  * limitations under the License.
  */
 
-#include "oak/client/per_call_policy.h"
+#include "oak/client/authorization_bearer_token_metadata.h"
 
 #include <map>
 
-#include "oak/common/nonce_generator.h"
 #include "oak/common/policy.h"
 
 namespace oak {
 
-PerCallPolicy::PerCallPolicy() {}
+AuthorizationBearerTokenMetadata::AuthorizationBearerTokenMetadata(
+    const std::string& authorization_bearer_token)
+    : authorization_bearer_token_(authorization_bearer_token) {}
 
-grpc::Status PerCallPolicy::GetMetadata(grpc::string_ref service_url, grpc::string_ref method_name,
-                                        const grpc::AuthContext& channel_auth_context,
-                                        std::multimap<grpc::string, grpc::string>* metadata) {
-  auto nonce = nonce_generator_.NextNonce();
+grpc::Status AuthorizationBearerTokenMetadata::GetMetadata(
+    grpc::string_ref service_url, grpc::string_ref method_name,
+    const grpc::AuthContext& channel_auth_context,
+    std::multimap<grpc::string, grpc::string>* metadata) {
   metadata->insert(
-      std::make_pair(kOakAuthorizationBearerTokenGrpcMetadataKey, NonceToBase64(nonce)));
-  // TODO: Also attach a policy restricting information flow to the freshly generated nonce, in
-  // order to emulate a "pure computation" policy.
+      std::make_pair(kOakAuthorizationBearerTokenGrpcMetadataKey, authorization_bearer_token_));
   return grpc::Status::OK;
 }
 

--- a/oak/client/authorization_bearer_token_metadata.h
+++ b/oak/client/authorization_bearer_token_metadata.h
@@ -14,34 +14,29 @@
  * limitations under the License.
  */
 
-#ifndef OAK_CLIENT_PER_CALL_POLICY_H_
-#define OAK_CLIENT_PER_CALL_POLICY_H_
+#ifndef OAK_CLIENT_AUTHORIZATION_BEARER_TOKEN_METADATA_H_
+#define OAK_CLIENT_AUTHORIZATION_BEARER_TOKEN_METADATA_H_
 
 #include "include/grpcpp/grpcpp.h"
-#include "oak/common/nonce_generator.h"
 
 namespace oak {
 
-namespace {
-constexpr size_t kPerCallNonceSizeBytes = 32;
-}  // namespace
-
-// This class generates a fresh per-call nonce and injects it to the gRPC metadata of each call as
-// an authorization bearer token.
+// This class injects the provided authorization bearer token to the gRPC metadata of each outgoing
+// call.
 //
 // See https://grpc.io/docs/guides/auth/.
-class PerCallPolicy : public grpc::MetadataCredentialsPlugin {
+class AuthorizationBearerTokenMetadata : public grpc::MetadataCredentialsPlugin {
  public:
-  PerCallPolicy();
+  AuthorizationBearerTokenMetadata(const std::string& authorization_bearer_token);
 
   grpc::Status GetMetadata(grpc::string_ref service_url, grpc::string_ref method_name,
                            const grpc::AuthContext& channel_auth_context,
                            std::multimap<grpc::string, grpc::string>* metadata) override;
 
  private:
-  NonceGenerator<kPerCallNonceSizeBytes> nonce_generator_;
+  const std::string authorization_bearer_token_;
 };
 
 }  // namespace oak
 
-#endif  // OAK_CLIENT_PER_CALL_POLICY_H_
+#endif  // OAK_CLIENT_AUTHORIZATION_BEARER_TOKEN_METADATA_H_

--- a/oak/client/policy_metadata.cc
+++ b/oak/client/policy_metadata.cc
@@ -19,18 +19,18 @@
 #include <map>
 #include <utility>
 
+#include "absl/strings/escaping.h"
 #include "oak/common/policy.h"
 
 namespace oak {
 
-PolicyMetadata::PolicyMetadata() {}
+PolicyMetadata::PolicyMetadata(const oak::policy::Labels& labels)
+    : serialized_policy_(SerializePolicy(labels)) {}
 
 grpc::Status PolicyMetadata::GetMetadata(grpc::string_ref service_url, grpc::string_ref method_name,
                                          const grpc::AuthContext& channel_auth_context,
                                          std::multimap<grpc::string, grpc::string>* metadata) {
-  // TODO: Make actual policy configurable. For now we are injecting a nonsense policy, which the
-  // server is not even checking yet.
-  metadata->insert(std::make_pair(kOakLabelGrpcMetadataKey, "test-oak-label"));
+  metadata->insert(std::make_pair(kOakPolicyGrpcMetadataKey, serialized_policy_));
   return grpc::Status::OK;
 }
 

--- a/oak/client/policy_metadata.h
+++ b/oak/client/policy_metadata.h
@@ -18,20 +18,27 @@
 #define OAK_CLIENT_POLICY_METADATA_H_
 
 #include "include/grpcpp/grpcpp.h"
+#include "oak/proto/policy.pb.h"
 
 namespace oak {
 
-// This class injects a pre-determined Oak Policy to each outgoing gRPC call.
+// This class injects the provided Oak Policy to each outgoing gRPC call, passed over gRPC binary
+// metadata.
+//
 // In real-world use cases it should be combined to channel credentials, providing enclave
 // attestation.
+//
 // See https://grpc.io/docs/guides/auth/.
 class PolicyMetadata : public grpc::MetadataCredentialsPlugin {
  public:
-  PolicyMetadata();
+  PolicyMetadata(const oak::policy::Labels& labels);
 
   grpc::Status GetMetadata(grpc::string_ref service_url, grpc::string_ref method_name,
                            const grpc::AuthContext& channel_auth_context,
                            std::multimap<grpc::string, grpc::string>* metadata) override;
+
+ private:
+  const std::string serialized_policy_;
 };
 
 }  // namespace oak

--- a/oak/common/BUILD
+++ b/oak/common/BUILD
@@ -68,7 +68,8 @@ cc_library(
     hdrs = ["policy.h"],
     visibility = ["//visibility:public"],
     deps = [
-        "@com_google_absl//absl/base",
+        "//oak/proto:policy_cc_proto",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/oak/common/nonce_generator.h
+++ b/oak/common/nonce_generator.h
@@ -46,11 +46,10 @@ class NonceGenerator {
   std::random_device prng_engine_;
 };
 
-// Converts the given nonce to its base64 representation.
+// Converts the given nonce to its binary string representation.
 template <size_t N>
-std::string NonceToBase64(const Nonce<N>& nonce) {
-  absl::string_view nonce_string_view(reinterpret_cast<const char*>(nonce.data()), nonce.size());
-  return absl::Base64Escape(nonce_string_view);
+std::string NonceToBytes(const Nonce<N>& nonce) {
+  return std::string(reinterpret_cast<const char*>(nonce.data()), nonce.size());
 }
 
 }  // namespace oak

--- a/oak/common/policy.h
+++ b/oak/common/policy.h
@@ -18,12 +18,13 @@
 #define OAK_COMMON_POLICY_H_
 
 #include "absl/base/attributes.h"
+#include "oak/proto/policy.pb.h"
 
 namespace oak {
 
-// Metadata key used to refer to Oak Policies associated with the gRPC request. This is effectively
-// treated as the name of a custom HTTP header.
-ABSL_CONST_INIT extern const char kOakLabelGrpcMetadataKey[];
+// Metadata key used to refer to the Oak Policy associated with the gRPC request. This is
+// effectively treated as the name of a custom HTTP header.
+ABSL_CONST_INIT extern const char kOakPolicyGrpcMetadataKey[];
 
 // Metadata key used to refer to per-call authorization tokens.
 //
@@ -35,6 +36,16 @@ ABSL_CONST_INIT extern const char kOakLabelGrpcMetadataKey[];
 //
 // See https://tools.ietf.org/html/rfc6750
 ABSL_CONST_INIT extern const char kOakAuthorizationBearerTokenGrpcMetadataKey[];
+
+// Serialized the provided policy so that it can be sent as a binary gRPC metadata value.
+std::string SerializePolicy(const oak::policy::Labels& policy);
+
+// Deserializes the provided binary gRPC metadata value into a policy.
+oak::policy::Labels DeserializePolicy(const std::string& serialized_policy);
+
+// Creates a policy that only allows declassifying data for gRPC clients that can present the
+// provided authorization bearer token.
+oak::policy::Labels AuthorizationBearerTokenPolicy(const std::string& authorization_token);
 
 }  // namespace oak
 

--- a/oak/proto/BUILD
+++ b/oak/proto/BUILD
@@ -99,6 +99,17 @@ cc_proto_library(
 )
 
 proto_library(
+    name = "policy_proto",
+    srcs = ["policy.proto"],
+    deps = [],
+)
+
+cc_proto_library(
+    name = "policy_cc_proto",
+    deps = [":policy_proto"],
+)
+
+proto_library(
     name = "storage_channel_proto",
     srcs = ["storage_channel.proto"],
     deps = [

--- a/oak/proto/policy.proto
+++ b/oak/proto/policy.proto
@@ -1,0 +1,49 @@
+//
+// Copyright 2019 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.policy;
+
+// Labels represents a policy associated with a message or a Node.
+//
+// See https://pdos.csail.mit.edu/papers/flume-sosp07.pdf section 3.1.
+message Labels {
+  repeated Tag secrecy_tags = 1;
+  // TODO: Support integrity tags.
+}
+
+// Tag represents a category of secrecy or integrity that is associated with data within Oak, and
+// refers to a Node or family of Nodes which are able to declassify data with that tag.
+//
+// For instance, a tag may refer to a user connected over gRPC, or to the functionality implemented
+// by a WebAssembly Node, and this would require that data with those tags are declassified by the
+// respective node before they can leave Oak.
+//
+// See https://pdos.csail.mit.edu/papers/flume-sosp07.pdf section 3.1.
+message Tag {
+  oneof tag {
+    GrpcTag grpc_tag = 1;
+  }
+}
+
+// Policies related to gRPC communication, referring to the native gRPC node within the TCB.
+message GrpcTag {
+  // TODO: Replace this with identity assertions based on public keys when Asylo supports it.
+  // See
+  // https://github.com/google/asylo/blob/3158887cb768112516424b3e65046f3946eb4465/asylo/identity/identity.proto#L40.
+  bytes authorization_bearer_token = 1;
+}

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -121,6 +121,7 @@ cc_library(
         "//oak/proto:application_cc_grpc",
         "//oak/proto:enclave_cc_proto",
         "//oak/proto:grpc_encap_cc_proto",
+        "//oak/proto:policy_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/synchronization",
         "@com_google_asylo//asylo/grpc/auth:null_credentials_options",
@@ -152,6 +153,7 @@ cc_library(
     hdrs = ["channel.h"],
     deps = [
         "//oak/proto:oak_api_cc_proto",
+        "//oak/proto:policy_cc_proto",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:variant",

--- a/oak/server/channel.h
+++ b/oak/server/channel.h
@@ -27,6 +27,7 @@
 #include "absl/synchronization/mutex.h"
 #include "absl/types/variant.h"
 #include "oak/proto/oak_api.pb.h"
+#include "oak/proto/policy.pb.h"
 
 namespace oak {
 
@@ -43,7 +44,8 @@ using ChannelHalf = absl::variant<std::unique_ptr<MessageChannelReadHalf>,
 struct Message {
   std::vector<char> data;
   std::vector<std::unique_ptr<ChannelHalf>> channels;
-  std::vector<std::string> labels;
+  // TODO: Consider using a native struct here instead of the proto representation.
+  oak::policy::Labels labels;
 };
 
 // Result of a read operation. If the operation would have produced a message

--- a/oak/server/module_invocation.cc
+++ b/oak/server/module_invocation.cc
@@ -20,6 +20,7 @@
 #include "asylo/util/logging.h"
 #include "oak/common/policy.h"
 #include "oak/proto/grpc_encap.pb.h"
+#include "oak/proto/policy.pb.h"
 #include "oak/server/channel.h"
 
 namespace oak {
@@ -103,11 +104,17 @@ void ModuleInvocation::ProcessRequest(bool ok) {
   std::unique_ptr<Message> req_msg = absl::make_unique<Message>();
   req_msg->data.insert(req_msg->data.end(), encap_req.begin(), encap_req.end());
   {
-    auto range = context_.client_metadata().equal_range(kOakLabelGrpcMetadataKey);
+    auto range = context_.client_metadata().equal_range(kOakPolicyGrpcMetadataKey);
     for (auto entry = range.first; entry != range.second; ++entry) {
-      std::string label(entry->second.data(), entry->second.size());
-      LOG(INFO) << "invocation#" << stream_id_ << " Oak policy label: " << label;
-      req_msg->labels.push_back(label);
+      std::string policy_base64(entry->second.data(), entry->second.size());
+      oak::policy::Labels policy = DeserializePolicy(policy_base64);
+      // TODO(https://github.com/project-oak/oak/issues/306): Note that at the moment policies may
+      // refer to authentication bearer tokens, which if logged in this way may be reused by
+      // unauthorized parties. For now we are fine with this, eventually bearer tokens will be
+      // removed and replaced by public key assertions, in which case it will always be safe to log
+      // policies.
+      LOG(INFO) << "invocation#" << stream_id_ << " Oak policy: " << policy.DebugString();
+      req_msg->labels = policy;
     }
   }
   {


### PR DESCRIPTION
This will probably be removed completely in favour of public key
assertions, but for now it lets us try out policies until Asylo supports
cert assertions.