### PR TITLE
Wrap Runtime in Mutex

### DIFF
--- a/oak/server/rust/oak_runtime/src/config.rs
+++ b/oak/server/rust/oak_runtime/src/config.rs
@@ -111,10 +111,8 @@ pub fn from_protobuf(
 /// writeable [`Handle`] to send messages into the runtime. Creating a new
 /// channel and passing the write [`Handle`] into the runtime will enable messages to be
 /// read back out from the [`Runtime`].
-pub fn configure_and_run(
-    app_config: ApplicationConfiguration,
-) -> Result<(RuntimeRef, Handle), OakStatus> {
+pub fn configure_and_run(app_config: ApplicationConfiguration) -> Result<Handle, OakStatus> {
     let configuration = from_protobuf(app_config)?;
-    let runtime = Runtime::create(configuration);
+    let runtime = Runtime::create(configuration).into_ref();
     runtime.run()
 }

--- a/oak/server/rust/oak_runtime/src/node/logger.rs
+++ b/oak/server/rust/oak_runtime/src/node/logger.rs
@@ -82,7 +82,7 @@ fn logger(pretty_name: &str, runtime: RuntimeRef, reader: Handle) -> Result<(), 
         // track their channels and make sure all channels are closed.
         // let _ = runtime.wait_on_channels(&[Some(&reader)]);
         runtime.wait_on_channels(&[Some(reader)])?;
-
+        let runtime = runtime.lock();
         if let Some(message) = runtime.channel_read(reader)? {
             match LogMessage::decode(&*message.data) {
                 Ok(msg) => info!(


### PR DESCRIPTION
Avoid relying on interior mutability.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
