### PR TITLE
runtime: cope with aux servers quitting first

### DIFF
--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -179,7 +179,9 @@ impl Drop for AuxServer {
         let notify_sender = self.notify_sender.take();
         if let Some(notify_sender) = notify_sender {
             info!("stopping {} server", self.name);
-            notify_sender.send(()).unwrap();
+            // The auxiliary server may already have stopped, so ignore
+            // errors when sending the stop notification.
+            let _ = notify_sender.send(());
         }
         if let Some(join_handle) = join_handle {
             let result = join_handle.join();


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
