### PR TITLE
Use localhost instead of 127.0.0.1 in docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -204,7 +204,7 @@ an Oak Runtime instance of its own.
 The client should run to completion and give output something like:
 
 ```log
-I0511 10:15:29.539814 244858 hello_world.cc:66] Connecting to Oak Application: 127.0.0.1:8080
+I0511 10:15:29.539814 244858 hello_world.cc:66] Connecting to Oak Application: localhost:8080
 I0511 10:15:29.541366 244858 hello_world.cc:36] Request: WORLD
 I0511 10:15:29.558292 244858 hello_world.cc:43] Response: HELLO WORLD!
 I0511 10:15:29.558353 244858 hello_world.cc:36] Request: MONDO

--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -55,7 +55,7 @@ Build and run the Client with the following command:
 ```bash
 ./scripts/build_example -e aggregator
 ./bazel-client-bin/examples/aggregator/client/client \
-  --address=127.0.0.1:8080 \
+  --address=localhost:8080 \
   --ca_cert=./examples/certs/local/ca.pem \
   --bucket=test \
   --data=1:10,2:20,3:30

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -40,13 +40,13 @@ This will emit a trace line that holds the information needed to:
 - join the chat room (with `--room_id`).
 
 ```log
-2019-10-24 10:47:20  INFO  chat.cc : 242 : Join this room with --address=localhost:32889 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
+2019-10-24 10:47:20  INFO  chat.cc : 242 : Join this room with --address=localhost:8080 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
 ```
 
 Another party can then join the same chat room by using these arguments:
 
 ```bash
-./scripts/run_example -s none -e chat -- --address=localhost:32889 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
+./scripts/run_example -s none -e chat -- --address=localhost:8080 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
 ```
 
 Alternatively, another party can create a new chat room running on the same Oak
@@ -54,14 +54,14 @@ Application by just copying the `--address` argument, but specifying a new room
 name:
 
 ```bash
-./scripts/run_example -s none -e chat -- --address=localhost:32889
+./scripts/run_example -s none -e chat -- --address=localhost:8080
 ```
 
 This will again emit a trace line with the information needed to join this new
 room (on the same server):
 
 ```log
-2019-10-24 11:04:40  INFO  chat.cc : 242 : Join this room with --address=localhost:32889 --room_id=msSGas1Ie2rtGIvG0bLa2Jh3ODjO35nix46R3j2iYjAcB8zDcJpn/P2DD7c0yB1NMmfoipBSAePJzlXjknm8gg==
+2019-10-24 11:04:40  INFO  chat.cc : 242 : Join this room with --address=localhost:8080 --room_id=msSGas1Ie2rtGIvG0bLa2Jh3ODjO35nix46R3j2iYjAcB8zDcJpn/P2DD7c0yB1NMmfoipBSAePJzlXjknm8gg==
 ```
 
 ## CI Invocation

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -40,13 +40,13 @@ This will emit a trace line that holds the information needed to:
 - join the chat room (with `--room_id`).
 
 ```log
-2019-10-24 10:47:20  INFO  chat.cc : 242 : Join this room with --address=127.0.0.1:32889 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
+2019-10-24 10:47:20  INFO  chat.cc : 242 : Join this room with --address=localhost:32889 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
 ```
 
 Another party can then join the same chat room by using these arguments:
 
 ```bash
-./scripts/run_example -s none -e chat -- --address=127.0.0.1:32889 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
+./scripts/run_example -s none -e chat -- --address=localhost:32889 --room_id=NKsceNlg69UbcvryfzmFGnMv9qnZ0DYh6u6gJxujnPPxvHsxMehoD368sumKawVaq9WaSkzrcStoNYLvVNdzhA==
 ```
 
 Alternatively, another party can create a new chat room running on the same Oak
@@ -54,14 +54,14 @@ Application by just copying the `--address` argument, but specifying a new room
 name:
 
 ```bash
-./scripts/run_example -s none -e chat -- --address=127.0.0.1:32889
+./scripts/run_example -s none -e chat -- --address=localhost:32889
 ```
 
 This will again emit a trace line with the information needed to join this new
 room (on the same server):
 
 ```log
-2019-10-24 11:04:40  INFO  chat.cc : 242 : Join this room with --address=127.0.0.1:32889 --room_id=msSGas1Ie2rtGIvG0bLa2Jh3ODjO35nix46R3j2iYjAcB8zDcJpn/P2DD7c0yB1NMmfoipBSAePJzlXjknm8gg==
+2019-10-24 11:04:40  INFO  chat.cc : 242 : Join this room with --address=localhost:32889 --room_id=msSGas1Ie2rtGIvG0bLa2Jh3ODjO35nix46R3j2iYjAcB8zDcJpn/P2DD7c0yB1NMmfoipBSAePJzlXjknm8gg==
 ```
 
 ## CI Invocation


### PR DESCRIPTION
This change updates docs to use localhost instead of `127.0.0.1`.

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have updated [documentation](docs/) accordingly.
