### PR TITLE
Drop unnecessary `extern crate` declarations

### DIFF
--- a/examples/abitest/abitest_common/src/lib.rs
+++ b/examples/abitest/abitest_common/src/lib.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-extern crate serde;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/examples/abitest/module/rust/Cargo.toml
+++ b/examples/abitest/module/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "abitest_frontend"
 version = "0.1.0"
 authors = ["David Drysdale <drysdale@google.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib","lib"]

--- a/examples/abitest/module/rust/build.rs
+++ b/examples/abitest/module/rust/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_rust_grpc;
-
 fn main() {
     protoc_rust_grpc::run(protoc_rust_grpc::Args {
         out_dir: "src/proto",

--- a/examples/abitest/module/rust/src/lib.rs
+++ b/examples/abitest/module/rust/src/lib.rs
@@ -14,23 +14,12 @@
 // limitations under the License.
 //
 
-extern crate abitest_common;
-extern crate byteorder;
-#[macro_use]
-extern crate expect;
-#[macro_use]
-extern crate log;
-extern crate oak;
-extern crate oak_log;
-extern crate protobuf;
-extern crate rand;
-extern crate regex;
-extern crate serde;
-
 pub mod proto;
 
 use abitest_common::InternalMessage;
 use byteorder::WriteBytesExt;
+use expect::{expect, expect_eq};
+use log::info;
 use oak::grpc::OakNode;
 use oak::{grpc, ChannelReadStatus, OakStatus};
 use proto::abitest::{ABITestRequest, ABITestResponse, ABITestResponse_TestResult};

--- a/examples/abitest/module2/rust/Cargo.toml
+++ b/examples/abitest/module2/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "abitest_backend"
 version = "0.1.0"
 authors = ["David Drysdale <drysdale@google.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/examples/abitest/module2/rust/src/lib.rs
+++ b/examples/abitest/module2/rust/src/lib.rs
@@ -14,15 +14,8 @@
 // limitations under the License.
 //
 
-#[macro_use]
-extern crate log;
-extern crate abitest_common;
-extern crate oak;
-extern crate oak_log;
-extern crate protobuf;
-extern crate serde;
-
 use abitest_common::InternalMessage;
+use log::info;
 use protobuf::ProtobufEnum;
 
 // Backend node for channel testing.  This node listens for read channel handles

--- a/examples/abitest/tests/Cargo.toml
+++ b/examples/abitest/tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "abitest_tests"
 version = "0.1.0"
 authors = ["David Drysdale <drysdale@google.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["dylib"]

--- a/examples/abitest/tests/src/lib.rs
+++ b/examples/abitest/tests/src/lib.rs
@@ -14,25 +14,8 @@
 // limitations under the License.
 //
 
-extern crate abitest_backend;
-extern crate abitest_frontend;
-#[macro_use]
-extern crate log;
-extern crate oak;
-extern crate protobuf;
-
+use log::error;
 use protobuf::ProtobufEnum;
-
-#[cfg(test)]
-#[macro_use]
-extern crate assert_matches;
-#[cfg(test)]
-extern crate oak_tests;
-#[cfg(test)]
-extern crate serial_test;
-#[cfg(test)]
-#[macro_use]
-extern crate serial_test_derive;
 
 #[cfg(test)]
 mod tests;

--- a/examples/abitest/tests/src/tests.rs
+++ b/examples/abitest/tests/src/tests.rs
@@ -15,11 +15,14 @@
 //
 
 use abitest_frontend::proto::abitest::{ABITestRequest, ABITestResponse};
+use assert_matches::assert_matches;
+use log::{error, info};
 use oak::grpc;
 use oak::OakStatus;
 use oak_tests::proto::manager::{
     ApplicationConfiguration, Channel, Channel_Endpoint, GrpcServerNode, Node, WebAssemblyNode,
 };
+use serial_test_derive::serial;
 use std::collections::HashMap;
 
 // Constants for node and port names that should match those in the textproto config

--- a/examples/chat/module/rust/Cargo.toml
+++ b/examples/chat/module/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "chat"
 version = "0.1.0"
 authors = ["David Drysdale <drysdale@google.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/chat/module/rust/build.rs
+++ b/examples/chat/module/rust/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_rust_grpc;
-
 fn main() {
     protoc_rust_grpc::run(protoc_rust_grpc::Args {
         out_dir: "src/proto",

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -14,16 +14,9 @@
 // limitations under the License.
 //
 
-#[macro_use]
-extern crate log;
-extern crate oak;
-extern crate oak_derive;
-extern crate oak_log;
-extern crate protobuf;
-extern crate rand;
-
 mod proto;
 
+use log::info;
 use oak::grpc;
 use oak::grpc::OakNode;
 use oak_derive::OakExports;

--- a/examples/hello_world/module/rust/Cargo.toml
+++ b/examples/hello_world/module/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hello_world"
 version = "0.1.0"
 authors = ["Tiziano Santoro <tzn@google.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/hello_world/module/rust/build.rs
+++ b/examples/hello_world/module/rust/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_rust_grpc;
-
 fn main() {
     protoc_rust_grpc::run(protoc_rust_grpc::Args {
         out_dir: "src/proto",

--- a/examples/hello_world/module/rust/src/lib.rs
+++ b/examples/hello_world/module/rust/src/lib.rs
@@ -14,28 +14,11 @@
 // limitations under the License.
 //
 
-#[macro_use]
-extern crate log;
-extern crate oak;
-extern crate oak_derive;
-extern crate oak_log;
-extern crate protobuf;
-
-#[cfg(test)]
-#[macro_use]
-extern crate assert_matches;
-#[cfg(test)]
-extern crate oak_tests;
-#[cfg(test)]
-extern crate serial_test;
-#[cfg(test)]
-#[macro_use]
-extern crate serial_test_derive;
-
 mod proto;
 #[cfg(test)]
 mod tests;
 
+use log::{info, warn};
 use oak::grpc;
 use oak::grpc::OakNode;
 use oak_derive::OakExports;

--- a/examples/hello_world/module/rust/src/tests.rs
+++ b/examples/hello_world/module/rust/src/tests.rs
@@ -14,11 +14,13 @@
 // limitations under the License.
 //
 
+use crate::proto::hello_world::{HelloRequest, HelloResponse};
+use crate::proto::hello_world_grpc::HelloWorldNode;
+use assert_matches::assert_matches;
 use oak::grpc;
 use oak::grpc::OakNode;
 use oak::OakStatus;
-use proto::hello_world::{HelloRequest, HelloResponse};
-use proto::hello_world_grpc::HelloWorldNode;
+use serial_test_derive::serial;
 
 // Test invoking a Node service method directly.
 #[test]

--- a/examples/machine_learning/module/rust/Cargo.toml
+++ b/examples/machine_learning/module/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "machine_learning"
 version = "0.1.0"
 authors = ["Tiziano Santoro <tzn@google.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/machine_learning/module/rust/src/lib.rs
+++ b/examples/machine_learning/module/rust/src/lib.rs
@@ -17,13 +17,6 @@
 // This model was inspired by
 // https://github.com/AtheMathmo/rusty-machine/blob/master/examples/naive_bayes_dogs.rs .
 
-extern crate oak;
-extern crate oak_derive;
-extern crate protobuf;
-extern crate rand;
-extern crate rand_distr;
-extern crate rusty_machine;
-
 use oak::grpc;
 use oak::grpc::OakNode;
 use oak_derive::OakExports;

--- a/examples/private_set_intersection/module/rust/Cargo.toml
+++ b/examples/private_set_intersection/module/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "private_set_intersection"
 version = "0.1.0"
 authors = ["Tiziano Santoro <tzn@google.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/private_set_intersection/module/rust/build.rs
+++ b/examples/private_set_intersection/module/rust/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_rust_grpc;
-
 fn main() {
     protoc_rust_grpc::run(protoc_rust_grpc::Args {
         out_dir: "src/proto",

--- a/examples/private_set_intersection/module/rust/src/lib.rs
+++ b/examples/private_set_intersection/module/rust/src/lib.rs
@@ -25,10 +25,6 @@
 //! TODO: Consider stopping accepting contributions after the first client retrieves the
 //! intersection.
 
-extern crate oak;
-extern crate oak_derive;
-extern crate protobuf;
-
 mod proto;
 
 use oak::grpc;

--- a/examples/running_average/module/rust/Cargo.toml
+++ b/examples/running_average/module/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "running_average"
 version = "0.1.0"
 authors = ["Tiziano Santoro <tzn@google.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/running_average/module/rust/build.rs
+++ b/examples/running_average/module/rust/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_rust_grpc;
-
 fn main() {
     protoc_rust_grpc::run(protoc_rust_grpc::Args {
         out_dir: "src/proto",

--- a/examples/running_average/module/rust/src/lib.rs
+++ b/examples/running_average/module/rust/src/lib.rs
@@ -22,10 +22,6 @@
 //! expressed in base 10, and get back a string representation of the accumulated average value up
 //! to and including the value provided in the request.
 
-extern crate oak;
-extern crate oak_derive;
-extern crate protobuf;
-
 mod proto;
 
 use oak::grpc;

--- a/examples/rustfmt/module/rust/Cargo.toml
+++ b/examples/rustfmt/module/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustfmt"
 version = "0.1.0"
 authors = ["Tiziano Santoro <tzn@google.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/rustfmt/module/rust/build.rs
+++ b/examples/rustfmt/module/rust/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_rust_grpc;
-
 fn main() {
     protoc_rust_grpc::run(protoc_rust_grpc::Args {
         out_dir: "src/proto",

--- a/examples/rustfmt/module/rust/src/lib.rs
+++ b/examples/rustfmt/module/rust/src/lib.rs
@@ -14,13 +14,6 @@
 // limitations under the License.
 //
 
-extern crate log;
-extern crate oak;
-extern crate oak_derive;
-extern crate oak_log;
-extern crate protobuf;
-extern crate rustfmt_nightly;
-
 mod proto;
 
 use oak::grpc;

--- a/rust/oak/Cargo.toml
+++ b/rust/oak/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oak"
 version = "0.1.0"
 authors = ["Tiziano Santoro <tzn@google.com>"]
+edition = "2018"
 
 [dependencies]
 protobuf = "*"

--- a/rust/oak/build.rs
+++ b/rust/oak/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_rust;
-
 fn main() {
     protoc_rust::run(protoc_rust::Args {
         out_dir: "src/proto",

--- a/rust/oak/src/grpc/mod.rs
+++ b/rust/oak/src/grpc/mod.rs
@@ -18,6 +18,7 @@
 
 pub use crate::proto::code::Code;
 use crate::{proto, wasm, Handle, OakStatus, ReadHandle, WriteHandle};
+use log::info;
 use protobuf::{Message, ProtobufEnum};
 
 /// Implicit port name for the write half of a channel that connects out of

--- a/rust/oak/src/io/mod.rs
+++ b/rust/oak/src/io/mod.rs
@@ -17,6 +17,8 @@
 //! Wrappers for Oak SDK types to allow their use with [`std::io`].
 
 use crate::{channel_close, channel_write, OakStatus};
+#[cfg(test)]
+use assert_matches::assert_matches;
 use std::io;
 
 /// Wrapper for a WriteHandle to implement the [`std::io::Write`] trait.

--- a/rust/oak/src/lib.rs
+++ b/rust/oak/src/lib.rs
@@ -14,14 +14,8 @@
 // limitations under the License.
 //
 
-extern crate byteorder;
-extern crate fmt;
-#[macro_use]
-extern crate log;
-extern crate protobuf;
-extern crate rand_core;
-
 use byteorder::WriteBytesExt;
+use log::{debug, error};
 pub use proto::oak_api::ChannelReadStatus;
 pub use proto::oak_api::OakStatus;
 use protobuf::ProtobufEnum;
@@ -36,13 +30,9 @@ mod tests;
 pub mod wasm;
 
 #[cfg(test)]
-#[macro_use]
-extern crate assert_matches;
+use assert_matches::assert_matches;
 #[cfg(test)]
-extern crate serial_test;
-#[cfg(test)]
-#[macro_use]
-extern crate serial_test_derive;
+use serial_test_derive::serial;
 
 /// Handle used to identify read or write channel halves.
 ///

--- a/rust/oak/src/storage/mod.rs
+++ b/rust/oak/src/storage/mod.rs
@@ -16,16 +16,15 @@
 
 //! Helper library for accessing Oak storage services.
 
-extern crate protobuf;
-
 use crate::grpc;
-use crate::wasm::INVALID_HANDLE;
-use crate::{ReadHandle, WriteHandle};
-use proto::grpc_encap::{GrpcRequest, GrpcResponse};
-use proto::storage_channel::{
+use crate::proto::grpc_encap::{GrpcRequest, GrpcResponse};
+use crate::proto::storage_channel::{
     StorageChannelDeleteRequest, StorageChannelDeleteResponse, StorageChannelReadRequest,
     StorageChannelReadResponse, StorageChannelWriteRequest, StorageChannelWriteResponse,
 };
+use crate::wasm::INVALID_HANDLE;
+use crate::{ReadHandle, WriteHandle};
+use log::info;
 use protobuf::Message;
 
 /// Local representation of the connection to an external storage service.

--- a/rust/oak/src/tests.rs
+++ b/rust/oak/src/tests.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-extern crate oak_tests;
-
 use crate::*;
 use std::io::Write;
 

--- a/rust/oak_derive/src/lib.rs
+++ b/rust/oak_derive/src/lib.rs
@@ -16,10 +16,7 @@
 
 //! Macro to derive standard boilerplate code for an Oak Node.
 
-extern crate oak;
 extern crate proc_macro;
-extern crate protobuf;
-extern crate syn;
 
 use proc_macro::TokenStream;
 use quote::quote;

--- a/rust/oak_log/src/lib.rs
+++ b/rust/oak_log/src/lib.rs
@@ -19,14 +19,6 @@
 //!
 //! [log facade]: https://crates.io/crates/log
 
-extern crate log;
-extern crate oak;
-#[cfg(test)]
-extern crate serial_test;
-#[cfg(test)]
-#[macro_use]
-extern crate serial_test_derive;
-
 #[cfg(test)]
 mod tests;
 

--- a/rust/oak_log/src/tests.rs
+++ b/rust/oak_log/src/tests.rs
@@ -14,11 +14,10 @@
 // limitations under the License.
 //
 
-extern crate oak_tests;
-
 use crate::OakChannelLogger;
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use oak_tests::last_message_as_string;
+use serial_test_derive::serial;
 
 fn test_logger() -> (oak::Handle, OakChannelLogger) {
     let (write_handle, _read_handle) = oak::channel_create().unwrap();

--- a/rust/oak_tests/build.rs
+++ b/rust/oak_tests/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_rust;
-
 fn main() {
     protoc_rust::run(protoc_rust::Args {
         out_dir: "src/proto",

--- a/rust/oak_tests/src/lib.rs
+++ b/rust/oak_tests/src/lib.rs
@@ -16,13 +16,8 @@
 
 //! Test utilities to help with unit testing of Oak SDK code.
 
-#[macro_use]
-extern crate log;
-extern crate byteorder;
-extern crate protobuf;
-extern crate rand;
-#[macro_use]
-extern crate lazy_static;
+use lazy_static::lazy_static;
+use log::{debug, info};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use oak::OakStatus;

--- a/rust/oak_tests/src/tests.rs
+++ b/rust/oak_tests/src/tests.rs
@@ -14,9 +14,6 @@
 // limitations under the License.
 //
 
-extern crate oak;
-extern crate oak_derive;
-
 use oak::grpc::OakNode;
 use protobuf::{Message, ProtobufEnum};
 


### PR DESCRIPTION
Shift to using Rust 2018 throughout, and drop `extern crate`
declarations as per:
https://doc.rust-lang.org/nightly/edition-guide/rust-2018/module-system/path-clarity.html

Fixes #316