### PR TITLE
Rust runtime tidy-ups

### DIFF
--- a/oak/server/rust/oak_glue/src/lib.rs
+++ b/oak/server/rust/oak_glue/src/lib.rs
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn glue_wait_on_channels(node_id: u64, buf: *mut u8, count
             let handle = mem_reader.read_u64::<byteorder::LittleEndian>().unwrap();
             let _b = mem_reader.read_u8().unwrap();
             debug!("{{{}}}: wait_on_channels handle {:?}", node_id, handle);
-            handles.push(Some(oak_runtime::Handle(handle)));
+            handles.push(oak_runtime::Handle(handle));
         }
 
         let proxy = proxy_for_node(node_id);

--- a/oak/server/rust/oak_runtime/src/node/grpc_server.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc_server.rs
@@ -114,7 +114,7 @@ impl GrpcServerNode {
     fn init_channel_writer(&self) -> Result<Handle, OakStatus> {
         let read_status = self
             .runtime
-            .wait_on_channels(&[Some(self.initial_reader)])
+            .wait_on_channels(&[self.initial_reader])
             .map_err(|error| {
                 error!("Couldn't wait on the initial reader handle: {:?}", error);
                 OakStatus::ErrInternal
@@ -263,7 +263,7 @@ impl GrpcServerNode {
     fn process_response(&self, response_reader: Handle) -> Result<Vec<u8>, GrpcServerError> {
         let read_status = self
             .runtime
-            .wait_on_channels(&[Some(response_reader)])
+            .wait_on_channels(&[response_reader])
             .map_err(|error| {
                 error!("Couldn't wait on the temporary gRPC channel: {:?}", error);
                 GrpcServerError::ResponseProcessingError

--- a/oak/server/rust/oak_runtime/src/node/logger.rs
+++ b/oak/server/rust/oak_runtime/src/node/logger.rs
@@ -60,7 +60,7 @@ impl LogNode {
             // An error indicates the Runtime is terminating. We ignore it here and keep trying to
             // read in case a Wasm Node wants to emit remaining messages. We will return
             // once the channel is closed.
-            let _ = self.runtime.wait_on_channels(&[Some(self.reader)]);
+            let _ = self.runtime.wait_on_channels(&[self.reader]);
 
             if let Some(message) = self.runtime.channel_read(self.reader)? {
                 match LogMessage::decode(&*message.data) {

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -40,17 +40,8 @@ use crate::{
 #[cfg(test)]
 mod tests;
 
-/// These number mappings are not exposed to the Wasm client, and are only used by `wasmi` to map
-/// import names to host functions. See https://docs.rs/wasmi/0.6.2/wasmi/trait.Externals.html
-///
-/// - 0: node_create: (usize, usize, usize, usize, u64) -> u32
-/// - 1: random_get: (usize, usize) -> u32
-/// - 2: channel_close: (u64) -> u32
-/// - 3: channel_create: (usize, usize) -> u32
-/// - 4: channel_write: (u64, usize, usize, usize, u32) -> u32
-/// - 5: channel_read: (u64, usize, usize, usize, usize, u32, usize) -> u32
-/// - 6: wait_on_channels: (usize, u32) -> u32
-
+/// Wasm host function index numbers for `wasmi` to map import names with.  This numbering is not
+/// exposed to the Wasm client.  See https://docs.rs/wasmi/0.6.2/wasmi/trait.Externals.html
 const NODE_CREATE: usize = 0;
 const RANDOM_GET: usize = 1;
 const CHANNEL_CLOSE: usize = 2;
@@ -58,7 +49,7 @@ const CHANNEL_CREATE: usize = 3;
 const CHANNEL_WRITE: usize = 4;
 const CHANNEL_READ: usize = 5;
 const WAIT_ON_CHANNELS: usize = 6;
-// TODO(#817): remove this
+// TODO(#817): remove this; we shouldn't need to have WASI stubs.
 const WASI_STUB: usize = 7;
 
 type AbiHandle = u64;
@@ -722,11 +713,9 @@ impl wasmi::ModuleImportResolver for WasmInterface {
         field_name: &str,
         signature: &wasmi::Signature,
     ) -> Result<wasmi::FuncRef, wasmi::Error> {
-        // The comments alongside the types in the signatures correspond to the parameter names from
+        // The types in the signatures correspond to the parameters from
         // /oak/server/rust/oak_abi/src/lib.rs
         let (index, sig) = match field_name {
-            //
-            // - 0: node_create: (usize, usize, usize, usize, usize, usize, u64) -> u32
             "node_create" => (
                 NODE_CREATE,
                 wasmi::Signature::new(
@@ -742,8 +731,6 @@ impl wasmi::ModuleImportResolver for WasmInterface {
                     Some(ABI_U32),
                 ),
             ),
-            //
-            // - 1: random_get: (usize, usize) -> u32
             "random_get" => (
                 RANDOM_GET,
                 wasmi::Signature::new(
@@ -754,8 +741,6 @@ impl wasmi::ModuleImportResolver for WasmInterface {
                     Some(ABI_U32),
                 ),
             ),
-            //
-            // - 2: channel_close: (u64) -> u32
             "channel_close" => (
                 CHANNEL_CLOSE,
                 wasmi::Signature::new(
@@ -765,8 +750,6 @@ impl wasmi::ModuleImportResolver for WasmInterface {
                     Some(ABI_U32),
                 ),
             ),
-            //
-            // - 3: channel_create: (usize, usize) -> u32
             "channel_create" => (
                 CHANNEL_CREATE,
                 wasmi::Signature::new(
@@ -777,8 +760,6 @@ impl wasmi::ModuleImportResolver for WasmInterface {
                     Some(ABI_U32),
                 ),
             ),
-            //
-            // - 4: channel_write: (u64, usize, usize, usize, u32) -> u32
             "channel_write" => (
                 CHANNEL_WRITE,
                 wasmi::Signature::new(
@@ -792,8 +773,6 @@ impl wasmi::ModuleImportResolver for WasmInterface {
                     Some(ABI_U32),
                 ),
             ),
-            //
-            // - 5: channel_read: (u64, usize, usize, usize, usize, u32, usize) -> u32
             "channel_read" => (
                 CHANNEL_READ,
                 wasmi::Signature::new(
@@ -809,8 +788,6 @@ impl wasmi::ModuleImportResolver for WasmInterface {
                     Some(ABI_U32),
                 ),
             ),
-            //
-            // - 6: wait_on_channels: (usize, u32) -> u32
             "wait_on_channels" => (
                 WAIT_ON_CHANNELS,
                 wasmi::Signature::new(

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -216,28 +216,7 @@ impl Runtime {
     /// Validate the [`NodeId`] has access to [`Handle`], returning `Err(OakStatus::ErrBadHandle)`
     /// if access is not allowed.
     fn validate_handle_access(&self, node_id: NodeId, handle: Handle) -> Result<(), OakStatus> {
-        // Allow RUNTIME_NODE_ID access to all handles.
-        if node_id == RUNTIME_NODE_ID {
-            return Ok(());
-        }
-
-        let node_infos = self.node_infos.read().unwrap();
-        // Lookup the node_id in the runtime's node_infos hashmap.
-        let node_info = node_infos
-            .get(&node_id)
-            .expect("Invalid node_id passed into validate_handle_access!");
-
-        // Check the handle exists in the handles associated with a Node, otherwise
-        // return ErrBadHandle.
-        if node_info.handles.contains(&handle) {
-            Ok(())
-        } else {
-            error!(
-                "{:?}: validate_handle_access: handle {:?} not found",
-                node_id, handle
-            );
-            Err(OakStatus::ErrBadHandle)
-        }
+        self.validate_handles_access(node_id, vec![handle])
     }
 
     /// Validate the [`NodeId`] has access to all [`Handle`]'s passed in the iterator, returning


### PR DESCRIPTION
As independent commits so things can be easily dropped if needed.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
