### PR TITLE
Define gRPC Invocation in Rust SDK

### DIFF
--- a/examples/chat/module/rust/src/backend.rs
+++ b/examples/chat/module/rust/src/backend.rs
@@ -57,7 +57,9 @@ impl Room {
     fn handle_command(&mut self, command: Command) -> Result<(), oak::OakError> {
         match command {
             Command::Join(h) => {
-                self.clients.push(oak::grpc::ChannelResponseWriter::new(h));
+                let sender = oak::io::Sender::new(h);
+                self.clients
+                    .push(oak::grpc::ChannelResponseWriter::new(sender));
                 Ok(())
             }
             Command::SendMessage(message_bytes) => {

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -70,6 +70,7 @@ impl MockChannel {
                 .collect(),
         }
     }
+    #[must_use]
     pub fn write_message(&mut self, msg: OakMessage) -> u32 {
         if let Some(status) = self.write_status {
             return status;
@@ -156,6 +157,7 @@ impl ChannelHalf {
             .expect("corrupt channel ref")
             .read_message(size, actual_size, handle_count, actual_handle_count)
     }
+    #[must_use]
     pub fn write_message(&mut self, msg: OakMessage) -> u32 {
         if self.direction != Direction::Write {
             return OakStatus::ERR_BAD_HANDLE.value() as u32;

--- a/sdk/rust/oak/src/grpc/invocation.rs
+++ b/sdk/rust/oak/src/grpc/invocation.rs
@@ -1,0 +1,60 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// A gRPC invocation, consisting of exactly two channels: one to read incoming requests from the
+/// client, and one to write outgoing responses to the client.
+pub struct Invocation {
+    pub request_receiver: crate::io::Receiver<crate::proto::grpc_encap::GrpcRequest>,
+    pub response_sender: crate::io::Sender<crate::proto::grpc_encap::GrpcResponse>,
+}
+
+// TODO(#389): Automatically generate this code.
+impl crate::io::Encodable for Invocation {
+    fn encode(&self) -> Result<crate::io::Message, crate::OakError> {
+        let bytes = vec![];
+        let handles = vec![
+            self.request_receiver.handle.handle,
+            self.response_sender.handle.handle,
+        ];
+        Ok(crate::io::Message { bytes, handles })
+    }
+}
+
+// TODO(#389): Automatically generate this code.
+impl crate::io::Decodable for Invocation {
+    fn decode(message: &crate::io::Message) -> Result<Self, crate::OakError> {
+        if !message.bytes.is_empty() {
+            panic!(
+                "incorrect number of bytes received: {} (expected: 0)",
+                message.bytes.len()
+            );
+        }
+        if message.handles.len() != 2 {
+            panic!(
+                "incorrect number of handles received: {} (expected: 2)",
+                message.handles.len()
+            );
+        }
+        Ok(Invocation {
+            request_receiver: crate::io::Receiver::new(crate::ReadHandle {
+                handle: message.handles[0],
+            }),
+            response_sender: crate::io::Sender::new(crate::WriteHandle {
+                handle: message.handles[1],
+            }),
+        })
+    }
+}


### PR DESCRIPTION
- Encapsulate a request receiver and a response sender into a single
object which implements `Encodable` and `Decodable`.
- Add `#[must_use]` to a couple places where return status codes were
not checked. We should probably consider using `Result` types
everywhere.

Fixes #528

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
