### PR TITLE
Track handles in `channel_read`

### DIFF
--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -807,7 +807,7 @@ impl Runtime {
                 self.channels.get_reader_channel(reference)?,
                 |channel| match channel.messages.write().unwrap().pop_front() {
                     Some(m) => {
-                        self.track_handles_in_node(node_id, vec![reference]);
+                        self.track_handles_in_node(node_id, m.channels.to_vec());
                         Ok(Some(m))
                     }
                     None => {


### PR DESCRIPTION
This change fixes a bug where `channel_read` was tracking the channel on which it read a message instead of tracking the received handles.

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
