### PR TITLE
Load proto_library in google/rpc

### DIFF
--- a/third_party/google/rpc/BUILD
+++ b/third_party/google/rpc/BUILD
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This change adds an explicit load of `proto_library` and `cc_proto_library` in `third_party/google/rpc`.