### PR TITLE
Fix gRPC error propagation

### DIFF
--- a/examples/hello_world/client/hello_world.cc
+++ b/examples/hello_world/client/hello_world.cc
@@ -38,6 +38,11 @@ void say_hello(HelloWorld::Stub* stub, std::string name) {
   if (!status.ok()) {
     LOG(WARNING) << "Could not call SayHello('" << name << "'): " << status.error_code() << ": "
                  << status.error_message();
+    // The server code includes a case with a deliberate error to check gRPC
+    // error code propagation; any other error should cause the client to fail.
+    if (status.error_code() != grpc::FAILED_PRECONDITION) {
+      LOG(QFATAL) << "Error code is not the deliberately-induced error!";
+    }
     return;
   }
   LOG(INFO) << "Response: " << response.reply();

--- a/examples/hello_world/module/rust/src/lib.rs
+++ b/examples/hello_world/module/rust/src/lib.rs
@@ -18,7 +18,7 @@ mod proto;
 #[cfg(test)]
 mod tests;
 
-use log::{info, warn};
+use log::{error, info, warn};
 use oak::grpc;
 use oak::grpc::OakNode;
 use proto::hello_world::{HelloRequest, HelloResponse};
@@ -57,8 +57,9 @@ impl OakNode for Node {
 impl HelloWorld for Node {
     fn say_hello(&mut self, req: HelloRequest) -> grpc::Result<HelloResponse> {
         if req.greeting == "Query-of-Error" {
+            error!("Return deliberate FAILED_PRECONDITION error!");
             return Err(grpc::build_status(
-                grpc::Code::INVALID_ARGUMENT,
+                grpc::Code::FAILED_PRECONDITION,
                 "Deliberate error",
             ));
         }

--- a/oak/server/module_invocation.cc
+++ b/oak/server/module_invocation.cc
@@ -209,8 +209,10 @@ void ModuleInvocation::BlockingSendResponse() {
     stream_.Write(bb, options, callback);
   } else if (!grpc_response.has_rsp_msg()) {
     // Final iteration but no response, just Finish.
-    LOG(INFO) << "invocation#" << stream_id_ << " SendResponse: Final inner response empty";
-    FinishAndCleanUp(::grpc::Status::OK);
+    google::rpc::Status status = grpc_response.status();
+    LOG(INFO) << "invocation#" << stream_id_ << " SendResponse: Final inner response empty, status "
+              << status.code();
+    FinishAndCleanUp(grpc::Status(static_cast<grpc::StatusCode>(status.code()), status.message()));
   } else {
     // Final response, so WriteAndFinish.
     LOG(INFO) << "invocation#" << stream_id_ << " SendResponse: Final inner response of size "


### PR DESCRIPTION
Fix error propagation and add a check to catch future regression.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
