### PR TITLE
Always run all clients in run_examples

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -81,7 +81,7 @@ steps:
     waitFor: ['run_tests_tsan']
     timeout: 60m
     entrypoint: 'bash'
-    args: ['./scripts/run_examples', '-s', 'base', '-c', 'cargo bazel npm']
+    args: ['./scripts/run_examples', '-s', 'base']
 
   - name: 'gcr.io/oak-ci/oak:latest'
     id: run_examples_cpp

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -115,29 +115,16 @@ do
   case "${client_variant}" in
     cargo)
       rust_client_manifest="${SCRIPTS_DIR}/../examples/${EXAMPLE}/client/rust/Cargo.toml"
-      if [[ -f "${rust_client_manifest}" ]]; then
           cargo run --release --manifest-path="${rust_client_manifest}" -- \
             --root-tls-certificate="${SCRIPTS_DIR}/../examples/certs/local/ca.pem" \
             "${CLIENT_ARGS[@]-}"
-      else
-        echo "The ${EXAMPLE} example does not contain a ${client_variant} client. Skipping this client."
-      fi
       ;;
     bazel)
-      build_file="${SCRIPTS_DIR}/../examples/${EXAMPLE}/client/BUILD"
-      if [[ -f "${build_file}" ]]; then
           "${SCRIPTS_DIR}/../bazel-client-bin/examples/${EXAMPLE}/client/client" "${TLS_ARGS[@]}" "${ADDITIONAL_ARGS[@]-}" "${CLIENT_ARGS[@]-}"
-      else
-        echo "The ${EXAMPLE} example does not contain a ${client_variant} client. Skipping this client."
-      fi
       ;;
     npm)
       npm_client="${SCRIPTS_DIR}/../examples/${EXAMPLE}/client/nodejs"
-      if [[ -d "${npm_client}" ]]; then
           npm start --prefix "${npm_client}"
-      else
-        echo "The ${EXAMPLE} example does not contain a ${client_variant} client. Skipping this client."
-      fi
       ;;
     *)
       echo "Invalid example client variant: ${client_variant}"

--- a/scripts/run_examples
+++ b/scripts/run_examples
@@ -6,7 +6,6 @@ source "${SCRIPTS_DIR}/common"
 
 server="base"
 application_language="rust"
-client_variants="bazel"
 while getopts "s:a:c:h" opt; do
   case "${opt}" in
     h)
@@ -17,17 +16,10 @@ while getopts "s:a:c:h" opt; do
   -a    Example application variant:
           - rust (default)
           - cpp
-  -c    Example client variants. Multiple clients can be specified by space
-        separating them. Eg -c \"cargo bazel npm\".
-        - cargo
-        - bazel (used by default)
-        - npm
   -h    Print Help (this message) and exit"
       exit 0;;
     a)
       application_language="${OPTARG}";;
-    c)
-      client_variants="${OPTARG}";;
     s)
       case "${OPTARG}" in
         base|logless)
@@ -46,12 +38,14 @@ done
 examples="$(find examples -mindepth 2 -maxdepth 4 -type d -regex '.*/module.*/'"${application_language}"'$' | cut -d'/' -f2 | uniq)"
 for example in ${examples}; do
   if [[ "${example}" == 'aggregator' ]]; then
-      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_variants}" -e aggregator -- --bucket=test --data=1:10,2:20,3:30
+      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -e aggregator -- --bucket=test --data=1:10,2:20,3:30
   elif [[ "${example}" == 'chat' ]]; then
-      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_variants}" -e chat -- --test
+      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -e chat -- --test
   elif [[ "${example}" == 'trusted_information_retrieval' ]]; then
-      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_variants}" -e trusted_information_retrieval -- --latitude 0.0 --longitude 0.0
+      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "bazel cargo" -e trusted_information_retrieval -- --latitude 0.0 --longitude 0.0
+  elif [[ "${example}" == 'hello_world' ]]; then
+      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "bazel npm" -e "${example}"
   else
-      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -c "${client_variants}" -e "${example}"
+      "${SCRIPTS_DIR}/run_example" -s "${server}" -a "${application_language}" -e "${example}"
   fi
 done


### PR DESCRIPTION
Replaces the current way of deducting available clients from the folder structure (#1148) with instead explicitly specifying them in the conditionals of the `run_examples` script. 

This is nice, because it allows us to explicitly fail if a client is not avaible.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
