### PR TITLE
Promote clang-tidy warnings to errors

### DIFF
--- a/oak/server/module_invocation.cc
+++ b/oak/server/module_invocation.cc
@@ -210,7 +210,7 @@ void ModuleInvocation::BlockingSendResponse() {
   }
 }
 
-void ModuleInvocation::Finish(bool ok) {
+void ModuleInvocation::Finish(bool /*ok*/) {
   LOG(INFO) << "invocation#" << stream_id_ << " Finish: delete self";
   delete this;
 }

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -95,7 +95,7 @@ std::string OakRuntime::NextNodeName(const std::string& config) {
 
 // Create (but don't start) a new Node instance.  Return a borrowed pointer to
 // the new Node (or nullptr on failure).
-OakNode* OakRuntime::CreateNode(const std::string& config, std::string* node_name) {
+OakNode* OakRuntime::CreateNode(const std::string& config, std::string* /*node_name*/) {
   std::string name = NextNodeName(config);
   std::unique_ptr<OakNode> node;
 

--- a/scripts/run_clang_tidy
+++ b/scripts/run_clang_tidy
@@ -9,14 +9,14 @@ bazel_build_flags+=(
     '--noshow_progress'
     '--noshow_loading_progress'
 )
+
+# Compilation database should be stored in the Bazel execution root.
+readonly BAZEL_ROOT=$(bazel info execution_root)
 readonly CLANG_TIDY_FLAGS=(
     "-p=${BAZEL_ROOT}"
     '-header-filter=-external'
     '-warnings-as-errors=*'
 )
-
-# Compilation database should be stored in the Bazel execution root.
-readonly BAZEL_ROOT=$(bazel info execution_root)
 
 # Generate compilation database.
 # Asylo is excluded since it requires an '--config=enc-sim' flag.
@@ -25,7 +25,6 @@ bazel build "${bazel_build_flags[@]}" -- //oak/...:all -//oak/server/asylo:all
 
 # Run clang-tidy.
 mapfile -t SOURCE_FILES < <(find oak -path oak/server/asylo -prune -o -name '*.cc')
-#clang-tidy -p "$BAZEL_ROOT" -header-filter='-external' "${SOURCE_FILES[@]}"
 clang-tidy "${CLANG_TIDY_FLAGS[@]}" "${SOURCE_FILES[@]}"
 
 # TODO: Uncomment when https://github.com/project-oak/oak/issues/354 will be closed.

--- a/scripts/run_clang_tidy
+++ b/scripts/run_clang_tidy
@@ -19,8 +19,14 @@ bazel build "${bazel_build_flags[@]}" -- //oak/...:all -//oak/server/asylo:all
 ./scripts/generate_compilation_database
 
 # Run clang-tidy.
+readonly CLANG_TIDY_FLAGS=(
+    "-p=${BAZEL_ROOT}"
+    '-header-filter=-external'
+    '-warnings-as-errors=*'
+)
 mapfile -t SOURCE_FILES < <(find oak -path oak/server/asylo -prune -o -name '*.cc')
-clang-tidy -p "$BAZEL_ROOT" -header-filter='-external' "${SOURCE_FILES[@]}"
+#clang-tidy -p "$BAZEL_ROOT" -header-filter='-external' "${SOURCE_FILES[@]}"
+clang-tidy "${CLANG_TIDY_FLAGS[@]}" "${SOURCE_FILES[@]}"
 
 # TODO: Uncomment when https://github.com/project-oak/oak/issues/354 will be closed.
 ## Compile Asylo server separately with an Asylo toolchain.

--- a/scripts/run_clang_tidy
+++ b/scripts/run_clang_tidy
@@ -9,6 +9,11 @@ bazel_build_flags+=(
     '--noshow_progress'
     '--noshow_loading_progress'
 )
+readonly CLANG_TIDY_FLAGS=(
+    "-p=${BAZEL_ROOT}"
+    '-header-filter=-external'
+    '-warnings-as-errors=*'
+)
 
 # Compilation database should be stored in the Bazel execution root.
 readonly BAZEL_ROOT=$(bazel info execution_root)
@@ -19,11 +24,6 @@ bazel build "${bazel_build_flags[@]}" -- //oak/...:all -//oak/server/asylo:all
 ./scripts/generate_compilation_database
 
 # Run clang-tidy.
-readonly CLANG_TIDY_FLAGS=(
-    "-p=${BAZEL_ROOT}"
-    '-header-filter=-external'
-    '-warnings-as-errors=*'
-)
 mapfile -t SOURCE_FILES < <(find oak -path oak/server/asylo -prune -o -name '*.cc')
 #clang-tidy -p "$BAZEL_ROOT" -header-filter='-external' "${SOURCE_FILES[@]}"
 clang-tidy "${CLANG_TIDY_FLAGS[@]}" "${SOURCE_FILES[@]}"
@@ -36,4 +36,4 @@ clang-tidy "${CLANG_TIDY_FLAGS[@]}" "${SOURCE_FILES[@]}"
 ## Check Asylo server separately, since clang-tidy requires all targets to be
 ## built at the same time.
 #mapfile -t ASYLO_SOURCE_FILES < <(find oak/server/asylo -name '*.cc')
-#clang-tidy -p "$BAZEL_ROOT" -header-filter='-external' "${ASYLO_SOURCE_FILES[@]}"
+#clang-tidy "${CLANG_TIDY_FLAGS[@]}" "${ASYLO_SOURCE_FILES[@]}"


### PR DESCRIPTION
This change promotes `clang-tidy` warnings to errors.

Fixes #363