### PR TITLE
Introspection Server: Use 405 http status code for disallowed methods

### DIFF
--- a/oak/server/rust/oak_runtime/src/runtime/introspect.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/introspect.rs
@@ -95,9 +95,9 @@ fn handle_request(
     runtime: Arc<Runtime>,
 ) -> Result<Response<Body>, hyper::Error> {
     if req.method() != Method::GET {
-        let mut not_found = Response::default();
-        *not_found.status_mut() = StatusCode::NOT_FOUND;
-        return Ok(not_found);
+        let mut method_not_allowed = Response::default();
+        *method_not_allowed.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+        return Ok(method_not_allowed);
     }
     // TODO(#672): Shift to a framework.
     let path = req.uri().path();


### PR DESCRIPTION
Kind of a minor thing, but using a 405, instead of 404 code seems more accurate here.

405 is specific for responding to requests of unsupported methods.

Before:
![image](https://user-images.githubusercontent.com/8875406/81196645-36d5f480-8fb7-11ea-8db2-b758665e25c2.png)


After:
![image](https://user-images.githubusercontent.com/8875406/81196664-3b9aa880-8fb7-11ea-896d-683f2c84844d.png)

Images brought to you by https://http.cat/

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
