### PR TITLE
Remove invisible chart edges

### DIFF
--- a/oak/server/rust/oak_runtime/src/runtime/introspect.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/introspect.rs
@@ -42,6 +42,7 @@ fn dot_wrap(title: &str, graph: &str) -> String {
         integrity="sha384-rhFJRiWvj+zkVQouZi5hc+vHuqhp1N8AnncxPSaKQ+PUhODpXC3Pgy4EcxjYCIYA"
         crossorigin="anonymous"></script>
 <div id="graph" style="text-align: center;"></div>
+<style>html, body, #graph, #graph > * {{ width: 100%; height: 100%; margin: 0;}}</style>
 <script>d3.select("#graph").graphviz().renderDot(`
 {}
 `);</script>


### PR DESCRIPTION
Removes the invisible chart edges, by making it cover the whole browser window.

Before:

![2020-05-05 3 32 05 pm](https://user-images.githubusercontent.com/8875406/81078441-24d85100-8ee6-11ea-846d-7172dd84ea14.gif)


After:

![2020-05-05 3 32 25 pm](https://user-images.githubusercontent.com/8875406/81078452-286bd800-8ee6-11ea-894c-ad43dfc5f543.gif)


# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

Ref #913