### PR TITLE
Fix hash of `oak_loader` binary

### DIFF
--- a/reproducibility_index
+++ b/reproducibility_index
@@ -1,1 +1,1 @@
-64e97f2701df8a8967f704a6c657d4fee0a92869d411fa1a512411ec9c0f6c4e  ./target/x86_64-unknown-linux-musl/release/oak_loader
+097de181dd94f6c91b9abfbd78d64ea98acf653c4881db98069fbab764ebaf4b  ./target/x86_64-unknown-linux-musl/release/oak_loader


### PR DESCRIPTION
Currently out of sync with the actual one due to a race condition in
submitting #880.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
