### PR TITLE
Return immediately from wait if at least one invalid channel

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -89,16 +89,14 @@ functions** as
 ### wait_on_channels
 
 `wait_on_channels(usize, u32) -> u32` blocks until data is available for reading
-from one of the specified channel handles. The channel handles are encoded in a
-buffer that holds N contiguous 9-byte chunks, each of which is made up of an
-8-byte channel handle value (little-endian `u64`) followed by a single channel
-status byte. Invalid handles will have an `INVALID_CHANNEL` status, but
-`wait_on_channels` return value will only fail for internal errors or if _all_
-channels are invalid.
-
-If reading from any of the specified (valid) channels would violate
-[information flow control](/docs/concepts.md#labels), returns
-`ERR_PERMISSION_DENIED`.
+from one of the specified channel handles, unless any of the channels is
+invalid, orphaned, or violates the
+[information flow control](/docs/concepts.md#labels). The channel handles are
+encoded in a buffer that holds N contiguous 9-byte chunks, each of which is made
+up of an 8-byte channel handle value (little-endian u64) followed by a single
+channel status byte. Invalid handles will have an `INVALID_CHANNEL`, `ORPHANED`,
+or `PERMISSION_DENIED` status, but `wait_on_channels` return value will only
+fail for internal errors or if _all_ channels are invalid.
 
 - arg 0: Address of handle status buffer
 - arg 1: Count N of handles provided

--- a/oak/proto/oak_abi.proto
+++ b/oak/proto/oak_abi.proto
@@ -57,4 +57,6 @@ enum ChannelReadStatus {
   INVALID_CHANNEL = 2;
   // Channel has no extant write halves (and is empty).
   ORPHANED = 3;
+  // A node trying to access the channel does not have the permission to do so.
+  PERMISSION_DENIED = 4;
 }

--- a/oak/server/rust/oak_abi/src/proto/oak_abi.rs
+++ b/oak/server/rust/oak_abi/src/proto/oak_abi.rs
@@ -40,4 +40,6 @@ pub enum ChannelReadStatus {
     InvalidChannel = 2,
     /// Channel has no extant write halves (and is empty).
     Orphaned = 3,
+    /// A node trying to access the channel does not have the permission to do so.
+    PermissionDenied = 4,
 }

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -452,10 +452,13 @@ impl WasmInterface {
                 })?;
         }
 
-        if statuses
-            .iter()
-            .all(|&s| s == ChannelReadStatus::InvalidChannel || s == ChannelReadStatus::Orphaned)
-        {
+        let is_invalid = |&s| {
+            s == ChannelReadStatus::InvalidChannel
+                || s == ChannelReadStatus::Orphaned
+                || s == ChannelReadStatus::PermissionDenied
+        };
+
+        if statuses.iter().all(is_invalid) {
             Err(OakStatus::ErrBadHandle)
         } else {
             Ok(())

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -208,7 +208,7 @@ pub fn wait_on_channels(handles: &[ReadHandle]) -> Result<Vec<ChannelReadStatus>
 /// It also returns an error if the underlying channel is empty (i.e. not ready to read).
 ///
 /// The provided vectors for received data and associated handles will be
-/// resized to accomodate the information in the message; any data already
+/// resized to accommodate the information in the message; any data already
 /// held in the vectors will be overwritten.
 pub fn channel_read(
     half: ReadHandle,


### PR DESCRIPTION
* `wait_on_channel` in `oak_runtime` returns early if any of the channels is invalid or orphaned
* `wait_on_channel` in `oak_runtime` returns a vector containing all statuses if any is inaccessible
* Added the a new status `PERMISSION_DENIED` to `ChannelReadStatus` 
* Updated documentation

Fixes #803 

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [x] I have updated [documentation](docs/) accordingly.
  - [x] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
