### PR TITLE
Add `.rustfmt.toml` configuration file

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,7 @@
+# See https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
+
+comment_width = 100
+format_code_in_doc_comments = true
+max_width = 100
+normalize_doc_attributes = true
+wrap_comments = true

--- a/sdk/rust/oak_derive/src/lib.rs
+++ b/sdk/rust/oak_derive/src/lib.rs
@@ -40,8 +40,12 @@ use quote::quote;
 /// struct Node;
 ///
 /// impl OakNode for Node {
-///     fn new() -> Self { Node }
-///     fn invoke(&mut self, method: &str, req: &[u8], writer: oak::grpc::ChannelResponseWriter) { /* ... */ }
+///     fn new() -> Self {
+///         Node
+///     }
+///     fn invoke(&mut self, method: &str, req: &[u8], writer: oak::grpc::ChannelResponseWriter) {
+///         /* ... */
+///     }
 /// }
 /// ```
 #[proc_macro_derive(OakExports)]


### PR DESCRIPTION
Mostly with comment-related settings.

I have re-run `cargo fmt` with these settings, but it does not reflow
comments that are already shorter than the limit, so we may have to do a
separate pass to fix them if we care about it.