### PR TITLE
runtime: emit CHANNEL_EMPTY for empty channel read

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -91,7 +91,8 @@ functions** as
   for data (args 1 and 2) or handles (args 4 and 5) are not large enough for the
   read operation, then no data will be returned and either `BUFFER_TOO_SMALL` or
   `HANDLE_SPACE_TOO_SMALL` will be returned; in either case, the required sizes
-  will be returned in the spaces provided by args 3 and 6.
+  will be returned in the spaces provided by args 3 and 6. If no messages are
+  available on the channel, `CHANNEL_EMPTY` will be returned.
 
   - arg 0: Handle to channel receive half
   - arg 1: Destination buffer address

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -317,7 +317,7 @@ impl FrontendNode {
 
             // Valid case.
             expect_eq!(
-                OakStatus::OK.value() as u32,
+                OakStatus::ERR_CHANNEL_EMPTY.value() as u32,
                 oak::wasm::channel_read(
                     in_channel,
                     buf.as_mut_ptr(),
@@ -346,7 +346,7 @@ impl FrontendNode {
         let mut buffer = Vec::<u8>::with_capacity(5);
         let mut handles = Vec::with_capacity(5);
         expect_eq!(
-            OakStatus::OK,
+            OakStatus::ERR_CHANNEL_EMPTY,
             oak::channel_read(in_channel, &mut buffer, &mut handles)
         );
         expect_eq!(0, buffer.len());
@@ -364,7 +364,7 @@ impl FrontendNode {
 
         // Reading again zeroes the vector length.
         expect_eq!(
-            OakStatus::OK,
+            OakStatus::ERR_CHANNEL_EMPTY,
             oak::channel_read(in_channel, &mut buffer, &mut handles)
         );
         expect_eq!(0, buffer.len());

--- a/examples/abitest/module_1/rust/src/lib.rs
+++ b/examples/abitest/module_1/rust/src/lib.rs
@@ -39,6 +39,8 @@ pub fn main(in_handle: u64) -> i32 {
         handle: oak::Handle::from_raw(in_handle),
     };
 
+    // We expect a single empty message holding a reply channel to already
+    // be waiting on the channel.
     let mut buf = Vec::<u8>::with_capacity(2);
     let mut handles = Vec::with_capacity(2);
     oak::channel_read(in_channel, &mut buf, &mut handles);

--- a/oak/proto/oak_api.proto
+++ b/oak/proto/oak_api.proto
@@ -40,6 +40,8 @@ enum OakStatus {
   ERR_INTERNAL = 8;
   // Node terminated.
   ERR_TERMINATED = 9;
+  // Channel has no messages available to read.
+  ERR_CHANNEL_EMPTY = 10;
 }
 
 // Single byte values used to indicate the read status of a channel on the

--- a/oak/server/rust/oak_abi/src/proto/oak_api.rs
+++ b/oak/server/rust/oak_abi/src/proto/oak_api.rs
@@ -38,6 +38,7 @@ pub enum OakStatus {
     ERR_OUT_OF_RANGE = 7,
     ERR_INTERNAL = 8,
     ERR_TERMINATED = 9,
+    ERR_CHANNEL_EMPTY = 10,
 }
 
 impl ::protobuf::ProtobufEnum for OakStatus {
@@ -57,6 +58,7 @@ impl ::protobuf::ProtobufEnum for OakStatus {
             7 => ::std::option::Option::Some(OakStatus::ERR_OUT_OF_RANGE),
             8 => ::std::option::Option::Some(OakStatus::ERR_INTERNAL),
             9 => ::std::option::Option::Some(OakStatus::ERR_TERMINATED),
+            10 => ::std::option::Option::Some(OakStatus::ERR_CHANNEL_EMPTY),
             _ => ::std::option::Option::None
         }
     }
@@ -73,6 +75,7 @@ impl ::protobuf::ProtobufEnum for OakStatus {
             OakStatus::ERR_OUT_OF_RANGE,
             OakStatus::ERR_INTERNAL,
             OakStatus::ERR_TERMINATED,
+            OakStatus::ERR_CHANNEL_EMPTY,
         ];
         values
     }
@@ -167,15 +170,15 @@ impl ::protobuf::reflect::ProtobufValue for ChannelReadStatus {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\roak_api.proto\x12\x03oak*\xe7\x01\n\tOakStatus\x12\x1a\n\x16OAK_STAT\
+    \n\roak_api.proto\x12\x03oak*\xfe\x01\n\tOakStatus\x12\x1a\n\x16OAK_STAT\
     US_UNSPECIFIED\x10\0\x12\x06\n\x02OK\x10\x01\x12\x12\n\x0eERR_BAD_HANDLE\
     \x10\x02\x12\x14\n\x10ERR_INVALID_ARGS\x10\x03\x12\x16\n\x12ERR_CHANNEL_\
     CLOSED\x10\x04\x12\x18\n\x14ERR_BUFFER_TOO_SMALL\x10\x05\x12\x1e\n\x1aER\
     R_HANDLE_SPACE_TOO_SMALL\x10\x06\x12\x14\n\x10ERR_OUT_OF_RANGE\x10\x07\
-    \x12\x10\n\x0cERR_INTERNAL\x10\x08\x12\x12\n\x0eERR_TERMINATED\x10\t*U\n\
-    \x11ChannelReadStatus\x12\r\n\tNOT_READY\x10\0\x12\x0e\n\nREAD_READY\x10\
-    \x01\x12\x13\n\x0fINVALID_CHANNEL\x10\x02\x12\x0c\n\x08ORPHANED\x10\x03b\
-    \x06proto3\
+    \x12\x10\n\x0cERR_INTERNAL\x10\x08\x12\x12\n\x0eERR_TERMINATED\x10\t\x12\
+    \x15\n\x11ERR_CHANNEL_EMPTY\x10\n*U\n\x11ChannelReadStatus\x12\r\n\tNOT_\
+    READY\x10\0\x12\x0e\n\nREAD_READY\x10\x01\x12\x13\n\x0fINVALID_CHANNEL\
+    \x10\x02\x12\x0c\n\x08ORPHANED\x10\x03b\x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -100,7 +100,7 @@ impl MockChannel {
                     // indicate that the channel is closed.
                     Err(OakStatus::ERR_CHANNEL_CLOSED.value() as u32)
                 } else {
-                    Err(OakStatus::OK.value() as u32)
+                    Err(OakStatus::ERR_CHANNEL_EMPTY.value() as u32)
                 }
             }
             Some(msg) => {

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -328,7 +328,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakChannelRead(wabt::interp::Environm
         LOG(INFO) << "{" << name_ << "} channel_read[" << channel_handle << "]: no writers left";
         results[0].set_i32(OakStatus::ERR_CHANNEL_CLOSED);
       } else {
-        results[0].set_i32(OakStatus::OK);
+        results[0].set_i32(OakStatus::ERR_CHANNEL_EMPTY);
       }
       return wabt::interp::Result::Ok;
     }

--- a/sdk/rust/oak/src/io/mod.rs
+++ b/sdk/rust/oak/src/io/mod.rs
@@ -81,6 +81,9 @@ pub fn error_from_nonok_status(status: OakStatus) -> io::Error {
         OakStatus::ERR_OUT_OF_RANGE => io::Error::new(io::ErrorKind::NotConnected, "Out of range"),
         OakStatus::ERR_INTERNAL => io::Error::new(io::ErrorKind::Other, "Internal error"),
         OakStatus::ERR_TERMINATED => io::Error::new(io::ErrorKind::Other, "Node terminated"),
+        OakStatus::ERR_CHANNEL_EMPTY => {
+            io::Error::new(io::ErrorKind::UnexpectedEof, "Channel empty")
+        }
     }
 }
 

--- a/sdk/rust/oak/src/wasm/mod.rs
+++ b/sdk/rust/oak/src/wasm/mod.rs
@@ -45,6 +45,8 @@ extern "C" {
     /// spaces provided by `actual_size` and `actual_handle_count`.
     ///
     /// Returns the status of the operation, as an [`OakStatus`] value.
+    /// If no message is available on the channel, [`ERR_CHANNEL_EMPTY`] will be
+    /// returned.
     ///
     /// [`ERR_BUFFER_TOO_SMALL`]: crate::OakStatus::ERR_BUFFER_TOO_SMALL
     /// [`ERR_HANDLE_SPACE_TOO_SMALL`]: crate::OakStatus::ERR_HANDLE_SPACE_TOO_SMALL

--- a/sdk/rust/oak_log/src/tests.rs
+++ b/sdk/rust/oak_log/src/tests.rs
@@ -86,7 +86,7 @@ fn test_log() {
     let mut buf = Vec::new();
     let mut handles = Vec::new();
     assert_eq!(
-        oak::OakStatus::OK,
+        oak::OakStatus::ERR_CHANNEL_EMPTY,
         oak::channel_read(handle, &mut buf, &mut handles)
     );
     assert_eq!(0, buf.len());

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -544,7 +544,7 @@ where
         let result = read_half.read_message(std::usize::MAX, &mut size, std::u32::MAX, &mut count);
         let rsp = match result {
             Err(e) => {
-                if e == OakStatus::OK.value() as u32 {
+                if e == OakStatus::ERR_CHANNEL_EMPTY.value() as u32 {
                     info!("no pending gRPC response message; poll again soon");
                     std::thread::sleep(std::time::Duration::from_millis(100));
                     continue;


### PR DESCRIPTION
Previously a Node could not distinguish between a channel_read operation
on an empty channel from one that returned an empty message.