### PR TITLE
Replace simple_logger with env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "abitest_0_frontend 0.1.0",
  "abitest_1_backend 0.1.0",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak 0.1.0",
@@ -56,7 +57,6 @@ dependencies = [
  "oak_runtime 0.1.0",
  "oak_tests 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -66,6 +66,7 @@ version = "0.1.0"
 dependencies = [
  "aggregator_common 0.1.0",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -75,7 +76,6 @@ dependencies = [
  "oak_tests 0.1.0",
  "oak_utils 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -785,13 +785,13 @@ name = "hello_world"
 version = "0.1.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak 0.1.0",
  "oak_runtime 0.1.0",
  "oak_tests 0.1.0",
  "oak_utils 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "translator_common 0.1.0",
 ]
 
@@ -1306,6 +1306,7 @@ name = "oak_loader"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak_abi 0.1.0",
@@ -1313,7 +1314,6 @@ dependencies = [
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1516,13 +1516,13 @@ name = "private_set_intersection"
 version = "0.1.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak 0.1.0",
  "oak_runtime 0.1.0",
  "oak_tests 0.1.0",
  "oak_utils 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1862,6 +1862,7 @@ name = "running_average"
 version = "0.1.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak 0.1.0",
  "oak_abi 0.1.0",
@@ -1869,7 +1870,6 @@ dependencies = [
  "oak_tests 0.1.0",
  "oak_utils 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2994,12 +2994,12 @@ name = "translator"
 version = "0.1.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oak 0.1.0",
  "oak_runtime 0.1.0",
  "oak_tests 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "translator_common 0.1.0",
 ]
 

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -462,7 +462,7 @@ framework via the Oak Runtime:
 // Test invoking the SayHello Node service method via the Oak runtime.
 #[test]
 fn test_say_hello() {
-    simple_logger::init_by_env();
+    env_logger::init();
 
     let (runtime, entry_handle) = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
         .expect("Unable to configure runtime with test wasm!");

--- a/examples/abitest/tests/Cargo.toml
+++ b/examples/abitest/tests/Cargo.toml
@@ -19,7 +19,7 @@ tonic = { version = "*", features = ["tls"] }
 
 [dev-dependencies]
 assert_matches = "*"
+env_logger = "*"
 oak_runtime = "=0.1.0"
 oak_tests = "=0.1.0"
 maplit = "*"
-simple_logger = "*"

--- a/examples/abitest/tests/src/tests.rs
+++ b/examples/abitest/tests/src/tests.rs
@@ -44,7 +44,7 @@ fn build_wasm() -> std::io::Result<HashMap<String, Vec<u8>>> {
 
 #[test]
 fn test_abi() {
-    simple_logger::init_by_env();
+    env_logger::init();
 
     let application_configuration = ApplicationConfiguration {
         wasm_modules: build_wasm().expect("failed to build wasm modules"),

--- a/examples/aggregator/module/rust/Cargo.toml
+++ b/examples/aggregator/module/rust/Cargo.toml
@@ -18,10 +18,10 @@ prost = "*"
 
 [dev-dependencies]
 assert_matches = "*"
+env_logger = "*"
 oak_runtime = "=0.1.0"
 oak_tests = "=0.1.0"
 maplit = "*"
-simple_logger = "*"
 
 [build-dependencies]
 oak_utils = "*"

--- a/examples/aggregator/module/rust/src/tests.rs
+++ b/examples/aggregator/module/rust/src/tests.rs
@@ -51,7 +51,7 @@ fn submit_sample(
 
 #[test]
 fn test_aggregator() {
-    simple_logger::init_by_env();
+    env_logger::init();
 
     let (runtime, entry_handle) = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
         .expect("Unable to configure runtime with test wasm!");

--- a/examples/hello_world/module/rust/Cargo.toml
+++ b/examples/hello_world/module/rust/Cargo.toml
@@ -16,9 +16,9 @@ translator_common = "=0.1.0"
 
 [dev-dependencies]
 assert_matches = "*"
+env_logger = "*"
 oak_runtime = "=0.1.0"
 oak_tests = "=0.1.0"
-simple_logger = "*"
 
 [build-dependencies]
 oak_utils = "*"

--- a/examples/hello_world/module/rust/src/tests.rs
+++ b/examples/hello_world/module/rust/src/tests.rs
@@ -23,7 +23,7 @@ const MODULE_CONFIG_NAME: &str = "hello_world";
 // Test invoking the SayHello Node service method via the Oak runtime.
 #[test]
 fn test_say_hello() {
-    simple_logger::init_by_env();
+    env_logger::init();
 
     let (runtime, entry_handle) = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
         .expect("Unable to configure runtime with test wasm!");

--- a/examples/private_set_intersection/module/rust/Cargo.toml
+++ b/examples/private_set_intersection/module/rust/Cargo.toml
@@ -15,9 +15,9 @@ prost = "*"
 
 [dev-dependencies]
 assert_matches = "*"
+env_logger = "*"
 oak_runtime = "=0.1.0"
 oak_tests = "=0.1.0"
-simple_logger = "*"
 
 [build-dependencies]
 oak_utils = "*"

--- a/examples/private_set_intersection/module/rust/src/tests.rs
+++ b/examples/private_set_intersection/module/rust/src/tests.rs
@@ -23,7 +23,7 @@ const MODULE_CONFIG_NAME: &str = "private_set_intersection";
 
 #[test]
 fn test_set_intersection() {
-    simple_logger::init_by_env();
+    env_logger::init();
 
     let (runtime, entry_channel) = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
         .expect("Unable to configure runtime with test wasm!");

--- a/examples/running_average/module/rust/Cargo.toml
+++ b/examples/running_average/module/rust/Cargo.toml
@@ -15,10 +15,10 @@ prost = "*"
 
 [dev-dependencies]
 assert_matches = "*"
+env_logger = "*"
 oak_abi = "=0.1.0"
 oak_runtime = "=0.1.0"
 oak_tests = "=0.1.0"
-simple_logger = "*"
 
 [build-dependencies]
 oak_utils = "*"

--- a/examples/running_average/module/rust/src/tests.rs
+++ b/examples/running_average/module/rust/src/tests.rs
@@ -33,7 +33,7 @@ fn submit_sample(runtime: &oak_runtime::RuntimeProxy, entry_handle: oak_abi::Han
 
 #[test]
 fn test_running_average() {
-    simple_logger::init_by_env();
+    env_logger::init();
 
     let (runtime, entry_handle) = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
         .expect("Unable to configure runtime with test wasm!");

--- a/examples/translator/module/rust/Cargo.toml
+++ b/examples/translator/module/rust/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 
 [dev-dependencies]
 assert_matches = "*"
+env_logger = "*"
 oak_runtime = "=0.1.0"
 oak_tests = "=0.1.0"
-simple_logger = "*"
 
 [dependencies]
 log = "*"

--- a/examples/translator/module/rust/src/tests.rs
+++ b/examples/translator/module/rust/src/tests.rs
@@ -22,7 +22,7 @@ const MODULE_CONFIG_NAME: &str = "translator";
 
 #[test]
 fn test_translate() {
-    simple_logger::init_by_env();
+    env_logger::init();
 
     let (runtime, entry_handle) = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
         .expect("Unable to configure runtime with test wasm!");

--- a/oak/server/rust/oak_loader/Cargo.toml
+++ b/oak/server/rust/oak_loader/Cargo.toml
@@ -14,13 +14,13 @@ default = ["oak_debug"]
 
 [dependencies]
 anyhow = "*"
+env_logger = "*"
 log = "*"
 oak_runtime = "=0.1.0"
 oak_abi = "=0.1.0"
 prost = "*"
 rustls = "*"
 signal-hook = "*"
-simple_logger = "*"
 structopt = "*"
 tonic = { version = "*", features = ["tls"] }
 

--- a/oak/server/rust/oak_loader/src/main.rs
+++ b/oak/server/rust/oak_loader/src/main.rs
@@ -150,7 +150,7 @@ fn load_certificate(certificate: &str) -> anyhow::Result<Certificate> {
 
 fn main() -> anyhow::Result<()> {
     if cfg!(feature = "oak_debug") {
-        simple_logger::init_by_env();
+        env_logger::init();
     } else {
         eprintln!("No debugging output configured at build time");
     }


### PR DESCRIPTION
The env_logger crate allows better control over the details of
what gets logged.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
