### PR TITLE
More accurate logging of gRPC requests lifecycle

### DIFF
--- a/examples/aggregator/client/aggregator.cc
+++ b/examples/aggregator/client/aggregator.cc
@@ -58,7 +58,7 @@ void submit_sample(Aggregator::Stub* stub, std::string& bucket, std::vector<uint
   google::protobuf::Empty response;
   grpc::Status status = stub->SubmitSample(&context, request, &response);
   if (!status.ok()) {
-    LOG(ERROR) << "Could not submit sample: " << status.error_code() << ": "
+    LOG(ERROR) << "Error submitting sample: " << status.error_code() << ": "
                << status.error_message();
   }
 }


### PR DESCRIPTION
If there is an error when reading a gRPC request from an invocation,
then attempt to send an error response to the caller rather than leave
it hanging forever (this happens in case of misplaced labels).

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
