### PR TITLE
rust/oak_runtime: Perform blocking channel waits instead of spinning

### DIFF
--- a/oak/server/rust/oak_runtime/src/channel.rs
+++ b/oak/server/rust/oak_runtime/src/channel.rs
@@ -153,7 +153,7 @@ impl ChannelWriter {
                 thread.unpark();
             }
         }
-        *waiting_threads = HashMap::new();
+        waiting_threads.clear();
 
         Ok(())
     }

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -46,10 +46,6 @@ mod platform {
     pub type RwLock<T> = std::sync::RwLock<T>;
     pub use std::thread;
     pub type JoinHandle = std::thread::JoinHandle<()>;
-
-    pub fn yield_thread() {
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
 }
 
 use platform::*;

--- a/oak/server/rust/oak_runtime/src/runtime.rs
+++ b/oak/server/rust/oak_runtime/src/runtime.rs
@@ -106,6 +106,11 @@ impl Runtime {
             std::mem::replace(&mut *node_threads, vec![])
         };
 
+        // Unpark any threads that are blocked waiting on channels.
+        for handle in handles.iter() {
+            handle.thread().unpark();
+        }
+
         for handle in handles {
             handle.join().expect("Failed to join handle");
         }


### PR DESCRIPTION
This uses thread park/unpark instead of other options. 

Related #288 #593 

### Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
