### PR TITLE
Add a WASI placeholder

### DIFF
--- a/examples/tensorflow/client/tensorflow.cc
+++ b/examples/tensorflow/client/tensorflow.cc
@@ -27,11 +27,7 @@
 #include "oak/client/manager_client.h"
 #include "oak/common/utils.h"
 
-ABSL_FLAG(std::string, manager_address, "127.0.0.1:8888",
-          "Address of the Oak Manager to connect to");
-ABSL_FLAG(std::string, storage_address, "127.0.0.1:7867",
-          "Address ot the storage provider to connect to");
-ABSL_FLAG(std::string, module, "", "File containing the compiled WebAssembly module");
+ABSL_FLAG(std::string, address, "127.0.0.1:8080", "Address of the Oak application to connect to");
 
 using ::oak::examples::tensorflow::InitRequest;
 using ::oak::examples::tensorflow::InitResponse;
@@ -52,36 +48,16 @@ void init_tensorflow(Tensorflow::Stub* stub) {
 int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
 
-  // Connect to the Oak Manager.
-  std::unique_ptr<oak::ManagerClient> manager_client =
-      absl::make_unique<oak::ManagerClient>(grpc::CreateChannel(
-          absl::GetFlag(FLAGS_manager_address), grpc::InsecureChannelCredentials()));
-
-  // Load the Oak Module to execute. This needs to be compiled from Rust to WebAssembly separately.
-  std::string module_bytes = oak::utils::read_file(absl::GetFlag(FLAGS_module));
-  std::unique_ptr<oak::CreateApplicationResponse> create_application_response =
-      manager_client->CreateApplication(module_bytes, /* logging= */ true,
-                                        absl::GetFlag(FLAGS_storage_address));
-  if (create_application_response == nullptr) {
-    LOG(QFATAL) << "Failed to create application";
-  }
-
-  std::stringstream addr;
-  addr << "127.0.0.1:" << create_application_response->grpc_port();
-  std::string application_id(create_application_response->application_id());
-  LOG(INFO) << "Connecting to Oak Application id=" << application_id << ": " << addr.str();
-
   oak::ApplicationClient::InitializeAssertionAuthorities();
 
+  std::string address = absl::GetFlag(FLAGS_address);
+  LOG(INFO) << "Connecting to Oak Application: " << address;
+
   // Connect to the newly created Oak Application.
-  auto stub = Tensorflow::NewStub(oak::ApplicationClient::CreateChannel(addr.str()));
+  auto stub = Tensorflow::NewStub(oak::ApplicationClient::CreateChannel(address));
 
-  // Perform multiple invocations of the same Oak Application, with different parameters.
+  // Initialize TensorFlow in Oak.
   init_tensorflow(stub.get());
-
-  // Request termination of the Oak Application.
-  LOG(INFO) << "Terminating application id=" << application_id;
-  manager_client->TerminateApplication(application_id);
 
   return EXIT_SUCCESS;
 }

--- a/examples/tensorflow/module/cpp/tensorflow.cc
+++ b/examples/tensorflow/module/cpp/tensorflow.cc
@@ -90,7 +90,7 @@ uint32_t channel_write(uint64_t handle, uint8_t* buff, size_t usize, uint8_t* ha
                        size_t handle_count);
 WASM_IMPORT("oak") uint32_t channel_close(uint64_t handle);
 
-WASM_EXPORT int32_t oak_main(uint64_t grpc_in_handle) {
+WASM_EXPORT void oak_main(uint64_t grpc_in_handle) {
   char grpc_in_name[] = "grpc_in";
   char grpc_out_name[] = "grpc_out";
   uint8_t handle_space[9] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -112,7 +112,7 @@ WASM_EXPORT int32_t oak_main(uint64_t grpc_in_handle) {
   while (true) {
     int32_t result = wait_on_channels(handle_space, 1);
     if (result != oak::OakStatus::OK) {
-      return result;
+      return;
     }
 
     uint64_t rsp_handle;
@@ -135,5 +135,4 @@ WASM_EXPORT int32_t oak_main(uint64_t grpc_in_handle) {
     channel_write(rsp_handle, buf, sizeof(buf) - 1, nullptr, 0);
     channel_close(rsp_handle);
   }
-  return oak::OakStatus::OK;
 }

--- a/examples/tensorflow/module/cpp/tensorflow_micro.cc
+++ b/examples/tensorflow/module/cpp/tensorflow_micro.cc
@@ -119,7 +119,7 @@ uint32_t channel_write(uint64_t handle, uint8_t* buff, size_t usize, uint8_t* ha
                        size_t handle_count);
 WASM_IMPORT("oak") uint32_t channel_close(uint64_t handle);
 
-WASM_EXPORT int32_t oak_main(uint64_t grpc_in_handle) {
+WASM_EXPORT void oak_main(uint64_t grpc_in_handle) {
   char grpc_in_name[] = "grpc_in";
   char grpc_out_name[] = "grpc_out";
   uint8_t handle_space[9] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -141,7 +141,7 @@ WASM_EXPORT int32_t oak_main(uint64_t grpc_in_handle) {
   while (true) {
     int32_t result = wait_on_channels(handle_space, 1);
     if (result != oak::OakStatus::OK) {
-      return result;
+      return;
     }
 
     uint64_t rsp_handle;
@@ -164,5 +164,4 @@ WASM_EXPORT int32_t oak_main(uint64_t grpc_in_handle) {
     channel_write(rsp_handle, buf, sizeof(buf) - 1, nullptr, 0);
     channel_close(rsp_handle);
   }
-  return oak::OakStatus::OK;
 }

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -228,7 +228,11 @@ void WasmNode::InitEnvironment(wabt::interp::Environment* env) {
                                   std::vector<wabt::Type>{wabt::Type::I32}),
       this->OakRandomGet(env));
 
-  // Experimental.
+  // These exported functions are used to run applications that have been ported to Wasm
+  // without code refactoring, and thus may require several WASI functions to be imported.
+  // WASI is an interface that provides access to OS features (e.g. filesystems, sockets, etc.).
+  // https://wasi.dev/
+  // These particular functions are required by TensorFlow Lite for Microcontrollers.
   wabt::interp::HostModule* wasi_module = env->AppendHostModule("wasi_snapshot_preview1");
   wasi_module->AppendFuncExport(
       "proc_exit",

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -232,39 +232,35 @@ void WasmNode::InitEnvironment(wabt::interp::Environment* env) {
   wabt::interp::HostModule* wasi_module = env->AppendHostModule("wasi_snapshot_preview1");
   wasi_module->AppendFuncExport(
       "proc_exit",
-      wabt::interp::FuncSignature(
-          std::vector<wabt::Type>{wabt::Type::I32},
-          std::vector<wabt::Type>{}),
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32},
+                                  std::vector<wabt::Type>{}),
       this->WasiPlaceholder(env));
   wasi_module->AppendFuncExport(
       "fd_write",
-      wabt::interp::FuncSignature(
-          std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32, wabt::Type::I32, wabt::Type::I32},
-          std::vector<wabt::Type>{wabt::Type::I32}),
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32,
+                                                          wabt::Type::I32, wabt::Type::I32},
+                                  std::vector<wabt::Type>{wabt::Type::I32}),
       this->WasiPlaceholder(env));
   wasi_module->AppendFuncExport(
       "fd_seek",
-      wabt::interp::FuncSignature(
-          std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I64, wabt::Type::I32, wabt::Type::I32},
-          std::vector<wabt::Type>{wabt::Type::I32}),
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I64,
+                                                          wabt::Type::I32, wabt::Type::I32},
+                                  std::vector<wabt::Type>{wabt::Type::I32}),
       this->WasiPlaceholder(env));
   wasi_module->AppendFuncExport(
       "fd_close",
-      wabt::interp::FuncSignature(
-          std::vector<wabt::Type>{wabt::Type::I32},
-          std::vector<wabt::Type>{wabt::Type::I32}),
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32},
+                                  std::vector<wabt::Type>{wabt::Type::I32}),
       this->WasiPlaceholder(env));
   wasi_module->AppendFuncExport(
       "environ_sizes_get",
-      wabt::interp::FuncSignature(
-          std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
-          std::vector<wabt::Type>{wabt::Type::I32}),
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
+                                  std::vector<wabt::Type>{wabt::Type::I32}),
       this->WasiPlaceholder(env));
   wasi_module->AppendFuncExport(
       "environ_get",
-      wabt::interp::FuncSignature(
-          std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
-          std::vector<wabt::Type>{wabt::Type::I32}),
+      wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
+                                  std::vector<wabt::Type>{wabt::Type::I32}),
       this->WasiPlaceholder(env));
 }
 

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -234,34 +234,34 @@ void WasmNode::InitEnvironment(wabt::interp::Environment* env) {
       "proc_exit",
       wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32},
                                   std::vector<wabt::Type>{}),
-      this->WasiPlaceholder(env));
+      this->WasiPlaceholder());
   wasi_module->AppendFuncExport(
       "fd_write",
       wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32,
                                                           wabt::Type::I32, wabt::Type::I32},
                                   std::vector<wabt::Type>{wabt::Type::I32}),
-      this->WasiPlaceholder(env));
+      this->WasiPlaceholder());
   wasi_module->AppendFuncExport(
       "fd_seek",
       wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I64,
                                                           wabt::Type::I32, wabt::Type::I32},
                                   std::vector<wabt::Type>{wabt::Type::I32}),
-      this->WasiPlaceholder(env));
+      this->WasiPlaceholder());
   wasi_module->AppendFuncExport(
       "fd_close",
       wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32},
                                   std::vector<wabt::Type>{wabt::Type::I32}),
-      this->WasiPlaceholder(env));
+      this->WasiPlaceholder());
   wasi_module->AppendFuncExport(
       "environ_sizes_get",
       wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
                                   std::vector<wabt::Type>{wabt::Type::I32}),
-      this->WasiPlaceholder(env));
+      this->WasiPlaceholder());
   wasi_module->AppendFuncExport(
       "environ_get",
       wabt::interp::FuncSignature(std::vector<wabt::Type>{wabt::Type::I32, wabt::Type::I32},
                                   std::vector<wabt::Type>{wabt::Type::I32}),
-      this->WasiPlaceholder(env));
+      this->WasiPlaceholder());
 }
 
 void WasmNode::Run(Handle handle) {
@@ -596,7 +596,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakRandomGet(wabt::interp::Environmen
   };
 }
 
-wabt::interp::HostFunc::Callback WasmNode::WasiPlaceholder(wabt::interp::Environment* env) {
+wabt::interp::HostFunc::Callback WasmNode::WasiPlaceholder() {
   return [this](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
                 const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -597,7 +597,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakRandomGet(wabt::interp::Environmen
 }
 
 wabt::interp::HostFunc::Callback WasmNode::WasiPlaceholder(wabt::interp::Environment* env) {
-  return [this, env](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
+  return [this](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
                      const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);
     LOG(QFATAL) << "{" << name_ << "} WASI is not implemented";

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -598,7 +598,7 @@ wabt::interp::HostFunc::Callback WasmNode::OakRandomGet(wabt::interp::Environmen
 
 wabt::interp::HostFunc::Callback WasmNode::WasiPlaceholder(wabt::interp::Environment* env) {
   return [this](const wabt::interp::HostFunc* func, const wabt::interp::FuncSignature*,
-                     const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
+                const wabt::interp::TypedValues& args, wabt::interp::TypedValues& results) {
     LogHostFunctionCall(name_, func, args);
     LOG(QFATAL) << "{" << name_ << "} WASI is not implemented";
     results[0].set_i32(OakStatus::ERR_INTERNAL);

--- a/oak/server/wasm_node.cc
+++ b/oak/server/wasm_node.cc
@@ -230,8 +230,10 @@ void WasmNode::InitEnvironment(wabt::interp::Environment* env) {
 
   // These exported functions are used to run applications that have been ported to Wasm
   // without code refactoring, and thus may require several WASI functions to be imported.
-  // WASI is an interface that provides access to OS features (e.g. filesystems, sockets, etc.).
+  // WASI is an interface that provides access to OS features (e.g. filesystems, sockets, etc.):
   // https://wasi.dev/
+  // WASI functions are imported from a `wasi_snapshot_preview1` module:
+  // https://github.com/CraneStation/wasi-libc/blob/12f5832b45c7450f8320db271334081247191d58/libc-bottom-half/headers/public/wasi/api.h#L1584
   // These particular functions are required by TensorFlow Lite for Microcontrollers.
   wabt::interp::HostModule* wasi_module = env->AppendHostModule("wasi_snapshot_preview1");
   wasi_module->AppendFuncExport(
@@ -606,7 +608,7 @@ wabt::interp::HostFunc::Callback WasmNode::WasiPlaceholder() {
     LogHostFunctionCall(name_, func, args);
     LOG(QFATAL) << "{" << name_ << "} WASI is not implemented";
     results[0].set_i32(OakStatus::ERR_INTERNAL);
-    return wabt::interp::Result::Ok;
+    return wabt::interp::Result::TrapUnreachable;
   };
 }
 

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -63,6 +63,9 @@ class WasmNode final : public NodeThread {
 
   // Native implementation of the `oak.random_get` host function.
   wabt::interp::HostFunc::Callback OakRandomGet(wabt::interp::Environment* env);
+  
+  // Placeholder for WASI functions.
+  wabt::interp::HostFunc::Callback WasiPlaceholder(wabt::interp::Environment* env);
 
   const std::string main_entrypoint_;
 

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -65,7 +65,7 @@ class WasmNode final : public NodeThread {
   wabt::interp::HostFunc::Callback OakRandomGet(wabt::interp::Environment* env);
 
   // Placeholder for WASI functions.
-  wabt::interp::HostFunc::Callback WasiPlaceholder(wabt::interp::Environment* env);
+  wabt::interp::HostFunc::Callback WasiPlaceholder();
 
   const std::string main_entrypoint_;
 

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -65,6 +65,8 @@ class WasmNode final : public NodeThread {
   wabt::interp::HostFunc::Callback OakRandomGet(wabt::interp::Environment* env);
 
   // Placeholder for WASI functions.
+  // Since WASI functions are currently not supported by Oak, this function
+  // will always log, return an error and terminate the program.
   wabt::interp::HostFunc::Callback WasiPlaceholder();
 
   const std::string main_entrypoint_;

--- a/oak/server/wasm_node.h
+++ b/oak/server/wasm_node.h
@@ -63,7 +63,7 @@ class WasmNode final : public NodeThread {
 
   // Native implementation of the `oak.random_get` host function.
   wabt::interp::HostFunc::Callback OakRandomGet(wabt::interp::Environment* env);
-  
+
   // Placeholder for WASI functions.
   wabt::interp::HostFunc::Callback WasiPlaceholder(wabt::interp::Environment* env);
 


### PR DESCRIPTION
This change:
- Adds a WASI placeholder in order to run TensorFlow Lite example in Oak
- Update TensorFlow Lite example `main` functions

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
