### PR TITLE
Free up space in reproducibility GitHub action

### DIFF
--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -26,6 +26,16 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
+      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
+      - name: free disk space
+        run: |
+          df --human-readable
+          sudo swapoff --all
+          sudo rm --force /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          df --human-readable
+
       # Build Docker image, caching from the latest version from the remote repository.
       - name: Docker build
         timeout-minutes: 30


### PR DESCRIPTION
This was already done in the Rust doc generation GitHub action, and
seems necessary here too now.

Ref #861
