### PR TITLE
Make wait_on_channels errors more consistent

### DIFF
--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -1069,7 +1069,7 @@ impl FrontendNode {
                 .unwrap();
             space.push(0x00);
             expect_eq!(
-                OakStatus::ErrBadHandle as u32,
+                OakStatus::Ok as u32,
                 oak_abi::wait_on_channels(space.as_mut_ptr(), COUNT as u32)
             );
             expect_eq!(ChannelReadStatus::Orphaned as i32, i32::from(space[8]));
@@ -1097,15 +1097,18 @@ impl FrontendNode {
 
         // Waiting on (just) non-read channel handles should fail immediately.
         expect_eq!(
-            Err(OakStatus::ErrBadHandle),
-            oak::wait_on_channels(&[
+            vec![
+                ChannelReadStatus::InvalidChannel,
+                ChannelReadStatus::InvalidChannel
+            ],
+            status_convert(oak::wait_on_channels(&[
                 oak::ReadHandle {
                     handle: out1.handle
                 },
                 oak::ReadHandle {
                     handle: oak::Handle::from_raw(9_999_999)
                 }
-            ])
+            ]))?
         );
 
         // Set up first channel with a pending message.

--- a/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/wasm/mod.rs
@@ -29,7 +29,7 @@ use oak_abi::{
     proto::oak::application::{
         ApplicationConfiguration, NodeConfiguration, WebAssemblyConfiguration,
     },
-    ChannelReadStatus, OakStatus,
+    OakStatus,
 };
 use prost::Message as _;
 use rand::RngCore;
@@ -461,17 +461,7 @@ impl WasmInterface {
                 })?;
         }
 
-        let is_invalid = |&s| {
-            s == ChannelReadStatus::InvalidChannel
-                || s == ChannelReadStatus::Orphaned
-                || s == ChannelReadStatus::PermissionDenied
-        };
-
-        if statuses.iter().all(is_invalid) {
-            Err(OakStatus::ErrBadHandle)
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
  Removes the extra check in `WasmInterface::wait_on_channels` that returns
  `Err(OakStatus::ErrBadHandle)` when all handles are invalid. This is done to
  make the behaviour more consistent with that of `Runtime::wait_on_channels`.

Ref [this comment](https://github.com/project-oak/oak/pull/1114#discussion_r437606434).

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
