### PR TITLE
Delete signal handler from `server_dev`

### DIFF
--- a/oak/server/dev/dev_oak_main.cc
+++ b/oak/server/dev/dev_oak_main.cc
@@ -14,34 +14,21 @@
  * limitations under the License.
  */
 
-#include <csignal>
-#include <fstream>
-#include <iostream>
 #include <string>
-#include <vector>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/synchronization/notification.h"
 #include "absl/time/time.h"
 #include "asylo/util/logging.h"
-#include "dev_oak_manager.h"
 #include "include/grpcpp/server.h"
 #include "include/grpcpp/server_builder.h"
+#include "oak/server/dev/dev_oak_manager.h"
 
 ABSL_FLAG(int, grpc_port, 8888, "Port to listen on");
 
-void sigint_handler(int) {
-  LOG(QFATAL) << "SIGINT received";
-  exit(1);
-}
-
 int main(int argc, char* argv[]) {
   absl::ParseCommandLine(argc, argv);
-
-  // We install an explicit SIGINT handler, as for some reason the default one
-  // does not seem to work.
-  std::signal(SIGINT, sigint_handler);
 
   // Create manager instance.
   std::unique_ptr<oak::Manager::Service> service = absl::make_unique<oak::DevOakManager>();


### PR DESCRIPTION
This change:
- Deletes an unnecessary signal handler from `server_dev`
- Updates includes

Done after the following comment: https://github.com/project-oak/oak/pull/553#discussion_r375389045

### Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
