### PR TITLE
Assign labels on channel creation

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -158,13 +158,21 @@ in Fuchsia.
 
 ### channel_create
 
-`channel_create: (usize, usize) -> u32` creates a new unidirectional channel and
-return the channel handles for its read and write halves.
+`channel_create: (usize, usize, usize, usize) -> u32` creates a new
+unidirectional channel assigning the label specified by args 2 and 3 to the
+newly created Channel, and returns the channel handles for its read and write
+halves as output parameters in args 0 and 1.
+
+If creating the specified Channel would violate
+[information flow control](/docs/concepts.md#labels), returns
+`ERR_PERMISSION_DENIED`.
 
 - arg 0: Address of an 8-byte location that will receive the handle for the
   write half of the channel (as a little-endian u64).
 - arg 1: Address of an 8-byte location that will receive the handle for the read
   half of the channel (as a little-endian u64).
+- arg 2: Source buffer holding label
+- arg 3: Label size in bytes
 - return 0: Status of operation
 
 ### channel_close
@@ -178,11 +186,12 @@ return the channel handles for its read and write halves.
 
 `node_create: (usize, usize, usize, usize, usize, usize, u64) -> u32` creates a
 new Node running the Node configuration identified by args 0 and 1, using the
-entrypoint specified by args 2 and 3, passing in an initial handle to the read
-half of a channel identified by arg 4. The entrypoint name is ignored when
-creating non-WebAssembly Nodes.
+entrypoint specified by args 2 and 3, assigning the label specified by args 4
+and 5 to the newly created Node, passing in an initial handle to the read half
+of a channel identified by arg 6. The entrypoint name is ignored when creating
+non-WebAssembly Nodes.
 
-If creating the specified node would violate
+If creating the specified Node would violate
 [information flow control](/docs/concepts.md#labels), returns
 `ERR_PERMISSION_DENIED`.
 

--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -15,23 +15,11 @@ output.
 Build and run the Backend with the following command:
 
 ```bash
+export RUST_LOG=info
 cargo run --release --package=aggregator_backend
 ```
 
 Backend code is in the `backend` directory.
-
-### Client
-
-Simple client that connects to the Aggregator and sends a data sample via gRPC.
-
-Build and run the Client with the following command:
-
-```bash
-./scripts/build_example -e aggregator
-./bazel-client-bin/examples/aggregator/client/client --address=127.0.0.1:8080 --bucket=test --data=1:10,2:20,3:30
-```
-
-Client code is in the `client` directory.
 
 ### Aggregator
 
@@ -47,12 +35,37 @@ a Sparse Vector - a dictionary with integer keys.
 Build and run the Aggregator with the following command:
 
 ```bash
+./scripts/build_example -e aggregator
 ./scripts/build_server -s base
-./bazel-bin/oak/server/loader/oak_runner --application=./bazel-client-bin/examples/aggregator/config/config.bin
+./bazel-clang-bin/oak/server/loader/oak_runner \
+  --application=./bazel-client-bin/examples/aggregator/config/config.bin \
+  --private_key=./examples/certs/local/local.key \
+  --cert_chain=./examples/certs/local/local.pem
 ```
 
 Aggregator code is in `common` and `module` directories (where `common` defines
 a generic Aggregator data structure).
+
+### Client
+
+Simple client that connects to the Aggregator and sends a data sample via gRPC.
+
+Build and run the Client with the following command:
+
+```bash
+./scripts/build_example -e aggregator
+./bazel-client-bin/examples/aggregator/client/client \
+  --address=127.0.0.1:8080 \
+  --ca_cert=./examples/certs/local/local.pem \
+  --bucket=test \
+  --data=1:10,2:20,3:30
+```
+
+A common use case is to keep running the client until the aggregation threshold
+is reached, at which point the aggregator should release the aggregated data to
+the backend over gRPC.
+
+Client code is in the `client` directory.
 
 ## Deployment
 

--- a/examples/aggregator/module/rust/Cargo.toml
+++ b/examples/aggregator/module/rust/Cargo.toml
@@ -13,6 +13,7 @@ aggregator_common = { path = "../../common" }
 itertools = "*"
 log = "*"
 oak = "=0.1.0"
+oak_abi = "=0.1.0"
 prost = "*"
 
 [dev-dependencies]

--- a/oak/server/rust/oak_abi/src/lib.rs
+++ b/oak/server/rust/oak_abi/src/lib.rs
@@ -109,15 +109,23 @@ extern "C" {
         handle_count: u32,
     ) -> u32;
 
-    /// Create a new unidirectional channel.
+    /// Create a new unidirectional Channel.
     ///
-    /// Returns handles for the the write and read halves of the channel in
-    /// the spaces given by `write` and `read`.
+    /// Returns handles for the the write and read halves of the Channel in the spaces given by
+    /// `write` and `read`.
+    ///
+    /// The label to assign to the newly created Channel is provided in the memory area given by
+    /// `label_buf` and `label_len`.
     ///
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///
     /// [`OakStatus`]: crate::OakStatus
-    pub fn channel_create(write: *mut u64, read: *mut u64) -> u32;
+    pub fn channel_create(
+        write: *mut u64,
+        read: *mut u64,
+        label_buf: *const u8,
+        label_len: usize,
+    ) -> u32;
 
     /// Close a channel.
     ///
@@ -128,13 +136,16 @@ extern "C" {
     /// [`OakStatus`]: crate::OakStatus
     pub fn channel_close(handle: u64) -> u32;
 
-    /// Create a new Node instance running code identified by configuration
-    /// name and entrypoint; the entrypoint is only used when creating a
-    /// WebAssembly Node; it is ignored when creating a pseudo-Node.
+    /// Create a new Node instance running code identified by configuration name and entrypoint; the
+    /// entrypoint is only used when creating a WebAssembly Node; it is ignored when creating a
+    /// pseudo-Node.
     ///
-    /// The configuration name is provided in the memory area given by
-    /// `config_buf` and `config_len`; the entrypoint name is provided in the
-    /// memory area given by `entrypoint_buf` and `entrypoint_len`.
+    /// The configuration name is provided in the memory area given by `config_buf` and
+    /// `config_len`; the entrypoint name is provided in the memory area given by `entrypoint_buf`
+    /// and `entrypoint_len`.
+    ///
+    /// The label to assign to the newly created Node is provided in the memory area given by
+    /// `label_buf` and `label_len`.
     ///
     /// Returns the status of the operation, as an [`OakStatus`] value.
     ///

--- a/oak/server/rust/oak_glue/src/lib.rs
+++ b/oak/server/rust/oak_glue/src/lib.rs
@@ -325,7 +325,10 @@ pub unsafe extern "C" fn glue_channel_create(node_id: u64, write: *mut u64, read
     debug!("{{{}}}: channel_create({:?}, {:?})", node_id, write, read);
     let proxy = proxy_for_node(node_id);
     let (write_handle, read_handle) =
-        proxy.channel_create(&oak_abi::label::Label::public_trusted());
+        match proxy.channel_create(&oak_abi::label::Label::public_trusted()) {
+            Ok(r) => r,
+            Err(s) => return s as u32,
+        };
     *write = write_handle;
     *read = read_handle;
     debug!(

--- a/oak/server/rust/oak_runtime/src/node/grpc/server.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/server.rs
@@ -260,9 +260,9 @@ impl GrpcRequestHandler {
     fn handle_grpc_request(&self, request: GrpcRequest) -> Result<oak_abi::Handle, OakStatus> {
         // Create a pair of temporary channels to pass the gRPC request and to receive the response.
         let (request_writer, request_reader) =
-            self.runtime.channel_create(&Label::public_trusted());
+            self.runtime.channel_create(&Label::public_trusted())?;
         let (response_writer, response_reader) =
-            self.runtime.channel_create(&Label::public_trusted());
+            self.runtime.channel_create(&Label::public_trusted())?;
 
         // Create an invocation message and attach the method-invocation specific channels to it.
         //

--- a/oak/server/rust/oak_runtime/src/node/wasm/tests.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/tests.rs
@@ -33,7 +33,7 @@ fn start_node<S: AsRef<[u8]>>(buffer: S, entrypoint: &str) -> Result<(), OakStat
         },
     );
     let proxy = RuntimeProxy::create_runtime(configuration);
-    let (_write_handle, read_handle) = proxy.channel_create(&Label::public_trusted());
+    let (_write_handle, read_handle) = proxy.channel_create(&Label::public_trusted())?;
 
     let result = proxy.node_create(
         "test_module",

--- a/sdk/rust/oak/src/io/mod.rs
+++ b/sdk/rust/oak/src/io/mod.rs
@@ -17,6 +17,7 @@
 //! Wrappers for Oak SDK types to allow their use with [`std::io`].
 
 use crate::OakStatus;
+use oak_abi::label::Label;
 use std::io;
 
 mod decodable;
@@ -32,6 +33,13 @@ pub use sender::Sender;
 /// Create a new channel for transmission of `Encodable` and `Decodable` types.
 pub fn channel_create<T: Encodable + Decodable>() -> Result<(Sender<T>, Receiver<T>), OakStatus> {
     let (wh, rh) = crate::channel_create()?;
+    Ok((Sender::<T>::new(wh), Receiver::<T>::new(rh)))
+}
+
+pub fn channel_create_with_label<T: Encodable + Decodable>(
+    label: &Label,
+) -> Result<(Sender<T>, Receiver<T>), OakStatus> {
+    let (wh, rh) = crate::channel_create_with_label(label)?;
     Ok((Sender::<T>::new(wh), Receiver::<T>::new(rh)))
 }
 

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -114,8 +114,9 @@ where
     //
     // In most cases we do not care about labels, so we use the least privileged label for this
     // channel.
-    let (req_write_handle, req_read_handle) =
-        proxy.channel_create(&oak_abi::label::Label::public_trusted());
+    let (req_write_handle, req_read_handle) = proxy
+        .channel_create(&oak_abi::label::Label::public_trusted())
+        .expect("could not create channel");
     proxy
         .channel_write(req_write_handle, req_msg)
         .expect("could not write message");
@@ -124,8 +125,9 @@ where
     //
     // In most cases we do not care about labels, so we use the least privileged label for this
     // channel.
-    let (rsp_write_handle, rsp_read_handle) =
-        proxy.channel_create(&oak_abi::label::Label::public_trusted());
+    let (rsp_write_handle, rsp_read_handle) = proxy
+        .channel_create(&oak_abi::label::Label::public_trusted())
+        .expect("could not create channel");
 
     // Create a notification message and attach the method-invocation specific channels to it.
     let notify_msg = oak_runtime::NodeMessage {


### PR DESCRIPTION
Expand `channel_create` host function call to accept a Label parameter,
similar to `node_create`.

Add `Client::new_with_label` method to allow creating a gRPC client
pseudo-node at a specific IFC label. This will act as a
declassification, once more IFC rules are implemented in the Runtime.

Update ABI documentation.

Fix aggregator example documentation.

Ref #972 #630

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
