### PR TITLE
runtime/storage: use BoringSSL directly

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -73,6 +73,17 @@ http_archive(
     ],
 )
 
+# BoringSSL
+http_archive(
+    name = "boringssl",
+    sha256 = "37fabee8aa25d4a7f4eb05071b2c1929991c272cc2cb1cb33305163faea3c668",
+    strip_prefix = "boringssl-6a47fc1adc71998756d275050351346e4fb4e2d5",
+    # Commit from 2019-12-13
+    urls = [
+        "https://github.com/google/boringssl/archive/6a47fc1adc71998756d275050351346e4fb4e2d5.tar.gz",
+    ],
+)
+
 # Asylo Framework.
 http_archive(
     name = "com_google_asylo",

--- a/oak/server/storage/BUILD
+++ b/oak/server/storage/BUILD
@@ -76,7 +76,6 @@ cc_library(
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
-        "@com_google_asylo//asylo/crypto:aes_gcm_siv",
     ],
 )
 

--- a/oak/server/storage/storage_node.cc
+++ b/oak/server/storage/storage_node.cc
@@ -18,7 +18,6 @@
 
 #include "absl/memory/memory.h"
 #include "absl/strings/escaping.h"
-#include "asylo/util/cleansing_types.h"
 #include "grpcpp/create_channel.h"
 #include "oak/common/logging.h"
 #include "oak/proto/grpc_encap.pb.h"


### PR DESCRIPTION
Drop dependency on the Asylo wrappers for BoringSSL's AEAD
functionality.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
