### PR TITLE
Use Rust Oak Loader in Docker images

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,7 +27,7 @@ package(
 exports_files(["LICENSE"])
 
 # These files are built via cargo outside of Bazel.
-exports_files(srcs = glob(["target/release/oak_loader"]))
+exports_files(srcs = glob(["target/x86_64-unknown-linux-musl/release/oak_loader"]))
 exports_files(srcs = glob(["target/wasm32-unknown-unknown/release/*.wasm"]))
 
 # These files are necessary for the backend server in the Aggregator example application.

--- a/BUILD
+++ b/BUILD
@@ -27,7 +27,7 @@ package(
 exports_files(["LICENSE"])
 
 # These files are built via cargo outside of Bazel.
-exports_files(srcs = glob(["target/x86_64-unknown-linux-musl/release/oak_loader"]))
+exports_files(srcs = glob(["target/x86_64-unknown-linux-musl/release/*oak_loader"]))
 
 exports_files(srcs = glob(["target/wasm32-unknown-unknown/release/*.wasm"]))
 

--- a/BUILD
+++ b/BUILD
@@ -27,6 +27,7 @@ package(
 exports_files(["LICENSE"])
 
 # These files are built via cargo outside of Bazel.
+exports_files(srcs = glob(["target/release/oak_loader"]))
 exports_files(srcs = glob(["target/wasm32-unknown-unknown/release/*.wasm"]))
 
 # These files are necessary for the backend server in the Aggregator example application.

--- a/BUILD
+++ b/BUILD
@@ -28,6 +28,7 @@ exports_files(["LICENSE"])
 
 # These files are built via cargo outside of Bazel.
 exports_files(srcs = glob(["target/x86_64-unknown-linux-musl/release/oak_loader"]))
+
 exports_files(srcs = glob(["target/wasm32-unknown-unknown/release/*.wasm"]))
 
 # These files are necessary for the backend server in the Aggregator example application.

--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -36,7 +36,7 @@ Build and run the Aggregator with the following command:
 
 ```bash
 ./scripts/build_example -e aggregator
-./scripts/build_server -s base
+./scripts/build_server -s rust
 ./bazel-clang-bin/oak/server/loader/oak_runner \
   --application=./bazel-client-bin/examples/aggregator/config/config.bin \
   --private_key=./examples/certs/local/local.key \
@@ -101,6 +101,6 @@ Deployment requires Docker images to be uploaded to the
 following command:
 
 ```bash
-./scripts/build_example -e aggregator -i base
+./scripts/build_example -e aggregator -i rust
 ./examples/aggregator/scripts/docker_push
 ```

--- a/examples/aggregator/gcp/pod.yaml
+++ b/examples/aggregator/gcp/pod.yaml
@@ -19,11 +19,21 @@ spec:
           readOnly: true
       args:
         - --application=config.bin
-        - --ca_cert=/etc/oak-secrets/ca.pem
-        - --cert_chain=/etc/oak-secrets/gcp.pem
-        - --private_key=/etc/oak-secrets/gcp.key
+        - --grpc-tls-private-key=/etc/oak-secrets/gcp.key
+        - --grpc-tls-certificate=/etc/oak-secrets/gcp.pem
+        - --root-tls-certificate=/etc/oak-secrets/ca.pem
+      env:
+        - name: RUST_LOG
+          value: info
     - name: backend
       image: gcr.io/oak-ci/oak-aggregator-backend:latest
+      volumeMounts:
+        - name: tls-secret
+          mountPath: '/etc/oak-secrets'
+          readOnly: true
+      args:
+        - --grpc-tls-private-key=/etc/oak-secrets/gcp.key
+        - --grpc-tls-certificate=/etc/oak-secrets/gcp.pem
       env:
         - name: RUST_LOG
           value: info

--- a/examples/tensorflow/config/BUILD
+++ b/examples/tensorflow/config/BUILD
@@ -17,6 +17,7 @@
 load("//oak/common:app_config.bzl", "serialized_config")
 
 package(
+    default_visibility = ["//examples/tensorflow:__subpackages__"],
     licenses = ["notice"],
 )
 

--- a/oak/server/loader/BUILD
+++ b/oak/server/loader/BUILD
@@ -64,7 +64,7 @@ container_image(
     name = "oak_docker",
     base = "@cc_image//image",
     files = [
-        "//:target/release/oak_loader",
+        "//:target/x86_64-unknown-linux-musl/release/oak_loader",
     ],
     ports = [
         "8080/tcp",  # Oak Application gRPC port.

--- a/oak/server/loader/BUILD
+++ b/oak/server/loader/BUILD
@@ -64,7 +64,7 @@ container_image(
     name = "oak_docker",
     base = "@cc_image//image",
     files = [
-        "oak_runner",
+        "//:target/release/oak_loader",
     ],
     ports = [
         "8080/tcp",  # Oak Application gRPC port.

--- a/oak/server/loader/oak_docker.bzl
+++ b/oak/server/loader/oak_docker.bzl
@@ -36,7 +36,7 @@ def oak_docker(name, application, ports):
         name = name,
         base = "//oak/server/loader:oak_docker",
         entrypoint = [
-            "./oak_runner",
+            "./oak_loader",
         ],
         # `files` must contain full file paths with extensions.
         files = [application_path],

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -6,6 +6,7 @@ source "${SCRIPTS_DIR}/common"
 
 language="rust"
 compilation_mode='fastbuild'
+server=''
 docker_config=''
 while getopts "e:l:di:h" opt; do
   case "${opt}" in
@@ -34,6 +35,7 @@ Options:
     d)
       compilation_mode='dbg';;
     i)
+      server="${OPTARG}"
       case "${OPTARG}" in
         rust)
           docker_config='clang';;
@@ -92,7 +94,12 @@ case "${language}" in
 esac
 
 if [[ -n "${docker_config}" ]]; then
-  bazel build "${bazel_build_flags[@]}" "--config=${docker_config}" "//examples/${EXAMPLE}/server:${EXAMPLE}_image.tar"
+  "${SCRIPTS_DIR}/build_server" -s "${server}"
+  if [[ "${EXAMPLE}" == "tensorflow" ]]; then
+    bazel --output_base="${CACHE_DIR}/emscripten" build "${bazel_build_flags[@]}" --config=emscripten //examples/tensorflow/server:tensorflow_image.tar
+  else
+    bazel build "${bazel_build_flags[@]}" "--config=${docker_config}" "//examples/${EXAMPLE}/server:${EXAMPLE}_image.tar"
+  fi
 
   # `aggregator` example has an additional Backend Docker image.
   if [[ "${EXAMPLE}" == "aggregator" ]]; then


### PR DESCRIPTION
This change:
- Makes Docker images to use Rust Oak Loader
- Adds support for `tensorflow` example Docker image

Fixes #448

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
