### PR TITLE
Only allow public Nodes to create entities

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -180,11 +180,15 @@ If writing to the specified channel would violate
 
 ### `channel_create`
 
-Creates a new unidirectional channel assigning the label specified by `param[2]`
-and `param[3]` to the newly created Channel, and returns the channel handles for
+Creates a new unidirectional Channel assigning the label specified by `param[2]`
+and `param[3]` to the newly created Channel, and returns the Channel handles for
 its read and write halves as output parameters in `param[0]` and `param[1]`.
 
 The label is a serialized [`Label`](/oak/proto/label.proto) protobuf message.
+
+Because the label of the newly created Channel is effectively public, this
+function may only be invoked by Nodes whose label "flows to" the "public
+untrusted" label.
 
 If creating the specified Channel would violate
 [information flow control](/docs/concepts.md#labels), returns
@@ -215,6 +219,10 @@ identified by `param[4]`.
 The Node configuration is a serialized
 [`NodeConfiguration`](/oak/proto/application.proto) protobuf message, and the
 label is a serialized [`Label`](/oak/proto/label.proto) protobuf message.
+
+Because the label of the newly created Node is effectively public, this function
+may only be invoked by Nodes whose label "flows to" the "public untrusted"
+label.
 
 If creating the specified Node would violate
 [information flow control](/docs/concepts.md#labels), returns

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -211,7 +211,7 @@ Intuitively, data can only flow from `a` to `b` if:
 - `b` is **at least as secret** as `a`
 - `a` is **at least as trusted** as `b`
 
-The least privileged label is usually referred to as "public trusted" (and
+The least privileged label is usually referred to as "public untrusted" (and
 represented as `⊥`, pronounced "bottom"), which corresponds to a Node or Channel
 which has only observed public data, and its inputs are not endorsed with any
 level of integrity; in this label, both confidentiality and integrity components
@@ -252,6 +252,20 @@ It follows that bi-directional communication between Nodes `a` and `b` is only
 allowed (via two uni-directional Channels) if
 `(L_a ⊑ L_b) ∧ (L_b ⊑ L_a) ⇒ L_a = L_b`, i.e. if `a` and `b` have identical
 confidentiality and integrity.
+
+#### Node and Channel Creation
+
+Labels associated with Nodes and Channels are themselves effectively public, in
+the sense that they may be observed from outside the system.
+
+For this reason, when a Node attempts to create a new Node or Channel, an
+additional check that the label of the caller Node "flows to" the "public
+untrusted" label. This prevents the caller node from encoding non-public
+information in the label of the newly created Node or Channel, or even in the
+mere fact that such a Node or Channel exists at all.
+
+This restricts the ability to create new Node and Channels to Nodes that are
+themselves already "public".
 
 #### Downgrades
 

--- a/oak/server/rust/oak_runtime/src/message.rs
+++ b/oak/server/rust/oak_runtime/src/message.rs
@@ -32,6 +32,7 @@ pub struct Message {
 /// internal counterpart of the SDK's `Message` type, whereas the internal `Message`
 /// type above holds internal channel references that can be moved between different
 /// Node contexts.
+#[derive(Clone, PartialEq)]
 pub struct NodeMessage {
     pub data: Vec<u8>,
     pub handles: Vec<oak_abi::Handle>,


### PR DESCRIPTION
Implement `Clone` and `PartialEq` for `NodeMessage` to facilitate
testing.

Add termination check to `channel_create` host function.

Add more logging around labels in various host functions.

The tests are not as comprehensive as I would like them to be, since it
is hard to simulate the case in which a public node creates a non-public
channel and passes that to a non-public node.

Fixes #1143

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [x] I have updated [documentation](/docs/) accordingly.

