### PR TITLE
Use futures select for stopping gRPC nodes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -75,7 +75,7 @@ steps:
     entrypoint: 'bash'
     args: ['./scripts/run_tests']
 
-  # TODO(942): Reenable `run_tests_tsan`.
+  # TODO(#942): Reenable `run_tests_tsan`.
   # - name: 'gcr.io/oak-ci/oak:latest'
   #   id: run_tests_tsan
   #   waitFor: ['run_tests']
@@ -88,7 +88,7 @@ steps:
     timeout: 60m
     entrypoint: 'bash'
     args: ['./scripts/run_examples', '-s', 'base']
-  # TODO(942): Reenable `run_examples` with `asan` and `tsan`.
+  # TODO(#942): Reenable `run_examples` with `asan` and `tsan`.
   # - name: 'gcr.io/oak-ci/oak:latest'
   #   id: run_examples_asan
   #   waitFor: ['run_examples']

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -47,7 +47,7 @@ struct FrontendNode {
     storage_name: Vec<u8>,
     // TODO(#874): Run abitest with Rust loader in order to provide gRPC client with a CA.
     // grpc_service: Option<OakAbiTestServiceClient>,
-    // TODO(#953, #954): Add streaming support for gRPC and re-enable all of the tests.
+    // TODO(#953): Add streaming support for gRPC and re-enable all of the tests.
     // absent_grpc_service: Option<OakAbiTestServiceClient>,
     roughtime: Option<oak::roughtime::Roughtime>,
     misconfigured_roughtime: Option<oak::roughtime::Roughtime>,
@@ -198,7 +198,7 @@ impl OakAbiTestService for FrontendNode {
         //     "GrpcClientUnaryMethod",
         //     FrontendNode::test_grpc_client_unary_method,
         // );
-        // TODO(#953, #954): Add streaming support for gRPC and re-enable all of the tests.
+        // TODO(#953): Add streaming support for gRPC and re-enable all of the tests.
         // tests.insert(
         //     "GrpcClientServerStreamingMethod",
         //     FrontendNode::test_grpc_client_server_streaming_method,
@@ -1633,7 +1633,7 @@ impl FrontendNode {
 
     //     Ok(())
     // }
-    // TODO(#953, #954): Add streaming support for gRPC and re-enable all of the tests.
+    // TODO(#953): Add streaming support for gRPC and re-enable all of the tests.
     // fn test_grpc_client_server_streaming_method(&mut self) -> TestResult {
     //     let grpc_stub = self.grpc_service.as_ref().ok_or_else(|| {
     //         Box::new(std::io::Error::new(
@@ -1658,7 +1658,7 @@ impl FrontendNode {
     //     loop {
     //         match receiver.receive() {
     //             Ok(grpc_rsp) => {
-    //                 // TODO(#592): get typed response directly from receiver.
+    // TODO(#592): get typed response directly from receiver.
     //                 expect_eq!(
     //                     oak::grpc::Code::Ok as i32,
     //                     grpc_rsp.status.unwrap_or_default().code
@@ -1705,7 +1705,7 @@ impl FrontendNode {
     //     receiver.close().expect("failed to close receiver");
     //     Ok(())
     // }
-    // TODO(#953, #954): Add streaming support for gRPC and re-enable all of the tests.
+    // TODO(#953): Add streaming support for gRPC and re-enable all of the tests.
     // fn test_absent_grpc_client(&mut self) -> TestResult {
     //     // Expect to have a channel to a gRPC client pseudo-Node, but the remote
     //     // gRPC service is unavailable.

--- a/oak/server/rust/oak_runtime/src/node/external.rs
+++ b/oak/server/rust/oak_runtime/src/node/external.rs
@@ -18,6 +18,7 @@ use crate::{NodeId, RuntimeProxy};
 use lazy_static::lazy_static;
 use log::info;
 use std::{sync::RwLock, thread};
+use tokio::sync::oneshot;
 
 /// Function pointer type for callbacks from Rust code into C/C++ code for
 /// pseudo-Node creation.
@@ -54,7 +55,12 @@ impl PseudoNode {
 }
 
 impl super::Node for PseudoNode {
-    fn run(self: Box<Self>, runtime: RuntimeProxy, handle: oak_abi::Handle) {
+    fn run(
+        self: Box<Self>,
+        runtime: RuntimeProxy,
+        handle: oak_abi::Handle,
+        _notify_receiver: oneshot::Receiver<()>,
+    ) {
         let factory_fn: NodeFactory = FACTORY
             .read()
             .expect("unlock failed")

--- a/oak/server/rust/oak_runtime/src/node/grpc/server.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/server.rs
@@ -30,6 +30,7 @@ use std::{
     net::SocketAddr,
     task::{Context, Poll},
 };
+use tokio::sync::oneshot;
 use tonic::{
     codegen::BoxFuture,
     server::{Grpc, UnaryService},
@@ -106,7 +107,12 @@ impl GrpcServerNode {
 
 /// Oak Node implementation for the gRPC server.
 impl Node for GrpcServerNode {
-    fn run(self: Box<Self>, runtime: RuntimeProxy, handle: oak_abi::Handle) {
+    fn run(
+        self: Box<Self>,
+        runtime: RuntimeProxy,
+        handle: oak_abi::Handle,
+        notify_receiver: oneshot::Receiver<()>,
+    ) {
         // Receive a `channel_writer` handle used to pass handles for temporary channels.
         info!("{}: Waiting for a channel writer", self.node_name);
         let channel_writer = GrpcServerNode::get_channel_writer(&runtime, handle)
@@ -122,7 +128,10 @@ impl Node for GrpcServerNode {
         let server = tonic::transport::Server::builder()
             .tls_config(tonic::transport::ServerTlsConfig::new().identity(self.tls_identity))
             .add_service(handler)
-            .serve(self.address);
+            .serve_with_shutdown(self.address, async {
+                // Treat notification failure the same as a notification.
+                let _ = notify_receiver.await;
+            });
 
         // Create an Async runtime for executing futures.
         // https://docs.rs/tokio/
@@ -149,6 +158,7 @@ impl Node for GrpcServerNode {
             "{}: Exiting gRPC server pseudo-Node thread {:?}",
             self.node_name, result
         );
+        info!("{}: Exiting gRPC server pseudo-Node thread", self.node_name);
     }
 }
 

--- a/oak/server/rust/oak_runtime/src/node/logger.rs
+++ b/oak/server/rust/oak_runtime/src/node/logger.rs
@@ -19,6 +19,7 @@ use log::{error, info, log};
 use oak_abi::proto::oak::log::{Level, LogMessage};
 use prost::Message;
 use std::string::String;
+use tokio::sync::oneshot;
 
 /// Logging pseudo-Node.
 pub struct LogNode {
@@ -37,7 +38,12 @@ impl LogNode {
 impl super::Node for LogNode {
     /// Main execution loop for the logging pseudo-Node just waits for incoming
     /// `LogMessage`s and outputs them.
-    fn run(self: Box<Self>, runtime: RuntimeProxy, handle: oak_abi::Handle) {
+    fn run(
+        self: Box<Self>,
+        runtime: RuntimeProxy,
+        handle: oak_abi::Handle,
+        _notify_receiver: oneshot::Receiver<()>,
+    ) {
         loop {
             // An error indicates the Runtime is terminating. We ignore it here and keep trying to
             // read in case a Wasm Node wants to emit remaining messages. We will return

--- a/oak/server/rust/oak_runtime/src/node/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/mod.rs
@@ -21,6 +21,7 @@ use std::{
     string::String,
     sync::Arc,
 };
+use tokio::sync::oneshot;
 use tonic::transport::{Certificate, Identity, Uri};
 
 pub mod external;
@@ -30,9 +31,17 @@ mod wasm;
 
 /// Trait encapsulating execution of a Node or pseudo-Node.
 pub trait Node {
-    /// Execute the Node, using the provided `Runtime` reference and initial handle.  The method
+    /// Execute the Node, using the provided `Runtime` reference and initial handle. The method
     /// should continue execution until the Node terminates.
-    fn run(self: Box<Self>, runtime: RuntimeProxy, handle: oak_abi::Handle);
+    ///
+    /// `notify_receiver` receives a notification from the Runtime upon termination. This
+    /// notification can be used by the Node to gracefully shut down.
+    fn run(
+        self: Box<Self>,
+        runtime: RuntimeProxy,
+        handle: oak_abi::Handle,
+        notify_receiver: oneshot::Receiver<()>,
+    );
 }
 
 /// A [`Configuration`] corresponds to a [`NodeConfiguration`] protobuf message, with parsed

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -23,6 +23,7 @@ use log::{debug, error, info, warn};
 use oak_abi::{label::Label, ChannelReadStatus, OakStatus};
 use rand::RngCore;
 use std::{string::String, sync::Arc};
+use tokio::sync::oneshot;
 use wasmi::ValueType;
 
 #[cfg(test)]
@@ -815,7 +816,12 @@ impl WasmNode {
 
 impl super::Node for WasmNode {
     /// Runs this instance of a Wasm Node.
-    fn run(self: Box<Self>, runtime: RuntimeProxy, handle: oak_abi::Handle) {
+    fn run(
+        self: Box<Self>,
+        runtime: RuntimeProxy,
+        handle: oak_abi::Handle,
+        _notify_receiver: oneshot::Receiver<()>,
+    ) {
         debug!(
             "{}: running entrypoint '{}'",
             self.node_name, self.entrypoint


### PR DESCRIPTION
This change:
- Adds futures select for Tokio Runtime
- Temporary disables gRPC client tests in `abitest` since they now require TLS certificates (will be re-enabled after examples start using Rust Loader)

Fixes https://github.com/project-oak/oak/issues/982

# Checklist
- [x] Pull request includes prototype/experimental work that is under
      construction.
