### PR TITLE
Improve handling of aborts in Wasm code (e.g from panic)

### DIFF
--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -866,13 +866,14 @@ impl super::Node for WasmNode {
             .as_memory()
             .cloned();
 
-        instance
-            .invoke_export(
-                &self.entrypoint_name,
-                &[wasmi::RuntimeValue::I64(handle as i64)],
-                &mut abi,
-            )
-            .expect("failed to execute export");
+        let result = instance.invoke_export(
+            &self.entrypoint_name,
+            &[wasmi::RuntimeValue::I64(handle as i64)],
+            &mut abi,
+        );
+        if let Err(err) = result {
+            error!("Invocation of Wasm entrypoint failed: {:?}", err);
+        }
         debug!(
             "{}: entrypoint '{}' completed",
             self.node_name, self.entrypoint_name


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
