### PR TITLE
Docs: Remove orphaned bullet point from the table of contents

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -9,8 +9,6 @@
 - [Labels](#labels)
 - [Pseudo-Nodes](#pseudo-nodes)
 - [Oak Application](#oak-application)
-- [Oak Runner](#oak-runner)
-  - [Workflow](#workflow)
 - [Remote Attestation](#remote-attestation)
 - [Time](#time)
 


### PR DESCRIPTION
The Oak runner docs have been removed (https://github.com/project-oak/oak/commit/25b36c05511841aa269471b3c68829a6946867ad) but the now orphaned item in the table of contents remains. 

Given that we're looking to migrate away from bash scripts to the runner (https://github.com/project-oak/oak/issues/396), it seems it would actually be nice to have docs on it though? 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
