### PR TITLE
oak_runtime: Gate protobuf configuration with `std` feature

### DIFF
--- a/examples/abitest/tests/src/tests.rs
+++ b/examples/abitest/tests/src/tests.rs
@@ -52,7 +52,7 @@ fn test_abi() {
         FRONTEND_ENTRYPOINT_NAME,
     );
 
-    let (runtime, entry_channel) = oak_runtime::Runtime::configure_and_run(configuration)
+    let (runtime, entry_channel) = oak_runtime::configure_and_run(configuration)
         .expect("unable to configure runtime with test wasm");
 
     let result: grpc::Result<ABITestResponse> = oak_tests::grpc_request(

--- a/oak/server/rust/oak_runtime/src/config.rs
+++ b/oak/server/rust/oak_runtime/src/config.rs
@@ -75,6 +75,9 @@ pub fn application_configuration<S: ::std::hash::BuildHasher>(
     }
 }
 
+/// Load a `runtime::Configuration` from a protobuf `ApplicationConfiguration`.
+/// This can fail if an unsupported node is passed, or if a node was unable to be initialized with
+/// the given configuration.
 pub fn from_protobuf(
     app_config: ApplicationConfiguration,
 ) -> Result<runtime::Configuration, OakStatus> {
@@ -112,6 +115,7 @@ pub fn from_protobuf(
     Ok(config)
 }
 
+/// Configure a `Runtime` from the given protobuf `ApplicationConfiguration` and begin execution.
 pub fn configure_and_run(
     app_config: ApplicationConfiguration,
 ) -> Result<(RuntimeRef, ChannelWriter), OakStatus> {

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -22,9 +22,11 @@
 
 extern crate no_std_compat as std;
 
+#[cfg(feature = "std")]
 pub mod proto;
 
 pub mod channel;
+#[cfg(feature = "std")]
 pub mod config;
 pub mod message;
 pub mod node;
@@ -33,8 +35,12 @@ pub mod runtime;
 #[cfg(test)]
 mod tests;
 
-pub use channel::{ChannelEither, ChannelReader, ChannelWriter};
+#[cfg(feature = "std")]
 pub use config::application_configuration;
+#[cfg(feature = "std")]
+pub use config::configure_and_run;
+
+pub use channel::{ChannelEither, ChannelReader, ChannelWriter};
 pub use message::Message;
 pub use runtime::{Runtime, RuntimeRef};
 

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -85,7 +85,7 @@ pub fn run_single_module(
         entrypoint_name,
     );
 
-    oak_runtime::Runtime::configure_and_run(configuration)
+    oak_runtime::configure_and_run(configuration)
 }
 
 // TODO(#543): move this to oak_runtime as it's not test-specific


### PR DESCRIPTION
Feature gate protobuf configuration behind `std` feature flag. This will allow configurations to be passed to a `no_std` variant directly without requiring protobuf. (Presumably the configuration will still be loaded from a protobuf definition and passed into the no_std variant.) 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
