### PR TITLE
oak_tests: Don't pass RUSTFLAGS to `compile_rust_wasm`

### DIFF
--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -36,6 +36,7 @@ pub fn compile_rust_wasm(cargo_path: &str, module_name: &str) -> std::io::Result
             "--target=wasm32-unknown-unknown",
             &format!("--manifest-path={}", cargo_path),
         ])
+        .env_remove("RUSTFLAGS")
         .spawn()?
         .wait()?;
 


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
