### PR TITLE
Export license in BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -21,3 +21,5 @@
 package(
     licenses = ["notice"],
 )
+
+exports_files(["LICENSE"])


### PR DESCRIPTION
This change exports the `LICENSE` file in the root `BUILD`.