### PR TITLE
Add musl-tools to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,6 +9,7 @@ apt install docker.io
 apt install curl
 apt install protobuf-compiler
 apt install libprotobuf-dev
+apt install musl-tools
 apt install openjdk-8-jdk-headless
 echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 curl https://bazel.build/bazel-release.pub.gpg | apt-key add -


### PR DESCRIPTION
This change adds `musl-tools` to `INSTALL.md`

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have updated [documentation](docs/) accordingly.
