### PR TITLE
Minor doc clarifications

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -79,7 +79,9 @@ functions** as
   reading from one of the specified channel handles. The channel handles are
   encoded in a buffer that holds N contiguous 9-byte chunks, each of which is
   made up of an 8-byte channel handle value (little-endian u64) followed by a
-  single byte that is set on return if data is available on that channel.
+  single status byte corresponding to `oak::ChannelReadStatus`. Invalid handles
+  will have an `INVALID_CHANNEL` status, but `wait_on_channels` return value
+  will only fail for internal errors.
 
   - arg0: Address of handle status buffer
   - arg1: Count N of handles provided

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -45,8 +45,8 @@ type.
 Three specific sets of integer values are also used in the ABI:
 
 - Many operations take a `u64` **handle** value; these values are Node-specific
-  and non-zero (zero is reserved to indicate an invalid handle), and reference
-  a particular [channel](concepts.md#channels).
+  and non-zero (zero is reserved to indicate an invalid handle), and reference a
+  particular [channel](concepts.md#channels).
 - Many ABI operations return a `u32` **status** value, indicating the result of
   the operation. The possible values for this are defined in the `OakStatus`
   enum in [oak_abi.proto](/oak/proto/oak_abi.proto).

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -49,11 +49,11 @@ Three specific sets of integer values are also used in the ABI:
   particular [channel](concepts.md#channels).
 - Many ABI operations return a `u32` **status** value, indicating the result of
   the operation. The possible values for this are defined in the `OakStatus`
-  enum in [oak_abi.proto](/oak/proto/oak_abi.proto).
+  enum in [oak_api.proto](/oak/proto/oak_api.proto).
 - The `wait_on_channels` host function fills in a **channel status** value,
   indicating the readiness status of a particular channel. The possible values
   for this are defined in the `ChannelReadStatus` enum in
-  [oak_abi.proto](/oak/proto/oak_abi.proto).
+  [oak_api.proto](/oak/proto/oak_api.proto).
 
 ## Exported Function
 

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -86,8 +86,8 @@ functions** as
   encoded in a buffer that holds N contiguous 9-byte chunks, each of which is
   made up of an 8-byte channel handle value (little-endian u64) followed by a
   single channel status byte. Invalid handles will have an `INVALID_CHANNEL`
-  status, but `wait_on_channels` return value will only fail for internal
-  errors or if _all_ channels are invalid.
+  status, but `wait_on_channels` return value will only fail for internal errors
+  or if _all_ channels are invalid.
 
   - arg0: Address of handle status buffer
   - arg1: Count N of handles provided

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -87,7 +87,7 @@ functions** as
   made up of an 8-byte channel handle value (little-endian u64) followed by a
   single channel status byte. Invalid handles will have an `INVALID_CHANNEL`
   status, but `wait_on_channels` return value will only fail for internal
-  errors.
+  errors or if _all_ channels are invalid.
 
   - arg0: Address of handle status buffer
   - arg1: Count N of handles provided

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -42,12 +42,18 @@ current WebAsssembly implementation(s). However, in any future
 version of WebAssembly this `usize` type would instead be an alias for the `u64`
 type.
 
-Two specific sets of integer values are used in multiple places in the ABI:
+Three specific sets of integer values are also used in the ABI:
 
-- Many ABI operations return a `u32` **status** value, indicating the result of
-  the operation.
 - Many operations take a `u64` **handle** value; these values are Node-specific
-  and non-zero (zero is reserved to indicate an invalid handle).
+  and non-zero (zero is reserved to indicate an invalid handle), and reference
+  a particular [channel](concepts.md#channels).
+- Many ABI operations return a `u32` **status** value, indicating the result of
+  the operation. The possible values for this are defined in the `OakStatus`
+  enum in [oak_abi.proto](/oak/proto/oak_abi.proto).
+- The `wait_on_channels` host function fills in a **channel status** value,
+  indicating the readiness status of a particular channel. The possible values
+  for this are defined in the `ChannelReadStatus` enum in
+  [oak_abi.proto](/oak/proto/oak_abi.proto).
 
 ## Exported Function
 
@@ -79,9 +85,9 @@ functions** as
   reading from one of the specified channel handles. The channel handles are
   encoded in a buffer that holds N contiguous 9-byte chunks, each of which is
   made up of an 8-byte channel handle value (little-endian u64) followed by a
-  single status byte corresponding to `oak::ChannelReadStatus`. Invalid handles
-  will have an `INVALID_CHANNEL` status, but `wait_on_channels` return value
-  will only fail for internal errors.
+  single channel status byte. Invalid handles will have an `INVALID_CHANNEL`
+  status, but `wait_on_channels` return value will only fail for internal
+  errors.
 
   - arg0: Address of handle status buffer
   - arg1: Count N of handles provided

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -16,7 +16,7 @@ includes wrapper functions for all of the
 types for easier use.
 
 - Status values are returned as
-  [`oak::OakStatus`](https://project-oak.github.io/oak/sdk/oak/proto/oak_api/enum.OakStatus.html)
+  [`oak::OakStatus`](https://project-oak.github.io/oak/sdk/oak/enum.OakStatus.html)
   `enum` values rather than `i32` values.
 - Channel handles are held in the
   [`Handle`](https://project-oak.github.io/oak/sdk/oak/type.Handle.html) type,


### PR DESCRIPTION
I believe this is the current runtime behaviour, specifically `wait_on_channels` won't return failure if one of the handles is invalid, it will instead set the corresponding status byte to a bad handle status. 

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [X] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
