### PR TITLE
sdk: grpc::ChannelResponseWriter doesn't need mut

### DIFF
--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -238,7 +238,7 @@ impl OakAbiTestService for FrontendNode {
     fn server_streaming_method(
         &mut self,
         req: GrpcTestRequest,
-        mut writer: grpc::ChannelResponseWriter,
+        writer: grpc::ChannelResponseWriter,
     ) {
         match req.method_result {
             Some(proto::grpc_test_request::MethodResult::ErrCode(err_code)) => {
@@ -294,7 +294,7 @@ impl OakAbiTestService for FrontendNode {
     fn bidi_streaming_method(
         &mut self,
         reqs: Vec<GrpcTestRequest>,
-        mut writer: grpc::ChannelResponseWriter,
+        writer: grpc::ChannelResponseWriter,
     ) {
         for req in &reqs {
             match &req.method_result {

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -106,7 +106,7 @@ impl Chat for Node {
         }
     }
 
-    fn subscribe(&mut self, req: SubscribeRequest, mut writer: grpc::ChannelResponseWriter) {
+    fn subscribe(&mut self, req: SubscribeRequest, writer: grpc::ChannelResponseWriter) {
         info!("subscribing to room");
         match self.rooms.get(&req.room_id) {
             None => {

--- a/examples/hello_world/module/rust/src/lib.rs
+++ b/examples/hello_world/module/rust/src/lib.rs
@@ -52,7 +52,7 @@ impl HelloWorld for Node {
         Ok(res)
     }
 
-    fn lots_of_replies(&mut self, req: HelloRequest, mut writer: grpc::ChannelResponseWriter) {
+    fn lots_of_replies(&mut self, req: HelloRequest, writer: grpc::ChannelResponseWriter) {
         info!("Say hello to {}", req.greeting);
         let mut res1 = HelloResponse::default();
         res1.reply = format!("HELLO {}!", req.greeting);
@@ -88,7 +88,7 @@ impl HelloWorld for Node {
         Ok(res)
     }
 
-    fn bidi_hello(&mut self, reqs: Vec<HelloRequest>, mut writer: grpc::ChannelResponseWriter) {
+    fn bidi_hello(&mut self, reqs: Vec<HelloRequest>, writer: grpc::ChannelResponseWriter) {
         info!("Say hello");
         let msg = recipients(&reqs);
         let mut res1 = HelloResponse::default();

--- a/examples/machine_learning/module/rust/src/lib.rs
+++ b/examples/machine_learning/module/rust/src/lib.rs
@@ -164,7 +164,7 @@ struct Node {
 }
 
 impl oak::grpc::ServerNode for Node {
-    fn invoke(&mut self, method: &str, _req: &[u8], mut writer: grpc::ChannelResponseWriter) {
+    fn invoke(&mut self, method: &str, _req: &[u8], writer: grpc::ChannelResponseWriter) {
         match method {
             "/oak.examples.machine_learning.MachineLearning/Data" => {
                 info!("Data");

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -70,7 +70,7 @@ impl ChannelResponseWriter {
     /// Write out a gRPC response and optionally close out the method
     /// invocation.  Any errors from the channel are silently dropped.
     pub fn write<T: prost::Message>(
-        &mut self,
+        &self,
         rsp: &T,
         mode: WriteMode,
     ) -> std::result::Result<(), OakError> {
@@ -95,7 +95,7 @@ impl ChannelResponseWriter {
 
     /// Write an empty gRPC response and optionally close out the method
     /// invocation. Any errors from the channel are silently dropped.
-    pub fn write_empty(&mut self, mode: WriteMode) -> std::result::Result<(), OakError> {
+    pub fn write_empty(&self, mode: WriteMode) -> std::result::Result<(), OakError> {
         let grpc_rsp = GrpcResponse {
             rsp_msg: Vec::new(),
             status: None,
@@ -112,7 +112,7 @@ impl ChannelResponseWriter {
     }
 
     /// Close out the gRPC method invocation with the given final result.
-    pub fn close(&mut self, result: Result<()>) -> std::result::Result<(), OakError> {
+    pub fn close(&self, result: Result<()>) -> std::result::Result<(), OakError> {
         // Build a final GrpcResponse message wrapper and serialize it into the
         // channel.
         let mut grpc_rsp = GrpcResponse::default();
@@ -266,7 +266,7 @@ where
 /// request/response pair.
 ///
 /// Panics if [de-]serialization or channel operations fail.
-pub fn handle_req_rsp<C, R, Q>(mut node_fn: C, req: &[u8], mut writer: ChannelResponseWriter)
+pub fn handle_req_rsp<C, R, Q>(mut node_fn: C, req: &[u8], writer: ChannelResponseWriter)
 where
     C: FnMut(R) -> Result<Q>,
     R: prost::Message + Default,
@@ -301,7 +301,7 @@ where
 /// stream of requests to produce a response.
 ///
 /// Panics if [de-]serialization or channel operations fail.
-pub fn handle_stream_rsp<C, R, Q>(mut node_fn: C, req: &[u8], mut writer: ChannelResponseWriter)
+pub fn handle_stream_rsp<C, R, Q>(mut node_fn: C, req: &[u8], writer: ChannelResponseWriter)
 where
     C: FnMut(Vec<R>) -> Result<Q>,
     R: prost::Message + Default,


### PR DESCRIPTION
Fixes #598

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
