### PR TITLE
rust oak_runtime: Fix any possible lock inversion issues

### DIFF
--- a/oak/server/rust/oak_runtime/src/runtime/channel.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/channel.rs
@@ -114,9 +114,9 @@ impl Channel {
     /// Insert the given `thread` reference into `thread_id` slot of the HashMap of waiting
     /// channels attached to an underlying channel. This allows the channel to wake up any waiting
     /// channels by calling `thread::unpark` on all the threads it knows about.
-    pub fn add_waiter(&self, thread_id: ThreadId, thread: &Arc<Thread>) {
+    pub fn add_waiter(&self, thread_id: ThreadId, thread: Arc<Thread>) {
         let mut waiting_threads = self.waiting_threads.lock().unwrap();
-        waiting_threads.insert(thread_id, Arc::downgrade(thread));
+        waiting_threads.insert(thread_id, Arc::downgrade(&thread));
     }
 
     /// Decrement the [`Channel`] writer counter.

--- a/oak/server/rust/oak_runtime/src/runtime/channel.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/channel.rs
@@ -114,9 +114,9 @@ impl Channel {
     /// Insert the given `thread` reference into `thread_id` slot of the HashMap of waiting
     /// channels attached to an underlying channel. This allows the channel to wake up any waiting
     /// channels by calling `thread::unpark` on all the threads it knows about.
-    pub fn add_waiter(&self, thread_id: ThreadId, thread: Arc<Thread>) {
+    pub fn add_waiter(&self, thread_id: ThreadId, thread: &Arc<Thread>) {
         let mut waiting_threads = self.waiting_threads.lock().unwrap();
-        waiting_threads.insert(thread_id, Arc::downgrade(&thread));
+        waiting_threads.insert(thread_id, Arc::downgrade(thread));
     }
 
     /// Decrement the [`Channel`] writer counter.

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -342,7 +342,7 @@ impl Runtime {
                     self.channels.with_channel(
                         self.channels.get_reader_channel(*reader)?,
                         |channel| {
-                            channel.add_waiter(thread_id, thread_ref.clone());
+                            channel.add_waiter(thread_id, &thread_ref);
                             Ok(())
                         },
                     )?;

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -579,6 +579,13 @@ impl Runtime {
         let mut nodes = self.nodes.write().unwrap();
         nodes.remove(&node_id);
     }
+
+    /// Add an [`NodeId`] [`Node`] pair to the [`Runtime`]. This method temporarily holds the node
+    /// write lock.
+    fn add_running_node(&self, reference: NodeId, node: Node) {
+        let mut nodes = self.nodes.write().unwrap();
+        nodes.insert(reference, node);
+    }
 }
 
 /// A reference to a [`Runtime`].
@@ -638,10 +645,8 @@ impl RuntimeRef {
         instance.start()?;
 
         // If the node was successfully started, insert it in the list of currently running
-        // nodes. Scope the lock as small as possible and inparticular don't hold it during the
-        // duplicate_reference call which opens a temporary lock on channels.
-        let mut nodes = self.nodes.write().unwrap();
-        nodes.insert(
+        // nodes.
+        self.add_running_node(
             reference,
             Node {
                 reference,

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -342,7 +342,7 @@ impl Runtime {
                     self.channels.with_channel(
                         self.channels.get_reader_channel(*reader)?,
                         |channel| {
-                            channel.add_waiter(thread_id, &thread_ref);
+                            channel.add_waiter(thread_id, thread_ref.clone());
                             Ok(())
                         },
                     )?;


### PR DESCRIPTION
See #780. Note this can be checked with 

- `RUSTFLAGS="-Z sanitizer=thread" cargo -Zbuild-std test --manifest-path=./examples/abitest/tests/Cargo.toml --target x86_64-unknown-linux-gnu -- --nocapture` 
(Note I believe`-Zbuild-std`, to instrument the standard library, is required).
- With a nightly compiler newer than 2020.03.19


# Checklist

- [X] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [X] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
