### PR TITLE
Reduce scope and number of locks in Rust runtime

### DIFF
--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -372,35 +372,28 @@ impl Runtime {
             return Err(OakStatus::ErrChannelClosed);
         }
 
-        {
-            let mut new_references = Vec::with_capacity(msg.channels.len());
-            let mut failure = None;
+        let mut new_references = Vec::with_capacity(msg.channels.len());
+        let mut failure = None;
 
-            for reference in msg.channels.iter() {
-                match self.channels.duplicate_reference(*reference) {
-                    Err(e) => {
-                        failure = Some(e);
-                        break;
-                    }
-                    Ok(reference) => new_references.push(reference),
+        for reference in msg.channels.iter() {
+            match self.channels.duplicate_reference(*reference) {
+                Err(e) => {
+                    failure = Some(e);
+                    break;
                 }
+                Ok(reference) => new_references.push(reference),
             }
-
-            if let Some(err) = failure {
-                for reference in new_references {
-                    self.channels.remove_reference(reference).expect("channel_write: Failed to deallocate channel references during backtracking from error during channel reference copying");
-                }
-                return Err(err);
-            }
-
-            let msg = Message { channels: new_references, ..msg };
-
-            let mut messages = channel.messages.write().unwrap();
-
-            messages.push_back(msg);
         }
 
-        let mut waiting_threads = channel.waiting_threads.lock().unwrap();
+        if let Some(err) = failure {
+            for reference in new_references {
+                self.channels.remove_reference(reference).expect("channel_write: Failed to deallocate channel references during backtracking from error during channel reference copying");
+            }
+            return Err(err);
+        }
+
+        let msg = Message { channels: new_references, ..msg };
+        channel.messages.write().unwrap().push_back(msg);
 
         // Unpark (wake up) all waiting threads that still have live references. The first thread
         // woken can immediately read the message, and others might find `messages` is empty before
@@ -412,6 +405,7 @@ impl Runtime {
         // add itself again. Note that since that lock is currently held, the woken thread will add
         // itself to waiting_threads *after* we call clear below as we release the lock implicilty
         // on leaving this function.
+        let mut waiting_threads = channel.waiting_threads.lock().unwrap();
         for thread in waiting_threads.values() {
             if let Some(thread) = thread.upgrade() {
                 thread.unpark();
@@ -432,9 +426,9 @@ impl Runtime {
     ) -> Result<Option<Message>, OakStatus> {
         self.validate_handle_access(node_id, reference)?;
         self.channels
-            .with_channel(self.channels.get_reader_channel(reference)?, |channel| {
-                let mut messages = channel.messages.write().unwrap();
-                match messages.pop_front() {
+            .with_channel(
+                self.channels.get_reader_channel(reference)?,
+                |channel| match channel.messages.write().unwrap().pop_front() {
                     Some(m) => {
                         self.track_handles_in_node(node_id, vec![reference]);
                         Ok(Some(m))
@@ -446,8 +440,8 @@ impl Runtime {
                             Ok(None)
                         }
                     }
-                }
-            })
+                },
+            )
     }
 
     /// Thread safe. This function returns:
@@ -462,8 +456,7 @@ impl Runtime {
         self.validate_handle_access(node_id, reference)?;
         self.channels
             .with_channel(self.channels.get_reader_channel(reference)?, |channel| {
-                let messages = channel.messages.read().unwrap();
-                Ok(if messages.front().is_some() {
+                Ok(if channel.messages.read().unwrap().front().is_some() {
                     ChannelReadStatus::ReadReady
                 } else if channel.is_orphan() {
                     ChannelReadStatus::Orphaned
@@ -535,14 +528,24 @@ impl Runtime {
     ) -> Result<HandleDirection, OakStatus> {
         self.validate_handle_access(node_id, reference)?;
         {
-            let readers = self.channels.readers.read().unwrap();
-            if readers.contains_key(&reference) {
+            if self
+                .channels
+                .readers
+                .read()
+                .unwrap()
+                .contains_key(&reference)
+            {
                 return Ok(HandleDirection::Read);
             }
         }
         {
-            let writers = self.channels.writers.read().unwrap();
-            if writers.contains_key(&reference) {
+            if self
+                .channels
+                .writers
+                .read()
+                .unwrap()
+                .contains_key(&reference)
+            {
                 return Ok(HandleDirection::Write);
             }
         }
@@ -559,8 +562,7 @@ impl Runtime {
             let node_info = node_infos
                 .get(&node_id)
                 .expect("channel_close: No such node_id");
-            let mut handles = node_info.handles.lock().unwrap();
-            handles.remove(&reference);
+            node_info.handles.lock().unwrap().remove(&reference);
         }
 
         self.channels.remove_reference(reference)
@@ -600,8 +602,9 @@ impl Runtime {
             }
         }
 
-        let mut node_infos = self.node_infos.write().unwrap();
-        node_infos
+        self.node_infos
+            .write()
+            .unwrap()
             .remove(&node_id)
             .expect("remove_node_id: Node didn't exist!");
     }

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -45,7 +45,7 @@ struct NodeInfo {
 
     /// A [`HashSet`] containing all the handles associated with this Node.
     // TODO(#777): this overlaps ChannelMapping.{reader,writer}
-    handles: Mutex<HashSet<Handle>>,
+    handles: HashSet<Handle>,
 }
 
 /// An identifier for a [`Node`] that is opaque for type safety.
@@ -193,14 +193,13 @@ impl Runtime {
             return;
         }
 
-        let node_infos = self.node_infos.read().unwrap();
+        let mut node_infos = self.node_infos.write().unwrap();
         let node_info = node_infos
-            .get(&node_id)
+            .get_mut(&node_id)
             .expect("Invalid node_id passed into track_handles_in_node!");
 
-        let mut tracked_handles = node_info.handles.lock().unwrap();
         for handle in handles {
-            tracked_handles.insert(handle);
+            node_info.handles.insert(handle);
         }
     }
 
@@ -217,11 +216,10 @@ impl Runtime {
         let node_info = node_infos
             .get(&node_id)
             .expect("Invalid node_id passed into validate_handle_access!");
-        let tracked_handles = node_info.handles.lock().unwrap();
 
         // Check the handle exists in the handles associated with a node, otherwise
         // return ErrBadHandle.
-        if tracked_handles.contains(&handle) {
+        if node_info.handles.contains(&handle) {
             Ok(())
         } else {
             error!(
@@ -248,10 +246,9 @@ impl Runtime {
             .get(&node_id)
             .expect("Invalid node_id passed into filter_optional_handles!");
 
-        let tracked_handles = node_info.handles.lock().unwrap();
         for handle in handles {
             // Check handle is accessible by the node.
-            if !tracked_handles.contains(&handle) {
+            if !node_info.handles.contains(&handle) {
                 error!(
                     "filter_optional_handles: handle {:?} not found in node {:?}",
                     handle, node_id
@@ -558,11 +555,11 @@ impl Runtime {
 
         if node_id != RUNTIME_NODE_ID {
             // Remove handle from the nodes available handles
-            let node_infos = self.node_infos.read().unwrap();
+            let mut node_infos = self.node_infos.write().unwrap();
             let node_info = node_infos
-                .get(&node_id)
+                .get_mut(&node_id)
                 .expect("channel_close: No such node_id");
-            node_info.handles.lock().unwrap().remove(&reference);
+            node_info.handles.remove(&reference);
         }
 
         self.channels.remove_reference(reference)
@@ -587,8 +584,7 @@ impl Runtime {
                 let node_info = node_infos
                     .get(&node_id)
                     .expect("remove_node_id: No such node_id");
-                let handles = node_info.handles.lock().unwrap();
-                handles.iter().copied().collect()
+                node_info.handles.iter().copied().collect()
             };
 
             debug!(
@@ -698,7 +694,7 @@ impl Runtime {
             node_reference,
             NodeInfo {
                 label: label.clone(),
-                handles: Mutex::new(HashSet::new()),
+                handles: HashSet::new(),
             },
         );
 


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
