### PR TITLE
Add a `serialized_config` Bazel rule

### DIFF
--- a/oak/common/app_config.bzl
+++ b/oak/common/app_config.bzl
@@ -1,0 +1,40 @@
+#
+# Copyright 2020 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Rule for serializing an Oak application configuration."""
+
+def serialized_config(name, textproto, modules, output):
+    """Serializes an Oak application configuration in a binary file.
+
+    Args:
+        name: Name of the build rule.
+        textproto: Textproto file with application configuration.
+        modules: A dictionary with module names as keys and module paths as values.
+        output: Output file.
+    """
+    srcs = [textproto] + modules.values()
+    apps = ",".join([n + ":$(location " + path + ")" for (n, path) in modules.items()])
+    cmd = "$(location //oak/common:app_config_serializer)" + \
+          " --textproto=$(location " + textproto + ")" + \
+          " --modules=" + apps + \
+          " --output_file=$@"
+    native.genrule(
+        name = name,
+        srcs = srcs,
+        outs = [output],
+        cmd = cmd,
+        tools = ["//oak/common:app_config_serializer"],
+    )

--- a/oak/common/app_config.bzl
+++ b/oak/common/app_config.bzl
@@ -26,10 +26,10 @@ def serialized_config(name, textproto, modules, output):
         output: Output file.
     """
     srcs = [textproto] + modules.values()
-    apps = ",".join([n + ":$(location " + path + ")" for (n, path) in modules.items()])
+    module_list = ",".join([n + ":$(location " + path + ")" for (n, path) in modules.items()])
     cmd = "$(location //oak/common:app_config_serializer)" + \
           " --textproto=$(location " + textproto + ")" + \
-          " --modules=" + apps + \
+          " --modules=" + module_list + \
           " --output_file=$@"
     native.genrule(
         name = name,

--- a/oak/common/app_config.bzl
+++ b/oak/common/app_config.bzl
@@ -20,13 +20,12 @@ def serialized_config(name, textproto, modules):
     """Serializes an Oak application configuration in a binary file.
 
     Args:
-        name: Name of the build rule.
+        name: Name of the generated binary file.
         textproto: Textproto file with application configuration.
         modules: A dictionary with module names as keys and module paths as values.
     """
     srcs = [textproto] + modules.values()
-    output = name + ".bin"
-    module_list = ",".join([n + ":$(location " + path + ")" for (n, path) in modules.items()])
+    module_list = ",".join(["{}:$(location {})".format(name, path) for (name, path) in modules.items()])
     cmd = "$(location //oak/common:app_config_serializer)" + \
           " --textproto=$(location {})".format(textproto) + \
           " --modules={}".format(module_list) + \
@@ -34,7 +33,7 @@ def serialized_config(name, textproto, modules):
     native.genrule(
         name = name,
         srcs = srcs,
-        outs = [output],
+        outs = [name],
         cmd = cmd,
         tools = ["//oak/common:app_config_serializer"],
     )

--- a/oak/common/app_config.bzl
+++ b/oak/common/app_config.bzl
@@ -16,16 +16,16 @@
 
 """Rule for serializing an Oak application configuration."""
 
-def serialized_config(name, textproto, modules, output):
+def serialized_config(name, textproto, modules):
     """Serializes an Oak application configuration in a binary file.
 
     Args:
         name: Name of the build rule.
         textproto: Textproto file with application configuration.
         modules: A dictionary with module names as keys and module paths as values.
-        output: Output file.
     """
     srcs = [textproto] + modules.values()
+    output = name + ".bin"
     module_list = ",".join([n + ":$(location " + path + ")" for (n, path) in modules.items()])
     cmd = "$(location //oak/common:app_config_serializer)" + \
           " --textproto=$(location " + textproto + ")" + \

--- a/oak/common/app_config.bzl
+++ b/oak/common/app_config.bzl
@@ -28,8 +28,8 @@ def serialized_config(name, textproto, modules):
     output = name + ".bin"
     module_list = ",".join([n + ":$(location " + path + ")" for (n, path) in modules.items()])
     cmd = "$(location //oak/common:app_config_serializer)" + \
-          " --textproto=$(location " + textproto + ")" + \
-          " --modules=" + module_list + \
+          " --textproto=$(location {})".format(textproto) + \
+          " --modules={}".format(module_list) + \
           " --output_file=$@"
     native.genrule(
         name = name,

--- a/oak/common/app_config.cc
+++ b/oak/common/app_config.cc
@@ -97,6 +97,7 @@ bool ValidApplicationConfig(const ApplicationConfiguration& config) {
   // Check name for the config of the initial node is present and is a Web
   // Assembly variant.
   if (wasm_names.count(config.initial_node_config_name()) == 0) {
+    LOG(ERROR) << "config of the initial node is not present in Wasm";
     return false;
   }
   if (config.initial_entrypoint_name().empty()) {

--- a/oak/common/app_config_serializer.cc
+++ b/oak/common/app_config_serializer.cc
@@ -41,17 +41,14 @@ int main(int argc, char* argv[]) {
   std::string textproto = absl::GetFlag(FLAGS_textproto);
   if (textproto.empty()) {
     LOG(QFATAL) << "Textproto file is not specified";
-    return 1;
   }
   std::vector<std::string> modules = absl::GetFlag(FLAGS_modules);
   if (modules.empty()) {
     LOG(QFATAL) << "Wasm modules are not specified";
-    return 1;
   }
   std::string output_file = absl::GetFlag(FLAGS_output_file);
   if (output_file.empty()) {
     LOG(QFATAL) << "Output file is not specified";
-    return 1;
   }
 
   // Parse module names.
@@ -60,7 +57,6 @@ int main(int argc, char* argv[]) {
     std::vector<std::string> module_info = absl::StrSplit(module, ':');
     if (module_info.size() != 2) {
       LOG(QFATAL) << "Incorrect module specification: " << module;
-      return 1;
     }
     module_map.emplace(module_info.front(), module_info.back());
   }
@@ -79,20 +75,17 @@ int main(int argc, char* argv[]) {
         std::string module_bytes = oak::utils::read_file(it->second);
         if (module_bytes.empty()) {
           LOG(QFATAL) << "Empty Wasm module:" << module_name;
-          return 1;
         }
         node_config.mutable_wasm_config()->set_module_bytes(module_bytes);
       } else {
         LOG(QFATAL) << "Module path for " << module_name << " is not specified";
-        return 1;
       }
     }
   }
 
   // Check application configuration validity.
   if (!oak::ValidApplicationConfig(*config.get())) {
-    LOG(INFO) << "Application config is not valid";
-    return 1;
+    LOG(QFATAL) << "Application config is not valid";
   }
 
   oak::WriteConfigToFile(config.get(), output_file);


### PR DESCRIPTION
This change adds a Bazel rule for creating a serialized config binary.

Necessary for #462

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
