### PR TITLE
Fix links to Rust documentation

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -33,15 +33,15 @@ An Oak Node needs to provide a single
 [main entrypoint](abi.md#exported-function), which is the point at which Node
 execution begins. However, Node authors don't _have_ to implement this function
 themselves; for a Node which receives messages (bytes + handles) that can be
-[decoded](https://project-oak.github.io/oak/sdk/oak/io/trait.Decodable.html)
+[decoded](https://project-oak.github.io/oak/doc/oak/io/trait.Decodable.html)
 into a Rust type, there are helper functions in the Oak SDK that make this
 easier.
 
 To use these helpers, an Oak Node should be a `struct` of some kind to represent
 the internal state of the Node itself (which may be empty), implement the
-[`Node`](https://project-oak.github.io/oak/sdk/oak/trait.Node.html) trait for
+[`Node`](https://project-oak.github.io/oak/doc/oak/trait.Node.html) trait for
 it, then define an
-[`entrypoint`](https://project-oak.github.io/oak/sdk/oak/macro.entrypoint.html)
+[`entrypoint`](https://project-oak.github.io/oak/doc/oak/macro.entrypoint.html)
 so the Oak SDK knows how to instantiate it:
 
 <!-- prettier-ignore-start -->
@@ -69,7 +69,7 @@ struct Node {
 <!-- prettier-ignore-end -->
 
 Under the covers the
-[`entrypoint!`](https://project-oak.github.io/oak/sdk/oak/macro.entrypoint.html)
+[`entrypoint!`](https://project-oak.github.io/oak/doc/oak/macro.entrypoint.html)
 macro implements a function identified by the name of the entrypoint for you,
 with the following default behaviour:
 
@@ -77,23 +77,23 @@ with the following default behaviour:
 - Create a new instance of the Node `struct` using the construction expression
   provided in the macro.
 - Pass the Node `struct` and the channel handle to the
-  [`run_event_loop()`](https://project-oak.github.io/oak/sdk/oak/fn.run_event_loop.html)
+  [`run_event_loop()`](https://project-oak.github.io/oak/doc/oak/fn.run_event_loop.html)
   function.
 
 For gRPC server nodes (the normal "front door" for an Oak application), the Node
 `struct` must implement the
-[`oak::grpc::OakNode`](https://project-oak.github.io/oak/sdk/oak/grpc/trait.OakNode.html)
+[`oak::grpc::OakNode`](https://project-oak.github.io/oak/doc/oak/grpc/trait.OakNode.html)
 trait (which provides an automatic implementation of the
-[`Node`](https://project-oak.github.io/oak/sdk/oak/trait.Node.html)). This has
+[`Node`](https://project-oak.github.io/oak/doc/oak/trait.Node.html)). This has
 two methods:
 
 - A
-  [`new()`](https://project-oak.github.io/oak/sdk/oak/grpc/trait.OakNode.html#tymethod.new)
+  [`new()`](https://project-oak.github.io/oak/doc/oak/grpc/trait.OakNode.html#tymethod.new)
   method to create an instance of the Node, and perform any one-off
   initialization. (A common initialization action is to enable logging for the
   Node, via the [`oak_log` crate](sdk.md#oak_log-crate).)
 - An
-  [`invoke()`](https://project-oak.github.io/oak/sdk/oak/grpc/trait.OakNode.html#tymethod.invoke)
+  [`invoke()`](https://project-oak.github.io/oak/doc/oak/grpc/trait.OakNode.html#tymethod.invoke)
   method that is called for each newly-arriving gRPC request from the outside
   world.
 
@@ -337,10 +337,10 @@ Regardless of how the application communicates with the new Node, the typical
 pattern for the existing Node is to:
 
 - Create a new channel with the
-  [`channel_create`](https://project-oak.github.io/oak/sdk/oak/fn.channel_create.html)
+  [`channel_create`](https://project-oak.github.io/oak/doc/oak/fn.channel_create.html)
   host function, receiving local handles for both halves of the channel.
 - Create a new Node instance with the
-  [`node_create`](https://project-oak.github.io/oak/sdk/oak/fn.node_create.html)
+  [`node_create`](https://project-oak.github.io/oak/doc/oak/fn.node_create.html)
   host function, passing in the handle for the read half of the new channel.
 - Afterwards, close the local handle for the read half, as it is no longer
   needed.
@@ -396,7 +396,7 @@ TODO: describe use of storage
 
 Regardless of how the code for an Oak Application is produced, it's always a
 good idea to write tests. The
-[oak_tests](https://project-oak.github.io/oak/sdk/oak_tests/index.html) crate
+[oak_tests](https://project-oak.github.io/oak/doc/oak_tests/index.html) crate
 allows node gRPC service methods to be tested with the [Oak SDK](sdk.md)
 framework via the Oak Runtime:
 
@@ -432,7 +432,7 @@ This has a little bit more boilerplate than testing a method directly:
 
 - After being configured, the runtime executes Nodes in separate threads
   (`oak_runtime::configure_and_run`). The `derive(OakExports)` macro (from the
-  [`oak_derive`](https://project-oak.github.io/oak/sdk/oak_derive/index.html)
+  [`oak_derive`](https://project-oak.github.io/oak/doc/oak_derive/index.html)
   crate) provides an entrypoint with a gRPC dispatch handler.
 - The injection of the gRPC request has to specify the method name (in
   `oak_tests::grpc_request`).

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -10,19 +10,18 @@ detailed information.
 
 ## `oak_abi` Crate
 
-The [`oak_abi`](https://project-oak.github.io/oak/server/oak_abi/index.html)
-crate provides Rust definitions that correspond to the [Oak ABI](abi.md). This
+The [`oak_abi`](https://project-oak.github.io/oak/doc/oak_abi/index.html) crate
+provides Rust definitions that correspond to the [Oak ABI](abi.md). This
 includes:
 
 - `extern "C"` declarations of the low-level
   [host functions](abi.md#host-functions) provided by the ABI; the `u32`, `u64`
   and `usize` [integer types described in the Oak ABI](abi.md#integer-types)
   definition are mapped to the Rust integer types with the same names.
-- A
-  [`Handle`](https://project-oak.github.io/oak/server/oak_abi/type.Handle.html)
+- A [`Handle`](https://project-oak.github.io/oak/doc/oak_abi/type.Handle.html)
   type alias for `u64`.
 - Constants used on the ABI (such as the
-  [`INVALID_HANDLE`](https://project-oak.github.io/oak/server/oak_abi/constant.INVALID_HANDLE.html)
+  [`INVALID_HANDLE`](https://project-oak.github.io/oak/doc/oak_abi/constant.INVALID_HANDLE.html)
   value).
 - Enum types (generated from the
   [master protocol buffer definitions](../oak/proto/oak_api.proto)) for
@@ -36,12 +35,12 @@ includes wrapper functions for all of the
 types for easier use.
 
 - Status values are returned as
-  [`oak::OakStatus`](https://project-oak.github.io/oak/sdk/oak/enum.OakStatus.html)
+  [`oak::OakStatus`](https://project-oak.github.io/oak/doc/oak/enum.OakStatus.html)
   `enum` values rather than `i32` values.
 - Channel handles are held in the
-  [`ReadHandle`](https://project-oak.github.io/oak/sdk/oak/struct.ReadHandle.html)
+  [`ReadHandle`](https://project-oak.github.io/oak/doc/oak/struct.ReadHandle.html)
   or
-  [`WriteHandle`](https://project-oak.github.io/oak/sdk/oak/struct.WriteHandle.html)
+  [`WriteHandle`](https://project-oak.github.io/oak/doc/oak/struct.WriteHandle.html)
   wrapper `struct`s for handles whose directionality is known.
 - Read channel readiness is handled with `Vec<oak::ReadHandle>` types rather
   than raw memory.
@@ -49,26 +48,26 @@ types for easier use.
   contents of read messages.
 
 The `oak` crate also provides the
-[`oak::set_panic_hook()`](https://project-oak.github.io/oak/sdk/oak/fn.set_panic_hook.html)
+[`oak::set_panic_hook()`](https://project-oak.github.io/oak/doc/oak/fn.set_panic_hook.html)
 helper, to ensure that Rust `panic`s are logged.
 
 ### `oak::io` Module
 
-The [`oak::io`](https://project-oak.github.io/oak/sdk/oak/io/index.html) module
+The [`oak::io`](https://project-oak.github.io/oak/doc/oak/io/index.html) module
 provides a higher level abstraction to allow Rust object to be communicated
 between Nodes.
 
 The
-[`oak::io::channel_create<T>`](https://project-oak.github.io/oak/sdk/oak/io/fn.channel_create.html)
+[`oak::io::channel_create<T>`](https://project-oak.github.io/oak/doc/oak/io/fn.channel_create.html)
 function creates
-[`oak::io::Sender`](https://project-oak.github.io/oak/sdk/oak/io/struct.Sender.html)
+[`oak::io::Sender`](https://project-oak.github.io/oak/doc/oak/io/struct.Sender.html)
 and
-[`oak::io::Receiver`](https://project-oak.github.io/oak/sdk/oak/io/struct.Receiver.html)
+[`oak::io::Receiver`](https://project-oak.github.io/oak/doc/oak/io/struct.Receiver.html)
 objects. These objects allow sending and receiving of values of type `T`,
 provided that `T` implements the
-[`oak::io::Encodable`](https://project-oak.github.io/oak/sdk/oak/io/trait.Encodable.html)
+[`oak::io::Encodable`](https://project-oak.github.io/oak/doc/oak/io/trait.Encodable.html)
 and
-[`oak::io::Decodable`](https://project-oak.github.io/oak/sdk/oak/io/trait.Decodable.html)
+[`oak::io::Decodable`](https://project-oak.github.io/oak/doc/oak/io/trait.Decodable.html)
 traits.
 
 ### `oak::rand` Module
@@ -80,34 +79,34 @@ trait, to allow use of the
 
 ### `oak::grpc` Module
 
-The [`oak::grpc`](https://project-oak.github.io/oak/sdk/oak/grpc/index.html)
+The [`oak::grpc`](https://project-oak.github.io/oak/doc/oak/grpc/index.html)
 module holds functionality that is helpful for interacting with the outside
 world over gRPC, via the implicit [gRPC pseudo-Node](concepts.md#pseudo-nodes)
 that has a channel to the Application's initial Node.
 
 An Oak Node that interacts with gRPC typically implements the
-[`oak::grpc::OakNode`](https://project-oak.github.io/oak/sdk/oak/grpc/trait.OakNode.html)
+[`oak::grpc::OakNode`](https://project-oak.github.io/oak/doc/oak/grpc/trait.OakNode.html)
 trait, which is used with the
-[`oak::run_event_loop()`](https://project-oak.github.io/oak/sdk/oak/fn.run_event_loop.html)
+[`oak::run_event_loop()`](https://project-oak.github.io/oak/doc/oak/fn.run_event_loop.html)
 function to services gRPC requests in a loop, invoking the trait's
-[`invoke()`](https://project-oak.github.io/oak/sdk/oak/grpc/trait.OakNode.html#tymethod.invoke)
+[`invoke()`](https://project-oak.github.io/oak/doc/oak/grpc/trait.OakNode.html#tymethod.invoke)
 method for each request.
 
 ### `oak::storage` Module
 
 The
-[`oak::storage`](https://project-oak.github.io/oak/sdk/oak/storage/index.html)
+[`oak::storage`](https://project-oak.github.io/oak/doc/oak/storage/index.html)
 module holds functionality that is helpful for interacting with an external
 provider of persistent storage.
 
 ### `oak::proto` Module
 
-The [`oak::proto`](https://project-oak.github.io/oak/sdk/oak/proto/index.html)
+The [`oak::proto`](https://project-oak.github.io/oak/doc/oak/proto/index.html)
 module holds auto-generated submodules for dealing with protocol buffers.
 
 ## `oak_log` Crate
 
-The [`oak_log`](https://project-oak.github.io/oak/sdk/oak_log/index.html) crate
+The [`oak_log`](https://project-oak.github.io/oak/doc/oak_log/index.html) crate
 is a logging implementation for the Rust
 [log facade](https://crates.io/crates/log), which uses an channel to a
 freshly-created logging pseudo-Node as the underlying logging mechanism.


### PR DESCRIPTION
After #616