### PR TITLE
Update Asylo dependency to current version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,6 +31,7 @@ build:wasm32 --symlink_prefix=bazel-wasm-
 build:clang --crosstool_top=//toolchain:clang
 build:clang --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 build:clang --cpu=k8
+build:clang --copt=-Wno-error=sign-compare
 
 # Use a different symlink prefix for clang-based artifacts.
 build:clang --symlink_prefix=bazel-clang-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,9 +32,9 @@ http_archive(
 # Asylo Framework.
 http_archive(
     name = "com_google_asylo",
-    sha256 = "c57507e103b76501d5a8e73147cf6323eedff05fa47912bc1f9182404d3d2cfc",
-    strip_prefix = "asylo-f620292381aae18b5d5fe73dcc63e46f4bd653cc",
-    urls = ["https://github.com/google/asylo/archive/f620292381aae18b5d5fe73dcc63e46f4bd653cc.tar.gz"],
+    sha256 = "a15b5b436d27b3fd426de2f3d8598264f7ccf8a79421b5cfd41b95c832e3e9b0",
+    strip_prefix = "asylo-361737de928acbd01a6ca206292bf79c0484c62b",
+    urls = ["https://github.com/google/asylo/archive/361737de928acbd01a6ca206292bf79c0484c62b.tar.gz"],
 )
 
 # Google Test

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,7 +47,7 @@ steps:
     waitFor: ['build_server_asylo']
     timeout: 5m
     entrypoint: 'cp'
-    args: ['./bazel-bin/oak/server/asylo/oak_enclave_unsigned.so', './oak_enclave_unsigned.so']
+    args: ['./bazel-bin/oak/server/asylo/liboak_enclave_unsigned.so', './liboak_enclave_unsigned.so']
 
 # Copy compiled enclave binary to Google Cloud Storage.
 # See:
@@ -58,7 +58,7 @@ artifacts:
   objects:
     location: gs://artifacts.oak-ci.appspot.com/test
     paths:
-      - ./oak_enclave_unsigned.so
+      - ./liboak_enclave_unsigned.so
 
 timeout: 2h
 


### PR DESCRIPTION
Also turn off forced errors for sign comparison warnings so Clang
builds still work.