### PR TITLE
Make sdk `Handle` an opaque non-serializable type

### DIFF
--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -521,6 +521,7 @@ impl FrontendNode {
 
         unsafe {
             // Wait on [write handle, ready read handle].
+            // TODO: Re-add NOT_READY subcase, removed in #429
             const COUNT: usize = 2;
             let mut space = Vec::with_capacity(COUNT * oak::wasm::SPACE_BYTES_PER_HANDLE);
             space

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -218,7 +218,7 @@ impl FrontendNode {
         let mut w = 0;
         let mut r = 0;
         unsafe {
-            oak::wasm::channel_create(&mut w as *mut u64, &mut r as *mut u64) as i32;
+            oak::wasm::channel_create(&mut w as *mut u64, &mut r as *mut u64);
         }
 
         unsafe {
@@ -257,8 +257,7 @@ impl FrontendNode {
         let mut out_channel = 0;
         let mut in_channel = 0;
         unsafe {
-            oak::wasm::channel_create(&mut out_channel as *mut u64, &mut in_channel as *mut u64)
-                as i32;
+            oak::wasm::channel_create(&mut out_channel as *mut u64, &mut in_channel as *mut u64);
         }
 
         let mut buf = Vec::<u8>::with_capacity(5);
@@ -419,8 +418,7 @@ impl FrontendNode {
         let mut out_channel = 0u64;
         let mut in_channel = 0u64;
         unsafe {
-            oak::wasm::channel_create(&mut out_channel as *mut u64, &mut in_channel as *mut u64)
-                as i32;
+            oak::wasm::channel_create(&mut out_channel as *mut u64, &mut in_channel as *mut u64);
         }
 
         let buf = vec![0x01];
@@ -507,8 +505,7 @@ impl FrontendNode {
         let mut in_channel = 0u64;
 
         unsafe {
-            oak::wasm::channel_create(&mut out_channel as *mut u64, &mut in_channel as *mut u64)
-                as i32;
+            oak::wasm::channel_create(&mut out_channel as *mut u64, &mut in_channel as *mut u64);
 
             // Write a message to the channel so wait operations don't block.
             let data = vec![0x01, 0x02, 0x03];
@@ -798,8 +795,7 @@ impl FrontendNode {
         let mut in_channel = 0u64;
 
         unsafe {
-            oak::wasm::channel_create(&mut out_channel as *mut u64, &mut in_channel as *mut u64)
-                as i32;
+            oak::wasm::channel_create(&mut out_channel as *mut u64, &mut in_channel as *mut u64);
 
             expect_eq!(
                 OakStatus::ERR_INVALID_ARGS.value() as u32,
@@ -926,7 +922,7 @@ impl FrontendNode {
         oak::node_create(LOG_CONFIG_NAME, read_handle);
         oak::channel_close(read_handle.handle);
 
-        expect!(logging_handle.handle != oak::Handle::from_raw(oak::wasm::INVALID_HANDLE));
+        expect!(logging_handle.handle.is_valid());
         let (out_handle, in_handle) = oak::channel_create().unwrap();
 
         oak::channel_write(

--- a/examples/abitest/module_1/rust/src/lib.rs
+++ b/examples/abitest/module_1/rust/src/lib.rs
@@ -33,13 +33,12 @@ pub extern "C" fn oak_main(handle: u64) -> i32 {
     }
 }
 pub fn main(in_handle: u64) -> i32 {
-    let _ = oak_log::init(log::Level::Debug, LOG_CONFIG_NAME);
-    oak::set_panic_hook();
-
-    // We expect a single empty message holding a reply channel.
     let in_channel = oak::ReadHandle {
         handle: oak::Handle::from_raw(in_handle),
     };
+    let _ = oak_log::init(log::Level::Debug, LOG_CONFIG_NAME);
+    oak::set_panic_hook();
+
     let mut buf = Vec::<u8>::with_capacity(2);
     let mut handles = Vec::with_capacity(2);
     oak::channel_read(in_channel, &mut buf, &mut handles);
@@ -47,7 +46,7 @@ pub fn main(in_handle: u64) -> i32 {
         return oak::OakStatus::ERR_INTERNAL.value();
     }
     let out_handle = handles[0];
-    info!("backend node: in={}, out={:?}", in_handle, out_handle);
+    info!("backend node: in={:?}, out={:?}", in_channel, out_handle);
 
     let out_channel = oak::WriteHandle { handle: out_handle };
     // Wait on 1+N read handles (starting with N=0).

--- a/examples/abitest/module_1/rust/src/lib.rs
+++ b/examples/abitest/module_1/rust/src/lib.rs
@@ -33,11 +33,11 @@ pub extern "C" fn oak_main(handle: u64) -> i32 {
     }
 }
 pub fn main(in_handle: u64) -> i32 {
+    let _ = oak_log::init(log::Level::Debug, LOG_CONFIG_NAME);
+    oak::set_panic_hook();
     let in_channel = oak::ReadHandle {
         handle: oak::Handle::from_raw(in_handle),
     };
-    let _ = oak_log::init(log::Level::Debug, LOG_CONFIG_NAME);
-    oak::set_panic_hook();
 
     let mut buf = Vec::<u8>::with_capacity(2);
     let mut handles = Vec::with_capacity(2);

--- a/examples/abitest/module_1/rust/src/lib.rs
+++ b/examples/abitest/module_1/rust/src/lib.rs
@@ -37,7 +37,9 @@ pub fn main(in_handle: u64) -> i32 {
     oak::set_panic_hook();
 
     // We expect a single empty message holding a reply channel.
-    let in_channel = oak::ReadHandle { handle: in_handle };
+    let in_channel = oak::ReadHandle {
+        handle: oak::Handle::from_raw(in_handle),
+    };
     let mut buf = Vec::<u8>::with_capacity(2);
     let mut handles = Vec::with_capacity(2);
     oak::channel_read(in_channel, &mut buf, &mut handles);
@@ -45,7 +47,7 @@ pub fn main(in_handle: u64) -> i32 {
         return oak::OakStatus::ERR_INTERNAL.value();
     }
     let out_handle = handles[0];
-    info!("backend node: in={}, out={}", in_handle, out_handle);
+    info!("backend node: in={}, out={:?}", in_handle, out_handle);
 
     let out_channel = oak::WriteHandle { handle: out_handle };
     // Wait on 1+N read handles (starting with N=0).
@@ -62,7 +64,7 @@ pub fn main(in_handle: u64) -> i32 {
             let mut handles = Vec::with_capacity(5);
             oak::channel_read(in_channel, &mut buf, &mut handles);
             for handle in handles {
-                info!("add new handle {} to waiting set", handle);
+                info!("add new handle {:?} to waiting set", handle);
                 wait_handles.push(oak::ReadHandle { handle });
             }
         }

--- a/examples/chat/module_1/rust/src/lib.rs
+++ b/examples/chat/module_1/rust/src/lib.rs
@@ -32,12 +32,13 @@ pub fn main(in_handle: u64) -> i32 {
     oak::set_panic_hook();
     info!("per-room node started");
 
+    let in_channel = oak::ReadHandle {
+        handle: oak::Handle::from_raw(in_handle),
+    };
+
     let mut rsp_writers: Vec<oak::grpc::ChannelResponseWriter> = Vec::with_capacity(1);
     loop {
         // Wait for something on our single input channel.
-        let in_channel = oak::ReadHandle {
-            handle: oak::Handle::from_raw(in_handle),
-        };
         let ready_status = match oak::wait_on_channels(&[in_channel]) {
             Ok(ready_status) => ready_status,
             Err(err) => {

--- a/examples/chat/module_1/rust/src/lib.rs
+++ b/examples/chat/module_1/rust/src/lib.rs
@@ -35,7 +35,9 @@ pub fn main(in_handle: u64) -> i32 {
     let mut rsp_writers: Vec<oak::grpc::ChannelResponseWriter> = Vec::with_capacity(1);
     loop {
         // Wait for something on our single input channel.
-        let in_channel = oak::ReadHandle { handle: in_handle };
+        let in_channel = oak::ReadHandle {
+            handle: oak::Handle::from_raw(in_handle),
+        };
         let ready_status = match oak::wait_on_channels(&[in_channel]) {
             Ok(ready_status) => ready_status,
             Err(err) => {
@@ -58,7 +60,7 @@ pub fn main(in_handle: u64) -> i32 {
             return status.value();
         }
         for handle in handles {
-            info!("add handle {} to output writers", handle);
+            info!("add handle {:?} to output writers", handle);
             rsp_writers.push(oak::grpc::ChannelResponseWriter::new(oak::WriteHandle {
                 handle,
             }));

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -144,7 +144,7 @@ pub trait OakNode {
 /// [`GrpcRequest`]: crate::proto::grpc_encap::GrpcRequest
 pub fn event_loop<T: OakNode>(mut node: T, grpc_in_handle: ReadHandle) -> i32 {
     info!("start event loop for node with handle {:?}", grpc_in_handle);
-    if grpc_in_handle.handle.id == wasm::INVALID_HANDLE {
+    if !grpc_in_handle.handle.is_valid() {
         return OakStatus::ERR_CHANNEL_CLOSED.value();
     }
     crate::set_panic_hook();

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -144,7 +144,7 @@ pub trait OakNode {
 /// [`GrpcRequest`]: crate::proto::grpc_encap::GrpcRequest
 pub fn event_loop<T: OakNode>(mut node: T, grpc_in_handle: ReadHandle) -> i32 {
     info!("start event loop for node with handle {:?}", grpc_in_handle);
-    if grpc_in_handle.handle == wasm::INVALID_HANDLE {
+    if grpc_in_handle.handle.id == wasm::INVALID_HANDLE {
         return OakStatus::ERR_CHANNEL_CLOSED.value();
     }
     crate::set_panic_hook();

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -44,9 +44,19 @@ pub struct Handle {
 
 impl Handle {
     /// When using the Oak SDK, this method should not need to be called directly
-    /// as `Handles` are directly provided via functions such as `channel_create`
+    /// as `Handles` are directly provided via functions such as `channel_create`.
     pub fn from_raw(id: u64) -> Handle {
-        Handle { id: id }
+        Handle { id }
+    }
+
+    /// Check this handle is valid.
+    pub fn is_valid(&self) -> bool {
+        return self.id != wasm::INVALID_HANDLE
+    }
+
+    /// Returns an intentionally invalid handle. Intended for debugging purposes.
+    pub fn invalid() -> Handle {
+        Handle { id: wasm::INVALID_HANDLE }
     }
 }
 
@@ -202,12 +212,8 @@ pub fn channel_write(half: WriteHandle, buf: &[u8], handles: &[Handle]) -> OakSt
 /// On success, returns [`WriteHandle`] and a [`ReadHandle`] values for the
 /// write and read halves (respectively).
 pub fn channel_create() -> Result<(WriteHandle, ReadHandle), OakStatus> {
-    let mut write = WriteHandle {
-        handle: Handle { id: 0 },
-    };
-    let mut read = ReadHandle {
-        handle: Handle { id: 0 },
-    };
+    let mut write = WriteHandle { Handle.invalid() };
+    let mut read = ReadHandle { Handle.invalid() };
     match OakStatus::from_i32(unsafe {
         wasm::channel_create(
             &mut write.handle.id as *mut u64,

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -50,13 +50,15 @@ impl Handle {
     }
 
     /// Check this handle is valid.
-    pub fn is_valid(&self) -> bool {
-        return self.id != wasm::INVALID_HANDLE
+    pub fn is_valid(self) -> bool {
+        self.id != wasm::INVALID_HANDLE
     }
 
     /// Returns an intentionally invalid handle. Intended for debugging purposes.
     pub fn invalid() -> Handle {
-        Handle { id: wasm::INVALID_HANDLE }
+        Handle {
+            id: wasm::INVALID_HANDLE,
+        }
     }
 }
 
@@ -212,8 +214,12 @@ pub fn channel_write(half: WriteHandle, buf: &[u8], handles: &[Handle]) -> OakSt
 /// On success, returns [`WriteHandle`] and a [`ReadHandle`] values for the
 /// write and read halves (respectively).
 pub fn channel_create() -> Result<(WriteHandle, ReadHandle), OakStatus> {
-    let mut write = WriteHandle { Handle.invalid() };
-    let mut read = ReadHandle { Handle.invalid() };
+    let mut write = WriteHandle {
+        handle: Handle::invalid(),
+    };
+    let mut read = ReadHandle {
+        handle: Handle::invalid(),
+    };
     match OakStatus::from_i32(unsafe {
         wasm::channel_create(
             &mut write.handle.id as *mut u64,

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -54,7 +54,7 @@ impl Handle {
         self.id != wasm::INVALID_HANDLE
     }
 
-    /// Returns an intentionally invalid handle. Intended for debugging purposes.
+    /// Returns an intentionally invalid handle.
     pub fn invalid() -> Handle {
         Handle {
             id: wasm::INVALID_HANDLE,

--- a/sdk/rust/oak/src/tests.rs
+++ b/sdk/rust/oak/src/tests.rs
@@ -23,7 +23,10 @@ fn test_write_message() {
     let (write_handle, read_handle) = channel_create().unwrap();
     let data = [0x44, 0x4d, 0x44];
     assert_eq!(OakStatus::OK, channel_write(write_handle, &data, &[]));
-    assert_eq!("DMD", oak_tests::last_message_as_string(read_handle.handle.id));
+    assert_eq!(
+        "DMD",
+        oak_tests::last_message_as_string(read_handle.handle.id)
+    );
 }
 
 #[test]
@@ -104,7 +107,14 @@ fn test_read_message_internal_failure() {
 
 #[test]
 fn test_handle_space() {
-    let h = vec![ReadHandle { handle: Handle::from_raw(1) }, ReadHandle { handle: Handle::from_raw(2) }];
+    let h = vec![
+        ReadHandle {
+            handle: Handle::from_raw(1),
+        },
+        ReadHandle {
+            handle: Handle::from_raw(2),
+        },
+    ];
     let data = [
         0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00,

--- a/sdk/rust/oak/src/tests.rs
+++ b/sdk/rust/oak/src/tests.rs
@@ -23,7 +23,7 @@ fn test_write_message() {
     let (write_handle, read_handle) = channel_create().unwrap();
     let data = [0x44, 0x4d, 0x44];
     assert_eq!(OakStatus::OK, channel_write(write_handle, &data, &[]));
-    assert_eq!("DMD", oak_tests::last_message_as_string(read_handle.handle));
+    assert_eq!("DMD", oak_tests::last_message_as_string(read_handle.handle.id));
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn test_write_message_failure() {
     let data = [0x44, 0x4d, 0x44];
     oak_tests::set_write_status(
         oak_tests::DEFAULT_NODE_NAME,
-        write_handle.handle,
+        write_handle.handle.id,
         Some(OakStatus::ERR_INVALID_ARGS.value() as u32),
     );
     assert_eq!(
@@ -70,7 +70,7 @@ fn test_read_message_failure() {
     let (_write_handle, read_handle) = channel_create().unwrap();
     oak_tests::set_read_status(
         oak_tests::DEFAULT_NODE_NAME,
-        read_handle.handle,
+        read_handle.handle.id,
         Some(OakStatus::ERR_INVALID_ARGS.value() as u32),
     );
 
@@ -90,7 +90,7 @@ fn test_read_message_internal_failure() {
     // Set buffer too small but don't set actual size, so the retry gets confused.
     oak_tests::set_read_status(
         oak_tests::DEFAULT_NODE_NAME,
-        read_handle.handle,
+        read_handle.handle.id,
         Some(OakStatus::ERR_BUFFER_TOO_SMALL.value() as u32),
     );
 
@@ -104,7 +104,7 @@ fn test_read_message_internal_failure() {
 
 #[test]
 fn test_handle_space() {
-    let h = vec![ReadHandle { handle: 1 }, ReadHandle { handle: 2 }];
+    let h = vec![ReadHandle { handle: Handle::from_raw(1) }, ReadHandle { handle: Handle::from_raw(2) }];
     let data = [
         0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00,

--- a/sdk/rust/oak_derive/src/lib.rs
+++ b/sdk/rust/oak_derive/src/lib.rs
@@ -61,7 +61,7 @@ pub fn derive_oak_exports(input: TokenStream) -> TokenStream {
             // https://doc.rust-lang.org/nomicon/ffi.html#ffi-and-panics
             std::panic::catch_unwind(||{
                 let mut node = <#name>::new();
-                oak::grpc::event_loop(node, oak::ReadHandle{ handle })
+                oak::grpc::event_loop(node, oak::ReadHandle{ handle: oak::Handle::from_raw(handle) })
             }).unwrap_or(oak::OakStatus::ERR_INTERNAL.value())
         }
     };

--- a/sdk/rust/oak_log/src/tests.rs
+++ b/sdk/rust/oak_log/src/tests.rs
@@ -83,6 +83,10 @@ fn test_log() {
         .module_path(Some("server"))
         .build();
     logger.log(&r1);
+
+    // TODO: let mut buf: Vec<u8>;
+    // let mut handles: Vec<Handle>;
+    // pub fn channel_read(half: ReadHandle, buf: &mut Vec<u8>, handles: &mut Vec<Handle>) -> OakStatus {
     assert_eq!("", last_message_as_string(handle));
 
     let error = Metadata::builder()

--- a/sdk/rust/oak_runtime/src/lib.rs
+++ b/sdk/rust/oak_runtime/src/lib.rs
@@ -29,6 +29,7 @@ use std::sync::{Arc, RwLock};
 
 pub mod proto;
 
+// TODO(#447)
 pub type Handle = u64;
 
 pub struct OakMessage {

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -330,7 +330,7 @@ pub unsafe extern "C" fn random_get(buf: *mut u8, size: usize) -> u32 {
 /// Convenience test helper which returns the last message on a channel as a
 /// string (without removing it from the channel), assuming that only a single
 /// Node (with the default internal name) is present and under test.
-pub fn last_message_as_string(handle: oak::Handle) -> String {
+pub fn last_message_as_string(handle: oak_runtime::Handle) -> String {
     let result = match RUNTIME
         .read()
         .expect(RUNTIME_MISSING)
@@ -344,7 +344,7 @@ pub fn last_message_as_string(handle: oak::Handle) -> String {
 }
 
 /// Test helper that injects a failure for future channel read operations.
-pub fn set_read_status(node_name: &str, handle: oak::Handle, status: Option<u32>) {
+pub fn set_read_status(node_name: &str, handle: oak_runtime::Handle, status: Option<u32>) {
     RUNTIME
         .write()
         .expect(RUNTIME_MISSING)
@@ -352,7 +352,7 @@ pub fn set_read_status(node_name: &str, handle: oak::Handle, status: Option<u32>
 }
 
 /// Test helper that injects a failure for future channel write operations.
-pub fn set_write_status(node_name: &str, handle: oak::Handle, status: Option<u32>) {
+pub fn set_write_status(node_name: &str, handle: oak_runtime::Handle, status: Option<u32>) {
     RUNTIME
         .write()
         .expect(RUNTIME_MISSING)
@@ -413,7 +413,7 @@ pub fn start(
 /// Start running a test of a single-Node Application.  This assumes that the
 /// single Node's main entrypoint is available as a global extern "C"
 /// oak_main(), as for a live version of the Application.
-pub fn start_node(handle: oak::Handle) {
+pub fn start_node(handle: oak_runtime::Handle) {
     RUNTIME
         .write()
         .expect(RUNTIME_MISSING)
@@ -462,7 +462,7 @@ pub fn stop() -> OakStatus {
 
 /// Test helper to set up a channel into the (single) Node under test for
 /// injected gRPC requests.
-pub fn grpc_channel_setup_default() -> oak::Handle {
+pub fn grpc_channel_setup_default() -> oak_runtime::Handle {
     RUNTIME
         .write()
         .expect(RUNTIME_MISSING)

--- a/sdk/rust/oak_tests/src/tests.rs
+++ b/sdk/rust/oak_tests/src/tests.rs
@@ -35,7 +35,9 @@ fn test_panic_catch() {
     crate::reset();
     crate::init_logging();
     let (mut write_handle, mut read_handle) = (0u64, 0u64);
-    unsafe { oak::wasm::channel_create(&mut write_handle as *mut u64, &mut read_handle as *mut u64); }
+    unsafe {
+        oak::wasm::channel_create(&mut write_handle as *mut u64, &mut read_handle as *mut u64);
+    }
 
     // Mock up a GrpcRequest to trigger invoke()
     let mut grpc_req = oak::proto::grpc_encap::GrpcRequest::new();
@@ -46,10 +48,13 @@ fn test_panic_catch() {
     // Serialize the request and send it with a handle.
     let mut req_data = Vec::new();
     grpc_req.write_to_writer(&mut req_data).unwrap();
-    oak::channel_write(oak::WriteHandle { handle: oak::Handle::from_raw(write_handle) }, &req_data, &[oak::Handle::from_raw(write_handle)]);
-
-    assert_eq!(
-        oak::OakStatus::ERR_INTERNAL.value(),
-        oak_main(read_handle)
+    oak::channel_write(
+        oak::WriteHandle {
+            handle: oak::Handle::from_raw(write_handle),
+        },
+        &req_data,
+        &[oak::Handle::from_raw(write_handle)],
     );
+
+    assert_eq!(oak::OakStatus::ERR_INTERNAL.value(), oak_main(read_handle));
 }

--- a/sdk/rust/oak_tests/src/tests.rs
+++ b/sdk/rust/oak_tests/src/tests.rs
@@ -34,7 +34,8 @@ impl oak::grpc::OakNode for PanicNode {
 fn test_panic_catch() {
     crate::reset();
     crate::init_logging();
-    let (write_handle, read_handle) = oak::channel_create().unwrap();
+    let (mut write_handle, mut read_handle) = (0u64, 0u64);
+    unsafe { oak::wasm::channel_create(&mut write_handle as *mut u64, &mut read_handle as *mut u64); }
 
     // Mock up a GrpcRequest to trigger invoke()
     let mut grpc_req = oak::proto::grpc_encap::GrpcRequest::new();
@@ -45,10 +46,10 @@ fn test_panic_catch() {
     // Serialize the request and send it with a handle.
     let mut req_data = Vec::new();
     grpc_req.write_to_writer(&mut req_data).unwrap();
-    oak::channel_write(write_handle, &req_data, &[write_handle.handle]);
+    oak::channel_write(oak::WriteHandle { handle: oak::Handle::from_raw(write_handle) }, &req_data, &[oak::Handle::from_raw(write_handle)]);
 
     assert_eq!(
         oak::OakStatus::ERR_INTERNAL.value(),
-        oak_main(read_handle.handle)
+        oak_main(read_handle)
     );
 }


### PR DESCRIPTION
Makes sdk `Handle` an opaque non-serializable type.

- `oak_runtime` keeps the Handle type alias to u64 as specified by the ABI. (This is used for example in `_raw` tests in `oak/examples/abitest/module/...` which are tests directly against the wasm which don't use the sdk)
- Tests updated to use opaque Handle where appropriate.  

#427