### PR TITLE
Replace panic! with error! in grpc-codegen (#762)

### DIFF
--- a/examples/abitest/module_0/rust/src/proto/abitest_grpc.rs
+++ b/examples/abitest/module_0/rust/src/proto/abitest_grpc.rs
@@ -22,6 +22,7 @@
 use oak::grpc;
 use protobuf::Message;
 use std::io::Write;
+use log::error;
 
 // Oak Node server interface
 pub trait OakABITestService {
@@ -50,7 +51,7 @@ impl<T: OakABITestService> grpc::ServerNode for Dispatcher<T> {
             "/oak.examples.abitest.OakABITestService/ClientStreamingMethod" => grpc::handle_stream_rsp(|rr| self.0.client_streaming_method(rr), req, writer),
             "/oak.examples.abitest.OakABITestService/BidiStreamingMethod" => grpc::handle_stream_stream(|rr, w| self.0.bidi_streaming_method(rr, w), req, writer),
             _ => {
-                panic!("unknown method name: {}", method);
+                error!("unknown method name: {}", method);
             }
         };
     }

--- a/examples/aggregator/module/rust/src/proto/aggregator_grpc.rs
+++ b/examples/aggregator/module/rust/src/proto/aggregator_grpc.rs
@@ -22,6 +22,7 @@
 use oak::grpc;
 use protobuf::Message;
 use std::io::Write;
+use log::error;
 
 // Oak Node server interface
 pub trait Aggregator {
@@ -42,7 +43,7 @@ impl<T: Aggregator> grpc::ServerNode for Dispatcher<T> {
         match method {
             "/oak.examples.aggregator.Aggregator/SubmitSample" => grpc::handle_req_rsp(|r| self.0.submit_sample(r), req, writer),
             _ => {
-                panic!("unknown method name: {}", method);
+                error!("unknown method name: {}", method);
             }
         };
     }

--- a/examples/chat/module/rust/src/proto/chat_grpc.rs
+++ b/examples/chat/module/rust/src/proto/chat_grpc.rs
@@ -22,6 +22,7 @@
 use oak::grpc;
 use protobuf::Message;
 use std::io::Write;
+use log::error;
 
 // Oak Node server interface
 pub trait Chat {
@@ -48,7 +49,7 @@ impl<T: Chat> grpc::ServerNode for Dispatcher<T> {
             "/oak.examples.chat.Chat/Subscribe" => grpc::handle_req_stream(|r, w| self.0.subscribe(r, w), req, writer),
             "/oak.examples.chat.Chat/SendMessage" => grpc::handle_req_rsp(|r| self.0.send_message(r), req, writer),
             _ => {
-                panic!("unknown method name: {}", method);
+                error!("unknown method name: {}", method);
             }
         };
     }

--- a/examples/hello_world/module/rust/src/proto/hello_world_grpc.rs
+++ b/examples/hello_world/module/rust/src/proto/hello_world_grpc.rs
@@ -22,6 +22,7 @@
 use oak::grpc;
 use protobuf::Message;
 use std::io::Write;
+use log::error;
 
 // Oak Node server interface
 pub trait HelloWorld {
@@ -48,7 +49,7 @@ impl<T: HelloWorld> grpc::ServerNode for Dispatcher<T> {
             "/oak.examples.hello_world.HelloWorld/LotsOfGreetings" => grpc::handle_stream_rsp(|rr| self.0.lots_of_greetings(rr), req, writer),
             "/oak.examples.hello_world.HelloWorld/BidiHello" => grpc::handle_stream_stream(|rr, w| self.0.bidi_hello(rr, w), req, writer),
             _ => {
-                panic!("unknown method name: {}", method);
+                error!("unknown method name: {}", method);
             }
         };
     }

--- a/examples/private_set_intersection/module/rust/src/proto/private_set_intersection_grpc.rs
+++ b/examples/private_set_intersection/module/rust/src/proto/private_set_intersection_grpc.rs
@@ -22,6 +22,7 @@
 use oak::grpc;
 use protobuf::Message;
 use std::io::Write;
+use log::error;
 
 // Oak Node server interface
 pub trait PrivateSetIntersection {
@@ -44,7 +45,7 @@ impl<T: PrivateSetIntersection> grpc::ServerNode for Dispatcher<T> {
             "/oak.examples.private_set_intersection.PrivateSetIntersection/SubmitSet" => grpc::handle_req_rsp(|r| self.0.submit_set(r), req, writer),
             "/oak.examples.private_set_intersection.PrivateSetIntersection/GetIntersection" => grpc::handle_req_rsp(|r| self.0.get_intersection(r), req, writer),
             _ => {
-                panic!("unknown method name: {}", method);
+                error!("unknown method name: {}", method);
             }
         };
     }

--- a/examples/running_average/module/rust/src/proto/running_average_grpc.rs
+++ b/examples/running_average/module/rust/src/proto/running_average_grpc.rs
@@ -22,6 +22,7 @@
 use oak::grpc;
 use protobuf::Message;
 use std::io::Write;
+use log::error;
 
 // Oak Node server interface
 pub trait RunningAverage {
@@ -44,7 +45,7 @@ impl<T: RunningAverage> grpc::ServerNode for Dispatcher<T> {
             "/oak.examples.running_average.RunningAverage/SubmitSample" => grpc::handle_req_rsp(|r| self.0.submit_sample(r), req, writer),
             "/oak.examples.running_average.RunningAverage/GetAverage" => grpc::handle_req_rsp(|r| self.0.get_average(r), req, writer),
             _ => {
-                panic!("unknown method name: {}", method);
+                error!("unknown method name: {}", method);
             }
         };
     }

--- a/examples/rustfmt/module/rust/src/proto/rustfmt_grpc.rs
+++ b/examples/rustfmt/module/rust/src/proto/rustfmt_grpc.rs
@@ -22,6 +22,7 @@
 use oak::grpc;
 use protobuf::Message;
 use std::io::Write;
+use log::error;
 
 // Oak Node server interface
 pub trait FormatService {
@@ -42,7 +43,7 @@ impl<T: FormatService> grpc::ServerNode for Dispatcher<T> {
         match method {
             "/oak.examples.rustfmt.FormatService/Format" => grpc::handle_req_rsp(|r| self.0.format(r), req, writer),
             _ => {
-                panic!("unknown method name: {}", method);
+                error!("unknown method name: {}", method);
             }
         };
     }

--- a/examples/translator/common/src/proto/translator_grpc.rs
+++ b/examples/translator/common/src/proto/translator_grpc.rs
@@ -22,6 +22,7 @@
 use oak::grpc;
 use protobuf::Message;
 use std::io::Write;
+use log::error;
 
 // Oak Node server interface
 pub trait Translator {
@@ -42,7 +43,7 @@ impl<T: Translator> grpc::ServerNode for Dispatcher<T> {
         match method {
             "/oak.examples.translator.Translator/Translate" => grpc::handle_req_rsp(|r| self.0.translate(r), req, writer),
             _ => {
-                panic!("unknown method name: {}", method);
+                error!("unknown method name: {}", method);
             }
         };
     }

--- a/third_party/grpc-rust/grpc-compiler/src/codegen.rs
+++ b/third_party/grpc-rust/grpc-compiler/src/codegen.rs
@@ -278,7 +278,7 @@ impl<'a> ServiceGen<'a> {
                         w.write_line(format!("\"{}\" => {},", method.full_path(), method.dispatch_method()));
                     }
                     w.block("_ => {", "}", |w| {
-                        w.write_line("panic!(\"unknown method name: {}\", method);");
+                        w.write_line("error!(\"unknown method name: {}\", method);");
                     });
                 });
             });
@@ -307,6 +307,7 @@ impl<'a> ServiceGen<'a> {
         w.write_line("use oak::grpc;");
         w.write_line("use protobuf::Message;");
         w.write_line("use std::io::Write;");
+        w.write_line("use log::error;");
         w.write_line("");
         w.comment("Oak Node server interface");
         self.write_server_intf(w);


### PR DESCRIPTION
Updates grpc codegen to log an error instead of panicking when trying to invoke an unknown method.

Fixes #726 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
