### PR TITLE
Use LogMessage in logger in `rust/oak_runtime`

### DIFF
--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -25,7 +25,7 @@ use proto::abitest::GrpcTestRequest_oneof_method_result::{err_code, ok_text};
 use proto::abitest::{ABITestRequest, ABITestResponse, ABITestResponse_TestResult};
 use proto::abitest::{GrpcTestRequest, GrpcTestResponse};
 use proto::abitest_grpc::{Dispatcher, OakABITestService, OakABITestServiceClient};
-use protobuf::ProtobufEnum;
+use protobuf::{Message, ProtobufEnum};
 use rand::Rng;
 use std::collections::HashMap;
 
@@ -1131,7 +1131,21 @@ impl FrontendNode {
 
         oak::channel_write(
             logging_handle,
-            "message sent direct to logging channel".as_bytes(),
+            "Malformed message sent direct to logging channel!".as_bytes(),
+            &[in_handle.handle, out_handle.handle],
+        )
+        .expect("could not write to channel");
+
+        oak::channel_write(
+            logging_handle,
+            &oak::proto::log::LogMessage {
+                level: oak::proto::log::Level::INFO,
+                file: "abitest".to_string(),
+                message: "Wellformed message sent direct to logging channel!".to_string(),
+                ..Default::default()
+            }
+            .write_to_bytes()
+            .unwrap()[..],
             &[in_handle.handle, out_handle.handle],
         )
         .expect("could not write to channel");

--- a/oak/server/rust/oak_runtime/build.rs
+++ b/oak/server/rust/oak_runtime/build.rs
@@ -17,7 +17,7 @@
 use std::path;
 
 fn main() {
-    let proto_files = vec!["application.proto"];
+    let proto_files = vec!["application.proto", "log.proto"];
 
     let proto_dir = path::Path::new("../../../../oak/proto/").to_path_buf();
     let proto_paths: Vec<path::PathBuf> = proto_files.iter().map(|f| proto_dir.join(f)).collect();

--- a/oak/server/rust/oak_runtime/src/proto.rs
+++ b/oak/server/rust/oak_runtime/src/proto.rs
@@ -15,3 +15,7 @@
 //
 
 include!(concat!(env!("OUT_DIR"), "/oak.rs"));
+
+pub mod log {
+    include!(concat!(env!("OUT_DIR"), "/oak.log.rs"));
+}


### PR DESCRIPTION
* Uses LogMessage protobuf for logging in `rust/oak_runtime`

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
