### PR TITLE
Revert "Fix Rust proto include path"

### DIFF
--- a/sdk/rust/oak/build.rs
+++ b/sdk/rust/oak/build.rs
@@ -6,11 +6,10 @@ fn main() {
             "../../../third_party/google/rpc/status.proto",
             "../../../oak/proto/grpc_encap.proto",
             "../../../oak/proto/oak_api.proto",
-            "../../../oak/proto/policy.proto",
             "../../../oak/proto/storage.proto",
             "../../../oak/proto/storage_channel.proto",
         ],
-        includes: &["../../.."],
+        includes: &["../../../oak/proto", "../../.."],
         customize: protoc_rust::Customize::default(),
     })
     .expect("protoc");

--- a/sdk/rust/oak/src/proto/grpc_encap.rs
+++ b/sdk/rust/oak/src/proto/grpc_encap.rs
@@ -17,7 +17,7 @@
 #![allow(unsafe_code)]
 #![allow(unused_imports)]
 #![allow(unused_results)]
-//! Generated file from `oak/proto/grpc_encap.proto`
+//! Generated file from `grpc_encap.proto`
 
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
@@ -564,14 +564,14 @@ impl ::protobuf::reflect::ProtobufValue for GrpcResponse {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x1aoak/proto/grpc_encap.proto\x12\x03oak\x1a\x19google/protobuf/any.p\
-    roto\x1a#third_party/google/rpc/status.proto\"q\n\x0bGrpcRequest\x12\x1f\
-    \n\x0bmethod_name\x18\x01\x20\x01(\tR\nmethodName\x12-\n\x07req_msg\x18\
-    \x02\x20\x01(\x0b2\x14.google.protobuf.AnyR\x06reqMsg\x12\x12\n\x04last\
-    \x18\x03\x20\x01(\x08R\x04last\"}\n\x0cGrpcResponse\x12-\n\x07rsp_msg\
-    \x18\x01\x20\x01(\x0b2\x14.google.protobuf.AnyR\x06rspMsg\x12*\n\x06stat\
-    us\x18\x02\x20\x01(\x0b2\x12.google.rpc.StatusR\x06status\x12\x12\n\x04l\
-    ast\x18\x03\x20\x01(\x08R\x04lastb\x06proto3\
+    \n\x10grpc_encap.proto\x12\x03oak\x1a\x19google/protobuf/any.proto\x1a#t\
+    hird_party/google/rpc/status.proto\"q\n\x0bGrpcRequest\x12\x1f\n\x0bmeth\
+    od_name\x18\x01\x20\x01(\tR\nmethodName\x12-\n\x07req_msg\x18\x02\x20\
+    \x01(\x0b2\x14.google.protobuf.AnyR\x06reqMsg\x12\x12\n\x04last\x18\x03\
+    \x20\x01(\x08R\x04last\"}\n\x0cGrpcResponse\x12-\n\x07rsp_msg\x18\x01\
+    \x20\x01(\x0b2\x14.google.protobuf.AnyR\x06rspMsg\x12*\n\x06status\x18\
+    \x02\x20\x01(\x0b2\x12.google.rpc.StatusR\x06status\x12\x12\n\x04last\
+    \x18\x03\x20\x01(\x08R\x04lastb\x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/sdk/rust/oak/src/proto/mod.rs
+++ b/sdk/rust/oak/src/proto/mod.rs
@@ -5,7 +5,6 @@
 pub mod code;
 pub mod grpc_encap;
 pub mod oak_api;
-pub mod policy;
 pub mod status;
 pub mod storage;
 pub mod storage_channel;

--- a/sdk/rust/oak/src/proto/oak_api.rs
+++ b/sdk/rust/oak/src/proto/oak_api.rs
@@ -17,7 +17,7 @@
 #![allow(unsafe_code)]
 #![allow(unused_imports)]
 #![allow(unused_results)]
-//! Generated file from `oak/proto/oak_api.proto`
+//! Generated file from `oak_api.proto`
 
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
@@ -167,15 +167,15 @@ impl ::protobuf::reflect::ProtobufValue for ChannelReadStatus {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x17oak/proto/oak_api.proto\x12\x03oak*\xe7\x01\n\tOakStatus\x12\x1a\n\
-    \x16OAK_STATUS_UNSPECIFIED\x10\0\x12\x06\n\x02OK\x10\x01\x12\x12\n\x0eER\
-    R_BAD_HANDLE\x10\x02\x12\x14\n\x10ERR_INVALID_ARGS\x10\x03\x12\x16\n\x12\
-    ERR_CHANNEL_CLOSED\x10\x04\x12\x18\n\x14ERR_BUFFER_TOO_SMALL\x10\x05\x12\
-    \x1e\n\x1aERR_HANDLE_SPACE_TOO_SMALL\x10\x06\x12\x14\n\x10ERR_OUT_OF_RAN\
-    GE\x10\x07\x12\x10\n\x0cERR_INTERNAL\x10\x08\x12\x12\n\x0eERR_TERMINATED\
-    \x10\t*U\n\x11ChannelReadStatus\x12\r\n\tNOT_READY\x10\0\x12\x0e\n\nREAD\
-    _READY\x10\x01\x12\x13\n\x0fINVALID_CHANNEL\x10\x02\x12\x0c\n\x08ORPHANE\
-    D\x10\x03b\x06proto3\
+    \n\roak_api.proto\x12\x03oak*\xe7\x01\n\tOakStatus\x12\x1a\n\x16OAK_STAT\
+    US_UNSPECIFIED\x10\0\x12\x06\n\x02OK\x10\x01\x12\x12\n\x0eERR_BAD_HANDLE\
+    \x10\x02\x12\x14\n\x10ERR_INVALID_ARGS\x10\x03\x12\x16\n\x12ERR_CHANNEL_\
+    CLOSED\x10\x04\x12\x18\n\x14ERR_BUFFER_TOO_SMALL\x10\x05\x12\x1e\n\x1aER\
+    R_HANDLE_SPACE_TOO_SMALL\x10\x06\x12\x14\n\x10ERR_OUT_OF_RANGE\x10\x07\
+    \x12\x10\n\x0cERR_INTERNAL\x10\x08\x12\x12\n\x0eERR_TERMINATED\x10\t*U\n\
+    \x11ChannelReadStatus\x12\r\n\tNOT_READY\x10\0\x12\x0e\n\nREAD_READY\x10\
+    \x01\x12\x13\n\x0fINVALID_CHANNEL\x10\x02\x12\x0c\n\x08ORPHANED\x10\x03b\
+    \x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/sdk/rust/oak/src/proto/storage.rs
+++ b/sdk/rust/oak/src/proto/storage.rs
@@ -17,7 +17,7 @@
 #![allow(unsafe_code)]
 #![allow(unused_imports)]
 #![allow(unused_results)]
-//! Generated file from `oak/proto/storage.proto`
+//! Generated file from `storage.proto`
 
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
@@ -2261,33 +2261,33 @@ impl ::protobuf::reflect::ProtobufValue for StorageRollbackResponse {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x17oak/proto/storage.proto\x12\x03oak\"y\n\x12StorageReadRequest\x12\
+    \n\rstorage.proto\x12\x03oak\"y\n\x12StorageReadRequest\x12\x1d\n\nstora\
+    ge_id\x18\x01\x20\x01(\x0cR\tstorageId\x12%\n\x0etransaction_id\x18\x02\
+    \x20\x01(\x0cR\rtransactionId\x12\x1d\n\ndatum_name\x18\x03\x20\x01(\x0c\
+    R\tdatumName\"6\n\x13StorageReadResponse\x12\x1f\n\x0bdatum_value\x18\
+    \x01\x20\x01(\x0cR\ndatumValue\"\x9b\x01\n\x13StorageWriteRequest\x12\
     \x1d\n\nstorage_id\x18\x01\x20\x01(\x0cR\tstorageId\x12%\n\x0etransactio\
     n_id\x18\x02\x20\x01(\x0cR\rtransactionId\x12\x1d\n\ndatum_name\x18\x03\
-    \x20\x01(\x0cR\tdatumName\"6\n\x13StorageReadResponse\x12\x1f\n\x0bdatum\
-    _value\x18\x01\x20\x01(\x0cR\ndatumValue\"\x9b\x01\n\x13StorageWriteRequ\
-    est\x12\x1d\n\nstorage_id\x18\x01\x20\x01(\x0cR\tstorageId\x12%\n\x0etra\
-    nsaction_id\x18\x02\x20\x01(\x0cR\rtransactionId\x12\x1d\n\ndatum_name\
-    \x18\x03\x20\x01(\x0cR\tdatumName\x12\x1f\n\x0bdatum_value\x18\x04\x20\
-    \x01(\x0cR\ndatumValue\"\x16\n\x14StorageWriteResponse\"{\n\x14StorageDe\
-    leteRequest\x12\x1d\n\nstorage_id\x18\x01\x20\x01(\x0cR\tstorageId\x12%\
-    \n\x0etransaction_id\x18\x02\x20\x01(\x0cR\rtransactionId\x12\x1d\n\ndat\
-    um_name\x18\x03\x20\x01(\x0cR\tdatumName\"\x17\n\x15StorageDeleteRespons\
-    e\"4\n\x13StorageBeginRequest\x12\x1d\n\nstorage_id\x18\x01\x20\x01(\x0c\
-    R\tstorageId\"=\n\x14StorageBeginResponse\x12%\n\x0etransaction_id\x18\
-    \x01\x20\x01(\x0cR\rtransactionId\"\\\n\x14StorageCommitRequest\x12\x1d\
-    \n\nstorage_id\x18\x01\x20\x01(\x0cR\tstorageId\x12%\n\x0etransaction_id\
-    \x18\x02\x20\x01(\x0cR\rtransactionId\"\x17\n\x15StorageCommitResponse\"\
-    ^\n\x16StorageRollbackRequest\x12\x1d\n\nstorage_id\x18\x01\x20\x01(\x0c\
-    R\tstorageId\x12%\n\x0etransaction_id\x18\x02\x20\x01(\x0cR\rtransaction\
-    Id\"\x19\n\x17StorageRollbackResponse2\x89\x03\n\x07Storage\x129\n\x04Re\
-    ad\x12\x17.oak.StorageReadRequest\x1a\x18.oak.StorageReadResponse\x12<\n\
-    \x05Write\x12\x18.oak.StorageWriteRequest\x1a\x19.oak.StorageWriteRespon\
-    se\x12?\n\x06Delete\x12\x19.oak.StorageDeleteRequest\x1a\x1a.oak.Storage\
-    DeleteResponse\x12<\n\x05Begin\x12\x18.oak.StorageBeginRequest\x1a\x19.o\
-    ak.StorageBeginResponse\x12?\n\x06Commit\x12\x19.oak.StorageCommitReques\
-    t\x1a\x1a.oak.StorageCommitResponse\x12E\n\x08Rollback\x12\x1b.oak.Stora\
-    geRollbackRequest\x1a\x1c.oak.StorageRollbackResponseb\x06proto3\
+    \x20\x01(\x0cR\tdatumName\x12\x1f\n\x0bdatum_value\x18\x04\x20\x01(\x0cR\
+    \ndatumValue\"\x16\n\x14StorageWriteResponse\"{\n\x14StorageDeleteReques\
+    t\x12\x1d\n\nstorage_id\x18\x01\x20\x01(\x0cR\tstorageId\x12%\n\x0etrans\
+    action_id\x18\x02\x20\x01(\x0cR\rtransactionId\x12\x1d\n\ndatum_name\x18\
+    \x03\x20\x01(\x0cR\tdatumName\"\x17\n\x15StorageDeleteResponse\"4\n\x13S\
+    torageBeginRequest\x12\x1d\n\nstorage_id\x18\x01\x20\x01(\x0cR\tstorageI\
+    d\"=\n\x14StorageBeginResponse\x12%\n\x0etransaction_id\x18\x01\x20\x01(\
+    \x0cR\rtransactionId\"\\\n\x14StorageCommitRequest\x12\x1d\n\nstorage_id\
+    \x18\x01\x20\x01(\x0cR\tstorageId\x12%\n\x0etransaction_id\x18\x02\x20\
+    \x01(\x0cR\rtransactionId\"\x17\n\x15StorageCommitResponse\"^\n\x16Stora\
+    geRollbackRequest\x12\x1d\n\nstorage_id\x18\x01\x20\x01(\x0cR\tstorageId\
+    \x12%\n\x0etransaction_id\x18\x02\x20\x01(\x0cR\rtransactionId\"\x19\n\
+    \x17StorageRollbackResponse2\x89\x03\n\x07Storage\x129\n\x04Read\x12\x17\
+    .oak.StorageReadRequest\x1a\x18.oak.StorageReadResponse\x12<\n\x05Write\
+    \x12\x18.oak.StorageWriteRequest\x1a\x19.oak.StorageWriteResponse\x12?\n\
+    \x06Delete\x12\x19.oak.StorageDeleteRequest\x1a\x1a.oak.StorageDeleteRes\
+    ponse\x12<\n\x05Begin\x12\x18.oak.StorageBeginRequest\x1a\x19.oak.Storag\
+    eBeginResponse\x12?\n\x06Commit\x12\x19.oak.StorageCommitRequest\x1a\x1a\
+    .oak.StorageCommitResponse\x12E\n\x08Rollback\x12\x1b.oak.StorageRollbac\
+    kRequest\x1a\x1c.oak.StorageRollbackResponseb\x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/sdk/rust/oak/src/proto/storage_channel.rs
+++ b/sdk/rust/oak/src/proto/storage_channel.rs
@@ -17,7 +17,7 @@
 #![allow(unsafe_code)]
 #![allow(unused_imports)]
 #![allow(unused_results)]
-//! Generated file from `oak/proto/storage_channel.proto`
+//! Generated file from `storage_channel.proto`
 
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
@@ -2303,37 +2303,37 @@ impl ::protobuf::reflect::ProtobufValue for StorageChannelRollbackResponse {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x1foak/proto/storage_channel.proto\x12\x03oak\"\x84\x01\n\x19StorageC\
-    hannelReadRequest\x12!\n\x0cstorage_name\x18\x01\x20\x01(\x0cR\x0bstorag\
-    eName\x12%\n\x0etransaction_id\x18\x02\x20\x01(\x0cR\rtransactionId\x12\
-    \x1d\n\ndatum_name\x18\x03\x20\x01(\x0cR\tdatumName\"=\n\x1aStorageChann\
-    elReadResponse\x12\x1f\n\x0bdatum_value\x18\x01\x20\x01(\x0cR\ndatumValu\
-    e\"\xa6\x01\n\x1aStorageChannelWriteRequest\x12!\n\x0cstorage_name\x18\
-    \x01\x20\x01(\x0cR\x0bstorageName\x12%\n\x0etransaction_id\x18\x02\x20\
-    \x01(\x0cR\rtransactionId\x12\x1d\n\ndatum_name\x18\x03\x20\x01(\x0cR\td\
-    atumName\x12\x1f\n\x0bdatum_value\x18\x04\x20\x01(\x0cR\ndatumValue\"\
-    \x1d\n\x1bStorageChannelWriteResponse\"\x86\x01\n\x1bStorageChannelDelet\
-    eRequest\x12!\n\x0cstorage_name\x18\x01\x20\x01(\x0cR\x0bstorageName\x12\
-    %\n\x0etransaction_id\x18\x02\x20\x01(\x0cR\rtransactionId\x12\x1d\n\nda\
-    tum_name\x18\x03\x20\x01(\x0cR\tdatumName\"\x1e\n\x1cStorageChannelDelet\
-    eResponse\"?\n\x1aStorageChannelBeginRequest\x12!\n\x0cstorage_name\x18\
-    \x01\x20\x01(\x0cR\x0bstorageName\"D\n\x1bStorageChannelBeginResponse\
-    \x12%\n\x0etransaction_id\x18\x01\x20\x01(\x0cR\rtransactionId\"g\n\x1bS\
-    torageChannelCommitRequest\x12!\n\x0cstorage_name\x18\x01\x20\x01(\x0cR\
-    \x0bstorageName\x12%\n\x0etransaction_id\x18\x02\x20\x01(\x0cR\rtransact\
-    ionId\"\x1e\n\x1cStorageChannelCommitResponse\"\x88\x01\n\x1dStorageChan\
-    nelRollbackRequest\x12!\n\x0cstorage_name\x18\x01\x20\x01(\x0cR\x0bstora\
-    geName\x12\x1d\n\nstorage_id\x18\x02\x20\x01(\x0cR\tstorageId\x12%\n\x0e\
-    transaction_id\x18\x03\x20\x01(\x0cR\rtransactionId\"\x20\n\x1eStorageCh\
-    annelRollbackResponse2\xe0\x03\n\x0bStorageNode\x12G\n\x04Read\x12\x1e.o\
-    ak.StorageChannelReadRequest\x1a\x1f.oak.StorageChannelReadResponse\x12J\
-    \n\x05Write\x12\x1f.oak.StorageChannelWriteRequest\x1a\x20.oak.StorageCh\
-    annelWriteResponse\x12M\n\x06Delete\x12\x20.oak.StorageChannelDeleteRequ\
-    est\x1a!.oak.StorageChannelDeleteResponse\x12J\n\x05Begin\x12\x1f.oak.St\
-    orageChannelBeginRequest\x1a\x20.oak.StorageChannelBeginResponse\x12L\n\
-    \x06Commit\x12\x1f.oak.StorageChannelBeginRequest\x1a!.oak.StorageChanne\
-    lCommitResponse\x12S\n\x08Rollback\x12\".oak.StorageChannelRollbackReque\
-    st\x1a#.oak.StorageChannelRollbackResponseb\x06proto3\
+    \n\x15storage_channel.proto\x12\x03oak\"\x84\x01\n\x19StorageChannelRead\
+    Request\x12!\n\x0cstorage_name\x18\x01\x20\x01(\x0cR\x0bstorageName\x12%\
+    \n\x0etransaction_id\x18\x02\x20\x01(\x0cR\rtransactionId\x12\x1d\n\ndat\
+    um_name\x18\x03\x20\x01(\x0cR\tdatumName\"=\n\x1aStorageChannelReadRespo\
+    nse\x12\x1f\n\x0bdatum_value\x18\x01\x20\x01(\x0cR\ndatumValue\"\xa6\x01\
+    \n\x1aStorageChannelWriteRequest\x12!\n\x0cstorage_name\x18\x01\x20\x01(\
+    \x0cR\x0bstorageName\x12%\n\x0etransaction_id\x18\x02\x20\x01(\x0cR\rtra\
+    nsactionId\x12\x1d\n\ndatum_name\x18\x03\x20\x01(\x0cR\tdatumName\x12\
+    \x1f\n\x0bdatum_value\x18\x04\x20\x01(\x0cR\ndatumValue\"\x1d\n\x1bStora\
+    geChannelWriteResponse\"\x86\x01\n\x1bStorageChannelDeleteRequest\x12!\n\
+    \x0cstorage_name\x18\x01\x20\x01(\x0cR\x0bstorageName\x12%\n\x0etransact\
+    ion_id\x18\x02\x20\x01(\x0cR\rtransactionId\x12\x1d\n\ndatum_name\x18\
+    \x03\x20\x01(\x0cR\tdatumName\"\x1e\n\x1cStorageChannelDeleteResponse\"?\
+    \n\x1aStorageChannelBeginRequest\x12!\n\x0cstorage_name\x18\x01\x20\x01(\
+    \x0cR\x0bstorageName\"D\n\x1bStorageChannelBeginResponse\x12%\n\x0etrans\
+    action_id\x18\x01\x20\x01(\x0cR\rtransactionId\"g\n\x1bStorageChannelCom\
+    mitRequest\x12!\n\x0cstorage_name\x18\x01\x20\x01(\x0cR\x0bstorageName\
+    \x12%\n\x0etransaction_id\x18\x02\x20\x01(\x0cR\rtransactionId\"\x1e\n\
+    \x1cStorageChannelCommitResponse\"\x88\x01\n\x1dStorageChannelRollbackRe\
+    quest\x12!\n\x0cstorage_name\x18\x01\x20\x01(\x0cR\x0bstorageName\x12\
+    \x1d\n\nstorage_id\x18\x02\x20\x01(\x0cR\tstorageId\x12%\n\x0etransactio\
+    n_id\x18\x03\x20\x01(\x0cR\rtransactionId\"\x20\n\x1eStorageChannelRollb\
+    ackResponse2\xe0\x03\n\x0bStorageNode\x12G\n\x04Read\x12\x1e.oak.Storage\
+    ChannelReadRequest\x1a\x1f.oak.StorageChannelReadResponse\x12J\n\x05Writ\
+    e\x12\x1f.oak.StorageChannelWriteRequest\x1a\x20.oak.StorageChannelWrite\
+    Response\x12M\n\x06Delete\x12\x20.oak.StorageChannelDeleteRequest\x1a!.o\
+    ak.StorageChannelDeleteResponse\x12J\n\x05Begin\x12\x1f.oak.StorageChann\
+    elBeginRequest\x1a\x20.oak.StorageChannelBeginResponse\x12L\n\x06Commit\
+    \x12\x1f.oak.StorageChannelBeginRequest\x1a!.oak.StorageChannelCommitRes\
+    ponse\x12S\n\x08Rollback\x12\".oak.StorageChannelRollbackRequest\x1a#.oa\
+    k.StorageChannelRollbackResponseb\x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {


### PR DESCRIPTION
Reverts project-oak/oak#400 because it broke the build (see https://github.com/project-oak/oak/pull/400#issuecomment-567618214)

I think the PR accidentally left out the `policy.rs` generated file -- @michael-kernel-sanders could you confirm this is the problem and retry with that file included?