### PR TITLE
Add label field to Channel struct

### DIFF
--- a/oak/server/rust/oak_runtime/src/node/wasm.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm.rs
@@ -201,7 +201,6 @@ impl WasmInterface {
                 &config_name,
                 &entrypoint,
                 // TODO(#630): Let caller provide this label via the Wasm ABI.
-                // TODO(#630): Check whether the label of the caller "flows to" the provided label.
                 &oak_abi::label::Label::public_trusted(),
                 channel_ref.clone(),
             )
@@ -220,7 +219,10 @@ impl WasmInterface {
         write_addr: AbiPointer,
         read_addr: AbiPointer,
     ) -> Result<(), OakStatus> {
-        let (writer, reader) = self.runtime.new_channel();
+        let (writer, reader) = self
+            .runtime
+            // TODO(#630): Let caller provide this label via the Wasm ABI.
+            .new_channel(&oak_abi::label::Label::public_trusted());
 
         self.validate_ptr(write_addr, 8)?;
         self.validate_ptr(read_addr, 8)?;

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -111,13 +111,21 @@ where
         .expect("failed to serialize GrpcRequest message");
 
     // Create a new channel to hold the request message.
-    let (req_write_half, req_read_half) = runtime.new_channel();
+    //
+    // In most cases we do not care about labels, so we use the least privileged label for this
+    // channel.
+    let (req_write_half, req_read_half) =
+        runtime.new_channel(&oak_abi::label::Label::public_trusted());
     runtime
         .channel_write(req_write_half, req_msg)
         .expect("could not write message");
 
     // Create a new channel for responses to arrive on and also attach that to the message.
-    let (rsp_write_half, rsp_read_half) = runtime.new_channel();
+    //
+    // In most cases we do not care about labels, so we use the least privileged label for this
+    // channel.
+    let (rsp_write_half, rsp_read_half) =
+        runtime.new_channel(&oak_abi::label::Label::public_trusted());
 
     // Create a notification message and attach the method-invocation specific channels to it.
     let notify_msg = oak_runtime::Message {


### PR DESCRIPTION
Will be used for enforcing Information Flow between Nodes and Channels
as part of #630.

Ref #603

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
