### PR TITLE
oak_runtime: add simple roughtime client

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@
 workspace(name = "oak")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
 # Docker rules should be loaded in the beginning of the WORKSPACE file
 # to avoid diamond dependencies:
@@ -299,9 +299,10 @@ http_archive(
 )
 
 # Roughtime
-http_archive(
+new_git_repository(
     name = "roughtime",
-    build_file = "@//third_party/roughtime:roughtime.BUILD",
-    #sha256 = "47c99712b4b34a6713ea7ecfec6860e6b88ba046df206386346de4c3409fe6dd",
-    url = "https://roughtime.googlesource.com/roughtime/+archive/51f6971f5f06ec101e5fbcabe5a49477708540f3.tar.gz",
+    build_file = "//third_party/roughtime:roughtime.BUILD",
+    commit = "51f6971f5f06ec101e5fbcabe5a49477708540f3",
+    remote = "https://roughtime.googlesource.com/roughtime",
+    shallow_since = "1555608176 +0000",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -303,5 +303,5 @@ http_archive(
     name = "roughtime",
     build_file = "@//third_party/roughtime:roughtime.BUILD",
     #sha256 = "47c99712b4b34a6713ea7ecfec6860e6b88ba046df206386346de4c3409fe6dd",
-    url = "https://roughtime.googlesource.com/roughtime/+archive/51f6971f5f06ec101e5fbcabe5a49477708540f3.tar.gz"
+    url = "https://roughtime.googlesource.com/roughtime/+archive/51f6971f5f06ec101e5fbcabe5a49477708540f3.tar.gz",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -297,3 +297,11 @@ http_archive(
     strip_prefix = "clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04",
     url = "http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
 )
+
+# Roughtime
+http_archive(
+    name = "roughtime",
+    build_file = "@//third_party/roughtime:roughtime.BUILD",
+    #sha256 = "47c99712b4b34a6713ea7ecfec6860e6b88ba046df206386346de4c3409fe6dd",
+    url = "https://roughtime.googlesource.com/roughtime/+archive/51f6971f5f06ec101e5fbcabe5a49477708540f3.tar.gz"
+)

--- a/oak/server/time/BUILD
+++ b/oak/server/time/BUILD
@@ -1,0 +1,50 @@
+#
+# Copyright 2019 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(
+    default_visibility = ["//oak/server:__pkg__"],
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "roughtime_client",
+    hdrs = ["roughtime_client.h"],
+    srcs = ["roughtime_client.cc"],
+    deps = [
+        "//oak/common:nonce_generator",
+        "@roughtime//:client",
+        "@com_google_asylo//asylo/util:status",
+    ],
+)
+
+test_suite(
+    name = "host_tests",
+    tags = ["host"],
+)
+
+cc_test(
+    name = "roughtime_client_test",
+    srcs = [
+        "roughtime_client_test.cc",
+    ],
+    tags = ["host"],
+    deps = [
+        ":roughtime_client",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/oak/server/time/BUILD
+++ b/oak/server/time/BUILD
@@ -27,6 +27,9 @@ cc_library(
     hdrs = ["roughtime_client.h"],
     deps = [
         "//oak/common:nonce_generator",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_asylo//asylo/util:logging",
         "@com_google_asylo//asylo/util:status",
         "@roughtime//:client",
     ],

--- a/oak/server/time/BUILD
+++ b/oak/server/time/BUILD
@@ -36,8 +36,8 @@ cc_library(
 )
 
 test_suite(
-    name = "host_tests",
-    tags = ["host"],
+    name = "local_tests",
+    tags = ["local"],
 )
 
 cc_test(
@@ -45,7 +45,7 @@ cc_test(
     srcs = [
         "roughtime_client_test.cc",
     ],
-    tags = ["host"],
+    tags = ["local"],
     deps = [
         ":roughtime_client",
         "@gtest//:gtest_main",

--- a/oak/server/time/BUILD
+++ b/oak/server/time/BUILD
@@ -23,12 +23,12 @@ package(
 
 cc_library(
     name = "roughtime_client",
-    hdrs = ["roughtime_client.h"],
     srcs = ["roughtime_client.cc"],
+    hdrs = ["roughtime_client.h"],
     deps = [
         "//oak/common:nonce_generator",
-        "@roughtime//:client",
         "@com_google_asylo//asylo/util:status",
+        "@roughtime//:client",
     ],
 )
 

--- a/oak/server/time/roughtime_client.cc
+++ b/oak/server/time/roughtime_client.cc
@@ -27,7 +27,6 @@
 #include <array>
 #include <string>
 #include <vector>
-//#include <unistd.h>
 
 #include "absl/memory/memory.h"
 #include "absl/strings/escaping.h"

--- a/oak/server/time/roughtime_client.cc
+++ b/oak/server/time/roughtime_client.cc
@@ -187,6 +187,7 @@ StatusOr<RoughtimeInterval> GetIntervalFromServer(const RoughtimeServerSpec& ser
                                   server.name.c_str(), timestamp));
   }
 
+  LOG(INFO) << "Time from " << server.name << ": " << timestamp << " +/- " << radius;
   return RoughtimeInterval{(timestamp - radius), (timestamp + radius)};
 }
 
@@ -195,7 +196,7 @@ StatusOr<RoughtimeInterval> FindOverlap(const std::vector<RoughtimeInterval>& in
   for (auto interval : intervals) {
     int count = 0;
     roughtime::rough_time_t min = 0;
-    roughtime::rough_time_t max = 0xFFFFFFFFFFFFFFFF;
+    roughtime::rough_time_t max = UINT64_MAX;
     roughtime::rough_time_t point = interval.min;
     for (auto test : intervals) {
       if (point >= test.min && point <= test.max) {

--- a/oak/server/time/roughtime_client.cc
+++ b/oak/server/time/roughtime_client.cc
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "roughtime_client.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <netdb.h>
+#include <netinet/udp.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <array>
+#include <string>
+#include <vector>
+//#include <unistd.h>
+
+#include "absl/memory/memory.h"
+#include "absl/strings/escaping.h"
+#include "absl/strings/str_format.h"
+#include "asylo/util/logging.h"
+#include "asylo/util/status.h"
+#include "asylo/util/status_macros.h"
+#include "client.h"
+#include "oak/common/nonce_generator.h"
+
+using ::asylo::Status;
+using ::asylo::StatusOr;
+
+namespace oak {
+
+// Information we need about roughtime servers.
+// Assume we will only support Ed25519 public key and UDP for now.
+struct RoughtimeServerSpec {
+  std::string name;
+  std::string host;
+  std::string port;
+  std::string public_key_base64;
+};
+
+struct RoughtimeInterval {
+  roughtime::rough_time_t min;
+  roughtime::rough_time_t max;
+};
+
+const std::vector<RoughtimeServerSpec> servers{{"Google", "roughtime.sandbox.google.com", "2002",
+                                                "etPaaIxcBMY1oUeGpwvPMCJMwlRVNxv51KK/tktoJTQ="},
+                                               {"Cloudflare", "roughtime.cloudflare.com", "2002",
+                                                "gD63hSj3ScS+wuOeGrubXlq35N1c5Lby/S+T7MNTjxo="}};
+
+// TODO: Make multiple requests and calculate overlapping interval.
+// The minimum number of overlapping intervals we need to trust the time.
+// constexpr int kMinOverlappingTimeIntervals = 2;
+
+// Number of seconds that we will wait for a reply from the server.
+constexpr int kTimeoutSeconds = 3;
+
+// TODO: Retry on connection failure.
+// Number of times we will retry connecting to the server.
+// constexpr int kServerRetries = 3;
+
+// The size of the receive buffer.
+// This seems to be the same as the minimum request size according to the Roughtime samples.
+// eg. https://roughtime.googlesource.com/roughtime/+/refs/heads/master/simple_client.cc#250
+constexpr size_t kReceiveBufferSize = roughtime::kMinRequestSize;
+
+// Maximum radius accepted for a roughtime response.
+constexpr uint32_t kMaxRadius = 60000000;
+
+// Creates a UDP socket connected to the host and port.
+StatusOr<int> CreateSocket(const std::string& host, const std::string& port) {
+  addrinfo hints = {};
+  hints.ai_socktype = SOCK_DGRAM;
+  hints.ai_protocol = IPPROTO_UDP;
+  hints.ai_flags = AI_NUMERICSERV;
+  addrinfo* address;
+  int error = getaddrinfo(host.c_str(), port.c_str(), &hints, &address);
+  if (error != 0) {
+    return Status(asylo::error::GoogleError::INVALID_ARGUMENT,
+                  absl::StrFormat("Could not resolve %s: %s", host.c_str(), gai_strerror(error)));
+  }
+  int handle = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
+  if (handle < 0) {
+    freeaddrinfo(address);
+    return Status(asylo::error::GoogleError::INTERNAL, "Failed to create UDP socket.");
+  }
+  if (connect(handle, address->ai_addr, address->ai_addrlen)) {
+    freeaddrinfo(address);
+    close(handle);
+    return Status(asylo::error::GoogleError::INTERNAL, "Failed to open UDP socket.");
+  }
+  freeaddrinfo(address);
+  return handle;
+}
+
+StatusOr<std::string> SendRequest(const RoughtimeServerSpec& server,
+                                  const Nonce<roughtime::kNonceLength>& nonce) {
+  int handle;
+  ASYLO_ASSIGN_OR_RETURN(handle, CreateSocket(server.host, server.port));
+  const std::string request = roughtime::CreateRequest(nonce.data());
+
+  timeval timeout = {};
+  timeout.tv_sec = kTimeoutSeconds;
+  timeout.tv_usec = 0;
+  setsockopt(handle, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+  ssize_t send_size;
+  do {
+    send_size = send(handle, request.data(), request.size(), 0 /* flags */);
+  } while (send_size == -1 && errno == EINTR);
+  if (send_size < 0 || static_cast<size_t>(send_size) != request.size()) {
+    close(handle);
+    return Status(asylo::error::GoogleError::INTERNAL,
+                  "Network error on sending request to " + server.name);
+  }
+
+  uint8_t receive_buffer[kReceiveBufferSize];
+  ssize_t receive_size;
+  do {
+    receive_size = recv(handle, receive_buffer, kReceiveBufferSize, 0 /* flags */);
+  } while (receive_size == -1 && errno == EINTR);
+  close(handle);
+  if (receive_size == -1) {
+    if (errno == EINTR) {
+      return Status(asylo::error::GoogleError::INTERNAL, "Request timed out for " + server.name);
+    }
+    return Status(asylo::error::GoogleError::INTERNAL, "No response received from " + server.name);
+  }
+
+  return std::string(reinterpret_cast<const char*>(receive_buffer),
+                     static_cast<size_t>(receive_size));
+}
+
+StatusOr<RoughtimeInterval> GetIntervalFromServer(const RoughtimeServerSpec& server) {
+  oak::NonceGenerator<roughtime::kNonceLength> generator;
+  std::string response;
+  Nonce<roughtime::kNonceLength> nonce = generator.NextNonce();
+  ASYLO_ASSIGN_OR_RETURN(response, SendRequest(server, nonce));
+  roughtime::rough_time_t timestamp;
+  uint32_t radius;
+  std::string error;
+  std::string public_key;
+  if (!absl::Base64Unescape(server.public_key_base64, &public_key)) {
+    return Status(asylo::error::GoogleError::INVALID_ARGUMENT,
+                  absl::StrFormat("Public key for server %s is not a valid base64 encoding.",
+                                  server.name.c_str()));
+  }
+
+  if (!roughtime::ParseResponse(
+          &timestamp, &radius, &error, reinterpret_cast<const uint8_t*>(public_key.data()),
+          reinterpret_cast<const uint8_t*>(response.data()), response.size(), nonce.data())) {
+    return Status(asylo::error::GoogleError::INTERNAL,
+                  absl::StrFormat("Response from %s failed verification: %s", server.name.c_str(),
+                                  error.c_str()));
+  }
+
+  if (radius > kMaxRadius) {
+    return Status(
+        asylo::error::GoogleError::INTERNAL,
+        absl::StrFormat("Radius from %s is too large: %" PRIu32 "", server.name.c_str(), radius));
+  }
+
+  if (radius > timestamp) {
+    return Status(asylo::error::GoogleError::INTERNAL,
+                  absl::StrFormat("Timestamp from %s is too small: %" PRIu64 "",
+                                  server.name.c_str(), timestamp));
+  }
+
+  return RoughtimeInterval{(timestamp - radius), (timestamp + radius)};
+}
+
+StatusOr<roughtime::rough_time_t> RoughtimeClient::GetRoughTime() {
+  // TODO: Connect to all servers and find overlapping intervals.
+  // TODO: Implement retries.
+  RoughtimeInterval interval;
+  ASYLO_ASSIGN_OR_RETURN(interval, GetIntervalFromServer(servers[0]));
+  return (interval.min + interval.max) / 2;
+}
+
+}  // namespace oak

--- a/oak/server/time/roughtime_client.h
+++ b/oak/server/time/roughtime_client.h
@@ -17,8 +17,6 @@
 #ifndef OAK_SERVER_TIME_ROUGHTIME_CLIENT_H_
 #define OAK_SERVER_TIME_ROUGHTIME_CLIENT_H_
 
-#include <stdint.h>
-
 #include "asylo/util/statusor.h"
 #include "protocol.h"
 

--- a/oak/server/time/roughtime_client.h
+++ b/oak/server/time/roughtime_client.h
@@ -23,6 +23,7 @@
 namespace oak {
 
 // Client for getting roughtime (in microseconds since Unix epoch) from multiple servers.
+// The list of servers are currently hardcoded in roughttime_client.cc
 // Based on https://roughtime.googlesource.com/roughtime/+/refs/heads/master/simple_client.cc
 // and https://roughtime.googlesource.com/roughtime/+/refs/heads/master/go/client/client.go
 class RoughtimeClient {

--- a/oak/server/time/roughtime_client.h
+++ b/oak/server/time/roughtime_client.h
@@ -24,7 +24,7 @@
 
 namespace oak {
 
-// Client for retrieving roughtime from multiple servers.
+// Client for getting roughtime (in microseconds since Unix epoch) from multiple servers.
 // Based on https://roughtime.googlesource.com/roughtime/+/refs/heads/master/simple_client.cc
 // and https://roughtime.googlesource.com/roughtime/+/refs/heads/master/go/client/client.go
 class RoughtimeClient {

--- a/oak/server/time/roughtime_client.h
+++ b/oak/server/time/roughtime_client.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_SERVER_TIME_ROUGHTIME_CLIENT_H_
+#define OAK_SERVER_TIME_ROUGHTIME_CLIENT_H_
+
+#include <stdint.h>
+
+#include "asylo/util/statusor.h"
+#include "protocol.h"
+
+namespace oak {
+
+// Client for retrieving roughtime from multiple servers.
+// Based on https://roughtime.googlesource.com/roughtime/+/refs/heads/master/simple_client.cc
+// and https://roughtime.googlesource.com/roughtime/+/refs/heads/master/go/client/client.go
+class RoughtimeClient {
+ public:
+  static asylo::StatusOr<roughtime::rough_time_t> GetRoughTime();
+};
+
+}  // namespace oak
+
+#endif  // OAK_SERVER_TIME_ROUGHTIME_CLIENT_H_

--- a/oak/server/time/roughtime_client_test.cc
+++ b/oak/server/time/roughtime_client_test.cc
@@ -27,7 +27,10 @@ TEST(RoughtimeClient, TestGetRoughtTime) {
   auto current = std::chrono::duration_cast<std::chrono::microseconds>(
                      std::chrono::system_clock::now().time_since_epoch())
                      .count();
-  auto time = RoughtimeClient::GetRoughTime().ValueOrDie();
+  auto time_or_status = RoughtimeClient::GetRoughTime();
+  ASSERT_TRUE(time_or_status.ok());
+  auto time = time_or_status.ValueOrDie();
+
   LOG(INFO) << "System time: " << current << "μs from the epoch.";
   LOG(INFO) << "Roughtime: " << time << "μs from the epoch.";
   LOG(INFO) << "Difference: " << time - current << "μs.";

--- a/oak/server/time/roughtime_client_test.cc
+++ b/oak/server/time/roughtime_client_test.cc
@@ -23,7 +23,9 @@
 
 namespace oak {
 
-TEST(RoughtimeClient, TestGetRoughTime) {
+// Tests getting the live roughtime from the hardcoded servers.
+// This requires an internet connection and both the roughtime servers to be up.
+TEST(RoughtimeClient, TestGetRoughTimeLive) {
   auto current = std::chrono::duration_cast<std::chrono::microseconds>(
                      std::chrono::system_clock::now().time_since_epoch())
                      .count();

--- a/oak/server/time/roughtime_client_test.cc
+++ b/oak/server/time/roughtime_client_test.cc
@@ -23,7 +23,7 @@
 
 namespace oak {
 
-TEST(RoughtimeClient, TestGetRoughtTime) {
+TEST(RoughtimeClient, TestGetRoughTime) {
   auto current = std::chrono::duration_cast<std::chrono::microseconds>(
                      std::chrono::system_clock::now().time_since_epoch())
                      .count();

--- a/oak/server/time/roughtime_client_test.cc
+++ b/oak/server/time/roughtime_client_test.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/server/time/roughtime_client.h"
+
+#include <chrono>
+
+#include "asylo/util/logging.h"
+#include "gtest/gtest.h"
+
+namespace oak {
+
+TEST(RoughtimeClient, TestGetRoughtTime) {
+  auto current = std::chrono::duration_cast<std::chrono::microseconds>(
+                     std::chrono::system_clock::now().time_since_epoch())
+                     .count();
+  auto time = RoughtimeClient::GetRoughTime().ValueOrDie();
+  LOG(INFO) << "System time: " << current << "μs from the epoch.";
+  LOG(INFO) << "Roughtime: " << time << "μs from the epoch.";
+  LOG(INFO) << "Difference: " << time - current << "μs.";
+
+  ASSERT_LE(current - 60000000, time);
+  ASSERT_GE(current + 60000000, time);
+}
+
+}  // namespace oak

--- a/third_party/roughtime/BUILD
+++ b/third_party/roughtime/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/third_party/roughtime/roughtime.BUILD
+++ b/third_party/roughtime/roughtime.BUILD
@@ -1,0 +1,31 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "roughtime_logging",
+    hdrs = ["logging.h"],
+    copts = ["-Wno-sometimes-uninitialized"],
+    deps = ["@com_google_protobuf//:protobuf"],
+)
+
+cc_library(
+    name = "protocol",
+    srcs = ["protocol.cc"],
+    hdrs = ["protocol.h"],
+    deps = [
+        ":roughtime_logging",
+        "@boringssl//:crypto",
+    ],
+)
+
+cc_library(
+    name = "client",
+    srcs = ["client.cc"],
+    hdrs = ["client.h"],
+    copts = ["-Wno-sometimes-uninitialized"],
+    deps = [
+        ":protocol",
+        ":roughtime_logging",
+    ],
+)


### PR DESCRIPTION
This is the initial implementation of a roughtime client to provide
trusted time to server components inside an enclave.