### PR TITLE
Add CI step for documentations

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,13 +41,6 @@ steps:
     args: ['info']
 
   - name: 'gcr.io/oak-ci/oak:latest'
-    id: check_formatting
-    waitFor: ['bazel_init']
-    timeout: 30m
-    entrypoint: 'bash'
-    args: ['./scripts/check_formatting']
-
-  - name: 'gcr.io/oak-ci/oak:latest'
     id: build_server
     waitFor: ['bazel_init']
     timeout: 60m
@@ -137,6 +130,20 @@ steps:
     timeout: 60m
     entrypoint: 'bash'
     args: ['./scripts/build_examples_android']
+
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: check_formatting
+    waitFor: ['bazel_init']
+    timeout: 30m
+    entrypoint: 'bash'
+    args: ['./scripts/check_formatting']
+
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: check_docs
+    waitFor: ['bazel_init']
+    timeout: 30m
+    entrypoint: 'bash'
+    args: ['./scripts/check_docs']
 
 # Copy compiled enclave binary to Google Cloud Storage.
 # See:

--- a/scripts/build_gh_pages
+++ b/scripts/build_gh_pages
@@ -32,7 +32,6 @@ rm --recursive --force "${TARGET_DIR:?}"/*
 # files, but does not remove artifacts generated from now-removed files.
 rm --recursive --force ./target/doc
 cargo doc --no-deps
-cargo deadlinks
 cp --recursive ./target/doc "${TARGET_DIR}"
 
 # The docs generated from the Cargo workspace do not include a workspace-level index, so we generate

--- a/scripts/check_docs
+++ b/scripts/check_docs
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Check that Rust documentation is generated without any warnings.
+
+readonly SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=scripts/common
+source "$SCRIPTS_DIR/common"
+
+# `cargo doc` produces warnings for incorrect paths. These warnings cannot be promoted to errors, so we use grep to detect them.
+if cargo doc --document-private-items --no-deps 2>&1 | grep --ignore-case --quiet --regexp='^warning'; then
+  echo "Warnings found when generating the docs."
+  exit 1
+fi
+
+# Check for any deadlinks in the generated docs. 
+if ! cargo deadlinks --dir target/doc; then
+  echo "Found deadlinks in the generated docs."
+  exit 1
+fi


### PR DESCRIPTION
* Added generate_docs to cloudbuild to check generation of doc
* Moved check_formatting towards the end of cloudbuild

Fixes #810 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
