### PR TITLE
Add a `--test` flag to chat

### DIFF
--- a/examples/chat/client/chat.cc
+++ b/examples/chat/client/chat.cc
@@ -252,32 +252,33 @@ int main(int argc, char** argv) {
   }
 
   if (absl::GetFlag(FLAGS_test)) {
-    return EXIT_SUCCESS;
-  } else {
-    RoomId room_id;
-    if (!absl::Base64Unescape(absl::GetFlag(FLAGS_room_id), &room_id)) {
-      LOG(QFATAL) << "Failed to parse --room_id as base 64";
-    }
-    std::unique_ptr<Room> room;
-    if (room_id.empty()) {
-      room = absl::make_unique<Room>(stub.get());
-      room_id = room->Id();
-      LOG(INFO) << "Join this room with --app_address=" << addr
-                << " --room_id=" << absl::Base64Escape(room_id);
-    }
-
-    // Calculate a user handle.
-    std::string user_handle = absl::GetFlag(FLAGS_handle);
-    if (user_handle.empty()) {
-      user_handle = std::getenv("USER");
-    }
-    if (user_handle.empty()) {
-      user_handle = "<anonymous>";
-    }
-
-    // Main chat loop.
-    Chat(stub.get(), room_id, user_handle);
-
+    // Disable interactive behaviour.
     return EXIT_SUCCESS;
   }
+  
+  RoomId room_id;
+  if (!absl::Base64Unescape(absl::GetFlag(FLAGS_room_id), &room_id)) {
+    LOG(QFATAL) << "Failed to parse --room_id as base 64";
+  }
+  std::unique_ptr<Room> room;
+  if (room_id.empty()) {
+    room = absl::make_unique<Room>(stub.get());
+    room_id = room->Id();
+    LOG(INFO) << "Join this room with --app_address=" << addr
+              << " --room_id=" << absl::Base64Escape(room_id);
+  }
+
+  // Calculate a user handle.
+  std::string user_handle = absl::GetFlag(FLAGS_handle);
+  if (user_handle.empty()) {
+    user_handle = std::getenv("USER");
+  }
+  if (user_handle.empty()) {
+    user_handle = "<anonymous>";
+  }
+
+  // Main chat loop.
+  Chat(stub.get(), room_id, user_handle);
+
+  return EXIT_SUCCESS;
 }

--- a/examples/chat/client/chat.cc
+++ b/examples/chat/client/chat.cc
@@ -251,7 +251,9 @@ int main(int argc, char** argv) {
     LOG(QFATAL) << "Failed to create application stub";
   }
 
-  if (!absl::GetFlag(FLAGS_test)) {
+  if (absl::GetFlag(FLAGS_test)) {
+    return EXIT_SUCCESS;
+  } else {
     RoomId room_id;
     if (!absl::Base64Unescape(absl::GetFlag(FLAGS_room_id), &room_id)) {
       LOG(QFATAL) << "Failed to parse --room_id as base 64";
@@ -275,7 +277,7 @@ int main(int argc, char** argv) {
 
     // Main chat loop.
     Chat(stub.get(), room_id, user_handle);
-  }
 
-  return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
+  }
 }

--- a/examples/chat/client/chat.cc
+++ b/examples/chat/client/chat.cc
@@ -34,8 +34,7 @@
 #include "oak/common/nonce_generator.h"
 #include "oak/common/utils.h"
 
-ABSL_FLAG(bool, test, false,
-         "Run a non-interactive version of chat application for testing");
+ABSL_FLAG(bool, test, false, "Run a non-interactive version of chat application for testing");
 ABSL_FLAG(std::string, manager_address, "127.0.0.1:8888",
           "Address of the Oak Manager to connect to");
 ABSL_FLAG(std::string, module, "", "File containing the compiled WebAssembly module");

--- a/examples/chat/client/chat.cc
+++ b/examples/chat/client/chat.cc
@@ -34,6 +34,8 @@
 #include "oak/common/nonce_generator.h"
 #include "oak/common/utils.h"
 
+ABSL_FLAG(bool, test, false,
+         "Run a non-interactive version of chat application for testing");
 ABSL_FLAG(std::string, manager_address, "127.0.0.1:8888",
           "Address of the Oak Manager to connect to");
 ABSL_FLAG(std::string, module, "", "File containing the compiled WebAssembly module");
@@ -250,29 +252,31 @@ int main(int argc, char** argv) {
     LOG(QFATAL) << "Failed to create application stub";
   }
 
-  RoomId room_id;
-  if (!absl::Base64Unescape(absl::GetFlag(FLAGS_room_id), &room_id)) {
-    LOG(QFATAL) << "Failed to parse --room_id as base 64";
-  }
-  std::unique_ptr<Room> room;
-  if (room_id.empty()) {
-    room = absl::make_unique<Room>(stub.get());
-    room_id = room->Id();
-    LOG(INFO) << "Join this room with --app_address=" << addr
-              << " --room_id=" << absl::Base64Escape(room_id);
-  }
+  if (!absl::GetFlag(FLAGS_test)) {
+    RoomId room_id;
+    if (!absl::Base64Unescape(absl::GetFlag(FLAGS_room_id), &room_id)) {
+      LOG(QFATAL) << "Failed to parse --room_id as base 64";
+    }
+    std::unique_ptr<Room> room;
+    if (room_id.empty()) {
+      room = absl::make_unique<Room>(stub.get());
+      room_id = room->Id();
+      LOG(INFO) << "Join this room with --app_address=" << addr
+                << " --room_id=" << absl::Base64Escape(room_id);
+    }
 
-  // Calculate a user handle.
-  std::string user_handle = absl::GetFlag(FLAGS_handle);
-  if (user_handle.empty()) {
-    user_handle = std::getenv("USER");
-  }
-  if (user_handle.empty()) {
-    user_handle = "<anonymous>";
-  }
+    // Calculate a user handle.
+    std::string user_handle = absl::GetFlag(FLAGS_handle);
+    if (user_handle.empty()) {
+      user_handle = std::getenv("USER");
+    }
+    if (user_handle.empty()) {
+      user_handle = "<anonymous>";
+    }
 
-  // Main chat loop.
-  Chat(stub.get(), room_id, user_handle);
+    // Main chat loop.
+    Chat(stub.get(), room_id, user_handle);
+  }
 
   return EXIT_SUCCESS;
 }

--- a/examples/chat/client/chat.cc
+++ b/examples/chat/client/chat.cc
@@ -255,7 +255,7 @@ int main(int argc, char** argv) {
     // Disable interactive behaviour.
     return EXIT_SUCCESS;
   }
-  
+
   RoomId room_id;
   if (!absl::Base64Unescape(absl::GetFlag(FLAGS_room_id), &room_id)) {
     LOG(QFATAL) << "Failed to parse --room_id as base 64";

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -14,7 +14,13 @@ readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '
 for example in ${RUST_EXAMPLES}; do
   ./bazel-bin/oak/server/asylo/oak &
   SERVER_PID=$!
-  "${SCRIPTS_DIR}/run_example" "${example}"
+  # Currently `chat` application starts an infinite loop, so `run_examples` just checks
+  # if the module can be loaded correctly.
+  if [[ "chat" == "${example}" ]]; then
+    "${SCRIPTS_DIR}/run_example" -C --test "${example}"
+  else
+    "${SCRIPTS_DIR}/run_example" "${example}"
+  fi
   # TODO: Ensure that background processes are killed with something like `trap cleanup_fn EXIT`.
   kill -s SIGTERM "$SERVER_PID"
 done

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -8,11 +8,8 @@ source "$SCRIPTS_DIR/common"
 "$SCRIPTS_DIR/build_server_asylo"
 
 # Run Rust-based Oak examples, each with their own Oak server instance.
-# Note that the chat example cannot be run because the client is interactive.
-# TODO(#462): Re-enable chat example, even if it may be just loading the server-side code and not
-# interact with it.
 # TODO(#594): Re-enable rustfmt when upstream rustc internal error is fixed.
-readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/rust$' | cut -d'/' -f2 | uniq | grep -v chat | grep -v rustfmt)"
+readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/rust$' | cut -d'/' -f2 | uniq | grep -v rustfmt)"
 
 for example in ${RUST_EXAMPLES}; do
   ./bazel-bin/oak/server/asylo/oak &

--- a/scripts/run_examples_dev
+++ b/scripts/run_examples_dev
@@ -13,11 +13,8 @@ SERVER_PID=$!
 # TODO: Ensure that background processes are killed with something like `trap cleanup_fn EXIT`.
 
 # Run Rust-based Oak examples against a common Oak server instance.
-# Note that the chat example cannot be run because the client is interactive.
-# TODO(#462): Re-enable chat example, even if it may be just loading the server-side code and not
-# interact with it.
 # TODO(#594): Re-enable rustfmt when upstream rustc internal error is fixed.
-readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/rust$' | cut -d'/' -f2 | uniq | grep -v chat | grep -v rustfmt)"
+readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/rust$' | cut -d'/' -f2 | uniq | grep -v rustfmt)"
 for example in ${RUST_EXAMPLES}; do
   "${SCRIPTS_DIR}/run_example" "${example}"
 done

--- a/scripts/run_examples_dev
+++ b/scripts/run_examples_dev
@@ -16,7 +16,13 @@ SERVER_PID=$!
 # TODO(#594): Re-enable rustfmt when upstream rustc internal error is fixed.
 readonly RUST_EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/rust$' | cut -d'/' -f2 | uniq | grep -v rustfmt)"
 for example in ${RUST_EXAMPLES}; do
-  "${SCRIPTS_DIR}/run_example" "${example}"
+  # Currently `chat` application starts an infinite loop, so `run_examples` just checks
+  # if the module can be loaded correctly.
+  if [[ "chat" == "${example}" ]]; then
+    "${SCRIPTS_DIR}/run_example" -C --test "${example}"
+  else
+    "${SCRIPTS_DIR}/run_example" "${example}"
+  fi
 done
 
 # Run C++-based Oak examples.


### PR DESCRIPTION
This change:
- Adds a non-interactive version of Chat application with `--test` flag
- Enables Chat application in `run_examples`

### Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
