### PR TITLE
Remove hard coded Wasm paths in abitest & hello_world

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -440,7 +440,7 @@ fn test_say_hello() {
     simple_logger::init().unwrap();
 
     let configuration = oak_tests::test_configuration(
-        &[(MODULE_CONFIG_NAME, WASM_PATH)],
+        build_wasm().expect("failed to build wasm modules"),
         LOG_CONFIG_NAME,
         MODULE_CONFIG_NAME,
         ENTRYPOINT_NAME,

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -466,8 +466,6 @@ fn test_say_hello() {
 
 This has a little bit more boilerplate than testing a method directly:
 
-- The inbound gRPC channel that requests are delivered over has to be explicitly
-  set up (`oak_tests::grpc_channel_setup_default`)
 - After being configured, the runtime executes Nodes in separate threads
   (`oak_runtime::configure_and_run`). The `derive(OakExports)` macro (from the
   [`oak_derive`](https://project-oak.github.io/oak/sdk/oak_derive/index.html)

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/examples/abitest/tests/src/tests.rs
+++ b/examples/abitest/tests/src/tests.rs
@@ -33,19 +33,15 @@ const FRONTEND_WASM_NAME: &str = "abitest_0_frontend.wasm";
 const BACKEND_WASM_NAME: &str = "abitest_1_backend.wasm";
 
 fn build_wasm() -> std::io::Result<Vec<(String, Vec<u8>)>> {
-    let mut frontend = oak_tests::compile_rust_to_wasm(FRONTEND_MANIFEST)?;
-    frontend.push("wasm32-unknown-unknown/debug");
-    frontend.push(FRONTEND_WASM_NAME);
-    let mut backend = oak_tests::compile_rust_to_wasm(BACKEND_MANIFEST)?;
-    backend.push("wasm32-unknown-unknown/debug");
-    backend.push(BACKEND_WASM_NAME);
-
-    let frontend_wasm = std::fs::read(frontend)?;
-    let backend_wasm = std::fs::read(backend)?;
-
     Ok(vec![
-        (FRONTEND_CONFIG_NAME.to_owned(), frontend_wasm),
-        (BACKEND_CONFIG_NAME.to_owned(), backend_wasm),
+        (
+            FRONTEND_CONFIG_NAME.to_owned(),
+            oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, FRONTEND_WASM_NAME)?,
+        ),
+        (
+            BACKEND_CONFIG_NAME.to_owned(),
+            oak_tests::compile_rust_wasm(BACKEND_MANIFEST, BACKEND_WASM_NAME)?,
+        ),
     ])
 }
 

--- a/examples/hello_world/module/rust/src/tests.rs
+++ b/examples/hello_world/module/rust/src/tests.rs
@@ -26,13 +26,10 @@ const MODULE_MANIFEST: &str = "Cargo.toml";
 const MODULE_WASM_NAME: &str = "hello_world.wasm";
 
 fn build_wasm() -> std::io::Result<Vec<(String, Vec<u8>)>> {
-    let mut wasm_file = oak_tests::compile_rust_to_wasm(MODULE_MANIFEST)?;
-    wasm_file.push("wasm32-unknown-unknown/debug");
-    wasm_file.push(MODULE_WASM_NAME);
-
-    let wasm = std::fs::read(wasm_file)?;
-
-    Ok(vec![(MODULE_CONFIG_NAME.to_owned(), wasm)])
+    Ok(vec![(
+        MODULE_CONFIG_NAME.to_owned(),
+        oak_tests::compile_rust_wasm(MODULE_MANIFEST, MODULE_WASM_NAME)?,
+    )])
 }
 
 // Test invoking the SayHello Node service method via the Oak runtime.

--- a/examples/hello_world/module/rust/src/tests.rs
+++ b/examples/hello_world/module/rust/src/tests.rs
@@ -22,8 +22,18 @@ const MODULE_CONFIG_NAME: &str = "hello_world";
 const LOG_CONFIG_NAME: &str = "log";
 const ENTRYPOINT_NAME: &str = "oak_main";
 
-// TODO(#541)
-const WASM_PATH: &str = "../../../target/wasm32-unknown-unknown/debug/hello_world.wasm";
+const MODULE_MANIFEST: &str = "Cargo.toml";
+const MODULE_WASM_NAME: &str = "hello_world.wasm";
+
+fn build_wasm() -> std::io::Result<Vec<(String, Vec<u8>)>> {
+    let mut wasm_file = oak_tests::compile_rust_to_wasm(MODULE_MANIFEST)?;
+    wasm_file.push("wasm32-unknown-unknown/debug");
+    wasm_file.push(MODULE_WASM_NAME);
+
+    let wasm = std::fs::read(wasm_file)?;
+
+    Ok(vec![(MODULE_CONFIG_NAME.to_owned(), wasm)])
+}
 
 // Test invoking the SayHello Node service method via the Oak runtime.
 #[test]
@@ -31,7 +41,7 @@ fn test_say_hello() {
     simple_logger::init().unwrap();
 
     let configuration = oak_tests::test_configuration(
-        &[(MODULE_CONFIG_NAME, WASM_PATH)],
+        build_wasm().expect("failed to build wasm modules"),
         LOG_CONFIG_NAME,
         MODULE_CONFIG_NAME,
         ENTRYPOINT_NAME,

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -4,8 +4,8 @@ readonly SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-# For each Rust workspace, first build Wasm modules where appropriate, then run tests, then
-# run doc tests, then run clippy (turning warnings into errors).
+# For each Rust workspace, run tests, then run doc tests, then run clippy
+# (turning warnings into errors).
 #
 # See:
 # - https://doc.rust-lang.org/cargo/commands/cargo-test.html
@@ -17,8 +17,7 @@ cargo test --all-targets --manifest-path=./sdk/rust/Cargo.toml
 cargo test --doc --manifest-path=./sdk/rust/Cargo.toml
 cargo clippy --all-targets --manifest-path=./sdk/rust/Cargo.toml -- --deny=warnings
 
-cargo build --target wasm32-unknown-unknown --manifest-path=./examples/Cargo.toml
-cargo test --all-targets --manifest-path=./examples/Cargo.toml
+cargo test --all-targets --manifest-path=./examples/Cargo.toml -- --nocapture
 cargo test --doc --manifest-path=./examples/Cargo.toml
 cargo clippy --all-targets --manifest-path=./examples/Cargo.toml -- --deny=warnings
 

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/sdk/rust/oak_tests/Cargo.toml
+++ b/sdk/rust/oak_tests/Cargo.toml
@@ -16,6 +16,7 @@ oak_log = "=0.1.0"
 oak_runtime = "=0.1.0"
 protobuf = "*"
 rand = { version = "*" }
+tempdir = "*"
 
 [build-dependencies]
 protoc-rust = "*"

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -21,31 +21,48 @@ use log::info;
 use oak_runtime::ChannelEither;
 use protobuf::{Message, ProtobufEnum};
 
+use std::process::Command;
+use tempdir::TempDir;
+
 use oak_runtime::proto::manager::{
     ApplicationConfiguration, LogConfiguration, NodeConfiguration, WebAssemblyConfiguration,
 };
 
 // TODO(#544)
 
+/// Uses cargo to compile a Rust manifest to Wasm module outputting to a temporary directory.
+pub fn compile_rust_to_wasm(cargo_path: &str) -> std::io::Result<std::path::PathBuf> {
+    let temp_dir = TempDir::new("")?;
+    Command::new("cargo")
+        .args(&["build", "--target=wasm32-unknown-unknown"])
+        .args(&[
+            format!("--manifest-path={}", cargo_path),
+            format!("--target-dir={}", temp_dir.path().display()),
+        ])
+        .spawn()?
+        .wait()?;
+
+    Ok(temp_dir.into_path())
+}
+
 /// Create a simple configuration with collection of Wasm nodes and a logger node.
 ///
-/// - module_name_wasm: Node name and path to associated Wasm file.
+/// - module_name_wasm: Node name and Wasm bytes.
 /// - logger_name: Node name to use for a logger configuration.
 /// - initial_node: Initial node to run on launch.
 /// - entrypoint: Entrypoint in the initial node to run on launch.
 // TODO(#563)
-pub fn test_configuration<P: AsRef<std::path::Path>>(
-    module_name_wasm: &[(&str, P)],
+pub fn test_configuration(
+    module_name_wasm: Vec<(String, Vec<u8>)>,
     logger_name: &str,
     initial_node: &str,
     entrypoint: &str,
 ) -> ApplicationConfiguration {
     let mut nodes: Vec<NodeConfiguration> = module_name_wasm
-        .iter()
-        .map(|(name, module)| {
-            let wasm = std::fs::read(module).expect("Module missing");
+        .into_iter()
+        .map(|(name, wasm)| {
             let mut node = NodeConfiguration::new();
-            node.set_name(name.to_string());
+            node.set_name(name);
             node.set_wasm_config({
                 let mut w = WebAssemblyConfiguration::new();
                 w.set_module_bytes(wasm);

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -30,8 +30,9 @@ use oak_runtime::proto::manager::{
 
 // TODO(#544)
 
-/// Uses cargo to compile a Rust manifest to Wasm module outputting to a temporary directory.
-pub fn compile_rust_to_wasm(cargo_path: &str) -> std::io::Result<std::path::PathBuf> {
+/// Uses cargo to compile a Rust manifest to Wasm bytes. Compilation is performed in a temporary
+/// directory.
+pub fn compile_rust_wasm(cargo_path: &str, module_name: &str) -> std::io::Result<Vec<u8>> {
     let temp_dir = TempDir::new("")?;
     Command::new("cargo")
         .args(&["build", "--target=wasm32-unknown-unknown"])
@@ -42,7 +43,11 @@ pub fn compile_rust_to_wasm(cargo_path: &str) -> std::io::Result<std::path::Path
         .spawn()?
         .wait()?;
 
-    Ok(temp_dir.into_path())
+    let mut path = temp_dir.into_path();
+    path.push("wasm32-unknown-unknown/debug");
+    path.push(module_name);
+
+    std::fs::read(path)
 }
 
 /// Create a simple configuration with collection of Wasm nodes and a logger node.


### PR DESCRIPTION
Removes hard coded Wasm paths in abitest & hello_world, and builds the Wasm modules during test invocation. 

The Wasm files are outputted to a temporary directory and cargo doesn't seem to use artefacts from the host target dir so this does currently cause the tests to do a full rebuild of their Wasm files. 

### Checklist

- [X] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [X] I have written tests that cover the code changes.
  - [X] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

#541