### PR TITLE
oak_runtime: Return a `Result` from load_wasm

### DIFF
--- a/oak/server/rust/oak_runtime/src/node/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/mod.rs
@@ -41,6 +41,7 @@ pub enum NodeConfiguration {
     WasmNode { module: Arc<wasmi::Module> },
 }
 
+/// A enumeration for errors occuring when building `NodeConfiguration` from protobuf types.
 pub enum ConfigurationError {
     WasmiModuleInializationError(wasmi::Error),
 }
@@ -55,7 +56,8 @@ impl std::fmt::Display for ConfigurationError {
     }
 }
 
-/// Loads a Wasm module into a node configuration.
+/// Loads a Wasm module into a node configuration, returning an error if `wasmi` failed to load the
+/// module.
 pub fn load_wasm(wasm_bytes: &[u8]) -> Result<NodeConfiguration, ConfigurationError> {
     let module = wasmi::Module::from_buffer(wasm_bytes)
         .map_err(ConfigurationError::WasmiModuleInializationError)?;

--- a/oak/server/rust/oak_runtime/src/runtime.rs
+++ b/oak/server/rust/oak_runtime/src/runtime.rs
@@ -67,7 +67,10 @@ impl Runtime {
                     }
                     Some(NodeConfiguration_oneof_config_type::wasm_config(
                         proto::manager::WebAssemblyConfiguration { module_bytes, .. },
-                    )) => load_wasm(&module_bytes),
+                    )) => load_wasm(&module_bytes).map_err(|e| {
+                        error!("Error loading wasm: {}", e);
+                        OakStatus::ERR_INVALID_ARGS
+                    })?,
                     Some(_) => {
                         error!("Pseudo-node not implemented!");
                         return Err(OakStatus::ERR_INVALID_ARGS);

--- a/oak/server/rust/oak_runtime/src/runtime.rs
+++ b/oak/server/rust/oak_runtime/src/runtime.rs
@@ -68,7 +68,7 @@ impl Runtime {
                     Some(NodeConfiguration_oneof_config_type::wasm_config(
                         proto::manager::WebAssemblyConfiguration { module_bytes, .. },
                     )) => load_wasm(&module_bytes).map_err(|e| {
-                        error!("Error loading wasm: {}", e);
+                        error!("Error loading Wasm module: {}", e);
                         OakStatus::ERR_INVALID_ARGS
                     })?,
                     Some(_) => {


### PR DESCRIPTION
#564

### Checklist

- [X] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [X] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
