### PR TITLE
oak_runtime: Track Nodes with u64 NodeRefs

### DIFF
--- a/oak/server/rust/oak_runtime/Cargo.toml
+++ b/oak/server/rust/oak_runtime/Cargo.toml
@@ -19,7 +19,7 @@ itertools = "*"
 log = { version = "*" }
 oak_abi = "=0.1.0"
 prost = "*"
-rand = { version = "*" }
+rand = { version = "*", default-features = false, features = ["alloc"] }
 wasmi = { version = "*", default-features = false, features = ["core"] }
 no-std-compat = { version = "0.2.0", features = ["alloc", "compat_hash"] }
 oak_platform = { version = "=0.1.0" }

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -33,4 +33,4 @@ pub use config::application_configuration;
 pub use config::configure_and_run;
 
 pub use message::Message;
-pub use runtime::{ChannelEither, ChannelReader, ChannelWriter, Runtime, RuntimeRef};
+pub use runtime::{ChannelEither, ChannelReader, ChannelWriter, NodeRef, Runtime, RuntimeRef};

--- a/oak/server/rust/oak_runtime/src/node/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/mod.rs
@@ -21,8 +21,7 @@ use std::sync::Arc;
 
 use oak_abi::OakStatus;
 
-use crate::runtime::ChannelReader;
-use crate::RuntimeRef;
+use crate::{ChannelReader, NodeRef, RuntimeRef};
 
 mod logger;
 mod wasm;
@@ -73,6 +72,7 @@ impl Configuration {
         &self,
         config_name: &str, // Used for pretty debugging
         runtime: RuntimeRef,
+        _noderef: NodeRef,
         entrypoint: String,
         initial_reader: ChannelReader,
     ) -> Result<oak_platform::JoinHandle, OakStatus> {


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
