### PR TITLE
Add `musl-tools`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get --yes update && \
   libfl2 \
   libncurses5 \
   libssl-dev \
+  musl-tools \
   pkg-config \
   procps \
   python-dev \


### PR DESCRIPTION
This change adds `musl-tools` package to the `Dockerfile`.
`musl-tools` contains `musl-gcc` that is necessary to compile `ring` (that is a `rustls` dependency) with a `--target=x86_64-unknown-linux-musl` flag.

# Checklist
- [x] Pull request includes prototype/experimental work that is under
      construction.