### PR TITLE
Add mailing list and slack links to text body

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,6 @@ to extract the received data.
 
 ## Getting involved
 
-We welcome contributors! To join our community, we recommend joining the [mailing list](https://groups.google.com/g/project-oak-discuss) and the [slack](https://join.slack.com/t/project-oak/shared_invite/zt-5hiliinq-f0fYZGwlzfH3kMrJuu3qlw). 
+We welcome contributors! To join our community, we recommend joining the
+[mailing list](https://groups.google.com/g/project-oak-discuss) and the
+[slack](https://join.slack.com/t/project-oak/shared_invite/zt-5hiliinq-f0fYZGwlzfH3kMrJuu3qlw).

--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ exchange data, there is a pre-existing basic trust relationship between them; in
 particular we assume that the recipient of the data is not going to
 intentionally circumvent robust protection mechanisms on their device in order
 to extract the received data.
+
+## Getting involved
+
+We welcome contributors! To join our community, we recommend joining the [mailing list](https://groups.google.com/g/project-oak-discuss) and the [slack](https://join.slack.com/t/project-oak/shared_invite/zt-5hiliinq-f0fYZGwlzfH3kMrJuu3qlw). 


### PR DESCRIPTION
We've received feedback that the mailing list and slack links are easy to miss, so it's been suggested we add them as links in the text body as well. I've added a 'getting involved' section at the bottom of the readme for this.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
