### PR TITLE
Add Asylo proto dependency in client

### DIFF
--- a/oak/client/BUILD
+++ b/oak/client/BUILD
@@ -68,6 +68,7 @@ cc_library(
         "@com_google_asylo//asylo/identity:enclave_assertion_authority_configs",
         "@com_google_asylo//asylo/identity:descriptions",
         "@com_google_asylo//asylo/identity:init",
+        "@com_google_asylo//asylo/identity/sgx:sgx_identity_cc_proto",
         "@com_google_asylo//asylo/identity/sgx:sgx_identity_util",
         "@com_google_asylo//asylo/identity/util:sha256_hash_cc_proto",
         "@com_google_asylo//asylo/util:logging",

--- a/oak/client/sgx_application_client.cc
+++ b/oak/client/sgx_application_client.cc
@@ -29,6 +29,7 @@
 #include "asylo/identity/descriptions.h"
 #include "asylo/identity/enclave_assertion_authority_configs.h"
 #include "asylo/identity/init.h"
+#include "asylo/identity/sgx/sgx_identity.pb.h"
 #include "asylo/identity/sgx/sgx_identity_util.h"
 #include "asylo/identity/util/sha256_hash.pb.h"
 #include "asylo/util/logging.h"


### PR DESCRIPTION
This change adds an explicit dependency on `asylo/identity/sgx:sgx_identity_cc_proto` to the `sgx_application_client` build target.