### PR TITLE
Check markdown links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,13 +87,17 @@ ENV EM_CACHE "${emscripten_dir}/.emscripten_cache"
 RUN chmod --recursive go+wx "${EM_CACHE}"
 
 # Install Go.
-ARG golang_version=1.13.1
-ARG golang_sha256=94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124
+ARG golang_version=1.14.4
+ARG golang_sha256=aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067
 ARG golang_temp=/tmp/golang.tar.gz
 ENV GOROOT /usr/local/go
 ENV GOPATH ${HOME}/go
 ENV PATH "${GOROOT}/bin:${PATH}"
 ENV PATH "${GOPATH}/bin:${PATH}"
+# Enable Go module behaviour even in the presence of GOPATH; this way we can specify precise
+# versions via `go get`.
+# See https://dev.to/maelvls/why-is-go111module-everywhere-and-everything-about-go-modules-24k
+ENV GO111MODULE on
 RUN mkdir --parents ${GOROOT} \
   && curl --location https://dl.google.com/go/go${golang_version}.linux-amd64.tar.gz > ${golang_temp} \
   && sha256sum --binary ${golang_temp} && echo "${golang_sha256} *${golang_temp}" | sha256sum --check \
@@ -101,9 +105,13 @@ RUN mkdir --parents ${GOROOT} \
   && rm ${golang_temp} \
   && go version
 
-# Install embedmd (via Go).
-RUN go get github.com/campoy/embedmd \
+# Install embedmd (Markdown snippet embedder) (via Go).
+RUN go get github.com/campoy/embedmd@97c13d6 \
   && embedmd -v
+
+# Install liche (Markdown link checker) (via Go).
+RUN go get github.com/raviqqe/liche@f57a5d1 \
+  && liche --version
 
 # Install prettier and markdownlint (via Node.js).
 # https://prettier.io/

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,9 @@
 
 - [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
   - [ ] I have written tests that cover the code changes.
-  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
-  - [ ] I have updated [documentation](docs/) accordingly.
+  - [ ] I have checked that these tests are run by
+        [Cloudbuild](/cloudbuild.yaml)
+  - [ ] I have updated [documentation](/docs/) accordingly.
   - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
         cover any TODOs and/or unfinished work.
 - [ ] Pull request includes prototype/experimental work that is under

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -52,11 +52,11 @@ Three specific sets of integer values are also used in the ABI:
   [channel](concepts.md#channels).
 - Many ABI operations return a `u32` **status** value, indicating the result of
   the operation. The possible values for this are defined in the `OakStatus`
-  enum in [oak_api.proto](/oak/proto/oak_api.proto).
+  enum in [oak_abi.proto](/oak/proto/oak_abi.proto).
 - The `wait_on_channels` host function fills in a **channel status** value,
   indicating the readiness status of a particular channel. The possible values
   for this are defined in the `ChannelReadStatus` enum in
-  [oak_api.proto](/oak/proto/oak_api.proto).
+  [oak_abi.proto](/oak/proto/oak_abi.proto).
 
 ## Exported Function
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,7 +1,7 @@
 # Oak Concepts
 
 - [Oak Runtime](#oak-runtime)
-- [Oak Node](#oak-node)
+- [Nodes](#nodes)
   - [WebAssembly](#webassembly)
 - [Channels](#channels)
   - [Orphaned Channels](#orphaned-channels)
@@ -174,7 +174,7 @@ The following types of security principals are supported in Oak:
   running within an Oak Node
 
 Tags and Labels are represented as serialized
-[protobuf messages](/oak/proto/policy.proto).
+[protobuf messages](/oak/proto/label.proto).
 
 Any security principal may be used (as a tag) as part of confidentiality or
 integrity components, depending on the required use case.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -27,7 +27,7 @@ includes:
   [`INVALID_HANDLE`](https://project-oak.github.io/oak/oak_abi/doc/oak_abi/constant.INVALID_HANDLE.html)
   value).
 - Enum types (generated from the
-  [master protocol buffer definitions](../oak/proto/oak_api.proto)) for
+  [master protocol buffer definitions](/oak/proto/oak_abi.proto)) for
   [operation and channel status values](abi.md#integer-types).
 - Generated Rust code corresponding to
   [protocol buffer message types](abi.md#protocol-buffer-messages) that are used

--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -100,8 +100,8 @@ For both commands, use the `-m` flag to deploy or undeploy the
 `metrics-sidecar`.
 
 Deployment requires Docker images to be uploaded to the
-[Cloud Container Registry](gcr.io/oak-ci/) (requires write-access) with the
-following command:
+[Cloud Container Registry](http://gcr.io/oak-ci/) (requires write-access) with
+the following command:
 
 ```bash
 ./scripts/build_example -e aggregator -i rust

--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -82,6 +82,19 @@ find . \
     \( -type f -name '*.md' \) \
   \) -exec markdownlint {} +
 
+# We exclude the following URLs from the checks:
+# - https://groups.google.com/g/project-oak-discuss : not publicly accessible
+# - https://crates.io/crates : returns 404 (see https://github.com/raviqqe/liche/issues/39)
+find . \
+  \(  \
+    -not \( -path ./.git -prune \) -and \
+    -not \( -path ./bazel-cache -prune \) -and \
+    -not \( -path ./cargo-cache -prune \) -and \
+    -not \( -path '*/target' -prune \) -and \
+    -not \( -path ./third_party -prune \) \
+    \( -type f -name '*.md' \) \
+  \) -exec liche --document-root=. --exclude='(https://groups.google.com/g/project-oak-discuss|https://crates.io/crates)' {} +
+
 find . \
   \(  \
     -not \( -path ./bazel-cache -prune \) -and \


### PR DESCRIPTION
I tried a few tools out there, but `liche` was the only one that
actually checks links between docs in the same repository.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](cloudbuild.yaml)
  - [ ] I have updated [documentation](docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
