### PR TITLE
Build scripts: Name client variants by their build system for clarity

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -81,7 +81,7 @@ steps:
     waitFor: ['run_tests_tsan']
     timeout: 60m
     entrypoint: 'bash'
-    args: ['./scripts/run_examples', '-s', 'base', '-c', 'rust cpp nodejs']
+    args: ['./scripts/run_examples', '-s', 'base', '-c', 'cargo bazel npm']
 
   - name: 'gcr.io/oak-ci/oak:latest'
     id: run_examples_cpp

--- a/examples/hello_world/client/nodejs/README.MD
+++ b/examples/hello_world/client/nodejs/README.MD
@@ -1,7 +1,7 @@
 # Node.js client example
 
 Run this example with the following command:
-`./scripts/docker_run ./scripts/run_example -e hello_world -c nodejs`
+`./scripts/docker_run ./scripts/run_example -e hello_world -c npm`
 
 If everything works smoothly, you should then find `HELLO Node.js!` logged to
 the console, alongside logs from the Oak application.

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -5,13 +5,13 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 source "${SCRIPTS_DIR}/common"
 
 application_language="rust"
-client_language="cpp"
+client_variant="bazel"
 compilation_mode='fastbuild'
 docker_config=''
 while getopts "e:a:c:di:h" opt; do
   case "${opt}" in
     h)
-      echo -e "Usage: ${0} [-h] [-a rust|cpp] [-c rust|cpp] [-i base|logless] [-d] -e EXAMPLE
+      echo -e "Usage: ${0} [-h] [-a rust|cpp] [-c cargo|bazel] [-i base|logless] [-d] -e EXAMPLE
 
 Build the given example Oak Application and client.
 
@@ -21,8 +21,8 @@ Options:
           - rust (used by default)
           - cpp
   -c    Example client variant:
-          - rust
-          - cpp (used by default)
+          - cargo
+          - bazel (used by default)
   -d    Build C++ code for example using debug mode
   -i    This flag enables packaging the application into a Docker image,
         and specifies the version of the Oak server, used by the application:
@@ -35,7 +35,7 @@ Options:
     a)
       application_language="${OPTARG}";;
     c)
-      client_language="${OPTARG}";;
+      client_variant="${OPTARG}";;
     d)
       compilation_mode='dbg';;
     i)
@@ -105,11 +105,11 @@ if [[ -n "${docker_config}" ]]; then
   fi
 fi
 
-case "${client_language}" in
-  rust)
+case "${client_variant}" in
+  cargo)
     cargo build --release "--manifest-path=./examples/${EXAMPLE}/client/rust/Cargo.toml"
     ;;
-  cpp)
+  bazel)
     bazel_build_flags+=(
       '--symlink_prefix=bazel-client-'
       "--compilation_mode=${compilation_mode}"
@@ -120,7 +120,7 @@ case "${client_language}" in
     bazel --output_base="${CACHE_DIR}/client" build "${bazel_build_flags[@]}" "//examples/${EXAMPLE}/client:all"
     ;;
   *)
-    echo "Invalid example client variant: ${client_language}"
+    echo "Invalid example client variant: ${client_variant}"
     exit 1;;
 esac
 

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -6,13 +6,13 @@ source "${SCRIPTS_DIR}/common"
 
 server="base"
 application_language="rust"
-client_languages="cpp"
+client_variants="bazel"
 buildargs=""
 serverargs=""
 while getopts "s:a:c:de:vh" opt; do
   case "${opt}" in
     h)
-      echo -e "Usage: ${0} [-h] [-s base|logless|none] [-a rust|cpp] [-c [rust|cpp|nodejs]...] [-d] [-v] -e EXAMPLE [-- CLIENT_ARGS]
+      echo -e "Usage: ${0} [-h] [-s base|logless|none] [-a rust|cpp] [-c [cargo|bazel|npm]...] [-d] [-v] -e EXAMPLE [-- CLIENT_ARGS]
 
 Build and run the given example Oak Application and client.
 
@@ -27,10 +27,10 @@ Options:
           - rust (used by default)
           - cpp
   -c    Example client variants. Multiple clients can be specified by space
-        seperating them. Eg -c \"rust cpp nodejs\".
-          - rust
-          - cpp (used by default)
-          - nodejs
+        separating them. Eg -c \"cargo bazel npm\".
+          - cargo
+          - bazel (used by default)
+          - npm
   -v    Enable verbose/debug output for the server
   -h    Print Help (this message) and exit
 Options after -- will be passed to the example client program."
@@ -38,7 +38,7 @@ Options after -- will be passed to the example client program."
     a)
       application_language="${OPTARG}";;
     c)
-      client_languages="${OPTARG}";;
+      client_variants="${OPTARG}";;
     s)
       case "${OPTARG}" in
         base|logless|none)
@@ -110,37 +110,37 @@ fi
 readonly CLIENT_ARGS=("${@-}")  # Choose client args provided after '--'.
 
 # Run the application clients.
-for client_language in $client_languages
+for client_variant in $client_variants
 do
-  case "${client_language}" in
-    rust)
+  case "${client_variant}" in
+    cargo)
       rust_client_manifest="${SCRIPTS_DIR}/../examples/${EXAMPLE}/client/rust/Cargo.toml"
       if [[ -f "${rust_client_manifest}" ]]; then
           cargo run --release --target=x86_64-unknown-linux-musl --manifest-path="${rust_client_manifest}" -- \
             --root-tls-certificate="${SCRIPTS_DIR}/../examples/certs/local/ca.pem" \
             "${CLIENT_ARGS[@]-}"
       else
-        echo "The ${EXAMPLE} example does not contain a ${client_language} client. Skipping this client."
+        echo "The ${EXAMPLE} example does not contain a ${client_variant} client. Skipping this client."
       fi
       ;;
-    cpp)
-      cpp_client="./bazel-client-bin/examples/${EXAMPLE}/client/client"
-      if [[ -f "${cpp_client}" ]]; then
-          "${cpp_client}" "${TLS_ARGS[@]}" "${ADDITIONAL_ARGS[@]-}" "${CLIENT_ARGS[@]-}"
+    bazel)
+      build_file="${SCRIPTS_DIR}/../examples/${EXAMPLE}/client/BUILD"
+      if [[ -f "${build_file}" ]]; then
+          "${SCRIPTS_DIR}/../bazel-client-bin/examples/${EXAMPLE}/client/client" "${TLS_ARGS[@]}" "${ADDITIONAL_ARGS[@]-}" "${CLIENT_ARGS[@]-}"
       else
-        echo "The ${EXAMPLE} example does not contain a ${client_language} client. Skipping this client."
+        echo "The ${EXAMPLE} example does not contain a ${client_variant} client. Skipping this client."
       fi
       ;;
-    nodejs)
-      nodejs_client="./examples/${EXAMPLE}/client/nodejs"
-      if [[ -d "${nodejs_client}" ]]; then
-          npm start --prefix "${nodejs_client}"
+    npm)
+      npm_client="${SCRIPTS_DIR}/../examples/${EXAMPLE}/client/nodejs"
+      if [[ -d "${npm_client}" ]]; then
+          npm start --prefix "${npm_client}"
       else
-        echo "The ${EXAMPLE} example does not contain a ${client_language} client. Skipping this client."
+        echo "The ${EXAMPLE} example does not contain a ${client_variant} client. Skipping this client."
       fi
       ;;
     *)
-      echo "Invalid example client variant: ${client_language}"
+      echo "Invalid example client variant: ${client_variant}"
       exit 1;;
   esac
 done

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -6,7 +6,7 @@ source "${SCRIPTS_DIR}/common"
 
 server="base"
 application_language="rust"
-client_languages="cpp"
+client_variants="bazel"
 while getopts "s:a:c:h" opt; do
   case "${opt}" in
     h)
@@ -18,16 +18,16 @@ while getopts "s:a:c:h" opt; do
           - rust (default)
           - cpp
   -c    Example client variants. Multiple clients can be specified by space
-        seperating them. Eg -c \"rust cpp nodejs\".
-        - rust
-        - cpp (used by default)
-        - nodejs
+        separating them. Eg -c \"cargo bazel npm\".
+        - cargo
+        - bazel (used by default)
+        - npm
   -h    Print Help (this message) and exit"
       exit 0;;
     a)
       application_language="${OPTARG}";;
     c)
-      client_languages="${OPTARG}";;
+      client_variants="${OPTARG}";;
     s)
       case "${OPTARG}" in
         base|logless)
@@ -46,12 +46,12 @@ done
 examples="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/'"${application_language}"'$' | cut -d'/' -f2 | uniq)"
 for example in ${examples}; do
   if [[ "${example}" == 'aggregator' ]]; then
-      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_languages}" -e aggregator -- --bucket=test --data=1:10,2:20,3:30
+      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_variants}" -e aggregator -- --bucket=test --data=1:10,2:20,3:30
   elif [[ "${example}" == 'chat' ]]; then
-      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_languages}" -e chat -- --test
+      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_variants}" -e chat -- --test
   elif [[ "${example}" == 'trusted_information_retrieval' ]]; then
-      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_languages}" -e trusted_information_retrieval -- --latitude 0.0 --longitude 0.0
+      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_variants}" -e trusted_information_retrieval -- --latitude 0.0 --longitude 0.0
   else
-      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_languages}" -e "${example}"
+      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_variants}" -e "${example}"
   fi
 done


### PR DESCRIPTION
TL;DR

`cpp` -> `bazel`
`rust` -> `cargo`
`nodejs` -> `npm`

----

Addresses @daviddrysdale's earlier comment: https://github.com/project-oak/oak/pull/1169#discussion_r442165207

This renames the issue of the somewhat confusing `cpp` variant. 

This makes sense, since bazel is the build system the scripts will use for this variant. And other non cpp clients (Go) that use bazel shouldn't use the `cpp` flag.

Similarly this renames `rust` to `cargo`, and `nodejs` to `npm`, so we always refer to the build system. 

This is quite similar to the naming used in the rust runner. 
https://github.com/project-oak/oak/blob/19ff6bb2c676f501816d8a57c3f430f5bed45463/runner/src/main.rs#L295

Imho it might be worth to think about doing the same for the server/application variants.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
