### PR TITLE
Run cargo doc tests

### DIFF
--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -300,14 +300,20 @@ impl OakRuntime {
         Some((node_name, entrypoint, handle))
     }
     // Record that a Node of the given name has been started in a distinct thread.
-    pub fn node_started(&mut self, node_name: &str, join_handle: std::thread::JoinHandle<Result<(), oak::OakStatus>>) {
+    pub fn node_started(
+        &mut self,
+        node_name: &str,
+        join_handle: std::thread::JoinHandle<Result<(), oak::OakStatus>>,
+    ) {
         self.nodes
             .get_mut(node_name)
             .unwrap_or_else(|| panic!("node {{{}}} not found", node_name))
             .thread_handle
             .replace(join_handle);
     }
-    pub fn stop_next(&mut self) -> Option<(String, std::thread::JoinHandle<Result<(), oak::OakStatus>>)> {
+    pub fn stop_next(
+        &mut self,
+    ) -> Option<(String, std::thread::JoinHandle<Result<(), oak::OakStatus>>)> {
         for (name, node) in &mut self.nodes {
             if let Some(h) = node.thread_handle.take() {
                 return Some((name.to_string(), h));

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -36,6 +36,7 @@ fn main() {
     run_embedmd(&root.with_prefix("embedmd"));
     run_cargo_fmt(&root.with_prefix("cargo fmt"));
     run_cargo_test(&root.with_prefix("cargo test"));
+    run_cargo_doc_test(&root.with_prefix("cargo doc test"));
     run_cargo_clippy(&root.with_prefix("cargo clippy"));
     run_bazel_build(&root.with_prefix("bazel build"));
     run_bazel_test(&root.with_prefix("bazel test"));
@@ -140,6 +141,21 @@ fn run_cargo_test(step: &Step) {
             &[
                 "test",
                 "--all-targets",
+                &format!("--manifest-path={}", manifest_filename),
+            ],
+        );
+    }
+}
+
+fn run_cargo_doc_test(step: &Step) {
+    for m in workspace_manifest_files() {
+        let manifest_filename = m.to_str().unwrap();
+        let step = step.with_prefix(manifest_filename);
+        step.run_command(
+            "cargo",
+            &[
+                "test",
+                "--doc",
                 &format!("--manifest-path={}", manifest_filename),
             ],
         );

--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -40,8 +40,9 @@ find scripts -type f -exec shellcheck {} +
 
 # Fortunately, rustfmt has the --check option that will make it exit with 1
 # if formatting has to be applied.
-cargo fmt --all --manifest-path examples/Cargo.toml -- --check
-cargo fmt --all --manifest-path sdk/rust/Cargo.toml -- --check
+cargo fmt --all --manifest-path ./examples/Cargo.toml -- --check
+cargo fmt --all --manifest-path ./sdk/rust/Cargo.toml -- --check
+cargo fmt --all --manifest-path ./oak/server/rust/Cargo.toml -- --check
 
 find . \
   \(  \
@@ -60,4 +61,3 @@ done
 
 # Check syntax in XML files.
 # TODO: Implement with `xmllint --noout your_test_file.xml`.
-

--- a/scripts/format
+++ b/scripts/format
@@ -29,8 +29,9 @@ find . \
     \( -type f -name '*.h' -or -name '*.cc' -or -name '*.proto' \) \
   \) -exec clang-format -i -style=file {} +
 
-cargo fmt --all --manifest-path examples/Cargo.toml
-cargo fmt --all --manifest-path sdk/rust/Cargo.toml
+cargo fmt --all --manifest-path ./examples/Cargo.toml
+cargo fmt --all --manifest-path ./sdk/rust/Cargo.toml
+cargo fmt --all --manifest-path ./oak/server/rust/Cargo.toml
 
 find . \
   \(  \

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -19,6 +19,10 @@ cargo test --all-targets --manifest-path=./examples/Cargo.toml
 cargo test --doc --manifest-path=./examples/Cargo.toml
 cargo clippy --all-targets --manifest-path=./examples/Cargo.toml -- --deny=warnings
 
+cargo test --all-targets --manifest-path=./oak/server/rust/Cargo.toml
+cargo test --doc --manifest-path=./oak/server/rust/Cargo.toml
+cargo clippy --all-targets --manifest-path=./oak/server/rust/Cargo.toml -- --deny=warnings
+
 bazel_build_flags+=(
   '--keep_going'
 )

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -4,13 +4,19 @@ readonly SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-# For each Rust workspace, first run tests, then run clippy, turning warnings into errors.
-# See https://github.com/rust-lang/rust-clippy.
+# For each Rust workspace, first run tests, then run doc tests, then run clippy (turning warnings
+# into errors).
+#
+# See:
+# - https://doc.rust-lang.org/cargo/commands/cargo-test.html
+# - https://github.com/rust-lang/rust-clippy.
 
 cargo test --all-targets --manifest-path=./sdk/rust/Cargo.toml
+cargo test --doc --manifest-path=./sdk/rust/Cargo.toml
 cargo clippy --all-targets --manifest-path=./sdk/rust/Cargo.toml -- --deny=warnings
 
 cargo test --all-targets --manifest-path=./examples/Cargo.toml
+cargo test --doc --manifest-path=./examples/Cargo.toml
 cargo clippy --all-targets --manifest-path=./examples/Cargo.toml -- --deny=warnings
 
 bazel_build_flags+=(


### PR DESCRIPTION
For some reason doc tests are excluded by `--all-targets`, so we need a
separate `cargo test` run for them.

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
