### PR TITLE
Add simple integration with cargo-crev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,3 +197,4 @@ RUN rustup component add \
 
 RUN cargo install cargo-deadlinks
 RUN cargo install cargo-deny
+RUN cargo install cargo-crev

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,6 +41,13 @@ steps:
     args: ['info']
 
   - name: 'gcr.io/oak-ci/oak:latest'
+    id: cargo_crev
+    entrypoint: 'bash'
+    waitFor: ['git_init']
+    timeout: 5m
+    args: ['./scripts/run_cargo_crev']
+
+  - name: 'gcr.io/oak-ci/oak:latest'
     id: build_server_no_debug
     waitFor: ['bazel_init']
     timeout: 60m

--- a/scripts/run_cargo_crev
+++ b/scripts/run_cargo_crev
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+readonly SCRIPTS_DIR="$(dirname "$0")"
+# shellcheck source=scripts/common
+source "$SCRIPTS_DIR/common"
+
+# Disable logging, or the output will be extremely verbose.
+unset RUST_LOG
+
+# Seed the crev repo with a few initial URLs.
+# These are not considered trusted by default.
+readonly CREV_REPOSITORIES=(
+  https://github.com/dpc/crev-proofs
+  https://github.com/oherrala/crev-proofs
+)
+
+for repository in "${CREV_REPOSITORIES[@]}"; do
+  cargo crev repo fetch url "${repository}"
+done
+
+# Recursively fetch any URL that was referenced by the previous ones.
+cargo crev repo fetch all
+
+(
+  cd ./oak/server
+  # Ignore status code from the verify command.
+  cargo crev crate verify --show-all || true
+)


### PR DESCRIPTION
This just adds a step to the cloud build process that outputs the
results of the cargo crev verification process. Given it does not have a
web of trust configured, none of the crates appear as reviewed by trusted reviewers yet.

Ref #1195

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
