### PR TITLE
Add absl/base dependency in policy

### DIFF
--- a/oak/common/BUILD
+++ b/oak/common/BUILD
@@ -75,6 +75,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//oak/proto:policy_cc_proto",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/strings",
     ],
 )


### PR DESCRIPTION
This change adds `@com_google_absl//absl/base` in `policy` library, since `policy.h` includes `absl/base/attributes.h`.