### PR TITLE
Rebuild reproducibility index on GitHub Actions

### DIFF
--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -1,0 +1,54 @@
+name: Build Reproducibility Index
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build_reproducibility_index:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      # Build Docker image, caching from the latest version from the remote repository.
+      - name: Docker build
+        timeout-minutes: 30
+        run: |
+          docker pull gcr.io/oak-ci/oak:latest
+          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+
+      # Build artifacts that are supposed to be reproducible.
+      - name: Build Rust server
+        run: ./scripts/docker_run ./scripts/build_server -s rust
+
+      - name: Build examples
+        run: ./scripts/docker_run ./scripts/build_examples
+
+      # Generate an index of the hashes of the reproducible artifacts.
+      - name: Generate Reproducibility Index
+        run: ./scripts/docker_run ./scripts/build_reproducibility_index
+
+      # Print out the index to the logs of the action.
+      - name: Print Reproducibility Index
+        run: cat ./reproducibility_index
+
+      # Also post a reply on the PR thread with the contents of the index, after merge.
+      - name: Post Reproducibility Index (post-merge only)
+        uses: actions/github-script@0.9.0
+        if: github.event_name == 'push'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs').promises;
+            file_content = await fs.readFile('./reproducibility_index');
+
+            await github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Reproducibility index:\n\n```\n' + file_content + '\n```\n'
+            })

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@
 # based on the name of the directory bazel is cloned into.
 /bazel-*
 
-# Directory used to compare artifacts for reproducibility.
-/diff/
+# Index file used to compare artifacts for reproducibility.
+/reproducibility_index
 
 # Cargo cache.
 /cargo-cache/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -101,27 +101,11 @@ steps:
     entrypoint: 'bash'
     args: ['./scripts/run_clang_tidy']
 
-  # Rebuild the index file with hashes of reproducible artifacts. If this changed compared to the
-  # checked-in version, it will be detected by the `git_check_diff` step below.
-  - name: 'gcr.io/oak-ci/oak:latest'
-    id: build_reproducibility_index
-    waitFor: ['run_examples', 'build_server_rust']
-    timeout: 5m
-    entrypoint: 'bash'
-    args: ['./scripts/build_reproducibility_index']
-
   # Check whether any of the previous steps resulted in file diffs that were not checked in or
   # ignored by git.
   - name: 'gcr.io/oak-ci/oak:latest'
     id: git_check_diff
-    waitFor:
-      [
-        'git_init',
-        'run_clang_tidy',
-        'run_tests',
-        'run_examples',
-        'build_reproducibility_index',
-      ]
+    waitFor: ['git_init', 'run_clang_tidy', 'run_tests', 'run_examples']
     timeout: 5m
     entrypoint: 'bash'
     args: ['./scripts/git_check_diff']

--- a/reproducibility_index
+++ b/reproducibility_index
@@ -1,1 +1,0 @@
-097de181dd94f6c91b9abfbd78d64ea98acf653c4881db98069fbab764ebaf4b  ./target/x86_64-unknown-linux-musl/release/oak_loader

--- a/scripts/build_reproducibility_index
+++ b/scripts/build_reproducibility_index
@@ -12,8 +12,7 @@ source "$SCRIPTS_DIR/common"
 
 # List of artifacts that are expected to be reproducibly built.
 readonly REPRODUCIBLE_ARTIFACTS=(
-  # TODO(#865): Include wasm files when they are reproducibly buildable.
-  # ./target/wasm32-unknown-unknown/release/*.wasm
+  ./target/wasm32-unknown-unknown/release/*.wasm
   ./target/x86_64-unknown-linux-musl/release/oak_loader
 )
 


### PR DESCRIPTION
Revert af85a1c since it is too annoying
to keep the index in sync at each commit.

Supersedes #895

Ref #861