### PR TITLE
Add support for Node.js clients to the run_example script

### DIFF
--- a/examples/hello_world/client/nodejs/README.MD
+++ b/examples/hello_world/client/nodejs/README.MD
@@ -1,13 +1,7 @@
 # Node.js client example
 
-To run this client, one first neeeds to install its dependencies by running
-`npm ci` in its directory.
-
-Then start the server of this example from the Oak root:
-`./scripts/docker_run ./scripts/run_server -e hello_world`
-
-In another terminal, you can then run this client from its directory:
-`npm start`.
+Run this example with the following command:
+`./scripts/docker_run ./scripts/run_server -e hello_world -c nodejs`
 
 If everything works smoothly, you should then find `HELLO Node.js!` logged to
-the client's console.
+the console, alongside logs from the Oak application.

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -123,6 +123,6 @@ esac
 
 # If a node client exists, install its dependencies
 nodejs_client="./examples/${EXAMPLE}/client/nodejs"
-if [ -d "${nodejs_client}" ]; then
+if [[ -d "${nodejs_client}" ]]; then
     npm ci --prefix "${nodejs_client}"
 fi

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -12,7 +12,7 @@ serverargs=""
 while getopts "s:a:c:de:vh" opt; do
   case "${opt}" in
     h)
-      echo -e "Usage: ${0} [-h] [-s base|logless|none] [-a rust|cpp] [-c rust|cpp] [-d] [-v] -e EXAMPLE [-- CLIENT_ARGS]
+      echo -e "Usage: ${0} [-h] [-s base|logless|none] [-a rust|cpp|nodejs] [-c rust|cpp] [-d] [-v] -e EXAMPLE [-- CLIENT_ARGS]
 
 Build and run the given example Oak Application and client.
 
@@ -29,6 +29,7 @@ Options:
   -c    Example client variant:
           - rust
           - cpp (used by default)
+          - nodejs
   -v    Enable verbose/debug output for the server
   -h    Print Help (this message) and exit
 Options after -- will be passed to the example client program."
@@ -105,6 +106,15 @@ case "${client_language}" in
     ;;
   cpp)
     "./bazel-client-bin/examples/${EXAMPLE}/client/client" "${TLS_ARGS[@]}" "${ADDITIONAL_ARGS[@]-}" "${CLIENT_ARGS[@]-}"
+    ;;
+  nodejs)
+    nodejs_client="./examples/${EXAMPLE}/client/nodejs"
+    if [ -d "${nodejs_client}" ]; then
+        npm start --prefix "./examples/${EXAMPLE}/client/nodejs"
+    else
+      echo "The ${EXAMPLE} example does not contain a ${client_language} client."
+      exit 1
+    fi
     ;;
   *)
     echo "Invalid example client variant: ${client_language}"

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -12,7 +12,7 @@ serverargs=""
 while getopts "s:a:c:de:vh" opt; do
   case "${opt}" in
     h)
-      echo -e "Usage: ${0} [-h] [-s base|logless|none] [-a rust|cpp|nodejs] [-c rust|cpp] [-d] [-v] -e EXAMPLE [-- CLIENT_ARGS]
+      echo -e "Usage: ${0} [-h] [-s base|logless|none] [-a rust|cpp] [-c rust|cpp|nodejs] [-d] [-v] -e EXAMPLE [-- CLIENT_ARGS]
 
 Build and run the given example Oak Application and client.
 
@@ -109,7 +109,7 @@ case "${client_language}" in
     ;;
   nodejs)
     nodejs_client="./examples/${EXAMPLE}/client/nodejs"
-    if [ -d "${nodejs_client}" ]; then
+    if [[ -d "${nodejs_client}" ]]; then
         npm start --prefix "./examples/${EXAMPLE}/client/nodejs"
     else
       echo "The ${EXAMPLE} example does not contain a ${client_language} client."


### PR DESCRIPTION
Thanks to the work done by @ipetr0v in #1110 this was super simple. :) 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
