### PR TITLE
Support rust toolchain override in `runner`

### DIFF
--- a/oak/server/rust/oak_runtime/Cargo.toml
+++ b/oak/server/rust/oak_runtime/Cargo.toml
@@ -60,4 +60,9 @@ wat = "*"
 [build-dependencies]
 oak_utils = "*"
 prost-build = "*"
-tonic-build = "*"
+# Disable the `rustfmt` feature, as it requires `rustfmt` which may not be supported for custom
+# toolchains.
+tonic-build = { version = "*", default-features = false, features = [
+  "prost",
+  "transport"
+] }

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -54,16 +54,25 @@ pub struct RunExamples {
     pub example_name: Option<String>,
     #[structopt(long, help = "only build the examples, do not run them")]
     pub build_only: bool,
+    #[structopt(flatten)]
+    pub build_server: BuildServer,
 }
 
 #[derive(StructOpt, Clone)]
 pub struct BuildServer {
+    #[structopt(long, help = "server variant: [base]", default_value = "base")]
+    pub server_variant: String,
     #[structopt(
         long,
-        help = "server variant: [base, logless, rust, arm, asan, tsan]",
-        default_value = "base"
+        help = "rust toolchain override to use for the server compilation [e.g. stable, nightly, stage2]"
     )]
-    pub variant: String,
+    pub server_rust_toolchain: Option<String>,
+    #[structopt(
+        long,
+        help = "rust target to use for the server compilation [e.g. x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]",
+        default_value = "x86_64-unknown-linux-musl"
+    )]
+    pub server_rust_target: String,
 }
 
 /// Encapsulates all the local state relative to a step, and is propagated to child steps.


### PR DESCRIPTION
Remove unused server variants.

Disable `rustfmt` build feature of `tonic-build`, to allow for
simpler compatibility with custom toolchains.
