### PR TITLE
Use same argument names in `policy.h` and `policy.cc`

### DIFF
--- a/oak/common/app_config_serializer.cc
+++ b/oak/common/app_config_serializer.cc
@@ -84,7 +84,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Check application configuration validity.
-  if (!oak::ValidApplicationConfig(*config.get())) {
+  if (!oak::ValidApplicationConfig(*config)) {
     LOG(QFATAL) << "Application config is not valid";
   }
 

--- a/oak/common/policy.h
+++ b/oak/common/policy.h
@@ -38,14 +38,14 @@ ABSL_CONST_INIT extern const char kOakPolicyGrpcMetadataKey[];
 ABSL_CONST_INIT extern const char kOakAuthorizationBearerTokenGrpcMetadataKey[];
 
 // Serialized the provided policy so that it can be sent as a binary gRPC metadata value.
-std::string SerializePolicy(const oak::policy::Label& policy);
+std::string SerializePolicy(const oak::policy::Label& policy_proto);
 
 // Deserializes the provided binary gRPC metadata value into a policy.
-oak::policy::Label DeserializePolicy(const std::string& serialized_policy);
+oak::policy::Label DeserializePolicy(const std::string& policy_bytes);
 
 // Creates a policy that only allows declassifying data for gRPC clients that can present the
 // provided authorization bearer token.
-oak::policy::Label AuthorizationBearerTokenPolicy(const std::string& authorization_token);
+oak::policy::Label AuthorizationBearerTokenPolicy(const std::string& authorization_token_hmac);
 
 // Creates a policy that only allows declassifying data for modules that match the
 // provided module attestation.


### PR DESCRIPTION
This change:
- Deletes a redundant `get()` call from `app_config_serializer.cc`
- Use same argument names in `policy.h` and `policy.cc`

### Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
