### PR TITLE
Chat example: Update outdated app_address flag

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -24,11 +24,11 @@ room inside it:
 
 This will emit a trace line that holds the information needed to:
 
-- connect to the same Oak application (with `--app_address`)
+- connect to the same Oak application (with `--address`)
 - join the chat room (with `--room_id`).
 
 ```log
-2019-10-24 10:47:20  INFO  chat.cc : 242 : Join this room with --app_address=127.0.0.1:32889 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
+2019-10-24 10:47:20  INFO  chat.cc : 242 : Join this room with --address=127.0.0.1:32889 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
 ```
 
 Another party can then join the same chat room by using these arguments:
@@ -38,8 +38,8 @@ Another party can then join the same chat room by using these arguments:
 ```
 
 Alternatively, another party can create a new chat room running on the same Oak
-Application by just copying the `--app_address` argument, but specifying a new
-room name:
+Application by just copying the `--address` argument, but specifying a new room
+name:
 
 ```bash
 ./scripts/run_example -s none -e chat -- --address=127.0.0.1:32889
@@ -49,7 +49,7 @@ This will again emit a trace line with the information needed to join this new
 room (on the same server):
 
 ```log
-2019-10-24 11:04:40  INFO  chat.cc : 242 : Join this room with --app_address=127.0.0.1:32889 --room_id=msSGas1Ie2rtGIvG0bLa2Jh3ODjO35nix46R3j2iYjAcB8zDcJpn/P2DD7c0yB1NMmfoipBSAePJzlXjknm8gg==
+2019-10-24 11:04:40  INFO  chat.cc : 242 : Join this room with --address=127.0.0.1:32889 --room_id=msSGas1Ie2rtGIvG0bLa2Jh3ODjO35nix46R3j2iYjAcB8zDcJpn/P2DD7c0yB1NMmfoipBSAePJzlXjknm8gg==
 ```
 
 ## CI Invocation

--- a/examples/chat/client/chat.cc
+++ b/examples/chat/client/chat.cc
@@ -198,7 +198,7 @@ int main(int argc, char** argv) {
   if (room_id.empty()) {
     room = absl::make_unique<Room>(stub.get());
     room_id = room->Id();
-    LOG(INFO) << "Join this room with --app_address=" << address
+    LOG(INFO) << "Join this room with --address=" << address
               << " --room_id=" << absl::Base64Escape(room_id);
   }
   // Calculate a user handle.


### PR DESCRIPTION
It appears that https://github.com/project-oak/oak/commit/a2c09489934f2ab22b010beb834980f2267804fa#diff-05fd908aa4ea56a3aef0a53b3fedae3c renamed the `--app-address` flag to `--address`. 

The logs and part of the README still mention the now defunct `--app-address` flag. This updates that. 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
