### PR TITLE
Run `cargo clippy` before actual tests

### DIFF
--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -13,9 +13,9 @@ source "$SCRIPTS_DIR/common"
 
 export RUST_BACKTRACE=1
 
+cargo clippy --all-targets -- --deny=warnings
 cargo test --all-targets
 cargo test --doc
-cargo clippy --all-targets -- --deny=warnings
 
 bazel_build_flags+=( '--keep_going' )
 


### PR DESCRIPTION
It is much faster to complete, so it makes sense to return any issues
from it as soon as possible.