### PR TITLE
Delete an unused variable

### DIFF
--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -42,8 +42,7 @@ for language in ${languages}; do
   examples="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/'"${language}"'$' | cut -d'/' -f2 | uniq | grep -v rustfmt)"
   for example in ${examples}; do
     if [[ "${example}" == "chat" ]]; then
-        client_args+=("--test")
-        "${SCRIPTS_DIR}/run_example" -s "${server}" -l "${language}" -e "${example}" -- --test
+        "${SCRIPTS_DIR}/run_example" -s "${server}" -l "${language}" -e chat -- --test
     else
         "${SCRIPTS_DIR}/run_example" -s "${server}" -l "${language}" -e "${example}"
     fi


### PR DESCRIPTION
This change deletes an unused Bash variable `client_args`.

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
