### PR TITLE
Fix runner hanging

### DIFF
--- a/scripts/run_example
+++ b/scripts/run_example
@@ -72,20 +72,13 @@ if [[ "${server}" != "none" ]]; then
   "${SCRIPTS_DIR}/run_server" -s "${server}" -l "${language}" -e "${EXAMPLE}" &
   readonly SERVER_PID=$!
   sleep 3  # Wait for the application to start.
+
+  function stop_server {
+    kill -s SIGTERM "${SERVER_PID}"
+  }
+  trap stop_server EXIT
 fi
 
 # Run the application client.
 readonly CLIENT_ARGS=("${@}")  # Choose client args provided after '--'.
-
-# Temporary disable `errexit` in order to be able to stop the Oak server in any scenario.
-set +o errexit
 "./bazel-client-bin/examples/${EXAMPLE}/client/client" "${CLIENT_ARGS[@]}"
-readonly RESULT="$?"  # Get the error code returned by the client.
-set -o errexit
-
-# TODO: Ensure that background processes are killed with something like `trap cleanup_fn EXIT`.
-if [[ "${server}" != "none" ]]; then
-  kill -s SIGTERM "${SERVER_PID}"
-fi
-
-exit "${RESULT}"

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -71,12 +71,13 @@ if [[ "${server}" != "none" ]]; then
   "${SCRIPTS_DIR}/build_server" -s "${server}"
   "${SCRIPTS_DIR}/run_server" -s "${server}" -l "${language}" -e "${EXAMPLE}" &
   readonly SERVER_PID=$!
-  sleep 3  # Wait for the application to start.
 
   function stop_server {
     kill -s SIGTERM "${SERVER_PID}"
   }
   trap stop_server EXIT
+
+  sleep 3  # Wait for the application to start.
 fi
 
 # Run the application client.

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -76,9 +76,16 @@ fi
 
 # Run the application client.
 readonly CLIENT_ARGS=("${@}")  # Choose client args provided after '--'.
+
+# Temporary disable `errexit` in order to be able to stop the Oak server in any scenario.
+set +o errexit
 "./bazel-client-bin/examples/${EXAMPLE}/client/client" "${CLIENT_ARGS[@]}"
+readonly RESULT="$?"  # Get the error code returned by the client.
+set -o errexit
 
 # TODO: Ensure that background processes are killed with something like `trap cleanup_fn EXIT`.
 if [[ "${server}" != "none" ]]; then
   kill -s SIGTERM "${SERVER_PID}"
 fi
+
+exit "${RESULT}"


### PR DESCRIPTION
This change allows `run_example` script to stop server even if client returned an error (adds an `exit-trap`).

Fixes #677

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
