### PR TITLE
Use absolute paths in `oak_derive` expansion

### DIFF
--- a/examples/chat/module_0/rust/src/lib.rs
+++ b/examples/chat/module_0/rust/src/lib.rs
@@ -19,7 +19,7 @@ use chat_common::proto::chat::{
     CreateRoomRequest, DestroyRoomRequest, SendMessageRequest, SubscribeRequest,
 };
 use chat_common::proto::chat_grpc::{dispatch, ChatNode};
-use log::{info, warn};
+use log::info;
 use oak::grpc;
 use oak::grpc::OakNode;
 use oak_derive::OakExports;

--- a/examples/private_set_intersection/module/rust/src/lib.rs
+++ b/examples/private_set_intersection/module/rust/src/lib.rs
@@ -27,7 +27,6 @@
 
 mod proto;
 
-use log::warn;
 use oak::grpc;
 use oak::grpc::OakNode;
 use oak_derive::OakExports;

--- a/examples/running_average/module/rust/src/lib.rs
+++ b/examples/running_average/module/rust/src/lib.rs
@@ -24,7 +24,6 @@
 
 mod proto;
 
-use log::warn;
 use oak::grpc;
 use oak::grpc::OakNode;
 use oak_derive::OakExports;

--- a/examples/rustfmt/module/rust/src/lib.rs
+++ b/examples/rustfmt/module/rust/src/lib.rs
@@ -16,7 +16,6 @@
 
 mod proto;
 
-use log::warn;
 use oak::grpc;
 use oak::grpc::OakNode;
 use oak_derive::OakExports;

--- a/sdk/rust/oak_derive/src/lib.rs
+++ b/sdk/rust/oak_derive/src/lib.rs
@@ -62,8 +62,8 @@ pub fn derive_oak_exports(input: TokenStream) -> TokenStream {
             // A panic in the Rust module code cannot safely pass through the FFI
             // boundary, so catch any panics here and drop them.
             // https://doc.rust-lang.org/nomicon/ffi.html#ffi-and-panics
-            let _ = std::panic::catch_unwind(||{
-                oak::set_panic_hook();
+            let _ = ::std::panic::catch_unwind(||{
+                ::oak::set_panic_hook();
                 inner_main(handle)
             });
         }
@@ -71,8 +71,13 @@ pub fn derive_oak_exports(input: TokenStream) -> TokenStream {
         // panic interception.
         pub fn inner_main(handle: u64) {
             let mut node = <#name>::new();
-            if let Err(s) = oak::grpc::event_loop(node, oak::ReadHandle{ handle: oak::Handle::from_raw(handle) }) {
-                warn!("Node terminating with {:?}", s);
+            if let ::std::result::Result::Err(s) = ::oak::grpc::event_loop(
+                node,
+                ::oak::ReadHandle{
+                    handle: ::oak::Handle::from_raw(handle),
+                },
+            ) {
+                ::log::warn!("Node terminating with {:?}", s);
             }
         }
     };


### PR DESCRIPTION
In order to avoid ambiguities. Also, `warn` was not fully qualified
previously, which means that it had to be manually imported in the
parent scope.

Also reformat the expanded code.

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
