### PR TITLE
Parallelize build steps

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,6 +36,8 @@ steps:
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/check_formatting']
+
+  # Run the various server builds in parallel, since they use different Bazel `output_base`.
   - name: 'gcr.io/oak-ci/oak:latest'
     id: build_server_asylo
     waitFor: ['build_image']
@@ -44,25 +46,32 @@ steps:
     args: ['./scripts/build_server_asylo']
   - name: 'gcr.io/oak-ci/oak:latest'
     id: build_server_dev
+    waitFor: ['build_image']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/build_server_dev']
   - name: 'gcr.io/oak-ci/oak:latest'
     id: build_server_dev_arm
+    waitFor: ['build_image']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/build_server_dev_arm']
+
+  # Package the Asylo Oak server in a Docker image.
   - name: 'gcr.io/oak-ci/oak:latest'
     id: build_server_docker
-    waitFor: ['build_server_dev']
+    waitFor: ['build_server_asylo']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/build_server_docker']
+
   - name: 'gcr.io/oak-ci/oak:latest'
     id: run_tests
+    waitFor: ['build_server_asylo']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/run_tests']
+
   - name: 'gcr.io/oak-ci/oak:latest'
     id: run_examples
     timeout: 30m
@@ -70,25 +79,34 @@ steps:
     args: ['./scripts/run_examples']
   - name: 'gcr.io/oak-ci/oak:latest'
     id: run_examples_asan
+    waitFor: ['run_examples']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/run_examples_dev', '-a']
   - name: 'gcr.io/oak-ci/oak:latest'
     id: run_examples_tsan
+    waitFor: ['run_examples_asan']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/run_examples_dev', '-t']
+
+  # Run clang-tidy after the examples finish running, since they share the same `output_base`.
   - name: 'gcr.io/oak-ci/oak:latest'
     id: run_clang_tidy
+    waitFor: ['run_examples']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/run_clang_tidy']
+
+  # Check whether any of the previous steps resulted in file diffs that were not checked in or
+  # ignored by git.
   - name: 'gcr.io/oak-ci/oak:latest'
     id: git_check_diff
-    waitFor: ['git_init', 'run_clang_tidy']
+    waitFor: ['git_init', 'run_clang_tidy', 'run_tests', 'run_examples']
     timeout: 5m
     entrypoint: 'bash'
     args: ['./scripts/git_check_diff']
+
   # Copy compiled enclave binary to workspace so that it can be uploaded as artifact.
   - name: 'gcr.io/oak-ci/oak:latest'
     id: copy_artifacts

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -151,13 +151,7 @@ fn run_embedmd() -> R {
         source_files()
             .filter(is_markdown_file)
             .map(to_string)
-            .map(|entry| {
-                step(
-                    &entry,
-                    &format!("{}/bin/embedmd", std::env::var("GOPATH").unwrap()),
-                    &["-d", &entry],
-                )
-            }),
+            .map(|entry| step(&entry, "embedmd", &["-d", &entry])),
     )
 }
 

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -75,10 +75,10 @@ if [[ -n "$CPP_FOLDER" ]]; then
     if [[ "tensorflow" == "$TARGET" ]]; then
         # TODO: Compile all examples in Emscripten when imports will be fixed.
         # https://github.com/project-oak/oak/issues/439
-        bazel build --config=emscripten "${BUILD_RULES[@]}"
+        bazel --output_base="${CACHE_DIR}/emscripten" build "${bazel_build_flags[@]}" --config=emscripten "${BUILD_RULES[@]}"
     else
         # TODO: support compilation mode wasm.
-        bazel build --config=wasm32 "${BUILD_RULES[@]}"
+        bazel --output_base="${CACHE_DIR}/wasm32" build "${bazel_build_flags[@]}" --config=wasm32 "${BUILD_RULES[@]}"
     fi
 fi
 

--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -73,7 +73,7 @@ find . \
 
 # Check embedded code snippets are up-to-date.
 grep --recursive --files-with-matches embedmd docs | while IFS= read -r file; do
-  "$GOPATH/bin/embedmd" -d "$file"
+  embedmd -d "$file"
 done
 
 # Check syntax in XML files.

--- a/scripts/common
+++ b/scripts/common
@@ -42,6 +42,11 @@ declare -a bazel_build_flags
 # See https://pantheon.corp.google.com/storage/browser/oak-bazel-cache?project=oak-ci
 bazel_build_flags+=(
     '--remote_cache=https://storage.googleapis.com/oak-bazel-cache'
+    # Fail immediately if the Bazel server lock cannot be acquired so that we can notice this in CI
+    # and avoid attempting to parallelize steps that are actually serialized by Bazel.
+    '--block_for_lock=false'
+    # Useful to determine how long individual steps are taking in CI.
+    '--show_timestamps'
 )
 
 # If we now have a key file, use it, otherwise disable uploading artifacts to remote cache.

--- a/scripts/format
+++ b/scripts/format
@@ -53,5 +53,5 @@ find . \
 
 # Update embedded code snippets
 grep --recursive --files-with-matches embedmd docs | while IFS= read -r file; do
-  "$GOPATH/bin/embedmd" -w "$file"
+  embedmd -w "$file"
 done


### PR DESCRIPTION
Reduces CI build time from ~35 minutes to ~21 minutes (see
https://pantheon.corp.google.com/cloud-build/builds?project=oak-ci).

Some of the build steps may be run in parallel; the main rule of thumb
is that they can if they don't share the same Bazel `output_base`,
because otherwise they would contend for the same lock.

Ensure that Bazel caching for wasm32 and emscripten works properly.

Ensure that Bazel is properly initialized in the Dockerfile.

Reorder steps in Dockerfile so that less frequently changed steps appear
first (namely, Emscripten, which is also quite large).

Fix various other minor things in the Dockerfile (env variables).

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
