### PR TITLE
storage: pass a response channel with each request

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -158,11 +158,9 @@ are configured by the `oak::DefaultConfig()`
   by a handle for the write half of a channel which should be used for sending
   the associated gRPC response messages (as serialized `GrpcResponse` protocol
   buffer messages).
-- `storage_in` (receive): This channel will be populated with incoming storage
-  response messages, for processing by the Oak Node. Each message is a
-  serialized `StorageOperationResponse` protocol buffer message (see
-  [/oak/proto/storage.proto](oak/proto/storage.proto)).
 - `storage_out` (send): This channel can be used to send storage request
   messages. Each such message should be encoded as a serialized
   `StorageOperationRequest` protocol buffer message (see
-  [/oak/proto/storage.proto](oak/proto/storage.proto)).
+  [/oak/proto/storage.proto](oak/proto/storage.proto)), and should be
+  accompanied by a handle for the write half of a channel for the response to be
+  returned on.

--- a/oak/common/testdata/channel_dest_missing.textproto
+++ b/oak/common/testdata/channel_dest_missing.textproto
@@ -17,10 +17,6 @@ nodes {
       name: "storage_out"
       type: OUT
     }
-    ports {
-      name: "storage_in"
-      type: IN
-    }
   }
 }
 nodes {
@@ -69,15 +65,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/channel_inverted.textproto
+++ b/oak/common/testdata/channel_inverted.textproto
@@ -17,10 +17,6 @@ nodes {
       name: "storage_out"
       type: OUT
     }
-    ports {
-      name: "storage_in"
-      type: IN
-    }
   }
 }
 nodes {
@@ -69,15 +65,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/channel_source_missing.textproto
+++ b/oak/common/testdata/channel_source_missing.textproto
@@ -17,10 +17,6 @@ nodes {
       name: "storage_out"
       type: OUT
     }
-    ports {
-      name: "storage_in"
-      type: IN
-    }
   }
 }
 nodes {
@@ -69,15 +65,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/default.textproto
+++ b/oak/common/testdata/default.textproto
@@ -17,10 +17,6 @@ nodes {
       name: "storage_out"
       type: OUT
     }
-    ports {
-      name: "storage_in"
-      type: IN
-    }
   }
 }
 nodes {
@@ -69,15 +65,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/dup_node_name.textproto
+++ b/oak/common/testdata/dup_node_name.textproto
@@ -17,10 +17,6 @@ nodes {
       name: "storage_out"
       type: OUT
     }
-    ports {
-      name: "storage_in"
-      type: IN
-    }
   }
 }
 nodes {
@@ -69,15 +65,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/dup_port.textproto
+++ b/oak/common/testdata/dup_port.textproto
@@ -21,10 +21,6 @@ nodes {
       name: "storage_out"
       type: OUT
     }
-    ports {
-      name: "storage_in"
-      type: IN
-    }
   }
 }
 nodes {
@@ -73,15 +69,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/in_port_empty.textproto
+++ b/oak/common/testdata/in_port_empty.textproto
@@ -18,10 +18,6 @@ nodes {
       type: OUT
     }
     ports {
-      name: "storage_in"
-      type: IN
-    }
-    ports {
       name: "unused"
       type: IN
     }
@@ -73,15 +69,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/out_port_empty.textproto
+++ b/oak/common/testdata/out_port_empty.textproto
@@ -18,10 +18,6 @@ nodes {
       type: OUT
     }
     ports {
-      name: "storage_in"
-      type: IN
-    }
-    ports {
       name: "unused"
       type: OUT
     }
@@ -73,15 +69,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/storagenode.textproto
+++ b/oak/common/testdata/storagenode.textproto
@@ -18,10 +18,6 @@ nodes {
       name: "storage_out"
       type: OUT
     }
-    ports {
-      name: "storage_in"
-      type: IN
-    }
   }
 }
 nodes {
@@ -52,15 +48,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/two_grpc.textproto
+++ b/oak/common/testdata/two_grpc.textproto
@@ -17,10 +17,6 @@ nodes {
       name: "storage_out"
       type: OUT
     }
-    ports {
-      name: "storage_in"
-      type: IN
-    }
   }
 }
 nodes {
@@ -73,15 +69,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/common/testdata/two_log.textproto
+++ b/oak/common/testdata/two_log.textproto
@@ -17,10 +17,6 @@ nodes {
       name: "storage_out"
       type: OUT
     }
-    ports {
-      name: "storage_in"
-      type: IN
-    }
   }
 }
 nodes {
@@ -73,15 +69,5 @@ channels {
   destination_endpoint {
     node_name: "storage"
     port_name: "request"
-  }
-}
-channels {
-  source_endpoint {
-    node_name: "storage"
-    port_name: "response"
-  }
-  destination_endpoint {
-    node_name: "app"
-    port_name: "storage_in"
   }
 }

--- a/oak/proto/manager.proto
+++ b/oak/proto/manager.proto
@@ -99,9 +99,9 @@ message WasmContents {
 // external storage provider.
 //
 // This Node defines the following implicit Ports:
-// - `request`: IN port on which outgoing storage requests are received.
-// - `response`: OUT port on which inbound responses to storage requests are
-// sent.
+// - `request`: IN port on which outgoing storage requests are received,
+//    each accompanied by a handle for a write half of a channel for responses
+//    to be delivered on.
 message StorageProxyNode {
   // The address of the external storage provider.
   string address = 1;


### PR DESCRIPTION
Rather than using a global response channel for the storage
pseudo-Node, instead expect that each request should be accompanied
by a response channel handle.  This is more consistent with how the
gRPC channels currently work, allows for easier parallelizing /
multiplexing, and will ease future changes for dynamic Node creation.