### PR TITLE
runtime: show backtrace on crash

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,7 @@ build:sgx --define=SGX_SIM=0
 build:sgx-sim --config=asylo
 build:sgx-sim --define=ASYLO_SGX=1
 build:sgx-sim --define=SGX_SIM=1
+build:sgx-sim --compilation_mode=dbg
 
 # The enclave simulation backend currently makes use of the SGX simulator.
 # However, this is subject to change and users of this config should not

--- a/oak/server/asylo/BUILD
+++ b/oak/server/asylo/BUILD
@@ -140,6 +140,8 @@ enclave_loader(
         "//oak/common:app_config",
         "//oak/common:utils",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/debugging:stacktrace",
+        "@com_google_absl//absl/debugging:symbolize",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/synchronization",

--- a/oak/server/asylo/asylo_oak_runner_main.cc
+++ b/oak/server/asylo/asylo_oak_runner_main.cc
@@ -62,10 +62,14 @@ int main(int argc, char* argv[]) {
   absl::ParseCommandLine(argc, argv);
 
   if (absl::GetFlag(FLAGS_debug)) {
+#if defined(NDEBUG)
+    LOG(ERROR) << "Debug mode not available in non-debug build!";
+#else
     absl::InitializeSymbolizer(argv[0]);
     std::signal(SIGILL, crash_handler);
     std::signal(SIGBUS, crash_handler);
     std::signal(SIGSEGV, crash_handler);
+#endif
   }
 
   // We install an explicit SIGINT handler, as for some reason the default one


### PR DESCRIPTION
For the Asylo runner, attempt to show a backtrace on signals
that indicate a crash (if --debug=true is set, which is the
default).

Shift the Asylo build to always include debug symbols.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
