### PR TITLE
Split node initialization and start

### DIFF
--- a/oak/server/rust/oak_runtime/src/node/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/mod.rs
@@ -29,6 +29,10 @@ mod wasm;
 /// Nodes must not do any work until the [`Node::start`] method is invoked.
 pub trait Node: Send + Sync {
     /// Starts executing the node.
+    ///
+    /// This method will be invoked in a blocking fashion by the [`Runtime`], therefore node
+    /// implementations should make sure that they create separate background threads to execute
+    /// actual work, and wait on them to terminate when [`Node::stop`] is called.
     fn start(&mut self) -> Result<(), OakStatus>;
 
     /// Stops executing the node.


### PR DESCRIPTION
This also allows to write tests for the newly created
`node_start_instance` function, extracted from `node_create`.

Fixes #788

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
- [x] Pull request includes prototype/experimental work that is under
      construction.
