### PR TITLE
oak_runtime: Move channel ownership to runtime

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -402,6 +402,7 @@ fn test_say_hello() {
         ..Default::default()
     };
     let result: grpc::Result<HelloResponse> = oak_tests::grpc_request(
+        &runtime,
         &entry_channel,
         "/oak.examples.hello_world.HelloWorld/SayHello",
         req,

--- a/examples/abitest/tests/src/tests.rs
+++ b/examples/abitest/tests/src/tests.rs
@@ -60,6 +60,7 @@ fn test_abi() {
     req.exclude = "(^Storage.*|GrpcClient)".to_string();
 
     let result: grpc::Result<ABITestResponse> = oak_tests::grpc_request(
+        &runtime,
         &entry_channel,
         "/oak.examples.abitest.OakABITestService/RunTests",
         req,

--- a/examples/hello_world/module/rust/src/tests.rs
+++ b/examples/hello_world/module/rust/src/tests.rs
@@ -33,6 +33,7 @@ fn test_say_hello() {
         ..Default::default()
     };
     let result: grpc::Result<HelloResponse> = oak_tests::grpc_request(
+        &runtime,
         &entry_channel,
         "/oak.examples.hello_world.HelloWorld/SayHello",
         req,

--- a/examples/private_set_intersection/module/rust/src/tests.rs
+++ b/examples/private_set_intersection/module/rust/src/tests.rs
@@ -35,6 +35,7 @@ fn test_set_intersection() {
         ..Default::default()
     };
     let result: grpc::Result<Empty> = oak_tests::grpc_request(
+        &runtime,
         &entry_channel,
         "/oak.examples.private_set_intersection.PrivateSetIntersection/SubmitSet",
         req,
@@ -46,6 +47,7 @@ fn test_set_intersection() {
         ..Default::default()
     };
     let result: grpc::Result<Empty> = oak_tests::grpc_request(
+        &runtime,
         &entry_channel,
         "/oak.examples.private_set_intersection.PrivateSetIntersection/SubmitSet",
         req,
@@ -54,6 +56,7 @@ fn test_set_intersection() {
 
     let req = Empty::new();
     let result: grpc::Result<GetIntersectionResponse> = oak_tests::grpc_request(
+        &runtime,
         &entry_channel,
         "/oak.examples.private_set_intersection.PrivateSetIntersection/GetIntersection",
         req,

--- a/examples/running_average/module/rust/src/tests.rs
+++ b/examples/running_average/module/rust/src/tests.rs
@@ -21,12 +21,17 @@ use protobuf::well_known_types::Empty;
 
 const MODULE_CONFIG_NAME: &str = "running_average";
 
-fn submit_sample(entry_channel: &oak_runtime::ChannelWriter, value: u64) {
+fn submit_sample(
+    runtime: &oak_runtime::RuntimeRef,
+    entry_channel: &oak_runtime::ChannelWriter,
+    value: u64,
+) {
     let req = SubmitSampleRequest {
         value,
         ..Default::default()
     };
     let result: grpc::Result<Empty> = oak_tests::grpc_request(
+        runtime,
         &entry_channel,
         "/oak.examples.running_average.RunningAverage/SubmitSample",
         req,
@@ -41,11 +46,12 @@ fn test_running_average() {
     let (runtime, entry_channel) = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
-    submit_sample(&entry_channel, 100);
-    submit_sample(&entry_channel, 200);
+    submit_sample(&runtime, &entry_channel, 100);
+    submit_sample(&runtime, &entry_channel, 200);
 
     let req = Empty::new();
     let result: grpc::Result<GetAverageResponse> = oak_tests::grpc_request(
+        &runtime,
         &entry_channel,
         "/oak.examples.running_average.RunningAverage/GetAverage",
         req,

--- a/examples/translator/module/rust/src/tests.rs
+++ b/examples/translator/module/rust/src/tests.rs
@@ -34,6 +34,7 @@ fn test_translate() {
         ..Default::default()
     };
     let result: grpc::Result<TranslateResponse> = oak_tests::grpc_request(
+        &runtime,
         &entry_channel,
         "/oak.examples.translator.Translator/Translate",
         req,

--- a/oak/server/rust/oak_runtime/src/config.rs
+++ b/oak/server/rust/oak_runtime/src/config.rs
@@ -28,7 +28,7 @@ use oak_abi::OakStatus;
 use crate::node;
 use crate::node::load_wasm;
 use crate::runtime;
-use crate::runtime::{Runtime, RuntimeRef, ChannelWriter};
+use crate::runtime::{ChannelWriter, Runtime, RuntimeRef};
 
 /// Create an application configuration.
 ///

--- a/oak/server/rust/oak_runtime/src/config.rs
+++ b/oak/server/rust/oak_runtime/src/config.rs
@@ -25,11 +25,10 @@ use log::error;
 
 use oak_abi::OakStatus;
 
-use crate::channel::ChannelWriter;
 use crate::node;
 use crate::node::load_wasm;
 use crate::runtime;
-use crate::runtime::{Runtime, RuntimeRef};
+use crate::runtime::{Runtime, RuntimeRef, ChannelWriter};
 
 /// Create an application configuration.
 ///

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -22,7 +22,7 @@ extern crate no_std_compat as std;
 #[cfg(feature = "std")]
 pub mod proto;
 
-pub mod channel;
+// pub mod channel;
 #[cfg(feature = "std")]
 pub mod config;
 pub mod message;
@@ -37,6 +37,5 @@ pub use config::application_configuration;
 #[cfg(feature = "std")]
 pub use config::configure_and_run;
 
-pub use channel::{ChannelEither, ChannelReader, ChannelWriter};
 pub use message::Message;
-pub use runtime::{Runtime, RuntimeRef};
+pub use runtime::{Runtime, RuntimeRef, ChannelEither, ChannelReader, ChannelWriter};

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -38,4 +38,4 @@ pub use config::application_configuration;
 pub use config::configure_and_run;
 
 pub use message::Message;
-pub use runtime::{Runtime, RuntimeRef, ChannelEither, ChannelReader, ChannelWriter};
+pub use runtime::{ChannelEither, ChannelReader, ChannelWriter, Runtime, RuntimeRef};

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -22,7 +22,6 @@ extern crate no_std_compat as std;
 #[cfg(feature = "std")]
 pub mod proto;
 
-// pub mod channel;
 #[cfg(feature = "std")]
 pub mod config;
 pub mod message;

--- a/oak/server/rust/oak_runtime/src/message.rs
+++ b/oak/server/rust/oak_runtime/src/message.rs
@@ -16,7 +16,7 @@
 
 use std::prelude::v1::*;
 
-pub use crate::channel::ChannelEither;
+pub use crate::runtime::ChannelEither;
 
 /// Encapsulates a message consisting of opaque data bytes and a vector of channels.
 /// The data bytes should not contain any pointers or handles.

--- a/oak/server/rust/oak_runtime/src/node/logger.rs
+++ b/oak/server/rust/oak_runtime/src/node/logger.rs
@@ -34,7 +34,7 @@ fn logger(pretty_name: &str, runtime: RuntimeRef, reader: ChannelReader) -> Resu
         // closed.
         let _ = runtime.wait_on_channels(&[Some(&reader)]);
 
-        if let Some(message) = reader.read()? {
+        if let Some(message) = runtime.channel_read(&reader)? {
             let message = String::from_utf8_lossy(&message.data);
             info!("{} LOG: {}", pretty_name, message);
         }

--- a/oak/server/rust/oak_runtime/src/node/logger.rs
+++ b/oak/server/rust/oak_runtime/src/node/logger.rs
@@ -23,7 +23,7 @@ use log::info;
 use oak_abi::OakStatus;
 use oak_platform::{current_thread, spawn, JoinHandle};
 
-use crate::channel::{wait_on_channels, ChannelReader};
+use crate::runtime::ChannelReader;
 use crate::RuntimeRef;
 
 /// A simple logger loop.
@@ -32,7 +32,7 @@ fn logger(pretty_name: &str, runtime: RuntimeRef, reader: ChannelReader) -> Resu
         // An error indicates the runtime is terminating. We ignore it here and keep trying to read
         // in case a Wasm node wants to emit remaining messages. We will return once the channel is
         // closed.
-        let _ = wait_on_channels(&runtime, &[Some(&reader)]);
+        let _ = runtime.wait_on_channels(&[Some(&reader)]);
 
         if let Some(message) = reader.read()? {
             let message = String::from_utf8_lossy(&message.data);

--- a/oak/server/rust/oak_runtime/src/node/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/mod.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use oak_abi::OakStatus;
 
-use crate::channel::ChannelReader;
+use crate::runtime::ChannelReader;
 use crate::RuntimeRef;
 
 mod logger;

--- a/oak/server/rust/oak_runtime/src/node/wasm.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm.rs
@@ -333,7 +333,11 @@ impl WasmInterface {
         self.validate_ptr(dest, dest_capacity)?;
         self.validate_ptr(handles_dest, handles_capcity * 8)?;
 
-        let msg = self.runtime.channel_try_read_message(reader, dest_capacity as usize, handles_capcity as usize)?;
+        let msg = self.runtime.channel_try_read_message(
+            reader,
+            dest_capacity as usize,
+            handles_capcity as usize,
+        )?;
 
         let (actual_length, actual_handle_count) = match &msg {
             None => (0, 0),

--- a/oak/server/rust/oak_runtime/src/node/wasm.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm.rs
@@ -305,7 +305,7 @@ impl WasmInterface {
             channels: channels?,
         };
 
-        writer.write(msg)?;
+        self.runtime.channel_write(writer, msg)?;
 
         Ok(())
     }
@@ -333,7 +333,7 @@ impl WasmInterface {
         self.validate_ptr(dest, dest_capacity)?;
         self.validate_ptr(handles_dest, handles_capcity * 8)?;
 
-        let msg = reader.try_read_message(dest_capacity as usize, handles_capcity as usize)?;
+        let msg = self.runtime.channel_try_read_message(reader, dest_capacity as usize, handles_capcity as usize)?;
 
         let (actual_length, actual_handle_count) = match &msg {
             None => (0, 0),

--- a/oak/server/rust/oak_runtime/src/node/wasm.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm.rs
@@ -29,7 +29,7 @@ use wasmi::ValueType;
 use oak_abi::{ChannelReadStatus, OakStatus};
 use oak_platform::{current_thread, spawn, JoinHandle};
 
-use crate::channel::{ChannelEither, ChannelReader, ChannelWriter, ReadStatus};
+use crate::runtime::{ChannelEither, ChannelReader, ChannelWriter, ReadStatus};
 use crate::{Message, RuntimeRef};
 
 /// These number mappings are not exposed to the Wasm client, and are only used by `wasmi` to map
@@ -215,7 +215,7 @@ impl WasmInterface {
         write_addr: AbiPointer,
         read_addr: AbiPointer,
     ) -> Result<(), OakStatus> {
-        let (writer, reader) = crate::channel::new();
+        let (writer, reader) = self.runtime.new_channel();
 
         self.validate_ptr(write_addr, 8)?;
         self.validate_ptr(read_addr, 8)?;
@@ -443,7 +443,7 @@ impl WasmInterface {
             })
             .collect();
 
-        let statuses = crate::channel::wait_on_channels(&self.runtime, &channels)?;
+        let statuses = self.runtime.wait_on_channels(&channels)?;
 
         for (i, &status) in statuses.iter().enumerate() {
             self.get_memory()

--- a/oak/server/rust/oak_runtime/src/runtime.rs
+++ b/oak/server/rust/oak_runtime/src/runtime.rs
@@ -234,7 +234,7 @@ impl Runtime {
         }
     }
 
-    /// Thread safe. This function will return:
+    /// Thread safe. This function returns:
     /// - [`ChannelReadStatus::ReadReady`] if there is at least one message in the channel.
     /// - [`ChannelReadStatus::Orphaned`] if there are no messages and there are no writers
     /// - [`ChannelReadStatus::NotReady`] if there are no messages but there are some writers
@@ -252,7 +252,7 @@ impl Runtime {
     /// Thread safe. Reads a message from the channel if `bytes_capacity` and `handles_capacity` are
     /// large enough to accept the message. Fails with `OakStatus::ErrChannelClosed` if the
     /// underlying channel has been orphaned _and_ is empty. If there was not enough
-    /// `bytes_capacity` or `handles_capacity`, `try_read_message` will return
+    /// `bytes_capacity` or `handles_capacity`, `try_read_message` returns
     /// `Some(ReadStatus::NeedsCapacity(needed_bytes_capacity,needed_handles_capacity))`. Does not
     /// guarantee that the next call will succeed after capacity adjustments as another thread may
     /// have read the original message.

--- a/oak/server/rust/oak_runtime/src/runtime.rs
+++ b/oak/server/rust/oak_runtime/src/runtime.rs
@@ -47,7 +47,6 @@ pub struct Runtime {
     configurations: HashMap<String, node::Configuration>,
     terminating: AtomicBool,
     channels: Mutex<Channels>,
-    // nodes:          Nodes,
     node_threads: Mutex<Vec<JoinHandle>>,
 }
 
@@ -99,8 +98,8 @@ impl Runtime {
         }
     }
 
+    /// Creates a new channel.
     pub fn new_channel(&self) -> (ChannelWriter, ChannelReader) {
-        // TODO: channel::new could take id or pretty name here
         let (c, w, r) = channel::new();
         let mut channels = self.channels.lock().unwrap();
         channels.push(Arc::downgrade(&c));
@@ -108,7 +107,7 @@ impl Runtime {
     }
 
     /// Reads the statuses from a slice of `Option<&ChannelReader>`s.
-    /// `ChannelReadStatus::InvalidChannel` is set for `None` readers in the slice. For `Some(_)`
+    /// [`ChannelReadStatus::InvalidChannel`] is set for `None` readers in the slice. For `Some(_)`
     /// readers, the result is set from a call to `has_message`.
     fn readers_statuses(&self, readers: &[Option<&ChannelReader>]) -> Vec<ChannelReadStatus> {
         readers
@@ -184,7 +183,7 @@ impl Runtime {
         Err(OakStatus::ErrTerminated)
     }
 
-    /// Write a message to a channel. Fails with `OakStatus::ErrChannelClosed` if the underlying
+    /// Write a message to a channel. Fails with [`OakStatus::ErrChannelClosed`] if the underlying
     /// channel has been orphaned.
     pub fn channel_write(&self, channel: &ChannelWriter, msg: Message) -> Result<(), OakStatus> {
         if channel.is_orphan() {
@@ -219,7 +218,7 @@ impl Runtime {
         Ok(())
     }
 
-    /// Thread safe. Read a message from a channel. Fails with `OakStatus::ErrChannelClosed` if
+    /// Thread safe. Read a message from a channel. Fails with [`OakStatus::ErrChannelClosed`] if
     /// the underlying channel is empty and has been orphaned.
     pub fn channel_read(&self, channel: &ChannelReader) -> Result<Option<Message>, OakStatus> {
         let mut messages = channel.messages.write().unwrap();
@@ -236,9 +235,9 @@ impl Runtime {
     }
 
     /// Thread safe. This function will return:
-    /// - `ReadReady` if there is at least one message in the channel.
-    /// - `Orphaned` if there are no messages and there are no writers
-    /// - `NOT_READ` if there are no messages but there are some writers
+    /// - [`ChannelReadStatus::ReadReady`] if there is at least one message in the channel.
+    /// - [`ChannelReadStatus::Orphaned`] if there are no messages and there are no writers
+    /// - [`ChannelReadStatus::NotReady`] if there are no messages but there are some writers
     pub fn channel_status(&self, channel: &ChannelReader) -> ChannelReadStatus {
         let messages = channel.messages.read().unwrap();
         if messages.front().is_some() {

--- a/oak/server/rust/oak_runtime/src/runtime/channel.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/channel.rs
@@ -56,7 +56,6 @@ pub struct Channel {
     pub waiting_threads: WaitingThreads,
 }
 
-
 /// Reference to a `Channel` that is `Clone`able and can be passed across threads. Channels are
 /// multi-writer mult-reader.
 #[derive(Clone)]

--- a/oak/server/rust/oak_runtime/src/runtime/channel.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/channel.rs
@@ -57,7 +57,7 @@ pub struct Channel {
 }
 
 /// Reference to a `Channel` that is `Clone`able and can be passed across threads. Channels are
-/// multi-writer mult-reader.
+/// multi-writer and mult-reader.
 #[derive(Clone)]
 struct ChannelRef(Arc<Channel>);
 


### PR DESCRIPTION
Channel reading/writing/status methods are moved to the runtime, and so all channel calls go through the runtime.

A more incremental approach to #648. This still allows flexibility to move to a different ownership model. 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
