### PR TITLE
Update fuzzer for new WasmNode::Create signature

### DIFF
--- a/oak/server/wasm_node_fuzzer.cc
+++ b/oak/server/wasm_node_fuzzer.cc
@@ -5,6 +5,9 @@
 // See https://llvm.org/docs/LibFuzzer.html#fuzz-target.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   std::string module(reinterpret_cast<char const*>(data), size);
-  std::unique_ptr<oak::WasmNode> node = oak::WasmNode::Create("test", module);
+  // Build a WasmNode instance treating the fuzzing input as Wasm module code.
+  // No need to pass in an owning runtime instance (first argument) since the
+  // built Node is never run.
+  std::unique_ptr<oak::WasmNode> node = oak::WasmNode::Create(nullptr, "test", module);
   return 0;
 }


### PR DESCRIPTION
Commit edb3a73a8930 ("Add owning-runtime link to Wasm node") changed
the signature of WasmNode::Create, but the fuzzer driver wasn't updated
at the time (and wasn't noticed because CI doesn't build this target).