### PR TITLE
examples: drop specific-commit deps for dirs/term

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1793,16 +1793,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
-[[patch.unused]]
-name = "dirs"
-version = "2.0.1"
-source = "git+https://github.com/soc/dirs-rs?rev=910b3561557dfa8034d39e1462a6cedadbfb6b6e#910b3561557dfa8034d39e1462a6cedadbfb6b6e"
-
-[[patch.unused]]
-name = "term"
-version = "0.5.2"
-source = "git+https://github.com/Stebalien/term?rev=11e754980706a53dda998ba5791a203ab3a5f8fa#11e754980706a53dda998ba5791a203ab3a5f8fa"
-
 [metadata]
 "checksum ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"
 "checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,13 +16,6 @@ members = [
 ]
 
 [patch.crates-io]
-# TODO: Remove when https://github.com/soc/dirs-rs/pull/24 is published.
-dirs = { git = "https://github.com/soc/dirs-rs", rev = "910b3561557dfa8034d39e1462a6cedadbfb6b6e" }
-# TODO: Remove when a new version of the term crate is published. The one currently published
-# depends on dirs=1.0.2 which means that it does not pick up the fix above, which is done on
-# dirs=2.0.1.
-term = { git = "https://github.com/Stebalien/term", rev = "11e754980706a53dda998ba5791a203ab3a5f8fa" }
-
 # Patch dependencies on oak crates so that they refer to the versions within this same repository.
 oak = { path = "../sdk/rust/oak" }
 oak_abi = { path = "../oak/server/rust/oak_abi" }


### PR DESCRIPTION
Commit d362ebd84172 ("Update Rust version (#588)") upgraded the
'dirs' (2.0.1->2.0.2) and 'term' (0.5.2->0.6.1) dependencies so
the pins to particular commits are no longer needed.

