### PR TITLE
Introduce config map format and parsing logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,7 +1362,9 @@ dependencies = [
 name = "oak_loader"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak_runtime 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cargo/BUILD
+++ b/cargo/BUILD
@@ -9,6 +9,10 @@ licenses([
   "notice" # See individual crates for specific licenses
 ])
 alias(
+    name = "anyhow",
+    actual = "@raze__anyhow__1_0_28//:anyhow",
+)
+alias(
     name = "byteorder",
     actual = "@raze__byteorder__1_3_4//:byteorder",
 )

--- a/cargo/Cargo.lock
+++ b/cargo/Cargo.lock
@@ -116,6 +116,7 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 name = "cargo_under_bazel"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "bytes",
  "futures",

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 path = "fake_lib.rs"
 
 [dependencies]
+anyhow = "*"
 byteorder = "*"
 bytes = "*"
 futures = "*"

--- a/oak/proto/application.proto
+++ b/oak/proto/application.proto
@@ -125,3 +125,14 @@ message RoughtimeServer {
   uint32 port = 3;
   string public_key_base64 = 4;
 }
+
+// A serialized list of key-value pairs that are specified as command line flags to the Oak Loader
+// binary, and are made available to the initial Node of the running Oak Application.
+//
+// Keys are human readable strings and usually correspond to file names.
+//
+// Values are raw binary blobs and usually correspond to file contents, which must be interpreted by
+// the running Oak Application.
+message ConfigMap {
+  map<string, bytes> items = 1;
+}

--- a/oak/server/rust/oak_loader/BUILD
+++ b/oak/server/rust/oak_loader/BUILD
@@ -28,6 +28,7 @@ rust_binary(
     ],
     edition = "2018",
     deps = [
+        "//cargo:anyhow",
         "//cargo:log",
         "//cargo:prost",
         "//cargo:signal_hook",

--- a/oak/server/rust/oak_loader/Cargo.toml
+++ b/oak/server/rust/oak_loader/Cargo.toml
@@ -13,9 +13,13 @@ oak_debug = []
 default = ["oak_debug"]
 
 [dependencies]
+anyhow = "*"
 log = "*"
 oak_runtime = "=0.1.0"
 prost = "*"
 signal-hook = "*"
 simple_logger = "*"
 structopt = "*"
+
+[dev-dependencies]
+maplit = "*"

--- a/oak/server/rust/oak_loader/src/tests.rs
+++ b/oak/server/rust/oak_loader/src/tests.rs
@@ -1,0 +1,133 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use super::*;
+use maplit::hashmap;
+
+#[test]
+fn parse_config_entry_ok() {
+    assert_eq!(
+        ConfigEntry {
+            key: "foo".to_string(),
+            filename: "/dev/null".to_string()
+        },
+        "foo=/dev/null"
+            .parse::<ConfigEntry>()
+            .expect("could not parse config entry")
+    );
+}
+
+#[test]
+fn parse_config_entry_multiple_equals_err() {
+    assert_eq!(
+        false,
+        "foo=/dev/null=/foo/bar".parse::<ConfigEntry>().is_ok()
+    );
+}
+
+#[test]
+fn parse_config_entry_missing_equals_err() {
+    assert_eq!(false, "/dev/null".parse::<ConfigEntry>().is_ok());
+}
+
+#[test]
+fn parse_config_map_multiple_ok() {
+    let result = parse_config_map(&[
+        ConfigEntry {
+            key: "foo".to_string(),
+            filename: "/dev/null".to_string(),
+        },
+        ConfigEntry {
+            key: "authors".to_string(),
+            filename: "../../../../AUTHORS".to_string(),
+        },
+    ]);
+    assert_eq!(
+        ConfigMap {
+            items: hashmap! {
+                "foo".to_string() => vec![],
+                "authors".to_string() => b"# This is the list of Project Oak authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Google LLC
+".iter().cloned().collect(),
+            },
+        },
+        result.expect("could not parse config")
+    );
+}
+
+#[test]
+fn parse_config_map_dev_null_ok() {
+    let result = parse_config_map(&[ConfigEntry {
+        key: "foo".to_string(),
+        filename: "/dev/null".to_string(),
+    }]);
+    assert_eq!(
+        ConfigMap {
+            items: hashmap! {
+                "foo".to_string() => vec![],
+            },
+        },
+        result.expect("could not parse config")
+    );
+}
+
+#[test]
+fn parse_config_map_duplicate_key_err() {
+    let result = parse_config_map(&[
+        ConfigEntry {
+            key: "foo".to_string(),
+            filename: "/dev/null".to_string(),
+        },
+        ConfigEntry {
+            key: "foo".to_string(),
+            filename: "/dev/null".to_string(),
+        },
+    ]);
+    assert_eq!(false, result.is_ok());
+}
+
+#[test]
+fn parse_config_map_non_existing_file_err() {
+    let result = parse_config_map(&[ConfigEntry {
+        key: "foo".to_string(),
+        filename: "/non-existing-file".to_string(),
+    }]);
+    assert_eq!(false, result.is_ok());
+}
+
+#[test]
+fn parse_config_map_directory_err() {
+    let result = parse_config_map(&[ConfigEntry {
+        key: "foo".to_string(),
+        // Directory.
+        filename: "/etc".to_string(),
+    }]);
+    assert_eq!(false, result.is_ok());
+}
+
+#[test]
+fn parse_config_map_no_permission_err() {
+    let result = parse_config_map(&[ConfigEntry {
+        key: "foo".to_string(),
+        // File only readable by the root user.
+        filename: "/etc/sudoers".to_string(),
+    }]);
+    assert_eq!(false, result.is_ok());
+}

--- a/oak/server/rust/oak_runtime/src/proto/oak.application.rs
+++ b/oak/server/rust/oak_runtime/src/proto/oak.application.rs
@@ -140,3 +140,15 @@ pub struct RoughtimeServer {
     #[prost(string, tag="4")]
     pub public_key_base64: std::string::String,
 }
+/// A serialized list of key-value pairs that are specified as command line flags to the Oak Loader
+/// binary, and are made available to the initial Node of the running Oak Application.
+///
+/// Keys are human readable strings and usually correspond to file names.
+///
+/// Values are raw binary blobs and usually correspond to file contents, which must be interpreted by
+/// the running Oak Application.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConfigMap {
+    #[prost(map="string, bytes", tag="1")]
+    pub items: ::std::collections::HashMap<std::string::String, std::vec::Vec<u8>>,
+}


### PR DESCRIPTION
This will be used to pass configuration files and secrets to Oak
Applications, by specifying them via command line flags to the
`oak_loader` binary.

Also switch the top-level `oak_loader` error handling to the `anyhow`
crate.

Ref #689

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
