### PR TITLE
Make scripts fail if any part of a pipeline fails

### DIFF
--- a/scripts/build_reproducibility_index
+++ b/scripts/build_reproducibility_index
@@ -13,7 +13,8 @@ source "$SCRIPTS_DIR/common"
 # List of artifacts that are expected to be reproducibly built.
 readonly REPRODUCIBLE_ARTIFACTS=(
   ./target/wasm32-unknown-unknown/release/*.wasm
-  ./target/x86_64-unknown-linux-musl/release/oak_loader
+  # TODO(#725): Include this line when `./scripts/build_server -s rust` actually builds the binary.
+  # ./target/x86_64-unknown-linux-musl/release/oak_loader
 )
 
 # Index file containing hashes of the reproducible artifacts, alongside their file names.

--- a/scripts/common
+++ b/scripts/common
@@ -4,6 +4,7 @@
 set -o errexit
 set -o nounset
 set -o xtrace
+set -o pipefail
 
 # Set the default Rust log level.
 # https://docs.rs/env_logger


### PR DESCRIPTION
Currently only the return value of the last command in a pipeline is
taken into account, any other failures are silently ignored.

In the reproducibility script this was actually causing the `sha256sum`
command failure to be ignored.

See
https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
