### PR TITLE
Add printing of warnings from `cargo doc`

### DIFF
--- a/scripts/check_docs
+++ b/scripts/check_docs
@@ -6,8 +6,10 @@ readonly SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
+DOCS_OUT="$(cargo doc --document-private-items --no-deps 2>&1)"
+
 # `cargo doc` produces warnings for incorrect paths. These warnings cannot be promoted to errors, so we use grep to detect them.
-if cargo doc --document-private-items --no-deps 2>&1 | grep --ignore-case --quiet --regexp='^warning'; then
+if grep --ignore-case --quiet --regexp='^warning' <<< "$DOCS_OUT"; then
   echo "Warnings found when generating the docs."
   exit 1
 fi


### PR DESCRIPTION
Fixes #810 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
