### PR TITLE
Use error instead of panic

### DIFF
--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -506,10 +506,11 @@ pub fn run_event_loop<T: crate::io::Decodable, N: Node<T>>(
                         return;
                     }
                     _ => {
-                        panic!(
-                            "{:?}: received status: {:?}, but Receiver::wait should never return an error other than Err(ErrTerminated)",
+                        error!(
+                            "{:?}: received status: {:?}; but `Receiver::wait` never returns an error other than `ErrTerminated`",
                             in_channel, status
                         );
+                        return;
                     }
                 }
             }
@@ -519,13 +520,16 @@ pub fn run_event_loop<T: crate::io::Decodable, N: Node<T>>(
                 | ChannelReadStatus::PermissionDenied
                 | ChannelReadStatus::InvalidChannel => {
                     warn!(
-                        "{:?}: invalid channel read status: {:?}; terminating event loop",
+                        "{:?}: received invalid channel read status: {:?}; terminating event loop",
                         in_channel, status
                     );
                     return;
                 }
                 ChannelReadStatus::NotReady => {
-                    panic!("Receiver::wait should never return Ok(ChannelReadStatus::NotReady)")
+                    error!(
+                        "{:?}: received `ChannelReadStatus::NotReady`, which should never be returned from `Receiver::wait`.", 
+                        in_channel);
+                    return;
                 }
             },
         }


### PR DESCRIPTION
Ref [discussion on Slack](https://project-oak.slack.com/archives/CHE9E13C3/p1591781120186400), I've replaced panics added in #1114  with error. Does this look better?
