### PR TITLE
scripts: exclude binary hash from diff

### DIFF
--- a/scripts/git_check_diff
+++ b/scripts/git_check_diff
@@ -5,4 +5,4 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 source "$SCRIPTS_DIR/common"
 
 # Check that any generated files match those that are checked in.
-git diff --exit-code -- . ':!*.bazelrc'
+git diff --exit-code -- . ':!*.bazelrc' ':!reproducibility_index'


### PR DESCRIPTION
We don't yet have a mechanism that automatically updates this hash,
so don't check it for changes in the git_check_diff script.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
