### PR TITLE
Add asserts to examples

### DIFF
--- a/examples/private_set_intersection/client/private_set_intersection.cc
+++ b/examples/private_set_intersection/client/private_set_intersection.cc
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <cassert>
-
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "examples/private_set_intersection/proto/private_set_intersection.grpc.pb.h"
@@ -97,14 +95,18 @@ int main(int argc, char** argv) {
   for (auto item : intersection_0) {
     LOG(INFO) << "- " << item;
   }
-  assert(std::set<std::string>(intersection_0.begin(), intersection_0.end()) == expected_set);
+  if (std::set<std::string>(intersection_0.begin(), intersection_0.end()) != expected_set) {
+    LOG(FATAL) << "Unexpected set";
+  }
 
   std::vector<std::string> intersection_1 = RetrieveIntersection(stub_1.get());
   LOG(INFO) << "client 1 intersection:";
   for (auto item : intersection_1) {
     LOG(INFO) << "- " << item;
   }
-  assert(std::set<std::string>(intersection_1.begin(), intersection_1.end()) == expected_set);
+  if (std::set<std::string>(intersection_1.begin(), intersection_1.end()) != expected_set) {
+    LOG(FATAL) << "Unexpected set";
+  }
 
   return EXIT_SUCCESS;
 }

--- a/examples/private_set_intersection/client/private_set_intersection.cc
+++ b/examples/private_set_intersection/client/private_set_intersection.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cassert>
+
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "examples/private_set_intersection/proto/private_set_intersection.grpc.pb.h"
@@ -87,18 +89,22 @@ int main(int argc, char** argv) {
   std::vector<std::string> set_1{"b", "c", "d"};
   SubmitSet(stub_1.get(), set_1);
 
+  std::set<std::string> expected_set{"b", "c"};
+
   // Retrieve intersection.
   std::vector<std::string> intersection_0 = RetrieveIntersection(stub_0.get());
   LOG(INFO) << "client 0 intersection:";
   for (auto item : intersection_0) {
     LOG(INFO) << "- " << item;
   }
+  assert(std::set<std::string>(intersection_0.begin(), intersection_0.end()) == expected_set);
 
   std::vector<std::string> intersection_1 = RetrieveIntersection(stub_1.get());
   LOG(INFO) << "client 1 intersection:";
   for (auto item : intersection_1) {
     LOG(INFO) << "- " << item;
   }
+  assert(std::set<std::string>(intersection_1.begin(), intersection_1.end()) == expected_set);
 
   return EXIT_SUCCESS;
 }

--- a/examples/running_average/client/running_average.cc
+++ b/examples/running_average/client/running_average.cc
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <cassert>
-
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "examples/running_average/proto/running_average.grpc.pb.h"
@@ -85,12 +83,16 @@ int main(int argc, char** argv) {
 
   // Retrieve average.
   int average_0 = retrieve_average(stub_0.get());
-  LOG(INFO) << "client 0 average: " << average_0;
-  assert(average_0 == 100);
+  LOG(INFO) << "Client 0 average: " << average_0;
+  if (average_0 != 100) {
+    LOG(FATAL) << "Unexpected average: " << average_0;
+  }
 
   int average_1 = retrieve_average(stub_1.get());
-  LOG(INFO) << "client 1 average: " << average_1;
-  assert(average_1 == 100);
+  LOG(INFO) << "Client 1 average: " << average_1;
+  if (average_1 != 100) {
+    LOG(FATAL) << "Unexpected average: " << average_0;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/examples/running_average/client/running_average.cc
+++ b/examples/running_average/client/running_average.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cassert>
+
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "examples/running_average/proto/running_average.grpc.pb.h"
@@ -84,9 +86,11 @@ int main(int argc, char** argv) {
   // Retrieve average.
   int average_0 = retrieve_average(stub_0.get());
   LOG(INFO) << "client 0 average: " << average_0;
+  assert(average_0 == 100);
 
   int average_1 = retrieve_average(stub_1.get());
   LOG(INFO) << "client 1 average: " << average_1;
+  assert(average_1 == 100);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This change adds `assert` to the `running_average` and `private_set_intersection` examples.

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.