### PR TITLE
Implement Rust allocator

### DIFF
--- a/oak/server/rust/BUILD
+++ b/oak/server/rust/BUILD
@@ -23,9 +23,7 @@ package(
 
 rust_library(
     name = "oak_runtime",
-    srcs = [
-        "src/lib.rs",
-    ],
+    srcs = glob(["src/*.rs"]),
     crate_type = "staticlib",
     edition = "2018",
 )

--- a/oak/server/rust/src/asylo_alloc.rs
+++ b/oak/server/rust/src/asylo_alloc.rs
@@ -1,0 +1,56 @@
+use core::alloc::{GlobalAlloc, Layout};
+
+extern "C" {
+    // Signatures of the functions exposed by the underlying standard library used in Asylo
+    // (newlib). They are statically linked when producing the final enclave executable.
+    //
+    // See https://www.sourceware.org/newlib/libc.html#malloc.
+    fn malloc(nbytes: usize) -> *mut u8;
+    fn memalign(align: usize, nbytes: usize) -> *mut u8;
+    fn free(aptr: *mut u8);
+}
+
+// This aligment is defined in the Intel SGX SDK, and it is used in this allocator to enable a fast
+// path optimization for low alignment values.
+//
+// See the `MALLOC_ALIGNMENT` value for `_TLIBC_` in
+// https://github.com/intel/linux-sgx/blob/d166ff0c808e2f78d37eebf1ab614d944437eea3/sdk/tlibc/stdlib/malloc.c#L541.
+//
+// Also see this paragraph from
+// https://github.com/intel/linux-sgx/blob/d166ff0c808e2f78d37eebf1ab614d944437eea3/sdk/tlibc/stdlib/malloc.c#L248-L253:
+//
+// > MALLOC_ALIGNMENT         default: (size_t)(2 * sizeof(void *))
+// > Controls the minimum alignment for malloc'ed chunks.  It must be a
+// > power of two and at least 8, even on machines for which smaller
+// > alignments would suffice. It may be defined as larger than this
+// > though. Note however that code and data structures are optimized for
+// > the case of 8-byte alignment.
+const MIN_ALIGN: usize = 8;
+
+/// A global memory allocator that links directly to the primitives exposed by Asylo, which in turn
+/// relies on [newlib](http://www.sourceware.org/newlib/libc.html) for standard `malloc` and `free`
+/// calls.
+///
+/// The allocator can be registered with the `#[global_allocator]` attribute (see
+/// https://doc.rust-lang.org/edition-guide/rust-2018/platform-and-target-support/global-allocators.html).
+pub struct System;
+
+// Inspired by https://github.com/apache/incubator-mesatee-sgx/blob/master/sgx_alloc/src/lib.rs.
+unsafe impl GlobalAlloc for System {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // If the alignment requested by the caller is sufficiently small, use a fast path. Since
+        // the alignment is usually a constant at the call site, only the correct branch will be
+        // inlined.
+        if layout.align() <= MIN_ALIGN {
+            malloc(layout.size())
+        } else {
+            memalign(layout.align(), layout.size())
+        }
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        free(ptr);
+    }
+}

--- a/oak/server/rust/src/lib.rs
+++ b/oak/server/rust/src/lib.rs
@@ -3,13 +3,43 @@
 
 #![no_std]
 #![feature(lang_items)]
+#![feature(alloc_prelude)]
+#![feature(alloc_error_handler)]
 
+extern crate alloc;
+
+// TODO: Move to separate crate.
+mod asylo_alloc;
+
+use alloc::prelude::v1::*;
+use core::alloc::Layout;
 use core::panic::PanicInfo;
+
+// TODO: Move to separate crate and expose safe wrappers.
+#[link(name = "sgx_trts")]
+extern "C" {
+    // SGX-enabled abort function that causes an undefined instruction (`UD2`) to be executed, which
+    // terminates the enclave execution.
+    //
+    // The C type of this function is `extern "C" void abort(void) __attribute__(__noreturn__);`
+    //
+    // See https://github.com/intel/linux-sgx/blob/d166ff0c808e2f78d37eebf1ab614d944437eea3/sdk/trts/linux/trts_pic.S#L565.
+    fn abort() -> !;
+}
+
+#[global_allocator]
+static A: asylo_alloc::System = asylo_alloc::System;
+
+// Define what happens in an Out Of Memory (OOM) condition.
+#[alloc_error_handler]
+fn alloc_error(_layout: Layout) -> ! {
+    unsafe { abort() }
+}
 
 // See https://doc.rust-lang.org/nomicon/panic-handler.html.
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
-    loop {}
+    unsafe { abort() }
 }
 
 // See https://doc.rust-lang.org/1.2.0/book/no-stdlib.html.
@@ -20,5 +50,7 @@ pub extern "C" fn eh_personality() {}
 /// It just adds "42" to the provided value and returns it to the caller.
 #[no_mangle]
 pub extern "C" fn add_magic_number(x: i32) -> i32 {
-    x + 42
+    // Allocate a bunch of elements on the heap in order to exercise the allocator.
+    let v: Vec<i32> = (0..10).map(|n| n + 40).collect();
+    x + v[2]
 }


### PR DESCRIPTION
This is a thin wrapper around `malloc` / `free` provided by newlib as
part of Asylo.

Fixes #322