### PR TITLE
Fix name duplication in `app_config` Bazel rule

### DIFF
--- a/oak/common/app_config.bzl
+++ b/oak/common/app_config.bzl
@@ -31,7 +31,8 @@ def serialized_config(name, textproto, modules):
           " --modules={}".format(module_list) + \
           " --output_file=$@"
     native.genrule(
-        name = name,
+        # Name of the rule cannot be the same as the output file.
+        name = "serialized_{}".format(name),
         srcs = srcs,
         outs = [name],
         cmd = cmd,

--- a/oak/common/app_config.bzl
+++ b/oak/common/app_config.bzl
@@ -19,8 +19,11 @@
 def serialized_config(name, textproto, modules):
     """Serializes an Oak application configuration in a binary file.
 
+    Implicit output targets:
+        name.bin: A binary file with a serialized application configuration.
+
     Args:
-        name: Name of the generated binary file (the output file will have a `.bin` extension, e.g. `name.bin`).
+        name: Name of the generated binary file (the output file will have a `.bin` extension).
         textproto: Textproto file with application configuration.
         modules: A dictionary with module names as keys and module paths as values.
     """

--- a/oak/common/app_config.bzl
+++ b/oak/common/app_config.bzl
@@ -20,7 +20,7 @@ def serialized_config(name, textproto, modules):
     """Serializes an Oak application configuration in a binary file.
 
     Args:
-        name: Name of the generated binary file.
+        name: Name of the generated binary file (the output file will have a `.bin` extension, e.g. `name.bin`).
         textproto: Textproto file with application configuration.
         modules: A dictionary with module names as keys and module paths as values.
     """
@@ -31,10 +31,10 @@ def serialized_config(name, textproto, modules):
           " --modules={}".format(module_list) + \
           " --output_file=$@"
     native.genrule(
-        # Name of the rule cannot be the same as the output file.
-        name = "serialized_{}".format(name),
+        name = name,
         srcs = srcs,
-        outs = [name],
+        # Name of the rule cannot be the same as the output file.
+        outs = ["{}.bin".format(name)],
         cmd = cmd,
         tools = ["//oak/common:app_config_serializer"],
     )


### PR DESCRIPTION
Use different `name` for `genrule` in `app_config.bzl`.

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
