### PR TITLE
Fix `ring` compilation errors in Bazel

### DIFF
--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -63,6 +63,18 @@ additional_flags = ["--cfg=atomic_cas"]
 # automatically add non-`*.rs` files to the Bazel workspace.
 # https://github.com/google/cargo-raze/issues/41
 [raze.crates.ring.'0.16.12']
+gen_buildrs = true
+additional_flags = [
+  # These flags are necessary to link a static `ring-core` library compiled from C sources.
+  #
+  # Do not change `remote/ring-0.16.12.BUILD` since it contains manually added evnironment variables
+  # that were added to solve #890:
+  # https://github.com/project-oak/oak/issues/890#issuecomment-621773356
+  # `cargo raze` can change `remote/ring-0.16.12.BUILD`, so before compiling run:
+  # `git checkout cargo/remote/ring-0.16.12.BUILD
+  "-lstatic=ring-core",
+  "-Lnative=../../../../../execroot/oak/ring_out_dir_outputs/",
+]
 data_attr = "glob([\"**/*.der\"])"
 
 [raze.crates.webpki.'0.21.2']

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -67,11 +67,12 @@ gen_buildrs = true
 additional_flags = [
   # These flags are necessary to link a static `ring-core` library compiled from C sources.
   #
-  # Do not change `remote/ring-0.16.12.BUILD` since it contains manually added evnironment variables
+  # Do not change `remote/ring-0.16.12.BUILD` since it contains manually added environment variables
   # that were added to solve #890:
   # https://github.com/project-oak/oak/issues/890#issuecomment-621773356
-  # `cargo raze` can change `remote/ring-0.16.12.BUILD`, so before compiling run:
+  # `cargo raze` can change `remote/ring-0.16.12.BUILD`, so before compiling, run:
   # git checkout cargo/remote/ring-0.16.12.BUILD
+  # Which is already added to the `./scripts/cargo_raze` script.
   "-lstatic=ring-core",
   "-Lnative=../../../../../execroot/oak/ring_out_dir_outputs/",
 ]

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -71,7 +71,7 @@ additional_flags = [
   # that were added to solve #890:
   # https://github.com/project-oak/oak/issues/890#issuecomment-621773356
   # `cargo raze` can change `remote/ring-0.16.12.BUILD`, so before compiling run:
-  # `git checkout cargo/remote/ring-0.16.12.BUILD
+  # git checkout cargo/remote/ring-0.16.12.BUILD
   "-lstatic=ring-core",
   "-Lnative=../../../../../execroot/oak/ring_out_dir_outputs/",
 ]

--- a/cargo/remote/ring-0.16.12.BUILD
+++ b/cargo/remote/ring-0.16.12.BUILD
@@ -52,7 +52,9 @@ genrule(
       ":ring_build_script",
     ],
     tags = ["no-sandbox"],
-    cmd = "mkdir -p ring_out_dir_outputs/;"
+    # Clear an output directory since `genrule` doesn't use Bazel cache.
+    cmd = "rm -rf ring_out_dir_outputs/*;"
+        + "mkdir -p ring_out_dir_outputs/;"
         + " (export CARGO_MANIFEST_DIR=\"$$PWD/$$(dirname $(location :Cargo.toml))\";"
         + " export TARGET='x86_64-unknown-linux-gnu';"
         + " export RUST_BACKTRACE=1;"
@@ -60,6 +62,8 @@ genrule(
         + " export CARGO_FEATURE_DEFAULT=1;"
         + " export CARGO_FEATURE_DEV_URANDOM_FALLBACK=1;"
         + " export CARGO_FEATURE_LAZY_STATIC=1;"
+
+        # Additional flags for `build.rs`.
         + " export CARGO_PKG_NAME=ring;"
         + " export CARGO_CFG_TARGET_ARCH=x86_64;"
         + " export CARGO_CFG_TARGET_OS=linux;"
@@ -67,6 +71,7 @@ genrule(
         + " export OPT_LEVEL=3;"
         + " export DEBUG=false;"
         + " export HOST=any;"
+
         + " export OUT_DIR=$$PWD/ring_out_dir_outputs;"
         + " export BINARY_PATH=\"$$PWD/$(location :ring_build_script)\";"
         + " export OUT_TAR=$$PWD/$@;"

--- a/cargo/remote/ring-0.16.12.BUILD
+++ b/cargo/remote/ring-0.16.12.BUILD
@@ -54,8 +54,6 @@ genrule(
     tags = ["no-sandbox"],
     cmd = "mkdir -p ring_out_dir_outputs/;"
         + " (export CARGO_MANIFEST_DIR=\"$$PWD/$$(dirname $(location :Cargo.toml))\";"
-        # TODO(acmcarther): This needs to be revisited as part of the cross compilation story.
-        #                   See also: https://github.com/google/cargo-raze/pull/54
         + " export TARGET='x86_64-unknown-linux-gnu';"
         + " export RUST_BACKTRACE=1;"
         + " export CARGO_FEATURE_ALLOC=1;"

--- a/cargo/remote/ring-0.16.12.BUILD
+++ b/cargo/remote/ring-0.16.12.BUILD
@@ -70,7 +70,7 @@ genrule(
         + " export OUT_DIR=$$PWD/ring_out_dir_outputs;"
         + " export BINARY_PATH=\"$$PWD/$(location :ring_build_script)\";"
         + " export OUT_TAR=$$PWD/$@;"
-        + " cd $$(dirname $(location :Cargo.toml)) && echo TEST && pwd && (echo OUT_DIR $$OUT_DIR) && $$BINARY_PATH && tar -czf $$OUT_TAR -C $$OUT_DIR .)"
+        + " cd $$(dirname $(location :Cargo.toml)) && $$BINARY_PATH && tar -czf $$OUT_TAR -C $$OUT_DIR .)"
 )
 
 # Unsupported target "aead_tests" with type "test" omitted

--- a/oak/server/rust/oak_abi/Cargo.toml
+++ b/oak/server/rust/oak_abi/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 # Note that if new dependencies are added here:
 #  - they need to be synced to //cargo/Cargo.toml
-#  - `cd cargo && cargo raze` needs re-running, and the results checked in
+#  - `./scripts/cargo_raze` needs re-running, and the results checked in
 log = "*"
 prost = "*"
 prost-types = "*"

--- a/oak/server/rust/oak_glue/Cargo.toml
+++ b/oak/server/rust/oak_glue/Cargo.toml
@@ -11,7 +11,7 @@ name = "oak_glue"
 [dependencies]
 # Note that if new dependencies are added here:
 #  - they need to be synced to //cargo/Cargo.toml
-#  - `cd cargo && cargo raze` needs re-running, and the results checked in
+#  - `./scripts/cargo_raze` needs re-running, and the results checked in
 byteorder = "*"
 lazy_static = "*"
 log = { version = "*", features = ["std"] }

--- a/oak/server/rust/oak_runtime/Cargo.toml
+++ b/oak/server/rust/oak_runtime/Cargo.toml
@@ -16,7 +16,7 @@ default = ["oak_debug"]
 [dependencies]
 # Note that if new dependencies are added here:
 #  - they need to be synced to //cargo/Cargo.toml
-#  - `cd cargo && cargo raze` needs re-running, and the results checked in
+#  - `./scripts/cargo_raze` needs re-running, and the results checked in
 byteorder = { version = "*", default-features = false }
 bytes = "*"
 futures = "*"

--- a/scripts/cargo_raze
+++ b/scripts/cargo_raze
@@ -9,3 +9,7 @@ cd cargo || exit 1
 # the files for removed/upgraded deps get cleared.
 rm -f remote/*
 cargo raze
+# `remote/ring-0.16.12.BUILD` contains manually added environment
+# variables that were added to solve #890:
+# https://github.com/project-oak/oak/issues/890#issuecomment-621773356
+git checkout remote/ring-0.16.12.BUILD

--- a/scripts/run_clang_tidy
+++ b/scripts/run_clang_tidy
@@ -19,7 +19,9 @@ readonly CLANG_TIDY_FLAGS=(
 )
 
 # Generate compilation database.
-bazel build "${bazel_build_flags[@]}" -- //oak/...:all
+# Clang is required to successfully build targets created by `cargo raze`.
+# `hmac_test` cannon be built with Clang (#936).
+bazel build '--config=clang' "${bazel_build_flags[@]}" -- //oak/...:all -//oak/common:hmac_test
 ./scripts/generate_compilation_database
 
 # Run clang-tidy.

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -17,13 +17,15 @@ cargo test --all-targets
 cargo test --doc
 cargo clippy --all-targets -- --deny=warnings
 
-
 if [[ "${OSTYPE}" == 'darwin'*  ]]; then
   bazel_build_flags+=( '--config=darwin' )
 fi
 bazel_build_flags+=( '--keep_going' )
 
 # Clang is required to successfully build targets created by `cargo raze`.
-bazel build '--config=clang' "${bazel_build_flags[@]}" -- //oak/...:all
+bazel build '--config=clang' "${bazel_build_flags[@]}" -- //oak/...:all -//oak/common:hmac_test
+# `hmac_test` cannon be built with Clang (#936).
+bazel build "${bazel_build_flags[@]}" -- //oak/common:hmac_test
 
-bazel test "${bazel_build_flags[@]}" -- //oak/...:all
+bazel test '--config=clang' "${bazel_build_flags[@]}" -- //oak/...:all -//oak/common:hmac_test
+bazel test "${bazel_build_flags[@]}" -- //oak/common:hmac_test

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -21,7 +21,7 @@ cargo clippy --all-targets -- --deny=warnings
 if [[ "${OSTYPE}" == 'darwin'*  ]]; then
   bazel_build_flags+=( '--config=darwin' )
 fi
-bazel_build_flags+=( '--keep_going' '--config=clang' )
+bazel_build_flags+=( '--keep_going' )
 
 bazel build "${bazel_build_flags[@]}" -- //oak/...:all
 

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -23,6 +23,7 @@ if [[ "${OSTYPE}" == 'darwin'*  ]]; then
 fi
 bazel_build_flags+=( '--keep_going' )
 
-bazel build "${bazel_build_flags[@]}" -- //oak/...:all
+# Clang is required to successfully build targets created by `cargo raze`.
+bazel build '--config=clang' "${bazel_build_flags[@]}" -- //oak/...:all
 
 bazel test "${bazel_build_flags[@]}" -- //oak/...:all

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -18,10 +18,10 @@ cargo test --doc
 cargo clippy --all-targets -- --deny=warnings
 
 
-if [[ "${OSTYPE}" == "darwin"*  ]]; then
-  bazel_build_flags+=( "--config=darwin" )
+if [[ "${OSTYPE}" == 'darwin'*  ]]; then
+  bazel_build_flags+=( '--config=darwin' )
 fi
-bazel_build_flags+=( '--keep_going' )
+bazel_build_flags+=( '--keep_going' '--config=clang' )
 
 bazel build "${bazel_build_flags[@]}" -- //oak/...:all
 


### PR DESCRIPTION
This change fixes `ring` compilation errors in Bazel.
Note: this contains a change in ` cargo/remote/ring-0.16.12.BUILD` that might be rewritten by running `cargo raze` (will require `git checkout cargo/remote/ring-0.16.12.BUILD` afterwards).

Fixes https://github.com/project-oak/oak/issues/890

# Checklist
- [x] Pull request includes prototype/experimental work that is under
      construction.
