### PR TITLE
rust/oak_abi: Make oak_abi

### DIFF
--- a/oak/server/rust/oak_abi/Cargo.toml
+++ b/oak/server/rust/oak_abi/Cargo.toml
@@ -5,8 +5,13 @@ authors = ["David Drysdale <drysdale@google.com>"]
 edition = "2018"
 license = "Apache-2.0"
 
+[features]
+std = ["protobuf"]
+no_std = []
+default = ["std"]
+
 [dependencies]
-protobuf = "*"
+protobuf = { version = "*", optional = true }
 
 [build-dependencies]
 oak_utils = "*"

--- a/oak/server/rust/oak_abi/src/lib.rs
+++ b/oak/server/rust/oak_abi/src/lib.rs
@@ -21,8 +21,7 @@
 pub mod proto;
 #[cfg(feature = "std")]
 mod inner {
-    pub use super::proto::oak_api::ChannelReadStatus;
-    pub use super::proto::oak_api::OakStatus;
+    pub use super::proto::oak_api::{ChannelReadStatus, OakStatus};
 }
 
 #[cfg(feature = "no_std")]

--- a/oak/server/rust/oak_abi/src/lib.rs
+++ b/oak/server/rust/oak_abi/src/lib.rs
@@ -16,10 +16,50 @@
 
 //! Type, constant and Wasm host function definitions for the Oak application binary interface.
 
+// TODO(#638): Generate from protobuf in a no_std compatible way
+#[cfg(feature = "std")]
 pub use proto::oak_api::ChannelReadStatus;
+#[cfg(feature = "std")]
 pub use proto::oak_api::OakStatus;
 
+#[cfg(feature = "std")]
 pub mod proto;
+
+// TODO(#638): Generate from protobuf in a no_std compatible way
+#[cfg(feature = "no_std")]
+pub mod proto {
+    #![allow(dead_code)]
+    #![allow(missing_docs)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(non_upper_case_globals)]
+
+    #[derive(Clone, PartialEq, Eq, Debug, Hash)]
+    pub enum OakStatus {
+        OAK_STATUS_UNSPECIFIED = 0,
+        OK = 1,
+        ERR_BAD_HANDLE = 2,
+        ERR_INVALID_ARGS = 3,
+        ERR_CHANNEL_CLOSED = 4,
+        ERR_BUFFER_TOO_SMALL = 5,
+        ERR_HANDLE_SPACE_TOO_SMALL = 6,
+        ERR_OUT_OF_RANGE = 7,
+        ERR_INTERNAL = 8,
+        ERR_TERMINATED = 9,
+        ERR_CHANNEL_EMPTY = 10,
+    }
+
+    #[derive(Clone, PartialEq, Eq, Debug, Hash)]
+    pub enum ChannelReadStatus {
+        NOT_READY = 0,
+        READ_READY = 1,
+        INVALID_CHANNEL = 2,
+        ORPHANED = 3,
+    }
+}
+
+#[cfg(feature = "no_std")]
+pub use proto::{ChannelReadStatus, OakStatus};
 
 /// Handle used to identify read or write channel halves.
 ///

--- a/oak/server/rust/oak_abi/src/lib.rs
+++ b/oak/server/rust/oak_abi/src/lib.rs
@@ -18,16 +18,15 @@
 
 // TODO(#638): Generate from protobuf in a no_std compatible way
 #[cfg(feature = "std")]
-pub use proto::oak_api::ChannelReadStatus;
-#[cfg(feature = "std")]
-pub use proto::oak_api::OakStatus;
-
-#[cfg(feature = "std")]
 pub mod proto;
+#[cfg(feature = "std")]
+mod inner {
+    pub use super::proto::oak_api::ChannelReadStatus;
+    pub use super::proto::oak_api::OakStatus;
+}
 
-// TODO(#638): Generate from protobuf in a no_std compatible way
 #[cfg(feature = "no_std")]
-pub mod proto {
+mod inner {
     #![allow(dead_code)]
     #![allow(missing_docs)]
     #![allow(non_camel_case_types)]
@@ -58,8 +57,7 @@ pub mod proto {
     }
 }
 
-#[cfg(feature = "no_std")]
-pub use proto::{ChannelReadStatus, OakStatus};
+pub use inner::*;
 
 /// Handle used to identify read or write channel halves.
 ///

--- a/oak/server/rust/oak_runtime/Cargo.toml
+++ b/oak/server/rust/oak_runtime/Cargo.toml
@@ -9,15 +9,15 @@ edition = "2018"
 license = "Apache-2.0"
 
 [features]
-std = ["no-std-compat/std"]
-no_std = []
+std = ["no-std-compat/std", "oak_abi/std"]
+no_std = ["oak_abi/no_std"]
 default = ["std"]
 
 [dependencies]
 byteorder = { version = "*", default-features = false }
 itertools = "*"
 log = { version = "*" }
-oak_abi = "=0.1.0"
+oak_abi = { version = "=0.1.0", default-features = false }
 protobuf = "*"
 rand = { version = "*" }
 wasmi = { version = "*", default-features = false, features = ["core"] }


### PR DESCRIPTION
This is a temporary fix to allow oak_abi `no_std` compilation. See #638, a follow up PR will be done to resolve this long term. I would like to add this as a temporary fix as it blocks work on making the oak_runtime `no_std` compatible. 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
