### PR TITLE
Provide blanket implementation for protobuf

### DIFF
--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -20,7 +20,7 @@ pub use crate::proto::code::Code;
 use crate::{proto, OakError, OakStatus, ReadHandle};
 use log::{error, info, warn};
 use proto::grpc_encap::{GrpcRequest, GrpcResponse};
-use protobuf::{Message, ProtobufEnum};
+use protobuf::ProtobufEnum;
 
 mod invocation;
 pub use invocation::Invocation;
@@ -36,41 +36,11 @@ pub fn build_status(code: Code, msg: &str) -> proto::status::Status {
     status
 }
 
-impl crate::io::Encodable for GrpcRequest {
-    fn encode(&self) -> std::result::Result<crate::io::Message, crate::OakError> {
-        let bytes = self.write_to_bytes()?;
-        let handles = Vec::new();
-        Ok(crate::io::Message { bytes, handles })
-    }
-}
-
-impl crate::io::Decodable for GrpcRequest {
-    fn decode(message: &crate::io::Message) -> std::result::Result<Self, crate::OakError> {
-        let value = protobuf::parse_from_bytes(&message.bytes)?;
-        Ok(value)
-    }
-}
-
 /// Channel-holding object that encapsulates response messages into
 /// `GrpcResponse` wrapper messages and writes serialized versions to a send
 /// channel.
 pub struct ChannelResponseWriter {
     sender: crate::io::Sender<GrpcResponse>,
-}
-
-impl crate::io::Encodable for GrpcResponse {
-    fn encode(&self) -> std::result::Result<crate::io::Message, crate::OakError> {
-        let bytes = self.write_to_bytes()?;
-        let handles = Vec::new();
-        Ok(crate::io::Message { bytes, handles })
-    }
-}
-
-impl crate::io::Decodable for GrpcResponse {
-    fn decode(message: &crate::io::Message) -> std::result::Result<Self, crate::OakError> {
-        let value = protobuf::parse_from_bytes(&message.bytes)?;
-        Ok(value)
-    }
 }
 
 /// Indicate whether a write method should leave the current gRPC method

--- a/sdk/rust/oak/src/io/decodable.rs
+++ b/sdk/rust/oak/src/io/decodable.rs
@@ -21,3 +21,15 @@ use crate::OakError;
 pub trait Decodable: Sized {
     fn decode(message: &Message) -> Result<Self, OakError>;
 }
+
+impl<T: protobuf::Message> Decodable for T {
+    fn decode(message: &Message) -> Result<Self, OakError> {
+        if !message.handles.is_empty() {
+            return Err(
+                protobuf::ProtobufError::WireError(protobuf::error::WireError::Other).into(),
+            );
+        }
+        let value = protobuf::parse_from_bytes(&message.bytes)?;
+        Ok(value)
+    }
+}

--- a/sdk/rust/oak/src/io/encodable.rs
+++ b/sdk/rust/oak/src/io/encodable.rs
@@ -21,3 +21,11 @@ use crate::OakError;
 pub trait Encodable {
     fn encode(&self) -> Result<Message, OakError>;
 }
+
+impl<T: protobuf::Message> Encodable for T {
+    fn encode(&self) -> Result<Message, OakError> {
+        let bytes = self.write_to_bytes()?;
+        let handles = Vec::new();
+        Ok(crate::io::Message { bytes, handles })
+    }
+}


### PR DESCRIPTION
Allow any protobuf message to be encoded and decoded as bytes + handles,
where handles are always empty.

Also validate that incoming handles are indeed empty when decoding, and
return an error if that's not the case.

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
