### PR TITLE
Disable rustfmt example in scripts/build_examples

### DIFF
--- a/scripts/build_examples
+++ b/scripts/build_examples
@@ -4,7 +4,8 @@ readonly SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-readonly EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -name module | cut -d'/' -f2)"
+# TODO(#594): Re-enable rustfmt when upstream rustc internal error is fixed.
+readonly EXAMPLES="$(find examples -mindepth 2 -maxdepth 4 -type d -name module | cut -d'/' -f2 | uniq | grep -v rustfmt)"
 
 for example in $EXAMPLES; do
   "$SCRIPTS_DIR/build_example" "$example"


### PR DESCRIPTION
Example `rustfmt` was disabled in `run_examples` and `run_tests` in #588. It seems `build_examples` has been broken since then (e.g. CI uses `run_examples` which doesn't use `build_examples`).

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
