### PR TITLE
runtime: set type_url for storage Any requests

### DIFF
--- a/oak/server/storage/storage_node.cc
+++ b/oak/server/storage/storage_node.cc
@@ -91,6 +91,9 @@ oak::StatusOr<std::unique_ptr<GrpcResponse>> StorageNode::ProcessMethod(GrpcRequ
 
   if (method_name == "/oak.StorageNode/Read") {
     StorageChannelReadRequest read_req;
+    // Assume the type of the embedded request is correct.
+    grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
+                                              read_req.GetDescriptor()->full_name());
     if (!grpc_req->req_msg().UnpackTo(&read_req)) {
       return absl::Status(absl::StatusCode::kInvalidArgument, "Failed to unpack request");
     }
@@ -105,6 +108,9 @@ oak::StatusOr<std::unique_ptr<GrpcResponse>> StorageNode::ProcessMethod(GrpcRequ
 
   } else if (method_name == "/oak.StorageNode/Write") {
     StorageChannelWriteRequest write_req;
+    // Assume the type of the embedded request is correct.
+    grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
+                                              write_req.GetDescriptor()->full_name());
     if (!grpc_req->req_msg().UnpackTo(&write_req)) {
       return absl::Status(absl::StatusCode::kInvalidArgument, "Failed to unpack request");
     }
@@ -116,6 +122,9 @@ oak::StatusOr<std::unique_ptr<GrpcResponse>> StorageNode::ProcessMethod(GrpcRequ
 
   } else if (method_name == "/oak.StorageNode/Delete") {
     StorageChannelDeleteRequest delete_req;
+    // Assume the type of the embedded request is correct.
+    grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
+                                              delete_req.GetDescriptor()->full_name());
     if (!grpc_req->req_msg().UnpackTo(&delete_req)) {
       return absl::Status(absl::StatusCode::kInvalidArgument, "Failed to unpack request");
     }
@@ -125,6 +134,9 @@ oak::StatusOr<std::unique_ptr<GrpcResponse>> StorageNode::ProcessMethod(GrpcRequ
 
   } else if (method_name == "/oak.StorageNode/Begin") {
     StorageChannelBeginRequest begin_req;
+    // Assume the type of the embedded request is correct.
+    grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
+                                              begin_req.GetDescriptor()->full_name());
     if (!grpc_req->req_msg().UnpackTo(&begin_req)) {
       return absl::Status(absl::StatusCode::kInvalidArgument, "Failed to unpack request");
     }
@@ -136,6 +148,9 @@ oak::StatusOr<std::unique_ptr<GrpcResponse>> StorageNode::ProcessMethod(GrpcRequ
 
   } else if (method_name == "/oak.StorageNode/Commit") {
     StorageChannelCommitRequest commit_req;
+    // Assume the type of the embedded request is correct.
+    grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
+                                              commit_req.GetDescriptor()->full_name());
     if (!grpc_req->req_msg().UnpackTo(&commit_req)) {
       return absl::Status(absl::StatusCode::kInvalidArgument, "Failed to unpack request");
     }
@@ -144,6 +159,9 @@ oak::StatusOr<std::unique_ptr<GrpcResponse>> StorageNode::ProcessMethod(GrpcRequ
 
   } else if (method_name == "/oak.StorageNode/Rollback") {
     StorageChannelRollbackRequest rollback_req;
+    // Assume the type of the embedded request is correct.
+    grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
+                                              rollback_req.GetDescriptor()->full_name());
     if (!grpc_req->req_msg().UnpackTo(&rollback_req)) {
       return absl::Status(absl::StatusCode::kInvalidArgument, "Failed to unpack request");
     }


### PR DESCRIPTION
The prost protobuf library does not support message descriptors, so
encapsulated Any messages from Nodes cannot fill in the type_url
field.  However, the C++ protobuf library code that unpacks an Any
message into a specific protobuf message type requires this field
to be present and match.

Work around this by assuming that storage requests are of the correct
type, and modify the Any message to set its type_url field
appropriately.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
