### PR TITLE
Rename secrecy to confidentiality

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -140,7 +140,7 @@ its ephemeral Channel handles.
 - Nodes and Channels have **Labels**, fixed at creation time
 - The Runtime keeps track of Labels, and enforces flow of data between Nodes and
   Channels based on them
-- Each Label has two **components**: **secrecy** and **integrity**
+- Each Label has two **components**: **confidentiality** and **integrity**
 - Each component is an unordered set of **tags**
 - Each tag is a structured representation of a **security principal**
 - A security principal is either a **user** or a **computation**
@@ -163,7 +163,7 @@ creation of side channels based on Labels.
 
 #### Components
 
-A Label has two components: **secrecy** and **integrity**.
+A Label has two components: **confidentiality** and **integrity**.
 
 Each component is represented as an (unordered) set of tags, and each tag refers
 to an individual security principal in the system.
@@ -178,12 +178,13 @@ The following types of security principals are supported in Oak:
 Tags and Labels are represented as serialized
 [protobuf messages](/oak/proto/policy.proto).
 
-Any security principal may be used (as a tag) as part of secrecy or integrity
-components, depending on the required use case.
+Any security principal may be used (as a tag) as part of confidentiality or
+integrity components, depending on the required use case.
 
-Intuitively, if the secrecy component contains tag `t`, the Node or Channel is
-allowed to see secrets owned by principal `t`. Similarly, if the integrity
-component contains tag `t`, that means the Node or Channel is trusted by `t`.
+Intuitively, if the confidentiality component contains tag `t`, the Node or
+Channel is allowed to see secrets owned by principal `t`. Similarly, if the
+integrity component contains tag `t`, that means the Node or Channel is trusted
+by `t`.
 
 #### Information Flow
 
@@ -191,21 +192,21 @@ Labels are compared to decide whether or not data movement is allowed, for
 example when a Node sends a value over a Channel. Given two labels `L_a` and
 `L_b`, `L_a ⊑ L_b` (pronounced "flows to") if a value from a source labeled
 `L_a` can be sent to a destination labeled `L_b`. The "flows to" operator
-compares both secrecy and integrity:
+compares both confidentiality and integrity:
 
-- the **secrecy** check ensures that the destination is permitted to view any
-  secrets that may have influenced the value
+- the **confidentiality** check ensures that the destination is permitted to
+  view any secrets that may have influenced the value
 - the **integrity** check ensures that the value sent is trusted by the
   destination
 
-More concretely, if `L_a = (S_a, I_a)` (where `S_a` and `I_a` are the secrecy
-and integrity components respectively), and `L_b = (S_b, I_b)` then `L_a ⊑ L_b`
-iff `S_a ⊆ S_b` and `I_a ⊇ I_b`. Notably, the integrity part of the check is
-"flipped" by convention (see "Integrity Considerations for Secure Computer
-Systems" below). More fundamental than adhering to convention, by flipping the
-integrity order in this way, we can retain the intuitive meaning behind
-integrity tags as representing trust by a principal (trust by a user, trust on a
-subject, etc.).
+More concretely, if `L_a = (C_a, I_a)` (where `C_a` and `I_a` are the
+confidentiality and integrity components respectively), and `L_b = (C_b, I_b)`
+then `L_a ⊑ L_b` iff `C_a ⊆ C_b` and `I_a ⊇ I_b`. Notably, the integrity part of
+the check is "flipped" by convention (see "Integrity Considerations for Secure
+Computer Systems" below). More fundamental than adhering to convention, by
+flipping the integrity order in this way, we can retain the intuitive meaning
+behind integrity tags as representing trust by a principal (trust by a user,
+trust on a subject, etc.).
 
 Intuitively, data can only flow from `a` to `b` if:
 
@@ -215,17 +216,17 @@ Intuitively, data can only flow from `a` to `b` if:
 The least privileged label is usually referred to as "public trusted" (and
 represented as `⊥`, pronounced "bottom"), which corresponds to a Node or Channel
 which has only observed public data, and its inputs are not endorsed with any
-level of integrity; in this label, both secrecy and integrity components are
-empty sets.
+level of integrity; in this label, both confidentiality and integrity components
+are empty sets.
 
-As an example, if the `a`'s secrecy is `{s_0, s_1}`, and `a`'s integrity is
-`{i_0, i_1}`, then:
+As an example, if the `a`'s confidentiality is `{c_0, c_1}`, and `a`'s integrity
+is `{i_0, i_1}`, then:
 
-- information can flow from `a` to `b` if `b`'s secrecy is
-  `{s_0, s_1, s_2} ⊇ {s_0, s_1}`, since `b` is "at least as secret" than `a`
-- information cannot flow from `a` to `b` if `b`'s secrecy is
-  `{s_0} ⊉ {s_0, s_1}`, since `b` is "less secret" than `a` (in particular, `b`
-  is not allowed to see secrets owned by `s_1`)
+- information can flow from `a` to `b` if `b`'s confidentiality is
+  `{c_0, c_1, c_2} ⊇ {c_0, c_1}`, since `b` is "at least as secret" than `a`
+- information cannot flow from `a` to `b` if `b`'s confidentiality is
+  `{c_0} ⊉ {c_0, c_1}`, since `b` is "less secret" than `a` (in particular, `b`
+  is not allowed to see secrets owned by `c_1`)
 - information cannot flow from `a` to `b` if `b`'s integrity is
   `{i_0, i_1, i_2} ⊈ {i_0, i_1}`, since `a` is "less trusted" than `b` (in
   particular, `a` is not trusted by `i_2`)
@@ -247,11 +248,11 @@ performed.
 It follows that bi-directional communication between Nodes `a` and `b` is only
 allowed (via two uni-directional Channels) if
 `(L_a ⊑ L_b) ∧ (L_b ⊑ L_a) ⇒ L_a = L_b`, i.e. if `a` and `b` have identical
-secrecy and integrity.
+confidentiality and integrity.
 
 #### Downgrades
 
-A Node may have the privilege to remove one or more secrecy tags
+A Node may have the privilege to remove one or more confidentiality tags
 (**declassification**) and / or add one or more integrity tags
 (**endorsement**). Both of these operations are instances of **downgrade**
 operations (which is a more general concept).
@@ -285,17 +286,17 @@ represented by a message containing two Channels handles:
 
 - a "request receiver" read handle to a Channel whose Label has:
 
-  - a secrecy component explicitly specified by the caller as gRPC request
-    metadata; this represents the secrecy guarantees that the caller wants to
-    impose on the request message.
+  - a confidentiality component explicitly specified by the caller as gRPC
+    request metadata; this represents the confidentiality guarantees that the
+    caller wants to impose on the request message.
   - an integrity component implicitly set by the gRPC pseudo-Node based on some
     trusted authentication mechanism that is performed as part of the gRPC
     connection itself; this represents the actual authority of the caller.
 
 - a "response sender" write handle to a Channel, whose Label has:
 
-  - a secrecy component implicitly set by the gRPC pseudo-Node based on some
-    trusted authentication mechanism that is performed as part of the gRPC
+  - a confidentiality component implicitly set by the gRPC pseudo-Node based on
+    some trusted authentication mechanism that is performed as part of the gRPC
     connection itself; this represents the actual authority of the caller.
   - an empty integrity component.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,7 +28,7 @@ following:
 2020-05-11 17:24:18,770 DEBUG [oak_runtime::runtime] waking waiters on NodeId(0) handle 11172775277784258633 => Channel 0 WRITE
 2020-05-11 17:24:18,770 INFO  [oak_runtime::runtime] Runtime instance dropped
 2020-05-11 17:24:18,770 DEBUG [oak_runtime::runtime::channel] last writer for channel 0 gone, wake waiters
-2020-05-11 17:24:18,770 DEBUG [oak_runtime::runtime::channel] dropping Channel object Channel { id=0, #readers=0, #writers=0, label=Label { secrecy_tags: [], integrity_tags: [] } }
+2020-05-11 17:24:18,770 DEBUG [oak_runtime::runtime::channel] dropping Channel object Channel { id=0, #readers=0, #writers=0, label=Label { confidentiality_tags: [], integrity_tags: [] } }
 ```
 
 The remainder of this document explores what's going on under the covers here,

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -94,14 +94,14 @@ impl AggregatorNode {
         );
 
         // Create a gRPC client Node with a less restrictive label than the current Node.
-        // In particular, the secrecy component of the current Node label includes the "aggregator"
-        // WebAssembly hash, which is declassified as part of the gRPC client Node creation. This is
-        // only allowed if the current Node actually has the appropriate capability (i.e. the
-        // correct WebAssembly module hash) as specified by the label component being removed, as
-        // set by the client.
-        // TODO(#814): Uncomment and use correct secrecy labels.
+        // In particular, the confidentiality component of the current Node label includes the
+        // "aggregator" WebAssembly hash, which is declassified as part of the gRPC client
+        // Node creation. This is only allowed if the current Node actually has the
+        // appropriate capability (i.e. the correct WebAssembly module hash) as specified by
+        // the label component being removed, as set by the client.
+        // TODO(#814): Uncomment and use correct confidentiality labels.
         // let label = Label {
-        //     secrecy_tags: vec![Tag {
+        //     confidentiality_tags: vec![Tag {
         //         tag: Some(tag::Tag::TlsEndpointTag(TlsEndpointTag {
         //             certificate_subject_alternative_name: "google.com".to_string(),
         //         })),

--- a/examples/chat/proto/chat.proto
+++ b/examples/chat/proto/chat.proto
@@ -25,8 +25,8 @@ message CreateRoomRequest {
   // should create a random bearer token of sufficient entropy to use as the room ID.
   //
   // TODO(#212): Once more of the labelling / policy system is implemented in the Oak Runtime, the
-  // secrecy of each chat room will not be based on the secrecy of this value, rather by the labels
-  // attached to individual messages by the various clients.
+  // confidentiality of each chat room will not be based on the confidentiality of this value,
+  // rather by the labels attached to individual messages by the various clients.
   bytes room_id = 1;
 
   // Bearer token used to administer the room; knowledge of this value allows control over the room

--- a/oak/common/label.cc
+++ b/oak/common/label.cc
@@ -43,9 +43,10 @@ oak::label::Label DeserializeLabel(const std::string& label_bytes) {
 
 oak::label::Label AuthorizationBearerTokenLabel(const std::string& authorization_token_hmac) {
   oak::label::Label label;
-  auto* secrecy_tag = label.add_secrecy_tags();
+  auto* confidentiality_tag = label.add_confidentiality_tags();
   auto* integrity_tag = label.add_integrity_tags();
-  secrecy_tag->mutable_grpc_tag()->set_authorization_bearer_token_hmac(authorization_token_hmac);
+  confidentiality_tag->mutable_grpc_tag()->set_authorization_bearer_token_hmac(
+      authorization_token_hmac);
   // We set integrity tag here, even though it would make more sense for the server to determine
   // what integrity tag to assign to the incoming message, based on the authentication mechanism
   // used (e.g. the actual bearer token, rather than its HMAC).
@@ -56,9 +57,10 @@ oak::label::Label AuthorizationBearerTokenLabel(const std::string& authorization
 
 oak::label::Label WebAssemblyModuleAttestationLabel(const std::string& module_attestation) {
   oak::label::Label label;
-  auto* secrecy_tag = label.add_secrecy_tags();
+  auto* confidentiality_tag = label.add_confidentiality_tags();
   auto* integrity_tag = label.add_integrity_tags();
-  secrecy_tag->mutable_web_assembly_module_tag()->set_module_attestation(module_attestation);
+  confidentiality_tag->mutable_web_assembly_module_tag()->set_module_attestation(
+      module_attestation);
   integrity_tag->mutable_web_assembly_module_tag()->set_module_attestation(module_attestation);
   return label;
 }

--- a/oak/proto/label.proto
+++ b/oak/proto/label.proto
@@ -22,12 +22,12 @@ package oak.label;
 //
 // See https://pdos.csail.mit.edu/papers/flume-sosp07.pdf section 3.1.
 message Label {
-  repeated Tag secrecy_tags = 1;
+  repeated Tag confidentiality_tags = 1;
   repeated Tag integrity_tags = 2;
 }
 
-// Tag represents a category of secrecy or integrity that is associated with data within Oak, and
-// refers to a Node or family of Nodes which are able to declassify data with that tag.
+// Tag represents a category of confidentiality or integrity that is associated with data within
+// Oak, and refers to a Node or family of Nodes which are able to declassify data with that tag.
 //
 // For instance, a tag may refer to a user connected over gRPC, or to the functionality implemented
 // by a WebAssembly Node, and this would require that data with those tags are declassified by the
@@ -49,7 +49,7 @@ message GrpcTag {
   // s such that h = HMAC-SHA256(s, "oak-grpc-bearer-token-1").
   //
   // We don't use the raw token t as the tag itself because labels are considered public by default,
-  // so the secrecy of the token would be compromised immediately.
+  // so the confidentiality of the token would be compromised immediately.
   bytes authorization_bearer_token_hmac = 1;
 }
 
@@ -67,7 +67,7 @@ message WebAssemblyModuleTag {
 // Applies to both the HTTP and gRPC client pseudo-nodes.
 message TlsEndpointTag {
   // The Subject Alternative Name (SAN) of a certificate that a remote endpoint must be able to
-  // present in order to be allowed to receive data with this secrecy tag.
+  // present in order to be allowed to receive data with this confidentiality tag.
   //
   // In general a certificate may have multiple SANs; an HTTP or gRPC client pseudo-node connected
   // to a remote endpoint with multiple SANs is able to declassify data with a TlsEndpointTag

--- a/oak/server/rust/oak_abi/src/label/mod.rs
+++ b/oak/server/rust/oak_abi/src/label/mod.rs
@@ -49,7 +49,7 @@ impl crate::proto::oak::label::Label {
     /// A Node or channel with this label has only observed public data and is trusted by no one.
     pub fn public_trusted() -> Self {
         Label {
-            secrecy_tags: vec![],
+            confidentiality_tags: vec![],
             integrity_tags: vec![],
         }
     }
@@ -58,15 +58,15 @@ impl crate::proto::oak::label::Label {
     pub fn flows_to(&self, other: &Self) -> bool {
         #![allow(clippy::mutable_key_type)]
 
-        let self_secrecy_tags: HashSet<_> = self.secrecy_tags.iter().collect();
-        let other_secrecy_tags: HashSet<_> = other.secrecy_tags.iter().collect();
+        let self_confidentiality_tags: HashSet<_> = self.confidentiality_tags.iter().collect();
+        let other_confidentiality_tags: HashSet<_> = other.confidentiality_tags.iter().collect();
         let self_integrity_tags: HashSet<_> = self.integrity_tags.iter().collect();
         let other_integrity_tags: HashSet<_> = other.integrity_tags.iter().collect();
 
         // The target label must have (compared to the self label):
-        // - same or more secrecy tags
+        // - same or more confidentiality tags
         // - same or fewer integrity tags
-        self_secrecy_tags.is_subset(&other_secrecy_tags)
+        self_confidentiality_tags.is_subset(&other_confidentiality_tags)
             && other_integrity_tags.is_subset(&self_integrity_tags)
     }
 }

--- a/oak/server/rust/oak_abi/src/label/tests.rs
+++ b/oak/server/rust/oak_abi/src/label/tests.rs
@@ -20,15 +20,15 @@ use super::*;
 fn serialize_deserialize() {
     let labels = vec![
         Label {
-            secrecy_tags: vec![],
+            confidentiality_tags: vec![],
             integrity_tags: vec![],
         },
         Label {
-            secrecy_tags: vec![authorization_bearer_token_hmac_tag(&[0, 0, 0])],
+            confidentiality_tags: vec![authorization_bearer_token_hmac_tag(&[0, 0, 0])],
             integrity_tags: vec![authorization_bearer_token_hmac_tag(&[1, 1, 1])],
         },
         Label {
-            secrecy_tags: vec![
+            confidentiality_tags: vec![
                 authorization_bearer_token_hmac_tag(&[0, 0, 0]),
                 authorization_bearer_token_hmac_tag(&[0, 0, 0]),
             ],
@@ -38,7 +38,7 @@ fn serialize_deserialize() {
             ],
         },
         Label {
-            secrecy_tags: vec![
+            confidentiality_tags: vec![
                 authorization_bearer_token_hmac_tag(&[0, 0, 0]),
                 authorization_bearer_token_hmac_tag(&[1, 1, 1]),
             ],
@@ -62,34 +62,34 @@ fn label_flow() {
 
     let public_trusted = Label::public_trusted();
 
-    // A label that corresponds to the secrecy of tag_0.
+    // A label that corresponds to the confidentiality of tag_0.
     //
     // A Node or channel with this label may have observed data related to tag_0.
     let label_0 = Label {
-        secrecy_tags: vec![tag_0.clone()],
+        confidentiality_tags: vec![tag_0.clone()],
         integrity_tags: vec![],
     };
 
-    // A label that corresponds to the secrecy of tag_1.
+    // A label that corresponds to the confidentiality of tag_1.
     //
     // A Node or channel with this label may have observed data related to tag_1.
     let label_1 = Label {
-        secrecy_tags: vec![tag_1.clone()],
+        confidentiality_tags: vec![tag_1.clone()],
         integrity_tags: vec![],
     };
 
-    // A label that corresponds to the combined secrecy of both tag_0 and tag_1.
+    // A label that corresponds to the combined confidentiality of both tag_0 and tag_1.
     //
     // A Node or channel with this label may have observed data related to tag_0 and tag_1.
     let label_0_1 = Label {
-        secrecy_tags: vec![tag_0.clone(), tag_1.clone()],
+        confidentiality_tags: vec![tag_0.clone(), tag_1.clone()],
         integrity_tags: vec![],
     };
 
     // A label identical to `label_0_1`, but in which tags appear in a different order. This
     // should not make any difference in terms of what the label actually represent.
     let label_1_0 = Label {
-        secrecy_tags: vec![tag_1, tag_0],
+        confidentiality_tags: vec![tag_1, tag_0],
         integrity_tags: vec![],
     };
 

--- a/oak/server/rust/oak_abi/src/proto/oak.label.rs
+++ b/oak/server/rust/oak_abi/src/proto/oak.label.rs
@@ -5,12 +5,12 @@
 #[derive(Eq, Hash)]
 pub struct Label {
     #[prost(message, repeated, tag="1")]
-    pub secrecy_tags: ::std::vec::Vec<Tag>,
+    pub confidentiality_tags: ::std::vec::Vec<Tag>,
     #[prost(message, repeated, tag="2")]
     pub integrity_tags: ::std::vec::Vec<Tag>,
 }
-/// Tag represents a category of secrecy or integrity that is associated with data within Oak, and
-/// refers to a Node or family of Nodes which are able to declassify data with that tag.
+/// Tag represents a category of confidentiality or integrity that is associated with data within
+/// Oak, and refers to a Node or family of Nodes which are able to declassify data with that tag.
 ///
 /// For instance, a tag may refer to a user connected over gRPC, or to the functionality implemented
 /// by a WebAssembly Node, and this would require that data with those tags are declassified by the
@@ -44,7 +44,7 @@ pub struct GrpcTag {
     /// s such that h = HMAC-SHA256(s, "oak-grpc-bearer-token-1").
     ///
     /// We don't use the raw token t as the tag itself because labels are considered public by default,
-    /// so the secrecy of the token would be compromised immediately.
+    /// so the confidentiality of the token would be compromised immediately.
     #[prost(bytes, tag="1")]
     pub authorization_bearer_token_hmac: std::vec::Vec<u8>,
 }
@@ -66,7 +66,7 @@ pub struct WebAssemblyModuleTag {
 #[derive(Eq, Hash)]
 pub struct TlsEndpointTag {
     /// The Subject Alternative Name (SAN) of a certificate that a remote endpoint must be able to
-    /// present in order to be allowed to receive data with this secrecy tag.
+    /// present in order to be allowed to receive data with this confidentiality tag.
     ///
     /// In general a certificate may have multiple SANs; an HTTP or gRPC client pseudo-node connected
     /// to a remote endpoint with multiple SANs is able to declassify data with a TlsEndpointTag

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -123,8 +123,9 @@ struct NodeInfo {
 /// See https://github.com/project-oak/oak/blob/master/docs/concepts.md#downgrades
 #[derive(Debug, Default, Clone)]
 pub struct NodePrivilege {
-    /// Tags that may be declassified (removed from the secrecy component of a label) by the Node.
-    can_declassify_secrecy_tags: HashSet<Tag>,
+    /// Tags that may be declassified (removed from the confidentiality component of a label) by
+    /// the Node.
+    can_declassify_confidentiality_tags: HashSet<Tag>,
 
     /// Tags that may be endorsed (added to the integrity component of a label) by the Node.
     can_endorse_integrity_tags: HashSet<Tag>,
@@ -759,11 +760,15 @@ impl Runtime {
         // Retrieve the set of tags that the node may downgrade.
         let node_privilege = self.get_node_privilege(node_id);
         Label {
-            // Remove all the secrecy tags that the Node may declassify.
-            secrecy_tags: node_label
-                .secrecy_tags
+            // Remove all the confidentiality tags that the Node may declassify.
+            confidentiality_tags: node_label
+                .confidentiality_tags
                 .iter()
-                .filter(|t| !node_privilege.can_declassify_secrecy_tags.contains(t))
+                .filter(|t| {
+                    !node_privilege
+                        .can_declassify_confidentiality_tags
+                        .contains(t)
+                })
                 .cloned()
                 .collect(),
             // Add all the integrity tags that the Node may endorse.

--- a/oak/server/rust/oak_runtime/src/runtime/tests.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/tests.rs
@@ -96,7 +96,7 @@ fn run_node_body(node_label: &Label, node_privilege: &NodePrivilege, node_body: 
 /// Returns a non-trivial label for testing.
 fn test_label() -> Label {
     Label {
-        secrecy_tags: vec![oak_abi::label::authorization_bearer_token_hmac_tag(&[
+        confidentiality_tags: vec![oak_abi::label::authorization_bearer_token_hmac_tag(&[
             1, 1, 1,
         ])],
         integrity_tags: vec![],
@@ -147,11 +147,11 @@ fn create_channel_less_secret_label_err() {
     let tag_0 = oak_abi::label::authorization_bearer_token_hmac_tag(&[1, 1, 1]);
     let tag_1 = oak_abi::label::authorization_bearer_token_hmac_tag(&[2, 2, 2]);
     let initial_label = Label {
-        secrecy_tags: vec![tag_0, tag_1.clone()],
+        confidentiality_tags: vec![tag_0, tag_1.clone()],
         integrity_tags: vec![],
     };
     let less_secret_label = Label {
-        secrecy_tags: vec![tag_1],
+        confidentiality_tags: vec![tag_1],
         integrity_tags: vec![],
     };
     run_node_body(
@@ -166,18 +166,18 @@ fn create_channel_less_secret_label_err() {
 }
 
 /// Create a test Node that creates a Channel with a less secret label and succeeds, because the
-/// node is granted the ability to declassify the removed secrecy tag.
+/// node is granted the ability to declassify the removed confidentiality tag.
 #[test]
 fn create_channel_less_secret_label_declassification_ok() {
     let tag_0 = oak_abi::label::authorization_bearer_token_hmac_tag(&[1, 1, 1]);
     let tag_1 = oak_abi::label::authorization_bearer_token_hmac_tag(&[2, 2, 2]);
     let other_tag = oak_abi::label::authorization_bearer_token_hmac_tag(&[3, 3, 3]);
     let initial_label = Label {
-        secrecy_tags: vec![tag_0.clone(), tag_1.clone()],
+        confidentiality_tags: vec![tag_0.clone(), tag_1.clone()],
         integrity_tags: vec![],
     };
     let less_secret_label = Label {
-        secrecy_tags: vec![tag_1],
+        confidentiality_tags: vec![tag_1],
         integrity_tags: vec![],
     };
     run_node_body(
@@ -185,7 +185,7 @@ fn create_channel_less_secret_label_declassification_ok() {
         // Grant this node the privilege to declassify `tag_0` and another unrelated tag, and
         // endorse another unrelated tag.
         &NodePrivilege {
-            can_declassify_secrecy_tags: hashset! { tag_0, other_tag.clone() },
+            can_declassify_confidentiality_tags: hashset! { tag_0, other_tag.clone() },
             can_endorse_integrity_tags: hashset! { other_tag },
         },
         Box::new(move |runtime| {
@@ -197,17 +197,17 @@ fn create_channel_less_secret_label_declassification_ok() {
 }
 
 /// Create a test Node that creates a Channel with a less secret label and fails, because the node
-/// is granted the ability to endorse (rather than declassify) the removed secrecy tag.
+/// is granted the ability to endorse (rather than declassify) the removed confidentiality tag.
 #[test]
 fn create_channel_less_secret_label_no_privilege_err() {
     let tag_0 = oak_abi::label::authorization_bearer_token_hmac_tag(&[1, 1, 1]);
     let tag_1 = oak_abi::label::authorization_bearer_token_hmac_tag(&[2, 2, 2]);
     let initial_label = Label {
-        secrecy_tags: vec![tag_0.clone(), tag_1.clone()],
+        confidentiality_tags: vec![tag_0.clone(), tag_1.clone()],
         integrity_tags: vec![],
     };
     let less_secret_label = Label {
-        secrecy_tags: vec![tag_1],
+        confidentiality_tags: vec![tag_1],
         integrity_tags: vec![],
     };
     run_node_body(
@@ -215,7 +215,7 @@ fn create_channel_less_secret_label_no_privilege_err() {
         // Grant this node the privilege to endorse (rather than declassify) `tag_0`, which in this
         // case is useless, so it should still fail.
         &NodePrivilege {
-            can_declassify_secrecy_tags: hashset! {},
+            can_declassify_confidentiality_tags: hashset! {},
             can_endorse_integrity_tags: hashset! { tag_0 },
         },
         Box::new(move |runtime| {
@@ -234,11 +234,11 @@ fn create_channel_more_secret_label_ok() {
     let tag_0 = oak_abi::label::authorization_bearer_token_hmac_tag(&[1, 1, 1]);
     let tag_1 = oak_abi::label::authorization_bearer_token_hmac_tag(&[2, 2, 2]);
     let initial_label = Label {
-        secrecy_tags: vec![tag_0.clone()],
+        confidentiality_tags: vec![tag_0.clone()],
         integrity_tags: vec![],
     };
     let more_secret_label = Label {
-        secrecy_tags: vec![tag_0, tag_1],
+        confidentiality_tags: vec![tag_0, tag_1],
         integrity_tags: vec![],
     };
     run_node_body(
@@ -300,11 +300,11 @@ fn create_node_invalid_configuration_err() {
 fn create_node_less_secret_label_err() {
     let tag_0 = oak_abi::label::authorization_bearer_token_hmac_tag(&[1, 1, 1]);
     let initial_label = Label {
-        secrecy_tags: vec![tag_0],
+        confidentiality_tags: vec![tag_0],
         integrity_tags: vec![],
     };
     let less_secret_label = Label {
-        secrecy_tags: vec![],
+        confidentiality_tags: vec![],
         integrity_tags: vec![],
     };
     let initial_label_clone = initial_label.clone();
@@ -326,11 +326,11 @@ fn create_node_more_secret_label_ok() {
     let tag_0 = oak_abi::label::authorization_bearer_token_hmac_tag(&[1, 1, 1]);
     let tag_1 = oak_abi::label::authorization_bearer_token_hmac_tag(&[2, 2, 2]);
     let initial_label = Label {
-        secrecy_tags: vec![tag_0.clone()],
+        confidentiality_tags: vec![tag_0.clone()],
         integrity_tags: vec![],
     };
     let more_secret_label = Label {
-        secrecy_tags: vec![tag_0, tag_1],
+        confidentiality_tags: vec![tag_0, tag_1],
         integrity_tags: vec![],
     };
     let initial_label_clone = initial_label.clone();


### PR DESCRIPTION
Seems a more accurate representation of the fact that data is kept
confidential to a set of subjects, as opposed to just secret, which
feels more like all-or-nothing.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
