### PR TITLE
Use the default target for backend components

### DIFF
--- a/scripts/build_example
+++ b/scripts/build_example
@@ -67,10 +67,10 @@ case "${application_language}" in
       cargo build --release --target=wasm32-unknown-unknown --manifest-path="examples/translator/module/rust/Cargo.toml"
     elif [[ "${EXAMPLE}" == "aggregator" ]]; then
       # `aggregator` example has an additional Backend binary.
-      cargo build --release --target=x86_64-unknown-linux-gnu --manifest-path="examples/aggregator/backend/Cargo.toml"
+      cargo build --release --target="${RUST_HOST_TARGET}" --manifest-path="examples/aggregator/backend/Cargo.toml"
     elif [[ "${EXAMPLE}" == "trusted_information_retrieval" ]]; then
       # `trusted_information_retrieval` example has an additional Backend binary.
-      cargo build --release --target=x86_64-unknown-linux-gnu --manifest-path="examples/trusted_information_retrieval/backend/Cargo.toml"
+      cargo build --release --target="${RUST_HOST_TARGET}" --manifest-path="examples/trusted_information_retrieval/backend/Cargo.toml"
     fi
     bazel --output_base="${CACHE_DIR}/client" build "${bazel_build_flags[@]}" "//examples/${EXAMPLE}/config:config";;
   cpp)

--- a/scripts/common
+++ b/scripts/common
@@ -86,6 +86,12 @@ else
   )
 fi
 
+if [[ "${OSTYPE}" == "darwin"*  ]]; then
+  readonly RUST_HOST_TARGET="${RUST_HOST_TARGET:-x86_64-apple-darwin}"
+else
+  readonly RUST_HOST_TARGET="${RUST_HOST_TARGET:-x86_64-unknown-linux-gnu}"
+fi
+
 # kill_pid tries to kill the given pid(s), first softly then more aggressively.
 kill_pid() {
   local pids=( "$@" )

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -80,8 +80,8 @@ if [[ "${server}" != "none" ]]; then
   # Run Backend for specific examples.
   if [[ "${EXAMPLE}" == 'aggregator' ]] || [[ "${EXAMPLE}" == 'trusted_information_retrieval' ]]; then
     # Building the Backend first, so it will not be built in the background.
-    cargo build --release --target=x86_64-unknown-linux-gnu --manifest-path="examples/${EXAMPLE}/backend/Cargo.toml"
-    cargo run --release --target=x86_64-unknown-linux-gnu --manifest-path="examples/${EXAMPLE}/backend/Cargo.toml" -- \
+    cargo build --release --target="${RUST_HOST_TARGET}" --manifest-path="examples/${EXAMPLE}/backend/Cargo.toml"
+    cargo run --release --target="${RUST_HOST_TARGET}" --manifest-path="examples/${EXAMPLE}/backend/Cargo.toml" -- \
       --grpc-tls-private-key="${SCRIPTS_DIR}/../examples/certs/local/local.key" \
       --grpc-tls-certificate="${SCRIPTS_DIR}/../examples/certs/local/local.pem" &
     readonly BACKEND_PID=$!


### PR DESCRIPTION
Possible fix for the [problem discussed on Slack](https://project-oak.slack.com/archives/CHE9E13C3/p1593003638448300). 
