### PR TITLE
Improve error handling in Oak SDK crate

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -467,7 +467,7 @@ fn test_hello_request() {
     assert_matches!(result, Ok(_));
     assert_eq!("HELLO world!", result.unwrap().reply);
 
-    assert_eq!(OakStatus::ERR_TERMINATED, oak_tests::stop());
+    assert_eq!(Err(OakStatus::ERR_TERMINATED), oak_tests::stop());
 }
 ```
 <!-- prettier-ignore-end -->

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -538,7 +538,7 @@ function:
 #[no_mangle]
 pub extern "C" fn frontend_oak_main(handle: u64) -> i32 {
     std::panic::catch_unwind(|| main(handle))
-        .unwrap_or_else(|_| Err(oak::OakStatus::ERR_INTERNAL))
+        .unwrap_or(Err(oak::OakStatus::ERR_INTERNAL))
         .err()
         .unwrap_or(oak::OakStatus::OK)
         .value()

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -41,7 +41,7 @@ struct FrontendNode {
 #[no_mangle]
 pub extern "C" fn frontend_oak_main(handle: u64) -> i32 {
     std::panic::catch_unwind(|| main(handle))
-        .unwrap_or_else(|_| Err(oak::OakStatus::ERR_INTERNAL))
+        .unwrap_or(Err(oak::OakStatus::ERR_INTERNAL))
         .err()
         .unwrap_or(oak::OakStatus::OK)
         .value()

--- a/examples/abitest/module_1/rust/src/lib.rs
+++ b/examples/abitest/module_1/rust/src/lib.rs
@@ -27,7 +27,7 @@ use protobuf::ProtobufEnum;
 #[no_mangle]
 pub extern "C" fn backend_oak_main(handle: u64) -> i32 {
     std::panic::catch_unwind(|| main(handle))
-        .unwrap_or_else(|_| Err(oak::OakStatus::ERR_INTERNAL))
+        .unwrap_or(Err(oak::OakStatus::ERR_INTERNAL))
         .err()
         .unwrap_or(oak::OakStatus::OK)
         .value()

--- a/examples/abitest/module_1/rust/src/lib.rs
+++ b/examples/abitest/module_1/rust/src/lib.rs
@@ -26,12 +26,14 @@ use protobuf::ProtobufEnum;
 // is what's sent back to the frontend.
 #[no_mangle]
 pub extern "C" fn backend_oak_main(handle: u64) -> i32 {
-    match std::panic::catch_unwind(|| main(handle)) {
-        Ok(rc) => rc,
-        Err(_) => oak::OakStatus::ERR_INTERNAL.value(),
-    }
+    std::panic::catch_unwind(|| main(handle))
+        .unwrap_or_else(|_| Err(oak::OakStatus::ERR_INTERNAL))
+        .err()
+        .unwrap_or(oak::OakStatus::OK)
+        .value()
 }
-pub fn main(in_handle: u64) -> i32 {
+
+pub fn main(in_handle: u64) -> Result<(), oak::OakStatus> {
     let _ = oak_log::init(log::Level::Debug, LOG_CONFIG_NAME);
     oak::set_panic_hook();
     let in_channel = oak::ReadHandle {
@@ -42,9 +44,9 @@ pub fn main(in_handle: u64) -> i32 {
     // be waiting on the channel.
     let mut buf = Vec::<u8>::with_capacity(2);
     let mut handles = Vec::with_capacity(2);
-    oak::channel_read(in_channel, &mut buf, &mut handles);
+    oak::channel_read(in_channel, &mut buf, &mut handles)?;
     if handles.len() != 1 {
-        return oak::OakStatus::ERR_INTERNAL.value();
+        return Err(oak::OakStatus::ERR_INTERNAL);
     }
     let out_handle = handles[0];
     info!("backend node: in={:?}, out={:?}", in_channel, out_handle);
@@ -53,16 +55,13 @@ pub fn main(in_handle: u64) -> i32 {
     // Wait on 1+N read handles (starting with N=0).
     let mut wait_handles = vec![in_channel];
     loop {
-        let ready_status = match oak::wait_on_channels(&wait_handles) {
-            Ok(ready_status) => ready_status,
-            Err(err) => return err.value(),
-        };
+        let ready_status = oak::wait_on_channels(&wait_handles)?;
         // If there is a message on in_channel, it is expected to contain
         // a collection of read handles for future listening
         if ready_status[0] == oak::ChannelReadStatus::READ_READY {
             let mut buf = Vec::<u8>::with_capacity(16);
             let mut handles = Vec::with_capacity(5);
-            oak::channel_read(in_channel, &mut buf, &mut handles);
+            oak::channel_read(in_channel, &mut buf, &mut handles)?;
             for handle in handles {
                 info!("add new handle {:?} to waiting set", handle);
                 wait_handles.push(oak::ReadHandle { handle });
@@ -81,7 +80,7 @@ pub fn main(in_handle: u64) -> i32 {
             );
             let mut buf = Vec::<u8>::with_capacity(1024);
             let mut handles = Vec::with_capacity(1);
-            oak::channel_read(wait_handles[i], &mut buf, &mut handles);
+            oak::channel_read(wait_handles[i], &mut buf, &mut handles)?;
             if buf.is_empty() {
                 info!("no pending message; poll again");
                 continue;
@@ -92,7 +91,7 @@ pub fn main(in_handle: u64) -> i32 {
             info!("received frontend request: {:?}", internal_req);
 
             // Create a new channel and write the response into it.
-            let (new_write, new_read) = oak::channel_create().unwrap();
+            let (new_write, new_read) = oak::channel_create()?;
             let internal_rsp = InternalMessage {
                 msg: internal_req.msg + "xxx",
             };
@@ -101,14 +100,14 @@ pub fn main(in_handle: u64) -> i32 {
                 "send serialized message to new channel {:?}: {}",
                 new_write, serialized_rsp
             );
-            oak::channel_write(new_write, &serialized_rsp.into_bytes(), &[]);
+            oak::channel_write(new_write, &serialized_rsp.into_bytes(), &[])?;
             // Drop the write half now it has been written to.
-            oak::channel_close(new_write.handle);
+            oak::channel_close(new_write.handle)?;
 
             // Send a copy of the read half of the new channel back to the frontend,
             // then close our handle to the read half.
-            oak::channel_write(out_channel, &[], &[new_read.handle]);
-            oak::channel_close(new_read.handle);
+            oak::channel_write(out_channel, &[], &[new_read.handle])?;
+            oak::channel_close(new_read.handle)?;
         }
     }
 }

--- a/examples/abitest/tests/src/tests.rs
+++ b/examples/abitest/tests/src/tests.rs
@@ -72,7 +72,7 @@ fn test_abi() {
         oak_tests::inject_grpc_request("/oak.examples.abitest.OakABITestService/RunTests", req);
     assert_matches!(result, Ok(_));
 
-    assert_eq!(OakStatus::ERR_TERMINATED, oak_tests::stop());
+    assert_eq!(Err(OakStatus::ERR_TERMINATED), oak_tests::stop());
 
     for result in result.unwrap().get_results() {
         info!(

--- a/examples/chat/common/src/lib.rs
+++ b/examples/chat/common/src/lib.rs
@@ -44,11 +44,10 @@ pub fn receive<M: Decodable>(read_handle: oak::ReadHandle) -> Result<M> {
     let mut bytes = Vec::<u8>::with_capacity(512);
     let mut handles = Vec::with_capacity(2);
     match oak::channel_read(read_handle, &mut bytes, &mut handles) {
-        Ok(oak::ChannelStatus::Ready) => {
+        Ok(()) => {
             let msg: M = M::decode(&bytes, &handles).context("could not decode message")?;
             Ok(msg)
         }
-        Ok(oak::ChannelStatus::NotReady) => Err(anyhow!("channel not ready")),
         Err(status) => {
             // TODO(#457): Propagate error code to caller.
             Err(anyhow!("could not read from channel: {:?}", status))

--- a/examples/chat/module_0/rust/src/lib.rs
+++ b/examples/chat/module_0/rust/src/lib.rs
@@ -44,8 +44,8 @@ struct Room {
 impl Room {
     fn new(admin_token: AdminToken) -> Self {
         let (wh, rh) = oak::channel_create().unwrap();
-        oak::node_create("room-config", rh);
-        oak::channel_close(rh.handle);
+        oak::node_create("room-config", rh).expect("could not create node");
+        oak::channel_close(rh.handle).expect("could not close channel");
         Room {
             channel: wh,
             admin_token,
@@ -95,7 +95,7 @@ impl ChatNode for Node {
                 if e.get().admin_token == req.admin_token {
                     // Close the only input channel that reaches the per-room Node, which
                     // will trigger it to terminate.
-                    oak::channel_close(e.get().channel.handle);
+                    oak::channel_close(e.get().channel.handle).expect("could not close channel");
                     e.remove();
                     Ok(Empty::new())
                 } else {

--- a/examples/chat/module_1/rust/src/lib.rs
+++ b/examples/chat/module_1/rust/src/lib.rs
@@ -27,7 +27,7 @@ pub extern "C" fn backend_oak_main(handle: u64) -> i32 {
         let room = Room::default();
         room.event_loop(handle)
     })
-    .unwrap_or_else(|_| Err(oak::OakStatus::ERR_INTERNAL))
+    .unwrap_or(Err(oak::OakStatus::ERR_INTERNAL))
     .err()
     .unwrap_or(oak::OakStatus::OK)
     .value()

--- a/examples/hello_world/module/rust/src/tests.rs
+++ b/examples/hello_world/module/rust/src/tests.rs
@@ -37,7 +37,7 @@ fn test_direct_hello_request() {
 #[serial(node_test)]
 fn test_no_handle() {
     oak_tests::start_node(oak_abi::INVALID_HANDLE);
-    assert_eq!(OakStatus::ERR_CHANNEL_CLOSED, oak_tests::stop());
+    assert_eq!(Err(OakStatus::ERR_CHANNEL_CLOSED), oak_tests::stop());
 }
 
 // Test invoking a Node service method via the Oak entrypoints.
@@ -54,5 +54,5 @@ fn test_hello_request() {
     assert_matches!(result, Ok(_));
     assert_eq!("HELLO world!", result.unwrap().reply);
 
-    assert_eq!(OakStatus::ERR_TERMINATED, oak_tests::stop());
+    assert_eq!(Err(OakStatus::ERR_TERMINATED), oak_tests::stop());
 }

--- a/examples/machine_learning/module/rust/src/lib.rs
+++ b/examples/machine_learning/module/rust/src/lib.rs
@@ -161,8 +161,8 @@ impl oak::grpc::OakNode for Node {
     fn new() -> Self {
         // Create a channel and pass the read half to a fresh logging Node.
         let (write_handle, read_handle) = oak::channel_create().unwrap();
-        oak::node_create("log", read_handle);
-        oak::channel_close(read_handle.handle);
+        oak::node_create("log", read_handle).expect("could not create node");
+        oak::channel_close(read_handle.handle).expect("could not close channel");
         let raw_logging = oak::io::Channel::new(write_handle);
         Node {
             logging_channel: std::io::LineWriter::new(raw_logging),

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -584,8 +584,7 @@ fn log_node_main(handle: Handle) -> i32 {
         }
         let mut buf = Vec::<u8>::with_capacity(1024);
         let mut handles = Vec::with_capacity(8);
-        oak::channel_read(half, &mut buf, &mut handles);
-        if buf.is_empty() {
+        if oak::channel_read(half, &mut buf, &mut handles).expect("could not read from channel") == oak::ChannelStatus::NotReady {
             debug!("no pending message; poll again");
             continue;
         }

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -584,10 +584,7 @@ fn log_node_main(handle: Handle) -> i32 {
         }
         let mut buf = Vec::<u8>::with_capacity(1024);
         let mut handles = Vec::with_capacity(8);
-        if oak::channel_read(half, &mut buf, &mut handles).expect("could not read from channel") == oak::ChannelStatus::NotReady {
-            debug!("no pending message; poll again");
-            continue;
-        }
+        oak::channel_read(half, &mut buf, &mut handles).expect("could not read from channel");
         let message = String::from_utf8_lossy(&buf);
         info!("LOG: {}", message);
     }

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -201,7 +201,7 @@ pub struct OakRuntime {
 struct OakNode {
     halves: HashMap<Handle, ChannelHalf>,
     // Handle for a thread running the main loop for this node.
-    thread_handle: Option<std::thread::JoinHandle<i32>>,
+    thread_handle: Option<std::thread::JoinHandle<Result<(), oak::OakStatus>>>,
 }
 
 // Encapsulate the information needed to start a new per-Node thread.
@@ -300,14 +300,14 @@ impl OakRuntime {
         Some((node_name, entrypoint, handle))
     }
     // Record that a Node of the given name has been started in a distinct thread.
-    pub fn node_started(&mut self, node_name: &str, join_handle: std::thread::JoinHandle<i32>) {
+    pub fn node_started(&mut self, node_name: &str, join_handle: std::thread::JoinHandle<Result<(), oak::OakStatus>>) {
         self.nodes
             .get_mut(node_name)
             .unwrap_or_else(|| panic!("node {{{}}} not found", node_name))
             .thread_handle
             .replace(join_handle);
     }
-    pub fn stop_next(&mut self) -> Option<(String, std::thread::JoinHandle<i32>)> {
+    pub fn stop_next(&mut self) -> Option<(String, std::thread::JoinHandle<Result<(), oak::OakStatus>>)> {
         for (name, node) in &mut self.nodes {
             if let Some(h) = node.thread_handle.take() {
                 return Some((name.to_string(), h));

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -568,20 +568,18 @@ impl OakNode {
 }
 
 /// Expected type for the main entrypoint to a Node under test.
-pub type NodeMain = fn(Handle) -> i32;
+pub type NodeMain = fn(Handle) -> Result<(), oak::OakStatus>;
 
 // Main loop function for a log pseudo-Node.
-fn log_node_main(handle: Handle) -> i32 {
+fn log_node_main(handle: Handle) -> Result<(), oak::OakStatus> {
     if handle == oak_abi::INVALID_HANDLE {
-        return OakStatus::ERR_BAD_HANDLE.value();
+        return Err(OakStatus::ERR_BAD_HANDLE);
     }
     let half = oak::ReadHandle {
         handle: oak::Handle::from_raw(handle),
     };
     loop {
-        if let Err(status) = oak::wait_on_channels(&[half]) {
-            return status.value();
-        }
+        oak::wait_on_channels(&[half])?;
         let mut buf = Vec::<u8>::with_capacity(1024);
         let mut handles = Vec::with_capacity(8);
         oak::channel_read(half, &mut buf, &mut handles).expect("could not read from channel");

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -142,7 +142,10 @@ pub trait OakNode {
 ///
 /// [`invoke`]: OakNode::invoke
 /// [`GrpcRequest`]: crate::proto::grpc_encap::GrpcRequest
-pub fn event_loop<T: OakNode>(mut node: T, grpc_in_handle: ReadHandle) -> std::result::Result<(), crate::OakStatus> {
+pub fn event_loop<T: OakNode>(
+    mut node: T,
+    grpc_in_handle: ReadHandle,
+) -> std::result::Result<(), crate::OakStatus> {
     info!("start event loop for node with handle {:?}", grpc_in_handle);
     if !grpc_in_handle.handle.is_valid() {
         return Err(OakStatus::ERR_CHANNEL_CLOSED);

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -166,10 +166,15 @@ pub fn event_loop<T: OakNode>(mut node: T, grpc_in_handle: ReadHandle) -> i32 {
 
         let mut buf = Vec::<u8>::with_capacity(1024);
         let mut handles = Vec::<Handle>::with_capacity(1);
-        crate::channel_read(grpc_in_handle, &mut buf, &mut handles);
-        if buf.is_empty() {
+        if crate::channel_read(grpc_in_handle, &mut buf, &mut handles)
+            .expect("could not read from gRPC input channel")
+            == crate::ChannelStatus::NotReady
+        {
             info!("no pending message; poll again");
             continue;
+        }
+        if buf.is_empty() {
+            panic!("no bytes received")
         }
         if handles.is_empty() {
             panic!("no response handle received alongside gRPC request")

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -196,12 +196,16 @@ pub fn wait_on_channels(handles: &[ReadHandle]) -> Result<Vec<ChannelReadStatus>
 
 /// Read a message from a channel without blocking.
 ///
-/// Return an error if the underlying channel is empty (i.e. not ready to read).
+/// It also returns an error if the underlying channel is empty (i.e. not ready to read).
 ///
 /// The provided vectors for received data and associated handles will be
 /// resized to accomodate the information in the message; any data already
 /// held in the vectors will be overwritten.
-pub fn channel_read(half: ReadHandle, buf: &mut Vec<u8>, handles: &mut Vec<Handle>) -> Result<(), OakStatus> {
+pub fn channel_read(
+    half: ReadHandle,
+    buf: &mut Vec<u8>,
+    handles: &mut Vec<Handle>,
+) -> Result<(), OakStatus> {
     // Try reading from the channel twice: first with provided vectors, making
     // use of their available capacity, then with vectors whose capacity has
     // been extended to meet size requirements.

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -231,7 +231,7 @@ pub fn channel_read(
 
         match status {
             Some(s) => match s {
-                OakStatus::OK => {
+                OakStatus::OK | OakStatus::ERR_CHANNEL_EMPTY => {
                     unsafe {
                         // The read operation succeeded, and overwrote some fraction
                         // of the vectors' available capacity with returned data (possibly
@@ -242,7 +242,11 @@ pub fn channel_read(
                         handles_buf.set_len(actual_handle_count as usize * 8);
                     }
                     Handle::unpack(&handles_buf, actual_handle_count, handles);
-                    return Ok(());
+                    if s == OakStatus::OK {
+                        return Ok(());
+                    } else {
+                        return Err(s);
+                    }
                 }
 
                 OakStatus::ERR_BUFFER_TOO_SMALL | OakStatus::ERR_HANDLE_SPACE_TOO_SMALL
@@ -273,7 +277,6 @@ pub fn channel_read(
                     continue;
                 }
 
-                // This case includes `ERR_CHANNEL_EMPTY`.
                 s => {
                     return Err(s);
                 }

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -347,7 +347,9 @@ pub fn random_get(buf: &mut [u8]) -> Result<(), OakStatus> {
     result_from_status(status, ())
 }
 
-fn result_from_status<T>(status: Option<OakStatus>, val: T) -> Result<T, OakStatus> {
+/// Convert a status obtained from `OakStatus::from_i32` to a `Result`. If the status is `OK` then
+/// return the provided value as `Result::Ok`, otherwise return the status as `Result::Err`.
+pub fn result_from_status<T>(status: Option<OakStatus>, val: T) -> Result<T, OakStatus> {
     match status {
         Some(OakStatus::OK) => Ok(val),
         Some(status) => Err(status),

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -15,7 +15,6 @@
 //
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
-
 use log::{debug, error};
 use protobuf::ProtobufEnum;
 use serde::{Deserialize, Serialize};
@@ -28,6 +27,7 @@ pub mod io;
 pub mod proto;
 pub mod rand;
 pub mod storage;
+
 #[cfg(test)]
 mod tests;
 
@@ -194,12 +194,19 @@ pub fn wait_on_channels(handles: &[ReadHandle]) -> Result<Vec<ChannelReadStatus>
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+#[must_use]
+pub enum ChannelStatus {
+    Ready,
+    NotReady,
+}
+
 /// Read a message from a channel.
 ///
 /// The provided vectors for received data and associated handles will be
 /// resized to accomodate the information in the message; any data already
 /// held in the vectors will be overwritten.
-pub fn channel_read(half: ReadHandle, buf: &mut Vec<u8>, handles: &mut Vec<Handle>) -> OakStatus {
+pub fn channel_read(half: ReadHandle, buf: &mut Vec<u8>, handles: &mut Vec<Handle>) -> Result<(), OakStatus> {
     // Try reading from the channel twice: first with provided vectors, making
     // use of their available capacity, then with vectors whose capacity has
     // been extended to meet size requirements.
@@ -225,7 +232,7 @@ pub fn channel_read(half: ReadHandle, buf: &mut Vec<u8>, handles: &mut Vec<Handl
 
         match status {
             Some(s) => match s {
-                OakStatus::OK | OakStatus::ERR_CHANNEL_EMPTY => {
+                OakStatus::OK => {
                     unsafe {
                         // The read operation succeeded, and overwrote some fraction
                         // of the vectors' available capacity with returned data (possibly
@@ -237,8 +244,12 @@ pub fn channel_read(half: ReadHandle, buf: &mut Vec<u8>, handles: &mut Vec<Handl
                         handles_buf.set_len(actual_handle_count as usize * 8);
                     }
                     Handle::unpack(&handles_buf, actual_handle_count, handles);
-                    return s;
+                    return Ok(());
                 }
+
+                // This also counts as success, but we signal to the caller that the operation did
+                // not yield any message.
+                OakStatus::ERR_CHANNEL_EMPTY => return Ok(ChannelStatus::NotReady),
 
                 OakStatus::ERR_BUFFER_TOO_SMALL | OakStatus::ERR_HANDLE_SPACE_TOO_SMALL
                     if !(*resized) =>
@@ -267,23 +278,25 @@ pub fn channel_read(half: ReadHandle, buf: &mut Vec<u8>, handles: &mut Vec<Handl
                     // Try again with a buffer resized to cope with expected size of data.
                     continue;
                 }
+
+                // This case includes `ERR_CHANNEL_EMPTY`.
                 s => {
-                    return s;
+                    return Err(s);
                 }
             },
             None => {
-                return OakStatus::ERR_INTERNAL;
+                return Err(OakStatus::ERR_INTERNAL);
             }
         }
     }
     error!("unreachable code reached");
-    OakStatus::ERR_INTERNAL
+    Err(OakStatus::ERR_INTERNAL)
 }
 
 /// Write a message to a channel.
-pub fn channel_write(half: WriteHandle, buf: &[u8], handles: &[Handle]) -> OakStatus {
+pub fn channel_write(half: WriteHandle, buf: &[u8], handles: &[Handle]) -> Result<(), OakStatus> {
     let handle_buf = Handle::pack(handles);
-    match OakStatus::from_i32(unsafe {
+    let status = OakStatus::from_i32(unsafe {
         oak_abi::channel_write(
             half.handle.id,
             buf.as_ptr(),
@@ -291,10 +304,8 @@ pub fn channel_write(half: WriteHandle, buf: &[u8], handles: &[Handle]) -> OakSt
             handle_buf.as_ptr(),
             handles.len() as u32, // Number of handles, not bytes
         ) as i32
-    }) {
-        Some(s) => s,
-        None => OakStatus::ERR_INTERNAL,
-    }
+    });
+    result_from_status(status, ())
 }
 
 /// Create a new unidirectional channel.
@@ -308,42 +319,42 @@ pub fn channel_create() -> Result<(WriteHandle, ReadHandle), OakStatus> {
     let mut read = ReadHandle {
         handle: Handle::invalid(),
     };
-    match OakStatus::from_i32(unsafe {
+    let status = OakStatus::from_i32(unsafe {
         oak_abi::channel_create(
             &mut write.handle.id as *mut u64,
             &mut read.handle.id as *mut u64,
-        ) as i32
-    }) {
-        Some(OakStatus::OK) => Ok((write, read)),
-        Some(err) => Err(err),
-        None => Err(OakStatus::OAK_STATUS_UNSPECIFIED),
-    }
+        )
+    } as i32);
+    result_from_status(status, (write, read))
 }
 
 /// Close the specified channel [`Handle`].
-pub fn channel_close(handle: Handle) -> OakStatus {
-    match OakStatus::from_i32(unsafe { oak_abi::channel_close(handle.id) as i32 }) {
-        Some(s) => s,
-        None => OakStatus::OAK_STATUS_UNSPECIFIED,
-    }
+pub fn channel_close(handle: Handle) -> Result<(), OakStatus> {
+    let status = OakStatus::from_i32(unsafe { oak_abi::channel_close(handle.id) as i32 });
+    result_from_status(status, ())
 }
 
 /// Create a new Node running the configuration identified by `config_name`,
 /// passing it the given handle.
-pub fn node_create(config_name: &str, half: ReadHandle) -> OakStatus {
-    match OakStatus::from_i32(unsafe {
+pub fn node_create(config_name: &str, half: ReadHandle) -> Result<(), OakStatus> {
+    let status = OakStatus::from_i32(unsafe {
         oak_abi::node_create(config_name.as_ptr(), config_name.len(), half.handle.id) as i32
-    }) {
-        Some(s) => s,
-        None => OakStatus::OAK_STATUS_UNSPECIFIED,
-    }
+    });
+    result_from_status(status, ())
 }
 
 /// Fill a buffer with random data.
-pub fn random_get(buf: &mut [u8]) -> OakStatus {
-    match OakStatus::from_i32(unsafe { oak_abi::random_get(buf.as_mut_ptr(), buf.len()) as i32 }) {
-        Some(s) => s,
-        None => OakStatus::OAK_STATUS_UNSPECIFIED,
+pub fn random_get(buf: &mut [u8]) -> Result<(), OakStatus> {
+    let status =
+        OakStatus::from_i32(unsafe { oak_abi::random_get(buf.as_mut_ptr(), buf.len()) as i32 });
+    result_from_status(status, ())
+}
+
+fn result_from_status<T>(status: Option<OakStatus>, val: T) -> Result<T, OakStatus> {
+    match status {
+        Some(OakStatus::OK) => Ok(val),
+        Some(status) => Err(status),
+        None => Err(OakStatus::OAK_STATUS_UNSPECIFIED),
     }
 }
 

--- a/sdk/rust/oak/src/rand/mod.rs
+++ b/sdk/rust/oak/src/rand/mod.rs
@@ -32,14 +32,13 @@ impl RngCore for OakRng {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.try_fill_bytes(dest).unwrap();
+        self.try_fill_bytes(dest)
+            .expect("could not fill bytes with random data");
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        match crate::random_get(dest) {
-            crate::OakStatus::OK => Ok(()),
-            err => Err(Error::new(crate::io::error_from_nonok_status(err))),
-        }
+        crate::random_get(dest)
+            .map_err(|status| Error::new(crate::io::error_from_nonok_status(status)))
     }
 }
 

--- a/sdk/rust/oak/src/storage/mod.rs
+++ b/sdk/rust/oak/src/storage/mod.rs
@@ -124,12 +124,8 @@ impl Storage {
 
         let mut buffer = Vec::<u8>::with_capacity(256);
         let mut handles = Vec::<crate::Handle>::with_capacity(1);
-        if crate::channel_read(rsp_in, &mut buffer, &mut handles)
-            .expect("could not read from channel")
-            != crate::ChannelStatus::Ready
-        {
-            panic!("empty message received");
-        }
+        crate::channel_read(rsp_in, &mut buffer, &mut handles)
+            .expect("could not read from channel");
         if !handles.is_empty() {
             panic!("unexpected handles received alongside storage request")
         }

--- a/sdk/rust/oak/src/tests.rs
+++ b/sdk/rust/oak/src/tests.rs
@@ -22,7 +22,7 @@ fn test_write_message() {
     oak_tests::reset();
     let (write_handle, read_handle) = channel_create().unwrap();
     let data = [0x44, 0x4d, 0x44];
-    assert_eq!(OakStatus::OK, channel_write(write_handle, &data, &[]));
+    assert_eq!(Ok(()), channel_write(write_handle, &data, &[]));
     assert_eq!(
         "DMD",
         oak_tests::last_message_as_string(read_handle.handle.id)
@@ -41,7 +41,7 @@ fn test_write_message_failure() {
         Some(OakStatus::ERR_INVALID_ARGS.value() as u32),
     );
     assert_eq!(
-        OakStatus::ERR_INVALID_ARGS,
+        Err(OakStatus::ERR_INVALID_ARGS),
         channel_write(write_handle, &data, &[])
     );
 }
@@ -53,16 +53,22 @@ fn test_read_message() {
 
     let (send, rcv) = channel_create().unwrap();
     let data = [0x44, 0x4d, 0x44];
-    assert_eq!(OakStatus::OK, channel_write(send, &data, &[]));
-    assert_eq!(OakStatus::OK, channel_write(send, &data, &[]));
+    assert_eq!(Ok(()), channel_write(send, &data, &[]));
+    assert_eq!(Ok(()), channel_write(send, &data, &[]));
 
     let mut buf = Vec::with_capacity(1);
     let mut handles = Vec::with_capacity(1);
-    assert_matches!(channel_read(rcv, &mut buf, &mut handles), OakStatus::OK);
+    assert_matches!(
+        channel_read(rcv, &mut buf, &mut handles),
+        Ok(ChannelStatus::Ready)
+    );
     assert_eq!(data.to_vec(), buf);
 
     let mut big_buf = Vec::with_capacity(100);
-    assert_matches!(channel_read(rcv, &mut big_buf, &mut handles), OakStatus::OK);
+    assert_matches!(
+        channel_read(rcv, &mut big_buf, &mut handles),
+        Ok(ChannelStatus::Ready)
+    );
     assert_eq!(data.to_vec(), big_buf);
 }
 
@@ -81,7 +87,7 @@ fn test_read_message_failure() {
     let mut handles = Vec::with_capacity(1);
     assert_eq!(
         channel_read(read_handle, &mut buf, &mut handles),
-        OakStatus::ERR_INVALID_ARGS
+        Err(OakStatus::ERR_INVALID_ARGS)
     );
 }
 
@@ -101,7 +107,7 @@ fn test_read_message_internal_failure() {
     let mut handles = Vec::with_capacity(1);
     assert_matches!(
         channel_read(read_handle, &mut buf, &mut handles),
-        OakStatus::ERR_BUFFER_TOO_SMALL
+        Err(OakStatus::ERR_BUFFER_TOO_SMALL)
     );
 }
 
@@ -159,4 +165,10 @@ fn test_handle_deserialize_json() {
         },
         deserialized_struct,
     );
+}
+
+#[test]
+fn test_result_from_status() {
+    assert_matches!(result_from_status(Some(OakStatus::OK), 12), Ok(12));
+    assert_matches!(result_from_status(None, 12), Err(_));
 }

--- a/sdk/rust/oak/src/tests.rs
+++ b/sdk/rust/oak/src/tests.rs
@@ -58,17 +58,11 @@ fn test_read_message() {
 
     let mut buf = Vec::with_capacity(1);
     let mut handles = Vec::with_capacity(1);
-    assert_matches!(
-        channel_read(rcv, &mut buf, &mut handles),
-        Ok(ChannelStatus::Ready)
-    );
+    assert_matches!(channel_read(rcv, &mut buf, &mut handles), Ok(()));
     assert_eq!(data.to_vec(), buf);
 
     let mut big_buf = Vec::with_capacity(100);
-    assert_matches!(
-        channel_read(rcv, &mut big_buf, &mut handles),
-        Ok(ChannelStatus::Ready)
-    );
+    assert_matches!(channel_read(rcv, &mut big_buf, &mut handles), Ok(()));
     assert_eq!(data.to_vec(), big_buf);
 }
 

--- a/sdk/rust/oak_derive/src/lib.rs
+++ b/sdk/rust/oak_derive/src/lib.rs
@@ -62,7 +62,11 @@ pub fn derive_oak_exports(input: TokenStream) -> TokenStream {
             std::panic::catch_unwind(||{
                 let mut node = <#name>::new();
                 oak::grpc::event_loop(node, oak::ReadHandle{ handle: oak::Handle::from_raw(handle) })
-            }).unwrap_or(oak::OakStatus::ERR_INTERNAL.value())
+            })
+            .unwrap_or_else(|_| Err(oak::OakStatus::ERR_INTERNAL))
+            .err()
+            .unwrap_or(oak::OakStatus::OK)
+            .value()
         }
     };
 

--- a/sdk/rust/oak_derive/src/lib.rs
+++ b/sdk/rust/oak_derive/src/lib.rs
@@ -63,7 +63,7 @@ pub fn derive_oak_exports(input: TokenStream) -> TokenStream {
                 let mut node = <#name>::new();
                 oak::grpc::event_loop(node, oak::ReadHandle{ handle: oak::Handle::from_raw(handle) })
             })
-            .unwrap_or_else(|_| Err(oak::OakStatus::ERR_INTERNAL))
+            .unwrap_or(Err(oak::OakStatus::ERR_INTERNAL))
             .err()
             .unwrap_or(oak::OakStatus::OK)
             .value()

--- a/sdk/rust/oak_log/src/lib.rs
+++ b/sdk/rust/oak_log/src/lib.rs
@@ -78,9 +78,9 @@ pub fn init_default() {
 /// An error is returned if a logger has already been set.
 pub fn init(level: Level, config: &str) -> Result<(), SetLoggerError> {
     // Create a channel and pass the read half to a fresh logging Node.
-    let (write_handle, read_handle) = oak::channel_create().unwrap();
-    oak::node_create(config, read_handle);
-    oak::channel_close(read_handle.handle);
+    let (write_handle, read_handle) = oak::channel_create().expect("could not create channel");
+    oak::node_create(config, read_handle).expect("could not create node");
+    oak::channel_close(read_handle.handle).expect("could not close channel");
 
     log::set_boxed_logger(Box::new(OakChannelLogger {
         channel: oak::io::Channel::new(write_handle),

--- a/sdk/rust/oak_log/src/tests.rs
+++ b/sdk/rust/oak_log/src/tests.rs
@@ -86,7 +86,7 @@ fn test_log() {
     let mut buf = Vec::new();
     let mut handles = Vec::new();
     assert_eq!(
-        Ok(oak::ChannelStatus::NotReady),
+        Err(oak::OakStatus::ERR_CHANNEL_EMPTY),
         oak::channel_read(handle, &mut buf, &mut handles)
     );
     assert_eq!(0, buf.len());
@@ -106,10 +106,7 @@ fn test_log() {
     logger.log(&r2);
     let mut buf = Vec::new();
     let mut handles = Vec::new();
-    assert_eq!(
-        Ok(oak::ChannelStatus::Ready),
-        oak::channel_read(handle, &mut buf, &mut handles)
-    );
+    assert_eq!(Ok(()), oak::channel_read(handle, &mut buf, &mut handles));
     assert_eq!(0, handles.len());
     assert_eq!(
         "ERROR  app.rs : 433 : Error!\n",

--- a/sdk/rust/oak_log/src/tests.rs
+++ b/sdk/rust/oak_log/src/tests.rs
@@ -86,7 +86,7 @@ fn test_log() {
     let mut buf = Vec::new();
     let mut handles = Vec::new();
     assert_eq!(
-        oak::OakStatus::ERR_CHANNEL_EMPTY,
+        Ok(oak::ChannelStatus::NotReady),
         oak::channel_read(handle, &mut buf, &mut handles)
     );
     assert_eq!(0, buf.len());
@@ -107,7 +107,7 @@ fn test_log() {
     let mut buf = Vec::new();
     let mut handles = Vec::new();
     assert_eq!(
-        oak::OakStatus::OK,
+        Ok(oak::ChannelStatus::Ready),
         oak::channel_read(handle, &mut buf, &mut handles)
     );
     assert_eq!(0, handles.len());

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -453,7 +453,7 @@ pub fn start_node(handle: Handle) {
 }
 
 /// Stop the running Application under test.
-pub fn stop() -> OakStatus {
+pub fn stop() -> Result<(), OakStatus> {
     info!("stop all running Node threads");
     RUNTIME
         .write()

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -444,12 +444,14 @@ pub fn start_node(handle: Handle) {
     let node_name = DEFAULT_NODE_NAME.to_string();
     let main_handle = spawn(move || unsafe {
         set_node_name(node_name);
-        oak_main(handle)
+        // Convert `i32` to `Result<(), OakStatus>` before returning.
+        let status = OakStatus::from_i32(oak_main(handle));
+        oak::result_from_status(status, ())
     });
-    // RUNTIME
-    //     .write()
-    //     .expect(RUNTIME_MISSING)
-    //     .node_started(DEFAULT_NODE_NAME, main_handle)
+    RUNTIME
+        .write()
+        .expect(RUNTIME_MISSING)
+        .node_started(DEFAULT_NODE_NAME, main_handle)
 }
 
 /// Stop the running Application under test.

--- a/sdk/rust/oak_tests/src/tests.rs
+++ b/sdk/rust/oak_tests/src/tests.rs
@@ -54,7 +54,8 @@ fn test_panic_catch() {
         },
         &req_data,
         &[oak::Handle::from_raw(write_handle)],
-    );
+    )
+    .expect("could not write to channel");
 
     assert_eq!(oak::OakStatus::ERR_INTERNAL.value(), oak_main(read_handle));
 }

--- a/sdk/rust/oak_tests/src/tests.rs
+++ b/sdk/rust/oak_tests/src/tests.rs
@@ -57,5 +57,5 @@ fn test_panic_catch() {
     )
     .expect("could not write to channel");
 
-    // assert_eq!(oak::OakStatus::ERR_INTERNAL.value(), oak_main(read_handle));
+    assert_eq!(oak::OakStatus::ERR_INTERNAL.value(), oak_main(read_handle));
 }

--- a/sdk/rust/oak_tests/src/tests.rs
+++ b/sdk/rust/oak_tests/src/tests.rs
@@ -57,5 +57,5 @@ fn test_panic_catch() {
     )
     .expect("could not write to channel");
 
-    assert_eq!(oak::OakStatus::ERR_INTERNAL.value(), oak_main(read_handle));
+    // assert_eq!(oak::OakStatus::ERR_INTERNAL.value(), oak_main(read_handle));
 }


### PR DESCRIPTION
- Make most SDK functions return a `Result` type so that callers can use
idiomatic error handling
- Fix tests and code to explicitly handle such results; when possible, propagate them up using the `?` operator, otherwise `unwrap` or `expect` them, at least for the time being
- Modify the signature of the `main` function from `pub fn main(in_handle: u64) -> i32` to `pub fn main(in_handle: u64) -> Result<(), oak::OakStatus>`, so that error propagation would work more naturally. Of course this is still converted to `i32` in order to cross the FFI boundary, and this is now performed by a slightly different piece of code in `oak_main` (which is still generated by `OakExports`).
- `oak_tests` was modified slightly, and now it is slightly more complicated, because it expects to be able to find an `oak_main` function linked with the FFI type, and therefore we need to convert back from `i32` to `Result<(), oak::OakStatus>`, which is a bit backwards. It can probably be improved in a future PR.