### PR TITLE
Move gRPC server to a separate directory

### DIFF
--- a/oak/server/rust/oak_runtime/src/node/grpc/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/mod.rs
@@ -1,0 +1,17 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub mod server;

--- a/oak/server/rust/oak_runtime/src/node/grpc/server.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/server.rs
@@ -34,7 +34,13 @@ use oak_abi::{
     grpc::encap_request, label::Label, proto::oak::encap::GrpcRequest, ChannelReadStatus, OakStatus,
 };
 
-use crate::{metrics::METRICS, pretty_name_for_thread, runtime::RuntimeProxy, Handle};
+use crate::{
+    Handle,
+    metrics::METRICS,
+    node::Node,
+    pretty_name_for_thread,
+    runtime::RuntimeProxy,
+};
 
 /// Struct that represents a gRPC server pseudo-Node.
 ///
@@ -188,7 +194,7 @@ impl GrpcServerNode {
 }
 
 /// Oak Node implementation for the gRPC server.
-impl super::Node for GrpcServerNode {
+impl Node for GrpcServerNode {
     fn start(self: Box<Self>) -> Result<JoinHandle<()>, OakStatus> {
         let thread_handle = thread::Builder::new()
             .name(self.to_string())

--- a/oak/server/rust/oak_runtime/src/node/grpc/server.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/server.rs
@@ -34,13 +34,7 @@ use oak_abi::{
     grpc::encap_request, label::Label, proto::oak::encap::GrpcRequest, ChannelReadStatus, OakStatus,
 };
 
-use crate::{
-    Handle,
-    metrics::METRICS,
-    node::Node,
-    pretty_name_for_thread,
-    runtime::RuntimeProxy,
-};
+use crate::{metrics::METRICS, node::Node, pretty_name_for_thread, runtime::RuntimeProxy, Handle};
 
 /// Struct that represents a gRPC server pseudo-Node.
 ///

--- a/oak/server/rust/oak_runtime/src/node/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/mod.rs
@@ -27,7 +27,7 @@ use oak_abi::OakStatus;
 use crate::{runtime::RuntimeProxy, Handle};
 
 pub mod external;
-mod grpc_server;
+mod grpc;
 mod logger;
 mod wasm;
 
@@ -136,7 +136,7 @@ impl Configuration {
             Configuration::GrpcServerNode {
                 address,
                 tls_identity,
-            } => Box::new(grpc_server::GrpcServerNode::new(
+            } => Box::new(grpc::server::GrpcServerNode::new(
                 config_name,
                 runtime,
                 *address,


### PR DESCRIPTION
This change moves gRPC server to a separate directory.

# Checklist
- [x] Pull request includes prototype/experimental work that is under
      construction.
