### PR TITLE
sdk: don't leak handles in grpc::Client

### DIFF
--- a/sdk/rust/oak/src/grpc/client.rs
+++ b/sdk/rust/oak/src/grpc/client.rs
@@ -46,13 +46,28 @@ impl Client {
             .expect("failed to close channel");
         match status {
             Ok(_) => {
-                info!("Client created for '{:?}'", config);
+                info!(
+                    "Client created for '{:?}', accessible via channel {:?}",
+                    config, invocation_sender.handle
+                );
                 Some(Client { invocation_sender })
             }
             Err(status) => {
                 warn!("failed to create Client for '{:?}': {:?}", config, status);
                 None
             }
+        }
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        info!("Closing Client channel {:?}", self.invocation_sender.handle);
+        if let Err(status) = self.invocation_sender.close() {
+            warn!(
+                "Failed to close Client channel {:?}: {:?}",
+                self.invocation_sender.handle, status
+            );
         }
     }
 }


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
