### PR TITLE
Disable build-id link-time generation

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,8 @@
+[target.x86_64-unknown-linux-gnu]
+# Make NT_GNU_BUILD_ID header generation deterministic.
+#
+# Either `none` or `sha1` values would make the header deterministic, assuming the rest of the build
+# process is deterministic.
+#
+# See https://linux.die.net/man/1/ld (--build-id flag).
+rustflags = ["-C", "link-args=-Xlinker --build-id=none"]


### PR DESCRIPTION
Partly addresses #862 (it looks like there are some other
non-deterministic diffs unrelated to this)

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
