### PR TITLE
Fix Java equals

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,4 +22,5 @@ package(
     licenses = ["notice"],
 )
 
+# Export LICENSE file for projects that reference Oak in Bazel as an external dependency.
 exports_files(["LICENSE"])

--- a/examples/hello_world/client/android/java/com/google/oak/hello_world/MainActivity.java
+++ b/examples/hello_world/client/android/java/com/google/oak/hello_world/MainActivity.java
@@ -20,8 +20,8 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.Button;
-import android.widget.TextView;
 import android.widget.EditText;
+import android.widget.TextView;
 
 import com.google.oak.hello_world.R;
 
@@ -60,7 +60,7 @@ public class MainActivity extends Activity {
     EditText addressInput = findViewById(R.id.addressInput);
     String address = addressInput.getText().toString();
 
-    if (address != rpcAddress) {
+    if (!address.equals(rpcAddress)) {
       Log.v("Oak", "Create channel to: " + address);
       createChannel(address);
       rpcAddress = address;


### PR DESCRIPTION
Reference types that declare an `equals()` method, should not be compared for reference equality with `==` or `!=`.