### PR TITLE
Add label support to the nodejs client

### DIFF
--- a/examples/hello_world/client/nodejs/index.js
+++ b/examples/hello_world/client/nodejs/index.js
@@ -12,6 +12,12 @@ const oakLabelGrpcMetadataKey = 'x-oak-label-bin';
 
 async function main() {
   const [oaklabelDefinition, helloWorldDefinition] = await Promise.all([
+    // We use two different libs with a similar APIs to load proto files,
+    // which due to the design of the `@grpc/grpc-js` lib.
+    // `@grpc/proto-loader` is a wrapper around `protobufjs` that adds
+    // functionality required for working with `grpc-js`, but omits others.
+    // Hence we use grpcProtoLoader for gRPC services, and protobufjs
+    // for all other protos.
     protobufjs.load(OAK_LABEL_PROTO_PATH),
     grpcProtoLoader.load(SERVICE_PROTO_PATH),
   ]);
@@ -36,9 +42,15 @@ async function main() {
 
   const client = new helloWorldProto.HelloWorld('localhost:8080', credentials);
 
+  // For documentation on client calls see the `@grpc/grpc-js` documentation:
+  // https://grpc.github.io/grpc/node/grpc.Client.html#~CallProperties
   client.sayHello(
+    // The arguments passed to the gRPC service. Corresponds to the
+    // `HelloRequest` message type in hello_world.proto file.
     { greeting: 'Node.js' },
+    // The metadata for this gRPC call.
     getGrpcMetadata(),
+    // Callback invoked with the response.
     (error, response) => {
       if (error) {
         console.error(error);

--- a/examples/hello_world/client/nodejs/index.js
+++ b/examples/hello_world/client/nodejs/index.js
@@ -4,16 +4,16 @@ const grpc = require('@grpc/grpc-js');
 const grpcProtoLoader = require('@grpc/proto-loader');
 
 const CERT_PATH = __dirname + '/../../../certs/local/ca.pem';
-const SERVICE_PROTO_PAH = __dirname + '/../../proto/hello_world.proto';
-const OAK_LABEL_PROTO_PAH = __dirname + '/../../../../oak/proto/label.proto';
+const SERVICE_PROTO_PATH = __dirname + '/../../proto/hello_world.proto';
+const OAK_LABEL_PROTO_PATH = __dirname + '/../../../../oak/proto/label.proto';
 
 // Keep in sync with /oak/server/rust/oak_runtime/src/node/grpc/server/mod.rs.
 const oakLabelGrpcMetadataKey = 'x-oak-label-bin';
 
 async function main() {
   const [oaklabelDefinition, helloWorldDefinition] = await Promise.all([
-    protobufjs.load(OAK_LABEL_PROTO_PAH),
-    grpcProtoLoader.load(SERVICE_PROTO_PAH),
+    protobufjs.load(OAK_LABEL_PROTO_PATH),
+    grpcProtoLoader.load(SERVICE_PROTO_PATH),
   ]);
 
   function getGrpcMetadata() {

--- a/examples/hello_world/client/nodejs/package-lock.json
+++ b/examples/hello_world/client/nodejs/package-lock.json
@@ -112,10 +112,40 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
+    "@types/node": {
+      "version": "13.13.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.12.tgz",
+      "integrity": "sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw=="
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "protobufjs": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+      "integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
+        "long": "^4.0.0"
+      }
     },
     "semver": {
       "version": "6.3.0",

--- a/examples/hello_world/client/nodejs/package.json
+++ b/examples/hello_world/client/nodejs/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "dependencies": {
     "@grpc/grpc-js": "^1.0.3",
-    "@grpc/proto-loader": "^0.5.4"
+    "@grpc/proto-loader": "^0.5.4",
+    "protobufjs": "^6.9.0"
   },
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
This was lot less complex than I feared. :) It should bring the node client up to par with #1068. 

Sets me up for my next PR, which should be running this client as part of the CI.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
