### PR TITLE
Update termination condition of `wait_on_channels`

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -87,12 +87,13 @@ functions** as
 ### wait_on_channels
 
 `wait_on_channels(usize, u32) -> u32` blocks until data is available for reading
-from one of the specified channel handles. The channel handles are encoded in a
-buffer that holds N contiguous 9-byte chunks, each of which is made up of an
-8-byte channel handle value (little-endian u64) followed by a single channel
-status byte. Invalid handles will have an `INVALID_CHANNEL` status, but
-`wait_on_channels` return value will only fail for internal errors or if _all_
-channels are invalid.
+from one of the specified channel handles, unless any of the channels is invalid
+or orphaned. The channel handles are encoded in a buffer that holds N contiguous
+9-byte chunks, each of which is made up of an 8-byte channel handle value
+(little-endian u64) followed by a single channel status byte. Invalid and
+orphaned handles will have an `INVALID_CHANNEL` or an `ORPHANED` status,
+respectively. `wait_on_channels` return value will fail for internal errors or
+if _any_ of the channels is invalid or orphaned.
 
 If reading from any of the specified (valid) channels would violate
 [information flow control](/docs/concepts.md#labels), returns

--- a/examples/abitest/module_1/rust/src/lib.rs
+++ b/examples/abitest/module_1/rust/src/lib.rs
@@ -63,7 +63,7 @@ fn inner_main(in_handle: u64) -> Result<(), oak::OakStatus> {
     // Wait on 1+N read handles (starting with N=0).
     let mut wait_handles = vec![in_channel];
     loop {
-        let ready_status = oak::wait_on_channels(&wait_handles)?;
+        let (ready_status, _all_valid) = oak::wait_on_channels(&wait_handles)?;
         // If there is a message on in_channel, it is expected to contain
         // a collection of read handles for future listening
         if ready_status[0] == oak::ChannelReadStatus::ReadReady {

--- a/oak/proto/oak_abi.proto
+++ b/oak/proto/oak_abi.proto
@@ -44,6 +44,8 @@ enum OakStatus {
   ERR_CHANNEL_EMPTY = 10;
   // The node does not have sufficient permissions to perform the requested operation.
   ERR_PERMISSION_DENIED = 11;
+  // One or more of the channels are invalid
+  ERR_INVALID_CHANNEL = 12;
 }
 
 // Single byte values used to indicate the read status of a channel on the

--- a/oak/proto/oak_abi.proto
+++ b/oak/proto/oak_abi.proto
@@ -44,7 +44,7 @@ enum OakStatus {
   ERR_CHANNEL_EMPTY = 10;
   // The node does not have sufficient permissions to perform the requested operation.
   ERR_PERMISSION_DENIED = 11;
-  // One or more of the channels are invalid
+  // One or more of the channels are invalid or orphaned.
   ERR_INVALID_CHANNEL = 12;
 }
 

--- a/oak/server/rust/oak_abi/src/lib.rs
+++ b/oak/server/rust/oak_abi/src/lib.rs
@@ -44,9 +44,14 @@ pub const SPACE_BYTES_PER_HANDLE: usize = 9;
 /// Invalid handle value.
 pub const INVALID_HANDLE: Handle = 0;
 
+/// Distinguishes between failure conditions that happen due to erroneous channel statuses, and
+/// general failures indicated by `OakStatus`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ChannelStatusError {
+    /// Provides the caller with `ChannelReadStatus`es to allow investigating the failure
+    /// condition.
     HasInvalid(Vec<ChannelReadStatus>),
+    /// Indicates general failure conditions.
     Error(OakStatus),
 }
 

--- a/oak/server/rust/oak_abi/src/lib.rs
+++ b/oak/server/rust/oak_abi/src/lib.rs
@@ -44,6 +44,23 @@ pub const SPACE_BYTES_PER_HANDLE: usize = 9;
 /// Invalid handle value.
 pub const INVALID_HANDLE: Handle = 0;
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ChannelStatusError {
+    HasInvalid(Vec<ChannelReadStatus>),
+    Error(OakStatus),
+}
+
+impl From<OakStatus> for ChannelStatusError {
+    fn from(status: OakStatus) -> Self {
+        match status {
+            OakStatus::ErrInvalidChannel => {
+                panic!("Cannot map OakStatus::ErrInvalidChannel to ChannelStatusError.")
+            }
+            s => ChannelStatusError::Error(s),
+        }
+    }
+}
+
 // The Oak ABI primarily consists of a collection of Wasm host functions in the
 // "oak" module that are made available to WebAssembly Nodes running under the
 // Oak runtime.

--- a/oak/server/rust/oak_abi/src/proto/oak_abi.rs
+++ b/oak/server/rust/oak_abi/src/proto/oak_abi.rs
@@ -26,6 +26,8 @@ pub enum OakStatus {
     ErrChannelEmpty = 10,
     /// The node does not have sufficient permissions to perform the requested operation.
     ErrPermissionDenied = 11,
+    /// One or more of the channels are invalid
+    ErrInvalidChannel = 12,
 }
 /// Single byte values used to indicate the read status of a channel on the
 /// `oak.wait_on_channels` host function.

--- a/oak/server/rust/oak_abi/src/proto/oak_abi.rs
+++ b/oak/server/rust/oak_abi/src/proto/oak_abi.rs
@@ -26,7 +26,7 @@ pub enum OakStatus {
     ErrChannelEmpty = 10,
     /// The node does not have sufficient permissions to perform the requested operation.
     ErrPermissionDenied = 11,
-    /// One or more of the channels are invalid
+    /// One or more of the channels are invalid or orphaned.
     ErrInvalidChannel = 12,
 }
 /// Single byte values used to indicate the read status of a channel on the

--- a/oak/server/rust/oak_glue/src/lib.rs
+++ b/oak/server/rust/oak_glue/src/lib.rs
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn glue_wait_on_channels(node_id: u64, buf: *mut u8, count
         }
 
         let proxy = proxy_for_node(node_id);
-        let channel_statuses = match proxy.wait_on_channels(&handles) {
+        let (channel_statuses, all_valid) = match proxy.wait_on_channels(&handles) {
             Ok(r) => r,
             Err(s) => return s as u32,
         };
@@ -192,7 +192,11 @@ pub unsafe extern "C" fn glue_wait_on_channels(node_id: u64, buf: *mut u8, count
 
             *p = *channel_status as u8;
         }
-        OakStatus::Ok as u32
+        if all_valid {
+            OakStatus::Ok as u32
+        } else {
+            OakStatus::ErrInvalidChannel as u32
+        }
     })
     .unwrap_or(OakStatus::ErrInternal as u32)
 }

--- a/oak/server/rust/oak_runtime/src/node/grpc_server.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc_server.rs
@@ -24,8 +24,7 @@ use std::{
 };
 
 use oak_abi::{
-    grpc::encap_request, label::Label, proto::oak::encap::GrpcRequest, ChannelReadStatus,
-    ChannelStatusError, OakStatus,
+    grpc::encap_request, label::Label, proto::oak::encap::GrpcRequest, ChannelReadStatus, OakStatus,
 };
 
 use crate::{metrics::METRICS, pretty_name_for_thread, runtime::RuntimeProxy, Handle};
@@ -118,10 +117,7 @@ impl GrpcServerNode {
             .wait_on_channels(&[self.initial_reader])
             .map_err(|error| {
                 error!("Couldn't wait on the initial reader handle: {:?}", error);
-                match error {
-                    ChannelStatusError::HasInvalid(_) => OakStatus::ErrInvalidChannel,
-                    ChannelStatusError::Error(_) => OakStatus::ErrInternal,
-                }
+                OakStatus::ErrInternal
             })?;
 
         if read_status[0] == ChannelReadStatus::ReadReady {

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -568,6 +568,7 @@ impl WasmInterface {
             }
         }
 
+        // If there are no valid channels, return with statuses of all the channels set to invalid.
         if valid_channels.is_empty() {
             self.set_statuses(&all_statuses, status_buff)?;
             return Err(OakStatus::ErrBadHandle);
@@ -599,6 +600,7 @@ impl WasmInterface {
         }
     }
 
+    // Fills the `status_buff` with channel statuses in `all_statuses`.
     fn set_statuses(
         &self,
         all_statuses: &[ChannelReadStatus],

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -568,12 +568,9 @@ impl WasmInterface {
             }
         }
 
-        // If there are no valid channels, return with statuses of all the channels set to invalid.
-        if valid_channels.is_empty() {
-            self.set_statuses(&all_statuses, status_buff)?;
-            return Err(OakStatus::ErrBadHandle);
-        }
-
+        // Set all statuses to invalid, so that in case of an error, the buffer matches the returned
+        // OakStatus.
+        self.set_statuses(&all_statuses, status_buff)?;
         let (valid_statuses, all_valid) = match self.runtime.wait_on_channels(&valid_channels) {
             Ok(s) => Ok((s, true)),
             Err(ChannelStatusError::HasInvalid(s)) => Ok((s, false)),

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -685,6 +685,10 @@ impl Runtime {
         node_id: NodeId,
         readers: &[Handle],
     ) -> Result<Vec<ChannelReadStatus>, ChannelStatusError> {
+        if readers.is_empty() {
+            return Err(ChannelStatusError::Error(OakStatus::ErrBadHandle));
+        }
+
         self.validate_handles_access(node_id, readers)?;
         self.validate_can_read_from_channels(node_id, readers)?;
 

--- a/sdk/rust/oak/src/io/mod.rs
+++ b/sdk/rust/oak/src/io/mod.rs
@@ -71,5 +71,8 @@ pub fn error_from_nonok_status(status: OakStatus) -> io::Error {
         OakStatus::ErrPermissionDenied => {
             io::Error::new(io::ErrorKind::PermissionDenied, "Permission denied")
         }
+        OakStatus::ErrInvalidChannel => {
+            io::Error::new(io::ErrorKind::InvalidInput, "Invalid channel")
+        }
     }
 }


### PR DESCRIPTION
- `Wait_on_channels` returns immediately if at least one channel is invalid or orphaned
- Updated in the `Runtime`, `ABI`, `SDK`, and `oak_glue`
- Added a new `OakStatus` named `ErrInvalidChannel` to signal the error 
- Added unit tests and updated docs

Fixes #803 

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [x] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
