### PR TITLE
Rust runtime smaller tweaks

### DIFF
--- a/oak/server/grpc_client_node.cc
+++ b/oak/server/grpc_client_node.cc
@@ -195,6 +195,7 @@ void GrpcClientNode::Run(Handle invocation_handle) {
       OAK_LOG(ERROR) << "Invocation processing failed!";
     }
   }
+  ChannelClose(invocation_handle);
 }
 
 }  // namespace oak

--- a/oak/server/roughtime_client_node.cc
+++ b/oak/server/roughtime_client_node.cc
@@ -92,8 +92,9 @@ void RoughtimeClientNode::Run(Handle invocation_handle) {
     grpc_rsp.SerializeToArray(rsp_msg->data.data(), rsp_msg->data.size());
     ChannelWrite(invocation->rsp_handle.get(), std::move(rsp_msg));
 
-    // The response channel reference is dropped here.
+    // The Invocation reference is dropped here, which closes the request & response channels.
   }
+  ChannelClose(invocation_handle);
 }
 
 }  // namespace oak

--- a/oak/server/rust/oak_runtime/src/node/logger.rs
+++ b/oak/server/rust/oak_runtime/src/node/logger.rs
@@ -52,6 +52,7 @@ impl LogNode {
         let pretty_name = pretty_name_for_thread(&thread::current());
         let result = self.logger_loop(&pretty_name);
         info!("{} LOG: exiting log thread {:?}", pretty_name, result);
+        let _ = self.runtime.channel_close(self.reader);
         self.runtime.exit_node();
     }
 

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -623,93 +623,42 @@ impl wasmi::Externals for WasmInterface {
         args: wasmi::RuntimeArgs,
     ) -> Result<Option<wasmi::RuntimeValue>, wasmi::Trap> {
         match index {
-            NODE_CREATE => {
-                let name_ptr: u32 = args.nth_checked(0)?;
-                let name_length: u32 = args.nth_checked(1)?;
-                let entrypoint_ptr: u32 = args.nth_checked(2)?;
-                let entrypoint_length: u32 = args.nth_checked(3)?;
-                let label_ptr: u32 = args.nth_checked(4)?;
-                let label_length: u32 = args.nth_checked(5)?;
-                let initial_handle: u64 = args.nth_checked(6)?;
-
-                map_host_errors(self.node_create(
-                    name_ptr,
-                    name_length,
-                    entrypoint_ptr,
-                    entrypoint_length,
-                    label_ptr,
-                    label_length,
-                    initial_handle,
-                ))
-            }
-
+            NODE_CREATE => map_host_errors(self.node_create(
+                args.nth_checked(0)?,
+                args.nth_checked(1)?,
+                args.nth_checked(2)?,
+                args.nth_checked(3)?,
+                args.nth_checked(4)?,
+                args.nth_checked(5)?,
+                args.nth_checked(6)?,
+            )),
             RANDOM_GET => {
-                let dest: u32 = args.nth_checked(0)?;
-                let dest_length: u32 = args.nth_checked(1)?;
-
-                map_host_errors(self.random_get(dest, dest_length))
+                map_host_errors(self.random_get(args.nth_checked(0)?, args.nth_checked(1)?))
             }
-
-            CHANNEL_CLOSE => {
-                let handle: u64 = args.nth_checked(0)?;
-
-                map_host_errors(self.channel_close(handle))
-            }
-
+            CHANNEL_CLOSE => map_host_errors(self.channel_close(args.nth_checked(0)?)),
             CHANNEL_CREATE => {
-                let write_addr: u32 = args.nth_checked(0)?;
-                let read_addr: u32 = args.nth_checked(1)?;
-
-                map_host_errors(self.channel_create(write_addr, read_addr))
+                map_host_errors(self.channel_create(args.nth_checked(0)?, args.nth_checked(1)?))
             }
-
-            CHANNEL_WRITE => {
-                let writer_handle: u64 = args.nth_checked(0)?;
-                let source: u32 = args.nth_checked(1)?;
-                let source_length: u32 = args.nth_checked(2)?;
-                let handles: u32 = args.nth_checked(3)?;
-                let handles_count: u32 = args.nth_checked(4)?;
-
-                map_host_errors(self.channel_write(
-                    writer_handle,
-                    source,
-                    source_length,
-                    handles,
-                    handles_count,
-                ))
-            }
-
-            CHANNEL_READ => {
-                let reader_handle: u64 = args.nth_checked(0)?;
-
-                let dest: u32 = args.nth_checked(1)?;
-                let dest_capacity: u32 = args.nth_checked(2)?;
-                let actual_length: u32 = args.nth_checked(3)?;
-
-                let handles: u32 = args.nth_checked(4)?;
-                let handles_capacity: u32 = args.nth_checked(5)?;
-                let actual_handle_count: u32 = args.nth_checked(6)?;
-
-                map_host_errors(self.channel_read(
-                    reader_handle,
-                    dest,
-                    dest_capacity,
-                    actual_length,
-                    handles,
-                    handles_capacity,
-                    actual_handle_count,
-                ))
-            }
-
+            CHANNEL_WRITE => map_host_errors(self.channel_write(
+                args.nth_checked(0)?,
+                args.nth_checked(1)?,
+                args.nth_checked(2)?,
+                args.nth_checked(3)?,
+                args.nth_checked(4)?,
+            )),
+            CHANNEL_READ => map_host_errors(self.channel_read(
+                args.nth_checked(0)?,
+                args.nth_checked(1)?,
+                args.nth_checked(2)?,
+                args.nth_checked(3)?,
+                args.nth_checked(4)?,
+                args.nth_checked(5)?,
+                args.nth_checked(6)?,
+            )),
             WAIT_ON_CHANNELS => {
-                let status_buff: u32 = args.nth_checked(0)?;
-                let handles_count: u32 = args.nth_checked(1)?;
-
-                map_host_errors(self.wait_on_channels(status_buff, handles_count))
+                map_host_errors(self.wait_on_channels(args.nth_checked(0)?, args.nth_checked(1)?))
             }
-
             WASI_STUB => panic!("Attempt to invoke unimplemented WASI function"),
-
             _ => panic!("Unimplemented function at {}", index),
         }
     }

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -235,7 +235,6 @@ impl WasmInterface {
         })?;
 
         self.runtime
-            .clone()
             .node_create(&config_name, &entrypoint, &label, channel_ref.clone())
             .map_err(|_| {
                 error!(

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -57,10 +57,6 @@ type AbiPointerOffset = u32;
 // Wasm would use a different value.
 const ABI_USIZE: ValueType = ValueType::I32;
 
-// Convenience short names for Wasm sized integer type identifiers.
-const ABI_U32: ValueType = ValueType::I32;
-const ABI_U64: ValueType = ValueType::I64;
-
 /// `WasmInterface` holds runtime values for a particular execution instance of Wasm, running a
 /// single Oak Wasm Node. This includes the host ABI function mapping between the Runtime and a
 /// Wasm instance, and the handle mapping between the instance and the runtime `Handle`s.
@@ -680,15 +676,15 @@ impl wasmi::ModuleImportResolver for WasmInterface {
                 NODE_CREATE,
                 wasmi::Signature::new(
                     &[
-                        ABI_USIZE, // config_buf
-                        ABI_USIZE, // config_len
-                        ABI_USIZE, // entrypoint_buf
-                        ABI_USIZE, // entrypoint_len
-                        ABI_USIZE, // label_buf
-                        ABI_USIZE, // label_len
-                        ABI_U64,   // handle
+                        ABI_USIZE,      // config_buf
+                        ABI_USIZE,      // config_len
+                        ABI_USIZE,      // entrypoint_buf
+                        ABI_USIZE,      // entrypoint_len
+                        ABI_USIZE,      // label_buf
+                        ABI_USIZE,      // label_len
+                        ValueType::I64, // handle
                     ][..],
-                    Some(ABI_U32),
+                    Some(ValueType::I32),
                 ),
             ),
             "random_get" => (
@@ -698,16 +694,16 @@ impl wasmi::ModuleImportResolver for WasmInterface {
                         ABI_USIZE, // buf
                         ABI_USIZE, // len
                     ][..],
-                    Some(ABI_U32),
+                    Some(ValueType::I32),
                 ),
             ),
             "channel_close" => (
                 CHANNEL_CLOSE,
                 wasmi::Signature::new(
                     &[
-                        ABI_U64, // handle
+                        ValueType::I64, // handle
                     ][..],
-                    Some(ABI_U32),
+                    Some(ValueType::I32),
                 ),
             ),
             "channel_create" => (
@@ -717,45 +713,45 @@ impl wasmi::ModuleImportResolver for WasmInterface {
                         ABI_USIZE, // write
                         ABI_USIZE, // read
                     ][..],
-                    Some(ABI_U32),
+                    Some(ValueType::I32),
                 ),
             ),
             "channel_write" => (
                 CHANNEL_WRITE,
                 wasmi::Signature::new(
                     &[
-                        ABI_U64,   // handle
-                        ABI_USIZE, // buf
-                        ABI_USIZE, // size
-                        ABI_USIZE, // handle_buf
-                        ABI_U32,   // handle_count
+                        ValueType::I64, // handle
+                        ABI_USIZE,      // buf
+                        ABI_USIZE,      // size
+                        ABI_USIZE,      // handle_buf
+                        ValueType::I32, // handle_count
                     ][..],
-                    Some(ABI_U32),
+                    Some(ValueType::I32),
                 ),
             ),
             "channel_read" => (
                 CHANNEL_READ,
                 wasmi::Signature::new(
                     &[
-                        ABI_U64,   // handle
-                        ABI_USIZE, // buf
-                        ABI_USIZE, // size
-                        ABI_USIZE, // actual_size
-                        ABI_USIZE, // handle_buf
-                        ABI_U32,   // handle_count
-                        ABI_USIZE, // actual_handle_count
+                        ValueType::I64, // handle
+                        ABI_USIZE,      // buf
+                        ABI_USIZE,      // size
+                        ABI_USIZE,      // actual_size
+                        ABI_USIZE,      // handle_buf
+                        ValueType::I32, // handle_count
+                        ABI_USIZE,      // actual_handle_count
                     ][..],
-                    Some(ABI_U32),
+                    Some(ValueType::I32),
                 ),
             ),
             "wait_on_channels" => (
                 WAIT_ON_CHANNELS,
                 wasmi::Signature::new(
                     &[
-                        ABI_USIZE, // buf
-                        ABI_U32,   // count
+                        ABI_USIZE,      // buf
+                        ValueType::I32, // count
                     ][..],
-                    Some(ABI_U32),
+                    Some(ValueType::I32),
                 ),
             ),
             _ => {
@@ -789,26 +785,45 @@ impl wasmi::ModuleImportResolver for WasiStub {
         signature: &wasmi::Signature,
     ) -> Result<wasmi::FuncRef, wasmi::Error> {
         let (index, sig) = match field_name {
-            "proc_exit" => (WASI_STUB, wasmi::Signature::new(&[ABI_U32][..], None)),
+            "proc_exit" => (
+                WASI_STUB,
+                wasmi::Signature::new(&[ValueType::I32][..], None),
+            ),
             "fd_write" => (
                 WASI_STUB,
-                wasmi::Signature::new(&[ABI_U32, ABI_U32, ABI_U32, ABI_U32][..], Some(ABI_U32)),
+                wasmi::Signature::new(
+                    &[
+                        ValueType::I32,
+                        ValueType::I32,
+                        ValueType::I32,
+                        ValueType::I32,
+                    ][..],
+                    Some(ValueType::I32),
+                ),
             ),
             "fd_seek" => (
                 WASI_STUB,
-                wasmi::Signature::new(&[ABI_U32, ABI_U64, ABI_U32, ABI_U32][..], Some(ABI_U32)),
+                wasmi::Signature::new(
+                    &[
+                        ValueType::I32,
+                        ValueType::I64,
+                        ValueType::I32,
+                        ValueType::I32,
+                    ][..],
+                    Some(ValueType::I32),
+                ),
             ),
             "fd_close" => (
                 WASI_STUB,
-                wasmi::Signature::new(&[ABI_U32][..], Some(ABI_U32)),
+                wasmi::Signature::new(&[ValueType::I32][..], Some(ValueType::I32)),
             ),
             "environ_sizes_get" => (
                 WASI_STUB,
-                wasmi::Signature::new(&[ABI_U32, ABI_U32][..], Some(ABI_U32)),
+                wasmi::Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I32)),
             ),
             "environ_get" => (
                 WASI_STUB,
-                wasmi::Signature::new(&[ABI_U32, ABI_U32][..], Some(ABI_U32)),
+                wasmi::Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I32)),
             ),
             _ => {
                 return Err(wasmi::Error::Instantiation(format!(
@@ -868,7 +883,7 @@ impl WasmNode {
         .expect("failed to instantiate wasm module")
         .assert_no_start();
 
-        let expected_signature = wasmi::Signature::new(&[ABI_U64][..], None);
+        let expected_signature = wasmi::Signature::new(&[ValueType::I64][..], None);
 
         let export = instance.export_by_name(&self.entrypoint).ok_or_else(|| {
             warn!("entrypoint '{}' export not found", self.entrypoint);

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -304,13 +304,13 @@ impl WasmInterface {
             return Err(OakStatus::ErrTerminated);
         }
 
+        self.validate_ptr(write_addr, 8)?;
+        self.validate_ptr(read_addr, 8)?;
+
         let (writer, reader) = self
             .runtime
             // TODO(#630): Let caller provide this label via the Wasm ABI.
             .channel_create(&Label::public_trusted());
-
-        self.validate_ptr(write_addr, 8)?;
-        self.validate_ptr(read_addr, 8)?;
 
         let write_handle = self.allocate_new_handle(writer, HandleDirection::Write);
         let read_handle = self.allocate_new_handle(reader, HandleDirection::Read);


### PR DESCRIPTION
Broke out the more straightforward parts of #894:
 - tweak `wasm/mod.rs` to reduce things than would need to be manually kept in sync
 - reorganize `wasm/mod.rs` to have distinct layers:
     - first get the Wasm arguments and forward on
     - next convert chunks of linear memory into Rust strings and vectors and forward on
     - innermost layer either performs the function (e.g. `random_get`) or forwards on to the `RuntimeProxy`
 - close channels on the way out of pseudo-Nodes.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
