### PR TITLE
Simplify node thread creation and management

### DIFF
--- a/oak/server/rust/oak_runtime/src/runtime/tests.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/tests.rs
@@ -36,10 +36,13 @@ fn run_node_body(node_label: Label, node_body: Box<NodeBody>) {
     };
 
     impl crate::node::Node for TestNode {
-        fn start(&mut self) -> Result<(), OakStatus> {
-            (self.node_body)(&self.runtime)
+        fn start(self: Box<Self>) -> Result<JoinHandle<()>, OakStatus> {
+            // Execute the `node_body` immediately, so that any errors may be returned to the test
+            // function.
+            (self.node_body)(&self.runtime)?;
+            // Spawn a no-op background thread and return its handle.
+            Ok(thread::spawn(|| {}))
         }
-        fn stop(&mut self) {}
     }
 
     // Manually allocate a new [`NodeId`].

--- a/scripts/check_docs
+++ b/scripts/check_docs
@@ -14,7 +14,7 @@ if grep --ignore-case --quiet --regexp='^warning' <<< "$DOCS_OUT"; then
   exit 1
 fi
 
-# Check for any deadlinks in the generated docs. 
+# Check for any deadlinks in the generated docs.
 if ! cargo deadlinks --dir target/doc; then
   echo "Found deadlinks in the generated docs."
   exit 1


### PR DESCRIPTION
Each node now just returns a JoinHandle to a main thread, and the main
thread is encapsulated in a separate method, in which the node itself is
moved, instead of having to clone all the fields from the parent node.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
