### PR TITLE
Return TSAN_OPTIONS

### DIFF
--- a/scripts/run_example
+++ b/scripts/run_example
@@ -55,6 +55,13 @@ if [[ -z "${EXAMPLE+z}" ]]; then
   exit 1
 fi
 
+if [[ "${server}" == "tsan" ]]; then
+  # Set flags for TSAN runs (https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags):
+  #  - exit on error
+  #  - don't check atomics (false positive on absl::MutexLock, github.com/google/sanitizers/issues/953)
+  export TSAN_OPTIONS="halt_on_error=1 report_atomic_races=0"
+fi
+
 if [[ "${server}" != "none" ]]; then
   "${SCRIPTS_DIR}/build_example" ${buildargs} -l "${language}" -e "${EXAMPLE}"
 

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -30,13 +30,6 @@ while getopts "s:h" opt; do
   esac
 done
 
-if [[ "${server}" == "tsan" ]]; then
-  # Set flags for TSAN runs (https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags):
-  #  - exit on error
-  #  - don't check atomics (false positive on absl::MutexLock, github.com/google/sanitizers/issues/953)
-  export TSAN_OPTIONS="halt_on_error=1 report_atomic_races=0"
-fi
-
 # Run all examples.
 for language in rust cpp; do
   # TODO(#594): Re-enable rustfmt when upstream rustc internal error is fixed.

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -30,6 +30,13 @@ while getopts "s:h" opt; do
   esac
 done
 
+if [[ "${server}" == "tsan" ]]; then
+  # Set flags for TSAN runs (https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags):
+  #  - exit on error
+  #  - don't check atomics (false positive on absl::MutexLock, github.com/google/sanitizers/issues/953)
+  export TSAN_OPTIONS="halt_on_error=1 report_atomic_races=0"
+fi
+
 # Run all examples.
 for language in rust cpp; do
   # TODO(#594): Re-enable rustfmt when upstream rustc internal error is fixed.


### PR DESCRIPTION
This change returns `TSAN_OPTIONS` to `run_example` script.
Adding to `run_example` instead of `run_examples`, so this variable will be set while running a single example (e.g. `abitest`).

Fixes #681

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
