### PR TITLE
Remove clang-tidy flag warnings

### DIFF
--- a/scripts/generate_compilation_database
+++ b/scripts/generate_compilation_database
@@ -17,8 +17,10 @@ find . -name '*.compile_command.json' -print0 | while read -r -d '' fname; do
     echo ',' >> "$FILE_NAME"
   fi
   sed -e "s|@BAZEL_ROOT@|$BAZEL_ROOT|g" < "$fname" | \
-  # Clang doesn't recognize '-fno-canonical-system-headers'.
-  sed -e "s|-fno-canonical-system-headers|-no-canonical-prefixes|g" >> "$FILE_NAME"
+  # Change GCC parameters to Clang.
+  sed -e "s|-fno-canonical-system-headers|-no-canonical-prefixes|g" | \
+  sed -e "s|-Wno-free-nonheap-object|-Wno-sequence-point|g" | \
+  sed -e "s|-Wunused-but-set-parameter|-Wunused-parameter|g" >> "$FILE_NAME"
 done
 echo ']' >> "$FILE_NAME"
 

--- a/scripts/run_clang_tidy
+++ b/scripts/run_clang_tidy
@@ -20,7 +20,7 @@ bazel build "${bazel_build_flags[@]}" -- //oak/...:all -//oak/server/asylo:all
 
 # Run clang-tidy.
 mapfile -t SOURCE_FILES < <(find oak -path oak/server/asylo -prune -o -name '*.cc')
-clang-tidy -p "$BAZEL_ROOT" -header-filter='.*' "${SOURCE_FILES[@]}"
+clang-tidy -p "$BAZEL_ROOT" -header-filter='-external' "${SOURCE_FILES[@]}"
 
 # TODO: Uncomment when https://github.com/project-oak/oak/issues/354 will be closed.
 ## Compile Asylo server separately with an Asylo toolchain.
@@ -30,4 +30,4 @@ clang-tidy -p "$BAZEL_ROOT" -header-filter='.*' "${SOURCE_FILES[@]}"
 ## Check Asylo server separately, since clang-tidy requires all targets to be
 ## built at the same time.
 #mapfile -t ASYLO_SOURCE_FILES < <(find oak/server/asylo -name '*.cc')
-#clang-tidy -p "$BAZEL_ROOT" -header-filter='.*' "${ASYLO_SOURCE_FILES[@]}"
+#clang-tidy -p "$BAZEL_ROOT" -header-filter='-external' "${ASYLO_SOURCE_FILES[@]}"


### PR DESCRIPTION
This commit changes GCC specific flags in the compilation database to Clang specific ones.

Fixes #362