### PR TITLE
Generate docs for the `oak_abi` crate

### DIFF
--- a/scripts/build_gh_pages
+++ b/scripts/build_gh_pages
@@ -12,7 +12,7 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-readonly TARGET_DIR="${1:-}"
+readonly TARGET_DIR="$(cd "${1:-}" && pwd)"
 
 if [[ -z "${TARGET_DIR}" ]]; then
   echo 'target dir not specified'
@@ -29,25 +29,38 @@ if [[ -n "$(ls "${TARGET_DIR}"/*)" ]]; then
   exit 1
 fi
 
-# Generate docs directly in the target dir.
-cargo doc --no-deps --target-dir="${TARGET_DIR}"
+readonly CURRENT_DIR="$(pwd)"
 
-# Remove non-doc artifacts from the target dir.
-rm --recursive --force "${TARGET_DIR}/debug"
+paths=("." "oak_abi" "oak_utils")
+names=("oak" "oak_abi" "oak_utils")
+titles=("SDK" "ABI" "Utils")
 
-# Remove non-deterministic files.
-rm "${TARGET_DIR}/.rustc_info.json"
+for i in {0..2}; do
+  cd "${CURRENT_DIR}"
+  target="${TARGET_DIR}/${names[$i]}"
+  mkdir -p target
+  cd "${paths[$i]}"
 
-# The docs generated from the Cargo workspace do not include a workspace-level index, so we generate
-# one here and redirect to the Oak SDK documentation.
-cat <<-END > "${TARGET_DIR}/index.html"
+  # Generate docs directly in the target dir.
+  cargo doc --no-deps --target-dir="${target}"
+
+  # Remove non-doc artifacts from the target dir.
+  rm --recursive --force "${target}/debug"
+
+  # Remove non-deterministic files.
+  rm "${target}/.rustc_info.json"
+
+  # The docs generated from the Cargo workspace do not include a workspace-level index, so we generate
+  # one here and redirect to the Oak SDK documentation.
+cat <<-END > "${target}/index.html"
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Refresh" content="0; url=./doc/oak/index.html" />
+    <meta http-equiv="Refresh" content="0; url=./doc/${names[$i]}/index.html" />
   </head>
   <body>
-    <p><a href="./doc/oak/index.html">Oak SDK main page</a></p>
+    <p><a href="./doc/${names[$i]}/index.html">Oak ${titles[$i]} main page</a></p>
   </body>
 </html>
 END
+done

--- a/scripts/build_gh_pages
+++ b/scripts/build_gh_pages
@@ -12,7 +12,7 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-readonly TARGET_DIR="$(cd "${1:-}" && pwd)"
+readonly TARGET_DIR="${1:-}"
 
 if [[ -z "${TARGET_DIR}" ]]; then
   echo 'target dir not specified'
@@ -29,38 +29,59 @@ if [[ -n "$(ls "${TARGET_DIR}"/*)" ]]; then
   exit 1
 fi
 
-readonly CURRENT_DIR="$(pwd)"
+# Absolute path to the target directory, to make sure that docs are generated into the correct directory.
+readonly TARGET_ABS_PATH="$(realpath "${TARGET_DIR}")"
 
-paths=("." "oak_abi" "oak_utils")
-names=("oak" "oak_abi" "oak_utils")
-titles=("SDK" "ABI" "Utils")
+# All the dirs that we want to generate docs for.
+declare -ar SOURCE_PATHS=("." "oak_abi" "oak_utils")
+declare -ar TARGET_SUBDIRS=("oak" "oak_abi" "oak_utils")
 
-for i in {0..2}; do
-  cd "${CURRENT_DIR}"
-  target="${TARGET_DIR}/${names[$i]}"
-  mkdir -p target
-  cd "${paths[$i]}"
+# Titles used in the top-level index.html files. 
+declare -ar PAGE_TITLES=("SDK" "ABI" "Utils")
 
-  # Generate docs directly in the target dir.
-  cargo doc --no-deps --target-dir="${target}"
+readonly LEN=${#SOURCE_PATHS[@]}
 
-  # Remove non-doc artifacts from the target dir.
-  rm --recursive --force "${target}/debug"
+for ((i=0;i<LEN;i++)); do
+  (
+    cd "${SOURCE_PATHS[$i]}"
 
-  # Remove non-deterministic files.
-  rm "${target}/.rustc_info.json"
+    target_dir="${TARGET_ABS_PATH}/${TARGET_SUBDIRS[$i]}"
+    mkdir --parent "${target_dir}"
 
-  # The docs generated from the Cargo workspace do not include a workspace-level index, so we generate
-  # one here and redirect to the Oak SDK documentation.
-cat <<-END > "${target}/index.html"
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="Refresh" content="0; url=./doc/${names[$i]}/index.html" />
-  </head>
-  <body>
-    <p><a href="./doc/${names[$i]}/index.html">Oak ${titles[$i]} main page</a></p>
-  </body>
-</html>
+    # Generate docs directly into the target dir.
+    cargo doc --no-deps --target-dir="${target_dir}"
+
+    # Remove non-doc artifacts from the target dir.
+    rm --recursive --force "${target_dir}/debug"
+
+    # Remove non-deterministic files.
+    rm "${target_dir}/.rustc_info.json"
+
+    # The docs generated from the Cargo workspace do not include a workspace-level index, so we generate
+    # one here and redirect to the appropriate documentation.
+    cat <<-END > "${target_dir}/index.html"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta http-equiv="Refresh" content="0; url=./doc/${TARGET_SUBDIRS[$i]}/index.html" />
+        </head>
+        <body>
+          <p><a href="./doc/${TARGET_SUBDIRS[$i]}/index.html">Oak ${PAGE_TITLES[$i]} main page</a></p>
+        </body>
+      </html>
 END
+  )
 done
+
+# A top-level index so that visiting https://project-oak.github.io/oak/ goes somewhere helpful.
+cat <<-END > "${TARGET_ABS_PATH}/index.html"
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <meta http-equiv="Refresh" content="0; url=./oak/doc/oak/index.html" />
+    </head>
+    <body>
+      <p><a href="./oak/doc/oak/index.html">Oak SDK main page</a></p>
+    </body>
+  </html>
+END

--- a/scripts/check_docs
+++ b/scripts/check_docs
@@ -10,16 +10,22 @@ source "$SCRIPTS_DIR/common"
 # false positive warning removed (https://github.com/rust-lang/rust/pull/70789)
 export RUSTDOCFLAGS="-A unused_braces"
 
-DOCS_OUT="$(cargo doc --document-private-items --no-deps 2>&1)"
+paths=("." "oak_abi" "../oak_utils")
 
-# `cargo doc` produces warnings for incorrect paths. These warnings cannot be promoted to errors, so we use grep to detect them.
-if grep --ignore-case --quiet --regexp='^warning' <<< "$DOCS_OUT"; then
-  echo "Warnings found when generating the docs."
-  exit 1
-fi
+for i in "${paths[@]}"
+do
+  cd "$i"
+  DOCS_OUT="$(cargo doc --document-private-items --no-deps 2>&1)"
 
-# Check for any deadlinks in the generated docs.
-if ! cargo deadlinks --dir target/doc; then
-  echo "Found deadlinks in the generated docs."
-  exit 1
-fi
+  # `cargo doc` produces warnings for incorrect paths. These warnings cannot be promoted to errors, so we use grep to detect them.
+  if grep --ignore-case --quiet --regexp='^warning' <<< "$DOCS_OUT"; then
+    echo "Warnings found when generating the docs."
+    exit 1
+  fi
+
+  # Check for any deadlinks in the generated docs.
+  if ! cargo deadlinks --dir target/doc; then
+    echo "Found deadlinks in the generated docs."
+    exit 1
+  fi
+done

--- a/scripts/check_docs
+++ b/scripts/check_docs
@@ -10,22 +10,24 @@ source "$SCRIPTS_DIR/common"
 # false positive warning removed (https://github.com/rust-lang/rust/pull/70789)
 export RUSTDOCFLAGS="-A unused_braces"
 
-paths=("." "oak_abi" "../oak_utils")
+# All the dirs that we generate docs for
+declare -ar PATHS=("." "oak_abi" "oak_utils")
 
-for i in "${paths[@]}"
-do
-  cd "$i"
-  DOCS_OUT="$(cargo doc --document-private-items --no-deps 2>&1)"
+for path in "${PATHS[@]}"; do
+  (
+    cd "$path"
+    DOCS_OUT="$(cargo doc --document-private-items --no-deps 2>&1)"
 
-  # `cargo doc` produces warnings for incorrect paths. These warnings cannot be promoted to errors, so we use grep to detect them.
-  if grep --ignore-case --quiet --regexp='^warning' <<< "$DOCS_OUT"; then
-    echo "Warnings found when generating the docs."
-    exit 1
-  fi
+    # `cargo doc` produces warnings for incorrect paths. These warnings cannot be promoted to errors, so we use grep to detect them.
+    if grep --ignore-case --quiet --regexp='^warning' <<< "$DOCS_OUT"; then
+      echo "Warnings found when generating the docs."
+      exit 1
+    fi
 
-  # Check for any deadlinks in the generated docs.
-  if ! cargo deadlinks --dir target/doc; then
-    echo "Found deadlinks in the generated docs."
-    exit 1
-  fi
+    # Check for any deadlinks in the generated docs.
+    if ! cargo deadlinks --dir target/doc; then
+      echo "Found deadlinks in the generated docs."
+      exit 1
+    fi
+  )
 done


### PR DESCRIPTION
Updates `check_docs` and `build_gh_docs` scripts to also check and generate docs
for `oak_abi`, now that it is a separate crate.

Creates the following hierarchy under the given `TARGET_DIR`:

```
├── oak
│   ├── index.html
│   └── doc
├── oak_abi
│   ├── index.html
│   └── doc
├── oak_utils
│    ├── index.html
│    └── doc
└─── index.html
```
Ref #1037 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
