### PR TITLE
Use latest version of buildifier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ RUN shellcheck --version
 RUN node --version
 RUN npm --version
 
-# Install prettier.
+# Install prettier (via Node.js).
 # https://prettier.io/
 RUN npm install --global prettier
 RUN prettier --version
 
 # Install buildifier.
-ARG BAZEL_TOOLS_VERSION=0.28.0
+ARG BAZEL_TOOLS_VERSION=0.29.0
 ARG BUILDIFIER_DIR=/usr/local/buildifier
 RUN mkdir -p $BUILDIFIER_DIR/bin
 RUN curl -L https://github.com/bazelbuild/buildtools/releases/download/${BAZEL_TOOLS_VERSION}/buildifier > $BUILDIFIER_DIR/bin/buildifier
@@ -59,7 +59,7 @@ RUN rustup component add \
   rust-analysis \
   rust-src
 
-# Install embedmd (via Go)
+# Install embedmd (via Go).
 ARG GOLANG_VERSION=1.13.1
 ENV GOROOT /usr/local/go
 ENV GOPATH $HOME/go

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,8 +90,8 @@ http_archive(
 # WebAssembly Binary Toolkit (forked by tiziano88).
 git_repository(
     name = "wabt",
-    remote = "https://github.com/daviddrysdale/wabt",
     commit = "30e914b1630db13080cc054b591ab5822b9b4768",
+    remote = "https://github.com/daviddrysdale/wabt",
 )
 
 load(

--- a/examples/abitest/client/BUILD
+++ b/examples/abitest/client/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(
     licenses = ["notice"],
 )

--- a/examples/abitest/proto/BUILD
+++ b/examples/abitest/proto/BUILD
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
-)
-
-load(
-    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
-    "cc_grpc_library",
 )
 
 proto_library(

--- a/examples/chat/client/BUILD
+++ b/examples/chat/client/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(
     licenses = ["notice"],
 )

--- a/examples/chat/proto/BUILD
+++ b/examples/chat/proto/BUILD
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
-)
-
-load(
-    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
-    "cc_grpc_library",
 )
 
 proto_library(

--- a/examples/hello_world/client/BUILD
+++ b/examples/hello_world/client/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(
     licenses = ["notice"],
 )

--- a/examples/hello_world/module/cpp/BUILD
+++ b/examples/hello_world/module/cpp/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(
     licenses = ["notice"],
 )

--- a/examples/hello_world/proto/BUILD
+++ b/examples/hello_world/proto/BUILD
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
-)
-
-load(
-    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
-    "cc_grpc_library",
 )
 
 proto_library(

--- a/examples/machine_learning/client/BUILD
+++ b/examples/machine_learning/client/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(
     licenses = ["notice"],
 )

--- a/examples/machine_learning/proto/BUILD
+++ b/examples/machine_learning/proto/BUILD
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
-)
-
-load(
-    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
-    "cc_grpc_library",
 )
 
 proto_library(

--- a/examples/private_set_intersection/client/BUILD
+++ b/examples/private_set_intersection/client/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(
     licenses = ["notice"],
 )

--- a/examples/private_set_intersection/proto/BUILD
+++ b/examples/private_set_intersection/proto/BUILD
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
-)
-
-load(
-    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
-    "cc_grpc_library",
 )
 
 proto_library(

--- a/examples/running_average/client/BUILD
+++ b/examples/running_average/client/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(
     licenses = ["notice"],
 )

--- a/examples/running_average/proto/BUILD
+++ b/examples/running_average/proto/BUILD
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/examples/rustfmt/client/BUILD
+++ b/examples/rustfmt/client/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(
     licenses = ["notice"],
 )

--- a/examples/rustfmt/proto/BUILD
+++ b/examples/rustfmt/proto/BUILD
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/examples/utils/BUILD
+++ b/examples/utils/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(
     licenses = ["notice"],
 )

--- a/oak/client/BUILD
+++ b/oak/client/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(
     licenses = ["notice"],
 )

--- a/oak/common/BUILD
+++ b/oak/common/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(
     licenses = ["notice"],
 )

--- a/oak/common/fuzzer.bzl
+++ b/oak/common/fuzzer.bzl
@@ -16,9 +16,11 @@
 
 """Fuzz-related definitions for Oak testing."""
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 # Inspired by https://github.com/grpc/grpc/blob/618a3f561d4a93f263cca23abad086ed8f4d5e86/test/core/util/grpc_fuzzer.bzl.
 def oak_fuzzer(name, srcs = [], deps = [], **kwargs):
-    native.cc_binary(
+    cc_binary(
         name = name,
         srcs = srcs,
         deps = deps,

--- a/oak/module/BUILD
+++ b/oak/module/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(
     licenses = ["notice"],
 )

--- a/oak/proto/BUILD
+++ b/oak/proto/BUILD
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
-)
-
-load(
-    "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
-    "cc_grpc_library",
 )
 
 proto_library(

--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -14,13 +14,14 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//oak/common:fuzzer.bzl", "oak_fuzzer")
+load("//oak/server:wabt.bzl", "wasm_group")
+
 package(
     default_visibility = ["//oak/server:__subpackages__"],
     licenses = ["notice"],
 )
-
-load("//oak/common:fuzzer.bzl", "oak_fuzzer")
-load("//oak/server:wabt.bzl", "wasm_group")
 
 # Mark tests that can be run on the host system (i.e. with a normal
 # compiler, not the Asylo toolchain) with 'host' tag.

--- a/oak/server/asylo/BUILD
+++ b/oak/server/asylo/BUILD
@@ -14,22 +14,14 @@
 # limitations under the License.
 #
 
+load("@com_google_asylo//asylo/bazel:asylo.bzl", "enclave_loader")
+load("@com_google_asylo//asylo/bazel:copts.bzl", "ASYLO_DEFAULT_COPTS")
+load("@linux_sgx//:sgx_sdk.bzl", "sgx")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(
     default_visibility = ["//oak/server:__subpackages__"],
     licenses = ["notice"],
-)
-
-load(
-    "@com_google_asylo//asylo/bazel:asylo.bzl",
-    "enclave_loader",
-)
-load(
-    "@com_google_asylo//asylo/bazel:copts.bzl",
-    "ASYLO_DEFAULT_COPTS",
-)
-load(
-    "@linux_sgx//:sgx_sdk.bzl",
-    "sgx",
 )
 
 cc_library(

--- a/oak/server/dev/BUILD
+++ b/oak/server/dev/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(
     default_visibility = ["//oak/server:__subpackages__"],
     licenses = ["notice"],

--- a/oak/server/storage/BUILD
+++ b/oak/server/storage/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 package(
     default_visibility = ["//oak/server:__pkg__"],
     licenses = ["notice"],

--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -7,8 +7,10 @@ readonly SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPTS_DIR/common"
 
 # Check which BUILD and .bzl files need to be reformatted.
-find oak examples toolchain \( -type f -name BUILD -or -name '*bzl' \) -exec buildifier -lint=warn -mode=check {} +
-find oak examples toolchain \( -type f -name BUILD \) -exec grep --files-without-match '^    licenses = \["notice"\],$' {} + && (echo 'missing license directive in BUILD file'; exit 1)
+find oak examples toolchain \( -type f -name BUILD -or -name WORKSPACE -or -name '*bzl' \) \
+  -exec buildifier -lint=warn -mode=check {} +
+find oak examples toolchain \( -type f -name BUILD \) \
+  -exec grep --files-without-match '^    licenses = \["notice"\],$' {} + && (echo 'missing license directive in BUILD file'; exit 1)
 
 # Check shell scripts for common mistakes.
 find scripts -type f -exec shellcheck {} +

--- a/scripts/format
+++ b/scripts/format
@@ -9,9 +9,10 @@ source "$SCRIPTS_DIR/common"
 # Run buildifier, clang-format and rustfmt on the entire codebase.
 # Applies all formattings in-place.
 
-find oak examples toolchain \( -type f -name BUILD -or -name '*bzl' \) -exec buildifier -lint=fix -mode=fix {} +
+find oak examples toolchain \( -type f -name BUILD -or -name WORKSPACE -or -name '*bzl' \) \
+  -exec buildifier -lint=fix -mode=fix {} +
 find oak examples \( -type f -name '*.h' -or -name '*.cc' -or -name '*.proto' \) \
-    -exec clang-format -i -style=file {} +
+  -exec clang-format -i -style=file {} +
 find examples rust -type f -name '*.rs' -exec rustfmt {} +
 
 find . \

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],


### PR DESCRIPTION
Fix newly introduced warnings, mostly to do with
https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#native-proto
or similar.

Include WORKSPACE in format checks.

Move `load` lines to the beginning of file, and keep them to one line
each (since there are so many of them now).