### PR TITLE
Add workaround for aarch64 Rust missing symbols

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -15,3 +15,8 @@ rustflags = ["-C", "link-args=-Xlinker --build-id=none"]
 #
 # See https://linux.die.net/man/1/ld (--build-id flag).
 rustflags = ["-C", "link-args=-Xlinker --build-id=none"]
+
+# Workaround for 'unable to find __addtf3, __multf3 and __subtf3'
+# Related issue: https://github.com/rust-lang/compiler-builtins/issues/201
+[target.aarch64-unknown-linux-musl]
+rustflags = [ "-C", "target-feature=+crt-static", "-C", "link-arg=-lgcc"]


### PR DESCRIPTION
When building for aarch64, cross or native,
linking with musl will fail due to missing symbols.

This change only affects Rust code targetting:
    - aarch64-unknown-linux-musl

Workaround for:
https://github.com/rust-lang/compiler-builtins/issues/201

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
