### PR TITLE
Introduce generic Node trait

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -31,13 +31,16 @@ things from there.
 An Oak Node needs to provide a single
 [main entrypoint](abi.md#exported-function), which is the point at which Node
 execution begins. However, Node authors don't _have_ to implement this function
-themselves; for a Node which is triggered by external gRPC requests (the normal
-"front door" for an Oak application), there are helper functions in the Oak SDK
-that make this easier.
+themselves; for a Node which receives messages (bytes + handles) that can be
+[decoded](https://project-oak.github.io/oak/sdk/oak/io/trait.Decodable.html)
+into a Rust type, there are helper functions in the Oak SDK that make this
+easier.
 
-To use these helpers, an Oak Node should implement a `struct` of some kind to
-represent the Node itself, and then add the `derive(OakExports)` attribute (from
-the [`oak_derive`](https://project-oak.github.io/oak/sdk/oak_derive/index.html)
+To use these helpers, an Oak Node should be a `struct` of some kind to represent
+the internal state of the Node itself (which may be empty), implement the
+[`Node`](https://project-oak.github.io/oak/sdk/oak/trait.Node.html) trait for
+it, and then add the `derive(OakExports)` attribute (from the
+[`oak_derive`](https://project-oak.github.io/oak/sdk/oak_derive/index.html)
 crate):
 
 <!-- prettier-ignore-start -->
@@ -69,16 +72,18 @@ macro implements a main function named `oak_main` for you, with the following
 default behaviour:
 
 - Create an instance of your Node `struct` (using the `new()` method from the
-  [`OakNode`](https://project-oak.github.io/oak/sdk/oak/grpc/trait.OakNode.html)
-  trait described below).
+  [`Node`](https://project-oak.github.io/oak/sdk/oak/trait.Node.html) trait.
 - Take the channel handle passed to `oak_main()` and use it for gRPC input.
 - Pass the Node `struct` and the channel handle to the
-  [`event_loop()`](https://project-oak.github.io/oak/sdk/oak/grpc/fn.event_loop.html)
-  function from the [`oak::grpc` module](sdk.md#oakgrpc-module).
+  [`run_event_loop()`](https://project-oak.github.io/oak/sdk/oak/fn.run_event_loop.html)
+  function.
 
-To make this work, the Node `struct` must implement the
+For gRPC server nodes (the normal "front door" for an Oak application), the Node
+`struct` must implement the
 [`oak::grpc::OakNode`](https://project-oak.github.io/oak/sdk/oak/grpc/trait.OakNode.html)
-trait. This has two methods:
+trait (which provides an automatic implementation of the
+[`Node`](https://project-oak.github.io/oak/sdk/oak/trait.Node.html)). This has
+two methods:
 
 - A
   [`new()`](https://project-oak.github.io/oak/sdk/oak/grpc/trait.OakNode.html#tymethod.new)
@@ -555,14 +560,14 @@ function:
 [embedmd]:# (../examples/abitest/module_0/rust/src/lib.rs Rust /^#.*no_mangle.*/ /pub fn main\(.*/)
 ```Rust
 #[no_mangle]
-pub extern "C" fn frontend_oak_main(handle: u64) {
+pub extern "C" fn frontend_oak_main(in_handle: u64) {
     let _ = std::panic::catch_unwind(|| {
         oak::set_panic_hook();
-        main(handle)
+        main(in_handle);
     });
 }
 
-pub fn main(handle: u64) {
+pub fn main(in_handle: u64) {
 ```
 <!-- prettier-ignore-end -->
 

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -19,7 +19,7 @@ pub mod proto;
 use abitest_common::{InternalMessage, LOG_CONFIG_NAME};
 use byteorder::WriteBytesExt;
 use expect::{expect, expect_eq};
-use log::{info, warn};
+use log::info;
 use oak::grpc::OakNode;
 use oak::{grpc, ChannelReadStatus, OakStatus};
 use proto::abitest::{ABITestRequest, ABITestResponse, ABITestResponse_TestResult};
@@ -39,23 +39,16 @@ struct FrontendNode {
 }
 
 #[no_mangle]
-pub extern "C" fn frontend_oak_main(handle: u64) {
+pub extern "C" fn frontend_oak_main(in_handle: u64) {
     let _ = std::panic::catch_unwind(|| {
         oak::set_panic_hook();
-        main(handle)
+        main(in_handle);
     });
 }
 
-pub fn main(handle: u64) {
+pub fn main(in_handle: u64) {
     let node = FrontendNode::new();
-    if let Err(s) = oak::grpc::event_loop(
-        node,
-        oak::ReadHandle {
-            handle: oak::Handle::from_raw(handle),
-        },
-    ) {
-        warn!("Node terminating with {:?}", s);
-    }
+    oak::run_event_loop(node, in_handle);
 }
 
 impl oak::grpc::OakNode for FrontendNode {

--- a/examples/translator/module/rust/src/lib.rs
+++ b/examples/translator/module/rust/src/lib.rs
@@ -22,7 +22,7 @@ use translator_common::proto::translator::{TranslateRequest, TranslateResponse};
 use translator_common::proto::translator_grpc::{dispatch, TranslatorNode};
 
 #[derive(OakExports)]
-struct Node {}
+struct Node;
 
 impl OakNode for Node {
     fn new() -> Self {

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -15,7 +15,7 @@
 //
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
-use log::{debug, error};
+use log::{debug, error, info};
 use protobuf::ProtobufEnum;
 use serde::{Deserialize, Serialize};
 
@@ -400,4 +400,71 @@ pub fn set_panic_hook() {
             file, line, msg
         );
     }));
+}
+
+/// Trait implemented by all Oak Nodes.
+///
+/// It has a single method for handling commands, which are [`Decodable`](crate::io::Decodable)
+/// objects that are received via the single incoming channel handle which is passed in at node
+/// creation time. The return value is only used for logging in case of failure.
+pub trait Node<T: crate::io::Decodable> {
+    fn new() -> Self;
+    fn handle_command(&mut self, command: T) -> Result<(), crate::OakError>;
+}
+
+/// Run an event loop on the provided `node`:
+///
+/// - wait for new messages on the provided channel `in_handle`
+/// - if the runtime signals that the node was terminated while waiting, then exit the event loop
+/// - otherwise, read the available message via the provided channel handle
+/// - decode the message from (bytes + handles) to the specified type `T`
+/// - pass the typed object to the `Node::handle_command` method of the `node`, which executes a
+///   single iteration of the event loop
+///
+/// Note the loop is only interrupted if the node is terminated while waiting. Other errors are just
+/// logged, and the event loop continues with the next iteration.
+pub fn run_event_loop<T: crate::io::Decodable, N: Node<T>>(mut node: N, in_handle: u64) {
+    let in_channel = crate::ReadHandle {
+        handle: crate::Handle::from_raw(in_handle),
+    };
+    if !in_channel.handle.is_valid() {
+        error!("invalid input handle");
+        return;
+    }
+    let receiver = crate::io::Receiver::new(in_channel);
+    info!("starting event loop");
+    loop {
+        // First wait until a message is available. If the node was terminated while waiting, this
+        // will return `ERR_TERMINATED`, which indicates that the event loop should be terminated.
+        // For any other error raised while waiting is logged, we try and determine whether it is
+        // transient or not, and then continue or terminate the event loop, respectively.
+        match receiver.wait() {
+            Err(status) => {
+                error!("error waiting for command: {:?}", status);
+                use crate::OakStatus::*;
+                match status {
+                    ERR_TERMINATED | ERR_BAD_HANDLE | ERR_CHANNEL_CLOSED => {
+                        info!("non-transient error: terminating event loop");
+                        return;
+                    }
+                    _ => {
+                        info!("(possibly) transient error: continuing event loop");
+                        continue;
+                    }
+                }
+            }
+            Ok(()) => {}
+        }
+        match receiver.try_receive() {
+            Ok(command) => {
+                info!("received command");
+                if let Err(err) = node.handle_command(command) {
+                    error!("error handling command: {}", err);
+                }
+            }
+            Err(err) => {
+                error!("error receiving command: {}", err);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Provide blanket implementation of it for gRPC server nodes.

Change code generated by `oak_derive` crate to depend only on the `Node`
trait, instead of being tied to gRPC.

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
