### PR TITLE
Use `anyhow` for error handling in oak_loader

### DIFF
--- a/oak_abi/src/lib.rs
+++ b/oak_abi/src/lib.rs
@@ -23,6 +23,14 @@ pub mod proto;
 
 pub use proto::oak::{ChannelReadStatus, OakStatus};
 
+impl std::fmt::Display for OakStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for OakStatus {}
+
 /// Handle used to identify read or write channel halves.
 ///
 /// These handles are used for all host function calls.


### PR DESCRIPTION
Example new error message:

```
Error: could not read gRPC TLS private key

Caused by:
    No such file or directory (os error 2)
```

Old error message:

```
Error: No such file or directory (os error 2)
```
