### PR TITLE
Run both C++ and Rust Loader

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -88,10 +88,16 @@ steps:
     timeout: 60m
     entrypoint: 'bash'
     args: ['./scripts/run_examples', '-s', 'base']
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: run_examples_rust
+    waitFor: ['run_examples']
+    timeout: 60m
+    entrypoint: 'bash'
+    args: ['./scripts/run_examples', '-s', 'rust']
   # TODO(942): Reenable `run_examples` with `asan` and `tsan`.
   # - name: 'gcr.io/oak-ci/oak:latest'
   #   id: run_examples_asan
-  #   waitFor: ['run_examples']
+  #   waitFor: ['run_examples_rust']
   #   timeout: 60m
   #   entrypoint: 'bash'
   #   args: ['./scripts/run_examples', '-s', 'asan']
@@ -114,7 +120,7 @@ steps:
   # ignored by git.
   - name: 'gcr.io/oak-ci/oak:latest'
     id: git_check_diff
-    waitFor: ['git_init', 'run_clang_tidy', 'run_examples']
+    waitFor: ['git_init', 'run_clang_tidy', 'run_examples', 'run_examples_rust']
     timeout: 5m
     entrypoint: 'bash'
     args: ['./scripts/git_check_diff']

--- a/examples/abitest/client/abitest.cc
+++ b/examples/abitest/client/abitest.cc
@@ -31,7 +31,7 @@
 #include "oak/server/storage/memory_provider.h"
 #include "oak/server/storage/storage_service.h"
 
-ABSL_FLAG(std::string, address, "127.0.0.1:8080", "Address of the Oak application to connect to");
+ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
 ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
 ABSL_FLAG(int, storage_port, 7867,
           "Port on which the test Storage Server listens; set to zero to disable.");

--- a/examples/abitest/config/BUILD
+++ b/examples/abitest/config/BUILD
@@ -30,3 +30,12 @@ serialized_config(
     },
     textproto = ":config.textproto",
 )
+
+serialized_config(
+    name = "config_rust",
+    modules = {
+        "frontend-config": "//:target/wasm32-unknown-unknown/release/abitest_0_frontend.wasm",
+        "backend-config": "//:target/wasm32-unknown-unknown/release/abitest_1_backend.wasm",
+    },
+    textproto = ":config_rust.textproto",
+)

--- a/examples/abitest/config/config_rust.textproto
+++ b/examples/abitest/config/config_rust.textproto
@@ -1,0 +1,61 @@
+node_configs {
+  name: "frontend-config"
+  wasm_config {
+    module_bytes: "<bytes>"
+  }
+}
+node_configs {
+  name: "backend-config"
+  wasm_config {
+    module_bytes: "<bytes>"
+  }
+}
+node_configs {
+  name: "logging-config"
+  log_config {}
+}
+node_configs {
+  name: "storage"
+  storage_config {
+    address: "localhost:7867"
+  }
+}
+node_configs {
+  name: "absent-storage"
+  storage_config {
+    address: "test.invalid:9999"
+  }
+}
+node_configs {
+  name: "grpc_server"
+  grpc_server_config {
+    address: "[::]:8080"
+    grpc_tls_private_key: "<bytes>"
+    grpc_tls_certificate: "<bytes>"
+  }
+}
+node_configs {
+  name: "grpc-client"
+  grpc_client_config {
+    address: "localhost:7878"
+  }
+}
+node_configs {
+  name: "absent-grpc-client"
+  grpc_client_config {
+    address: "test.invalid:9999"
+  }
+}
+node_configs {
+  name: "roughtime-client"
+  roughtime_client_config {}
+}
+node_configs {
+  name: "roughtime-misconfig"
+  roughtime_client_config {
+    min_overlapping_intervals: 99
+  }
+}
+grpc_port: 8080
+initial_node_config_name: "frontend-config"
+initial_entrypoint_name: "frontend_oak_main_rust"

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -125,6 +125,17 @@ pub extern "C" fn frontend_oak_main(in_handle: u64) {
     });
 }
 
+#[no_mangle]
+pub extern "C" fn frontend_oak_main_rust(_: u64) {
+    let _ = std::panic::catch_unwind(|| {
+        oak::set_panic_hook();
+        let node = FrontendNode::new();
+        let dispatcher = OakAbiTestServiceDispatcher::new(node);
+        let grpc_channel = oak::grpc::server::init_default();
+        oak::run_event_loop_impl(dispatcher, grpc_channel);
+    });
+}
+
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 type TestFn = fn(&mut FrontendNode) -> TestResult;
 

--- a/examples/chat/client/chat.cc
+++ b/examples/chat/client/chat.cc
@@ -28,7 +28,7 @@
 #include "oak/common/nonce_generator.h"
 
 ABSL_FLAG(bool, test, false, "Run a non-interactive version of chat application for testing");
-ABSL_FLAG(std::string, address, "127.0.0.1:8080", "Address of the Oak application to connect to");
+ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
 ABSL_FLAG(std::string, room_id, "",
           "Base64-encoded room ID to join (only used if room_name is blank)");
 ABSL_FLAG(std::string, handle, "", "User handle to display");

--- a/examples/chat/config/BUILD
+++ b/examples/chat/config/BUILD
@@ -29,3 +29,11 @@ serialized_config(
     },
     textproto = ":config.textproto",
 )
+
+serialized_config(
+    name = "config_rust",
+    modules = {
+        "app": "//:target/wasm32-unknown-unknown/release/chat.wasm",
+    },
+    textproto = ":config_rust.textproto",
+)

--- a/examples/chat/config/config_rust.textproto
+++ b/examples/chat/config/config_rust.textproto
@@ -1,0 +1,21 @@
+node_configs {
+  name: "app"
+  wasm_config {
+    module_bytes: "<bytes>"
+  }
+}
+node_configs {
+  name: "log"
+  log_config {}
+}
+node_configs {
+  name: "grpc_server"
+  grpc_server_config {
+    address: "[::]:8080"
+    grpc_tls_private_key: "<bytes>"
+    grpc_tls_certificate: "<bytes>"
+  }
+}
+grpc_port: 8080
+initial_node_config_name: "app"
+initial_entrypoint_name: "oak_main_rust"

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -43,6 +43,13 @@ oak::entrypoint!(oak_main => {
     ChatDispatcher::new(Node::default())
 });
 
+oak::entrypoint_rust!(oak_main_rust => {
+    oak::logger::init_default();
+    let dispatcher = ChatDispatcher::new(Node::default());
+    let grpc_channel = oak::grpc::server::init_default();
+    oak::run_event_loop_impl(dispatcher, grpc_channel);
+});
+
 struct Room {
     sender: oak::io::Sender<Command>,
     admin_token: AdminToken,

--- a/examples/machine_learning/client/machine_learning.cc
+++ b/examples/machine_learning/client/machine_learning.cc
@@ -22,7 +22,7 @@
 #include "include/grpcpp/grpcpp.h"
 #include "oak/client/application_client.h"
 
-ABSL_FLAG(std::string, address, "127.0.0.1:8080", "Address of the Oak application to connect to");
+ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
 ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
 
 using ::oak::examples::machine_learning::MachineLearning;

--- a/examples/machine_learning/config/BUILD
+++ b/examples/machine_learning/config/BUILD
@@ -29,3 +29,11 @@ serialized_config(
     },
     textproto = ":config.textproto",
 )
+
+serialized_config(
+    name = "config_rust",
+    modules = {
+        "app": "//:target/wasm32-unknown-unknown/release/machine_learning.wasm",
+    },
+    textproto = ":config_rust.textproto",
+)

--- a/examples/machine_learning/config/config_rust.textproto
+++ b/examples/machine_learning/config/config_rust.textproto
@@ -1,0 +1,21 @@
+node_configs {
+  name: "app"
+  wasm_config {
+    module_bytes: "<bytes>"
+  }
+}
+node_configs {
+  name: "log"
+  log_config {}
+}
+node_configs {
+  name: "grpc_server"
+  grpc_server_config {
+    address: "[::]:8080"
+    grpc_tls_private_key: "<bytes>"
+    grpc_tls_certificate: "<bytes>"
+  }
+}
+grpc_port: 8080
+initial_node_config_name: "app"
+initial_entrypoint_name: "oak_main_rust"

--- a/examples/machine_learning/module/rust/src/lib.rs
+++ b/examples/machine_learning/module/rust/src/lib.rs
@@ -156,6 +156,18 @@ oak::entrypoint!(oak_main => {
     }
 });
 
+oak::entrypoint_rust!(oak_main_rust => {
+    oak::logger::init_default();
+    let node = Node {
+        training_set_size: 1000,
+        test_set_size: 1000,
+        config: None,
+        model: NaiveBayes::new(),
+    };
+    let grpc_channel = oak::grpc::server::init_default();
+    oak::run_event_loop_impl(node, grpc_channel);
+});
+
 struct Node {
     training_set_size: usize,
     test_set_size: usize,

--- a/examples/private_set_intersection/client/private_set_intersection.cc
+++ b/examples/private_set_intersection/client/private_set_intersection.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cassert>
+
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "examples/private_set_intersection/proto/private_set_intersection.grpc.pb.h"
@@ -23,7 +25,7 @@
 #include "oak/client/application_client.h"
 #include "oak/common/nonce_generator.h"
 
-ABSL_FLAG(std::string, address, "127.0.0.1:8080", "Address of the Oak application to connect to");
+ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
 ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
 
 using ::oak::examples::private_set_intersection::GetIntersectionResponse;
@@ -87,18 +89,22 @@ int main(int argc, char** argv) {
   std::vector<std::string> set_1{"b", "c", "d"};
   SubmitSet(stub_1.get(), set_1);
 
+  std::set<std::string> expected_set{"b", "c"};
+
   // Retrieve intersection.
   std::vector<std::string> intersection_0 = RetrieveIntersection(stub_0.get());
   LOG(INFO) << "client 0 intersection:";
   for (auto item : intersection_0) {
     LOG(INFO) << "- " << item;
   }
+  assert(std::set<std::string>(intersection_0.begin(), intersection_0.end()) == expected_set);
 
   std::vector<std::string> intersection_1 = RetrieveIntersection(stub_1.get());
   LOG(INFO) << "client 1 intersection:";
   for (auto item : intersection_1) {
     LOG(INFO) << "- " << item;
   }
+  assert(std::set<std::string>(intersection_1.begin(), intersection_1.end()) == expected_set);
 
   return EXIT_SUCCESS;
 }

--- a/examples/private_set_intersection/config/BUILD
+++ b/examples/private_set_intersection/config/BUILD
@@ -29,3 +29,11 @@ serialized_config(
     },
     textproto = ":config.textproto",
 )
+
+serialized_config(
+    name = "config_rust",
+    modules = {
+        "app": "//:target/wasm32-unknown-unknown/release/private_set_intersection.wasm",
+    },
+    textproto = ":config_rust.textproto",
+)

--- a/examples/private_set_intersection/config/config_rust.textproto
+++ b/examples/private_set_intersection/config/config_rust.textproto
@@ -1,0 +1,21 @@
+node_configs {
+  name: "app"
+  wasm_config {
+    module_bytes: "<bytes>"
+  }
+}
+node_configs {
+  name: "log"
+  log_config {}
+}
+node_configs {
+  name: "grpc_server"
+  grpc_server_config {
+    address: "[::]:8080"
+    grpc_tls_private_key: "<bytes>"
+    grpc_tls_certificate: "<bytes>"
+  }
+}
+grpc_port: 8080
+initial_node_config_name: "app"
+initial_entrypoint_name: "oak_main_rust"

--- a/examples/private_set_intersection/module/rust/src/lib.rs
+++ b/examples/private_set_intersection/module/rust/src/lib.rs
@@ -43,6 +43,12 @@ use std::collections::HashSet;
 
 oak::entrypoint!(oak_main => PrivateSetIntersectionDispatcher::new(Node::default()));
 
+oak::entrypoint_rust!(oak_main_rust => {
+    let dispatcher = PrivateSetIntersectionDispatcher::new(Node::default());
+    let grpc_channel = oak::grpc::server::init_default();
+    oak::run_event_loop_impl(dispatcher, grpc_channel);
+});
+
 #[derive(Default)]
 struct Node {
     values: Option<HashSet<String>>,

--- a/examples/running_average/client/running_average.cc
+++ b/examples/running_average/client/running_average.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cassert>
+
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "examples/running_average/proto/running_average.grpc.pb.h"
@@ -23,7 +25,7 @@
 #include "oak/client/application_client.h"
 #include "oak/common/nonce_generator.h"
 
-ABSL_FLAG(std::string, address, "127.0.0.1:8080", "Address of the Oak application to connect to");
+ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
 ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
 
 using ::oak::examples::running_average::GetAverageResponse;
@@ -84,9 +86,11 @@ int main(int argc, char** argv) {
   // Retrieve average.
   int average_0 = retrieve_average(stub_0.get());
   LOG(INFO) << "client 0 average: " << average_0;
+  assert(average_0 == 100);
 
   int average_1 = retrieve_average(stub_1.get());
   LOG(INFO) << "client 1 average: " << average_1;
+  assert(average_1 == 100);
 
   return EXIT_SUCCESS;
 }

--- a/examples/running_average/config/BUILD
+++ b/examples/running_average/config/BUILD
@@ -29,3 +29,11 @@ serialized_config(
     },
     textproto = ":config.textproto",
 )
+
+serialized_config(
+    name = "config_rust",
+    modules = {
+        "app": "//:target/wasm32-unknown-unknown/release/running_average.wasm",
+    },
+    textproto = ":config_rust.textproto",
+)

--- a/examples/running_average/config/config_rust.textproto
+++ b/examples/running_average/config/config_rust.textproto
@@ -1,0 +1,21 @@
+node_configs {
+  name: "app"
+  wasm_config {
+    module_bytes: "<bytes>"
+  }
+}
+node_configs {
+  name: "log"
+  log_config {}
+}
+node_configs {
+  name: "grpc_server"
+  grpc_server_config {
+    address: "[::]:8080"
+    grpc_tls_private_key: "<bytes>"
+    grpc_tls_certificate: "<bytes>"
+  }
+}
+grpc_port: 8080
+initial_node_config_name: "app"
+initial_entrypoint_name: "oak_main_rust"

--- a/examples/running_average/module/rust/src/lib.rs
+++ b/examples/running_average/module/rust/src/lib.rs
@@ -33,6 +33,12 @@ use proto::{GetAverageResponse, RunningAverage, RunningAverageDispatcher, Submit
 
 oak::entrypoint!(oak_main => RunningAverageDispatcher::new(Node::default()));
 
+oak::entrypoint_rust!(oak_main_rust => {
+    let dispatcher = RunningAverageDispatcher::new(Node::default());
+    let grpc_channel = oak::grpc::server::init_default();
+    oak::run_event_loop_impl(dispatcher, grpc_channel);
+});
+
 #[derive(Default)]
 struct Node {
     sum: u64,

--- a/examples/rustfmt/client/rustfmt.cc
+++ b/examples/rustfmt/client/rustfmt.cc
@@ -22,7 +22,7 @@
 #include "include/grpcpp/grpcpp.h"
 #include "oak/client/application_client.h"
 
-ABSL_FLAG(std::string, address, "127.0.0.1:8080", "Address of the Oak application to connect to");
+ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
 ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
 
 using ::oak::examples::rustfmt::FormatRequest;

--- a/examples/rustfmt/config/BUILD
+++ b/examples/rustfmt/config/BUILD
@@ -29,3 +29,11 @@ serialized_config(
     },
     textproto = ":config.textproto",
 )
+
+serialized_config(
+    name = "config_rust",
+    modules = {
+        "app": "//:target/wasm32-unknown-unknown/release/rustfmt.wasm",
+    },
+    textproto = ":config_rust.textproto",
+)

--- a/examples/rustfmt/config/config_rust.textproto
+++ b/examples/rustfmt/config/config_rust.textproto
@@ -1,0 +1,21 @@
+node_configs {
+  name: "app"
+  wasm_config {
+    module_bytes: "<bytes>"
+  }
+}
+node_configs {
+  name: "log"
+  log_config {}
+}
+node_configs {
+  name: "grpc_server"
+  grpc_server_config {
+    address: "[::]:8080"
+    grpc_tls_private_key: "<bytes>"
+    grpc_tls_certificate: "<bytes>"
+  }
+}
+grpc_port: 8080
+initial_node_config_name: "app"
+initial_entrypoint_name: "oak_main_rust"

--- a/examples/rustfmt/module/rust/src/lib.rs
+++ b/examples/rustfmt/module/rust/src/lib.rs
@@ -26,6 +26,13 @@ oak::entrypoint!(oak_main => {
     FormatServiceDispatcher::new(Node)
 });
 
+oak::entrypoint_rust!(oak_main_rust => {
+    oak::logger::init_default();
+    let dispatcher = FormatServiceDispatcher::new(Node);
+    let grpc_channel = oak::grpc::server::init_default();
+    oak::run_event_loop_impl(dispatcher, grpc_channel);
+});
+
 struct Node;
 
 impl FormatService for Node {

--- a/examples/translator/client/translator.go
+++ b/examples/translator/client/translator.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	address = flag.String("address", "127.0.0.1:8080", "Address of the Oak application to connect to")
+	address = flag.String("address", "localhost:8080", "Address of the Oak application to connect to")
 	caCert  = flag.String("ca_cert", "", "Path to the PEM-encoded CA root certificate")
 )
 

--- a/examples/translator/config/BUILD
+++ b/examples/translator/config/BUILD
@@ -29,3 +29,11 @@ serialized_config(
     },
     textproto = ":config.textproto",
 )
+
+serialized_config(
+    name = "config_rust",
+    modules = {
+        "app": "//:target/wasm32-unknown-unknown/release/translator.wasm",
+    },
+    textproto = ":config_rust.textproto",
+)

--- a/examples/translator/config/config_rust.textproto
+++ b/examples/translator/config/config_rust.textproto
@@ -1,0 +1,21 @@
+node_configs {
+  name: "app"
+  wasm_config {
+    module_bytes: "<bytes>"
+  }
+}
+node_configs {
+  name: "log"
+  log_config {}
+}
+node_configs {
+  name: "grpc_server"
+  grpc_server_config {
+    address: "[::]:8080"
+    grpc_tls_private_key: "<bytes>"
+    grpc_tls_certificate: "<bytes>"
+  }
+}
+grpc_port: 8080
+initial_node_config_name: "app"
+initial_entrypoint_name: "oak_main_rust"

--- a/examples/translator/module/rust/src/lib.rs
+++ b/examples/translator/module/rust/src/lib.rs
@@ -28,6 +28,13 @@ oak::entrypoint!(oak_main => {
     TranslatorDispatcher::new(Node)
 });
 
+oak::entrypoint_rust!(oak_main_rust => {
+    oak::logger::init_default();
+    let dispatcher = TranslatorDispatcher::new(Node);
+    let grpc_channel = oak::grpc::server::init_default();
+    oak::run_event_loop_impl(dispatcher, grpc_channel);
+});
+
 struct Node;
 
 impl Translator for Node {

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -69,6 +69,11 @@ case "${language}" in
       cargo build --release --package=aggregator_backend
     fi
     bazel --output_base="${CACHE_DIR}/client" build "${bazel_build_flags[@]}" "//examples/${EXAMPLE}/config:config"
+
+    # Compile examples that are supported by the Rust Oak Loader.
+    if [[ " ${RUST_LOADER_EXAMPLES[@]} " =~ " ${EXAMPLE} " ]]; then
+      bazel --output_base="${CACHE_DIR}/client" build "${bazel_build_flags[@]}" "//examples/${EXAMPLE}/config:config_rust"
+    fi
     ;;
   cpp)
     # `config_cpp` depends on a Wasm module, so it should be built with `wasm32` or `emscripten`.

--- a/scripts/common
+++ b/scripts/common
@@ -65,6 +65,17 @@ else
   )
 fi
 
+# Examples that are supported by the Rust Oak Loader.
+readonly RUST_LOADER_EXAMPLES=(
+  'abitest'
+  'chat'
+  'machine_learning'
+  'private_set_intersection'
+  'running_average'
+  'rustfmt'
+  'translator'
+)
+
 # kill_pid tries to kill the given pid(s), first softly then more aggressively.
 kill_pid() {
   local pids=( "$@" )

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -13,6 +13,7 @@ while getopts "s:l:h" opt; do
   -s    Server type used to run examples:
           - base: base version of the server (default)
           - logless: base version of the server with debug logging compiled out
+          - rust: Rust version of the server
           - asan: server with address sanitizer
           - tsan: server with thread santizer
   -l    Run examples implemented in which language (default: both):
@@ -24,7 +25,7 @@ while getopts "s:l:h" opt; do
       languages="${OPTARG}";;
     s)
       case "${OPTARG}" in
-        base|logless|asan|tsan)
+        base|logless|rust|asan|tsan)
           server="${OPTARG}";;
         *)
           echo "Invalid server type: ${OPTARG}"
@@ -36,15 +37,28 @@ while getopts "s:l:h" opt; do
   esac
 done
 
-# Run all examples.
-for language in ${languages}; do
-  # TODO(#594): Re-enable rustfmt when upstream rustc internal error is fixed.
-  examples="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/'"${language}"'$' | cut -d'/' -f2 | uniq | grep -v rustfmt)"
-  for example in ${examples}; do
-    if [[ "${example}" == "chat" ]]; then
-        "${SCRIPTS_DIR}/run_example" -s "${server}" -l "${language}" -e chat -- --test
+if [[ "${server}" == "rust" ]]; then
+  # Run examples that are supported by the Rust Oak Loader.
+  for example in ${RUST_LOADER_EXAMPLES}; do
+    if [[ "${example}" == "abitest" ]]; then
+      # Run only currently supported tests.
+      "${SCRIPTS_DIR}/run_example" -s rust -l rust -e abitest -- \
+        --test_include UnaryMethodOK UnaryMethodErr
     else
-        "${SCRIPTS_DIR}/run_example" -s "${server}" -l "${language}" -e "${example}"
+      "${SCRIPTS_DIR}/run_example" -s rust -l rust -e "${example}"
     fi
   done
-done
+else
+  # Run all examples.
+  for language in ${languages}; do
+    # TODO(#594): Re-enable rustfmt when upstream rustc internal error is fixed.
+    examples="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/'"${language}"'$' | cut -d'/' -f2 | uniq | grep -v rustfmt)"
+    for example in ${examples}; do
+      if [[ "${example}" == "chat" ]]; then
+          "${SCRIPTS_DIR}/run_example" -s "${server}" -l "${language}" -e chat -- --test
+      else
+          "${SCRIPTS_DIR}/run_example" -s "${server}" -l "${language}" -e "${example}"
+      fi
+    done
+  done
+fi

--- a/scripts/run_server
+++ b/scripts/run_server
@@ -55,7 +55,17 @@ if [[ -n ${EXAMPLE+x} ]]; then
   # Determine expected configuration file from example name and language variant.
   case "${language}" in
     rust)
-      readonly APPLICATION="${PWD}/bazel-client-bin/examples/${EXAMPLE}/config/config.bin";;
+      # Compile examples that are supported by the Rust Oak Loader.
+      if [[ "${server}" == "rust" ]]; then
+        if [[ " ${RUST_LOADER_EXAMPLES[@]} " =~ " ${EXAMPLE} " ]]; then
+          readonly APPLICATION="${PWD}/bazel-client-bin/examples/${EXAMPLE}/config/config_rust.bin"
+        else
+          echo "Example ${EXAMPLE} is not supported by the rust server"
+          exit 1
+        fi
+      else
+        readonly APPLICATION="${PWD}/bazel-client-bin/examples/${EXAMPLE}/config/config.bin"
+      fi;;
     cpp)
       # TensorFlow example is compiled with Emscripten and other examples with Clang.
       if [[ "${EXAMPLE}" == "tensorflow" ]]; then

--- a/sdk/rust/oak/src/grpc/server.rs
+++ b/sdk/rust/oak/src/grpc/server.rs
@@ -22,8 +22,8 @@ use crate::{OakStatus, ReadHandle};
 pub const DEFAULT_CONFIG_NAME: &str = "grpc_server";
 
 /// Initialize a gRPC pseudo-Node with the default configuration.
-pub fn init_default() {
-    init(DEFAULT_CONFIG_NAME).expect("Coundn't create a gRPC pseudo-Node");
+pub fn init_default() -> ReadHandle {
+    init(DEFAULT_CONFIG_NAME).expect("Coundn't create a gRPC pseudo-Node")
 }
 
 /// Initializes a gRPC server pseudo-Node and passes it a handle to write invocations to.


### PR DESCRIPTION
This change updates macro and scripts in order to be able to run C++ and Rust Oak Loaders on the same examples.

Fixes #874

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)