### PR TITLE
Add build examples and build server to runner

### DIFF
--- a/scripts/runner
+++ b/scripts/runner
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cargo run --package=runner -- "$@"


### PR DESCRIPTION
It's not quite on par with the other scripts there, but getting there

Add `./scripts/runner` to make it easier to invoke.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
