### PR TITLE
Commonize termination-pending flags

### DIFF
--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -35,6 +35,7 @@ cc_library(
     srcs = ["oak_node.cc"],
     hdrs = ["oak_node.h"],
     deps = [
+        ":base_runtime",
         ":channel",
         "//oak/common:handles",
         "@com_google_absl//absl/synchronization",
@@ -53,7 +54,6 @@ cc_library(
         "wasm_node.h",
     ],
     deps = [
-        ":base_runtime",
         ":channel",
         "//oak/common:handles",
         "//oak/proto:grpc_encap_cc_proto",

--- a/oak/server/base_runtime.h
+++ b/oak/server/base_runtime.h
@@ -33,6 +33,7 @@ class BaseRuntime {
   virtual ~BaseRuntime() {}
   virtual bool CreateAndRunNode(const std::string& config, std::unique_ptr<ChannelHalf> half,
                                 std::string* node_name) = 0;
+  virtual bool TerminationPending() = 0;
 };  // class BaseRuntime
 
 }  // namespace oak

--- a/oak/server/logging_node.h
+++ b/oak/server/logging_node.h
@@ -29,7 +29,7 @@ namespace oak {
 // Pseudo-node to perform logging.
 class LoggingNode final : public NodeThread {
  public:
-  explicit LoggingNode(const std::string& name) : NodeThread(name) {}
+  explicit LoggingNode(BaseRuntime* runtime, const std::string& name) : NodeThread(runtime, name) {}
 
  private:
   void Run(Handle handle) override;

--- a/oak/server/node_thread.cc
+++ b/oak/server/node_thread.cc
@@ -27,7 +27,7 @@ void NodeThread::Start() {
     LOG(ERROR) << "Attempt to Start() an already-running NodeThread";
     return;
   }
-  if (termination_pending_.load()) {
+  if (runtime_->TerminationPending()) {
     LOG(ERROR) << "Attempt to Start() an already-terminated NodeThread";
     return;
   }
@@ -48,7 +48,6 @@ void NodeThread::Stop() {
 
 void NodeThread::StopThread() {
   LOG(INFO) << "Termination pending for {" << name_ << "}";
-  termination_pending_ = true;
   if (thread_.joinable()) {
     LOG(INFO) << "Waiting for completion of {" << name_ << "} node thread";
     thread_.join();

--- a/oak/server/node_thread.h
+++ b/oak/server/node_thread.h
@@ -29,7 +29,7 @@ namespace oak {
 class NodeThread : public OakNode {
  public:
   // Construct a thread, identified by the given name in diagnostic messages.
-  NodeThread(const std::string& name) : OakNode(name) {}
+  NodeThread(BaseRuntime* runtime, const std::string& name) : OakNode(runtime, name) {}
   virtual ~NodeThread();
 
   // Start kicks off a separate thread that invokes the Run() method.

--- a/oak/server/oak_grpc_node.cc
+++ b/oak/server/oak_grpc_node.cc
@@ -26,8 +26,9 @@
 
 namespace oak {
 
-std::unique_ptr<OakGrpcNode> OakGrpcNode::Create(const std::string& name, const uint16_t port) {
-  std::unique_ptr<OakGrpcNode> node = absl::WrapUnique(new OakGrpcNode(name));
+std::unique_ptr<OakGrpcNode> OakGrpcNode::Create(BaseRuntime* runtime, const std::string& name,
+                                                 const uint16_t port) {
+  std::unique_ptr<OakGrpcNode> node = absl::WrapUnique(new OakGrpcNode(runtime, name));
 
   // Build Server
   grpc::ServerBuilder builder;

--- a/oak/server/oak_grpc_node.cc
+++ b/oak/server/oak_grpc_node.cc
@@ -73,7 +73,7 @@ void OakGrpcNode::CompletionQueueLoop() {
     bool ok;
     void* tag;
     if (!completion_queue_->Next(&tag, &ok)) {
-      if (!termination_pending_.load()) {
+      if (!runtime_->TerminationPending()) {
         LOG(FATAL) << "{" << name_ << "} Failure reading from completion queue";
       }
       LOG(INFO) << "{" << name_
@@ -93,7 +93,6 @@ grpc::Status OakGrpcNode::GetAttestation(grpc::ServerContext*, const GetAttestat
 }
 
 void OakGrpcNode::Stop() {
-  termination_pending_ = true;
   if (server_) {
     LOG(INFO) << "{" << name_ << "} Shutting down gRPC server...";
     server_->Shutdown();

--- a/oak/server/oak_grpc_node.h
+++ b/oak/server/oak_grpc_node.h
@@ -32,7 +32,8 @@ class OakGrpcNode final : public Application::Service, public OakNode {
  public:
   // Create an Oak node with the `name` and gRPC `port`.
   // If `port` equals 0, then gRPC port is assigned automatically.
-  static std::unique_ptr<OakGrpcNode> Create(const std::string& name, const uint16_t port = 0);
+  static std::unique_ptr<OakGrpcNode> Create(BaseRuntime* runtime, const std::string& name,
+                                             const uint16_t port = 0);
   virtual ~OakGrpcNode(){};
 
   void Start() override;
@@ -48,7 +49,8 @@ class OakGrpcNode final : public Application::Service, public OakNode {
  private:
   friend class ModuleInvocation;
 
-  OakGrpcNode(const std::string& name) : OakNode(name), next_stream_id_(1) {}
+  OakGrpcNode(BaseRuntime* runtime, const std::string& name)
+      : OakNode(runtime, name), next_stream_id_(1) {}
   OakGrpcNode(const OakGrpcNode&) = delete;
   OakGrpcNode& operator=(const OakGrpcNode&) = delete;
 

--- a/oak/server/oak_node.cc
+++ b/oak/server/oak_node.cc
@@ -113,7 +113,7 @@ bool OakNode::WaitOnChannels(std::vector<std::unique_ptr<ChannelStatus>>* status
       }
     }
 
-    if (termination_pending_.load()) {
+    if (runtime_->TerminationPending()) {
       LOG(WARNING) << "{" << name_ << "} Node is pending termination";
       return false;
     }

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -34,7 +34,7 @@ namespace oak {
 class OakNode {
  public:
   OakNode(BaseRuntime* runtime, const std::string& name)
-      : runtime_(runtime), name_(name), termination_pending_(false), prng_engine_() {}
+      : runtime_(runtime), name_(name), prng_engine_() {}
   virtual ~OakNode() {}
 
   virtual void Start() = 0;
@@ -76,8 +76,6 @@ class OakNode {
   BaseRuntime* const runtime_;
 
   const std::string name_;
-
-  std::atomic_bool termination_pending_;
 
  private:
   Handle NextHandle() EXCLUSIVE_LOCKS_REQUIRED(mu_);

--- a/oak/server/oak_node.h
+++ b/oak/server/oak_node.h
@@ -26,13 +26,15 @@
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "oak/common/handles.h"
+#include "oak/server/base_runtime.h"
 #include "oak/server/channel.h"
 
 namespace oak {
 
 class OakNode {
  public:
-  OakNode(const std::string& name) : name_(name), termination_pending_(false), prng_engine_() {}
+  OakNode(BaseRuntime* runtime, const std::string& name)
+      : runtime_(runtime), name_(name), termination_pending_(false), prng_engine_() {}
   virtual ~OakNode() {}
 
   virtual void Start() = 0;
@@ -70,7 +72,11 @@ class OakNode {
   // parameter to the Node's oak_main() entrypoint.
   Handle SingleHandle() const LOCKS_EXCLUDED(mu_);
 
+  // Runtime instance that owns this Node.
+  BaseRuntime* const runtime_;
+
   const std::string name_;
+
   std::atomic_bool termination_pending_;
 
  private:

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -69,7 +69,7 @@ grpc::Status OakRuntime::Initialize(const ApplicationConfiguration& config) {
     return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid gRPC port");
   }
   LOG(INFO) << "Create gRPC pseudo-Node named {" << grpc_name << "}";
-  std::unique_ptr<OakGrpcNode> grpc_node = OakGrpcNode::Create(grpc_name, grpc_port);
+  std::unique_ptr<OakGrpcNode> grpc_node = OakGrpcNode::Create(this, grpc_name, grpc_port);
   grpc_node_ = grpc_node.get();  // borrowed copy
   nodes_[grpc_name] = std::move(grpc_node);
 
@@ -110,11 +110,11 @@ OakNode* OakRuntime::CreateNode(const std::string& config, std::string* node_nam
     node = WasmNode::Create(this, name, *module_bytes);
   } else if (log_config_.count(config) > 0) {
     LOG(INFO) << "Create log node named {" << name << "}";
-    node = absl::make_unique<LoggingNode>(name);
+    node = absl::make_unique<LoggingNode>(this, name);
   } else if (storage_config_.count(config) > 0) {
     std::string address = *(storage_config_[config].get());
     LOG(INFO) << "Create storage proxy node named {" << name << "} connecting to " << address;
-    node = absl::make_unique<StorageNode>(name, address);
+    node = absl::make_unique<StorageNode>(this, name, address);
   } else {
     LOG(ERROR) << "failed to find config with name " << config;
     return nullptr;

--- a/oak/server/oak_runtime.cc
+++ b/oak/server/oak_runtime.cc
@@ -132,7 +132,7 @@ OakNode* OakRuntime::CreateNode(const std::string& config, std::string* node_nam
 
 bool OakRuntime::CreateAndRunNode(const std::string& config, std::unique_ptr<ChannelHalf> half,
                                   std::string* node_name) {
-  if (termination_pending_.load()) {
+  if (TerminationPending()) {
     LOG(WARNING) << "Runtime is pending termination, fail node creation";
     return false;
   }

--- a/oak/server/oak_runtime.h
+++ b/oak/server/oak_runtime.h
@@ -53,6 +53,8 @@ class OakRuntime : public BaseRuntime {
   bool CreateAndRunNode(const std::string& config, std::unique_ptr<ChannelHalf> half,
                         std::string* node_name) override;
 
+  bool TerminationPending() override { return termination_pending_.load(); }
+
   int32_t GetPort();
 
  private:

--- a/oak/server/storage/storage_node.cc
+++ b/oak/server/storage/storage_node.cc
@@ -27,8 +27,9 @@
 
 namespace oak {
 
-StorageNode::StorageNode(const std::string& name, const std::string& storage_address)
-    : NodeThread(name), storage_processor_(storage_address) {}
+StorageNode::StorageNode(BaseRuntime* runtime, const std::string& name,
+                         const std::string& storage_address)
+    : NodeThread(runtime, name), storage_processor_(storage_address) {}
 
 void StorageNode::Run(Handle request_handle) {
   // Borrow a pointer to the relevant channel half.

--- a/oak/server/storage/storage_node.h
+++ b/oak/server/storage/storage_node.h
@@ -27,7 +27,7 @@ namespace oak {
 
 class StorageNode final : public NodeThread {
  public:
-  StorageNode(const std::string& name, const std::string& storage_address);
+  StorageNode(BaseRuntime* runtime, const std::string& name, const std::string& storage_address);
 
  private:
   void Run(Handle handle) override;

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -177,7 +177,7 @@ static bool CheckModuleExports(wabt::interp::Environment* env, wabt::interp::Mod
 }
 
 WasmNode::WasmNode(BaseRuntime* runtime, const std::string& name)
-    : NodeThread(name), runtime_(runtime), prng_engine_() {}
+    : NodeThread(runtime, name), prng_engine_() {}
 
 std::unique_ptr<WasmNode> WasmNode::Create(BaseRuntime* runtime, const std::string& name,
                                            const std::string& module) {

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -452,7 +452,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakWaitOnChannels(wabt::interp::Envir
     }
     if (wait_success) {
       results[0].set_i32(OakStatus::OK);
-    } else if (termination_pending_.load()) {
+    } else if (runtime_->TerminationPending()) {
       results[0].set_i32(OakStatus::ERR_TERMINATED);
     } else {
       results[0].set_i32(OakStatus::ERR_BAD_HANDLE);

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -20,7 +20,6 @@
 #include <memory>
 #include <random>
 
-#include "oak/server/base_runtime.h"
 #include "oak/server/node_thread.h"
 #include "src/interp/interp.h"
 
@@ -63,9 +62,6 @@ class WasmNode final : public NodeThread {
 
   // Native implementation of the `oak.random_get` host function.
   wabt::interp::HostFunc::Callback OakRandomGet(wabt::interp::Environment* env);
-
-  // Runtime instance that owns this Node.
-  BaseRuntime* runtime_;
 
   wabt::interp::Environment env_;
 


### PR DESCRIPTION
Following up on #417, I realized that having per-Node and per-Runtime termination-pending flags is probably unnecessary.