### PR TITLE
Manage prometheus registry in Oak Runtime

### DIFF
--- a/oak/server/rust/oak_runtime/tests/integration_test.rs
+++ b/oak/server/rust/oak_runtime/tests/integration_test.rs
@@ -61,7 +61,7 @@ mod common {
         info!("Reading the metrics.");
         let client = Client::new();
 
-        let uri = format!("http://localhost:{}", &super::METRICS_PORT)
+        let uri = format!("http://localhost:{}/metrics", &super::METRICS_PORT)
             .parse::<Uri>()
             .expect("Could not parse URI.");
 
@@ -92,8 +92,8 @@ fn test_metrics_gives_the_correct_number_of_nodes() {
         .block_on(common::read_metrics())
         .expect("Reading the metrics failed.");
 
-    let value = get_int_metric_value(&res, "runtime_nodes_count");
-    assert_eq!(value, Some(2));
+    let value = get_int_metric_value(&res, "runtime_nodes_total");
+    assert_eq!(value, Some(2), "{}", &res);
 
     runtime.stop_runtime();
 }


### PR DESCRIPTION
- Instantiates and manages prometheus registry in the Runtime,
  instead of using a static instance
- Uses labels for finer grained collection of metrics
- Better instrumentation for gRPC server pseudo-node
- Exposes metrics on `/metrics` endpoint

Fixes #899 

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
