### PR TITLE
Add initial authentication server implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,27 @@ dependencies = [
  "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "open 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "auth_server"
+version = "0.1.0"
+dependencies = [
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "examples/aggregator/common",
   "examples/aggregator/module/rust",
   "examples/authentication/client",
+  "examples/authentication/server",
   "examples/chat/module/rust",
   "examples/hello_world/module/rust",
   "examples/machine_learning/module/rust",

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -12,10 +12,16 @@ of the redirection URL and returned to the main thread.
 TODO(#855): The authentication code can then be exchanged for an identity token
 by the authentication server.
 
-The client can be executed using:
+The server can be run using:
 
 ```bash
-cargo run --package=auth_client -- --client-id=691249393555-0h52jim9ni9clkpd5chi82q9ccn44ebm.apps.googleusercontent.com
+cargo run --package=auth_server -- --client-id=691249393555-0h52jim9ni9clkpd5chi82q9ccn44ebm.apps.googleusercontent.com
+```
+
+While the server is running, the client can be executed using:
+
+```bash
+cargo run --package=auth_client
 ```
 
 This requires a valid OAuth Client ID, which can be created as described in

--- a/examples/authentication/client/Cargo.toml
+++ b/examples/authentication/client/Cargo.toml
@@ -13,6 +13,11 @@ futures-util = { version = "*", default-features = false }
 hyper = "*"
 log = "*"
 open = "*"
+prost = "*"
 structopt = "*"
-tokio = "*"
+tokio = { version = "*", features = ["fs", "macros", "sync", "stream"] }
+tonic = { version = "*", features = ["tls"] }
 url = "*"
+
+[build-dependencies]
+tonic-build = "*"

--- a/examples/authentication/client/build.rs
+++ b/examples/authentication/client/build.rs
@@ -1,0 +1,32 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto_path = Path::new("../../../examples/authentication/proto");
+    let file_path = proto_path.join("authentication.proto");
+
+    // Tell cargo to rerun this build script if the proto file has changed.
+    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
+    println!("cargo:rerun-if-changed={}", file_path.display());
+
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(false)
+        .compile(&[file_path.as_path()], &[proto_path])?;
+    Ok(())
+}

--- a/examples/authentication/client/src/auth_client.rs
+++ b/examples/authentication/client/src/auth_client.rs
@@ -1,0 +1,60 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use proto::authentication_client::AuthenticationClient;
+use tonic::transport::{Certificate, Channel, ClientTlsConfig};
+use url::Url;
+
+pub mod proto {
+    tonic::include_proto!("oak.examples.authentication");
+}
+
+/// Gets the URL for authentication requests.
+///
+/// See: https://developers.google.com/identity/protocols/oauth2/openid-connect#sendauthrequest
+/// for more details on the request URL for the Google Identity Platform.
+pub async fn get_authentication_request_url(
+    ca_cert: &str,
+    auth_server: &str,
+    redirect_address: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let root_cert = tokio::fs::read(ca_cert).await?;
+    let root_cert = Certificate::from_pem(root_cert);
+    let tls_config = ClientTlsConfig::new().ca_certificate(root_cert);
+
+    let channel = Channel::from_shared(auth_server.to_owned())?
+        .tls_config(tls_config)
+        .connect()
+        .await?;
+
+    let mut auth_client = AuthenticationClient::new(channel);
+
+    let request = tonic::Request::new(());
+    let response = auth_client.get_auth_parameters(request).await?.into_inner();
+
+    let mut auth_endpoint = Url::parse(&response.auth_endpoint).unwrap();
+    // TODO(#886): Consider retrieving scope from server.
+    let scope = "openid email";
+    let redirect_url = format!("http://{}", redirect_address);
+    // TODO(#886): Retrieve state and code challenge from server and add to request.
+    auth_endpoint
+        .query_pairs_mut()
+        .append_pair("scope", scope)
+        .append_pair("response_type", "code")
+        .append_pair("redirect_uri", &redirect_url)
+        .append_pair("client_id", &response.client_id);
+    Ok(auth_endpoint.to_string())
+}

--- a/examples/authentication/client/src/main.rs
+++ b/examples/authentication/client/src/main.rs
@@ -20,7 +20,7 @@
 //! https://developers.google.com/identity/
 
 use hyper::Server;
-use log::info;
+use log::{info, warn};
 use structopt::StructOpt;
 use tokio::sync::{mpsc, oneshot};
 
@@ -105,8 +105,10 @@ async fn get_authentication_code(
     // Notify local HTTP server to shutdown.
     shutdown_sender.send(()).unwrap();
 
-    // Wait until graceful shutdown is completed, ignoring shutdown errors.
-    task.await.ok();
+    // Wait until graceful shutdown is completed, logging shutdown errors.
+    if let Err(error) = task.await {
+        warn!("Error while shutting down server: {}", error);
+    }
     let code = result.unwrap().unwrap();
     Ok(code)
 }

--- a/examples/authentication/client/src/main.rs
+++ b/examples/authentication/client/src/main.rs
@@ -19,19 +19,13 @@
 //! This example uses the Google Identity Platform.
 //! https://developers.google.com/identity/
 
-use futures_util::future;
-use hyper::{service::Service, Body, Request, Response, Server, StatusCode};
-use log::{info, warn};
-use std::{
-    collections::HashMap,
-    task::{Context, Poll},
-};
+use hyper::Server;
+use log::info;
 use structopt::StructOpt;
-use tokio::sync::{
-    mpsc::{self, Sender},
-    oneshot,
-};
-use url::{form_urlencoded, Url};
+use tokio::sync::{mpsc, oneshot};
+
+mod auth_client;
+mod redirect_handler;
 
 #[derive(StructOpt, Clone)]
 #[structopt(about = "OpenID Connect Client Example.")]
@@ -39,34 +33,56 @@ pub struct Opt {
     #[structopt(
         long,
         help = "Address of the Oak application to connect to.",
-        default_value = "127.0.0.1:8080"
+        default_value = "https://127.0.0.1:8080"
     )]
     address: String,
+    #[structopt(
+        long,
+        help = "Address of the authentication server.",
+        default_value = "https://localhost:8081"
+    )]
+    auth_server: String,
     #[structopt(
         long,
         help = "Address to listen on for the OAuth redirect.",
         default_value = "127.0.0.1:8089"
     )]
     redirect_address: String,
-    #[structopt(long, help = "Path to the PEM-encoded CA root certificate.")]
-    ca_cert: Option<String>,
-    // TODO(#886): Retrieve client_id from server, rather than flag.
-    #[structopt(long, help = "The OAuth client ID.")]
-    client_id: String,
+    #[structopt(
+        long,
+        help = "Path to the PEM-encoded CA root certificate.",
+        default_value = "examples/certs/local/ca.pem"
+    )]
+    ca_cert: String,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let opt = Opt::from_args();
-    let redirect_address = opt.redirect_address.parse()?;
-    info!("Listening for redirect on {}", &redirect_address);
+    let mut runner = tokio::runtime::Runtime::new().unwrap();
+    let request_url = runner.block_on(auth_client::get_authentication_request_url(
+        &opt.ca_cert,
+        &opt.auth_server,
+        &opt.redirect_address,
+    ))?;
+    let code = runner.block_on(get_authentication_code(&opt.redirect_address, &request_url))?;
+    info!("Received code: {}", code);
+    Ok(())
+}
 
+/// Gets the OIDC authentication code by opening the default browser and extracting it from the
+/// resulting redirect URL.
+async fn get_authentication_code(
+    redirect_address: &str,
+    request_url: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (result_sender, mut result_receiver) = mpsc::channel(1);
-    let producer = RedirectHandlerProducer { result_sender };
+    let producer = redirect_handler::RedirectHandlerProducer::new(result_sender);
 
-    let mut runner = tokio::runtime::Runtime::new().unwrap();
-    let task = runner.spawn(async move {
+    let redirect_address = redirect_address.parse()?;
+    info!("Listening for redirect on {}", &redirect_address);
+    let task = tokio::spawn(async move {
         Server::bind(&redirect_address)
             .serve(producer)
             // Use oneshot channel as signal for shutdown.
@@ -77,127 +93,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap();
     });
 
-    let request_url = get_authentication_request_url(opt);
     info!("Opening Auth request in Browser");
     info!("URL: {}", &request_url);
     // Open the URL in the system-configured default browser.
     open::that(request_url)?;
 
     // Wait for result sent by redirect handler.
-    let result = runner.block_on(result_receiver.recv());
+    let result = result_receiver.recv().await;
     result_receiver.close();
 
-    // Notify server to shutdown.
+    // Notify local HTTP server to shutdown.
     shutdown_sender.send(()).unwrap();
 
-    // Wait until graceful shutdown is completed..
-    runner.block_on(task)?;
-
+    // Wait until graceful shutdown is completed, ignoring shutdown errors.
+    task.await.ok();
     let code = result.unwrap().unwrap();
-    info!("Received code: {}", code);
-    Ok(())
-}
-
-/// Gets the URL for authentication requests.
-///
-/// See: https://developers.google.com/identity/protocols/oauth2/openid-connect#sendauthrequest
-/// for more details on the request URL for the Google Identity Platform.
-fn get_authentication_request_url(opt: Opt) -> String {
-    // TODO(#886): Retrieve endpoint from server.
-    let mut auth_endpoint = Url::parse("https://accounts.google.com/o/oauth2/v2/auth").unwrap();
-    // TODO(#886): Consider retrieving scope from server.
-    let scope = "openid email";
-    let redirect_url = format!("http://{}", opt.redirect_address);
-    // TODO(#886): Retrieve state and code challenge from server and add to request.
-    auth_endpoint
-        .query_pairs_mut()
-        .append_pair("scope", scope)
-        .append_pair("response_type", "code")
-        .append_pair("redirect_uri", &redirect_url)
-        .append_pair("client_id", &opt.client_id);
-    auth_endpoint.to_string()
-}
-
-/// Handles the redirects to extract code from the query string.
-///
-/// A new instance is created for every incoming request. The redirect URL contains the result of
-/// the authentication as query string parameters. If the the authentication is successful the
-/// authentication code is passed in the `code` parameter. If it failed the reason is passed in
-/// the `error` parameter.
-///
-/// The `result_sender` is used to communicate the results back to the main function.
-///
-/// The handler is responsible for sending an appropriate response to the client browser.
-struct RedirectHandler {
-    result_sender: Sender<Result<String, String>>,
-}
-
-impl Service<Request<Body>> for RedirectHandler {
-    type Response = Response<Body>;
-    type Error = hyper::Error;
-    type Future = future::Ready<Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Ok(()).into()
-    }
-
-    fn call(&mut self, request: Request<Body>) -> Self::Future {
-        if let Some(query) = request.uri().query() {
-            let lookup: HashMap<_, _> = form_urlencoded::parse(query.as_bytes()).collect();
-            if let Some(code) = lookup.get("code") {
-                let code = code.to_string();
-                info!("Auth code: {:?}", code);
-                self.result_sender.try_send(Ok(code)).unwrap();
-                future::ok(Response::new(Body::from("Success!")))
-            } else if let Some(error) = lookup.get("error") {
-                let error = error.to_string();
-                warn!("Error: {:?}", error);
-                self.result_sender.try_send(Err(error)).unwrap();
-                future::ok(
-                    Response::builder()
-                        .status(StatusCode::UNAUTHORIZED)
-                        .body(Body::from("Authentication failed!"))
-                        .unwrap(),
-                )
-            } else {
-                future::ok(
-                    Response::builder()
-                        .status(StatusCode::BAD_REQUEST)
-                        .body(Body::from("Invalid query string!"))
-                        .unwrap(),
-                )
-            }
-        } else {
-            future::ok(
-                Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(Body::from("No query string!"))
-                    .unwrap(),
-            )
-        }
-    }
-}
-
-/// Produces instances of the redirect handler service.
-///
-/// Hyper uses it to create a new handler for every incoming request. The handler needs a copy of
-/// the reference to the ResultSender to communicate the results back to the main thread.
-struct RedirectHandlerProducer {
-    result_sender: Sender<Result<String, String>>,
-}
-
-impl<T> Service<T> for RedirectHandlerProducer {
-    type Response = RedirectHandler;
-    type Error = std::io::Error;
-    type Future = future::Ready<Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Ok(()).into()
-    }
-
-    fn call(&mut self, _: T) -> Self::Future {
-        future::ok(RedirectHandler {
-            result_sender: self.result_sender.clone(),
-        })
-    }
+    Ok(code)
 }

--- a/examples/authentication/client/src/main.rs
+++ b/examples/authentication/client/src/main.rs
@@ -56,16 +56,17 @@ pub struct Opt {
     ca_cert: String,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let opt = Opt::from_args();
-    let mut runner = tokio::runtime::Runtime::new().unwrap();
-    let request_url = runner.block_on(auth_client::get_authentication_request_url(
+    let request_url = auth_client::get_authentication_request_url(
         &opt.ca_cert,
         &opt.auth_server,
         &opt.redirect_address,
-    ))?;
-    let code = runner.block_on(get_authentication_code(&opt.redirect_address, &request_url))?;
+    )
+    .await?;
+    let code = get_authentication_code(&opt.redirect_address, &request_url).await?;
     info!("Received code: {}", code);
     Ok(())
 }

--- a/examples/authentication/client/src/redirect_handler.rs
+++ b/examples/authentication/client/src/redirect_handler.rs
@@ -1,0 +1,115 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use futures_util::future;
+use hyper::{service::Service, Body, Request, Response, StatusCode};
+use log::{info, warn};
+use std::{
+    collections::HashMap,
+    task::{Context, Poll},
+};
+use tokio::sync::mpsc::Sender;
+use url::form_urlencoded;
+
+/// Handles the redirects to extract code from the query string.
+///
+/// A new instance is created for every incoming request. The redirect URL contains the result of
+/// the authentication as query string parameters. If the the authentication is successful the
+/// authentication code is passed in the `code` parameter. If it failed the reason is passed in
+/// the `error` parameter.
+///
+/// The `result_sender` is used to communicate the results back to the main function.
+///
+/// The handler is responsible for sending an appropriate response to the client browser.
+pub struct RedirectHandler {
+    result_sender: Sender<Result<String, String>>,
+}
+
+impl Service<Request<Body>> for RedirectHandler {
+    type Response = Response<Body>;
+    type Error = hyper::Error;
+    type Future = future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Ok(()).into()
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        if let Some(query) = request.uri().query() {
+            let lookup: HashMap<_, _> = form_urlencoded::parse(query.as_bytes()).collect();
+            if let Some(code) = lookup.get("code") {
+                let code = code.to_string();
+                info!("Auth code: {:?}", code);
+                self.result_sender.try_send(Ok(code)).unwrap();
+                future::ok(Response::new(Body::from("Success!")))
+            } else if let Some(error) = lookup.get("error") {
+                let error = error.to_string();
+                warn!("Error: {:?}", error);
+                self.result_sender.try_send(Err(error)).unwrap();
+                future::ok(
+                    Response::builder()
+                        .status(StatusCode::UNAUTHORIZED)
+                        .body(Body::from("Authentication failed!"))
+                        .unwrap(),
+                )
+            } else {
+                future::ok(
+                    Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(Body::from("Invalid query string!"))
+                        .unwrap(),
+                )
+            }
+        } else {
+            future::ok(
+                Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Body::from("No query string!"))
+                    .unwrap(),
+            )
+        }
+    }
+}
+
+/// Produces instances of the redirect handler service.
+///
+/// Hyper uses it to create a new handler for every incoming request. The handler needs a copy of
+/// the reference to the ResultSender to communicate the results back to the main thread.
+pub struct RedirectHandlerProducer {
+    result_sender: Sender<Result<String, String>>,
+}
+
+impl RedirectHandlerProducer {
+    pub fn new(result_sender: Sender<Result<String, String>>) -> RedirectHandlerProducer {
+        RedirectHandlerProducer { result_sender }
+    }
+}
+
+impl<T> Service<T> for RedirectHandlerProducer {
+    type Response = RedirectHandler;
+    type Error = std::io::Error;
+    type Future = future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Ok(()).into()
+    }
+
+    fn call(&mut self, _: T) -> Self::Future {
+        future::ok(RedirectHandler {
+            result_sender: self.result_sender.clone(),
+        })
+    }
+}

--- a/examples/authentication/proto/authentication.proto
+++ b/examples/authentication/proto/authentication.proto
@@ -1,0 +1,32 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.examples.authentication;
+
+import "google/protobuf/empty.proto";
+
+// Parameters needed by clients to initiate OpenID Connect authentication requests.
+message AuthParameters {
+  string client_id = 1;
+  string auth_endpoint = 2;
+  // TODO(#886): Add support for scope, state and code challenge.
+}
+
+service Authentication {
+  rpc GetAuthParameters(google.protobuf.Empty) returns (AuthParameters);
+}

--- a/examples/authentication/server/Cargo.toml
+++ b/examples/authentication/server/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "auth_server"
+version = "0.1.0"
+authors = ["Conrad Grobler <grobler@google.com>"]
+edition = "2018"
+
+[dependencies]
+env_logger = "*"
+futures-core = "*"
+futures-util = "*"
+log = "*"
+prost = "*"
+structopt = "*"
+tokio = { version = "*", features = ["fs", "macros", "sync", "stream"] }
+tonic = { version = "*", features = ["tls"] }
+
+[build-dependencies]
+tonic-build = "*"

--- a/examples/authentication/server/build.rs
+++ b/examples/authentication/server/build.rs
@@ -1,0 +1,32 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto_path = Path::new("../../../examples/authentication/proto");
+    let file_path = proto_path.join("authentication.proto");
+
+    // Tell cargo to rerun this build script if the proto file has changed.
+    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
+    println!("cargo:rerun-if-changed={}", file_path.display());
+
+    tonic_build::configure()
+        .build_client(false)
+        .build_server(true)
+        .compile(&[file_path.as_path()], &[proto_path])?;
+    Ok(())
+}

--- a/examples/authentication/server/src/main.rs
+++ b/examples/authentication/server/src/main.rs
@@ -50,6 +50,8 @@ impl Authentication for AuthenticationHandler {
     ) -> Result<Response<AuthParameters>, Status> {
         Ok(Response::new(AuthParameters {
             client_id: self.client_id.clone(),
+            // Using Google Identity Platform enpoint for this example.
+            // See https://developers.google.com/identity/protocols/oauth2/openid-connect
             auth_endpoint: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
         }))
     }

--- a/examples/authentication/server/src/main.rs
+++ b/examples/authentication/server/src/main.rs
@@ -1,0 +1,104 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Example implemenation of an OpenID Connect authentication server.
+//!
+//! This example uses the Google Identity Platform.
+//! https://developers.google.com/identity/
+//!
+//! The additional authentication server is primarily used so that we do not have to expose the
+//! client secret to the client app, where it could be extracted.
+
+pub mod proto {
+    tonic::include_proto!("oak.examples.authentication");
+}
+
+use log::info;
+use proto::{
+    authentication_server::{Authentication, AuthenticationServer},
+    AuthParameters,
+};
+use structopt::StructOpt;
+use tonic::{
+    transport::{Identity, Server, ServerTlsConfig},
+    Request, Response, Status,
+};
+
+#[derive(Default)]
+pub struct AuthenticationHandler {
+    client_id: String,
+}
+
+#[tonic::async_trait]
+impl Authentication for AuthenticationHandler {
+    async fn get_auth_parameters(
+        &self,
+        _req: Request<()>,
+    ) -> Result<Response<AuthParameters>, Status> {
+        Ok(Response::new(AuthParameters {
+            client_id: self.client_id.clone(),
+            auth_endpoint: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
+        }))
+    }
+}
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "OpenID Connect Server Example.")]
+pub struct Opt {
+    #[structopt(
+        long,
+        help = "Address to listen on for client connections.",
+        default_value = "127.0.0.1:8081"
+    )]
+    address: String,
+    #[structopt(long, help = "The OAuth client ID.")]
+    client_id: String,
+    #[structopt(
+        long,
+        help = "The path to the PEM-encoded TLS certificate.",
+        default_value = "examples/certs/local/local.pem"
+    )]
+    cert: String,
+    #[structopt(
+        long,
+        help = "The path to the private key for the TLS certificate.",
+        default_value = "examples/certs/local/local.key"
+    )]
+    private_key: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    let opt = Opt::from_args();
+    let address = opt.address.parse()?;
+    let cert = tokio::fs::read(opt.cert).await?;
+    let key = tokio::fs::read(opt.private_key).await?;
+    let identity = Identity::from_pem(cert, key);
+    let handler = AuthenticationHandler {
+        client_id: opt.client_id.clone(),
+    };
+
+    info!("Starting the auth server at {:?}", address);
+
+    Server::builder()
+        .tls_config(ServerTlsConfig::new().identity(identity))
+        .add_service(AuthenticationServer::new(handler))
+        .serve(address)
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This initial version of the auth server only provides the client ID and OAuth endpoint to the client. Subsequent versions will expand the parameters provided and implement the logic the exchange the authentication code for an identity token.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
