### PR TITLE
Update cargo lock

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1349,6 +1349,8 @@ dependencies = [
  "byteorder",
  "bytes",
  "futures",
+ "futures-core",
+ "futures-util",
  "http",
  "hyper",
  "itertools 0.9.0",


### PR DESCRIPTION
Github misled me to believe that merging #1045 would be conflict free! Here is the fix. 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
