### PR TITLE
Minimize use of `unwrap()` in oak_tests

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -435,7 +435,7 @@ fn test_abi() {
     let be: oak_tests::NodeMain = abitest_backend::main;
     entrypoints.insert(FRONTEND_CONFIG_NAME.to_string(), fe);
     entrypoints.insert(BACKEND_CONFIG_NAME.to_string(), be);
-    oak_tests::start(test_config(), entrypoints);
+    assert_eq!(Some(()), oak_tests::start(test_config(), entrypoints));
 ```
 <!-- prettier-ignore-end -->
 

--- a/examples/abitest/module/rust/src/lib.rs
+++ b/examples/abitest/module/rust/src/lib.rs
@@ -760,6 +760,14 @@ impl FrontendNode {
             OakStatus::ERR_INVALID_ARGS,
             oak::node_create("no-such-config", self.backend_in[0])
         );
+        let non_utf8_name: Vec<u8> = vec![0xc3, 0x28];
+        expect_eq!(OakStatus::ERR_INVALID_ARGS.value() as u32, unsafe {
+            oak::wasm::node_create(
+                non_utf8_name.as_ptr(),
+                non_utf8_name.len(),
+                self.backend_in[0].handle,
+            )
+        });
         expect_eq!(
             OakStatus::ERR_BAD_HANDLE,
             oak::node_create(

--- a/examples/abitest/tests/src/tests.rs
+++ b/examples/abitest/tests/src/tests.rs
@@ -63,7 +63,7 @@ fn test_abi() {
     let be: oak_tests::NodeMain = abitest_backend::main;
     entrypoints.insert(FRONTEND_CONFIG_NAME.to_string(), fe);
     entrypoints.insert(BACKEND_CONFIG_NAME.to_string(), be);
-    oak_tests::start(test_config(), entrypoints);
+    assert_eq!(Some(()), oak_tests::start(test_config(), entrypoints));
 
     let mut req = ABITestRequest::new();
     // Skip raw tests (which use invalid memory addresses etc.).

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -302,9 +302,7 @@ impl OakRuntime {
         None
     }
     fn reset(&mut self) {
-        let names: Vec<String> = self.nodes.keys().cloned().collect();
-        for name in &names {
-            let node = self.nodes.get_mut(name).unwrap();
+        for node in self.nodes.values_mut() {
             node.halves.clear();
         }
         self.grpc_in_half = None;

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -575,7 +575,10 @@ pub unsafe extern "C" fn wait_on_channels(buf: *mut u8, count: u32) -> u32 {
             let p = buf.add(
                 i * oak::wasm::SPACE_BYTES_PER_HANDLE + (oak::wasm::SPACE_BYTES_PER_HANDLE - 1),
             );
-            *p = channel_status.value().try_into().unwrap();
+            *p = channel_status
+                .value()
+                .try_into()
+                .expect("failed to convert status to u8");
         }
         if RUNTIME.read().expect(RUNTIME_MISSING).termination_pending {
             debug!("{{{}}}: wait_on_channels() -> ERR_TERMINATED", name);
@@ -789,7 +792,7 @@ pub fn last_message_as_string(handle: oak::Handle) -> String {
     let half = RUNTIME.read().expect(RUNTIME_MISSING).nodes[DEFAULT_NODE_NAME]
         .halves
         .get(&handle)
-        .unwrap()
+        .expect("invalid handle passed to test helper")
         .clone();
     let result = match half
         .channel
@@ -810,7 +813,7 @@ pub fn set_read_status(node_name: &str, handle: oak::Handle, status: Option<u32>
     let half = RUNTIME.read().expect(RUNTIME_MISSING).nodes[node_name]
         .halves
         .get(&handle)
-        .unwrap()
+        .expect("invalid handle passed to test helper")
         .clone();
     half.channel
         .write()
@@ -823,7 +826,7 @@ pub fn set_write_status(node_name: &str, handle: oak::Handle, status: Option<u32
     let half = RUNTIME.read().expect(RUNTIME_MISSING).nodes[node_name]
         .halves
         .get(&handle)
-        .unwrap()
+        .expect("invalid handle passed to test helper")
         .clone();
     half.channel
         .write()
@@ -996,7 +999,10 @@ where
         .expect(RUNTIME_MISSING)
         .grpc_channel()
         .expect("no gRPC channel setup");
-    grpc_channel.write().unwrap().write_message(msg);
+    grpc_channel
+        .write()
+        .expect("corrupt gRPC channel ref")
+        .write_message(msg);
 
     // Read the serialized, encapsulated response.
     loop {

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -295,8 +295,8 @@ impl OakRuntime {
     }
     fn stop_next(&mut self) -> Option<(String, std::thread::JoinHandle<i32>)> {
         for (name, node) in &mut self.nodes {
-            if node.thread_handle.is_some() {
-                return Some((name.to_string(), node.thread_handle.take().unwrap()));
+            if let Some(h) = node.thread_handle.take() {
+                return Some((name.to_string(), h));
             }
         }
         None

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -328,13 +328,19 @@ impl OakRuntime {
         Some(half)
     }
     fn node_add_half(&mut self, node_name: &str, half: ChannelHalf) -> oak::Handle {
-        self.nodes.get_mut(node_name).unwrap().add_half(half)
+        self.nodes
+            .get_mut(node_name)
+            .unwrap_or_else(|| panic!("node {{{}}} not found", node_name))
+            .add_half(half)
     }
     fn node_channel_create(&mut self, node_name: &str) -> (oak::Handle, oak::Handle) {
         let channel = self.new_channel();
         let write_half = ChannelHalf::new(Direction::Write, channel.clone());
         let read_half = ChannelHalf::new(Direction::Read, channel.clone());
-        let node = self.nodes.get_mut(node_name).unwrap();
+        let node = self
+            .nodes
+            .get_mut(node_name)
+            .unwrap_or_else(|| panic!("node {{{}}} not found", node_name));
         (node.add_half(write_half), node.add_half(read_half))
     }
     fn node_channel_write(&mut self, node_name: &str, handle: oak::Handle, msg: OakMessage) -> u32 {

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -393,7 +393,10 @@ impl OakRuntime {
     fn grpc_channel_setup(&mut self, node_name: &str) -> oak::Handle {
         let channel = self.new_channel();
         let half = ChannelHalf::new(Direction::Read, channel.clone());
-        let node = self.nodes.get_mut(node_name).unwrap();
+        let node = self
+            .nodes
+            .get_mut(node_name)
+            .unwrap_or_else(|| panic!("node {{{}}} not found", node_name));
         let read_handle = node.add_half(half);
         debug!(
             "set up gRPC channel to node {} with handle {}",
@@ -719,7 +722,7 @@ pub extern "C" fn channel_close(handle: u64) -> u32 {
         .expect(RUNTIME_MISSING)
         .nodes
         .get_mut(&name)
-        .unwrap()
+        .unwrap_or_else(|| panic!("node {{{}}} not found", name))
         .close_channel(handle);
     debug!("{{{}}}: channel_close({}) -> {}", name, handle, result);
     result

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -311,11 +311,8 @@ impl OakRuntime {
         Arc::new(RwLock::new(MockChannel::new()))
     }
     fn node_half_for_handle(&self, node_name: &str, handle: oak::Handle) -> Option<ChannelHalf> {
-        let node = self.nodes.get(node_name).unwrap();
-        if !node.halves.contains_key(&handle) {
-            return None;
-        }
-        let half = node.halves.get(&handle).unwrap();
+        let node = self.nodes.get(node_name)?;
+        let half = node.halves.get(&handle)?;
         Some(half.clone())
     }
     fn node_half_for_handle_dir(

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -270,18 +270,18 @@ impl OakRuntime {
         let entrypoint = self.entrypoint(&config.initial_node)?;
 
         let node_name = self.next_node_name(&config.initial_node);
-        let node = OakNode::new();
+        let mut node = OakNode::new();
         debug!(
             "{{{}}}: add Wasm node running config '{}'",
             node_name, config.initial_node
         );
-        self.nodes.insert(node_name.clone(), node);
 
         // Setup the initial channel from gRPC pseudo-Node to Node.
         let channel = self.new_channel();
         self.grpc_in_half = Some(ChannelHalf::new(Direction::Write, channel.clone()));
         let half = ChannelHalf::new(Direction::Read, channel.clone());
-        let handle = self.nodes.get_mut(&node_name).unwrap().add_half(half);
+        let handle = node.add_half(half);
+        self.nodes.insert(node_name.clone(), node);
 
         Some((node_name, entrypoint, handle))
     }

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -149,7 +149,7 @@ impl ChannelHalf {
             .unwrap()
             .half_count
             .get_mut(&direction)
-            .unwrap() += 1;
+            .expect("missing enum value in half_count") += 1;
         ChannelHalf { direction, channel }
     }
 }
@@ -169,7 +169,7 @@ impl Drop for ChannelHalf {
             .unwrap()
             .half_count
             .get_mut(&self.direction)
-            .unwrap() -= 1;
+            .expect("missing enum value in half_count") -= 1;
         assert!(self.channel.read().unwrap().half_count[&self.direction] >= 0);
     }
 }

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -741,7 +741,10 @@ pub unsafe fn node_create(buf: *const u8, len: usize, handle: u64) -> u32 {
     let mut data = Vec::with_capacity(len as usize);
     std::ptr::copy_nonoverlapping(buf, data.as_mut_ptr(), len as usize);
     data.set_len(len as usize);
-    let config = String::from_utf8(data).unwrap();
+    let config = match String::from_utf8(data) {
+        Err(_) => return OakStatus::ERR_INVALID_ARGS.value() as u32,
+        Ok(s) => s,
+    };
     debug!("{{{}}}: node_create('{}', {})", name, config, handle);
 
     let start_info = match RUNTIME


### PR DESCRIPTION
[Lots of little commits for ease of rebasing; not sure whether it's easier to review in one go or commit-by-commit though.]

General aim here is to make the test runtime more suitable for non-test use, by making it more robust.  Many of the changes are of the form:
 - Convert `unwrap` to `expect` to make diagnostics better.
 - Re-write code that checks an `Option` / `Result` for an early `return` then `unwrap`s to use an inline `match` instead.

(But there's a few other things too.)