### PR TITLE
runtime: disallow sending of empty messages

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -109,7 +109,8 @@ functions** as
   in Fuchsia.
 
 - `channel_write: (u64, usize, usize, usize, u32) -> u32`: Writes a single
-  message to the specified channel, together with any associated handles.
+  message to the specified channel, together with any associated handles. The
+  message must include at least one byte or one handle.
 
   - arg 0: Handle to channel send half
   - arg 1: Source buffer address holding message

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -439,7 +439,10 @@ impl FrontendNode {
 
         // Empty message.
         let empty = vec![];
-        expect_eq!(OakStatus::OK, oak::channel_write(out_channel, &empty, &[]));
+        expect_eq!(
+            OakStatus::ERR_INVALID_ARGS,
+            oak::channel_write(out_channel, &empty, &[])
+        );
 
         // Single message.
         let data = vec![0x01, 0x02, 0x03];

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -363,6 +363,13 @@ wabt::interp::HostFunc::Callback WasmNode::OakChannelWrite(wabt::interp::Environ
     uint32_t handle_offset = args[3].get_i32();
     uint32_t handle_count = args[4].get_i32();
 
+    // Completely empty messages are not allowed.
+    if (size == 0 && handle_count == 0) {
+      LOG(WARNING) << "{" << name_ << "} Node provided completely empty message";
+      results[0].set_i32(OakStatus::ERR_INVALID_ARGS);
+      return wabt::interp::Result::Ok;
+    }
+
     // Check all provided linear memory is accessible.
     if (!MemoryAvailable(env, offset, size) ||
         !MemoryAvailable(env, handle_offset, handle_count * sizeof(Handle))) {

--- a/sdk/rust/oak_runtime/src/lib.rs
+++ b/sdk/rust/oak_runtime/src/lib.rs
@@ -78,6 +78,10 @@ impl MockChannel {
             // Channel is orphaned; no-one can ever read this message.
             return OakStatus::ERR_CHANNEL_CLOSED.value() as u32;
         }
+        if msg.data.is_empty() && msg.channels.is_empty() {
+            // Disallow empty messages
+            return OakStatus::ERR_INVALID_ARGS.value() as u32;
+        }
         self.messages.push_back(msg);
         OakStatus::OK.value() as u32
     }


### PR DESCRIPTION
Previously a Node could not distinguish between a channel_read operation
on an empty channel from one that returned an empty message.