### PR TITLE
docs: remove live links to pages that are 404

### DIFF
--- a/scripts/check_formatting
+++ b/scripts/check_formatting
@@ -92,6 +92,7 @@ find . \
 # We exclude the following URLs from the checks:
 # - https://groups.google.com/g/project-oak-discuss : not publicly accessible
 # - https://crates.io/crates : returns 404 (see https://github.com/raviqqe/liche/issues/39)
+# - https://www.cs.cornell.edu/andru : returns 404 (hopefully temporarily)
 find . \
   \(  \
     -not \( -path ./.git -prune \) -and \
@@ -101,7 +102,7 @@ find . \
     -not \( -path ./third_party -prune \) -and \
     -not \( -path '*/node_modules' -prune \) \
     \( -type f -name '*.md' \) \
-  \) -exec liche --document-root=. --exclude='(https://groups.google.com/g/project-oak-discuss|https://crates.io/crates)' {} +
+  \) -exec liche --document-root=. --exclude='(https://groups.google.com/g/project-oak-discuss|https://crates.io/crates|https://www.cs.cornell.edu/andru)' {} +
 
 find . \
   \(  \

--- a/scripts/format_doc
+++ b/scripts/format_doc
@@ -8,5 +8,5 @@ source "$SCRIPTS_DIR/common"
 
 prettier --write "$@"
 markdownlint --fix "$@"
-liche --document-root=. --exclude='(https://groups.google.com/g/project-oak-discuss|https://crates.io/crates)' "$@"
+liche --document-root=. --exclude='(https://groups.google.com/g/project-oak-discuss|https://crates.io/crates|https://www.cs.cornell.edu/andru)' "$@"
 embedmd -w "$@"


### PR DESCRIPTION
Hopefully we can revert this commit in future once the stable links
reappear.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
