### PR TITLE
Replace tuple with named struct for `oak::io`

### DIFF
--- a/sdk/rust/oak/src/io/decodable.rs
+++ b/sdk/rust/oak/src/io/decodable.rs
@@ -14,9 +14,10 @@
 // limitations under the License.
 //
 
-use crate::{Handle, OakError};
+use crate::io::Message;
+use crate::OakError;
 
 /// A trait for objects that can be decoded from bytes + handles.
 pub trait Decodable: Sized {
-    fn decode(bytes: &[u8], handles: &[Handle]) -> Result<Self, OakError>;
+    fn decode(message: &Message) -> Result<Self, OakError>;
 }

--- a/sdk/rust/oak/src/io/encodable.rs
+++ b/sdk/rust/oak/src/io/encodable.rs
@@ -14,9 +14,10 @@
 // limitations under the License.
 //
 
-use crate::{Handle, OakError};
+use crate::io::Message;
+use crate::OakError;
 
 /// A trait for objects that can be encoded as bytes + handles.
 pub trait Encodable {
-    fn encode(&self) -> Result<(Vec<u8>, Vec<Handle>), OakError>;
+    fn encode(&self) -> Result<Message, OakError>;
 }

--- a/sdk/rust/oak/src/io/mod.rs
+++ b/sdk/rust/oak/src/io/mod.rs
@@ -29,6 +29,13 @@ pub use encodable::Encodable;
 pub use receiver::Receiver;
 pub use sender::Sender;
 
+/// A simple holder for bytes + handles, using internally owned buffers.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Message {
+    pub bytes: Vec<u8>,
+    pub handles: Vec<crate::Handle>,
+}
+
 /// Map a non-OK [`OakStatus`] value to the nearest available [`std::io::Error`].
 ///
 /// Panics if passed an `OakStatus::OK` value.

--- a/sdk/rust/oak/src/io/receiver.rs
+++ b/sdk/rust/oak/src/io/receiver.rs
@@ -61,7 +61,9 @@ impl Receiver {
         let mut bytes = Vec::with_capacity(1024);
         let mut handles = Vec::with_capacity(16);
         crate::channel_read(self.handle, &mut bytes, &mut handles)?;
-        T::decode(&bytes, &handles)
+        // `bytes` and `handles` are moved into `Message`, so there is no extra copy happening here.
+        let message = crate::io::Message { bytes, handles };
+        T::decode(&message)
     }
 
     /// Wait for a value to be available from this receiver.

--- a/sdk/rust/oak/src/io/sender.rs
+++ b/sdk/rust/oak/src/io/sender.rs
@@ -46,8 +46,8 @@ impl Sender {
     where
         T: Encodable,
     {
-        let (bytes, handles) = t.encode()?;
-        crate::channel_write(self.handle, &bytes, &handles)?;
+        let message = t.encode()?;
+        crate::channel_write(self.handle, &message.bytes, &message.handles)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This will be needed as part of #488 when implementing a node routing
messages based on policies.

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
