### PR TITLE
Pass `--remap-path-prefix` to cargo

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -10,6 +10,9 @@ set -o pipefail
 # https://docs.rs/env_logger
 export RUST_LOG="${RUST_LOG:-info}"
 
+# Reduce build nondeterminism by remapping paths so that they don't include local segments.
+export RUSTFLAGS="--remap-path-prefix=$PWD=/ ${RUSTFLAGS:-}"
+
 # See https://pantheon.corp.google.com/gcr/images/oak-ci/GLOBAL/oak
 readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak'
 readonly SERVER_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-server'


### PR DESCRIPTION
This is meant to reduce nondeterminism across machines or docker vs host, but it does not seem to fully
solve the problem yet (it does remove some paths from the resulting
binary, so I think it is necessary, but not sufficient).

Ref #865

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
