### PR TITLE
RFC: document expected ABI when IFC functionality added

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -125,6 +125,25 @@ runtime is terminating.
 - `param[1]: u32`: Count N of handles provided
 - `result[0]: u32`: Status of operation
 
+### `wait_on_channels_with_privilege`
+
+Variant of `wait_on_channels` that allows a Node to indicate that subsequent
+read operations will use its downgrade privilege to satisfy
+[information flow control](/docs/concepts.md#information-flow-control) flows-to
+checks. In particular, if there are waited-on channels that can only be read
+from if the caller uses downgrade privilege, then this variant returns those
+channel's read status rather than the `PERMISSION_DENIED` value that would be
+returned by `wait_on_channels`.
+
+The privilege to use is provided as a serialized
+[`Label`](/oak/proto/label.proto) protobuf message; if the calling Node does not
+have this privilege, `ERR_INVALID_ARGS` is returned.
+
+- `param[0]` to `param[1]`: As for `wait_on_channels`
+- `param[2]: usize`: Privilege to use in downgrade, as a serialized `Label`
+- `param[3]: usize`: Privilege label size in bytes
+- `result[0]: u32`: Status of operation
+
 ### `channel_read`
 
 Reads a single message and associated channel handles from the specified

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -155,6 +155,22 @@ If reading from the specified channel would violate
   of handles retrieved with the message (as a little-endian u32)
 - `result[0]: u32`: Status of operation
 
+### `channel_read_with_privilege`
+
+Variant of `channel_read` that allows a Node to perform a read operation that
+requires use of its downgrade privilege to satisfy
+[information flow control](/docs/concepts.md#information-flow-control) flows-to
+checks.
+
+The privilege to use is provided as a serialized
+[`Label`](/oak/proto/label.proto) protobuf message; if the calling Node does not
+have this privilege, `ERR_INVALID_ARGS` is returned.
+
+- `param[0]` to `param[6]`: As for `channel_read`
+- `param[7]: usize`: Privilege to use in downgrade, as a serialized `Label`
+- `param[8]: usize`: Privilege label size in bytes
+- `result[0]: u32`: Status of operation
+
 ### `channel_write`
 
 Writes a single message to the specified channel, together with any associated
@@ -169,6 +185,22 @@ If writing to the specified channel would violate
 - `param[2]: usize`: Source buffer size in bytes
 - `param[3]: usize`: Source handle array (of little-endian u64 values)
 - `param[4]: u32`: Source handle array count
+- `result[0]: u32`: Status of operation
+
+### `channel_write_with_privilege`
+
+Variant of `channel_write` that allows a Node to perform a write operation that
+requires use of its downgrade privilege to satisfy
+[information flow control](/docs/concepts.md#information-flow-control) flows-to
+checks.
+
+The privilege to use is provided as a serialized
+[`Label`](/oak/proto/label.proto) protobuf message; if the calling Node does not
+have this privilege, `ERR_INVALID_ARGS` is returned.
+
+- `param[0]` to `param[4]`: As for `channel_write`
+- `param[5]: usize`: Privilege to use in downgrade, as a serialized `Label`
+- `param[6]: usize`: Privilege label size in bytes
 - `result[0]: u32`: Status of operation
 
 ### `channel_create`
@@ -189,6 +221,22 @@ If creating the specified Channel would violate
   for the read half of the channel (as a little-endian u64).
 - `param[2]: usize`: Source buffer holding serialized `Label`
 - `param[3]: usize`: Label size in bytes
+- `result[0]: u32`: Status of operation
+
+### `channel_create_with_privilege`
+
+Variant of `channel_create` that allows a Node to perform a channel creation
+operation that requires use of its downgrade privilege to satisfy
+[information flow control](/docs/concepts.md#information-flow-control) flows-to
+checks.
+
+The privilege to use is provided as a serialized
+[`Label`](/oak/proto/label.proto) protobuf message; if the calling Node does not
+have this privilege, `ERR_INVALID_ARGS` is returned.
+
+- `param[0]` to `param[3]`: As for `channel_create`
+- `param[4]: usize`: Privilege to use in downgrade, as a serialized `Label`
+- `param[5]: usize`: Privilege label size in bytes
 - `result[0]: u32`: Status of operation
 
 ### `channel_close`
@@ -220,10 +268,75 @@ If creating the specified Node would violate
 - `param[4]: usize`: Handle to channel
 - `result[0]: u32`: Status of operation
 
+### `node_create_with_privilege`
+
+Variant of `node_create` that allows a Node to perform a Node creation operation
+that requires use of its downgrade privilege to satisfy
+[information flow control](/docs/concepts.md#information-flow-control) flows-to
+checks.
+
+The privilege to use is provided as a serialized
+[`Label`](/oak/proto/label.proto) protobuf message; if the calling Node does not
+have this privilege, `ERR_INVALID_ARGS` is returned.
+
+- `param[0]` to `param[4]`: As for `node_create`
+- `param[5]: usize`: Privilege to use in downgrade, as a serialized `Label`
+- `param[6]: usize`: Privilege label size in bytes
+- `result[0]: u32`: Status of operation
+
 ### `random_get`
 
 Fills a buffer with random bytes.
 
 - `param[0]: usize`: Destination buffer
 - `param[1]: usize`: Destination buffer size in bytes
+- `result[0]: u32`: Status of operation
+
+### `node_label`
+
+Returns the label for the calling Node, as a serialized
+[`Label`](/oak/proto/label.proto) protobuf message.
+
+If the provided space for label data (`param[0]` and `param[1]`) is not large
+enough, the function returns `BUFFER_TOO_SMALL` and the required size is written
+in the space provided by `param[2]`.
+
+- `param[0]: usize`: Destination buffer
+- `param[1]: usize`: Destination buffer size in bytes
+- `param[2]: usize`: Address of a 4-byte location that will receive the number
+  of bytes in the label (as a little-endian u32) if the provided buffer is not
+  large enough.
+- `result[0]: u32`: Status of operation
+
+### `channel_label`
+
+Returns the label for the specified channel, as a serialized
+[`Label`](/oak/proto/label.proto) protobuf message.
+
+If the provided space for label data (`param[1]` and `param[2]`) is not large
+enough, the function returns `BUFFER_TOO_SMALL` and the required size is written
+in the space provided by `param[3]`.
+
+- `param[0]: u64`: Handle to channel
+- `param[1]: usize`: Destination buffer
+- `param[2]: usize`: Destination buffer size in bytes
+- `param[3]: usize`: Address of a 4-byte location that will receive the number
+  of bytes in the label (as a little-endian u32) if the provided buffer is not
+  large enough.
+- `result[0]: u32`: Status of operation
+
+### `node_privilege`
+
+Returns a label indicating the downgrade privilege of the calling Node, as a
+serialized [`Label`](/oak/proto/label.proto) protobuf message.
+
+If the provided space for label data (`param[0]` and `param[1]`) is not large
+enough, the function returns `BUFFER_TOO_SMALL` and the required size is written
+in the space provided by `param[2]`.
+
+- `param[0]: usize`: Destination buffer
+- `param[1]: usize`: Destination buffer size in bytes
+- `param[2]: usize`: Address of a 4-byte location that will receive the number
+  of bytes in the label (as a little-endian u32) if the provided buffer is not
+  large enough.
 - `result[0]: u32`: Status of operation

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -113,12 +113,13 @@ functions** as
 
 Blocks until data is available for reading from one of the specified channel
 handles, unless any of the channels is invalid, orphaned, or violates the
-[information flow control](/docs/concepts.md#labels). The channel handles are
-encoded in a buffer that holds N contiguous 9-byte chunks, each of which is made
-up of an 8-byte channel handle value (little-endian u64) followed by a single
-channel status byte. Invalid handles will have an `INVALID_CHANNEL`, `ORPHANED`,
-or `PERMISSION_DENIED` status, but `wait_on_channels` return value will only
-fail for internal errors or if the runtime is terminating.
+[information flow control](/docs/concepts.md#information-flow-control). The
+channel handles are encoded in a buffer that holds N contiguous 9-byte chunks,
+each of which is made up of an 8-byte channel handle value (little-endian u64)
+followed by a single channel status byte. Invalid handles will have an
+`INVALID_CHANNEL`, `ORPHANED`, or `PERMISSION_DENIED` status, but
+`wait_on_channels` return value will only fail for internal errors or if the
+runtime is terminating.
 
 - `param[0]: usize`: Address of handle status buffer
 - `param[1]: u32`: Count N of handles provided
@@ -139,7 +140,7 @@ sizes are written in the spaces provided by `param[3]` and `param[6]`.
 If no messages are available on the channel, returns `CHANNEL_EMPTY`.
 
 If reading from the specified channel would violate
-[information flow control](/docs/concepts.md#labels), returns
+[information flow control](/docs/concepts.md#information-flow-control), returns
 `ERR_PERMISSION_DENIED`.
 
 - `param[0]: u64`: Handle to channel receive half
@@ -160,7 +161,7 @@ Writes a single message to the specified channel, together with any associated
 handles.
 
 If writing to the specified channel would violate
-[information flow control](/docs/concepts.md#labels), returns
+[information flow control](/docs/concepts.md#information-flow-control), returns
 `ERR_PERMISSION_DENIED`.
 
 - `param[0]: u64`: Handle to channel send half
@@ -179,7 +180,7 @@ its read and write halves as output parameters in `param[0]` and `param[1]`.
 The label is a serialized [`Label`](/oak/proto/label.proto) protobuf message.
 
 If creating the specified Channel would violate
-[information flow control](/docs/concepts.md#labels), returns
+[information flow control](/docs/concepts.md#information-flow-control), returns
 `ERR_PERMISSION_DENIED`.
 
 - `param[0]: usize`: Address of an 8-byte location that will receive the handle
@@ -209,7 +210,7 @@ The Node configuration is a serialized
 label is a serialized [`Label`](/oak/proto/label.proto) protobuf message.
 
 If creating the specified Node would violate
-[information flow control](/docs/concepts.md#labels), returns
+[information flow control](/docs/concepts.md#information-flow-control), returns
 `ERR_PERMISSION_DENIED`.
 
 - `param[0]: usize`: Source buffer holding serialized `NodeConfiguration`

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -6,7 +6,7 @@
 - [Channels](#channels)
   - [Orphaned Channels](#orphaned-channels)
   - [Invocations](#invocations)
-- [Labels](#labels)
+- [Information Flow Control](#information-flow-control)
 - [Pseudo-Nodes](#pseudo-nodes)
 - [Oak Application](#oak-application)
 - [Remote Attestation](#remote-attestation)
@@ -131,172 +131,63 @@ its ephemeral Channel handles.
 
 <img src="images/InvocationPattern.gif" width="550">
 
-## Labels
+## Information Flow Control
 
-### Overview
+The Oak Runtime implements an **information flow control** (IFC) system that has
+rules about when information (in the form of messages) can flow. The core idea
+is that Oak Nodes and Channels have **labels**, fixed at creation time. Each
+Label has two **components**: **confidentiality** and **integrity**, where:
 
-- Nodes and Channels have **Labels**, fixed at creation time
-- The Runtime keeps track of Labels, and enforces flow of data between Nodes and
-  Channels based on them
-- Each Label has two **components**: **confidentiality** and **integrity**
-- Each component is an unordered set of **tags**
-- Each tag is a structured representation of a **security principal**
-- A security principal is either a **user** or a **computation**
+- Confidentiality is roughly equivalent to "secrecy" or "privacy"; confidential
+  data becomes "more" confidential as it is mixed with other data.
+- Integrity is roughly equivalent to "trusted", "validated", or "authenticated":
+  trusted data becomes "less" trusted as it is mixed with other data sources.
 
-### Details
+Each label component is an unordered set of **tags**, and each **tag** is either
+opaque (representing a **bearer token**), or represents a security principal.
+For a confidentiality tag, the available principals are:
 
-Labels are used to enforce information flow control (IFC) between Nodes and
-Channels in an Oak Application and the outside world.
+- A **user**: this tag indicates that data is confidential to this user.
+- A particular piece of **code**: this tag indicates that a known Oak
+  Application (or part thereof) has access to the data.
+- A remote **domain**: this tag indicates that a service at this domain has
+  access to the data.
 
-#### Runtime
+The Runtime keeps track of labels, and enforces **flows-to** checks on data
+moving between Nodes and Channels based on these labels.
 
-The Oak Runtime keeps track of the Label associated with each Node and each
-Channel. When a Node creates a new Node or Channel, the creator Node specifies
-the Label to associate with the newly created Node or Channel. The Label does
-not change any more after that (apart from explicit declassification operations,
-which are not currently supported). Labels are always considered public, and a
-Node may inspect its own Label or that of any Channel it has access to, and (if
-the Oak Runtime is implemented correctly) this is guaranteed to not allow the
-creation of side channels based on Labels.
+- Data can only flow from a smaller to a larger confidentiality label: every tag
+  in the source label must be present in the destination label.
+- Data can only flow from a larger to a smaller integrity label: every tag in
+  the destination label must be present in the source label.
 
-#### Components
+There are exceptions to these rules; some Nodes have the **privilege** to bypass
+particular data flow label checks. For confidentiality labels, the
+**declassification** privileges are:
 
-A Label has two components: **confidentiality** and **integrity**.
+- The gRPC server pseudo-Node can bypass **user** tag checks, provided that it
+  has an authenticated connection (e.g. with OpenID Connect) to the specific
+  user.
+- The gRPC client pseudo-Node can bypass **domain** tag checks, provided that it
+  has an authenticated connection to a gRPC service on the specific domain.
+- An individual WebAssembly Node can bypass a **code** tag check, provided that
+  the code tag identifies that WebAssembly Node.
 
-Each component is represented as an (unordered) set of tags, and each tag refers
-to an individual security principal in the system.
+At an ABI level, this IFC functionality is visible to Oak Applications as
+follows:
 
-The following types of security principals are supported in Oak:
+- The primitives for creating Nodes and channels include a `label` parameter to
+  apply to the new Node or channel. The label of the creating Node must flow-to
+  the label of the new Node or channel.
+- Channel read and write operations can fail with a `PERMISSION_DENIED` error if
+  data flow label checks have failed.
+- There are `.._with_privilege` variants of all operations that involve flows-to
+  checks, to indicate that a declassification privilege should be taken
+  allowance of in the flows-to check.
+  - `{node,channel}_create_with_privilege` for creation of new objects.
+  - `channel_{read,write}_with_privilege` for message passing.
 
-- **user**: specified by a bearer token, public key, or some other assertion of
-  a user identity
-- **computation**: specified by a measurement (hash) of the WebAssembly module
-  running within an Oak Node
-
-Tags and Labels are represented as serialized
-[protobuf messages](/oak/proto/label.proto).
-
-Any security principal may be used (as a tag) as part of confidentiality or
-integrity components, depending on the required use case.
-
-Intuitively, if the confidentiality component contains tag `t`, the Node or
-Channel is allowed to see secrets owned by principal `t`. Similarly, if the
-integrity component contains tag `t`, that means the Node or Channel is trusted
-by `t`.
-
-#### Information Flow
-
-Labels are compared to decide whether or not data movement is allowed, for
-example when a Node sends a value over a Channel. Given two labels `L_a` and
-`L_b`, `L_a ⊑ L_b` (pronounced "flows to") if a value from a source labeled
-`L_a` can be sent to a destination labeled `L_b`. The "flows to" operator
-compares both confidentiality and integrity:
-
-- the **confidentiality** check ensures that the destination is permitted to
-  view any secrets that may have influenced the value
-- the **integrity** check ensures that the value sent is trusted by the
-  destination
-
-More concretely, if `L_a = (C_a, I_a)` (where `C_a` and `I_a` are the
-confidentiality and integrity components respectively), and `L_b = (C_b, I_b)`
-then `L_a ⊑ L_b` iff `C_a ⊆ C_b` and `I_a ⊇ I_b`. Notably, the integrity part of
-the check is "flipped" by convention (see "Integrity Considerations for Secure
-Computer Systems" below). More fundamental than adhering to convention, by
-flipping the integrity order in this way, we can retain the intuitive meaning
-behind integrity tags as representing trust by a principal (trust by a user,
-trust on a subject, etc.).
-
-Intuitively, data can only flow from `a` to `b` if:
-
-- `b` is **at least as secret** as `a`
-- `a` is **at least as trusted** as `b`
-
-The least privileged label is usually referred to as "public trusted" (and
-represented as `⊥`, pronounced "bottom"), which corresponds to a Node or Channel
-which has only observed public data, and its inputs are not endorsed with any
-level of integrity; in this label, both confidentiality and integrity components
-are empty sets.
-
-As an example, if the `a`'s confidentiality is `{c_0, c_1}`, and `a`'s integrity
-is `{i_0, i_1}`, then:
-
-- information can flow from `a` to `b` if `b`'s confidentiality is
-  `{c_0, c_1, c_2} ⊇ {c_0, c_1}`, since `b` is "at least as secret" than `a`
-- information cannot flow from `a` to `b` if `b`'s confidentiality is
-  `{c_0} ⊉ {c_0, c_1}`, since `b` is "less secret" than `a` (in particular, `b`
-  is not allowed to see secrets owned by `c_1`)
-- information cannot flow from `a` to `b` if `b`'s integrity is
-  `{i_0, i_1, i_2} ⊈ {i_0, i_1}`, since `a` is "less trusted" than `b` (in
-  particular, `a` is not trusted by `i_2`)
-- information can flow from `a` to `b` if `b`'s integrity is
-  `{i_0} ⊆ {i_0, i_1}`, since `a` is "at least as trusted" than `b`
-
-In particular:
-
-- A Node with label `L_w` may write to a Channel with Label `L_c` iff
-  `L_w ⊑ L_c`.
-- A Node with label `L_r` may read from a Channel with Label `L_c` iff
-  `L_c ⊑ L_r`.
-
-If a Node tries to write to or read from a Channel that it is not allowed to,
-based on the `⊑` relation, the operation fails immediately (i.e. the read or
-write ABI call returns an error to the caller), and no side effects are
-performed.
-
-It follows that bi-directional communication between Nodes `a` and `b` is only
-allowed (via two uni-directional Channels) if
-`(L_a ⊑ L_b) ∧ (L_b ⊑ L_a) ⇒ L_a = L_b`, i.e. if `a` and `b` have identical
-confidentiality and integrity.
-
-#### Downgrades
-
-A Node may have the privilege to remove one or more confidentiality tags
-(**declassification**) and / or add one or more integrity tags
-(**endorsement**). Both of these operations are instances of **downgrade**
-operations (which is a more general concept).
-
-The set of tags that may be downgraded by a Node is determined by the Oak
-Runtime based on the initial or current state of the Node. For instance, the Oak
-Runtime grants the privilege to declassify user tags to each instance of gRPC
-Server Node, which is trusted to only use it in order to declassify data for the
-user that is in fact currently authenticated over a gRPC connection.
-
-When Node A attempts to create another Node B, it specifies the desired label
-for B, which is checked by the Oak Runtime to be allowed by the "flows to"
-relationship, but A does not have a way to influence the privilege of B; this is
-always entirely determined by the Oak Runtime itself, which is trusted to assign
-the appropriate privilege to all Nodes.
-
-#### References
-
-More details on Information Flow Control may be found in the following
-references:
-
-- [Information Flow Control for Standard OS Abstractions](https://pdos.csail.mit.edu/papers/flume-sosp07.pdf)
-- [Flow-Limited Authorization](https://www.cs.cornell.edu/andru/papers/flam/flam-csf15.pdf)
-- [Integrity Considerations for Secure Computer Systems](http://seclab.cs.ucdavis.edu/projects/history/papers/biba75.pdf)
-- [Protecting Privacy using the Decentralized Label Model](https://www.cs.cornell.edu/andru/papers/iflow-tosem.pdf)
-
-### gRPC and user labels
-
-As [described below](#pseudo-nodes), each incoming gRPC invocation is
-represented by a message containing two Channels handles:
-
-- a "request receiver" read handle to a Channel whose Label has:
-
-  - a confidentiality component explicitly specified by the caller as gRPC
-    request metadata; this represents the confidentiality guarantees that the
-    caller wants to impose on the request message.
-  - an integrity component implicitly set by the gRPC pseudo-Node based on some
-    trusted authentication mechanism that is performed as part of the gRPC
-    connection itself; this represents the actual authority of the caller.
-
-- a "response sender" write handle to a Channel, whose Label has:
-
-  - a confidentiality component implicitly set by the gRPC pseudo-Node based on
-    some trusted authentication mechanism that is performed as part of the gRPC
-    connection itself; this represents the actual authority of the caller.
-  - an empty integrity component.
+More details are described in a [separate IFC document](/docs/ifc.md).
 
 ## Pseudo-Nodes
 

--- a/docs/ifc.md
+++ b/docs/ifc.md
@@ -1,0 +1,169 @@
+# Information Flow Control (IFC) in Oak
+
+This document describes details of the Information Flow Control system
+implemented in Oak.
+
+## Overview
+
+- Nodes and Channels have **Labels**, fixed at creation time
+- The Runtime keeps track of Labels, and enforces flow of data between Nodes and
+  Channels based on them
+- Each Label has two **components**: **confidentiality** and **integrity**
+- Each component is an unordered set of **tags**
+- Each tag is a structured representation of a **security principal**
+- A security principal is either a **user** or a **computation**
+
+## Details
+
+Labels are used to enforce information flow control (IFC) between Nodes and
+Channels in an Oak Application and the outside world.
+
+### Runtime
+
+The Oak Runtime keeps track of the Label associated with each Node and each
+Channel. When a Node creates a new Node or Channel, the creator Node specifies
+the Label to associate with the newly created Node or Channel. The Label does
+not change any more after that (apart from explicit declassification operations,
+which are not currently supported). Labels are always considered public, and a
+Node may inspect its own Label or that of any Channel it has access to, and (if
+the Oak Runtime is implemented correctly) this is guaranteed to not allow the
+creation of side channels based on Labels.
+
+### Components
+
+A Label has two components: **confidentiality** and **integrity**.
+
+Each component is represented as an (unordered) set of tags, and each tag refers
+to an individual security principal in the system.
+
+The following types of security principals are supported in Oak:
+
+- **user**: specified by a bearer token, public key, or some other assertion of
+  a user identity
+- **computation**: specified by a measurement (hash) of the WebAssembly module
+  running within an Oak Node
+
+Tags and Labels are represented as serialized
+[protobuf messages](/oak/proto/label.proto).
+
+Any security principal may be used (as a tag) as part of confidentiality or
+integrity components, depending on the required use case.
+
+Intuitively, if the confidentiality component contains tag `t`, the Node or
+Channel is allowed to see secrets owned by principal `t`. Similarly, if the
+integrity component contains tag `t`, that means the Node or Channel is trusted
+by `t`.
+
+### Information Flow
+
+Labels are compared to decide whether or not data movement is allowed, for
+example when a Node sends a value over a Channel. Given two labels `L_a` and
+`L_b`, `L_a ⊑ L_b` (pronounced "flows to") if a value from a source labeled
+`L_a` can be sent to a destination labeled `L_b`. The "flows to" operator
+compares both confidentiality and integrity:
+
+- the **confidentiality** check ensures that the destination is permitted to
+  view any secrets that may have influenced the value
+- the **integrity** check ensures that the value sent is trusted by the
+  destination
+
+More concretely, if `L_a = (C_a, I_a)` (where `C_a` and `I_a` are the
+confidentiality and integrity components respectively), and `L_b = (C_b, I_b)`
+then `L_a ⊑ L_b` iff `C_a ⊆ C_b` and `I_a ⊇ I_b`. Notably, the integrity part of
+the check is "flipped" by convention (see "Integrity Considerations for Secure
+Computer Systems" below). More fundamental than adhering to convention, by
+flipping the integrity order in this way, we can retain the intuitive meaning
+behind integrity tags as representing trust by a principal (trust by a user,
+trust on a subject, etc.).
+
+Intuitively, data can only flow from `a` to `b` if:
+
+- `b` is **at least as secret** as `a`
+- `a` is **at least as trusted** as `b`
+
+The least privileged label is usually referred to as "public trusted" (and
+represented as `⊥`, pronounced "bottom"), which corresponds to a Node or Channel
+which has only observed public data, and its inputs are not endorsed with any
+level of integrity; in this label, both confidentiality and integrity components
+are empty sets.
+
+As an example, if the `a`'s confidentiality is `{c_0, c_1}`, and `a`'s integrity
+is `{i_0, i_1}`, then:
+
+- information can flow from `a` to `b` if `b`'s confidentiality is
+  `{c_0, c_1, c_2} ⊇ {c_0, c_1}`, since `b` is "at least as secret" than `a`
+- information cannot flow from `a` to `b` if `b`'s confidentiality is
+  `{c_0} ⊉ {c_0, c_1}`, since `b` is "less secret" than `a` (in particular, `b`
+  is not allowed to see secrets owned by `c_1`)
+- information cannot flow from `a` to `b` if `b`'s integrity is
+  `{i_0, i_1, i_2} ⊈ {i_0, i_1}`, since `a` is "less trusted" than `b` (in
+  particular, `a` is not trusted by `i_2`)
+- information can flow from `a` to `b` if `b`'s integrity is
+  `{i_0} ⊆ {i_0, i_1}`, since `a` is "at least as trusted" than `b`
+
+In particular:
+
+- A Node with label `L_w` may write to a Channel with Label `L_c` iff
+  `L_w ⊑ L_c`.
+- A Node with label `L_r` may read from a Channel with Label `L_c` iff
+  `L_c ⊑ L_r`.
+
+If a Node tries to write to or read from a Channel that it is not allowed to,
+based on the `⊑` relation, the operation fails immediately (i.e. the read or
+write ABI call returns an error to the caller), and no side effects are
+performed.
+
+It follows that bi-directional communication between Nodes `a` and `b` is only
+allowed (via two uni-directional Channels) if
+`(L_a ⊑ L_b) ∧ (L_b ⊑ L_a) ⇒ L_a = L_b`, i.e. if `a` and `b` have identical
+confidentiality and integrity.
+
+### Downgrades
+
+A Node may have the privilege to remove one or more confidentiality tags
+(**declassification**) and / or add one or more integrity tags
+(**endorsement**). Both of these operations are instances of **downgrade**
+operations (which is a more general concept).
+
+The set of tags that may be downgraded by a Node is determined by the Oak
+Runtime based on the initial or current state of the Node. For instance, the Oak
+Runtime grants the privilege to declassify user tags to each instance of gRPC
+Server Node, which is trusted to only use it in order to declassify data for the
+user that is in fact currently authenticated over a gRPC connection.
+
+When Node A attempts to create another Node B, it specifies the desired label
+for B, which is checked by the Oak Runtime to be allowed by the "flows to"
+relationship, but A does not have a way to influence the privilege of B; this is
+always entirely determined by the Oak Runtime itself, which is trusted to assign
+the appropriate privilege to all Nodes.
+
+### References
+
+More details on Information Flow Control may be found in the following
+references:
+
+- [Information Flow Control for Standard OS Abstractions](https://pdos.csail.mit.edu/papers/flume-sosp07.pdf)
+- [Flow-Limited Authorization](https://www.cs.cornell.edu/andru/papers/flam/flam-csf15.pdf)
+- [Integrity Considerations for Secure Computer Systems](http://seclab.cs.ucdavis.edu/projects/history/papers/biba75.pdf)
+- [Protecting Privacy using the Decentralized Label Model](https://www.cs.cornell.edu/andru/papers/iflow-tosem.pdf)
+
+## gRPC and user labels
+
+As [described elsewhere](/docs/concepts.md#pseudo-nodes), each incoming gRPC
+invocation is represented by a message containing two Channels handles:
+
+- a "request receiver" read handle to a Channel whose Label has:
+
+  - a confidentiality component explicitly specified by the caller as gRPC
+    request metadata; this represents the confidentiality guarantees that the
+    caller wants to impose on the request message.
+  - an integrity component implicitly set by the gRPC pseudo-Node based on some
+    trusted authentication mechanism that is performed as part of the gRPC
+    connection itself; this represents the actual authority of the caller.
+
+- a "response sender" write handle to a Channel, whose Label has:
+
+  - a confidentiality component implicitly set by the gRPC pseudo-Node based on
+    some trusted authentication mechanism that is performed as part of the gRPC
+    connection itself; this represents the actual authority of the caller.
+  - an empty integrity component.

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -288,9 +288,10 @@ Oak Application).
 
 The client connects to the gRPC service, and sends (Application-specific) gRPC
 requests to it, over a channel that has end-to-end encryption into the Runtime
-instance, and also specifies a [Label](/docs/concepts.md#labels) to attach to
-the request, which is used to enforce Information Flow Control within the
-running Oak Application:
+instance, and also specifies a
+[Label](/docs/concepts.md#information-flow-control) to attach to the request,
+which is used to enforce Information Flow Control within the running Oak
+Application:
 
 <!-- prettier-ignore-start -->
 [embedmd]:# (../examples/hello_world/client/hello_world.cc C++ /.*Connect to the/ /GetTlsChannelCredentials.*/)


### PR DESCRIPTION
This PR attempts to describe what the ABI will end up looking like once we've added the IFC functionality. 

I don't think this should be merged until the relevant function is there (i.e. I think the ABI doc should stay in sync with the current state of the code), but having this written down & agreed as an expected destination might be useful.
