### PR TITLE
Docs: Clarify that Channels and Nodes each only have one Label

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -135,7 +135,7 @@ its ephemeral Channel handles.
 
 ### Overview
 
-- Nodes and Channels have **Labels**, fixed at creation time
+- Nodes and Channels each have a **Label**, fixed at creation time
 - The Runtime keeps track of Labels, and enforces flow of data between Nodes and
   Channels based on them
 - Each Label has two **components**: **confidentiality** and **integrity**


### PR DESCRIPTION
Super minor, but I think it makes it a bit clearer that a given entity is only ever described by a single label. 

My understanding is that while a label consists of a collection of multiple tags, Channels and Nodes each only ever have one Label. 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
