### PR TITLE
Revert "Install node deps when building an example"

### DIFF
--- a/scripts/build_example
+++ b/scripts/build_example
@@ -104,9 +104,3 @@ bazel_build_flags+=(
 # Build the client with a different output_base so that we don't lose incremental state.
 # See https://docs.bazel.build/versions/master/command-line-reference.html#flag--output_base.
 bazel --output_base="${CACHE_DIR}/client" build "${bazel_build_flags[@]}" "//examples/${EXAMPLE}/client:all"
-
-# If a node client exists, install its dependencies
-nodejs_client="./examples/${EXAMPLE}/client/nodejs"
-if [ -d "${nodejs_client}" ]; then
-    npm ci --prefix ${nodejs_client}
-fi


### PR DESCRIPTION
Reverts project-oak/oak#1096

Running this in our docker images leads to build_example failing with 

```
+ npm ci --prefix ./examples/hello_world/client/nodejs
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /.npm
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1001:0 "/.npm"
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /.npm
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1001:0 "/.npm"
```

We should probably revert this while I figure out a solution to that. :) I'll remember to await the CI results before merging next time.