### PR TITLE
Remove `RuntimeRef` object

### DIFF
--- a/examples/aggregator/module/rust/src/tests.rs
+++ b/examples/aggregator/module/rust/src/tests.rs
@@ -28,7 +28,7 @@ use std::convert::{From, TryFrom};
 const MODULE_CONFIG_NAME: &str = "aggregator";
 
 fn submit_sample(
-    runtime: &oak_runtime::RuntimeRef,
+    runtime: &oak_runtime::Runtime,
     entry_channel: oak_runtime::Handle,
     bucket: &str,
     indices: Vec<u32>,

--- a/examples/running_average/module/rust/src/tests.rs
+++ b/examples/running_average/module/rust/src/tests.rs
@@ -21,17 +21,13 @@ use protobuf::well_known_types::Empty;
 
 const MODULE_CONFIG_NAME: &str = "running_average";
 
-fn submit_sample(
-    runtime: &oak_runtime::RuntimeRef,
-    entry_channel: oak_runtime::Handle,
-    value: u64,
-) {
+fn submit_sample(runtime: &oak_runtime::Runtime, entry_channel: oak_runtime::Handle, value: u64) {
     let req = SubmitSampleRequest {
         value,
         ..Default::default()
     };
     let result: grpc::Result<Empty> = oak_tests::grpc_request(
-        runtime,
+        &runtime,
         entry_channel,
         "/oak.examples.running_average.RunningAverage/SubmitSample",
         &req,

--- a/oak/server/rust/oak_runtime/src/config.rs
+++ b/oak/server/rust/oak_runtime/src/config.rs
@@ -20,6 +20,7 @@ use crate::proto::{
 };
 use itertools::Itertools;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use log::error;
 
@@ -28,7 +29,7 @@ use oak_abi::OakStatus;
 use crate::node;
 use crate::node::load_wasm;
 use crate::runtime;
-use crate::runtime::{Handle, Runtime, RuntimeRef};
+use crate::runtime::{Handle, Runtime};
 
 /// Create an application configuration.
 ///
@@ -113,8 +114,9 @@ pub fn from_protobuf(
 /// read back out from the [`Runtime`].
 pub fn configure_and_run(
     app_config: ApplicationConfiguration,
-) -> Result<(RuntimeRef, Handle), OakStatus> {
+) -> Result<(Arc<Runtime>, Handle), OakStatus> {
     let configuration = from_protobuf(app_config)?;
-    let runtime = Runtime::create(configuration);
-    runtime.run()
+    let runtime = Arc::new(Runtime::create(configuration));
+    let handle = runtime.clone().run()?;
+    Ok((runtime, handle))
 }

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -28,4 +28,4 @@ pub use config::application_configuration;
 pub use config::configure_and_run;
 
 pub use message::Message;
-pub use runtime::{Handle, NodeId, Runtime, RuntimeRef};
+pub use runtime::{Handle, NodeId, Runtime};

--- a/oak/server/rust/oak_runtime/src/node/logger.rs
+++ b/oak/server/rust/oak_runtime/src/node/logger.rs
@@ -20,18 +20,19 @@ use log::{error, info};
 
 use oak_abi::OakStatus;
 use std::{
+    sync::Arc,
     thread,
     thread::{spawn, JoinHandle},
 };
 
 use crate::proto::log::{Level, LogMessage};
 use crate::runtime::Handle;
-use crate::{NodeId, RuntimeRef};
+use crate::{NodeId, Runtime};
 use prost::Message;
 
 pub struct LogNode {
     config_name: String,
-    runtime: RuntimeRef,
+    runtime: Arc<Runtime>,
     node_id: NodeId,
     reader: Handle,
     thread_handle: Option<JoinHandle<()>>,
@@ -39,7 +40,7 @@ pub struct LogNode {
 
 impl LogNode {
     /// Creates a new [`LogNode`] instance, but does not start it.
-    pub fn new(config_name: &str, runtime: RuntimeRef, node_id: NodeId, reader: Handle) -> Self {
+    pub fn new(config_name: &str, runtime: Arc<Runtime>, node_id: NodeId, reader: Handle) -> Self {
         Self {
             config_name: config_name.to_string(),
             runtime,
@@ -78,7 +79,7 @@ impl super::Node for LogNode {
 
 fn logger(
     pretty_name: &str,
-    runtime: RuntimeRef,
+    runtime: Arc<Runtime>,
     node_id: NodeId,
     reader: Handle,
 ) -> Result<(), OakStatus> {

--- a/oak/server/rust/oak_runtime/src/node/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/mod.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use oak_abi::OakStatus;
 
-use crate::{Handle, NodeId, RuntimeRef};
+use crate::{Handle, NodeId, Runtime};
 
 mod logger;
 mod wasm;
@@ -88,7 +88,7 @@ impl Configuration {
     pub fn create_node(
         &self,
         config_name: &str, // Used for pretty debugging
-        runtime: RuntimeRef,
+        runtime: Arc<Runtime>,
         node_id: NodeId,
         entrypoint: String,
         initial_reader: Handle,

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -21,6 +21,7 @@ use log::info;
 use protobuf::{Message, ProtobufEnum};
 use std::collections::HashMap;
 use std::process::Command;
+use std::sync::Arc;
 
 use oak_runtime::runtime::TEST_NODE_ID;
 
@@ -58,7 +59,7 @@ const MODULE_WASM_SUFFIX: &str = ".wasm";
 /// given module name, using the default name "oak_main" for its entrypoint.
 pub fn run_single_module_default(
     module_config_name: &str,
-) -> Result<(oak_runtime::RuntimeRef, oak_runtime::Handle), oak::OakStatus> {
+) -> Result<(Arc<oak_runtime::Runtime>, oak_runtime::Handle), oak::OakStatus> {
     run_single_module(module_config_name, DEFAULT_ENTRYPOINT_NAME)
 }
 
@@ -67,7 +68,7 @@ pub fn run_single_module_default(
 pub fn run_single_module(
     module_config_name: &str,
     entrypoint_name: &str,
-) -> Result<(oak_runtime::RuntimeRef, oak_runtime::Handle), oak::OakStatus> {
+) -> Result<(Arc<oak_runtime::Runtime>, oak_runtime::Handle), oak::OakStatus> {
     let wasm: HashMap<String, Vec<u8>> = [(
         module_config_name.to_owned(),
         compile_rust_wasm(
@@ -92,7 +93,7 @@ pub fn run_single_module(
 
 // TODO(#543): move this to oak_runtime as it's not test-specific
 pub fn grpc_request<R, Q>(
-    runtime: &oak_runtime::RuntimeRef,
+    runtime: &oak_runtime::Runtime,
     channel: oak_runtime::Handle,
     method_name: &str,
     req: &R,


### PR DESCRIPTION
Instead define methods on `Arc<Self>` receiver when necessary.

Ref #630

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
