### PR TITLE
Define base `Node` trait

### DIFF
--- a/oak/server/rust/oak_runtime/src/config.rs
+++ b/oak/server/rust/oak_runtime/src/config.rs
@@ -114,6 +114,7 @@ pub fn from_protobuf(
 pub fn configure_and_run(
     app_config: ApplicationConfiguration,
 ) -> Result<(RuntimeRef, Handle), OakStatus> {
-    let config = from_protobuf(app_config)?;
-    Runtime::configure_and_run(config)
+    let configuration = from_protobuf(app_config)?;
+    let runtime = Runtime::create(configuration);
+    runtime.run()
 }

--- a/oak/server/rust/oak_runtime/src/runtime/channel.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/channel.rs
@@ -157,7 +157,7 @@ impl ChannelMapping {
         }
     }
 
-    /// Create a new [`Channel`] and return a `(writer handle, reader handle)` pair.
+    /// Creates a new [`Channel`] and returns a `(writer handle, reader handle)` pair.
     pub fn new_channel(&self, label: &oak_abi::label::Label) -> (Handle, Handle) {
         let channel_id = self.next_channel_id.fetch_add(1, SeqCst);
         let mut channels = self.channels.write().unwrap();


### PR DESCRIPTION
Have Log and Wasm nodes implement it.

Add a simple test for the Wasm node.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)

