### PR TITLE
Encapsulate gRPC requests in a separate per-method invocation channel

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -65,8 +65,9 @@ generally expected to run forever, but may return if the Node choses to
 terminate (whether expectedly or unexpectedly).
 
 Each Oak Application starts with a single initial Oak Node; this Node receives
-as its initial handle the read half of a channel that receives gRPC requests
-from an implicit [gRPC pseudo-Node](concepts.md#pseudo-nodes).
+as its initial handle the read half of a channel that receives notifications of
+gRPC method invocations from an implicit
+[gRPC pseudo-Node](concepts.md#pseudo-nodes).
 
 ## Host Functions
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -88,13 +88,16 @@ outside world.
 The available pseudo-Nodes are:
 
 - **gRPC pseudo-node**: Provides a 'front door' for external interaction with an
-  Oak Application, by implementing a gRPC service. External requests to the gRPC
-  service are written to a channel that connects from the pseudo-Node to the
-  initial Node of the Application. Each new request is accompanied by a
-  corresponding inbound channel handle, which the initial Node uses to send
-  response messages. The Oak Runtime automatically creates a gRPC pseudo-Node at
-  Application start-of-day (and so gRPC pseudo-Nodes cannot be created with
-  `node_create()`).
+  Oak Application, by implementing a gRPC service. The Oak Runtime automatically
+  creates a gRPC pseudo-Node at Application start-of-day (and so gRPC
+  pseudo-Nodes cannot be created with `node_create()`). External method
+  invocations of the Application's gRPC service are delivered to a channel that
+  connects from the pseudo-Node to the initial Node of the Application, as a
+  message no data bytes but with two attached handles (in the following order):
+  - A handle for the read half of a channel holding the inbound request, ready
+    for the Node to read.
+  - A handle for the write half of a channel that the Node should write the
+    corresponding response message(s) to.
 - **Logging pseudo-node**: Provides a logging mechanism for Nodes under
   development by including a single inbound channel; anything received on the
   channel will be logged. This node should only be enabled during application

--- a/oak/server/module_invocation.h
+++ b/oak/server/module_invocation.h
@@ -64,10 +64,10 @@ class ModuleInvocation {
   void BlockingSendResponse();
 
   // Cleans up by deleting this object.
-  void Finish(bool ok);
+  void CleanUp(bool ok);
 
  private:
-  void FinishAndRestart(const grpc::Status& status);
+  void FinishAndCleanUp(const grpc::Status& status);
 
   grpc::AsyncGenericService* const service_;
   grpc::ServerCompletionQueue* const queue_;

--- a/oak/server/module_invocation.h
+++ b/oak/server/module_invocation.h
@@ -75,6 +75,9 @@ class ModuleInvocation {
   // Borrowed references to gRPC Node that this invocation is on behalf of.
   OakGrpcNode* grpc_node_;
 
+  // Channel references for the two channels that are used for communication
+  // related to this method invocation.
+  std::unique_ptr<MessageChannelWriteHalf> req_half_;
   std::unique_ptr<MessageChannelReadHalf> rsp_half_;
 
   grpc::GenericServerContext context_;

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -156,6 +156,15 @@ impl ChannelHalf {
             .expect("corrupt channel ref")
             .read_message(size, actual_size, handle_count, actual_handle_count)
     }
+    pub fn write_message(&mut self, msg: OakMessage) -> u32 {
+        if self.direction != Direction::Write {
+            return OakStatus::ERR_BAD_HANDLE.value() as u32;
+        }
+        self.channel
+            .write()
+            .expect("corrupt channel ref")
+            .write_message(msg)
+    }
 }
 
 impl Clone for ChannelHalf {
@@ -201,7 +210,7 @@ pub struct OakRuntime {
     // Map name of Node config names to next index.
     next_index: HashMap<String, u32>,
     // Track a reference to the write half of the channel used for sending
-    // gRPC requests in to the Application under test.
+    // gRPC method notifications in to the Application under test.
     grpc_in_half: Option<ChannelHalf>,
     // Node instances organized by internal Node name.
     nodes: HashMap<String, OakNode>,
@@ -430,7 +439,7 @@ impl OakRuntime {
             node_name, read_handle
         );
         // Remember the write half of the channel to allow future test
-        // injection of gRPC requests.
+        // injection of gRPC method notifications.
         self.grpc_in_half = Some(write_half);
         read_handle
     }


### PR DESCRIPTION
### Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [x] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
