### PR TITLE
Remove unused function parameter names

### DIFF
--- a/oak/client/authorization_bearer_token_metadata.cc
+++ b/oak/client/authorization_bearer_token_metadata.cc
@@ -27,8 +27,8 @@ AuthorizationBearerTokenMetadata::AuthorizationBearerTokenMetadata(
     : authorization_bearer_token_(authorization_bearer_token) {}
 
 grpc::Status AuthorizationBearerTokenMetadata::GetMetadata(
-    grpc::string_ref service_url, grpc::string_ref method_name,
-    const grpc::AuthContext& channel_auth_context,
+    grpc::string_ref /*service_url*/, grpc::string_ref /*method_name*/,
+    const grpc::AuthContext& /*channel_auth_context*/,
     std::multimap<grpc::string, grpc::string>* metadata) {
   metadata->insert(
       std::make_pair(kOakAuthorizationBearerTokenGrpcMetadataKey, authorization_bearer_token_));

--- a/oak/client/policy_metadata.cc
+++ b/oak/client/policy_metadata.cc
@@ -27,8 +27,9 @@ namespace oak {
 PolicyMetadata::PolicyMetadata(const oak::policy::Label& label)
     : serialized_policy_(SerializePolicy(label)) {}
 
-grpc::Status PolicyMetadata::GetMetadata(grpc::string_ref service_url, grpc::string_ref method_name,
-                                         const grpc::AuthContext& channel_auth_context,
+grpc::Status PolicyMetadata::GetMetadata(grpc::string_ref /*service_url*/,
+                                         grpc::string_ref /*method_name*/,
+                                         const grpc::AuthContext& /*channel_auth_context*/,
                                          std::multimap<grpc::string, grpc::string>* metadata) {
   metadata->insert(std::make_pair(kOakPolicyGrpcMetadataKey, serialized_policy_));
   return grpc::Status::OK;

--- a/oak/server/dev/dev_oak_main.cc
+++ b/oak/server/dev/dev_oak_main.cc
@@ -31,7 +31,7 @@
 
 ABSL_FLAG(int, grpc_port, 8888, "Port to listen on");
 
-void sigint_handler(int param) {
+void sigint_handler(int) {
   LOG(QFATAL) << "SIGINT received";
   exit(1);
 }

--- a/oak/server/dev/dev_oak_manager.cc
+++ b/oak/server/dev/dev_oak_manager.cc
@@ -32,7 +32,7 @@ DevOakManager::DevOakManager() : Service(), next_application_id_(0) {
   InitializeAssertionAuthorities();
 }
 
-grpc::Status DevOakManager::CreateApplication(grpc::ServerContext* context,
+grpc::Status DevOakManager::CreateApplication(grpc::ServerContext*,
                                               const oak::CreateApplicationRequest* request,
                                               oak::CreateApplicationResponse* response) {
   std::string application_id = NewApplicationId();
@@ -57,9 +57,9 @@ grpc::Status DevOakManager::CreateApplication(grpc::ServerContext* context,
   return grpc::Status::OK;
 }
 
-grpc::Status DevOakManager::TerminateApplication(grpc::ServerContext* context,
+grpc::Status DevOakManager::TerminateApplication(grpc::ServerContext*,
                                                  const oak::TerminateApplicationRequest* request,
-                                                 oak::TerminateApplicationResponse* response) {
+                                                 oak::TerminateApplicationResponse*) {
   LOG(INFO) << "Terminating application with ID " << request->application_id();
 
   OakRuntime* runtime = runtimes_[request->application_id()].get();

--- a/oak/server/oak_grpc_node.cc
+++ b/oak/server/oak_grpc_node.cc
@@ -83,9 +83,8 @@ void OakGrpcNode::CompletionQueueLoop() {
   }
 }
 
-grpc::Status OakGrpcNode::GetAttestation(grpc::ServerContext* context,
-                                         const GetAttestationRequest* request,
-                                         GetAttestationResponse* response) {
+grpc::Status OakGrpcNode::GetAttestation(grpc::ServerContext*, const GetAttestationRequest*,
+                                         GetAttestationResponse*) {
   // TODO: Move this method to the application and implement it there.
   return ::grpc::Status::OK;
 }

--- a/oak/server/storage/memory_provider.cc
+++ b/oak/server/storage/memory_provider.cc
@@ -36,12 +36,12 @@ grpc::Status MemoryProvider::Read(const StorageReadRequest* req, StorageReadResp
   return grpc::Status::OK;
 }
 
-grpc::Status MemoryProvider::Write(const StorageWriteRequest* req, StorageWriteResponse* rsp) {
+grpc::Status MemoryProvider::Write(const StorageWriteRequest* req, StorageWriteResponse*) {
   stores_[req->storage_id()][req->datum_name()] = req->datum_value();
   return grpc::Status::OK;
 }
 
-grpc::Status MemoryProvider::Delete(const StorageDeleteRequest* req, StorageDeleteResponse* rsp) {
+grpc::Status MemoryProvider::Delete(const StorageDeleteRequest* req, StorageDeleteResponse*) {
   auto store = stores_.find(req->storage_id());
   if (store == stores_.end()) {
     return grpc::Status(grpc::StatusCode::NOT_FOUND,
@@ -51,14 +51,13 @@ grpc::Status MemoryProvider::Delete(const StorageDeleteRequest* req, StorageDele
   return grpc::Status::OK;
 }
 
-grpc::Status MemoryProvider::Begin(const StorageBeginRequest* req, StorageBeginResponse* rsp) {
+grpc::Status MemoryProvider::Begin(const StorageBeginRequest*, StorageBeginResponse*) {
   return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "No transaction semantics here");
 }
-grpc::Status MemoryProvider::Commit(const StorageCommitRequest* req, StorageCommitResponse* rsp) {
+grpc::Status MemoryProvider::Commit(const StorageCommitRequest*, StorageCommitResponse*) {
   return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "No transaction semantics here");
 }
-grpc::Status MemoryProvider::Rollback(const StorageRollbackRequest* req,
-                                      StorageRollbackResponse* rsp) {
+grpc::Status MemoryProvider::Rollback(const StorageRollbackRequest*, StorageRollbackResponse*) {
   return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "No transaction semantics here");
 }
 

--- a/oak/server/storage/storage_processor.cc
+++ b/oak/server/storage/storage_processor.cc
@@ -34,7 +34,7 @@ std::string GetStorageId(const std::string& storage_name) {
   return storage_name;
 }
 
-asylo::CleansingVector<uint8_t> GetStorageEncryptionKey(const std::string& storage_name) {
+asylo::CleansingVector<uint8_t> GetStorageEncryptionKey(const std::string& /*storage_name*/) {
   // TODO: Request encryption key from escrow service.
   std::string encryption_key =
       absl::HexStringToBytes("c0dedeadc0dedeadc0dedeadc0dedeadc0dedeadc0dedeadc0dedeadc0dedead");

--- a/oak/server/storage/storage_service.cc
+++ b/oak/server/storage/storage_service.cc
@@ -21,35 +21,32 @@ namespace oak {
 StorageService::StorageService(StorageProvider* storage_provider)
     : storage_provider_(storage_provider) {}
 
-grpc::Status StorageService::Read(grpc::ServerContext* context, const StorageReadRequest* request,
+grpc::Status StorageService::Read(grpc::ServerContext*, const StorageReadRequest* request,
                                   StorageReadResponse* response) {
   return storage_provider_->Read(request, response);
 }
 
-grpc::Status StorageService::Write(grpc::ServerContext* context, const StorageWriteRequest* request,
+grpc::Status StorageService::Write(grpc::ServerContext*, const StorageWriteRequest* request,
                                    StorageWriteResponse* response) {
   return storage_provider_->Write(request, response);
 }
 
-grpc::Status StorageService::Delete(grpc::ServerContext* context,
-                                    const StorageDeleteRequest* request,
+grpc::Status StorageService::Delete(grpc::ServerContext*, const StorageDeleteRequest* request,
                                     StorageDeleteResponse* response) {
   return storage_provider_->Delete(request, response);
 }
 
-grpc::Status StorageService::Begin(grpc::ServerContext* context, const StorageBeginRequest* request,
+grpc::Status StorageService::Begin(grpc::ServerContext*, const StorageBeginRequest* request,
                                    StorageBeginResponse* response) {
   return storage_provider_->Begin(request, response);
 }
 
-grpc::Status StorageService::Commit(grpc::ServerContext* context,
-                                    const StorageCommitRequest* request,
+grpc::Status StorageService::Commit(grpc::ServerContext*, const StorageCommitRequest* request,
                                     StorageCommitResponse* response) {
   return storage_provider_->Commit(request, response);
 }
 
-grpc::Status StorageService::Rollback(grpc::ServerContext* context,
-                                      const StorageRollbackRequest* request,
+grpc::Status StorageService::Rollback(grpc::ServerContext*, const StorageRollbackRequest* request,
                                       StorageRollbackResponse* response) {
   return storage_provider_->Rollback(request, response);
 }

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -272,7 +272,7 @@ void WasmNode::Run(Handle handle) {
 }
 
 wabt::interp::HostFunc::Callback WasmNode::OakChannelRead(wabt::interp::Environment* env) {
-  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature* sig,
+  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
                      const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);
 
@@ -353,7 +353,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakChannelRead(wabt::interp::Environm
 }
 
 wabt::interp::HostFunc::Callback WasmNode::OakChannelWrite(wabt::interp::Environment* env) {
-  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature* sig,
+  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
                      const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);
 
@@ -416,7 +416,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakChannelWrite(wabt::interp::Environ
 }
 
 wabt::interp::HostFunc::Callback WasmNode::OakWaitOnChannels(wabt::interp::Environment* env) {
-  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature* sig,
+  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
                      const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);
 
@@ -462,7 +462,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakWaitOnChannels(wabt::interp::Envir
 }
 
 wabt::interp::HostFunc::Callback WasmNode::OakChannelCreate(wabt::interp::Environment* env) {
-  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature* sig,
+  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
                      const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);
 
@@ -489,8 +489,8 @@ wabt::interp::HostFunc::Callback WasmNode::OakChannelCreate(wabt::interp::Enviro
   };
 }
 
-wabt::interp::HostFunc::Callback WasmNode::OakChannelClose(wabt::interp::Environment* env) {
-  return [this](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature* sig,
+wabt::interp::HostFunc::Callback WasmNode::OakChannelClose(wabt::interp::Environment*) {
+  return [this](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
                 const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);
 
@@ -508,7 +508,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakChannelClose(wabt::interp::Environ
 }
 
 wabt::interp::HostFunc::Callback WasmNode::OakNodeCreate(wabt::interp::Environment* env) {
-  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature* sig,
+  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
                      const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);
 
@@ -551,7 +551,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakNodeCreate(wabt::interp::Environme
 }
 
 wabt::interp::HostFunc::Callback WasmNode::OakRandomGet(wabt::interp::Environment* env) {
-  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature* sig,
+  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
                      const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);
 


### PR DESCRIPTION
Comment out unused parameter names where they look like placeholders
that will be used in future, and remove altogether if they don't
look like they will be needed.

For #374.