### PR TITLE
Add initial OpenID Connect auth client example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "auth_client"
+version = "0.1.0"
+dependencies = [
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "open 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +802,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +933,11 @@ dependencies = [
 [[package]]
 name = "maplit"
 version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "matches"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1139,7 +1169,7 @@ dependencies = [
 name = "oak_loader"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak_runtime 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,6 +1227,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "open"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1288,11 @@ dependencies = [
 [[package]]
 name = "percent-encoding"
 version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2534,6 +2577,22 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,6 +2616,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "untrusted"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "vec_map"
@@ -2857,6 +2926,7 @@ dependencies = [
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fa1c527bbc634be72aa7ba31e4e4def9bbb020f5416916279b7c705cd838893e"
+"checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum ignore 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "522daefc3b69036f80c7d2990b28ff9e0471c683bad05ca258e0a01dd22c5a1e"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
@@ -2872,6 +2942,7 @@ dependencies = [
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum matrixmultiply 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "dcad67dcec2d58ff56f6292582377e6921afdf3bfbd533e26fb8900ae575e002"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
@@ -2892,12 +2963,14 @@ dependencies = [
 "checksum num-rational 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "da4dc79f9e6c81bef96148c8f6b8e72ad4541caa4a24373e900a36da07de03a3"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+"checksum open 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48"
 "checksum parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
 "checksum pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
 "checksum pin-project-internal 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
@@ -3017,11 +3090,14 @@ dependencies = [
 "checksum tracing-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
 "checksum tracing-futures 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "58b6233e421bf43203d36a8cd430acd24a75bed39832b0e07bec24541f9759e9"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+"checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unicode_categories 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
+"checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "examples/aggregator/backend",
   "examples/aggregator/common",
   "examples/aggregator/module/rust",
+  "examples/authentication/client",
   "examples/chat/module/rust",
   "examples/hello_world/module/rust",
   "examples/machine_learning/module/rust",

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -1,0 +1,24 @@
+# OpenID Connect Authentication Example
+
+This example authenticates using the
+[Google Identity Platform](https://developers.google.com/identity/), which
+implements OpenID Connect.
+
+The client application opens a browser which allows the user to authenticate. On
+successful authentication, the browser is redirected to connect to a web server
+running on localhost. The authentication code is extracted from the query string
+of the redirection URL and returned to the main thread.
+
+TODO(#855): The authenctication code can then be exchanged for an identity token
+by the authentication server.
+
+The client can be executed using:
+
+```bash
+
+cargo run -b auth_client -- --client-id $YOUR_CLIENT_ID
+
+```
+
+This requires a valid OAuth Client ID, which can be created as described in
+https://developers.google.com/identity/protocols/oauth2/openid-connect#getcredentials

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -9,14 +9,14 @@ successful authentication, the browser is redirected to connect to a web server
 running on localhost. The authentication code is extracted from the query string
 of the redirection URL and returned to the main thread.
 
-TODO(#855): The authenctication code can then be exchanged for an identity token
+TODO(#855): The authentication code can then be exchanged for an identity token
 by the authentication server.
 
 The client can be executed using:
 
 ```bash
 
-cargo run -b auth_client -- --client-id $YOUR_CLIENT_ID
+cargo run --package auth_client -- --client-id $YOUR_CLIENT_ID
 
 ```
 

--- a/examples/authentication/client/Cargo.toml
+++ b/examples/authentication/client/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "auth_client"
+version = "0.1.0"
+authors = ["grobler <grobler@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+env_logger = "*"
+futures = "*"
+futures-util = { version = "*", default-features = false }
+hyper = "*"
+log = "*"
+open = "*"
+structopt = "*"
+tokio = "*"
+url = "*"

--- a/examples/authentication/client/src/main.rs
+++ b/examples/authentication/client/src/main.rs
@@ -1,0 +1,194 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Example client authenticating to Oak using OpenID Connect.
+//!
+//! This example uses the Google Identity Platform.
+//! https://developers.google.com/identity/
+
+use futures::channel::oneshot::{self, Sender};
+use futures_util::future;
+use hyper::{service::Service, Body, Request, Response, Server, StatusCode};
+use log::{info, warn};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+};
+use structopt::StructOpt;
+use url::{form_urlencoded, Url};
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "OpenID Connect Client Example.")]
+pub struct Opt {
+    #[structopt(
+        long,
+        help = "Address of the Oak application to connect to.",
+        default_value = "127.0.0.1:8080"
+    )]
+    address: String,
+    #[structopt(
+        long,
+        help = "Address to listen on for the OAuth redirect.",
+        default_value = "127.0.0.1:8089"
+    )]
+    redirect_address: String,
+    #[structopt(long, help = "Path to the PEM-encoded CA root certificate.")]
+    ca_cert: Option<String>,
+    // TODO(#886): Retrieve client_id from server, rather than flag.
+    #[structopt(long, help = "The OAuth client ID.")]
+    client_id: String,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    let opt = Opt::from_args();
+    let redirect_address = opt.redirect_address.parse()?;
+    info!("Listening for redirect on {}", &redirect_address);
+
+    info!("Opening Auth request in Browser");
+    let request_uri = get_request(opt);
+    info!("URI: {}", &request_uri);
+    let (sender, receiver) = oneshot::channel();
+    let result_sender = Arc::new(Mutex::new(ResultSender {
+        sender: Some(sender),
+        result: None,
+    }));
+    let maker = MakeHandler {
+        result_sender: result_sender.clone(),
+    };
+
+    let mut runner = tokio::runtime::Runtime::new().unwrap();
+    let task = runner.spawn(async move {
+        Server::bind(&redirect_address)
+            .serve(maker)
+            .with_graceful_shutdown(async move {
+                receiver.await.unwrap();
+            })
+            .await
+    });
+    open::that(request_uri)?;
+    runner.block_on(task)??;
+
+    let result = result_sender.lock().unwrap();
+    let code = result.result.as_ref().unwrap().as_ref().ok().unwrap();
+    info!("Received code: {}", code);
+    Ok(())
+}
+
+fn get_request(opt: Opt) -> String {
+    // TODO(#886): Retrieve endpoint from server.
+    let mut auth_endpoint = Url::parse("https://accounts.google.com/o/oauth2/v2/auth").unwrap();
+    // TODO(#886): Consider retrieving scope from server.
+    let scope = "openid email";
+    let redirect_uri = format!("http://{}", opt.redirect_address);
+    // TODO(#886): Retrieve state and code challenge from server and add to request.
+    auth_endpoint
+        .query_pairs_mut()
+        .append_pair("scope", scope)
+        .append_pair("response_type", "code")
+        .append_pair("redirect_uri", &redirect_uri)
+        .append_pair("client_id", &opt.client_id);
+    auth_endpoint.to_string()
+}
+
+struct ResultSender {
+    sender: Option<Sender<()>>,
+    result: Option<Result<String, String>>,
+}
+
+impl ResultSender {
+    fn notify(&mut self) {
+        if self.sender.is_some() {
+            self.sender.take().unwrap().send(()).unwrap();
+        }
+    }
+}
+
+// Handles the redirects to extract code from the query string.
+struct RedirectHandler {
+    result_sender: Arc<Mutex<ResultSender>>,
+}
+
+impl Service<Request<Body>> for RedirectHandler {
+    type Response = Response<Body>;
+    type Error = hyper::Error;
+    type Future = future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Ok(()).into()
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        if let Some(query) = request.uri().query() {
+            let lookup: HashMap<_, _> = form_urlencoded::parse(query.as_bytes()).collect();
+            let result_sender = &mut self.result_sender.lock().unwrap();
+            if lookup.contains_key("code") {
+                let code = lookup.get("code").unwrap().to_string();
+                info!("Auth code: {:?}", code);
+                result_sender.result = Some(Ok(code));
+                result_sender.notify();
+                future::ok(Response::new(Body::from("Success!")))
+            } else if lookup.contains_key("error") {
+                let error = lookup.get("error").unwrap().to_string();
+                warn!("Error: {:?}", error);
+                result_sender.result = Some(Ok(error));
+                result_sender.notify();
+                future::ok(
+                    Response::builder()
+                        .status(StatusCode::UNAUTHORIZED)
+                        .body(Body::from("Authentication failed!"))
+                        .unwrap(),
+                )
+            } else {
+                future::ok(
+                    Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(Body::from("Invalid query string!"))
+                        .unwrap(),
+                )
+            }
+        } else {
+            future::ok(
+                Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Body::from("No query string!"))
+                    .unwrap(),
+            )
+        }
+    }
+}
+
+// Produces instances of the redirect handler service.
+struct MakeHandler {
+    result_sender: Arc<Mutex<ResultSender>>,
+}
+
+impl<T> Service<T> for MakeHandler {
+    type Response = RedirectHandler;
+    type Error = std::io::Error;
+    type Future = future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Ok(()).into()
+    }
+
+    fn call(&mut self, _: T) -> Self::Future {
+        future::ok(RedirectHandler {
+            result_sender: self.result_sender.clone(),
+        })
+    }
+}


### PR DESCRIPTION
This is the first part of the authentication client example. It opens the browser to allow the user to authenticate, and then receives the resulting authentication code. The example will be extended to exhange the auth code for an identity token once the authentication service is availble to support it and then pass the token to the runtime as proof of identity (#855).

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [x] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
