### PR TITLE
Implement bearer token authentication using HMAC

### DIFF
--- a/oak/client/BUILD
+++ b/oak/client/BUILD
@@ -39,6 +39,7 @@ cc_library(
         ":authorization_bearer_token_metadata",
         ":policy_metadata",
         "//oak/common:app_config",
+        "//oak/common:hmac",
         "//oak/common:nonce_generator",
         "//oak/proto:application_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",

--- a/oak/common/BUILD
+++ b/oak/common/BUILD
@@ -38,6 +38,26 @@ cc_library(
 )
 
 cc_library(
+    name = "hmac",
+    srcs = ["hmac.cc"],
+    hdrs = ["hmac.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boringssl//:crypto",
+        "@com_google_asylo//asylo/util:status",
+    ],
+)
+
+cc_test(
+    name = "hmac_test",
+    srcs = ["hmac_test.cc"],
+    deps = [
+        ":hmac",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "app_config",
     srcs = ["app_config.cc"],
     hdrs = ["app_config.h"],

--- a/oak/common/hmac.cc
+++ b/oak/common/hmac.cc
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/common/hmac.h"
+
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+
+#include "asylo/util/status.h"
+#include "asylo/util/statusor.h"
+
+using asylo::Status;
+using asylo::StatusOr;
+
+namespace oak {
+namespace utils {
+
+StatusOr<std::string> hmac_sha256(const std::string& key, const std::string& message) {
+  const EVP_MD* digest = EVP_sha256();
+  uint8_t mac[SHA256_DIGEST_LENGTH];
+  unsigned int out_size;
+  if (HMAC(digest, key.data(), key.size(), reinterpret_cast<const uint8_t*>(message.data()),
+           message.size(), mac, &out_size) == nullptr) {
+    return Status(asylo::error::GoogleError::INTERNAL, "Could not compute HMAC-SHA256");
+  };
+  return std::string(reinterpret_cast<const char*>(mac), out_size);
+}
+
+}  // namespace utils
+}  // namespace oak

--- a/oak/common/hmac.h
+++ b/oak/common/hmac.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Project Oak Authors
+ * Copyright 2020 The Project Oak Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
-#ifndef OAK_COMMON_HANDLES_H_
-#define OAK_COMMON_HANDLES_H_
+#ifndef OAK_COMMON_HMAC_H_
+#define OAK_COMMON_HMAC_H_
 
-#include <stdint.h>
+#include "asylo/util/statusor.h"
 
-#include "absl/base/attributes.h"
+using asylo::StatusOr;
 
 namespace oak {
-using Handle = uint64_t;
-ABSL_CONST_INIT extern const Handle kInvalidHandle;
+namespace utils {
+
+// Computes a HMAC-SHA256 with the provided key over the provided message.
+//
+// See https://en.wikipedia.org/wiki/HMAC.
+StatusOr<std::string> hmac_sha256(const std::string& key, const std::string& message);
+
+}  // namespace utils
 }  // namespace oak
 
-#endif  // OAK_COMMON_HANDLES_H_
+#endif  // OAK_COMMON_HMAC_H_

--- a/oak/common/hmac_test.cc
+++ b/oak/common/hmac_test.cc
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/common/hmac.h"
+
+#include "gtest/gtest.h"
+
+namespace oak {
+namespace utils {
+
+// Reference:
+// https://gchq.github.io/CyberChef/#recipe=HMAC(%7B'option':'UTF8','string':''%7D,'SHA256')From_Hex('None')To_Hex('%5C%5Cx')
+TEST(Hmac, EmptyKeyEmptyMessage) {
+  auto out = hmac_sha256("", "").ValueOrDie();
+  ASSERT_EQ(
+      "\xb6\x13\x67\x9a\b\x14\xd9\xec\x77\x2f\x95\xd7\x78\xc3\x5f\xc5\xff\x16\x97\xc4\x93\x71\x56"
+      "\x53\xc6\xc7\x12\x14\x42\x92\xc5\xad",
+      out);
+}
+
+// Reference:
+// https://gchq.github.io/CyberChef/#recipe=HMAC(%7B'option':'UTF8','string':''%7D,'SHA256')From_Hex('None')To_Hex('%5C%5Cx')&input=dGVzdC1tZXNzYWdl
+TEST(Hmac, EmptyKeyNonemptyMessage) {
+  auto out = hmac_sha256("", "test-message").ValueOrDie();
+  ASSERT_EQ(
+      "\x88\xf9\xb4\x1c\xe3\x7a\x83\x87\xcd\x42\x5b\x46\x1a\x79\x59\xf3\x28\x3d\xb8\x49\x4a\x61\xdb"
+      "\x44\xb3\x41\x18\x9d\xd7\xd2\x35\x96",
+      out);
+}
+
+// Reference:
+// https://gchq.github.io/CyberChef/#recipe=HMAC(%7B'option':'UTF8','string':'test-key'%7D,'SHA256')From_Hex('None')To_Hex('%5C%5Cx')
+TEST(Hmac, NonemptyKeyEmptyMessage) {
+  auto out = hmac_sha256("test-key", "").ValueOrDie();
+  ASSERT_EQ(
+      "\x27\x11\xcc\x23\xe9\xab\x1b\x8a\x9b\xc0\xfe\x99\x12\x38\xda\x92\x67\x16\x24\xa9\xeb\xda\xf1"
+      "\xc1\xab\xec\x06\xe7\xe9\xa1\x4f\x9b",
+      out);
+}
+
+// Reference:
+// https://gchq.github.io/CyberChef/#recipe=HMAC(%7B'option':'UTF8','string':'test-key'%7D,'SHA256')From_Hex('None')To_Hex('%5C%5Cx')&input=dGVzdC1tZXNzYWdl
+TEST(Hmac, NonemptyKeyNonemptyMessage) {
+  auto out = hmac_sha256("test-key", "test-message").ValueOrDie();
+  ASSERT_EQ(
+      "\xf8\xc2\xbb\x87\xc1\x76\x08\xc9\x03\x8e\xab\x4e\x92\xef\x27\x75\xe4\x26\x29\xc9\x39\xd6\xfd"
+      "\x33\x90\xd4\x2f\x80\xaf\x6b\xb7\x12",
+      out);
+}
+
+}  // namespace utils
+}  // namespace oak

--- a/oak/common/policy.cc
+++ b/oak/common/policy.cc
@@ -41,12 +41,16 @@ oak::policy::Label DeserializePolicy(const std::string& policy_bytes) {
   return policy_proto;
 }
 
-oak::policy::Label AuthorizationBearerTokenPolicy(const std::string& authorization_token) {
+oak::policy::Label AuthorizationBearerTokenPolicy(const std::string& authorization_token_hmac) {
   oak::policy::Label label;
   auto* secrecy_tag = label.add_secrecy_tags();
   auto* integrity_tag = label.add_integrity_tags();
-  secrecy_tag->mutable_grpc_tag()->set_authorization_bearer_token(authorization_token);
-  integrity_tag->mutable_grpc_tag()->set_authorization_bearer_token(authorization_token);
+  secrecy_tag->mutable_grpc_tag()->set_authorization_bearer_token_hmac(authorization_token_hmac);
+  // We set integrity tag here, even though it would make more sense for the server to determine
+  // what integrity tag to assign to the incoming message, based on the authentication mechanism
+  // used (e.g. the actual bearer token, rather than its HMAC).
+  // Partly tracked in #420.
+  integrity_tag->mutable_grpc_tag()->set_authorization_bearer_token_hmac(authorization_token_hmac);
   return label;
 }
 

--- a/oak/proto/policy.proto
+++ b/oak/proto/policy.proto
@@ -43,17 +43,24 @@ message Tag {
 
 // Policies related to gRPC communication, referring to the native gRPC node within the TCB.
 message GrpcTag {
-  // TODO: Replace this with identity assertions based on public keys when Asylo supports it.
+  // TODO: Add identity assertions based on public keys when Asylo supports it.
   // See
   // https://github.com/google/asylo/blob/3158887cb768112516424b3e65046f3946eb4465/asylo/identity/identity.proto#L40.
-  bytes authorization_bearer_token = 1;
+
+  // In order for a client to be authorized to fulfill a tag with (public)
+  // `authorization_bearer_token_hmac` value h, the client needs to provide a (secret) bearer token
+  // s such that h = HMAC-SHA256(s, "oak-grpc-bearer-token-1").
+  //
+  // We don't use the raw token t as the tag itself because labels are considered public by default,
+  // so the secrecy of the token would be compromised immediately.
+  bytes authorization_bearer_token_hmac = 1;
 }
 
 // Policies related to modules, referring to the native WebAssembly node within the TCB.
 message WebAssemblyModuleTag {
-  // The attestation for a single WebAssembly module, a sha256 digest of the
-  // module in binary format.
-  // TODO: Replace this with identity assertions for multiple module versions,
-  // based on a public verifiable log.
+  // The attestation for a single WebAssembly module, a SHA256 digest of the module in binary
+  // format.
+  // TODO: Replace this with identity assertions for multiple module versions, based on a public
+  // verifiable log.
   bytes module_attestation = 1;
 }

--- a/sdk/rust/oak/src/proto/policy.rs
+++ b/sdk/rust/oak/src/proto/policy.rs
@@ -546,7 +546,7 @@ impl ::protobuf::reflect::ProtobufValue for Tag {
 #[derive(PartialEq,Clone,Default)]
 pub struct GrpcTag {
     // message fields
-    pub authorization_bearer_token: ::std::vec::Vec<u8>,
+    pub authorization_bearer_token_hmac: ::std::vec::Vec<u8>,
     // special fields
     pub unknown_fields: ::protobuf::UnknownFields,
     pub cached_size: ::protobuf::CachedSize,
@@ -563,30 +563,30 @@ impl GrpcTag {
         ::std::default::Default::default()
     }
 
-    // bytes authorization_bearer_token = 1;
+    // bytes authorization_bearer_token_hmac = 1;
 
 
-    pub fn get_authorization_bearer_token(&self) -> &[u8] {
-        &self.authorization_bearer_token
+    pub fn get_authorization_bearer_token_hmac(&self) -> &[u8] {
+        &self.authorization_bearer_token_hmac
     }
-    pub fn clear_authorization_bearer_token(&mut self) {
-        self.authorization_bearer_token.clear();
+    pub fn clear_authorization_bearer_token_hmac(&mut self) {
+        self.authorization_bearer_token_hmac.clear();
     }
 
     // Param is passed by value, moved
-    pub fn set_authorization_bearer_token(&mut self, v: ::std::vec::Vec<u8>) {
-        self.authorization_bearer_token = v;
+    pub fn set_authorization_bearer_token_hmac(&mut self, v: ::std::vec::Vec<u8>) {
+        self.authorization_bearer_token_hmac = v;
     }
 
     // Mutable pointer to the field.
     // If field is not initialized, it is initialized with default value first.
-    pub fn mut_authorization_bearer_token(&mut self) -> &mut ::std::vec::Vec<u8> {
-        &mut self.authorization_bearer_token
+    pub fn mut_authorization_bearer_token_hmac(&mut self) -> &mut ::std::vec::Vec<u8> {
+        &mut self.authorization_bearer_token_hmac
     }
 
     // Take field
-    pub fn take_authorization_bearer_token(&mut self) -> ::std::vec::Vec<u8> {
-        ::std::mem::replace(&mut self.authorization_bearer_token, ::std::vec::Vec::new())
+    pub fn take_authorization_bearer_token_hmac(&mut self) -> ::std::vec::Vec<u8> {
+        ::std::mem::replace(&mut self.authorization_bearer_token_hmac, ::std::vec::Vec::new())
     }
 }
 
@@ -600,7 +600,7 @@ impl ::protobuf::Message for GrpcTag {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_singular_proto3_bytes_into(wire_type, is, &mut self.authorization_bearer_token)?;
+                    ::protobuf::rt::read_singular_proto3_bytes_into(wire_type, is, &mut self.authorization_bearer_token_hmac)?;
                 },
                 _ => {
                     ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
@@ -614,8 +614,8 @@ impl ::protobuf::Message for GrpcTag {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        if !self.authorization_bearer_token.is_empty() {
-            my_size += ::protobuf::rt::bytes_size(1, &self.authorization_bearer_token);
+        if !self.authorization_bearer_token_hmac.is_empty() {
+            my_size += ::protobuf::rt::bytes_size(1, &self.authorization_bearer_token_hmac);
         }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -623,8 +623,8 @@ impl ::protobuf::Message for GrpcTag {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
-        if !self.authorization_bearer_token.is_empty() {
-            os.write_bytes(1, &self.authorization_bearer_token)?;
+        if !self.authorization_bearer_token_hmac.is_empty() {
+            os.write_bytes(1, &self.authorization_bearer_token_hmac)?;
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -669,9 +669,9 @@ impl ::protobuf::Message for GrpcTag {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
                 fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "authorization_bearer_token",
-                    |m: &GrpcTag| { &m.authorization_bearer_token },
-                    |m: &mut GrpcTag| { &mut m.authorization_bearer_token },
+                    "authorization_bearer_token_hmac",
+                    |m: &GrpcTag| { &m.authorization_bearer_token_hmac },
+                    |m: &mut GrpcTag| { &mut m.authorization_bearer_token_hmac },
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<GrpcTag>(
                     "GrpcTag",
@@ -695,7 +695,7 @@ impl ::protobuf::Message for GrpcTag {
 
 impl ::protobuf::Clear for GrpcTag {
     fn clear(&mut self) {
-        self.authorization_bearer_token.clear();
+        self.authorization_bearer_token_hmac.clear();
         self.unknown_fields.clear();
     }
 }
@@ -888,10 +888,10 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     yTags\"\x99\x01\n\x03Tag\x120\n\x08grpc_tag\x18\x01\x20\x01(\x0b2\x13.oa\
     k.policy.GrpcTagH\0R\x07grpcTag\x12Y\n\x17web_assembly_module_tag\x18\
     \x02\x20\x01(\x0b2\x20.oak.policy.WebAssemblyModuleTagH\0R\x14webAssembl\
-    yModuleTagB\x05\n\x03tag\"G\n\x07GrpcTag\x12<\n\x1aauthorization_bearer_\
-    token\x18\x01\x20\x01(\x0cR\x18authorizationBearerToken\"E\n\x14WebAssem\
-    blyModuleTag\x12-\n\x12module_attestation\x18\x01\x20\x01(\x0cR\x11modul\
-    eAttestationb\x06proto3\
+    yModuleTagB\x05\n\x03tag\"P\n\x07GrpcTag\x12E\n\x1fauthorization_bearer_\
+    token_hmac\x18\x01\x20\x01(\x0cR\x1cauthorizationBearerTokenHmac\"E\n\
+    \x14WebAssemblyModuleTag\x12-\n\x12module_attestation\x18\x01\x20\x01(\
+    \x0cR\x11moduleAttestationb\x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {


### PR DESCRIPTION
The previous implementation used the actual (secret) token as both the
policy and the authentication mechanism.

This commit makes it so that the policy only uses a (public) HMAC
derived from the token, so that the actual (secret) token is only used
for actual authentication.

Ref #488

### Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
