### PR TITLE
Lint Dockerfile using Hadolint

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,8 @@
+ignored:
+  # Pin versions in apt get install.
+  # See https://github.com/hadolint/hadolint/wiki/DL3008.
+  - DL3008
+  # Set the SHELL option -o pipefail before RUN with a pipe in.
+  # This does not seem to work well with android.Dockerfile.
+  # See https://github.com/hadolint/hadolint/wiki/DL4006.
+  - DL4006

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 # Use fixed snapshot of Debian to create a deterministic environment.
 # Snapshot tags can be found at https://hub.docker.com/r/debian/snapshot/tags
-ARG debian_snapshot=buster-20191118
+ARG debian_snapshot=buster-20200327
 FROM debian/snapshot:${debian_snapshot}
 
-RUN apt-get --yes update && \
-  apt-get install --no-install-recommends --yes \
+# Set the SHELL option -o pipefail before RUN with a pipe in.
+# See https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get --yes update \
+  && apt-get install --no-install-recommends --yes \
   build-essential \
   clang-format \
   clang-tidy \
@@ -23,138 +27,150 @@ RUN apt-get --yes update && \
   python3-six \
   shellcheck \
   vim \
-  wget \
-  xml2
+  xml2 \
+  # `unzip` and `zlib1g-dev` are needed for Bazel.
+  unzip \
+  zlib1g-dev \
+  && apt-get clean \
+  && rm --recursive --force /var/lib/apt/lists/* \
+  # Print version of various installed tools.
+  && git --version \
+  && clang-format -version \
+  && shellcheck --version
 
 # Use a later version of clang-format from buster-backports.
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
-RUN apt-get --yes update && apt-get install --no-install-recommends --yes clang-format-8
-RUN ln -s -f clang-format-8 /usr/bin/clang-format
+RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list \
+  && apt-get --yes update \
+  && apt-get install --no-install-recommends --yes clang-format-8 \
+  && apt-get clean \
+  && rm --recursive --force /var/lib/apt/lists/* \
+  && ln --symbolic --force clang-format-8 /usr/bin/clang-format
 
 # Use a fixed version of Bazel.
-ARG bazel_version=1.2.1
-ARG bazel_sha=4bbb2718d451db5922223fda3aed3810c4ca50f431481e86a7fec4c585f18b1f
+ARG bazel_version=3.0.0
+ARG bazel_sha256=dfa79c10bbfa39cd778e1813a273fd3236beb495497baa046f26d393c58bdc35
 ARG bazel_url=https://storage.googleapis.com/bazel-apt/pool/jdk1.8/b/bazel/bazel_${bazel_version}_amd64.deb
-
-RUN wget "${bazel_url}" --no-verbose --output-file=- --output-document=bazel.deb && \
-  echo "${bazel_sha}  bazel.deb" > bazel.sha256 && \
-  sha256sum --check bazel.sha256 && \
-  apt-get install --yes ./bazel.deb && \
-  rm bazel.deb bazel.sha256 && \
-  apt-get clean
+RUN curl --location "${bazel_url}" > bazel.deb \
+  && sha256sum --binary bazel.deb && echo "${bazel_sha256} *bazel.deb" | sha256sum --check \
+  && apt-get install --no-install-recommends --yes ./bazel.deb \
+  && rm bazel.deb \
+  && apt-get clean \
+  && bazel version
 
 # Install Node.js and npm.
-RUN curl --location https://deb.nodesource.com/setup_12.x | bash -
-RUN apt-get install --yes nodejs
-
-# Print version of various tools.
-RUN git --version
-RUN clang-format -version
-RUN shellcheck --version
-RUN node --version
-RUN npm --version
-
-# Make sure Bazel is correctly initialized.
-RUN bazel version
+RUN curl --location https://deb.nodesource.com/setup_12.x | bash - \
+  && apt-get install --no-install-recommends --yes nodejs \
+  && node --version \
+  && npm --version
 
 # Install the necessary binaries and SDKs, ordering them from the less frequently changed to the
 # more frequently changed.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache.
 
 # Install Emscripten.
-ARG EMSCRIPTEN_VERSION=1.39.6
-ARG EMSCRIPTEN_COMMIT=6bfbe2a7da68e650054af2d272d2b79307a6ad72
-ARG EMSCRIPTEN_SHA256=aa4c3b8f23fd26363f98207674bffcc138105c621c6c8bf12175f6aab1231357
-ARG EMSCRIPTEN_DIR=/usr/local/emsdk
-ARG EMSCRIPTEN_TEMP=/tmp/emscripten.zip
-RUN mkdir --parents ${EMSCRIPTEN_DIR}
-RUN curl --location https://github.com/emscripten-core/emsdk/archive/${EMSCRIPTEN_COMMIT}.tar.gz > ${EMSCRIPTEN_TEMP}
-RUN sha256sum --binary ${EMSCRIPTEN_TEMP} && echo "${EMSCRIPTEN_SHA256} *${EMSCRIPTEN_TEMP}" | sha256sum --check
-RUN tar --extract --gzip --file=${EMSCRIPTEN_TEMP} --directory=${EMSCRIPTEN_DIR} --strip-components=1
-RUN rm ${EMSCRIPTEN_TEMP}
-RUN cd ${EMSCRIPTEN_DIR} \
-  && ./emsdk install ${EMSCRIPTEN_VERSION} \
-  && ./emsdk activate --embedded ${EMSCRIPTEN_VERSION}
-ENV EMSDK "${EMSCRIPTEN_DIR}"
-ENV EM_CONFIG "${EMSCRIPTEN_DIR}/.emscripten"
-ENV EM_CACHE "${EMSCRIPTEN_DIR}/.emscripten_cache"
+ARG emscripten_version=1.39.6
+ARG emscripten_commit=6bfbe2a7da68e650054af2d272d2b79307a6ad72
+ARG emscripten_sha256=aa4c3b8f23fd26363f98207674bffcc138105c621c6c8bf12175f6aab1231357
+ARG emscripten_dir=/usr/local/emsdk
+ARG emscripten_temp=/tmp/emscripten.zip
+RUN mkdir --parents ${emscripten_dir} \
+  && curl --location https://github.com/emscripten-core/emsdk/archive/${emscripten_commit}.tar.gz > ${emscripten_temp} \
+  && sha256sum --binary ${emscripten_temp} && echo "${emscripten_sha256} *${emscripten_temp}" | sha256sum --check \
+  && tar --extract --gzip --file=${emscripten_temp} --directory=${emscripten_dir} --strip-components=1 \
+  && rm ${emscripten_temp} \
+  && ${emscripten_dir}/emsdk install ${emscripten_version} \
+  && ${emscripten_dir}/emsdk activate --embedded ${emscripten_version}
+ENV EMSDK "${emscripten_dir}"
+ENV EM_CONFIG "${emscripten_dir}/.emscripten"
+ENV EM_CACHE "${emscripten_dir}/.emscripten_cache"
 # We need to allow a non-root Docker container to write into the `EM_CACHE` directory.
 RUN chmod --recursive go+wx "${EM_CACHE}"
 
 # Install Go.
-ARG GOLANG_VERSION=1.13.1
-ARG GOLANG_SHA256=94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124
-ARG GOLANG_TEMP=/tmp/golang.tar.gz
+ARG golang_version=1.13.1
+ARG golang_sha256=94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124
+ARG golang_temp=/tmp/golang.tar.gz
 ENV GOROOT /usr/local/go
 ENV GOPATH ${HOME}/go
-RUN mkdir --parents ${GOROOT}
-RUN curl --location https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz > ${GOLANG_TEMP}
-RUN sha256sum --binary ${GOLANG_TEMP} && echo "${GOLANG_SHA256} *${GOLANG_TEMP}" | sha256sum --check
-RUN tar --extract --gzip --file=${GOLANG_TEMP} --directory=${GOROOT} --strip-components=1
-RUN rm ${GOLANG_TEMP}
 ENV PATH "${GOROOT}/bin:${PATH}"
 ENV PATH "${GOPATH}/bin:${PATH}"
-RUN go version
+RUN mkdir --parents ${GOROOT} \
+  && curl --location https://dl.google.com/go/go${golang_version}.linux-amd64.tar.gz > ${golang_temp} \
+  && sha256sum --binary ${golang_temp} && echo "${golang_sha256} *${golang_temp}" | sha256sum --check \
+  && tar --extract --gzip --file=${golang_temp} --directory=${GOROOT} --strip-components=1 \
+  && rm ${golang_temp} \
+  && go version
 
 # Install embedmd (via Go).
-RUN go get github.com/campoy/embedmd
-RUN embedmd -v
+RUN go get github.com/campoy/embedmd \
+  && embedmd -v
 
 # Install prettier and markdownlint (via Node.js).
 # https://prettier.io/
 # https://github.com/igorshubovych/markdownlint-cli
-ARG PRETTIER_VERSION=1.19.1
-ARG PRETTIER_PLUGIN_TOML_VERSION=0.3.1
-ARG MARKDOWNLINT_VERSION=0.22.0
+ARG prettier_version=1.19.1
+ARG prettier_plugin_toml_version=0.3.1
+ARG markdownlint_version=0.22.0
 RUN npm install --global \
-  prettier@${PRETTIER_VERSION} \
-  prettier-plugin-toml@${PRETTIER_PLUGIN_TOML_VERSION} \
-  markdownlint-cli@${MARKDOWNLINT_VERSION}
-RUN prettier --version
-RUN markdownlint --version
+  prettier@${prettier_version} \
+  prettier-plugin-toml@${prettier_plugin_toml_version} \
+  markdownlint-cli@${markdownlint_version} \
+  && prettier --version \
+  && markdownlint --version
+
+ARG hadolint_version=1.17.5
+ARG hadolint_sha256=20dd38bc0602040f19268adc14c3d1aae11af27b463af43f3122076baf827a35
+ARG hadolint_dir=/usr/local/hadolint/bin
+ARG hadolint_bin=${hadolint_dir}/hadolint
+ENV PATH "${hadolint_dir}:${PATH}"
+RUN mkdir --parents ${hadolint_dir} \
+  && curl --location https://github.com/hadolint/hadolint/releases/download/v${hadolint_version}/hadolint-Linux-x86_64 > ${hadolint_bin} \
+  && sha256sum --binary ${hadolint_bin} && echo "${hadolint_sha256} *${hadolint_bin}" | sha256sum --check \
+  && chmod +x ${hadolint_bin} \
+  && hadolint --version
 
 # Install buildifier.
-ARG BAZEL_TOOLS_VERSION=1.0.0
-ARG BUILDIFIER_SHA256=ec064a5edd2a2a210cf8162305869a27b3ed6c7e50caa70687bc9d72177f61f3
-ARG BUILDIFIER_DIR=/usr/local/buildifier/bin
-ARG BUILDIFIER_BIN=${BUILDIFIER_DIR}/buildifier
-RUN mkdir --parents ${BUILDIFIER_DIR}
-RUN curl --location https://github.com/bazelbuild/buildtools/releases/download/${BAZEL_TOOLS_VERSION}/buildifier > ${BUILDIFIER_BIN}
-RUN sha256sum --binary ${BUILDIFIER_BIN} && echo "${BUILDIFIER_SHA256} *${BUILDIFIER_BIN}" | sha256sum --check
-ENV PATH "${BUILDIFIER_DIR}:${PATH}"
-RUN chmod +x ${BUILDIFIER_BIN}
-RUN buildifier --version
+ARG bazel_tools_version=2.2.1
+ARG buildifier_sha256=731a6a9bf8fca8a00a165cd5b3fbac9907a7cf422ec9c2f206b0a76c0a7e3d62
+ARG buildifier_dir=/usr/local/buildifier/bin
+ARG buildifier_bin=${buildifier_dir}/buildifier
+ENV PATH "${buildifier_dir}:${PATH}"
+RUN mkdir --parents ${buildifier_dir} \
+  && curl --location https://github.com/bazelbuild/buildtools/releases/download/${bazel_tools_version}/buildifier > ${buildifier_bin} \
+  && sha256sum --binary ${buildifier_bin} && echo "${buildifier_sha256} *${buildifier_bin}" | sha256sum --check \
+  && chmod +x ${buildifier_bin} \
+  && buildifier --version
 
 # Install Protobuf compiler.
-ARG PROTOBUF_VERSION=3.11.2
-ARG PROTOBUF_SHA256=c0c666fb679a8221bed01bffeed1f80727c6c7827d0cbd8f162195efb12df9e0
-ARG PROTOBUF_DIR=/usr/local/protobuf
-ARG PROTOBUF_TEMP=/tmp/protobuf.zip
-RUN curl --location https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip > ${PROTOBUF_TEMP}
-RUN sha256sum --binary ${PROTOBUF_TEMP} && echo "${PROTOBUF_SHA256} *${PROTOBUF_TEMP}" | sha256sum --check
-RUN unzip ${PROTOBUF_TEMP} -d ${PROTOBUF_DIR}
-RUN rm ${PROTOBUF_TEMP}
-ENV PATH "${PROTOBUF_DIR}/bin:${PATH}"
-RUN protoc --version
+ARG protobuf_version=3.11.4
+ARG protobuf_sha256=6d0f18cd84b918c7b3edd0203e75569e0c8caecb1367bbbe409b45e28514f5be
+ARG protobuf_dir=/usr/local/protobuf
+ARG protobuf_temp=/tmp/protobuf.zip
+ENV PATH "${protobuf_dir}/bin:${PATH}"
+RUN curl --location https://github.com/protocolbuffers/protobuf/releases/download/v${protobuf_version}/protoc-${protobuf_version}-linux-x86_64.zip > ${protobuf_temp} \
+  && sha256sum --binary ${protobuf_temp} && echo "${protobuf_sha256} *${protobuf_temp}" | sha256sum --check \
+  && unzip ${protobuf_temp} -d ${protobuf_dir} \
+  && rm ${protobuf_temp} \
+  && protoc --version
 
 # Install rustup.
-ARG RUSTUP_DIR=/usr/local/cargo
-ENV RUSTUP_HOME ${RUSTUP_DIR}
-ENV CARGO_HOME ${RUSTUP_DIR}
-RUN curl --location https://sh.rustup.rs > /tmp/rustup
-RUN sh /tmp/rustup -y --default-toolchain=none
-ENV PATH "${RUSTUP_DIR}/bin:${PATH}"
-RUN rustup --version
-RUN chmod a+rwx ${RUSTUP_DIR}
+ARG rustup_dir=/usr/local/cargo
+ENV RUSTUP_HOME ${rustup_dir}
+ENV CARGO_HOME ${rustup_dir}
+ENV PATH "${rustup_dir}/bin:${PATH}"
+RUN curl --location https://sh.rustup.rs > /tmp/rustup \
+  && sh /tmp/rustup -y --default-toolchain=none \
+  && chmod a+rwx ${rustup_dir} \
+  && rustup --version
 
 # Install Rust toolchain.
 # We currently need the nightly version in order to be able to compile some of the examples.
 # See https://rust-lang.github.io/rustup-components-history/ for how to pick a version that supports
 # the appropriate set of components.
 # Make sure to update WORKSPACE too, e.g. when updating nightly version
-ARG RUST_VERSION=nightly-2020-02-06
-RUN rustup toolchain install ${RUST_VERSION}
-RUN rustup default ${RUST_VERSION}
+ARG rust_version=nightly-2020-02-06
+RUN rustup toolchain install ${rust_version} \
+  && rustup default ${rust_version}
 
 # Install WebAssembly target for Rust.
 RUN rustup target add wasm32-unknown-unknown

--- a/android.Dockerfile
+++ b/android.Dockerfile
@@ -1,85 +1,88 @@
 # Download Debian-9 (Stretch) with openjdk-8 that is required for Android.
-ARG debian_snapshot=stretch-20191118
+ARG debian_snapshot=stretch-20200327
 FROM debian/snapshot:${debian_snapshot}
 
-RUN apt-get update && \
-    apt-get install -y \
-        bash-completion \
-        bison \
-        build-essential \
-        curl \
-        flex \
-        git \
-        libisl-dev \
-        libmpc-dev \
-        libmpfr-dev \
-        libncurses5 \
-        ocaml-nox \
-        openjdk-8-jdk \
-        python-dev \
-        python2.7-dev \
-        python3-dev \
-        rsync \
-        texinfo \
-        vim \
-        wget \
-        xml2 \
-        zlib1g-dev
+RUN apt-get --yes update && \
+    apt-get install --no-install-recommends --yes \
+    bash-completion \
+    bison \
+    build-essential \
+    curl \
+    flex \
+    git \
+    libisl-dev \
+    libmpc-dev \
+    libmpfr-dev \
+    libncurses5 \
+    ocaml-nox \
+    openjdk-8-jdk \
+    python-dev \
+    python2.7-dev \
+    python3-dev \
+    rsync \
+    texinfo \
+    vim \
+    wget \
+    xml2 \
+    # `unzip` and `zlib1g-dev` are needed for Bazel.
+    unzip \
+    zlib1g-dev \
+    && apt-get clean \
+    && rm --recursive --force /var/lib/apt/lists/* \
+    # Print version of various installed tools.
+    && git --version
 
-RUN git --version
-
-# Install Bazel. 
-ARG bazel_version=1.2.1
-ARG bazel_sha=4bbb2718d451db5922223fda3aed3810c4ca50f431481e86a7fec4c585f18b1f
+# Use a fixed version of Bazel.
+ARG bazel_version=3.0.0
+ARG bazel_sha256=dfa79c10bbfa39cd778e1813a273fd3236beb495497baa046f26d393c58bdc35
 ARG bazel_url=https://storage.googleapis.com/bazel-apt/pool/jdk1.8/b/bazel/bazel_${bazel_version}_amd64.deb
-RUN wget "${bazel_url}" -nv -o- -O bazel.deb && \
-    echo "${bazel_sha}  bazel.deb" > bazel.sha256 && \
-    sha256sum --check bazel.sha256 && \
-    apt-get install -y ./bazel.deb
+RUN curl --location "${bazel_url}" > bazel.deb \
+    && sha256sum --binary bazel.deb && echo "${bazel_sha256} *bazel.deb" | sha256sum --check \
+    && apt-get install --no-install-recommends --yes ./bazel.deb \
+    && rm bazel.deb \
+    && apt-get clean \
+    && bazel version
 
 # Install Android SDK.
 # https://developer.android.com/studio/#downloads
+ARG android_sdk_version=4333796
 ENV ANDROID_HOME /opt/android-sdk
-ARG ANDROID_SDK_VERSION=4333796
-RUN mkdir -p ${ANDROID_HOME} && cd ${ANDROID_HOME} && \
-    wget -q https://dl.google.com/android/repository/sdk-tools-linux-"${ANDROID_SDK_VERSION}".zip && \
-    unzip *tools*linux*.zip && \
-    rm *tools*linux*.zip
+RUN mkdir --parents ${ANDROID_HOME} \
+    && curl --location https://dl.google.com/android/repository/sdk-tools-linux-"${android_sdk_version}".zip > android_sdk.zip \
+    && unzip android_sdk.zip -d ${ANDROID_HOME} \
+    && rm android_sdk.zip
 
 # Install Android Platform Tools.
 # https://developer.android.com/studio/releases/platform-tools
 # https://developer.android.com/studio/releases/platforms
 # https://developer.android.com/studio/releases/build-tools
 # '28.0.3' is the maximal version supported by NDK.
-ARG PLATFORM='28'
-ARG TOOLS='28.0.3'
-RUN cd ${ANDROID_HOME}/tools/bin && \
-    ./sdkmanager --update && \
-    yes | ./sdkmanager --licenses && \
-    yes | ./sdkmanager \
-        'tools' 'platform-tools' 'cmake;3.6.4111459' \
-        "platforms;android-${PLATFORM}" "build-tools;${TOOLS}" \
-        "system-images;android-${PLATFORM};default;x86_64"
+ARG platform=28
+ARG tools=28.0.3
+RUN ${ANDROID_HOME}/tools/bin/sdkmanager --update \
+    && yes | ${ANDROID_HOME}/tools/bin/sdkmanager --licenses \
+    && yes | ${ANDROID_HOME}/tools/bin/sdkmanager \
+    'tools' 'platform-tools' 'cmake;3.6.4111459' \
+    "platforms;android-${platform}" "build-tools;${tools}" \
+    "system-images;android-${platform};default;x86_64"
 
 # Set up Android SDK paths.
-ENV PATH ${PATH}:${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools/bin
-ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib
+ENV PATH "${PATH}:${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools/bin"
+ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib"
 
 # Create an Android emulator.
 # `no` is used to opt-out from custom hardware profile.
-RUN cd ${ANDROID_HOME}/tools/bin && \
-    echo no | ./avdmanager create avd \
-        -n "android-${PLATFORM}-x86_64" \
-        -k "system-images;android-${PLATFORM};default;x86_64" \
-        -b x86_64
+RUN echo no | ${ANDROID_HOME}/tools/bin/avdmanager create avd \
+    -n "android-${platform}-x86_64" \
+    -k "system-images;android-${platform};default;x86_64" \
+    -b x86_64
 
 # Install Android NDK
 # https://developer.android.com/ndk/downloads
+ARG android_ndk_version=r20b
 ENV ANDROID_NDK_HOME /opt/android-ndk
-ARG ANDROID_NDK_VERSION=r20b
-RUN mkdir -p ${ANDROID_NDK_HOME} && cd ${ANDROID_NDK_HOME} && \
-    wget -q https://dl.google.com/android/repository/android-ndk-"${ANDROID_NDK_VERSION}"-linux-x86_64.zip && \
-	unzip android-ndk*.zip && \
-	rm -f android-ndk*.zip && \
-    mv android-ndk-r20b/* . && \
-    rm -rf android-ndk-r20b
+RUN mkdir --parents ${ANDROID_NDK_HOME} \
+    && curl --location https://dl.google.com/android/repository/android-ndk-"${android_ndk_version}"-linux-x86_64.zip > android_ndk.zip \
+    && unzip android_ndk.zip -d ${ANDROID_NDK_HOME} \
+    && mv ${ANDROID_NDK_HOME}/android-ndk-${android_ndk_version}/* ${ANDROID_NDK_HOME} \
+    && rm --recursive --force android_ndk.zip

--- a/docs/INSTALL-OSX.md
+++ b/docs/INSTALL-OSX.md
@@ -23,23 +23,23 @@ integration system, check the specific details in the project
 [embedmd]:# (../Dockerfile bash /^# Install rustup/ /^ +rustfmt/)
 ```bash
 # Install rustup.
-ARG RUSTUP_DIR=/usr/local/cargo
-ENV RUSTUP_HOME ${RUSTUP_DIR}
-ENV CARGO_HOME ${RUSTUP_DIR}
-RUN curl --location https://sh.rustup.rs > /tmp/rustup
-RUN sh /tmp/rustup -y --default-toolchain=none
-ENV PATH "${RUSTUP_DIR}/bin:${PATH}"
-RUN rustup --version
-RUN chmod a+rwx ${RUSTUP_DIR}
+ARG rustup_dir=/usr/local/cargo
+ENV RUSTUP_HOME ${rustup_dir}
+ENV CARGO_HOME ${rustup_dir}
+ENV PATH "${rustup_dir}/bin:${PATH}"
+RUN curl --location https://sh.rustup.rs > /tmp/rustup \
+  && sh /tmp/rustup -y --default-toolchain=none \
+  && chmod a+rwx ${rustup_dir} \
+  && rustup --version
 
 # Install Rust toolchain.
 # We currently need the nightly version in order to be able to compile some of the examples.
 # See https://rust-lang.github.io/rustup-components-history/ for how to pick a version that supports
 # the appropriate set of components.
 # Make sure to update WORKSPACE too, e.g. when updating nightly version
-ARG RUST_VERSION=nightly-2020-02-06
-RUN rustup toolchain install ${RUST_VERSION}
-RUN rustup default ${RUST_VERSION}
+ARG rust_version=nightly-2020-02-06
+RUN rustup toolchain install ${rust_version} \
+  && rustup default ${rust_version}
 
 # Install WebAssembly target for Rust.
 RUN rustup target add wasm32-unknown-unknown

--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -51,6 +51,16 @@ find . \
     -not \( -path ./cargo-cache -prune \) -and \
     -not \( -path ./target -prune \) -and \
     -not \( -path ./third_party -prune \) \
+    \( -type f -name '*Dockerfile' \) \
+  \) -exec hadolint {} +
+
+find . \
+  \(  \
+    -not \( -path ./.git -prune \) -and \
+    -not \( -path ./bazel-cache -prune \) -and \
+    -not \( -path ./cargo-cache -prune \) -and \
+    -not \( -path ./target -prune \) -and \
+    -not \( -path ./third_party -prune \) \
     \( -type f -name '*.md' -or -name '*.yaml' -or -name '*.toml' \) \
   \) -exec prettier --check {} +
 


### PR DESCRIPTION
See https://github.com/hadolint/hadolint

Fix various issues brought up by hadolint, plus extra ones.

- update base image to a more recent one
- use consistent naming for `ARG` (lowercase)
- use `curl` instead of `wget`
- move `&&` continuations to new line
- clear apt cache after install commands
- set PIPEFAIL option