### PR TITLE
Add placeholders for Wasm imports

### DIFF
--- a/examples/tensorflow/module/cpp/BUILD
+++ b/examples/tensorflow/module/cpp/BUILD
@@ -42,9 +42,19 @@ cc_binary(
         "-s STANDALONE_WASM=1",  # WASM file should run without JavaScript.
         "-s WARN_ON_UNDEFINED_SYMBOLS=0",
         "-s WASM=1",
+
+        "-s USE_SDL=0",
+        "-nostdlib"
+        #"-s ONLY_MY_CODE=1",
+        #"-v",
+        #"-s SINGLE_FILE",
+        #"-s SIDE_MODULE=1",
+        #"-s MAIN_MODULE=1",
+        #"-s EMCC_FORCE_STDLIBS=1",
     ],
     deps = [
         "//oak/module:defines",
+        "//oak/module:placeholders",
         # TODO: Sort out inclusion of protobuf files
         # "//oak/proto:oak_api_cc_proto",
         "@org_tensorflow//tensorflow/lite:framework",

--- a/examples/tensorflow/module/cpp/BUILD
+++ b/examples/tensorflow/module/cpp/BUILD
@@ -42,9 +42,8 @@ cc_binary(
         "-s STANDALONE_WASM=1",  # WASM file should run without JavaScript.
         "-s WARN_ON_UNDEFINED_SYMBOLS=0",
         "-s WASM=1",
-
         "-s USE_SDL=0",
-        "-nostdlib"
+        "-nostdlib",
         #"-s ONLY_MY_CODE=1",
         #"-v",
         #"-s SINGLE_FILE",

--- a/examples/tensorflow/module/cpp/BUILD
+++ b/examples/tensorflow/module/cpp/BUILD
@@ -42,14 +42,6 @@ cc_binary(
         "-s STANDALONE_WASM=1",  # WASM file should run without JavaScript.
         "-s WARN_ON_UNDEFINED_SYMBOLS=0",
         "-s WASM=1",
-        "-s USE_SDL=0",
-        "-nostdlib",
-        #"-s ONLY_MY_CODE=1",
-        #"-v",
-        #"-s SINGLE_FILE",
-        #"-s SIDE_MODULE=1",
-        #"-s MAIN_MODULE=1",
-        #"-s EMCC_FORCE_STDLIBS=1",
     ],
     deps = [
         "//oak/module:defines",

--- a/examples/tensorflow/module/cpp/tensorflow.cc
+++ b/examples/tensorflow/module/cpp/tensorflow.cc
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include "oak/module/defines.h"  // for imports and exports
+#include "oak/module/placeholders.h"
 #include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/kernels/register.h"
 #include "tensorflow/lite/model.h"

--- a/oak/module/BUILD
+++ b/oak/module/BUILD
@@ -25,3 +25,9 @@ cc_library(
     hdrs = ["defines.h"],
     visibility = ["//visibility:public"],
 )
+
+cc_library(
+    name = "placeholders",
+    hdrs = ["placeholders.h"],
+    visibility = ["//visibility:public"],
+)

--- a/oak/module/placeholders.h
+++ b/oak/module/placeholders.h
@@ -17,6 +17,7 @@
 #ifndef OAK_MODULE_PLACEHOLDERS_H_
 #define OAK_MODULE_PLACEHOLDERS_H_
 
+#include <assert.h>
 #include <math.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -26,7 +27,13 @@
 #include <time.h>
 #include <unistd.h>
 
-// These placeholders were originally added to remove imports from the TensorFlow Lite.
+// When Emscripten generates a Wasm file from TensorFlow, it leaves unresolved symbols 
+// (imported functions), and these symbols prevend running TensorFlow in the Oak Runtime.
+// So we currently patch these unresolved symbols with non-functional implementations.
+// TODO: These placeholders should be deleted after resolving:
+// https://github.com/project-oak/oak/issues/482
+#define PLACEHOLDER(ret, name, ...) ret name(__VA_ARGS__) { abort(); }
+
 extern "C" {
 
 int __syscall5(int, int) { return NULL; }
@@ -45,6 +52,9 @@ int nanosleep(const struct timespec*, struct timespec*) { return NULL; }
 
 double round(double x) { return __builtin_round(x); }
 float roundf(float x) { return __builtin_roundf(x); }
+
+// The implementation was taken from:
+// https://github.com/m-labs/compiler-rt-lm32/blob/06cc76fb7060dcd822cd67ca9affef9cadf8c443/lib/powidf2.c#L19-L34
 double __powidf2(double a, int b) {
   const int recip = b < 0;
   double r = 1;

--- a/oak/module/placeholders.h
+++ b/oak/module/placeholders.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_MODULE_PLACEHOLDERS_H_
+#define OAK_MODULE_PLACEHOLDERS_H_
+
+#include <math.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+// These placeholders were originally added to remove imports from the TensorFlow Lite.
+extern "C" {
+
+int __syscall5(int, int) { return NULL; }
+int __syscall192(int, int) { return NULL; }
+int __syscall194(int, int) { return NULL; }
+
+int fstat(int, struct stat*) { return NULL; }
+ssize_t lgetxattr(const char*, const char*, void*, size_t) { return NULL; }
+ssize_t listxattr(const char*, char*, size_t) { return NULL; }
+
+void* dlopen(const char*, int) { return NULL; }
+long sysconf(int) { return NULL; }
+
+int clock_gettime(clockid_t, struct timespec*) { return NULL; }
+int nanosleep(const struct timespec*, struct timespec*) { return NULL; }
+
+double round(double x) { return __builtin_round(x); }
+float roundf(float x) { return __builtin_roundf(x); }
+double __powidf2(double a, int b) {
+  const int recip = b < 0;
+  double r = 1;
+  while (1) {
+    if (b & 1) r *= a;
+    b /= 2;
+    if (b == 0) break;
+    a *= a;
+  }
+  return recip ? 1 / r : r;
+}
+
+int pthread_cond_destroy(pthread_cond_t*) { return NULL; }
+int pthread_cond_init(pthread_cond_t*, const pthread_condattr_t*) { return NULL; }
+int pthread_create(pthread_t*, const pthread_attr_t*, void* (*)(void*), void*) { return NULL; }
+int pthread_equal(pthread_t, pthread_t) { return NULL; }
+void pthread_exit(void*) { exit(0); }
+int pthread_join(pthread_t, void**) { return NULL; }
+int pthread_setcancelstate(int, int*) { return NULL; }
+
+}  // extern "C"
+
+#endif  // OAK_MODULE_PLACEHOLDERS_H_

--- a/oak/module/placeholders.h
+++ b/oak/module/placeholders.h
@@ -27,12 +27,13 @@
 #include <time.h>
 #include <unistd.h>
 
-// When Emscripten generates a Wasm file from TensorFlow, it leaves unresolved symbols 
+// When Emscripten generates a Wasm file from TensorFlow, it leaves unresolved symbols
 // (imported functions), and these symbols prevend running TensorFlow in the Oak Runtime.
 // So we currently patch these unresolved symbols with non-functional implementations.
 // TODO: These placeholders should be deleted after resolving:
 // https://github.com/project-oak/oak/issues/482
-#define PLACEHOLDER(ret, func, ...) ret func(__VA_ARGS__) { abort(); }
+#define PLACEHOLDER(ret, func, ...) \
+  ret func(__VA_ARGS__) { abort(); }
 
 extern "C" {
 
@@ -68,11 +69,9 @@ double __powidf2(double a, int b) {
   const int recip = b < 0;
   double r = 1;
   while (1) {
-    if (b & 1)
-      r *= a;
+    if (b & 1) r *= a;
     b /= 2;
-    if (b == 0)
-      break;
+    if (b == 0) break;
     a *= a;
   }
   return recip ? 1 / r : r;

--- a/oak/module/placeholders.h
+++ b/oak/module/placeholders.h
@@ -32,48 +32,51 @@
 // So we currently patch these unresolved symbols with non-functional implementations.
 // TODO: These placeholders should be deleted after resolving:
 // https://github.com/project-oak/oak/issues/482
-#define PLACEHOLDER(ret, name, ...) ret name(__VA_ARGS__) { abort(); }
+#define PLACEHOLDER(ret, func, ...) ret func(__VA_ARGS__) { abort(); }
 
 extern "C" {
 
-int __syscall5(int, int) { return NULL; }
-int __syscall192(int, int) { return NULL; }
-int __syscall194(int, int) { return NULL; }
+PLACEHOLDER(int, __syscall5, int, int)
+PLACEHOLDER(int, __syscall192, int, int)
+PLACEHOLDER(int, __syscall194, int, int)
 
-int fstat(int, struct stat*) { return NULL; }
-ssize_t lgetxattr(const char*, const char*, void*, size_t) { return NULL; }
-ssize_t listxattr(const char*, char*, size_t) { return NULL; }
+PLACEHOLDER(int, fstat, int, struct stat*)
+PLACEHOLDER(ssize_t, lgetxattr, const char*, const char*, void*, size_t)
+PLACEHOLDER(ssize_t, listxattr, const char*, char*, size_t)
 
-void* dlopen(const char*, int) { return NULL; }
-long sysconf(int) { return NULL; }
+PLACEHOLDER(void*, dlopen, const char*, int)
+PLACEHOLDER(void*, dlsym, void*, const char*)
+PLACEHOLDER(long, sysconf, int)
 
-int clock_gettime(clockid_t, struct timespec*) { return NULL; }
-int nanosleep(const struct timespec*, struct timespec*) { return NULL; }
+PLACEHOLDER(int, clock_gettime, clockid_t, struct timespec*)
+PLACEHOLDER(int, nanosleep, const struct timespec*, struct timespec*)
+
+PLACEHOLDER(int, pthread_cond_destroy, pthread_cond_t*)
+PLACEHOLDER(int, pthread_cond_init, pthread_cond_t*, const pthread_condattr_t*)
+PLACEHOLDER(int, pthread_create, pthread_t*, const pthread_attr_t*, void* (*)(void*), void*)
+PLACEHOLDER(int, pthread_equal, pthread_t, pthread_t)
+PLACEHOLDER(void, pthread_exit, void*)
+PLACEHOLDER(int, pthread_join, pthread_t, void**)
+PLACEHOLDER(int, pthread_setcancelstate, int, int*)
 
 double round(double x) { return __builtin_round(x); }
 float roundf(float x) { return __builtin_roundf(x); }
 
 // The implementation was taken from:
-// https://github.com/m-labs/compiler-rt-lm32/blob/06cc76fb7060dcd822cd67ca9affef9cadf8c443/lib/powidf2.c#L19-L34
+// https://github.com/llvm-mirror/compiler-rt/blob/f0745e8476f069296a7c71accedd061dce4cdf79/lib/builtins/powidf2.c#L17-L29
 double __powidf2(double a, int b) {
   const int recip = b < 0;
   double r = 1;
   while (1) {
-    if (b & 1) r *= a;
+    if (b & 1)
+      r *= a;
     b /= 2;
-    if (b == 0) break;
+    if (b == 0)
+      break;
     a *= a;
   }
   return recip ? 1 / r : r;
 }
-
-int pthread_cond_destroy(pthread_cond_t*) { return NULL; }
-int pthread_cond_init(pthread_cond_t*, const pthread_condattr_t*) { return NULL; }
-int pthread_create(pthread_t*, const pthread_attr_t*, void* (*)(void*), void*) { return NULL; }
-int pthread_equal(pthread_t, pthread_t) { return NULL; }
-void pthread_exit(void*) { exit(0); }
-int pthread_join(pthread_t, void**) { return NULL; }
-int pthread_setcancelstate(int, int*) { return NULL; }
 
 }  // extern "C"
 


### PR DESCRIPTION
This change adds placeholder functions to reduce the amount of Wasm imports from the TensorFlow example, that was built with Emscripten.

Fixes #439