### PR TITLE
Use `oak_utils` wrapper for protobuf generation

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "oak 0.1.0",
  "oak_derive 0.1.0",
  "oak_log 0.1.0",
+ "oak_utils 0.1.0",
  "protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust-grpc 0.7.0",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1604,7 +1605,6 @@ dependencies = [
  "oak_derive 0.1.0",
  "oak_log 0.1.0",
  "protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc-rust-grpc 0.7.0",
  "translator_common 0.1.0",
 ]
 
@@ -1614,6 +1614,7 @@ version = "0.1.0"
 dependencies = [
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak 0.1.0",
+ "oak_utils 0.1.0",
  "protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust-grpc 0.7.0",
 ]

--- a/examples/chat/module/rust/Cargo.toml
+++ b/examples/chat/module/rust/Cargo.toml
@@ -19,4 +19,5 @@ rand = "*"
 serde = {version = "*", features = ["derive"]}
 
 [build-dependencies]
+oak_utils = "*"
 protoc-rust-grpc = { path = "../../../../third_party/grpc-rust/protoc-rust-grpc" }

--- a/examples/chat/module/rust/build.rs
+++ b/examples/chat/module/rust/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    protoc_rust_grpc::run(protoc_rust_grpc::Args {
+    oak_utils::run_protoc_rust_grpc(protoc_rust_grpc::Args {
         out_dir: "src/proto",
         input: &["../../proto/chat.proto"],
         includes: &["../../proto", "../../third_party"],

--- a/examples/translator/common/Cargo.toml
+++ b/examples/translator/common/Cargo.toml
@@ -10,4 +10,5 @@ oak = "=0.1.0"
 protobuf = "*"
 
 [build-dependencies]
+oak_utils = "*"
 protoc-rust-grpc = { path = "../../../third_party/grpc-rust/protoc-rust-grpc" }

--- a/examples/translator/common/build.rs
+++ b/examples/translator/common/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    protoc_rust_grpc::run(protoc_rust_grpc::Args {
+    oak_utils::run_protoc_rust_grpc(protoc_rust_grpc::Args {
         out_dir: "src/proto",
         input: &["../proto/translator.proto"],
         includes: &["../proto", "../third_party"],

--- a/examples/translator/module/rust/Cargo.toml
+++ b/examples/translator/module/rust/Cargo.toml
@@ -14,6 +14,3 @@ oak_derive = "=0.1.0"
 oak_log = "=0.1.0"
 protobuf = "*"
 translator_common = "=0.1.0"
-
-[build-dependencies]
-protoc-rust-grpc = { path = "../../../../third_party/grpc-rust/protoc-rust-grpc" }


### PR DESCRIPTION
We should find a way of enforcing that we always use `oak_utils`
wrappers instead of the underlying `grpc` functions.

See #510

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
