### PR TITLE
Fix name of `public_untrusted` label

### DIFF
--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -409,7 +409,7 @@ unsafe fn invalid_raw_offset() -> *mut u64 {
 fn channel_create_raw() -> (u64, u64, u32) {
     let mut w = 0u64;
     let mut r = 0u64;
-    let label_bytes = Label::public_trusted().serialize();
+    let label_bytes = Label::public_untrusted().serialize();
     let result = unsafe {
         oak_abi::channel_create(
             &mut w as *mut u64,
@@ -425,7 +425,7 @@ impl FrontendNode {
     fn test_channel_create_raw(&mut self) -> TestResult {
         let mut write = 0u64;
         let mut read = 0u64;
-        let label_bytes = Label::public_trusted().serialize();
+        let label_bytes = Label::public_untrusted().serialize();
         expect_eq!(OakStatus::ErrInvalidArgs as u32, unsafe {
             oak_abi::channel_create(
                 invalid_raw_offset(),
@@ -1215,7 +1215,7 @@ impl FrontendNode {
     fn test_node_create_raw(&mut self) -> TestResult {
         let (_, in_channel, _) = channel_create_raw();
 
-        let valid_label_bytes = Label::public_trusted().serialize();
+        let valid_label_bytes = Label::public_untrusted().serialize();
 
         // This sequence of bytes should not deserialize as a [`oak_abi::proto::policy::Label`] or
         // [`oak_abi::proto::oak::application::NodeConfiguration`] protobuf. We make sure

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -110,7 +110,7 @@ impl AggregatorNode {
         // };
         match oak::grpc::client::Client::new_with_label(
             &oak::node_config::grpc_client("127.0.0.1:8888"),
-            &Label::public_trusted(),
+            &Label::public_untrusted(),
         )
         .map(AggregatorClient)
         {

--- a/oak/server/rust/oak_glue/src/lib.rs
+++ b/oak/server/rust/oak_glue/src/lib.rs
@@ -329,7 +329,7 @@ pub unsafe extern "C" fn glue_channel_create(node_id: u64, write: *mut u64, read
     debug!("{{{}}}: channel_create({:?}, {:?})", node_id, write, read);
     let proxy = proxy_for_node(node_id);
     let (write_handle, read_handle) =
-        match proxy.channel_create(&oak_abi::label::Label::public_trusted()) {
+        match proxy.channel_create(&oak_abi::label::Label::public_untrusted()) {
             Ok(r) => r,
             Err(s) => return s as u32,
         };

--- a/oak/server/rust/oak_runtime/src/node/grpc/server/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/server/mod.rs
@@ -337,9 +337,9 @@ impl GrpcRequestHandler {
     fn handle_grpc_request(&self, request: GrpcRequest) -> Result<oak_abi::Handle, OakStatus> {
         // Create a pair of temporary channels to pass the gRPC request and to receive the response.
         let (request_writer, request_reader) =
-            self.runtime.channel_create(&Label::public_trusted())?;
+            self.runtime.channel_create(&Label::public_untrusted())?;
         let (response_writer, response_reader) =
-            self.runtime.channel_create(&Label::public_trusted())?;
+            self.runtime.channel_create(&Label::public_untrusted())?;
 
         // Create an invocation message and attach the method-invocation specific channels to it.
         //

--- a/oak/server/rust/oak_runtime/src/node/wasm/tests.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/tests.rs
@@ -34,7 +34,7 @@ fn start_node(wasm_module: Vec<u8>, entrypoint_name: &str) -> Result<(), OakStat
     };
     let proxy =
         RuntimeProxy::create_runtime(application_configuration, GrpcConfiguration::default());
-    let (_write_handle, read_handle) = proxy.channel_create(&Label::public_trusted())?;
+    let (_write_handle, read_handle) = proxy.channel_create(&Label::public_untrusted())?;
 
     let result = proxy.node_create(
         &NodeConfiguration {
@@ -44,7 +44,7 @@ fn start_node(wasm_module: Vec<u8>, entrypoint_name: &str) -> Result<(), OakStat
                 wasm_entrypoint_name: entrypoint_name.to_string(),
             })),
         },
-        &oak_abi::label::Label::public_trusted(),
+        &oak_abi::label::Label::public_untrusted(),
         read_handle,
     );
 

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -330,7 +330,7 @@ impl RuntimeProxy {
         proxy.runtime.node_configure_instance(
             proxy.node_id,
             "implicit.initial",
-            &Label::public_trusted(),
+            &Label::public_untrusted(),
             &NodePrivilege::default(),
         );
         proxy
@@ -388,7 +388,7 @@ impl RuntimeProxy {
 
         // When first starting, we assign the least privileged label to the channel connecting the
         // outside world to the entry point Node.
-        let (write_handle, read_handle) = self.channel_create(&Label::public_trusted())?;
+        let (write_handle, read_handle) = self.channel_create(&Label::public_untrusted())?;
         debug!(
             "{:?}: created initial channel ({}, {})",
             self.node_id, write_handle, read_handle,
@@ -397,7 +397,7 @@ impl RuntimeProxy {
         self.node_create(
             &node_configuration,
             // When first starting, we assign the least privileged label to the entry point Node.
-            &Label::public_trusted(),
+            &Label::public_untrusted(),
             read_handle,
         )?;
         self.channel_close(read_handle)

--- a/oak_abi/src/label/mod.rs
+++ b/oak_abi/src/label/mod.rs
@@ -47,7 +47,7 @@ impl crate::proto::oak::label::Label {
     /// Return the least privileged label.
     ///
     /// A Node or channel with this label has only observed public data and is trusted by no one.
-    pub fn public_trusted() -> Self {
+    pub fn public_untrusted() -> Self {
         Label {
             confidentiality_tags: vec![],
             integrity_tags: vec![],

--- a/oak_abi/src/label/tests.rs
+++ b/oak_abi/src/label/tests.rs
@@ -60,7 +60,7 @@ fn label_flow() {
     let tag_0 = authorization_bearer_token_hmac_tag(&[0, 0, 0]);
     let tag_1 = authorization_bearer_token_hmac_tag(&[1, 1, 1]);
 
-    let public_trusted = Label::public_trusted();
+    let public_untrusted = Label::public_untrusted();
 
     // A label that corresponds to the confidentiality of tag_0.
     //
@@ -101,10 +101,10 @@ fn label_flow() {
     //       label_0    label_1
     //             \     /
     //              \   /
-    //          public_trusted
+    //          public_untrusted
 
     // Data with any label can flow to the same label.
-    assert_eq!(true, public_trusted.flows_to(&public_trusted));
+    assert_eq!(true, public_untrusted.flows_to(&public_untrusted));
     assert_eq!(true, label_0.flows_to(&label_0));
     assert_eq!(true, label_1.flows_to(&label_1));
     assert_eq!(true, label_0_1.flows_to(&label_0_1));
@@ -115,15 +115,15 @@ fn label_flow() {
     assert_eq!(true, label_0_1.flows_to(&label_1_0));
     assert_eq!(true, label_1_0.flows_to(&label_0_1));
 
-    // public_trusted data can flow to more private data;
-    assert_eq!(true, public_trusted.flows_to(&label_0));
-    assert_eq!(true, public_trusted.flows_to(&label_1));
-    assert_eq!(true, public_trusted.flows_to(&label_0_1));
+    // public_untrusted data can flow to more private data;
+    assert_eq!(true, public_untrusted.flows_to(&label_0));
+    assert_eq!(true, public_untrusted.flows_to(&label_1));
+    assert_eq!(true, public_untrusted.flows_to(&label_0_1));
 
-    // Private data cannot flow to public_trusted.
-    assert_eq!(false, label_0.flows_to(&public_trusted));
-    assert_eq!(false, label_1.flows_to(&public_trusted));
-    assert_eq!(false, label_0_1.flows_to(&public_trusted));
+    // Private data cannot flow to public_untrusted.
+    assert_eq!(false, label_0.flows_to(&public_untrusted));
+    assert_eq!(false, label_1.flows_to(&public_untrusted));
+    assert_eq!(false, label_0_1.flows_to(&public_untrusted));
 
     // Private data with non-comparable labels cannot flow to each other.
     assert_eq!(false, label_0.flows_to(&label_1));

--- a/sdk/rust/oak/src/grpc/client.rs
+++ b/sdk/rust/oak/src/grpc/client.rs
@@ -24,9 +24,9 @@ pub struct Client {
 
 impl Client {
     /// Similar to [`Client::new_with_label`] but with a fixed label corresponding to "public
-    /// trusted".
+    /// untrusted".
     pub fn new(config: &NodeConfiguration) -> Option<Client> {
-        Client::new_with_label(config, &Label::public_trusted())
+        Client::new_with_label(config, &Label::public_untrusted())
     }
 
     /// Creates a new Node that implements a gRPC service, and if successful return a Client.

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -316,9 +316,9 @@ pub fn channel_write(half: WriteHandle, buf: &[u8], handles: &[Handle]) -> Resul
 }
 
 /// Similar to [`channel_create_with_label`], but with a fixed label corresponding to "public
-/// trusted".
+/// untrusted".
 pub fn channel_create() -> Result<(WriteHandle, ReadHandle), OakStatus> {
-    channel_create_with_label(&Label::public_trusted())
+    channel_create_with_label(&Label::public_untrusted())
 }
 
 /// Create a new unidirectional channel.
@@ -353,9 +353,10 @@ pub fn channel_close(handle: Handle) -> Result<(), OakStatus> {
     result_from_status(status as i32, ())
 }
 
-/// Similar to [`node_create_with_label`], but with a fixed label corresponding to "public trusted".
+/// Similar to [`node_create_with_label`], but with a fixed label corresponding to "public
+/// untrusted".
 pub fn node_create(config: &NodeConfiguration, half: ReadHandle) -> Result<(), OakStatus> {
-    node_create_with_label(config, &Label::public_trusted(), half)
+    node_create_with_label(config, &Label::public_untrusted(), half)
 }
 
 /// Creates a new Node running the configuration identified by `config_name`, running the entrypoint

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -133,7 +133,7 @@ where
     // In most cases we do not care about labels, so we use the least privileged label for this
     // channel.
     let (req_write_handle, req_read_handle) = proxy
-        .channel_create(&oak_abi::label::Label::public_trusted())
+        .channel_create(&oak_abi::label::Label::public_untrusted())
         .expect("could not create channel");
     proxy
         .channel_write(req_write_handle, req_msg)
@@ -144,7 +144,7 @@ where
     // In most cases we do not care about labels, so we use the least privileged label for this
     // channel.
     let (rsp_write_handle, rsp_read_handle) = proxy
-        .channel_create(&oak_abi::label::Label::public_trusted())
+        .channel_create(&oak_abi::label::Label::public_untrusted())
         .expect("could not create channel");
 
     // Create a notification message and attach the method-invocation specific channels to it.


### PR DESCRIPTION
This was incorrectly referred to as `public_trusted`, while in fact it
is not trusted by anyone, as it has an empty integrity label.

Fix #980