### PR TITLE
Propagate gRPC request label

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -288,13 +288,16 @@ Oak Application).
 
 The client connects to the gRPC service, and sends (Application-specific) gRPC
 requests to it, over a channel that has end-to-end encryption into the Runtime
-instance:
+instance, and also specifies a [Label](/docs/concepts.md#labels) to attach to
+the request, which is used to enforce Information Flow Control within the
+running Oak Application:
 
 <!-- prettier-ignore-start -->
-[embedmd]:# (../examples/hello_world/client/hello_world.cc C++ /.*Connect to the/ /CreateTlsChannel.*/)
+[embedmd]:# (../examples/hello_world/client/hello_world.cc C++ /.*Connect to the/ /GetTlsChannelCredentials.*/)
 ```C++
   // Connect to the Oak Application.
-  auto stub = HelloWorld::NewStub(oak::ApplicationClient::CreateTlsChannel(address, ca_cert));
+  auto stub = HelloWorld::NewStub(oak::ApplicationClient::CreateChannel(
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
 ```
 <!-- prettier-ignore-end -->
 
@@ -309,6 +312,7 @@ any language that supports gRPC can use the service. For example in Go:
 	if err != nil {
 		glog.Exitf("Failed to set up TLS client credentials from %q: %v", *caCert, err)
 	}
+	// TODO(#1066): Use a more restrictive Label.
 	conn, err := grpc.Dial(*address, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		glog.Exitf("Failed to dial Oak Application at %v: %v", *address, err)

--- a/examples/abitest/client/abitest.cc
+++ b/examples/abitest/client/abitest.cc
@@ -212,8 +212,14 @@ int main(int argc, char** argv) {
   std::string address = absl::GetFlag(FLAGS_address);
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
-  auto stub =
-      OakABITestService::NewStub(oak::ApplicationClient::CreateTlsChannel(address, ca_cert));
+  // TODO(#1066): Assign a more restrictive label.
+  oak::label::Label label = oak::PublicUntrustedLabel();
+  // Connect to the Oak Application.
+  auto stub = OakABITestService::NewStub(oak::ApplicationClient::CreateChannel(
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+  if (stub == nullptr) {
+    LOG(FATAL) << "Failed to create application stub";
+  }
 
   bool success = true;
   if (absl::GetFlag(FLAGS_test_abi)) {

--- a/examples/aggregator/client/android/cpp/client.cc
+++ b/examples/aggregator/client/android/cpp/client.cc
@@ -46,7 +46,10 @@ JNIEXPORT void JNICALL Java_com_google_oak_aggregator_MainActivity_createChannel
                                                                                  jstring jca_cert) {
   auto address = env->GetStringUTFChars(jaddress, 0);
   auto ca_cert = env->GetStringUTFChars(jca_cert, 0);
-  kChannel = Aggregator::NewStub(oak::ApplicationClient::CreateTlsChannel(address, ca_cert));
+  // TODO(#1066): Assign a more restrictive label.
+  oak::label::Label label = oak::PublicUntrustedLabel();
+  kChannel = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
   JNI_LOG("gRPC channel has been created");
 }
 

--- a/examples/chat/client/chat.cc
+++ b/examples/chat/client/chat.cc
@@ -178,9 +178,11 @@ int main(int argc, char** argv) {
   std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
-  // Connect to the Oak Application.
   // TODO(#488): Use the token provided on command line for authorization and labelling of data.
-  auto stub = Chat::NewStub(oak::ApplicationClient::CreateTlsChannel(address, ca_cert));
+  oak::label::Label label = oak::PublicUntrustedLabel();
+  // Connect to the Oak Application.
+  auto stub = Chat::NewStub(oak::ApplicationClient::CreateChannel(
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
   if (stub == nullptr) {
     LOG(FATAL) << "Failed to create application stub";
   }

--- a/examples/hello_world/client/nodejs/index.js
+++ b/examples/hello_world/client/nodejs/index.js
@@ -9,6 +9,8 @@ const packageDefinition = protoLoader.loadSync(PROTO_PAH);
 const helloWorldProto = grpc.loadPackageDefinition(packageDefinition).oak
   .examples.hello_world;
 const credentials = grpc.credentials.createSsl(fs.readFileSync(CERT_PATH));
+
+// TODO(#1066): Use a more restrictive Label.
 const client = new helloWorldProto.HelloWorld('localhost:8080', credentials);
 
 client.sayHello({ greeting: 'Node.js' }, (error, response) => {

--- a/examples/machine_learning/client/machine_learning.cc
+++ b/examples/machine_learning/client/machine_learning.cc
@@ -73,8 +73,14 @@ int main(int argc, char** argv) {
   std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
+  // TODO(#1066): Use a more restrictive Label.
+  oak::label::Label label = oak::PublicUntrustedLabel();
   // Connect to the Oak Application.
-  auto stub = MachineLearning::NewStub(oak::ApplicationClient::CreateTlsChannel(address, ca_cert));
+  auto stub = MachineLearning::NewStub(oak::ApplicationClient::CreateChannel(
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+  if (stub == nullptr) {
+    LOG(FATAL) << "Failed to create application stub";
+  }
 
   // Perform multiple invocations of the same Oak Application, with different parameters.
   auto message_0 = send_data(stub.get());

--- a/examples/private_set_intersection/client/private_set_intersection.cc
+++ b/examples/private_set_intersection/client/private_set_intersection.cc
@@ -66,19 +66,15 @@ int main(int argc, char** argv) {
   std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
-  // Connect to the Oak Application from different clients sharing the same access token.
-  oak::NonceGenerator<oak::kPerChannelNonceSizeBytes> nonce_generator;
-  std::string authorization_bearer_token = oak::NonceToBytes(nonce_generator.NextNonce());
+  // TODO(#1066): Use a more restrictive Label, based on a bearer token shared between the two
+  // clients.
+  oak::label::Label label = oak::PublicUntrustedLabel();
 
   auto stub_0 = PrivateSetIntersection::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert),
-      oak::ApplicationClient::authorization_bearer_token_call_credentials(
-          authorization_bearer_token)));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
 
   auto stub_1 = PrivateSetIntersection::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert),
-      oak::ApplicationClient::authorization_bearer_token_call_credentials(
-          authorization_bearer_token)));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
 
   // Submit sets from different clients.
   std::vector<std::string> set_0{"a", "b", "c"};

--- a/examples/running_average/client/running_average.cc
+++ b/examples/running_average/client/running_average.cc
@@ -65,15 +65,21 @@ int main(int argc, char** argv) {
   oak::NonceGenerator<oak::kPerChannelNonceSizeBytes> nonce_generator;
   std::string authorization_bearer_token = oak::NonceToBytes(nonce_generator.NextNonce());
 
+  // TODO(#1066): Use a more restrictive Label, based on a bearer token shared between the two
+  // clients.
+  oak::label::Label label = oak::PublicUntrustedLabel();
+
   auto stub_0 = RunningAverage::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert),
-      oak::ApplicationClient::authorization_bearer_token_call_credentials(
-          authorization_bearer_token)));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+  if (stub_0 == nullptr) {
+    LOG(FATAL) << "Failed to create application stub";
+  }
 
   auto stub_1 = RunningAverage::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert),
-      oak::ApplicationClient::authorization_bearer_token_call_credentials(
-          authorization_bearer_token)));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+  if (stub_1 == nullptr) {
+    LOG(FATAL) << "Failed to create application stub";
+  }
 
   // Submit samples from different clients.
   submit_sample(stub_0.get(), 100);

--- a/examples/tensorflow/client/tensorflow.cc
+++ b/examples/tensorflow/client/tensorflow.cc
@@ -48,8 +48,14 @@ int main(int argc, char** argv) {
   std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
+  // TODO(#1066): Assign a more restrictive label.
+  oak::label::Label label = oak::PublicUntrustedLabel();
   // Connect to the Oak Application.
-  auto stub = Tensorflow::NewStub(oak::ApplicationClient::CreateTlsChannel(address, ca_cert));
+  auto stub = Tensorflow::NewStub(oak::ApplicationClient::CreateChannel(
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+  if (stub == nullptr) {
+    LOG(FATAL) << "Failed to create application stub";
+  }
 
   // Initialize TensorFlow in Oak.
   init_tensorflow(stub.get());

--- a/examples/translator/client/translator.go
+++ b/examples/translator/client/translator.go
@@ -50,6 +50,7 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to set up TLS client credentials from %q: %v", *caCert, err)
 	}
+	// TODO(#1066): Use a more restrictive Label.
 	conn, err := grpc.Dial(*address, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		glog.Exitf("Failed to dial Oak Application at %v: %v", *address, err)

--- a/oak/client/application_client.h
+++ b/oak/client/application_client.h
@@ -97,22 +97,13 @@ class ApplicationClient {
     return grpc::CreateChannel(addr, composite_credentials);
   }
 
-  // Returns a gRPC Channel initialized with TLS channel credentials and a private authorization
-  // bearer token.
-  //
-  // See `private_authorization_bearer_token_call_credentials`.
-  static std::shared_ptr<grpc::Channel> CreateTlsChannel(std::string addr) {
-    return CreateChannel(addr, GetTlsChannelCredentials(),
-                         private_authorization_bearer_token_call_credentials());
-  }
-
-  // Returns a gRPC Channel initialized with Tls channel credentials and a non-default PEM-encoded
-  // CA root certificate, and a private authorization bearer token.
-  //
-  // See `private_authorization_bearer_token_call_credentials`.
-  static std::shared_ptr<grpc::Channel> CreateTlsChannel(std::string addr, std::string ca_cert) {
-    return CreateChannel(addr, GetTlsChannelCredentials(ca_cert),
-                         private_authorization_bearer_token_call_credentials());
+  // Returns a gRPC Channel connecting to the specified address, initialised with a fixed Oak Label.
+  static std::shared_ptr<grpc::Channel> CreateChannel(
+      std::string addr, std::shared_ptr<grpc::ChannelCredentials> channel_credentials,
+      oak::label::Label label) {
+    auto call_credentials =
+        grpc::MetadataCredentialsFromPlugin(absl::make_unique<LabelMetadata>(label));
+    return CreateChannel(addr, channel_credentials, call_credentials);
   }
 
   // Gets TLS channel credentials with default options.

--- a/oak/common/label.cc
+++ b/oak/common/label.cc
@@ -23,6 +23,8 @@ namespace oak {
 // The `-bin` suffix allows sending binary data for this metadata key.
 //
 // See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.
+//
+// Keep in sync with /oak/server/rust/oak_runtime/src/node/grpc/server/mod.rs.
 const char kOakLabelGrpcMetadataKey[] = "x-oak-label-bin";
 
 // The `-bin` suffix allows sending binary data for this metadata key.
@@ -44,24 +46,21 @@ oak::label::Label DeserializeLabel(const std::string& label_bytes) {
 oak::label::Label AuthorizationBearerTokenLabel(const std::string& authorization_token_hmac) {
   oak::label::Label label;
   auto* confidentiality_tag = label.add_confidentiality_tags();
-  auto* integrity_tag = label.add_integrity_tags();
   confidentiality_tag->mutable_grpc_tag()->set_authorization_bearer_token_hmac(
       authorization_token_hmac);
-  // We set integrity tag here, even though it would make more sense for the server to determine
-  // what integrity tag to assign to the incoming message, based on the authentication mechanism
-  // used (e.g. the actual bearer token, rather than its HMAC).
-  // Partly tracked in #420.
-  integrity_tag->mutable_grpc_tag()->set_authorization_bearer_token_hmac(authorization_token_hmac);
   return label;
 }
 
 oak::label::Label WebAssemblyModuleAttestationLabel(const std::string& module_attestation) {
   oak::label::Label label;
   auto* confidentiality_tag = label.add_confidentiality_tags();
-  auto* integrity_tag = label.add_integrity_tags();
   confidentiality_tag->mutable_web_assembly_module_tag()->set_module_attestation(
       module_attestation);
-  integrity_tag->mutable_web_assembly_module_tag()->set_module_attestation(module_attestation);
+  return label;
+}
+
+oak::label::Label PublicUntrustedLabel() {
+  oak::label::Label label;
   return label;
 }
 

--- a/oak/common/label.h
+++ b/oak/common/label.h
@@ -47,9 +47,13 @@ oak::label::Label DeserializeLabel(const std::string& label_bytes);
 // provided authorization bearer token.
 oak::label::Label AuthorizationBearerTokenLabel(const std::string& authorization_token_hmac);
 
-// Creates a label that only allows declassifying data for modules that match the
-// provided module attestation.
+// Creates a label that only allows declassifying data for modules that match the provided module
+// attestation.
 oak::label::Label WebAssemblyModuleAttestationLabel(const std::string& module_attestation);
+
+// Creates a public untrusted label, which is the least confidential and least trusted label and
+// applies no confidentiality restrictions to the data contained in the request.
+oak::label::Label PublicUntrustedLabel();
 
 }  // namespace oak
 

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -627,7 +627,7 @@ impl Runtime {
             trace!("{:?}: can write to {:?}", node_id, target_label);
             Ok(())
         } else {
-            debug!("{:?}: cannot write to {:?}", node_id, target_label);
+            warn!("{:?}: cannot write to {:?}", node_id, target_label);
             Err(OakStatus::ErrPermissionDenied)
         }
     }


### PR DESCRIPTION
- Enforce that **exactly** one label is specified per gRPC request. From
now on, the gRPC server will reject requests with no label attached, or
with multiple labels. It is possible to attach a "public" label, but it
needs to be specified explicitly.

- Change the examples to attach such "public" label, until we figure out
the rest of the downgrading functionality in the Oak Runtime.

- Change return type of `handle_grpc_request` and `handle_grpc_response`
from `Result<GrpcResponse, OakStatus>` to `Result<GrpcResponse, ()>`, to
make it clear that all errors are actually logged within the body of the
functions. Previously there was a comment somewhere else that was
explaining why those errors were being ignored, and also a statement
that confirmed that they were all logged (which turned out to
be false).

- Log errors generated by gRPC channel creation.

- More uniform error handling in C++ example clients.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.