### PR TITLE
Allow running of other dependencies alongside examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get --yes update && apt-get install --yes \
   git \
   libncurses5 \
   shellcheck \
-  xml2
+  xml2 \
+  procps
 
 # Install Node.js and npm.
 RUN curl --location https://deb.nodesource.com/setup_12.x | bash -

--- a/examples/hello_world/run_deps
+++ b/examples/hello_world/run_deps
@@ -1,0 +1,1 @@
+bazel run //oak/server/storage:storage_server

--- a/scripts/common
+++ b/scripts/common
@@ -45,3 +45,44 @@ else
         '--remote_upload_local_results=false'
     )
 fi
+
+# kill_pid tries to kill the given pid(s), first softly then more aggressively.
+kill_pid() {
+  local pids=( "$@" )
+  echo "Killing ${pids[*]}"
+  set +e
+  local count=0
+  while kill -INT "${pids[@]}" > /dev/null 2>&1; do
+    sleep 1
+    ((count++))
+    still_alive=()
+    for pid in "${pids[@]}"; do
+      if ps -p "${pid}" > /dev/null ; then
+        still_alive+=("${pid}")
+      fi
+    done
+    if [ ${#still_alive[@]} -eq 0 ]; then
+      break
+    fi
+    if [ $count -gt 5 ]; then
+      echo "Now do kill -KILL ${still_alive[*]}"
+      kill -KILL "${still_alive[@]}"
+      break
+    fi
+    pids=("${still_alive[@]}")
+    echo "Retry kill -INT ${pids[*]}"
+  done
+  set -e
+}
+
+declare -a to_kill
+
+# kill_bg_pids will clean up any pids in ${to_kill}.
+kill_bg_pids() {
+  if [ -v to_kill ]; then
+    kill_pid "${to_kill[@]}"
+    to_kill=()
+  fi
+}
+
+trap kill_bg_pids EXIT

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -11,17 +11,22 @@ source "$SCRIPTS_DIR/common"
 readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module/rust$' | cut -d'/' -f2)"
 for example in ${RUST_EXAMPLES}; do
   ./bazel-bin/oak/server/asylo/oak &
-  SERVER_PID=$!
+  server_pid=$!
+  to_kill+=("${server_pid}")
+
   "${SCRIPTS_DIR}/run_example" "${example}"
-  # TODO: Ensure that background processes are killed with something like `trap cleanup_fn EXIT`.
-  kill -s SIGTERM "$SERVER_PID"
+
+  kill_bg_pids
 done
 
 # Run C++-based Oak examples.
 readonly CPP_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module/cpp$' | cut -d'/' -f2)"
 for example in ${CPP_EXAMPLES}; do
   ./bazel-bin/oak/server/asylo/oak &
-  SERVER_PID=$!
+  server_pid=$!
+  to_kill+=("${server_pid}")
+
   "${SCRIPTS_DIR}/run_example" -c "${example}"
-  kill -s SIGTERM "$SERVER_PID"
+
+  kill_bg_pids
 done

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -14,6 +14,14 @@ for example in ${RUST_EXAMPLES}; do
   server_pid=$!
   to_kill+=("${server_pid}")
 
+  deps_cmd=$(cat "./examples/${example}/run_deps" || true)
+  if [ -n "${deps_cmd}" ]; then
+    # Run the dependencies of the example.
+    ${deps_cmd} &
+    deps_pid=$!
+    to_kill+=("${deps_pid}")
+  fi
+
   "${SCRIPTS_DIR}/run_example" "${example}"
 
   kill_bg_pids

--- a/scripts/run_examples_dev
+++ b/scripts/run_examples_dev
@@ -7,10 +7,10 @@ source "$SCRIPTS_DIR/common"
 # Build Oak server.
 "$SCRIPTS_DIR/build_server_dev" "$@"
 
-# Run Oak server.
+# Run Oak server and ensure it is killed on exit.
 ./bazel-clang-bin/oak/server/dev/oak &
-SERVER_PID=$!
-# TODO: Ensure that background processes are killed with something like `trap cleanup_fn EXIT`.
+readonly server_pid=$!
+to_kill+=("${server_pid}")
 
 # Run Rust-based Oak examples, each with their own Oak server instance.
 readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module/rust$' | cut -d'/' -f2)"
@@ -23,6 +23,3 @@ readonly CPP_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.
 for example in ${CPP_EXAMPLES}; do
   "${SCRIPTS_DIR}/run_example" -c "${example}"
 done
-
-# Terminate the server
-kill -s SIGTERM "$SERVER_PID"

--- a/scripts/run_examples_dev
+++ b/scripts/run_examples_dev
@@ -12,10 +12,22 @@ source "$SCRIPTS_DIR/common"
 readonly server_pid=$!
 to_kill+=("${server_pid}")
 
-# Run Rust-based Oak examples, each with their own Oak server instance.
+# Run Rust-based Oak examples, re-using the same Oak server instance.
 readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module/rust$' | cut -d'/' -f2)"
 for example in ${RUST_EXAMPLES}; do
+  deps_pid=""
+  deps_cmd=$(cat "./examples/${example}/run_deps" || true)
+  if [ -n "${deps_cmd}" ]; then
+    # Run the dependencies of the example.
+    ${deps_cmd} &
+    deps_pid=$!
+  fi
+
   "${SCRIPTS_DIR}/run_example" "${example}"
+
+  if [ -n "${deps_pid}" ]; then
+    kill_pid "${deps_pid}"
+  fi
 done
 
 # Run C++-based Oak examples.


### PR DESCRIPTION
[not ready for review, adding draft PR to trigger cloudbuild]

This allows the storage processing of the hello_world application to be exercised, and might be useful for future examples that (say) connect to an external HTTP server (#339)