### PR TITLE
Introduce label parameter to `Runtime::node_create` 

### DIFF
--- a/oak/server/rust/oak_abi/src/lib.rs
+++ b/oak/server/rust/oak_abi/src/lib.rs
@@ -15,7 +15,7 @@
 //
 
 //! Type, constant and Wasm host function definitions for the Oak application binary interface.
-pub mod proto;
+mod proto;
 pub use proto::*;
 
 pub mod label;

--- a/oak/server/rust/oak_runtime/src/node/wasm.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm.rs
@@ -200,7 +200,14 @@ impl WasmInterface {
         })?;
 
         self.runtime
-            .node_create(&config_name, &entrypoint, channel_ref.clone())
+            .node_create(
+                &config_name,
+                &entrypoint,
+                // TODO(#630): Let caller provide this label via the Wasm ABI.
+                // TODO(#630): Check whether the label of the caller "flows to" the provided label.
+                &oak_abi::label::Label::public_trusted(),
+                channel_ref.clone(),
+            )
             .map_err(|_| {
                 error!(
                     "node_create: Config \"{}\" entrypoint \"{}\" not found",


### PR DESCRIPTION
This is not part of the Wasm ABI yet, just part of the implementation of
the Rust oak_runtime, but not used for information flow yet.

Unify Label trait and struct in oak_abi (there is no strong reason for
the separation at this point, though we may want to reintroduce it in
the future).

Rename `Label::can_flow_to` to `Label::flows_to` in accordance with
literature.

Add various missing doc links.

Ref #603

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
