### PR TITLE
Cargo update ambiguous version fix

### DIFF
--- a/examples/abitest/module_0/rust/Cargo.toml
+++ b/examples/abitest/module_0/rust/Cargo.toml
@@ -12,7 +12,7 @@ abitest_common = { path = "../../abitest_common" }
 byteorder = "1"
 expect = { path = "../../../../third_party/expect" }
 log = "*"
-oak = "*"
+oak = "=0.1.0"
 oak_abi = "*"
 oak_log = "*"
 protobuf = "*"

--- a/examples/abitest/module_1/rust/Cargo.toml
+++ b/examples/abitest/module_1/rust/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 log = "*"
 abitest_common = { path = "../../abitest_common" }
-oak = "*"
+oak = "=0.1.0"
 oak_log = "*"
 protobuf = "*"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/abitest/tests/Cargo.toml
+++ b/examples/abitest/tests/Cargo.toml
@@ -11,13 +11,13 @@ crate-type = ["dylib"]
 abitest_0_frontend = { path = "../module_0/rust" }
 abitest_1_backend = { path = "../module_1/rust" }
 log = "*"
-oak = "*"
+oak = "=0.1.0"
 oak_log = "*"
 protobuf = "*"
 
 [dev-dependencies]
 assert_matches = "*"
-oak_runtime = "*"
+oak_runtime = "=0.1.0"
 oak_tests = "*"
 serial_test = "0.2"
 serial_test_derive = "0.2"

--- a/examples/chat/common/Cargo.toml
+++ b/examples/chat/common/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["lib"]
 
 [dependencies]
 log = "*"
-oak = "*"
+oak = "=0.1.0"
 protobuf = "*"
 bincode = "*"
 serde = {version = "*", features = ["derive"]}

--- a/examples/chat/module_0/rust/Cargo.toml
+++ b/examples/chat/module_0/rust/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 chat_common = { path = "../../common" }
 log = "*"
-oak = "*"
+oak = "=0.1.0"
 oak_derive = "*"
 oak_log = "*"
 protobuf = "*"

--- a/examples/chat/module_1/rust/Cargo.toml
+++ b/examples/chat/module_1/rust/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 chat_common = { path = "../../common" }
 log = "*"
-oak = "*"
+oak = "=0.1.0"
 oak_log = "*"
 protobuf = "*"

--- a/examples/hello_world/module/rust/Cargo.toml
+++ b/examples/hello_world/module/rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 log = "*"
-oak = "*"
+oak = "=0.1.0"
 oak_derive = "*"
 oak_log = "*"
 protobuf = "*"

--- a/examples/machine_learning/module/rust/Cargo.toml
+++ b/examples/machine_learning/module/rust/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 rusty-machine = "*"
 rand = "*"
 rand_distr = "*"
-oak = "*"
+oak = "=0.1.0"
 oak_derive = "*"
 protobuf = "*"

--- a/examples/private_set_intersection/module/rust/Cargo.toml
+++ b/examples/private_set_intersection/module/rust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-oak = "*"
+oak = "=0.1.0"
 oak_derive = "*"
 protobuf = "*"
 

--- a/examples/running_average/module/rust/Cargo.toml
+++ b/examples/running_average/module/rust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-oak = "*"
+oak = "=0.1.0"
 oak_derive = "*"
 protobuf = "*"
 

--- a/examples/rustfmt/module/rust/Cargo.toml
+++ b/examples/rustfmt/module/rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 log = "*"
-oak = "*"
+oak = "=0.1.0"
 oak_derive = "*"
 oak_log = "*"
 protobuf = "*"

--- a/oak/server/rust/oak_runtime/Cargo.toml
+++ b/oak/server/rust/oak_runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 log = { version = "^0.4.0", features = ["std"] }
-oak = "*"
+oak = "=0.1.0"
 oak_abi = "*"
 protobuf = "*"
 rand = { version = "0.7", features = ["std"] }

--- a/sdk/rust/oak_derive/Cargo.toml
+++ b/sdk/rust/oak_derive/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 proc-macro = true
 
 [dependencies]
-oak = "*"
+oak = "=0.1.0"
 protobuf = "*"
 quote = "*"
 syn = { version = "*", features = ["extra-traits"]}

--- a/sdk/rust/oak_log/Cargo.toml
+++ b/sdk/rust/oak_log/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-oak = "*"
+oak = "=0.1.0"
 log = { version = "^0.4.0", features = ["std"] }
 
 [dev-dependencies]

--- a/sdk/rust/oak_tests/Cargo.toml
+++ b/sdk/rust/oak_tests/Cargo.toml
@@ -9,11 +9,11 @@ license = "Apache-2.0"
 byteorder = "1"
 lazy_static = "1.4"
 log = { version = "^0.4.0", features = ["std"] }
+oak = "=0.1.0"
 oak_abi = "*"
 oak_derive = "*"
 oak_log = "*"
-oak_runtime = "*"
-oak = "*"
+oak_runtime = "=0.1.0"
 protobuf = "*"
 rand = { version = "0.7", features = ["std"] }
 simple_logger = "1"


### PR DESCRIPTION
This change adds `=0.1.0` oak version to `Cargo.toml` files to remove intersection with existing `oak` crate on `crates.io`.

Fixes #477
