### PR TITLE
Use `RUST_LOG` in `simple_logger`

### DIFF
--- a/oak/server/rust/oak_loader/src/main.rs
+++ b/oak/server/rust/oak_loader/src/main.rs
@@ -78,7 +78,7 @@ fn read_file(filename: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    simple_logger::init().expect("failed to initialize logger");
+    simple_logger::init_by_env();
     let opt = Opt::from_args();
 
     // Load application configuration.


### PR DESCRIPTION
This change makes `simple_logger` use `RUST_LOG` environment variable to set up log level.

# Checklist
- [x] Pull request includes prototype/experimental work that is under
      construction.
