### PR TITLE
Support structured output in runner script

### DIFF
--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             run_bazel_test(),
         ],
     );
-    run(root, opt);
+    run_all(root, &opt);
     Ok(())
 }
 


### PR DESCRIPTION
The downside is that it now requires all the steps to have finished
before printing anything at all, which makes it hard to figure out at
what point of the overall execution it is.

On the other hand this will make it easier to support future-based
return value in the future, at which point we will reimplement the
streaming-line output functionality.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
