### PR TITLE
Use named threads for nodes and loggers

### DIFF
--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -29,3 +29,17 @@ pub use config::configure_and_run;
 
 pub use message::Message;
 pub use runtime::{Handle, NodeId, Runtime};
+
+use std::thread::Thread;
+
+/// Formats the thread for logging. Threads should be given a name with
+/// [`std::thread::Builder::name`] to make the output more readable.
+fn pretty_name_for_thread(thread_handle: &Thread) -> String {
+    format!(
+        "{:?}:{}",
+        thread_handle.id(),
+        // Note: Use "<unnamed>" to make it stand out in the logs (and
+        // hopefully fixed).
+        thread_handle.name().unwrap_or("<unnamed>")
+    )
+}

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -29,6 +29,7 @@ use log::{debug, error};
 
 use crate::message::Message;
 use crate::node;
+use crate::pretty_name_for_thread;
 
 mod channel;
 pub use channel::{Handle, HandleDirection};
@@ -346,13 +347,16 @@ impl Runtime {
             }
 
             debug!(
-                "wait_on_channels: channels not ready, parking thread {:?}",
-                thread::current()
+                "wait_on_channels: channels not ready, parking thread {}",
+                pretty_name_for_thread(&thread::current())
             );
 
             thread::park();
 
-            debug!("wait_on_channels: thread {:?} re-woken", thread::current());
+            debug!(
+                "wait_on_channels: thread {} re-woken",
+                pretty_name_for_thread(&thread::current())
+            );
         }
         Err(OakStatus::ErrTerminated)
     }


### PR DESCRIPTION
Using named threads should help identifying threads during debugging.

https://doc.rust-lang.org/std/thread/struct.Builder.html#method.name

Example log:

2020-03-31 13:49:42,080 DEBUG [oak_runtime::runtime] wait_on_channels: \
    thread Thread { id: ThreadId(4), name: Some("node_logger=log") } re-woken
2020-03-31 13:49:42,080 DEBUG [oak_runtime::runtime] wait_on_channels: \
    thread Thread { id: ThreadId(3), name: Some("node=translator") } re-woken

Before it would show: Thread { id: ThreadId(4), name: None }

Fixes #770

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
