### PR TITLE
Return exit code from runner

### DIFF
--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -47,7 +47,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             run_bazel_test(),
         ],
     );
-    run_all(root, &opt);
+    let status = root.run(&opt);
+    print_all(&opt, &status);
+
+    // If the overall status value is an error, terminate with a nonzero exit code.
+    if status.values().contains(&StatusResultValue::Error) {
+        std::process::exit(1);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Return a set of statuses from each combined step (including top-level)
so that it is possible to have an overview of the various steps.

Sample output:

```
 ➡ root ➡ prettier ➡ ./docs/development.md ⊢ OK
 ➡ root ➡ prettier ➡ ./INSTALL.md ⊢ OK
 ➡ root ➡ prettier ➡ ./README.md ⊢ OK
 ➡ root ➡ prettier } ⊢ [OK]
 ➡ root ➡ embedmd {
 ➡ root ➡ embedmd ➡ ./examples/chat/README.md ⊢ OK
 ➡ root ➡ embedmd ➡ ./PULL_REQUEST_TEMPLATE.md ⊢ OK
 ➡ root ➡ embedmd ➡ ./CONTRIBUTING.md ⊢ OK
 ➡ root ➡ embedmd ➡ ./docs/abi.md ⊢ OK
 ➡ root ➡ embedmd ➡ ./docs/concepts.md ⊢ OK
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ⊢ ERROR
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ╔════════════════════════
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║ @@ -405,7 +405,7 @@
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║  ```Rust
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║  // Test invoking the SayHello Node service method via the Oak runtime.
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║  #[test]
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║ -fn test_say_helloxx() {
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║ +fn test_say_hello() {
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║      simple_logger::init().unwrap();
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║      let (runtime, entry_channel) = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║ ----
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ║
 ➡ root ➡ embedmd ➡ ./docs/programming-oak.md ╚════════════════════════
 ➡ root ➡ embedmd ➡ ./docs/sdk.md ⊢ OK
 ➡ root ➡ embedmd ➡ ./docs/development.md ⊢ OK
 ➡ root ➡ embedmd ➡ ./INSTALL.md ⊢ OK
 ➡ root ➡ embedmd ➡ ./README.md ⊢ OK
 ➡ root ➡ embedmd } ⊢ [ERROR,OK]
 ➡ root ➡ cargo fmt {
 ➡ root ➡ cargo fmt ➡ ./Cargo.toml ⊢ OK
 ➡ root ➡ cargo fmt } ⊢ [OK]
 ➡ root ➡ cargo test {
 ➡ root ➡ cargo test ➡ ./Cargo.toml ⊢ OK
 ➡ root ➡ cargo test } ⊢ [OK]
 ➡ root ➡ cargo doc test {
 ➡ root ➡ cargo doc test ➡ ./Cargo.toml ⊢ OK
 ➡ root ➡ cargo doc test } ⊢ [OK]
 ➡ root ➡ cargo clippy {
 ➡ root ➡ cargo clippy ➡ ./Cargo.toml ⊢ OK
 ➡ root ➡ cargo clippy } ⊢ [OK]
 ➡ root ➡ non-Asylo targets ⊢ OK
 ➡ root ➡ host targets ⊢ OK
 ➡ root } ⊢ [ERROR,OK]
 ```


# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
