### PR TITLE
Support additional panic hook payload types

### DIFF
--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -308,10 +308,14 @@ pub fn random_get(buf: &mut [u8]) -> OakStatus {
 /// [panic information]: std::panic::PanicInfo
 pub fn set_panic_hook() {
     std::panic::set_hook(Box::new(|panic_info| {
-        let msg = panic_info
-            .payload()
-            .downcast_ref::<&str>()
-            .unwrap_or(&"<UNKNOWN MESSAGE>");
+        let payload = panic_info.payload();
+        let msg = match payload.downcast_ref::<&'static str>() {
+            Some(content) => *content,
+            None => match payload.downcast_ref::<String>() {
+                Some(content) => &content[..],
+                None => "<UNKNOWN MESSAGE>",
+            },
+        };
         let (file, line) = match panic_info.location() {
             Some(location) => (location.file(), location.line()),
             None => ("<UNKNOWN FILE>", 0),

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -309,6 +309,9 @@ pub fn random_get(buf: &mut [u8]) -> OakStatus {
 pub fn set_panic_hook() {
     std::panic::set_hook(Box::new(|panic_info| {
         let payload = panic_info.payload();
+        // The payload can be a static string slice or a string, depending on how panic was called.
+        // Code for extracting the message is inspired by the rust default panic hook:
+        // https://github.com/rust-lang/rust/blob/master/src/libstd/panicking.rs#L188-L194
         let msg = match payload.downcast_ref::<&'static str>() {
             Some(content) => *content,
             None => match payload.downcast_ref::<String>() {


### PR DESCRIPTION
Code is inspired by the default panic hook.

https://github.com/rust-lang/rust/blob/7d761fe0462ba0f671a237d0bb35e3579b8ba0e8/src/libstd/panicking.rs#L171-L177