### PR TITLE
Tweak build_gh_pages script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM gcr.io/asylo-framework/asylo:buildenv-v0.5.2
 
-RUN apt-get --yes update && apt-get install --yes \
+RUN apt-get --yes update && apt-get install --no-install-recommends --yes \
   clang-format \
   clang-tidy \
   curl \
   git \
   libncurses5 \
+  libssl-dev \
+  pkg-config \
   python3-six \
   shellcheck \
   xml2
@@ -76,6 +78,8 @@ RUN rustup component add \
   rust-src \
   rustfmt
 
+RUN cargo install cargo-deadlinks
+
 # Install embedmd (via Go).
 ARG GOLANG_VERSION=1.13.1
 ARG GOLANG_SHA256=94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124
@@ -101,8 +105,8 @@ RUN sha256sum --binary ${EMSCRIPTEN_TEMP} && echo "${EMSCRIPTEN_SHA256} *${EMSCR
 RUN tar --extract --gzip --file=${EMSCRIPTEN_TEMP} --directory=${EMSCRIPTEN_DIR} --strip-components=1
 RUN rm ${EMSCRIPTEN_TEMP}
 RUN cd ${EMSCRIPTEN_DIR} \
-    && ./emsdk install ${EMSCRIPTEN_VERSION} \
-    && ./emsdk activate --embedded ${EMSCRIPTEN_VERSION}
+  && ./emsdk install ${EMSCRIPTEN_VERSION} \
+  && ./emsdk activate --embedded ${EMSCRIPTEN_VERSION}
 ENV EMSDK "${EMSCRIPTEN_DIR}"
 ENV EM_CONFIG "${EMSCRIPTEN_DIR}/.emscripten"
 ENV EM_CACHE "${EMSCRIPTEN_DIR}/.emscripten_cache"

--- a/scripts/build_gh_pages
+++ b/scripts/build_gh_pages
@@ -4,71 +4,68 @@ readonly SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-readonly SRC_SUBDIRS=(sdk/rust oak/server/rust)
-readonly DOC_SUBDIRS=(sdk server)
+# First check if the current commit is "clean" with respect to the master branch.
+readonly BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+([[ "${BRANCH}" == 'master' ]] && git diff --exit-code master && git diff --cached --exit-code master) \
+  || (echo "please commit any pending changes first and run this script from the master branch"; exit 1)
 
-# Update the gh-pages branch. Note that `cargo doc` is **not deterministic** so
-# this should only be done when there is a real change.
-readonly BRANCH=${1:-master}
-readonly PREV_COMMIT=$(git log --oneline -n 1 gh-pages | sed 's/.*branch at \([0-9a-f]*\)/\1/')
-
-readonly CHANGES=$(git diff "${PREV_COMMIT}..${BRANCH}" -- "${SRC_SUBDIRS[@]}" | grep -e '[+-]//[/!]')
-
-if [ -z "${CHANGES}" ]; then
-  echo "No doc comment changes found in ${PREV_COMMIT}..${BRANCH}" subdirs "${SRC_SUBDIRS[@]}"
-  exit 0
-fi
-
-git checkout "${BRANCH}"
-readonly BRANCH_SHA1=$(git rev-parse --short HEAD)
+readonly BRANCH_SHA1=$(git rev-parse --short=12 HEAD)
 readonly BRANCH_SUBJECT=$(git log -n 1 --format=format:%s)
 readonly COMMIT_MESSAGE=$(cat <<-END
-Update gh-pages to ${BRANCH} branch at ${BRANCH_SHA1}
+Update gh-pages from ${BRANCH_SHA1}
 
 Auto-generated from commit ${BRANCH_SHA1} ("${BRANCH_SUBJECT}").
 END
 )
 
-tgz_gen() {
+# Create a temporary directory to stage the output of the generation process.
+readonly TARGET_DIR=$(mktemp --directory --tmpdir=/tmp 'project-oak-gh-pages-XXXXXXXXXX')
+
+# Clone the gh-pages branch to the target directory, limiting to one commit.
+git clone git@github.com:project-oak/oak.git --branch=gh-pages --depth=1 "${TARGET_DIR}"
+
+# Remove everything from the target directory. This script is supposed to automatically recreate
+# everything within that directory.
+rm --recursive --force "${TARGET_DIR:?}"/*
+
+readonly SRC_SUBDIRS=(sdk/rust oak/server/rust)
+readonly DOC_SUBDIRS=(sdk server)
+
+doc_gen() {
   local srcdir=$1
   local docdir=$2
-  local tarfile="/tmp/oak-doc-${docdir}-${BRANCH_SHA1}.tgz"
-  # Build Cargo docs and save them off outside the repo
   (
     cd "${srcdir}" || exit
-    rm -rf target/doc
+    # Remove previously generated artifacts, since `cargo doc` only regenerates new or modified
+    # files, but does not remove artifacts generated from now-removed files.
+    rm --recursive --force ./target/doc
     cargo doc --no-deps
     cargo deadlinks
-    cd target/doc || exit
-    tar czf "${tarfile}" ./*
+    cp --recursive ./target/doc "${TARGET_DIR}/${docdir}"
   )
-  echo "${tarfile}"
 }
 
-tarfiles=()
 for ii in "${!SRC_SUBDIRS[@]}"; do
-   tarfiles+=( "$(tgz_gen "${SRC_SUBDIRS[$ii]}" "${DOC_SUBDIRS[$ii]}")" )
+  doc_gen "${SRC_SUBDIRS[$ii]}" "${DOC_SUBDIRS[$ii]}"
 done
 
-# Shift to gh-pages branch and replace contents
-git checkout gh-pages
+cat <<-END > "${TARGET_DIR}/index.html"
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Refresh" content="0; url=./sdk/oak/index.html" />
+  </head>
+  <body>
+    <p><a href="./sdk/oak/index.html">Oak SDK main page</a></p>
+  </body>
+</html>
+END
 
-doc_update() {
-  local docdir=$1
-  local tgzfile=$2
-  rm -rf "${docdir}"
-  mkdir "${docdir}"
-  (
-    cd "${docdir}" || exit
-    tar xzf "${tgzfile}"
-  )
-}
-
-for ii in "${!DOC_SUBDIRS[@]}"; do
-  doc_update "${DOC_SUBDIRS[$ii]}" "${tarfiles[$ii]}"
-done
-
-# Commit any differences
-git add "${DOC_SUBDIRS[@]}"
-git commit --message="${COMMIT_MESSAGE}"
-git checkout "${BRANCH}"
+(
+  cd "${TARGET_DIR}"
+  # Stage everything for commit, including the `index.html` page.
+  git add .
+  git commit --message="${COMMIT_MESSAGE}"
+  echo "to push changes, run the following command:"
+  echo "(cd ${TARGET_DIR} && git push)"
+)


### PR DESCRIPTION
Remove diff logic so that it can be run at any commit and just push the
latest version, even if it causes extra diffs because of the
non-determinism. Incidentally, it seems to be deterministic on my
machine (but maybe it's just because generated docs are cached).

Add generation of index.html file.

Use a temporary directory to stage the output of the generation process.

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
