### PR TITLE
Create a home dir for the docker_run user, to avoid permission problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,3 +196,11 @@ RUN rustup component add \
 
 RUN cargo install cargo-deadlinks
 RUN cargo install cargo-deny
+
+ARG DOCKER_UID
+ARG DOCKER_GID
+RUN if [ ${DOCKER_GID:-0} -ne 0 ] ; then groupadd -g ${DOCKER_GID} docker_runner; fi \
+  && if [ ${DOCKER_UID:-0} -ne 0 ] ; then \
+  useradd --uid ${DOCKER_UID} --gid ${DOCKER_GID} docker_runner --home-dir /home/docker_runner --create-home \
+  && chown -R ${DOCKER_UID}:${DOCKER_GID} /home/docker_runner \
+  ;fi \

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -24,6 +24,8 @@ mkdir -p './cargo-cache'
 docker build \
   --cache-from="$DOCKER_IMAGE_NAME:latest" \
   --tag="$DOCKER_IMAGE_NAME:latest" \
+  --build-arg DOCKER_UID="$DOCKER_UID" \
+  --build-arg DOCKER_GID="$DOCKER_GID" \
   . 1>&2
 
 docker_run_flags=(
@@ -33,7 +35,7 @@ docker_run_flags=(
   "--env=USER=$DOCKER_USER"
   '--env=BAZEL_REMOTE_CACHE_ENABLED'
   '--env=BAZEL_GOOGLE_CREDENTIALS'
-  "--volume=$PWD/bazel-cache:/.cache/bazel"
+  "--volume=$PWD/bazel-cache:/home/docker_runner/.cache/bazel"
   "--volume=$PWD/cargo-cache:/usr/local/cargo/registry"
   "--volume=$PWD:/opt/my-project"
   '--workdir=/opt/my-project'


### PR DESCRIPTION
Previously the the non-root user used in the `docker_run` script would not have its own home directory. This meant that `$HOME` or `~/` would evaluate to the root dir of the docker image, `/`. 

Since the non root user does not have write permission for its `$HOME` dir (aka the root dir), we [alias](https://github.com/project-oak/oak/blob/5d8891f380573a2f5183136288d328f67b48b2a1/scripts/docker_run#L36) all relevant paths it might write to. Eg the default bazel cache lives at `~/.cache/bazel`, which evaluates to `/.cache/bazel`, which is aliased [here](https://github.com/project-oak/oak/blob/5d8891f380573a2f5183136288d328f67b48b2a1/scripts/docker_run#L36).

Doing this worked ok so far, but doesn't work for all tools out there. For example, Node's NPM always creates some caches/config files under `~/.npm` when installing packages. And unlike previous cases, we wouldn't be able to alias the root path `/.npm` path with an outside folder, since we install NPM packages both in our build_example script and also in the root-ran Dockerfile. In the absence of a home-dir, both use the same folder. Aliasing the root `/.npm` folder would hence write root-owned files into our workspace during the docker build process, [which we don't want](https://github.com/project-oak/oak/blob/master/scripts/docker_run#L16).

This PR addresses the permissions issue, by creating an actual home-dir that is owned by the non-root user used to run our scripts in docker. It can safely write files there, meaning that new tools can be added easily without encountering permissions issues. Caches can still be aliased to outside folders, as an enhancement to enable fasters builds on GCP. 

By avoiding a class of permission issues, it should hopefully make contributing to our docker build system overall more friendly. 

## More in depth

This is a more elegant solution to the permissions issues I encountered in: #1116. If you're curious you can see my first attempt at navigating the permission issues there.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
