### PR TITLE
Add prometheus-to-sd to scrape metrics

### DIFF
--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -101,6 +101,6 @@ Deployment requires Docker images to be uploaded to the
 following command:
 
 ```bash
-./scripts/build_example -e aggregator -i
+./scripts/build_example -e aggregator -i base
 ./examples/aggregator/scripts/docker_push
 ```

--- a/examples/aggregator/gcp/pod.yaml
+++ b/examples/aggregator/gcp/pod.yaml
@@ -10,6 +10,9 @@ spec:
       image: gcr.io/oak-ci/oak-aggregator:latest
       ports:
         - containerPort: 8080
+          name: aggregator
+        - containerPort: 3030
+          name: metrics
       volumeMounts:
         - name: tls-secret
           mountPath: '/etc/oak-secrets'
@@ -24,6 +27,31 @@ spec:
       env:
         - name: RUST_LOG
           value: info
+    # Additional container to scrape prometheus metrics:
+    # https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd
+    - name: prometheus-to-stackdriver
+      image: gcr.io/google-containers/prometheus-to-sd:v0.9.2
+      ports:
+        - containerPort: 6060
+      command:
+        - /monitor
+        # To be able to push custom metrics to the Stackdriver, the `stackdriver-prefix`
+        # flag must be set to `custom.googleapis.com`.
+        # Ref: https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd#custom-metrics
+        # On custom metrics: https://cloud.google.com/monitoring/custom-metrics#about_custom_metrics
+        - --stackdriver-prefix=custom.googleapis.com
+        - --source=oak-application:http://localhost:3030/metrics
+        - --pod-id=$(POD_NAME)
+        - --namespace-id=$(POD_NAMESPACE)
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
   volumes:
     - name: tls-secret
       secret:


### PR DESCRIPTION
Added a new container from [prometheus-to-sd](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd)  to the aggregator pod. This container scrapes metrics from the aggregator oak-application.

Fixes #976 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
