### PR TITLE
Aggregator grpc dispatcher fix

### DIFF
--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -31,7 +31,7 @@ use aggregator::{Monoid, ThresholdAggregator};
 use log::info;
 use oak::grpc;
 use proto::aggregator::Vector;
-use proto::aggregator_grpc::{dispatch, Aggregator};
+use proto::aggregator_grpc::{Dispatcher, Aggregator};
 use protobuf::well_known_types::Empty;
 
 const SAMPLE_THRESHOLD: u64 = 3;
@@ -71,10 +71,9 @@ impl Monoid for Vector {
     }
 }
 
-impl grpc::OakNode for AggregatorNode {
-    fn invoke(&mut self, method: &str, req: &[u8], writer: grpc::ChannelResponseWriter) {
-        dispatch(self, method, req, writer)
-    }
+/// Oak Node that collects aggregated data.
+pub struct AggregatorNode {
+    aggregator: ThresholdAggregator<Vector>,
 }
 
 /// A gRPC service implementation for the Aggregator example.

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -31,7 +31,7 @@ use aggregator::{Monoid, ThresholdAggregator};
 use log::info;
 use oak::grpc;
 use proto::aggregator::Vector;
-use proto::aggregator_grpc::{Dispatcher, Aggregator};
+use proto::aggregator_grpc::{Aggregator, Dispatcher};
 use protobuf::well_known_types::Empty;
 
 const SAMPLE_THRESHOLD: u64 = 3;

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -38,9 +38,10 @@ const SAMPLE_THRESHOLD: u64 = 3;
 
 oak::entrypoint!(oak_main => {
     oak_log::init_default();
-    AggregatorNode {
+    let node = AggregatorNode {
         aggregator: ThresholdAggregator::<Vector>::new(SAMPLE_THRESHOLD),
-    }
+    };
+    Dispatcher::new(node)
 });
 
 impl Monoid for Vector {
@@ -68,11 +69,6 @@ impl Monoid for Vector {
             ..Default::default()
         }
     }
-}
-
-/// Oak Node that collects aggregated data.
-pub struct AggregatorNode {
-    aggregator: ThresholdAggregator<Vector>,
 }
 
 impl grpc::OakNode for AggregatorNode {


### PR DESCRIPTION
This change fixes build Aggregator failure with the new gRPC dispatcher architecture.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
