### PR TITLE
Cleanup remaining references to `RuntimeRef`

### DIFF
--- a/oak/server/rust/oak_runtime/src/config.rs
+++ b/oak/server/rust/oak_runtime/src/config.rs
@@ -108,10 +108,9 @@ pub fn from_protobuf(
 }
 
 /// Configure a [`Runtime`] from the given protobuf [`ApplicationConfiguration`] and begin
-/// execution. This returns a [`RuntimeRef`] reference to the created runtime, and a
-/// writeable [`Handle`] to send messages into the runtime. Creating a new
-/// channel and passing the write [`Handle`] into the runtime will enable messages to be
-/// read back out from the [`Runtime`].
+/// execution. This returns an [`Arc`] reference to the created [`Runtime`], and a writeable
+/// [`Handle`] to send messages into the runtime. Creating a new channel and passing the write
+/// [`Handle`] into the runtime will enable messages to be read back out from the [`Runtime`].
 pub fn configure_and_run(
     app_config: ApplicationConfiguration,
 ) -> Result<(Arc<Runtime>, Handle), OakStatus> {

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -106,9 +106,9 @@ impl Runtime {
     /// After starting a [`Runtime`], calling [`Runtime::stop`] will send termination signals to
     /// nodes and wait for them to terminate.
     ///
-    /// Returns a [`RuntimeRef`] reference to the created runtime, and a writeable [`Handle`] to
-    /// send messages into the runtime. To receive messages, creating a new channel and passing
-    /// the write [`Handle`] into the runtime will enable messages to be read back out.
+    /// Returns a writeable [`Handle`] to send messages into the [`Runtime`]. To receive messages,
+    /// creating a new channel and passing the write [`Handle`] into the runtime will enable
+    /// messages to be read back out.
     pub fn run(self: Arc<Self>) -> Result<Handle, OakStatus> {
         let module_name = self.configuration.entry_module.clone();
         let entrypoint = self.configuration.entrypoint.clone();
@@ -767,9 +767,9 @@ impl Runtime {
     /// <https://github.com/project-oak/oak/blob/master/docs/concepts.md#labels> for more
     /// information on labels.
     ///
-    /// [`RuntimeRef::node_create`] is a method of [`RuntimeRef`] and not [`Runtime`], so that the
-    /// underlying `Arc<Runtime>` can be passed to [`crate::node::Configuration::new_instance`]
-    /// and given to a new node thread.
+    /// This method is defined on [`Arc`] and not [`Runtime`] itself, so that the [`Arc`] can clone
+    /// itself and be passed to [`crate::node::Configuration::new_instance`] to be given to a new
+    /// node thread.
     pub fn node_create(
         self: Arc<Self>,
         node_id: NodeId,


### PR DESCRIPTION
This was removed in 99b7d31c

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
