### PR TITLE
Avoid polling in C++ runtime

### DIFF
--- a/oak/server/BUILD
+++ b/oak/server/BUILD
@@ -167,6 +167,7 @@ cc_library(
     srcs = ["channel.cc"],
     hdrs = ["channel.h"],
     deps = [
+        ":notification",
         "//oak/proto:oak_api_cc_proto",
         "//oak/proto:policy_cc_proto",
         "@com_google_absl//absl/memory",
@@ -223,5 +224,28 @@ cc_library(
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/memory",
         "@com_google_asylo//asylo/util:logging",
+    ],
+)
+
+cc_library(
+    name = "notification",
+    srcs = ["notification.cc"],
+    hdrs = ["notification.h"],
+    deps = [
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+cc_test(
+    name = "notification_test",
+    srcs = ["notification_test.cc"],
+    tags = ["host"],
+    deps = [
+        ":channel",
+        ":notification",
+        "@com_google_absl//absl/memory",
+        "@com_google_asylo//asylo/util:logging",
+        "@gtest//:gtest_main",
     ],
 )

--- a/oak/server/notification.cc
+++ b/oak/server/notification.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/server/notification.h"
+
+namespace oak {
+
+Notification::~Notification() { absl::MutexLock lock(&mu_); }
+
+void Notification::Notify() {
+  absl::MutexLock lock(&mu_);
+  count_++;
+}
+
+void Notification::WaitForNotification() {
+  auto notified = [this] { return count_ > 0; };
+  absl::MutexLock lock(&mu_);
+  mu_.Await(absl::Condition(&notified));
+}
+
+bool Notification::WaitForNotificationWithTimeout(absl::Duration timeout) const {
+  auto notified = [this] { return count_ > 0; };
+  absl::MutexLock lock(&mu_);
+  return mu_.AwaitWithTimeout(absl::Condition(&notified), timeout);
+}
+
+}  // namespace oak

--- a/oak/server/notification.h
+++ b/oak/server/notification.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OAK_SERVER_NOTIFICATION_H_
+#define OAK_SERVER_NOTIFICATION_H_
+
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
+
+namespace oak {
+
+// A Notification allows threads to receive notification of an event.
+class Notification {
+ public:
+  Notification() : count_(0) {}
+  Notification(const Notification&) = delete;
+  Notification& operator=(const Notification&) = delete;
+  ~Notification();
+
+  // Trigger the notification.  May be called multiple times.
+  void Notify();
+
+  // Await one or more triggers of the notification.
+  void WaitForNotification();
+  bool WaitForNotificationWithTimeout(absl::Duration timeout) const;
+
+ private:
+  mutable absl::Mutex mu_;
+  int count_;
+};
+
+}  // namespace oak
+
+#endif  // OAK_SERVER_NOTIFICATION_H_

--- a/oak/server/notification_test.cc
+++ b/oak/server/notification_test.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "oak/server/notification.h"
+
+#include <thread>
+#include <vector>
+
+#include "asylo/util/logging.h"
+#include "gtest/gtest.h"
+#include "oak/server/channel.h"
+
+namespace oak {
+
+TEST(Notification, MultipleNotify) {
+  const int kChannelCount = 5;
+  const int kWaiterCount = 4;
+
+  std::vector<MessageChannel::ChannelHalves> channels;
+  for (int chan = 0; chan < kChannelCount; chan++) {
+    channels.push_back(MessageChannel::Create());
+  }
+
+  absl::Mutex mu;
+  int waiting_count = 0;
+
+  std::vector<std::thread> waiters;
+  for (int wait = 0; wait < kWaiterCount; wait++) {
+    LOG(INFO) << "start new waiter thread " << wait;
+    waiters.push_back(std::thread([wait, &channels, &mu, &waiting_count] {
+      LOG(INFO) << "new waiter thread " << wait;
+      auto notify = std::make_shared<Notification>();
+      for (int chan = 0; chan < kChannelCount; chan++) {
+        LOG(INFO) << "register notification for waiter " << wait << " with channel " << chan;
+        channels[chan].read->ReadStatus(std::weak_ptr<Notification>(notify));
+      }
+
+      mu.Lock();
+      waiting_count++;
+      mu.Unlock();
+
+      LOG(INFO) << "waiter thread " << wait << " awaiting...";
+      notify->WaitForNotification();
+      LOG(INFO) << "waiter thread " << wait << " awaiting...done";
+    }));
+  }
+
+  // Make sure all waiters are up and running before writing notifications.
+  mu.Lock();
+  auto all_up = [&waiting_count] { return waiting_count == kWaiterCount; };
+  mu.Await(absl::Condition(&all_up));
+  mu.Unlock();
+
+  for (int chan = 0; chan < kChannelCount; chan++) {
+    auto msg = absl::make_unique<Message>();
+    channels[chan].write->Write(std::move(msg));
+  }
+
+  for (int wait = 0; wait < kWaiterCount; wait++) {
+    LOG(INFO) << "await completion of waiter thread " << wait;
+    waiters[wait].join();
+    LOG(INFO) << "await completion of waiter thread " << wait << " done";
+  }
+}
+
+}  // namespace oak


### PR DESCRIPTION
### Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
