### PR TITLE
Add grpc streaming metrics

### DIFF
--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -17,8 +17,8 @@ Build and run the Backend with the following command:
 ```bash
 export RUST_LOG=info
 cargo run --release --manifest-path=examples/aggregator/backend/Cargo.toml -- \
-  --grpc-tls-private-key="<path-to-grpc-tls-private-key>" \
-  --grpc-tls-certificate="<path-to-grpc-tls-certificate>"
+  --grpc-tls-private-key=./examples/certs/local/local.key \
+  --grpc-tls-certificate=./examples/certs/local/local.pem
 ```
 
 Backend code is in the `backend` directory.

--- a/oak/server/rust/oak_runtime/src/metrics/mod.rs
+++ b/oak/server/rust/oak_runtime/src/metrics/mod.rs
@@ -38,6 +38,8 @@ pub struct GrpcServerMetrics {
     pub grpc_server_handled_latency_seconds: HistogramVec,
     /// Histogram of response sizes of RPCs handled by the server.
     pub grpc_response_size_bytes: HistogramVec,
+    /// Total number of stream messages sent by the server.
+    pub grpc_server_msg_sent_total: HistogramVec,
 }
 
 /// Struct that collects all metrics for monitoring the Oak Runtime.
@@ -73,9 +75,9 @@ fn counter_vec(metric_name: &str, labels: &[&str], help: &str) -> IntCounterVec 
     IntCounterVec::new(opts, labels).unwrap()
 }
 
-fn histogram_vec(metric_name: &str, label: &[&str], help: &str) -> HistogramVec {
+fn histogram_vec(metric_name: &str, labels: &[&str], help: &str) -> HistogramVec {
     let opts = HistogramOpts::new(metric_name, help);
-    HistogramVec::new(opts, label).unwrap()
+    HistogramVec::new(opts, labels).unwrap()
 }
 
 fn int_gauge(metric_name: &str, help: &str) -> IntGauge {
@@ -105,6 +107,11 @@ impl GrpcServerMetrics {
                 "grpc_response_size_bytes",
                 &["method_name"],
                 "Histogram of response sizes of RPCs handled by the server.",
+            )),
+            grpc_server_msg_sent_total: builder.register(histogram_vec(
+                "grpc_server_msg_sent_total",
+                &["method_name"],
+                "Total number of RPC response messages sent by the server.",
             )),
         }
     }

--- a/oak/server/rust/oak_runtime/src/node/grpc/server/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/server/mod.rs
@@ -101,7 +101,7 @@ impl GrpcServerNode {
         })
     }
 
-    /// Reads the [`oak_abi::Handle`] for the write half of an invcation from a startup channel.
+    /// Reads the [`oak_abi::Handle`] for the write half of an invocation from a startup channel.
     /// Returns an error if the startup channel couldn't be read, or if the initial message
     /// is invalid (doesn't contain exactly one write handle).
     fn get_invocation_channel(
@@ -617,6 +617,11 @@ impl Iterator for GrpcResponseIterator {
                             .grpc_response_size_bytes
                             .with_label_values(&[&self.method_name])
                             .observe(grpc_rsp.rsp_msg.len() as f64);
+                        self.metrics_data
+                            .grpc_server_metrics
+                            .grpc_server_msg_sent_total
+                            .with_label_values(&[&self.method_name])
+                            .observe(1.0);
                         if grpc_rsp.last {
                             // The Node has definitively marked this as the last response for this
                             // invocation; keep track of this and don't bother attempting to read


### PR DESCRIPTION
Adds a new metric `grpc_server_msg_sent_total` to measure the total number of RPC response messages sent by the server..

Ref #736 