### PR TITLE
Add runtime health-check metric

### DIFF
--- a/oak/server/rust/oak_runtime/src/metrics/mod.rs
+++ b/oak/server/rust/oak_runtime/src/metrics/mod.rs
@@ -42,6 +42,7 @@ pub struct GrpcServerMetrics {
 #[derive(Clone)]
 pub struct RuntimeMetrics {
     pub runtime_nodes_total: IntGauge,
+    pub runtime_health_check: IntGauge,
 }
 
 /// Struct that collects all the metrics in one place
@@ -113,6 +114,10 @@ impl RuntimeMetrics {
             runtime_nodes_total: builder.register(int_gauge(
                 "runtime_nodes_total",
                 "Number of nodes in the runtime.",
+            )),
+            runtime_health_check: builder.register(int_gauge(
+                "runtime_health_check",
+                "Health indicator for the runtime.",
             )),
         }
     }

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -358,6 +358,10 @@ impl RuntimeProxy {
     ) -> Result<oak_abi::Handle, OakStatus> {
         let module_name = self.runtime.configuration.entry_module.clone();
         let entrypoint = self.runtime.configuration.entrypoint.clone();
+        self.metrics_data()
+            .runtime_metrics
+            .runtime_health_check
+            .set(1);
 
         if cfg!(feature = "oak_debug") {
             if let Some(port) = runtime_config.introspect_port {

--- a/oak/server/rust/oak_runtime/tests/integration_test.rs
+++ b/oak/server/rust/oak_runtime/tests/integration_test.rs
@@ -95,5 +95,8 @@ fn test_metrics_gives_the_correct_number_of_nodes() {
     let value = get_int_metric_value(&res, "runtime_nodes_total");
     assert_eq!(value, Some(2), "{}", &res);
 
+    let value = get_int_metric_value(&res, "runtime_health_check");
+    assert_eq!(value, Some(1), "{}", &res);
+
     runtime.stop_runtime();
 }


### PR DESCRIPTION
- Adds a metric, with a fixed value of 1, to indicate that the Runtime is up.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
