### PR TITLE
Support passing handles inline in protobuf messages

### DIFF
--- a/oak/server/rust/oak_abi/src/lib.rs
+++ b/oak/server/rust/oak_abi/src/lib.rs
@@ -146,4 +146,7 @@ extern "C" {
     ///
     /// [`OakStatus`]: crate::OakStatus
     pub fn random_get(buf: *mut u8, len: usize) -> u32;
+
+    pub fn create_invite(handle: u64, invite_token: *mut u64) -> u32;
+    pub fn exchange_token(invite_token: u64, handle: *mut u64) -> u32;
 }

--- a/sdk/rust/oak/build.rs
+++ b/sdk/rust/oak/build.rs
@@ -24,6 +24,7 @@ fn main() {
             "../../../oak/proto/policy.proto",
             "../../../oak/proto/storage.proto",
             "../../../oak/proto/storage_channel.proto",
+            "../../../oak/proto/handle_invite.proto",
         ],
         includes: &["../../.."],
         customize: protoc_rust::Customize::default(),

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -98,6 +98,32 @@ impl Handle {
         }
     }
 
+    pub fn create_invite(&self) -> Result<u64, OakStatus> {
+        let mut invite_token = 0u64;
+        let status =
+            OakStatus::from_i32(
+                unsafe { oak_abi::create_invite(self.id, &mut invite_token) } as i32,
+            );
+        match status {
+            Some(OakStatus::Ok) => Ok(invite_token),
+            Some(x) => Err(x),
+            None => Err(OakStatus::ErrInternal),
+        }
+    }
+
+    pub fn from_invite(invite_token: u64) -> Result<Handle, OakStatus> {
+        let mut handle = Handle::invalid();
+        let status =
+            OakStatus::from_i32(
+                unsafe { oak_abi::exchange_token(invite_token, &mut handle.id) } as i32,
+            );
+        match status {
+            Some(OakStatus::Ok) => Ok(handle),
+            Some(x) => Err(x),
+            None => Err(OakStatus::ErrInternal),
+        }
+    }
+
     /// Pack a slice of `Handles` into the Wasm host ABI format.
     fn pack(handles: &[Handle]) -> Vec<u8> {
         let mut packed = Vec::with_capacity(handles.len() * 8);


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

Fixes #673.

These changes implement a way of passing channels inline in protobuf messages using channel invite tokens.

This is just an experiment for now. TODO list:
- [x] Add ABI calls to create and use invites
- [x] Support new ABI calls in Rust runtime
- [ ] Support new ABI calls in C++ runtime
- [ ] Define Protobuf format for handle invites
- [ ] Annotate handles in protobuf with the correct type (Current top priority)
- [ ] SDK changes to ergonomically convert to and from channel invites