### PR TITLE
Move generated protos into oak_abi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,9 +1150,11 @@ name = "oak_abi"
 version = "0.1.0"
 dependencies = [
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak_utils 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1176,7 +1178,6 @@ dependencies = [
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "oak 0.1.0",
  "oak_abi 0.1.0",
  "oak_utils 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -11,9 +11,12 @@ specific entrypoints which form the **Oak ABI**:
 
 These host functions provided by the Oak TCB revolve around the creation of
 other Nodes, and the use of [channels](concepts.md#channels) for inter-node
-communication. To communicate with the outside world beyond the Oak system, a
-Node may also create and communicate with
-[pseudo-Nodes](concepts.md#pseudo-nodes).
+communication.
+
+To communicate with the outside world beyond the Oak system, a Node may also
+create and communicate with [pseudo-Nodes](concepts.md#pseudo-nodes). The
+messages exchanged with pseudo-Nodes are encoded as serialized protocol buffer
+messages.
 
 Note also that the Oak ABI interactions are quite low-level; for example, they
 involve manual management of linear memory. Oak Applications will typically use
@@ -197,3 +200,13 @@ If creating the specified node would violate
 - arg 0: Destination buffer
 - arg 1: Destination buffer size in bytes
 - return 0: Status of operation
+
+## Protocol Buffer Messages
+
+The host functions described in the previous section allow opaque blobs of data
+to be exchanged (along with handles to other channels). When communicating with
+the pseudo-Nodes provided by the Oak system, these opaque blobs of data are
+defined to take the form of serialized protocol buffer messages. These include:
+
+- [Structured logging messages](../oak/proto/log.proto).
+- [Encapsulated gRPC requests and responses](../oak/proto/grpc_encap.proto).

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -1182,8 +1182,8 @@ impl FrontendNode {
         .expect("could not write to channel");
 
         let mut bytes = Vec::new();
-        oak::proto::oak::log::LogMessage {
-            level: oak::proto::oak::log::Level::Info as i32,
+        oak_abi::proto::oak::log::LogMessage {
+            level: oak_abi::proto::oak::log::Level::Info as i32,
             file: "abitest".to_string(),
             line: 1988,
             message: "Wellformed message sent direct to logging channel!".to_string(),
@@ -1502,7 +1502,7 @@ impl FrontendNode {
 }
 
 // Helper for storage error conversion.
-fn from_proto(status: oak::proto::google::rpc::Status) -> Box<dyn std::error::Error> {
+fn from_proto(status: oak::grpc::Status) -> Box<dyn std::error::Error> {
     Box::new(std::io::Error::new(
         std::io::ErrorKind::Other,
         format!("status code {} message '{}'", status.code, status.message),

--- a/oak/proto/BUILD
+++ b/oak/proto/BUILD
@@ -88,17 +88,16 @@ cc_proto_library(
 )
 
 proto_library(
-    name = "storage_channel_proto",
-    srcs = ["storage_channel.proto"],
+    name = "storage_service_proto",
+    srcs = ["storage_service.proto"],
     deps = [
         ":label_proto",
-        "//third_party/google/rpc:status_proto",
     ],
 )
 
 cc_proto_library(
-    name = "storage_channel_cc_proto",
-    deps = [":storage_channel_proto"],
+    name = "storage_service_cc_proto",
+    deps = [":storage_service_proto"],
 )
 
 proto_library(

--- a/oak/proto/grpc_encap.proto
+++ b/oak/proto/grpc_encap.proto
@@ -16,7 +16,7 @@
 
 syntax = "proto3";
 
-package oak;
+package oak.encap;
 
 import "google/protobuf/any.proto";
 import "third_party/google/rpc/status.proto";

--- a/oak/proto/storage_service.proto
+++ b/oak/proto/storage_service.proto
@@ -16,7 +16,7 @@
 
 syntax = "proto3";
 
-package oak;
+package oak.storage;
 
 import "oak/proto/label.proto";
 
@@ -86,7 +86,7 @@ message StorageChannelRollbackResponse {
 
 // Interface exposed by the Storage Node to other nodes over a pair of Oak Channels.
 // Methods in this interface map 1:1 with those in storage.proto.
-service StorageNode {
+service StorageService {
   rpc Read(StorageChannelReadRequest) returns (StorageChannelReadResponse);
   rpc Write(StorageChannelWriteRequest) returns (StorageChannelWriteResponse);
   rpc Delete(StorageChannelDeleteRequest) returns (StorageChannelDeleteResponse);

--- a/oak/server/grpc_client_node.cc
+++ b/oak/server/grpc_client_node.cc
@@ -57,7 +57,7 @@ bool GrpcClientNode::HandleInvocation(Handle invocation_handle) {
     OAK_LOG(ERROR) << "Unexpectedly received channel handles in request channel";
     return false;
   }
-  GrpcRequest grpc_req;
+  oak::encap::GrpcRequest grpc_req;
   grpc_req.ParseFromString(std::string(req_result.msg->data.data(), req_result.msg->data.size()));
   std::string method_name = grpc_req.method_name();
   const grpc::string& req_data = grpc_req.req_msg().value();
@@ -115,7 +115,7 @@ bool GrpcClientNode::HandleInvocation(Handle invocation_handle) {
     }
 
     // Build an encapsulation of the gRPC response and put it in an Oak Message.
-    oak::GrpcResponse grpc_rsp;
+    oak::encap::GrpcResponse grpc_rsp;
     grpc_rsp.set_last(false);
     google::protobuf::Any* any = new google::protobuf::Any();
     any->set_value(rsp_data.data(), rsp_data.size());
@@ -140,7 +140,7 @@ bool GrpcClientNode::HandleInvocation(Handle invocation_handle) {
   }
   if (!status.ok()) {
     // Final status includes an error, so pass it back on the response channel.
-    oak::GrpcResponse grpc_rsp;
+    oak::encap::GrpcResponse grpc_rsp;
     grpc_rsp.set_last(true);
     grpc_rsp.mutable_status()->set_code(status.error_code());
     grpc_rsp.mutable_status()->set_message(status.error_message());

--- a/oak/server/module_invocation.cc
+++ b/oak/server/module_invocation.cc
@@ -94,7 +94,7 @@ void ModuleInvocation::ProcessRequest(bool ok) {
   }
 
   // Build an encapsulation of the gRPC request invocation and put it in a Message.
-  oak::GrpcRequest grpc_request;
+  oak::encap::GrpcRequest grpc_request;
   grpc_request.set_method_name(context_.method());
   google::protobuf::Any* any = new google::protobuf::Any();
   any->set_value(request_msg->data.data(), request_msg->data.size());
@@ -200,7 +200,7 @@ void ModuleInvocation::BlockingSendResponse() {
   OAK_LOG(INFO) << "invocation#" << stream_id_
                 << " SendResponse: Read encapsulated message of size "
                 << rsp_result.msg->data.size() << " from gRPC output channel";
-  oak::GrpcResponse grpc_response;
+  oak::encap::GrpcResponse grpc_response;
   if (!grpc_response.ParseFromString(
           std::string(rsp_result.msg->data.data(), rsp_result.msg->data.size()))) {
     OAK_LOG(ERROR) << "invocation#" << stream_id_

--- a/oak/server/rust/oak_abi/Cargo.toml
+++ b/oak/server/rust/oak_abi/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-prost = "*"
 hashbrown = "*"
+log = "*"
+prost = "*"
+prost-types = "*"
 
 [build-dependencies]
 oak_utils = "*"

--- a/oak/server/rust/oak_abi/build.rs
+++ b/oak/server/rust/oak_abi/build.rs
@@ -17,9 +17,13 @@
 fn main() {
     oak_utils::compile_protos(
         &[
-            "../../../../oak/proto/oak_abi.proto",
+            "../../../../oak/proto/grpc_encap.proto",
             "../../../../oak/proto/label.proto",
+            "../../../../oak/proto/log.proto",
+            "../../../../oak/proto/oak_abi.proto",
+            "../../../../third_party/google/rpc/code.proto",
+            "../../../../third_party/google/rpc/status.proto",
         ],
-        &["../../../../oak/proto"],
+        &["../../../.."],
     );
 }

--- a/oak/server/rust/oak_abi/src/grpc/mod.rs
+++ b/oak/server/rust/oak_abi/src/grpc/mod.rs
@@ -1,0 +1,41 @@
+//
+// Copyright 2019 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::proto::oak::encap::GrpcRequest;
+use log::warn;
+
+/// Encapsulate a protocol buffer message in a GrpcRequest wrapper using the
+/// given method name.
+pub fn encap_request<T: prost::Message>(
+    req: &T,
+    req_type_url: Option<&str>,
+    method_name: &str,
+) -> Option<GrpcRequest> {
+    // Put the request in a GrpcRequest wrapper and serialize it.
+    let mut grpc_req = GrpcRequest::default();
+    grpc_req.method_name = method_name.to_string();
+    let mut any = prost_types::Any::default();
+    if let Err(e) = req.encode(&mut any.value) {
+        warn!("failed to serialize gRPC request: {}", e);
+        return None;
+    };
+    if let Some(type_url) = req_type_url {
+        any.type_url = type_url.to_string();
+    }
+    grpc_req.req_msg = Some(any);
+    grpc_req.last = true;
+    Some(grpc_req)
+}

--- a/oak/server/rust/oak_abi/src/label/mod.rs
+++ b/oak/server/rust/oak_abi/src/label/mod.rs
@@ -23,14 +23,14 @@
 use hashbrown::HashSet;
 use prost::Message;
 
-pub use crate::proto::label::*;
+pub use crate::proto::oak::label::*;
 
 #[cfg(test)]
 mod tests;
 
 /// Add helper methods to the `Label` struct that is auto-generated from
 /// the protobuf message definition.
-impl crate::proto::label::Label {
+impl crate::proto::oak::label::Label {
     /// Convert a label to bytes.
     pub fn serialize(&self) -> Vec<u8> {
         let mut bytes = Vec::new();

--- a/oak/server/rust/oak_abi/src/lib.rs
+++ b/oak/server/rust/oak_abi/src/lib.rs
@@ -16,10 +16,12 @@
 
 //! Type, constant and Wasm host function definitions for the Oak application
 //! binary interface (ABI).
-mod proto;
-pub use proto::*;
 
+pub mod grpc;
 pub mod label;
+pub mod proto;
+
+pub use proto::oak::{ChannelReadStatus, OakStatus};
 
 /// Handle used to identify read or write channel halves.
 ///

--- a/oak/server/rust/oak_abi/src/proto.rs
+++ b/oak/server/rust/oak_abi/src/proto.rs
@@ -14,8 +14,24 @@
 // limitations under the License.
 //
 
-include!(concat!(env!("OUT_DIR"), "/oak_abi.rs"));
+pub mod google {
+    pub mod rpc {
+        include!(concat!(env!("OUT_DIR"), "/google.rpc.rs"));
+    }
+}
 
-pub mod label {
-    include!(concat!(env!("OUT_DIR"), "/oak.label.rs"));
+pub mod oak {
+    include!(concat!(env!("OUT_DIR"), "/oak_abi.rs"));
+
+    pub mod label {
+        include!(concat!(env!("OUT_DIR"), "/oak.label.rs"));
+    }
+
+    pub mod encap {
+        include!(concat!(env!("OUT_DIR"), "/oak.encap.rs"));
+    }
+
+    pub mod log {
+        include!(concat!(env!("OUT_DIR"), "/oak.log.rs"));
+    }
 }

--- a/oak/server/rust/oak_runtime/Cargo.toml
+++ b/oak/server/rust/oak_runtime/Cargo.toml
@@ -18,7 +18,6 @@ http = "*"
 hyper = "*"
 itertools = "*"
 log = { version = "*" }
-oak = "0.1.0"
 oak_abi = "=0.1.0"
 prost = "*"
 prost-types = "*"

--- a/oak/server/rust/oak_runtime/build.rs
+++ b/oak/server/rust/oak_runtime/build.rs
@@ -16,10 +16,7 @@
 
 fn main() {
     oak_utils::compile_protos(
-        &[
-            "../../../../oak/proto/application.proto",
-            "../../../../oak/proto/log.proto",
-        ],
+        &["../../../../oak/proto/application.proto"],
         &["../../../../oak/proto"],
     );
 }

--- a/oak/server/rust/oak_runtime/src/node/grpc_server.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc_server.rs
@@ -23,7 +23,8 @@ use std::{
     thread::{self, JoinHandle},
 };
 
-use oak::grpc::{encap_request, GrpcRequest};
+use oak_abi::grpc::encap_request;
+use oak_abi::proto::oak::encap::GrpcRequest;
 use oak_abi::{label::Label, ChannelReadStatus, OakStatus};
 
 use crate::{pretty_name_for_thread, runtime::RuntimeProxy, Handle};

--- a/oak/server/rust/oak_runtime/src/node/logger.rs
+++ b/oak/server/rust/oak_runtime/src/node/logger.rs
@@ -23,9 +23,9 @@ use oak_abi::OakStatus;
 use std::thread::{self, JoinHandle};
 
 use crate::pretty_name_for_thread;
-use crate::proto::log::{Level, LogMessage};
 use crate::runtime::Handle;
 use crate::runtime::RuntimeProxy;
+use oak_abi::proto::oak::log::{Level, LogMessage};
 use prost::Message;
 
 pub struct LogNode {

--- a/oak/server/rust/oak_runtime/src/proto.rs
+++ b/oak/server/rust/oak_runtime/src/proto.rs
@@ -15,7 +15,3 @@
 //
 
 include!(concat!(env!("OUT_DIR"), "/oak.rs"));
-
-pub mod log {
-    include!(concat!(env!("OUT_DIR"), "/oak.log.rs"));
-}

--- a/oak/server/storage/BUILD
+++ b/oak/server/storage/BUILD
@@ -51,7 +51,7 @@ cc_library(
         "//oak/common:handles",
         "//oak/common:logging",
         "//oak/proto:grpc_encap_cc_proto",
-        "//oak/proto:storage_channel_cc_proto",
+        "//oak/proto:storage_service_cc_proto",
         "//oak/server:invocation",
         "//oak/server:node_thread",
         "//third_party/asylo:statusor",
@@ -68,7 +68,6 @@ cc_library(
     deps = [
         "//oak/common:logging",
         "//oak/proto:storage_cc_grpc",
-        "//oak/proto:storage_channel_cc_proto",
         "//third_party/asylo:status_macros",
         "//third_party/asylo:statusor",
         "@boringssl//:crypto",

--- a/oak/server/storage/storage_node.cc
+++ b/oak/server/storage/storage_node.cc
@@ -58,15 +58,15 @@ void StorageNode::Run(Handle invocation_handle) {
       OAK_LOG(ERROR) << "Unexpectedly received channel handles in request channel";
       return;
     }
-    GrpcRequest grpc_req;
+    oak::encap::GrpcRequest grpc_req;
     grpc_req.ParseFromString(std::string(req_result.msg->data.data(), req_result.msg->data.size()));
 
-    std::unique_ptr<GrpcResponse> grpc_rsp;
-    oak::StatusOr<std::unique_ptr<GrpcResponse>> rsp_or = ProcessMethod(&grpc_req);
+    std::unique_ptr<oak::encap::GrpcResponse> grpc_rsp;
+    oak::StatusOr<std::unique_ptr<oak::encap::GrpcResponse>> rsp_or = ProcessMethod(&grpc_req);
     if (!rsp_or.ok()) {
       OAK_LOG(ERROR) << "Failed to perform " << grpc_req.method_name() << ": "
                      << rsp_or.status().code() << ", '" << rsp_or.status().message() << "'";
-      grpc_rsp = absl::make_unique<GrpcResponse>();
+      grpc_rsp = absl::make_unique<oak::encap::GrpcResponse>();
       grpc_rsp->mutable_status()->set_code(static_cast<int>(rsp_or.status().code()));
       grpc_rsp->mutable_status()->set_message(std::string(rsp_or.status().message()));
     } else {
@@ -84,8 +84,9 @@ void StorageNode::Run(Handle invocation_handle) {
   }
 }
 
-oak::StatusOr<std::unique_ptr<GrpcResponse>> StorageNode::ProcessMethod(GrpcRequest* grpc_req) {
-  auto grpc_rsp = absl::make_unique<GrpcResponse>();
+oak::StatusOr<std::unique_ptr<oak::encap::GrpcResponse>> StorageNode::ProcessMethod(
+    oak::encap::GrpcRequest* grpc_req) {
+  auto grpc_rsp = absl::make_unique<oak::encap::GrpcResponse>();
   grpc::Status status;
   std::string method_name = grpc_req->method_name();
 

--- a/oak/server/storage/storage_node.cc
+++ b/oak/server/storage/storage_node.cc
@@ -21,7 +21,7 @@
 #include "grpcpp/create_channel.h"
 #include "oak/common/logging.h"
 #include "oak/proto/grpc_encap.pb.h"
-#include "oak/proto/storage_channel.pb.h"
+#include "oak/proto/storage_service.pb.h"
 #include "oak/server/invocation.h"
 #include "third_party/asylo/status_macros.h"
 
@@ -90,15 +90,15 @@ oak::StatusOr<std::unique_ptr<oak::encap::GrpcResponse>> StorageNode::ProcessMet
   grpc::Status status;
   std::string method_name = grpc_req->method_name();
 
-  if (method_name == "/oak.StorageNode/Read") {
-    StorageChannelReadRequest read_req;
+  if (method_name == "/oak.storage.StorageService/Read") {
+    oak::storage::StorageChannelReadRequest read_req;
     // Assume the type of the embedded request is correct.
     grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
                                               read_req.GetDescriptor()->full_name());
     if (!grpc_req->req_msg().UnpackTo(&read_req)) {
       return absl::Status(absl::StatusCode::kInvalidArgument, "Failed to unpack request");
     }
-    StorageChannelReadResponse read_rsp;
+    oak::storage::StorageChannelReadResponse read_rsp;
     std::string value;
     OAK_ASSIGN_OR_RETURN(value,
                          storage_processor_.Read(read_req.storage_name(), read_req.item().name(),
@@ -107,8 +107,8 @@ oak::StatusOr<std::unique_ptr<oak::encap::GrpcResponse>> StorageNode::ProcessMet
     // TODO(#449): Check security policy for item.
     grpc_rsp->mutable_rsp_msg()->PackFrom(read_rsp);
 
-  } else if (method_name == "/oak.StorageNode/Write") {
-    StorageChannelWriteRequest write_req;
+  } else if (method_name == "/oak.storage.StorageService/Write") {
+    oak::storage::StorageChannelWriteRequest write_req;
     // Assume the type of the embedded request is correct.
     grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
                                               write_req.GetDescriptor()->full_name());
@@ -121,8 +121,8 @@ oak::StatusOr<std::unique_ptr<oak::encap::GrpcResponse>> StorageNode::ProcessMet
     OAK_RETURN_IF_ERROR(storage_processor_.Write(write_req.storage_name(), write_req.item().name(),
                                                  item, write_req.transaction_id()));
 
-  } else if (method_name == "/oak.StorageNode/Delete") {
-    StorageChannelDeleteRequest delete_req;
+  } else if (method_name == "/oak.storage.StorageService/Delete") {
+    oak::storage::StorageChannelDeleteRequest delete_req;
     // Assume the type of the embedded request is correct.
     grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
                                               delete_req.GetDescriptor()->full_name());
@@ -133,22 +133,22 @@ oak::StatusOr<std::unique_ptr<oak::encap::GrpcResponse>> StorageNode::ProcessMet
     OAK_RETURN_IF_ERROR(storage_processor_.Delete(
         delete_req.storage_name(), delete_req.item().name(), delete_req.transaction_id()));
 
-  } else if (method_name == "/oak.StorageNode/Begin") {
-    StorageChannelBeginRequest begin_req;
+  } else if (method_name == "/oak.storage.StorageService/Begin") {
+    oak::storage::StorageChannelBeginRequest begin_req;
     // Assume the type of the embedded request is correct.
     grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
                                               begin_req.GetDescriptor()->full_name());
     if (!grpc_req->req_msg().UnpackTo(&begin_req)) {
       return absl::Status(absl::StatusCode::kInvalidArgument, "Failed to unpack request");
     }
-    StorageChannelBeginResponse begin_rsp;
+    oak::storage::StorageChannelBeginResponse begin_rsp;
     std::string transaction_id;
     OAK_ASSIGN_OR_RETURN(transaction_id, storage_processor_.Begin(begin_req.storage_name()));
     begin_rsp.set_transaction_id(transaction_id);
     grpc_rsp->mutable_rsp_msg()->PackFrom(begin_rsp);
 
-  } else if (method_name == "/oak.StorageNode/Commit") {
-    StorageChannelCommitRequest commit_req;
+  } else if (method_name == "/oak.storage.StorageService/Commit") {
+    oak::storage::StorageChannelCommitRequest commit_req;
     // Assume the type of the embedded request is correct.
     grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
                                               commit_req.GetDescriptor()->full_name());
@@ -158,8 +158,8 @@ oak::StatusOr<std::unique_ptr<oak::encap::GrpcResponse>> StorageNode::ProcessMet
     OAK_RETURN_IF_ERROR(
         storage_processor_.Commit(commit_req.storage_name(), commit_req.transaction_id()));
 
-  } else if (method_name == "/oak.StorageNode/Rollback") {
-    StorageChannelRollbackRequest rollback_req;
+  } else if (method_name == "/oak.storage.StorageService/Rollback") {
+    oak::storage::StorageChannelRollbackRequest rollback_req;
     // Assume the type of the embedded request is correct.
     grpc_req->mutable_req_msg()->set_type_url("type.googleapis.com/" +
                                               rollback_req.GetDescriptor()->full_name());

--- a/oak/server/storage/storage_node.h
+++ b/oak/server/storage/storage_node.h
@@ -34,7 +34,8 @@ class StorageNode final : public NodeThread {
 
  private:
   void Run(Handle handle) override;
-  oak::StatusOr<std::unique_ptr<GrpcResponse>> ProcessMethod(GrpcRequest* channel_request);
+  oak::StatusOr<std::unique_ptr<oak::encap::GrpcResponse>> ProcessMethod(
+      oak::encap::GrpcRequest* channel_request);
 
   StorageProcessor storage_processor_;
 };

--- a/sdk/rust/oak/build.rs
+++ b/sdk/rust/oak/build.rs
@@ -15,11 +15,5 @@
 //
 
 fn main() {
-    oak_utils::compile_protos(
-        &[
-            "../../../oak/proto/storage.proto",
-            "../../../oak/proto/storage_channel.proto",
-        ],
-        &["../../.."],
-    );
+    oak_utils::compile_protos(&["../../../oak/proto/storage_channel.proto"], &["../../.."]);
 }

--- a/sdk/rust/oak/build.rs
+++ b/sdk/rust/oak/build.rs
@@ -15,5 +15,5 @@
 //
 
 fn main() {
-    oak_utils::compile_protos(&["../../../oak/proto/storage_channel.proto"], &["../../.."]);
+    oak_utils::compile_protos(&["../../../oak/proto/storage_service.proto"], &["../../.."]);
 }

--- a/sdk/rust/oak/build.rs
+++ b/sdk/rust/oak/build.rs
@@ -17,13 +17,8 @@
 fn main() {
     oak_utils::compile_protos(
         &[
-            "../../../third_party/google/rpc/code.proto",
-            "../../../third_party/google/rpc/status.proto",
-            "../../../oak/proto/grpc_encap.proto",
-            "../../../oak/proto/label.proto",
             "../../../oak/proto/storage.proto",
             "../../../oak/proto/storage_channel.proto",
-            "../../../oak/proto/log.proto",
         ],
         &["../../.."],
     );

--- a/sdk/rust/oak/src/grpc/invocation.rs
+++ b/sdk/rust/oak/src/grpc/invocation.rs
@@ -17,8 +17,8 @@
 /// A gRPC invocation, consisting of exactly two channels: one to read incoming requests from the
 /// client, and one to write outgoing responses to the client.
 pub struct Invocation {
-    pub request_receiver: crate::io::Receiver<crate::proto::oak::GrpcRequest>,
-    pub response_sender: crate::io::Sender<crate::proto::oak::GrpcResponse>,
+    pub request_receiver: crate::io::Receiver<oak_abi::proto::oak::encap::GrpcRequest>,
+    pub response_sender: crate::io::Sender<oak_abi::proto::oak::encap::GrpcResponse>,
 }
 
 // TODO(#389): Automatically generate this code.

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -31,26 +31,15 @@ pub mod rand;
 pub mod storage;
 
 pub mod proto {
-    pub mod google {
-        pub mod protobuf {
-            include!(concat!(env!("OUT_DIR"), "/google.protobuf.rs"));
-        }
-        pub mod rpc {
-            include!(concat!(env!("OUT_DIR"), "/google.rpc.rs"));
-        }
-    }
     pub mod oak {
+        // The storage protobuf messages use the label.Label type which is built
+        // in the `oak_abi` crate, so make it available here too.
+        use oak_abi::proto::oak::label;
         include!(concat!(env!("OUT_DIR"), "/oak.rs"));
-        pub mod label {
-            include!(concat!(env!("OUT_DIR"), "/oak.label.rs"));
-        }
-        pub mod log {
-            include!(concat!(env!("OUT_DIR"), "/oak.log.rs"));
-        }
     }
 }
 
-// TODO(#544)
+// TODO(#544): re-enable relevant SDK tests
 
 /// Handle used to identify read or write channel halves.
 ///

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -35,7 +35,9 @@ pub mod proto {
         // The storage protobuf messages use the label.Label type which is built
         // in the `oak_abi` crate, so make it available here too.
         use oak_abi::proto::oak::label;
-        include!(concat!(env!("OUT_DIR"), "/oak.rs"));
+        pub mod storage {
+            include!(concat!(env!("OUT_DIR"), "/oak.storage.rs"));
+        }
     }
 }
 

--- a/sdk/rust/oak/src/logger/mod.rs
+++ b/sdk/rust/oak/src/logger/mod.rs
@@ -24,7 +24,7 @@
 use log::{Level, Log, Metadata, Record, SetLoggerError};
 
 struct OakChannelLogger {
-    channel: crate::io::Sender<crate::proto::oak::log::LogMessage>,
+    channel: crate::io::Sender<oak_abi::proto::oak::log::LogMessage>,
 }
 
 impl Log for OakChannelLogger {
@@ -35,7 +35,7 @@ impl Log for OakChannelLogger {
         if !self.enabled(record.metadata()) {
             return;
         }
-        let log_msg = crate::proto::oak::log::LogMessage {
+        let log_msg = oak_abi::proto::oak::log::LogMessage {
             file: record.file().unwrap_or("<unknown-file>").to_string(),
             line: record.line().unwrap_or_default(),
             level: map_level(record.level()) as i32,
@@ -50,13 +50,13 @@ impl Log for OakChannelLogger {
     fn flush(&self) {}
 }
 
-fn map_level(level: Level) -> crate::proto::oak::log::Level {
+fn map_level(level: Level) -> oak_abi::proto::oak::log::Level {
     match level {
-        Level::Error => crate::proto::oak::log::Level::Error,
-        Level::Warn => crate::proto::oak::log::Level::Warn,
-        Level::Info => crate::proto::oak::log::Level::Info,
-        Level::Debug => crate::proto::oak::log::Level::Debug,
-        Level::Trace => crate::proto::oak::log::Level::Trace,
+        Level::Error => oak_abi::proto::oak::log::Level::Error,
+        Level::Warn => oak_abi::proto::oak::log::Level::Warn,
+        Level::Info => oak_abi::proto::oak::log::Level::Info,
+        Level::Debug => oak_abi::proto::oak::log::Level::Debug,
+        Level::Trace => oak_abi::proto::oak::log::Level::Trace,
     }
 }
 

--- a/sdk/rust/oak/src/storage/mod.rs
+++ b/sdk/rust/oak/src/storage/mod.rs
@@ -17,7 +17,7 @@
 //! Helper library for accessing Oak storage services.
 
 use crate::grpc;
-use crate::proto::oak::{
+use crate::proto::oak::storage::{
     StorageChannelDeleteRequest, StorageChannelDeleteResponse, StorageChannelReadRequest,
     StorageChannelReadResponse, StorageChannelWriteRequest, StorageChannelWriteResponse,
     StorageItem,
@@ -80,7 +80,7 @@ impl Storage {
         // TODO(#757): Automatically generate boilerplate from the proto
         // definition.
         self.execute_operation::<StorageChannelReadRequest, StorageChannelReadResponse>(
-            "/oak.StorageNode/Read",
+            "/oak.storage.StorageService/Read",
             read_request,
         )
         .map(|r| r.item.unwrap_or_default().value.to_vec())
@@ -102,7 +102,7 @@ impl Storage {
 
         // TODO(#757): Automatically generate boilerplate from the proto definition.
         self.execute_operation::<StorageChannelWriteRequest, StorageChannelWriteResponse>(
-            "/oak.StorageNode/Write",
+            "/oak.storage.StorageService/Write",
             write_request,
         )
         .map(|_| ())
@@ -123,7 +123,7 @@ impl Storage {
 
         // TODO(#757): Automatically generate boilerplate from the proto definition.
         self.execute_operation::<StorageChannelDeleteRequest, StorageChannelDeleteResponse>(
-            "/oak.StorageNode/Delete",
+            "/oak.storage.StorageService/Delete",
             delete_request,
         )
         .map(|_| ())

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -104,7 +104,7 @@ where
 {
     // Put the request in a GrpcRequest wrapper and serialize into a message.
     let grpc_req =
-        oak::grpc::encap_request(req, None, method_name).expect("failed to build GrpcRequest");
+        oak_abi::grpc::encap_request(req, None, method_name).expect("failed to build GrpcRequest");
     let mut req_msg = oak_runtime::Message {
         data: vec![],
         channels: vec![],
@@ -160,7 +160,7 @@ where
             std::thread::sleep(std::time::Duration::from_millis(100));
             continue;
         }
-        let rsp = oak::proto::oak::GrpcResponse::decode(rsp.data.as_slice())
+        let rsp = oak_abi::proto::oak::encap::GrpcResponse::decode(rsp.data.as_slice())
             .expect("failed to parse GrpcResponse message");
         if !rsp.last {
             panic!("Expected single final response");


### PR DESCRIPTION
Protocol buffer messages that are exchanged in serialized form between
Wasm Nodes and Oak-provided pseudo-Nodes are effectively part of the
Oak ABI, so move the generated code for them into the oak_abi crate.

This allows us to remove the oak_runtime->oak dependency that was
introduced by #772.

Along the way, put the gRPC encapsulation protobuf messages into an
`encap` submodule/namespace.

Fixes #764.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [x] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
