### PR TITLE
Add MRENCLAVE generation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,9 +32,12 @@ http_archive(
 # Asylo Framework.
 http_archive(
     name = "com_google_asylo",
-    sha256 = "a15b5b436d27b3fd426de2f3d8598264f7ccf8a79421b5cfd41b95c832e3e9b0",
-    strip_prefix = "asylo-361737de928acbd01a6ca206292bf79c0484c62b",
-    urls = ["https://github.com/google/asylo/archive/361737de928acbd01a6ca206292bf79c0484c62b.tar.gz"],
+    sha256 = "7f53d61d91a8d6963a5665088b02129d643a4cfbcab883f1076b71bcbe07184d",
+    strip_prefix = "asylo-088ea3490dd4579655bd5b65b0e31fe18de7f6dd",
+    urls = [
+        # Head commit on 2019-11-21
+        "https://github.com/google/asylo/archive/088ea3490dd4579655bd5b65b0e31fe18de7f6dd.tar.gz"
+    ],
 )
 
 # Google Test

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ http_archive(
     strip_prefix = "asylo-088ea3490dd4579655bd5b65b0e31fe18de7f6dd",
     urls = [
         # Head commit on 2019-11-21.
-        "https://github.com/google/asylo/archive/088ea3490dd4579655bd5b65b0e31fe18de7f6dd.tar.gz"
+        "https://github.com/google/asylo/archive/088ea3490dd4579655bd5b65b0e31fe18de7f6dd.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,7 +35,7 @@ http_archive(
     sha256 = "7f53d61d91a8d6963a5665088b02129d643a4cfbcab883f1076b71bcbe07184d",
     strip_prefix = "asylo-088ea3490dd4579655bd5b65b0e31fe18de7f6dd",
     urls = [
-        # Head commit on 2019-11-21
+        # Head commit on 2019-11-21.
         "https://github.com/google/asylo/archive/088ea3490dd4579655bd5b65b0e31fe18de7f6dd.tar.gz"
     ],
 )

--- a/oak/server/asylo/BUILD
+++ b/oak/server/asylo/BUILD
@@ -93,13 +93,19 @@ sgx.debug_enclave(
     config = ":grpc_enclave_config",
 )
 
-# TODO: Use genrule from asylo, when it will become available
+# TODO: Use genrule from asylo, when it will become available.
 genrule(
     name = "oak_mrenclave",
     srcs = [":oak_enclave_signing_material"],
     outs = ["oak_mrenclave.txt"],
-    # Gets the enclave hash from the enclave signing material as a hex string
-    # 188 is an offset of the hash, 32 is the size of the hash
+    # Gets the enclave hash from the enclave signing material as a hex string.
+    # Signing material consists of the header and the body of the SIGSTRUCT
+    # struct (excluding keys), defined here:
+    # https://github.com/intel/linux-sgx/blob/d10cabebb5512878e84f5d21cdf27c39c428ffe2/common/inc/internal/arch.h#L240-L245
+    # Signing material generation is defined here:
+    # https://github.com/intel/linux-sgx/blob/d10cabebb5512878e84f5d21cdf27c39c428ffe2/sdk/sign_tool/SignTool/sign_tool.cpp#L528-L548
+    # 188 is an offset of the hash (instead of the original 960 from the SIGSTRUCT),
+    # 32 is the size of the hash.
     cmd = "xxd -p -s 188 -l 32 -c 32 $< > $@",
 )
 

--- a/oak/server/asylo/BUILD
+++ b/oak/server/asylo/BUILD
@@ -93,10 +93,20 @@ sgx.debug_enclave(
     config = ":grpc_enclave_config",
 )
 
+# TODO: Use genrule from asylo, when it will become available
+genrule(
+    name = "oak_mrenclave",
+    srcs = [":oak_enclave_signing_material"],
+    outs = ["oak_mrenclave.txt"],
+    # Gets the enclave hash from the enclave signing material as a hex string
+    # 188 is an offset of the hash, 32 is the size of the hash
+    cmd = "xxd -p -s 188 -l 32 -c 32 $< > $@",
+)
+
 # Produces oak_enclave_sigstruct.dat file, which is used to generate the remote attestation of the
 # enclave code. See https://software.intel.com/en-us/node/703003.
-sgx.generate_sigstruct(
-    name = "oak_enclave_sigstruct",
+sgx.generate_enclave_signing_material(
+    name = "oak_enclave_signing_material",
     unsigned = ":oak_enclave_unsigned.so",
     config = ":grpc_enclave_config",
 )

--- a/scripts/print_mrenclave
+++ b/scripts/print_mrenclave
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+readonly SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=scripts/common
+source "$SCRIPTS_DIR/common"
+
+# Prints the MRENCLAVE value of the unsigned enclave code
+bazel build --config=sgx-sim //oak/server/asylo:oak_mrenclave
+cat bazel-bin/oak/server/asylo/oak_mrenclave.txt

--- a/scripts/print_mrenclave
+++ b/scripts/print_mrenclave
@@ -4,6 +4,6 @@ readonly SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-# Prints the MRENCLAVE value of the unsigned enclave code
+# Prints the MRENCLAVE value of the unsigned enclave code.
 bazel build --config=sgx-sim //oak/server/asylo:oak_mrenclave
 cat bazel-bin/oak/server/asylo/oak_mrenclave.txt


### PR DESCRIPTION
This change:
- adds a new Bazel build rule, that generates oak_mrenclave.txt file (with a hex string)
- updates Asylo
- adds print_mrenclave script
