### PR TITLE
Rerun build.rs only if proto file changed

### DIFF
--- a/experimental/split_grpc/client/build.rs
+++ b/experimental/split_grpc/client/build.rs
@@ -16,20 +16,19 @@
 
 use std::path::Path;
 
-const PROTO_PATH: &'static str = "../../../examples/hello_world/proto/";
-const SOURCE_FILE: &'static str = "hello_world.proto";
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let file_path = std::format!("{}{}", PROTO_PATH, SOURCE_FILE);
+    let proto_path = Path::new("../../../examples/hello_world/proto");
+    let file_name = Path::new("hello_world.proto");
+    let file_path = proto_path.join(file_name);
     tonic_build::configure()
         .build_client(true)
         .build_server(false)
         .out_dir("src/proto")
-        .compile(&[Path::new(&file_path)], &[Path::new(PROTO_PATH)])?;
+        .compile(&[file_path.as_path()], &[proto_path])?;
 
     // Tell cargo to not rerun this script unless the proto file has changed.
     // This is required because the proto compiler is outputting the file into the source tree.
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path);
+    println!("cargo:rerun-if-changed={}", file_path.display());
     Ok(())
 }

--- a/experimental/split_grpc/client/build.rs
+++ b/experimental/split_grpc/client/build.rs
@@ -14,15 +14,22 @@
 // limitations under the License.
 //
 
+use std::path::Path;
+
+const PROTO_PATH: &'static str = "../../../examples/hello_world/proto/";
+const SOURCE_FILE: &'static str = "hello_world.proto";
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let file_path = std::format!("{}{}", PROTO_PATH, SOURCE_FILE);
     tonic_build::configure()
         .build_client(true)
         .build_server(false)
         .out_dir("src/proto")
-        .compile(
-            &["../../../examples/hello_world/proto/hello_world.proto"],
-            &["../../../examples/hello_world/proto/"],
-        )?;
-    println!("cargo:rerun-if-changed=../../../examples/hello_world/proto/hello_world.proto");
+        .compile(&[Path::new(&file_path)], &[Path::new(PROTO_PATH)])?;
+
+    // Tell cargo to not rerun this script unless the proto file has changed.
+    // This is required because the proto compiler is outputting the file into the source tree.
+    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
+    println!("cargo:rerun-if-changed={}", file_path);
     Ok(())
 }

--- a/experimental/split_grpc/client/build.rs
+++ b/experimental/split_grpc/client/build.rs
@@ -23,5 +23,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &["../../../examples/hello_world/proto/hello_world.proto"],
             &["../../../examples/hello_world/proto/"],
         )?;
+    println!("cargo:rerun-if-changed=../../../examples/hello_world/proto/hello_world.proto");
     Ok(())
 }

--- a/experimental/split_grpc/server/build.rs
+++ b/experimental/split_grpc/server/build.rs
@@ -14,15 +14,22 @@
 // limitations under the License.
 //
 
+use std::path::Path;
+
+const PROTO_PATH: &'static str = "../../../examples/hello_world/proto/";
+const SOURCE_FILE: &'static str = "hello_world.proto";
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let file_path = std::format!("{}{}", PROTO_PATH, SOURCE_FILE);
     tonic_build::configure()
         .build_client(false)
         .build_server(true)
         .out_dir("src/proto")
-        .compile(
-            &["../../../examples/hello_world/proto/hello_world.proto"],
-            &["../../../examples/hello_world/proto/"],
-        )?;
-    println!("cargo:rerun-if-changed=../../../examples/hello_world/proto/hello_world.proto");
+        .compile(&[Path::new(&file_path)], &[Path::new(PROTO_PATH)])?;
+
+    // Tell cargo to not rerun this script unless the proto file has changed.
+    // This is required because the proto compiler is outputting the file into the source tree.
+    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
+    println!("cargo:rerun-if-changed={}", file_path);
     Ok(())
 }

--- a/experimental/split_grpc/server/build.rs
+++ b/experimental/split_grpc/server/build.rs
@@ -16,20 +16,19 @@
 
 use std::path::Path;
 
-const PROTO_PATH: &'static str = "../../../examples/hello_world/proto/";
-const SOURCE_FILE: &'static str = "hello_world.proto";
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let file_path = std::format!("{}{}", PROTO_PATH, SOURCE_FILE);
+    let proto_path = Path::new("../../../examples/hello_world/proto");
+    let file_name = Path::new("hello_world.proto");
+    let file_path = proto_path.join(file_name);
     tonic_build::configure()
         .build_client(false)
         .build_server(true)
         .out_dir("src/proto")
-        .compile(&[Path::new(&file_path)], &[Path::new(PROTO_PATH)])?;
+        .compile(&[file_path.as_path()], &[proto_path])?;
 
     // Tell cargo to not rerun this script unless the proto file has changed.
     // This is required because the proto compiler is outputting the file into the source tree.
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path);
+    println!("cargo:rerun-if-changed={}", file_path.display());
     Ok(())
 }

--- a/experimental/split_grpc/server/build.rs
+++ b/experimental/split_grpc/server/build.rs
@@ -23,5 +23,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &["../../../examples/hello_world/proto/hello_world.proto"],
             &["../../../examples/hello_world/proto/"],
         )?;
+    println!("cargo:rerun-if-changed=../../../examples/hello_world/proto/hello_world.proto");
     Ok(())
 }


### PR DESCRIPTION
Fixes #661

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
