### PR TITLE
Add `default_visibility` to `third_party/rust`

### DIFF
--- a/third_party/rust/BUILD
+++ b/third_party/rust/BUILD
@@ -17,6 +17,7 @@
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
 
 package(
+    default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )
 
@@ -25,5 +26,4 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     crate_type = "lib",
     edition = "2018",
-    visibility = ["//visibility:public"],
 )

--- a/third_party/rust/src/libstd/BUILD
+++ b/third_party/rust/src/libstd/BUILD
@@ -17,6 +17,7 @@
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
 
 package(
+    default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )
 
@@ -25,5 +26,4 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     crate_type = "lib",
     edition = "2018",
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This change adds a `default_visibility` argument to `third_party/rust/*/BUILD` files. 

This argument was added because the `rust_library` rule doesn't have a `visibility` argument:
https://github.com/bazelbuild/rules_rust/blob/master/docs/index.md#rust_library

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
