### PR TITLE
protoc-rust-grpc: update from upstream

### DIFF
--- a/third_party/grpc-rust/protoc-rust-grpc/Cargo.toml
+++ b/third_party/grpc-rust/protoc-rust-grpc/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Stepan Koltsov <stepan.koltsov@gmail.com>"]
 homepage = "https://github.com/stepancheg/rust-protobuf/protoc-rust/"
 repository = "https://github.com/stepancheg/rust-protobuf/protoc-rust/"
 license = "MIT/Apache-2.0"
+edition = "2018"
 description = """
 protoc --rust-grpc_out=... available as API. protoc needs to be in $PATH, protoc-gen-rust-grpc does not.
 """
@@ -14,8 +15,8 @@ doctest = false
 test = false
 
 [dependencies]
-protoc        = "2.8"
-protoc-rust   = "2.8"
-protobuf      = "2.8"
+protoc        = "2"
+protoc-rust   = "2"
+protobuf      = "2"
 grpc-compiler = { path = "../grpc-compiler", version = "=0.7.0" }
 tempdir       = "0.3"

--- a/third_party/grpc-rust/protoc-rust-grpc/src/lib.rs
+++ b/third_party/grpc-rust/protoc-rust-grpc/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run(args: Args) -> Result<()> {
             includes: args.includes,
             input: args.input,
             customize: args.rust_protobuf_customize,
+            ..Default::default()
         })?;
     }
 
@@ -67,7 +68,7 @@ pub fn run(args: Args) -> Result<()> {
 
     let mut includes = args.includes;
     if includes.is_empty() {
-        static DOT_SLICE: &[&str] = &["."];
+        static DOT_SLICE: &'static [&'static str] = &["."];
         includes = DOT_SLICE;
     }
 
@@ -120,7 +121,7 @@ fn remove_path_prefix<'a>(mut path: &'a str, mut prefix: &str) -> Option<&'a str
         return Some(path);
     }
 
-    if prefix.ends_with('/') || prefix.ends_with('\\') {
+    if prefix.ends_with("/") || prefix.ends_with("\\") {
         prefix = &prefix[..prefix.len() - 1];
     }
 
@@ -133,9 +134,9 @@ fn remove_path_prefix<'a>(mut path: &'a str, mut prefix: &str) -> Option<&'a str
     }
 
     if path.as_bytes()[prefix.len()] == b'/' || path.as_bytes()[prefix.len()] == b'\\' {
-        Some(&path[prefix.len() + 1..])
+        return Some(&path[prefix.len() + 1..]);
     } else {
-        None
+        return None;
     }
 }
 


### PR DESCRIPTION
### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

Updates protoc-rust-grpc from upstream. The relaxed bounds prevent building examples generating protoc v2.8 code. Related #520 