### PR TITLE
Produce statically linked `oak_loader` binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG debian_snapshot=buster-20191118
 FROM debian/snapshot:${debian_snapshot}
 
 RUN apt-get --yes update && \
-    apt-get install --no-install-recommends --yes \
+  apt-get install --no-install-recommends --yes \
   build-essential \
   clang-format \
   clang-tidy \
@@ -36,11 +36,11 @@ ARG bazel_sha=4bbb2718d451db5922223fda3aed3810c4ca50f431481e86a7fec4c585f18b1f
 ARG bazel_url=https://storage.googleapis.com/bazel-apt/pool/jdk1.8/b/bazel/bazel_${bazel_version}_amd64.deb
 
 RUN wget "${bazel_url}" --no-verbose --output-file=- --output-document=bazel.deb && \
-    echo "${bazel_sha}  bazel.deb" > bazel.sha256 && \
-    sha256sum --check bazel.sha256 && \
-    apt-get install --yes ./bazel.deb && \
-    rm bazel.deb bazel.sha256 && \
-    apt-get clean
+  echo "${bazel_sha}  bazel.deb" > bazel.sha256 && \
+  sha256sum --check bazel.sha256 && \
+  apt-get install --yes ./bazel.deb && \
+  rm bazel.deb bazel.sha256 && \
+  apt-get clean
 
 # Install Node.js and npm.
 RUN curl --location https://deb.nodesource.com/setup_12.x | bash -
@@ -157,6 +157,9 @@ RUN rustup default ${RUST_VERSION}
 
 # Install WebAssembly target for Rust.
 RUN rustup target add wasm32-unknown-unknown
+
+# Install musl target for Rust (for statically linked binaries).
+RUN rustup target add x86_64-unknown-linux-musl
 
 # Install rustfmt, clippy, and the Rust Language Server.
 RUN rustup component add \

--- a/docs/INSTALL-OSX.md
+++ b/docs/INSTALL-OSX.md
@@ -44,6 +44,9 @@ RUN rustup default ${RUST_VERSION}
 # Install WebAssembly target for Rust.
 RUN rustup target add wasm32-unknown-unknown
 
+# Install musl target for Rust (for statically linked binaries).
+RUN rustup target add x86_64-unknown-linux-musl
+
 # Install rustfmt, clippy, and the Rust Language Server.
 RUN rustup component add \
   clippy \

--- a/scripts/build_server
+++ b/scripts/build_server
@@ -50,7 +50,7 @@ if [[ "${config}" == "clang" && "${OSTYPE}" == "darwin"*  ]]; then
 fi
 
 if [[ "${config}" == "rust" ]]; then
-  cargo build --package=oak_loader
+  cargo build --release --target=x86_64-unknown-linux-musl --package=oak_loader
 else
   bazel_build_flags+=(
     "--config=${config}"

--- a/scripts/run_server
+++ b/scripts/run_server
@@ -79,7 +79,7 @@ fi
 # Launching the server requires a `--application=<dir>/config.bin` flag.
 # `exec` is necessary for the `run_example` script to be able to get a PID of a background server.
 if [[ "${server}" == "rust" ]]; then
-  exec cargo run --package=oak_loader -- \
+  exec cargo run --release --target=x86_64-unknown-linux-musl --package=oak_loader -- \
     --application="${APPLICATION}" \
     --ca-cert="${SCRIPTS_DIR}/../examples/certs/local/ca.pem" \
     --cert-chain="${SCRIPTS_DIR}/../examples/certs/local/local.pem" \


### PR DESCRIPTION
Relies on the `x86_64-unknown-linux-musl` build target to produce a
fully static binary.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
