### PR TITLE
Vendor and patch Prost

### DIFF
--- a/scripts/vendor_prost.sh
+++ b/scripts/vendor_prost.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Vendors https://github.com/danburkert/prost and applies a small patch to add 
+# support for the message_type field option.
+# Add -c to create a pristine commit without the patch applied.
+
+readonly SCRIPTS_DIR="$(dirname "$0")"
+# shellcheck source=scripts/common
+source "${SCRIPTS_DIR}/common"
+
+patch=true
+while getopts "hc" opt; do
+  case "${opt}" in
+    h)
+      echo -e "Usage: ${0} [-h] [-c] 
+
+Vendors https://github.com/danburkert/prost and applies a small patch to add 
+support for the message_type field option.
+
+Options:
+  -c    Do not apply the patch, create a clean checkout instead.
+  -h    Print Help (this message) and exit"
+      exit 0;;
+    c)
+      patch=false;;
+    *)
+      echo "Invalid argument: ${opt}"
+      exit 1;;
+  esac
+done
+
+# Master branch as of 2020-06-11
+readonly PROST_ZIP_URL="https://github.com/danburkert/prost/archive/80256277997975948d257faf3f35c2890bf12787.zip"
+readonly PROST_ZIP_SHA256="02c086f2d1b7aad110745ac701f001618cd8343f882fc9ce034aa007c4c53773"
+readonly PROST_ZIP_PREFIX="prost-80256277997975948d257faf3f35c2890bf12787"
+readonly PATCH_FILE="prost-0001-Patch-to-generate-typesafe-Sender-and-Receiver.patch"
+
+readonly THIRD_PARTY_DIR="${SCRIPTS_DIR}/../third_party"
+readonly PROST_DIR="${SCRIPTS_DIR}/../third_party/prost"
+readonly PROST_ZIP_FILE="${THIRD_PARTY_DIR}/${PROST_ZIP_PREFIX}.zip"
+
+# Download prost
+curl -L "$PROST_ZIP_URL" -o "${PROST_ZIP_FILE}"
+
+# Make sure the SHA256 checks out
+echo "${PROST_ZIP_SHA256} ${PROST_ZIP_FILE}" | sha256sum -c -
+
+# Clean up from previous runs
+rm -rf "${THIRD_PARTY_DIR:?}/${PROST_ZIP_PREFIX}" "${PROST_DIR}"
+
+# Unzip and move into third_party/prost.
+unzip -q "${PROST_ZIP_FILE}" -d "${THIRD_PARTY_DIR}"
+mv "${THIRD_PARTY_DIR}/${PROST_ZIP_PREFIX}" "${PROST_DIR}"
+
+# We do not need the bundled protobuf because we already require users to have it installed.
+rm -r "${PROST_DIR}/prost-build/third-party"
+
+if [ "${patch}" = true ]; then
+  # Apply the patch
+  patch -p1 -d "${PROST_DIR}" < "${THIRD_PARTY_DIR}/${PATCH_FILE}"
+fi
+
+# Remove the downloaded zip file
+rm "${PROST_ZIP_FILE}"

--- a/third_party/prost-0001-Patch-to-generate-typesafe-Sender-and-Receiver.patch
+++ b/third_party/prost-0001-Patch-to-generate-typesafe-Sender-and-Receiver.patch
@@ -1,0 +1,49 @@
+Date: Fri, 27 Mar 2020 14:34:20 +0000
+Patch to generate typesafe Sender and Receiver.
+
+---
+ prost-build/src/code_generator.rs | 13 +++++++++++++
+ prost-types/src/protobuf.rs       |  3 +++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/prost-build/src/code_generator.rs b/prost-build/src/code_generator.rs
+index 7323eb6..f500791 100644
+--- a/prost-build/src/code_generator.rs
++++ b/prost-build/src/code_generator.rs
+@@ -715,7 +715,20 @@ impl<'a> CodeGenerator<'a> {
+         self.buf.push_str("}\n");
+     }
+ 
++    fn resolve_message_type(&self, field: &FieldDescriptorProto) -> Option<String> {
++        let message_type = self.resolve_ident(&field.options.as_ref()?.message_type.as_ref()?);
++        let direction = match field.type_name() {
++            ".oak.handle.Sender" => Some("Sender"),
++            ".oak.handle.Receiver" => Some("Receiver"),
++            _ => None,
++        }?;
++        Some(format!("::oak::io::{}<{}>", direction, message_type))
++    }
++
+     fn resolve_type(&self, field: &FieldDescriptorProto) -> String {
++        if let Some(ty) = self.resolve_message_type(field) {
++            return ty;
++        }
+         match field.r#type() {
+             Type::Float => String::from("f32"),
+             Type::Double => String::from("f64"),
+diff --git a/prost-types/src/protobuf.rs b/prost-types/src/protobuf.rs
+index 6649f76..0e2edbf 100644
+--- a/prost-types/src/protobuf.rs
++++ b/prost-types/src/protobuf.rs
+@@ -567,6 +567,9 @@ pub struct FieldOptions {
+     /// The parser stores options it doesn't recognize here. See above.
+     #[prost(message, repeated, tag="999")]
+     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
++    /// Oak `message_type` annotation.
++    #[prost(string, optional, tag="79658")]
++    pub message_type: ::core::option::Option<::prost::alloc::string::String>,
+ }
+ /// Nested message and enum types in `FieldOptions`.
+ pub mod field_options {
+-- 
+2.20.1

--- a/third_party/prost/.github/workflows/continuous-integration-workflow.yaml
+++ b/third_party/prost/.github/workflows/continuous-integration-workflow.yaml
@@ -1,0 +1,111 @@
+name: continuous integration
+on: pull_request
+
+jobs:
+
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            profile: minimal
+            components: rustfmt
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            profile: minimal
+            components: clippy
+      - name: install ninja
+        uses: seanmiddleditch/gha-setup-ninja@v1
+      - name: clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --workspace --all-features --all-targets
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - 1.39.0
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ matrix.toolchain }}
+            default: true
+            profile: minimal
+      - name: install ninja
+        uses: seanmiddleditch/gha-setup-ninja@v1
+      - name: test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --all-targets
+      - name: test no-default-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+
+  no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            default: true
+            profile: minimal
+      - name: install cargo-no-std-check
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-no-std-check
+      - name: prost cargo-no-std-check
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-std-check
+          args: --manifest-path Cargo.toml --no-default-features
+      - name: prost-types cargo-no-std-check
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-std-check
+          args: --manifest-path prost-types/Cargo.toml --no-default-features
+      # prost-build depends on prost with --no-default-features, but when
+      # prost-build is built through the workspace, prost typically has default
+      # features enabled due to vagaries in Cargo workspace feature resolution.
+      # This additional check ensures that prost-build does not rely on any of
+      # prost's default features to compile.
+      - name: prost-build check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path prost-build/Cargo.toml

--- a/third_party/prost/.gitignore
+++ b/third_party/prost/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/third_party/prost/Cargo.toml
+++ b/third_party/prost/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "prost"
+version = "0.6.1"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+license = "Apache-2.0"
+repository = "https://github.com/danburkert/prost"
+documentation = "https://docs.rs/prost"
+readme = "README.md"
+description = "A Protocol Buffers implementation for the Rust Language."
+keywords = ["protobuf", "serialization"]
+categories = ["encoding"]
+edition = "2018"
+
+[badges]
+travis-ci = { repository = "danburkert/prost" }
+appveyor = { repository = "danburkert/prost" }
+
+[workspace]
+members = [
+  "conformance",
+  "prost-build",
+  "prost-derive",
+  "prost-types",
+  "protobuf",
+  "tests",
+  "tests-2015",
+  "tests-no-std",
+]
+exclude = [
+  # The fuzz crate can't be compiled or tested without the 'cargo fuzz' command,
+  # so exclude it from normal builds.
+  "fuzz",
+]
+
+[lib]
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+[features]
+default = ["prost-derive", "std"]
+no-recursion-limit = []
+std = []
+
+[dependencies]
+bytes = { version = "0.5", default-features = false }
+prost-derive = { version = "0.6.1", path = "prost-derive", optional = true }
+
+[dev-dependencies]
+criterion = "0.3"
+env_logger = { version = "0.7", default-features = false }
+log = "0.4"
+quickcheck = "0.9"
+rand = "0.7"
+
+[profile.bench]
+debug = true
+
+[[bench]]
+name = "varint"
+harness = false

--- a/third_party/prost/LICENSE
+++ b/third_party/prost/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/third_party/prost/README.md
+++ b/third_party/prost/README.md
@@ -1,0 +1,368 @@
+[![Build Status](https://travis-ci.org/danburkert/prost.svg?branch=master)](https://travis-ci.org/danburkert/prost)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/24rpba3x2vqe8lje/branch/master?svg=true)](https://ci.appveyor.com/project/danburkert/prost/branch/master)
+[![Documentation](https://docs.rs/prost/badge.svg)](https://docs.rs/prost/)
+[![Crate](https://img.shields.io/crates/v/prost.svg)](https://crates.io/crates/prost)
+[![Dependency Status](https://deps.rs/repo/github/danburkert/prost/status.svg)](https://deps.rs/repo/github/danburkert/prost)
+
+# *PROST!*
+
+`prost` is a [Protocol Buffers](https://developers.google.com/protocol-buffers/)
+implementation for the [Rust Language](https://www.rust-lang.org/). `prost`
+generates simple, idiomatic Rust code from `proto2` and `proto3` files.
+
+Compared to other Protocol Buffers implementations, `prost`
+
+* Generates simple, idiomatic, and readable Rust types by taking advantage of
+  Rust `derive` attributes.
+* Retains comments from `.proto` files in generated Rust code.
+* Allows existing Rust types (not generated from a `.proto`) to be serialized
+  and deserialized by adding attributes.
+* Uses the [`bytes::{Buf, BufMut}`](https://github.com/carllerche/bytes)
+  abstractions for serialization instead of `std::io::{Read, Write}`.
+* Respects the Protobuf `package` specifier when organizing generated code
+  into Rust modules.
+* Preserves unknown enum values during deserialization.
+* Does not include support for runtime reflection or message descriptors.
+
+## Using `prost` in a Cargo Project
+
+First, add `prost` and its public dependencies to your `Cargo.toml`:
+
+```
+[dependencies]
+prost = "0.6"
+# Only necessary if using Protobuf well-known types:
+prost-types = "0.6"
+```
+
+The recommended way to add `.proto` compilation to a Cargo project is to use the
+`prost-build` library. See the [`prost-build` documentation](prost-build) for
+more details and examples.
+
+## Generated Code
+
+`prost` generates Rust code from source `.proto` files using the `proto2` or
+`proto3` syntax. `prost`'s goal is to make the generated code as simple as
+possible.
+
+### Packages
+
+All `.proto` files used with `prost` must contain a
+[`package` specifier][package]. `prost` will translate the Protobuf package into
+a Rust module. For example, given the `package` specifier:
+
+[package]: https://developers.google.com/protocol-buffers/docs/proto#packages
+
+```proto
+package foo.bar;
+```
+
+All Rust types generated from the file will be in the `foo::bar` module.
+
+### Messages
+
+Given a simple message declaration:
+
+```proto
+// Sample message.
+message Foo {
+}
+```
+
+`prost` will generate the following Rust struct:
+
+```rust
+/// Sample message.
+#[derive(Clone, Debug, PartialEq, Message)]
+pub struct Foo {
+}
+```
+
+### Fields
+
+Fields in Protobuf messages are translated into Rust as public struct fields of the
+corresponding type.
+
+#### Scalar Values
+
+Scalar value types are converted as follows:
+
+| Protobuf Type | Rust Type |
+| --- | --- |
+| `double` | `f64` |
+| `float` | `f32` |
+| `int32` | `i32` |
+| `int64` | `i64` |
+| `uint32` | `u32` |
+| `uint64` | `u64` |
+| `sint32` | `i32` |
+| `sint64` | `i64` |
+| `fixed32` | `u32` |
+| `fixed64` | `u64` |
+| `sfixed32` | `i32` |
+| `sfixed64` | `i64` |
+| `bool` | `bool` |
+| `string` | `String` |
+| `bytes` | `Vec<u8>` |
+
+#### Enumerations
+
+All `.proto` enumeration types convert to the Rust `i32` type. Additionally,
+each enumeration type gets a corresponding Rust `enum` type, with helper methods
+to convert `i32` values to the enum type. The `enum` type isn't used directly as
+a field, because the Protobuf spec mandates that enumerations values are 'open',
+and decoding unrecognized enumeration values must be possible.
+
+#### Field Modifiers
+
+Protobuf scalar value and enumeration message fields can have a modifier
+depending on the Protobuf version. Modifiers change the corresponding type of
+the Rust field:
+
+| `.proto` Version | Modifier | Rust Type |
+| --- | --- | --- |
+| `proto2` | `optional` | `Option<T>` |
+| `proto2` | `required` | `T` |
+| `proto3` | default | `T` |
+| `proto2`/`proto3` | repeated | `Vec<T>` |
+
+#### Map Fields
+
+Map fields are converted to a Rust `HashMap` with key and value type converted
+from the Protobuf key and value types.
+
+#### Message Fields
+
+Message fields are converted to the corresponding struct type. The table of
+field modifiers above applies to message fields, except that `proto3` message
+fields without a modifier (the default) will be wrapped in an `Option`.
+Typically message fields are unboxed. `prost` will automatically box a message
+field if the field type and the parent type are recursively nested in order to
+avoid an infinite sized struct.
+
+#### Oneof Fields
+
+Oneof fields convert to a Rust enum. Protobuf `oneof`s types are not named, so
+`prost` uses the name of the `oneof` field for the resulting Rust enum, and
+defines the enum in a module under the struct. For example, a `proto3` message
+such as:
+
+```proto
+message Foo {
+  oneof widget {
+    int32 quux = 1;
+    string bar = 2;
+  }
+}
+```
+
+generates the following Rust[1]:
+
+```rust
+pub struct Foo {
+    pub widget: Option<foo::Widget>,
+}
+pub mod foo {
+    pub enum Widget {
+        Quux(i32),
+        Bar(String),
+    }
+}
+```
+
+`oneof` fields are always wrapped in an `Option`.
+
+[1] Annotations have been elided for clarity. See below for a full example.
+
+### Services
+
+`prost-build` allows a custom code-generator to be used for processing `service`
+definitions. This can be used to output Rust traits according to an
+application's specific needs.
+
+### Generated Code Example
+
+Example `.proto` file:
+
+```proto
+syntax = "proto3";
+package tutorial;
+
+message Person {
+  string name = 1;
+  int32 id = 2;  // Unique ID number for this person.
+  string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    string number = 1;
+    PhoneType type = 2;
+  }
+
+  repeated PhoneNumber phones = 4;
+}
+
+// Our address book file is just one of these.
+message AddressBook {
+  repeated Person people = 1;
+}
+```
+
+and the generated Rust code (`tutorial.rs`):
+
+```rust
+#[derive(Clone, Debug, PartialEq, Message)]
+pub struct Person {
+    #[prost(string, tag="1")]
+    pub name: String,
+    /// Unique ID number for this person.
+    #[prost(int32, tag="2")]
+    pub id: i32,
+    #[prost(string, tag="3")]
+    pub email: String,
+    #[prost(message, repeated, tag="4")]
+    pub phones: Vec<person::PhoneNumber>,
+}
+pub mod person {
+    #[derive(Clone, Debug, PartialEq, Message)]
+    pub struct PhoneNumber {
+        #[prost(string, tag="1")]
+        pub number: String,
+        #[prost(enumeration="PhoneType", tag="2")]
+        pub type_: i32,
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+    pub enum PhoneType {
+        Mobile = 0,
+        Home = 1,
+        Work = 2,
+    }
+}
+/// Our address book file is just one of these.
+#[derive(Clone, Debug, PartialEq, Message)]
+pub struct AddressBook {
+    #[prost(message, repeated, tag="1")]
+    pub people: Vec<Person>,
+}
+```
+
+## Using `prost` in a `no_std` Crate
+
+`prost` is compatible with `no_std` crates. To enable `no_std` support, disable
+the `std` features in `prost` and `prost-types`:
+
+```
+[dependencies]
+prost = { version = "0.6", default-features = false, features = ["prost-derive"] }
+# Only necessary if using Protobuf well-known types:
+prost-types = { version = "0.6", default-features = false }
+```
+
+Additionally, configure `prost-buid` to output `BTreeMap`s instead of `HashMap`s
+for all Protobuf `map` fields in your `build.rs`:
+
+```rust
+let mut config = prost_build::Config::new();
+config.btree_map(&["."]);
+```
+
+When using edition 2015, it may be necessary to add an `extern crate core;`
+directive to the crate which includes `prost`-generated code.
+
+## Serializing Existing Types
+
+`prost` uses a custom derive macro to handle encoding and decoding types, which
+means that if your existing Rust type is compatible with Protobuf types, you can
+serialize and deserialize it by adding the appropriate derive and field
+annotations.
+
+Currently the best documentation on adding annotations is to look at the
+generated code examples above.
+
+### Tag Inference for Existing Types
+
+Prost automatically infers tags for the struct.
+
+Fields are tagged sequentially in the order they
+are specified, starting with `1`.
+
+You may skip tags which have been reserved, or where there are gaps between
+sequentially occurring tag values by specifying the tag number to skip to with
+the `tag` attribute on the first field after the gap. The following fields will
+be tagged sequentially starting from the next number.
+
+```rust
+#[derive(Clone, Debug, PartialEq, Message)]
+struct Person {
+  pub id: String, // tag=1
+
+  // NOTE: Old "name" field has been removed
+  // pub name: String, // tag=2 (Removed)
+
+  #[prost(tag="6")]
+  pub given_name: String, // tag=6
+  pub family_name: String, // tag=7
+  pub formatted_name: String, // tag=8
+
+  #[prost(tag="3")]
+  pub age: u32, // tag=3
+  pub height: u32, // tag=4
+  #[prost(enumeration="Gender")]
+  pub gender: i32, // tag=5
+
+  // NOTE: Skip to less commonly occurring fields
+  #[prost(tag="16")]
+  pub name_prefix: String, // tag=16  (eg. mr/mrs/ms)
+  pub name_suffix: String, // tag=17  (eg. jr/esq)
+  pub maiden_name: String, // tag=18
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+pub enum Gender {
+  Unknown = 0,
+  Female = 1,
+  Male = 2,
+}
+```
+
+## FAQ
+
+1. **Could `prost` be implemented as a serializer for [Serde](https://serde.rs/)?**
+
+  Probably not, however I would like to hear from a Serde expert on the matter.
+  There are two complications with trying to serialize Protobuf messages with
+  Serde:
+
+  - Protobuf fields require a numbered tag, and curently there appears to be no
+    mechanism suitable for this in `serde`.
+  - The mapping of Protobuf type to Rust type is not 1-to-1. As a result,
+    trait-based approaches to dispatching don't work very well. Example: six
+    different Protobuf field types correspond to a Rust `Vec<i32>`: `repeated
+    int32`, `repeated sint32`, `repeated sfixed32`, and their packed
+    counterparts.
+
+  But it is possible to place `serde` derive tags onto the generated types, so
+  the same structure can support both `prost` and `Serde`.
+
+2. **I get errors when trying to run `cargo test` on MacOS**
+
+  If the errors are about missing `autoreconf` or similar, you can probably fix
+  them by running
+
+  ```
+  brew install automake
+  brew install libtool
+  ```
+
+## License
+
+`prost` is distributed under the terms of the Apache License (Version 2.0).
+
+See [LICENSE](LICENSE) for details.
+
+Copyright 2017 Dan Burkert

--- a/third_party/prost/benches/varint.rs
+++ b/third_party/prost/benches/varint.rs
@@ -1,0 +1,94 @@
+use std::mem;
+
+use bytes::Buf;
+use criterion::{Benchmark, Criterion, Throughput};
+use prost::encoding::{decode_varint, encode_varint, encoded_len_varint};
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+
+fn benchmark_varint(criterion: &mut Criterion, name: &str, mut values: Vec<u64>) {
+    // Shuffle the values in a stable order.
+    values.shuffle(&mut StdRng::seed_from_u64(0));
+
+    let encoded_len = values
+        .iter()
+        .cloned()
+        .map(encoded_len_varint)
+        .sum::<usize>() as u64;
+    let decoded_len = (values.len() * mem::size_of::<u64>()) as u64;
+
+    let encode_values = values.clone();
+    let encode = Benchmark::new("encode", move |b| {
+        let mut buf = Vec::<u8>::with_capacity(encode_values.len() * 10);
+        b.iter(|| {
+            buf.clear();
+            for &value in &encode_values {
+                encode_varint(value, &mut buf);
+            }
+            criterion::black_box(&buf);
+        })
+    })
+    .throughput(Throughput::Bytes(encoded_len));
+
+    let mut decode_values = values.clone();
+    let decode = Benchmark::new("decode", move |b| {
+        let mut buf = Vec::with_capacity(decode_values.len() * 10);
+        for &value in &decode_values {
+            encode_varint(value, &mut buf);
+        }
+
+        b.iter(|| {
+            decode_values.clear();
+            let mut buf = &mut buf.as_slice();
+            while buf.has_remaining() {
+                let value = decode_varint(&mut buf).unwrap();
+                decode_values.push(value);
+            }
+            criterion::black_box(&decode_values);
+        })
+    })
+    .throughput(Throughput::Bytes(decoded_len));
+
+    let encoded_len = Benchmark::new("encoded_len", move |b| {
+        b.iter(|| {
+            let mut sum = 0;
+            for &value in &values {
+                sum += encoded_len_varint(value);
+            }
+            criterion::black_box(sum);
+        })
+    })
+    .throughput(Throughput::Bytes(decoded_len));
+
+    let name = format!("varint/{}", name);
+    criterion
+        .bench(&name, encode)
+        .bench(&name, decode)
+        .bench(&name, encoded_len);
+}
+
+fn main() {
+    let mut criterion = Criterion::default().configure_from_args();
+
+    // Benchmark encoding and decoding 100 small (1 byte) varints.
+    benchmark_varint(&mut criterion, "small", (0..100).collect());
+
+    // Benchmark encoding and decoding 100 medium (5 byte) varints.
+    benchmark_varint(&mut criterion, "medium", (1 << 28..).take(100).collect());
+
+    // Benchmark encoding and decoding 100 large (10 byte) varints.
+    benchmark_varint(&mut criterion, "large", (1 << 63..).take(100).collect());
+
+    // Benchmark encoding and decoding 100 varints of mixed width (average 5.5 bytes).
+    benchmark_varint(
+        &mut criterion,
+        "mixed",
+        (0..10)
+            .flat_map(move |width| {
+                let exponent = width * 7;
+                (0..10).map(move |offset| offset + (1 << exponent))
+            })
+            .collect(),
+    );
+
+    criterion.final_summary();
+}

--- a/third_party/prost/clippy.toml
+++ b/third_party/prost/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold=8

--- a/third_party/prost/conformance/Cargo.toml
+++ b/third_party/prost/conformance/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "conformance"
+version = "0.0.0"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+publish = false
+edition = "2018"
+
+[dependencies]
+bytes = "0.5"
+env_logger = { version = "0.7", default-features = false }
+log = "0.4"
+prost = { path = ".." }
+protobuf = { path = "../protobuf" }
+tests = { path = "../tests" }

--- a/third_party/prost/conformance/failing_tests.txt
+++ b/third_party/prost/conformance/failing_tests.txt
@@ -1,0 +1,3 @@
+# TODO(danburkert/prost#2): prost doesn't preserve unknown fields.
+Required.Proto2.ProtobufInput.UnknownVarint.ProtobufOutput
+Required.Proto3.ProtobufInput.UnknownVarint.ProtobufOutput

--- a/third_party/prost/conformance/src/main.rs
+++ b/third_party/prost/conformance/src/main.rs
@@ -1,0 +1,115 @@
+use std::io::{self, Read, Write};
+
+use bytes::{Buf, BufMut};
+use prost::Message;
+
+use protobuf::conformance::{
+    conformance_request, conformance_response, ConformanceRequest, ConformanceResponse, WireFormat,
+};
+use protobuf::test_messages::proto2::TestAllTypesProto2;
+use protobuf::test_messages::proto3::TestAllTypesProto3;
+use tests::{roundtrip, RoundtripResult};
+
+fn main() -> io::Result<()> {
+    env_logger::init();
+    let mut bytes = Vec::new();
+
+    loop {
+        bytes.resize(4, 0);
+
+        if io::stdin().read_exact(&mut *bytes).is_err() {
+            // No more test cases.
+            return Ok(());
+        }
+
+        let len = bytes.as_slice().get_u32_le() as usize;
+
+        bytes.resize(len, 0);
+        io::stdin().read_exact(&mut *bytes)?;
+
+        let result = match ConformanceRequest::decode(&*bytes) {
+            Ok(request) => handle_request(request),
+            Err(error) => conformance_response::Result::ParseError(format!("{:?}", error)),
+        };
+
+        let mut response = ConformanceResponse::default();
+        response.result = Some(result);
+
+        let len = response.encoded_len();
+        bytes.clear();
+        bytes.put_u32_le(len as u32);
+        response.encode(&mut bytes)?;
+        assert_eq!(len + 4, bytes.len());
+
+        let mut stdout = io::stdout();
+        stdout.lock().write_all(&bytes)?;
+        stdout.flush()?;
+    }
+}
+
+fn handle_request(request: ConformanceRequest) -> conformance_response::Result {
+    match request.requested_output_format() {
+        WireFormat::Unspecified => {
+            return conformance_response::Result::ParseError(
+                "output format unspecified".to_string(),
+            );
+        }
+        WireFormat::Json => {
+            return conformance_response::Result::Skipped(
+                "JSON output is not supported".to_string(),
+            );
+        }
+        WireFormat::Jspb => {
+            return conformance_response::Result::Skipped(
+                "JSPB output is not supported".to_string(),
+            );
+        }
+        WireFormat::TextFormat => {
+            return conformance_response::Result::Skipped(
+                "TEXT_FORMAT output is not supported".to_string(),
+            );
+        }
+        WireFormat::Protobuf => (),
+    };
+
+    let buf = match request.payload {
+        None => return conformance_response::Result::ParseError("no payload".to_string()),
+        Some(conformance_request::Payload::JsonPayload(_)) => {
+            return conformance_response::Result::Skipped(
+                "JSON input is not supported".to_string(),
+            );
+        }
+        Some(conformance_request::Payload::JspbPayload(_)) => {
+            return conformance_response::Result::Skipped(
+                "JSON input is not supported".to_string(),
+            );
+        }
+        Some(conformance_request::Payload::TextPayload(_)) => {
+            return conformance_response::Result::Skipped(
+                "JSON input is not supported".to_string(),
+            );
+        }
+        Some(conformance_request::Payload::ProtobufPayload(buf)) => buf,
+    };
+
+    let roundtrip = match &*request.message_type {
+        "protobuf_test_messages.proto2.TestAllTypesProto2" => roundtrip::<TestAllTypesProto2>(&buf),
+        "protobuf_test_messages.proto3.TestAllTypesProto3" => roundtrip::<TestAllTypesProto3>(&buf),
+        _ => {
+            return conformance_response::Result::ParseError(format!(
+                "unknown message type: {}",
+                request.message_type
+            ));
+        }
+    };
+
+    match roundtrip {
+        RoundtripResult::Ok(buf) => conformance_response::Result::ProtobufPayload(buf),
+        RoundtripResult::DecodeError(error) => {
+            conformance_response::Result::ParseError(error.to_string())
+        }
+        RoundtripResult::Error(error) => {
+            conformance_response::Result::RuntimeError(error.to_string())
+        }
+    }
+}

--- a/third_party/prost/conformance/tests/conformance.rs
+++ b/third_party/prost/conformance/tests/conformance.rs
@@ -1,0 +1,33 @@
+#![cfg(not(target_os = "windows"))]
+
+use std::env;
+use std::process::Command;
+
+use protobuf::conformance;
+
+/// Runs the protobuf conformance test. This must be done in an integration test
+/// so that Cargo will build the proto-conformance binary.
+#[test]
+fn test_conformance() {
+    // Get the path to the proto-conformance binary. Adapted from
+    // https://github.com/rust-lang/cargo/blob/19fdb308cdbb25faf4f1e25a71351d8d603fa447/tests/cargotest/support/mod.rs#L306.
+    let proto_conformance = env::current_exe()
+        .map(|mut path| {
+            path.pop();
+            if path.ends_with("deps") {
+                path.pop();
+            }
+            path.join("conformance")
+        })
+        .unwrap();
+
+    let status = Command::new(conformance::test_runner())
+        .arg("--enforce_recommended")
+        .arg("--failure_list")
+        .arg("failing_tests.txt")
+        .arg(proto_conformance)
+        .status()
+        .expect("failed to execute conformance-test-runner");
+
+    assert!(status.success(), "proto conformance test failed");
+}

--- a/third_party/prost/fuzz/.gitignore
+++ b/third_party/prost/fuzz/.gitignore
@@ -1,0 +1,2 @@
+artifacts
+corpus

--- a/third_party/prost/fuzz/Cargo.toml
+++ b/third_party/prost/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "fuzz"
+version = "0.0.0"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+protobuf = { path = "../protobuf" }
+tests = { path = "../tests" }
+
+[[bin]]
+name = "proto3"
+path = "fuzzers/proto3.rs"
+
+[[bin]]
+name = "proto2"
+path = "fuzzers/proto2.rs"

--- a/third_party/prost/fuzz/fuzzers/proto2.rs
+++ b/third_party/prost/fuzz/fuzzers/proto2.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use protobuf::test_messages::proto2::TestAllTypesProto2;
+use tests::roundtrip;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = roundtrip::<TestAllTypesProto2>(data).unwrap_error();
+});
+

--- a/third_party/prost/fuzz/fuzzers/proto3.rs
+++ b/third_party/prost/fuzz/fuzzers/proto3.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use protobuf::test_messages::proto3::TestAllTypesProto3;
+use tests::roundtrip;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = roundtrip::<TestAllTypesProto3>(data).unwrap_error();
+});

--- a/third_party/prost/prepare-release.sh
+++ b/third_party/prost/prepare-release.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Script which automates modifying source version fields, and creating a release
+# commit and tag. The commit and tag are not automatically pushed, nor are the
+# crates published (see publish-release.sh).
+
+set -ex
+
+if [ "$#" -ne 1 ]
+then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+VERSION="$1"
+MINOR="$( echo ${VERSION} | cut -d\. -f1-2 )"
+
+VERSION_MATCHER="([a-z0-9\\.-]+)"
+PROST_CRATE_MATCHER="(prost|prost-[a-z]+)"
+
+# Update the README.md.
+sed -i -E "s/${PROST_CRATE_MATCHER} = \"${VERSION_MATCHER}\"/\1 = \"${MINOR}\"/" "$DIR/README.md"
+
+# Update html_root_url attributes.
+sed -i -E "s~html_root_url = \"https://docs\.rs/${PROST_CRATE_MATCHER}/$VERSION_MATCHER\"~html_root_url = \"https://docs.rs/\1/${VERSION}\"~" \
+  "$DIR/src/lib.rs" \
+  "$DIR/prost-derive/src/lib.rs" \
+  "$DIR/prost-build/src/lib.rs" \
+  "$DIR/prost-types/src/lib.rs"
+
+# Update Cargo.toml version fields.
+sed -i -E "s/^version = \"${VERSION_MATCHER}\"$/version = \"${VERSION}\"/" \
+  "$DIR/Cargo.toml" \
+  "$DIR/prost-derive/Cargo.toml" \
+  "$DIR/prost-build/Cargo.toml" \
+  "$DIR/prost-types/Cargo.toml"
+
+# Update Cargo.toml dependency versions.
+sed -i -E "s/^${PROST_CRATE_MATCHER} = \{ version = \"${VERSION_MATCHER}\"/\1 = { version = \"${VERSION}\"/" \
+  "$DIR/Cargo.toml" \
+  "$DIR/prost-derive/Cargo.toml" \
+  "$DIR/prost-build/Cargo.toml" \
+  "$DIR/prost-types/Cargo.toml"
+
+git commit -a -m "release ${VERSION}"
+git tag -a "v${VERSION}" -m "release ${VERSION}"

--- a/third_party/prost/prost-build/Cargo.toml
+++ b/third_party/prost/prost-build/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "prost-build"
+version = "0.6.1"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+license = "Apache-2.0"
+repository = "https://github.com/danburkert/prost"
+documentation = "https://docs.rs/prost-build"
+readme = "README.md"
+description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
+
+[dependencies]
+bytes = { version = "0.5", default-features = false }
+heck = "0.3"
+itertools = "0.9"
+log = "0.4"
+multimap = { version = "0.8", default-features = false }
+petgraph = { version = "0.5", default-features = false }
+prost = { version = "0.6.1", path = "..", default-features = false }
+prost-types = { version = "0.6.1", path = "../prost-types", default-features = false }
+tempfile = "3"
+
+[build-dependencies]
+which = { version = "3", default-features = false }
+
+[dev-dependencies]
+env_logger = { version = "0.7", default-features = false }

--- a/third_party/prost/prost-build/README.md
+++ b/third_party/prost/prost-build/README.md
@@ -1,0 +1,16 @@
+[![Documentation](https://docs.rs/prost-build/badge.svg)](https://docs.rs/prost-build/)
+[![Crate](https://img.shields.io/crates/v/prost-build.svg)](https://crates.io/crates/prost-build)
+
+# `prost-build`
+
+`prost-build` makes it easy to generate Rust code from `.proto` files as part of
+a Cargo build. See the crate [documentation](https://docs.rs/prost-build/) for examples
+of how to integrate `prost-build` into a Cargo project.
+
+## License
+
+`prost-build` is distributed under the terms of the Apache License (Version 2.0).
+
+See [LICENSE](../LICENSE) for details.
+
+Copyright 2017 Dan Burkert

--- a/third_party/prost/prost-build/build.rs
+++ b/third_party/prost/prost-build/build.rs
@@ -1,0 +1,104 @@
+//! Finds the appropriate `protoc` binary and Protobuf include directory for this host, and outputs
+//! build directives so that the main `prost-build` crate can use them.
+//!
+//! The following locations are checked for `protoc` in decreasing priority:
+//!
+//!     1. The `PROTOC` environment variable.
+//!     2. The bundled `protoc`.
+//!     3. The `protoc` on the `PATH`.
+//!
+//! If no `protoc` binary is available in these locations, the build fails.
+//!
+//! The following locations are checked for the Protobuf include directory in decreasing priority:
+//!
+//!     1. The `PROTOC_INCLUDE` environment variable.
+//!     2. The bundled Protobuf include directory.
+
+use std::env;
+use std::path::PathBuf;
+
+/// Returns the path to the location of the bundled Protobuf artifacts.
+fn bundle_path() -> PathBuf {
+    env::current_dir()
+        .unwrap()
+        .join("third-party")
+        .join("protobuf")
+}
+
+/// Returns the path to the `protoc` pointed to by the `PROTOC` environment variable, if it is set.
+fn env_protoc() -> Option<PathBuf> {
+    let protoc = match env::var_os("PROTOC") {
+        Some(path) => PathBuf::from(path),
+        None => return None,
+    };
+
+    Some(protoc)
+}
+
+/// Returns the path to the bundled `protoc`, if it is available for the host platform.
+fn bundled_protoc() -> Option<PathBuf> {
+    let protoc_bin_name = match (env::consts::OS, env::consts::ARCH) {
+        ("linux", "x86") => "protoc-linux-x86_32",
+        ("linux", "x86_64") => "protoc-linux-x86_64",
+        ("linux", "aarch64") => "protoc-linux-aarch_64",
+        ("macos", "x86_64") => "protoc-osx-x86_64",
+        ("windows", _) => "protoc-win32.exe",
+        _ => return None,
+    };
+
+    Some(bundle_path().join(protoc_bin_name))
+}
+
+/// Returns the path to the `protoc` included on the `PATH`, if it exists.
+fn path_protoc() -> Option<PathBuf> {
+    which::which("protoc").ok()
+}
+
+/// Returns the path to the Protobuf include directory pointed to by the `PROTOC_INCLUDE`
+/// environment variable, if it is set.
+fn env_protoc_include() -> Option<PathBuf> {
+    let protoc_include = match env::var_os("PROTOC_INCLUDE") {
+        Some(path) => PathBuf::from(path),
+        None => return None,
+    };
+
+    if !protoc_include.exists() {
+        panic!(
+            "PROTOC_INCLUDE environment variable points to non-existent directory ({:?})",
+            protoc_include
+        );
+    }
+    if !protoc_include.is_dir() {
+        panic!(
+            "PROTOC_INCLUDE environment variable points to a non-directory file ({:?})",
+            protoc_include
+        );
+    }
+
+    Some(protoc_include)
+}
+
+/// Returns the path to the bundled Protobuf include directory.
+fn bundled_protoc_include() -> PathBuf {
+    bundle_path().join("include")
+}
+
+fn main() {
+    let protoc = env_protoc()
+        .or_else(bundled_protoc)
+        .or_else(path_protoc)
+        .expect(
+            "Failed to find the protoc binary. The PROTOC environment variable is not set, \
+             there is no bundled protoc for this platform, and protoc is not in the PATH",
+        );
+
+    let protoc_include = env_protoc_include().unwrap_or_else(bundled_protoc_include);
+
+    println!("cargo:rustc-env=PROTOC={}", protoc.display());
+    println!(
+        "cargo:rustc-env=PROTOC_INCLUDE={}",
+        protoc_include.display()
+    );
+    println!("cargo:rerun-if-env-changed=PROTOC");
+    println!("cargo:rerun-if-env-changed=PROTOC_INCLUDE");
+}

--- a/third_party/prost/prost-build/src/ast.rs
+++ b/third_party/prost/prost-build/src/ast.rs
@@ -1,0 +1,132 @@
+use prost_types::source_code_info::Location;
+
+/// Comments on a Protobuf item.
+#[derive(Debug)]
+pub struct Comments {
+    /// Leading detached blocks of comments.
+    pub leading_detached: Vec<Vec<String>>,
+
+    /// Leading comments.
+    pub leading: Vec<String>,
+
+    /// Trailing comments.
+    pub trailing: Vec<String>,
+}
+
+impl Comments {
+    pub(crate) fn from_location(location: &Location) -> Comments {
+        fn get_lines<S>(comments: S) -> Vec<String>
+        where
+            S: AsRef<str>,
+        {
+            comments.as_ref().lines().map(str::to_owned).collect()
+        }
+
+        let leading_detached = location
+            .leading_detached_comments
+            .iter()
+            .map(get_lines)
+            .collect();
+        let leading = location
+            .leading_comments
+            .as_ref()
+            .map_or(Vec::new(), get_lines);
+        let trailing = location
+            .trailing_comments
+            .as_ref()
+            .map_or(Vec::new(), get_lines);
+        Comments {
+            leading_detached,
+            leading,
+            trailing,
+        }
+    }
+
+    /// Appends the comments to a buffer with indentation.
+    ///
+    /// Each level of indentation corresponds to four space (' ') characters.
+    pub fn append_with_indent(&self, indent_level: u8, buf: &mut String) {
+        // Append blocks of detached comments.
+        for detached_block in &self.leading_detached {
+            for line in detached_block {
+                for _ in 0..indent_level {
+                    buf.push_str("    ");
+                }
+                buf.push_str("//");
+                buf.push_str(line);
+                buf.push_str("\n");
+            }
+            buf.push_str("\n");
+        }
+
+        // Append leading comments.
+        for line in &self.leading {
+            for _ in 0..indent_level {
+                buf.push_str("    ");
+            }
+            buf.push_str("///");
+            buf.push_str(line);
+            buf.push_str("\n");
+        }
+
+        // Append an empty comment line if there are leading and trailing comments.
+        if !self.leading.is_empty() && !self.trailing.is_empty() {
+            for _ in 0..indent_level {
+                buf.push_str("    ");
+            }
+            buf.push_str("///\n");
+        }
+
+        // Append trailing comments.
+        for line in &self.trailing {
+            for _ in 0..indent_level {
+                buf.push_str("    ");
+            }
+            buf.push_str("///");
+            buf.push_str(line);
+            buf.push_str("\n");
+        }
+    }
+}
+
+/// A service descriptor.
+#[derive(Debug)]
+pub struct Service {
+    /// The service name in Rust style.
+    pub name: String,
+    /// The service name as it appears in the .proto file.
+    pub proto_name: String,
+    /// The package name as it appears in the .proto file.
+    pub package: String,
+    /// The service comments.
+    pub comments: Comments,
+    /// The service methods.
+    pub methods: Vec<Method>,
+    /// The service options.
+    pub options: prost_types::ServiceOptions,
+}
+
+/// A service method descriptor.
+#[derive(Debug)]
+pub struct Method {
+    /// The name of the method in Rust style.
+    pub name: String,
+    /// The name of the method as it appears in the .proto file.
+    pub proto_name: String,
+    /// The method comments.
+    pub comments: Comments,
+    /// The input Rust type.
+    pub input_type: String,
+    /// The output Rust type.
+    pub output_type: String,
+    /// The input Protobuf type.
+    pub input_proto_type: String,
+    /// The output Protobuf type.
+    pub output_proto_type: String,
+    /// The method options.
+    pub options: prost_types::MethodOptions,
+    /// Identifies if client streams multiple client messages.
+    pub client_streaming: bool,
+    /// Identifies if server streams multiple server messages.
+    pub server_streaming: bool,
+}

--- a/third_party/prost/prost-build/src/code_generator.rs
+++ b/third_party/prost/prost-build/src/code_generator.rs
@@ -1,0 +1,1004 @@
+use std::ascii;
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+use std::iter;
+
+use itertools::{Either, Itertools};
+use log::debug;
+use multimap::MultiMap;
+use prost_types::field_descriptor_proto::{Label, Type};
+use prost_types::source_code_info::Location;
+use prost_types::{
+    DescriptorProto, EnumDescriptorProto, EnumValueDescriptorProto, FieldDescriptorProto,
+    FieldOptions, FileDescriptorProto, OneofDescriptorProto, ServiceDescriptorProto,
+    SourceCodeInfo,
+};
+
+use crate::ast::{Comments, Method, Service};
+use crate::extern_paths::ExternPaths;
+use crate::ident::{match_ident, to_snake, to_upper_camel};
+use crate::message_graph::MessageGraph;
+use crate::Config;
+
+#[derive(PartialEq)]
+enum Syntax {
+    Proto2,
+    Proto3,
+}
+
+pub struct CodeGenerator<'a> {
+    config: &'a mut Config,
+    package: String,
+    source_info: SourceCodeInfo,
+    syntax: Syntax,
+    message_graph: &'a MessageGraph,
+    extern_paths: &'a ExternPaths,
+    depth: u8,
+    path: Vec<i32>,
+    buf: &'a mut String,
+}
+
+impl<'a> CodeGenerator<'a> {
+    pub fn generate(
+        config: &mut Config,
+        message_graph: &MessageGraph,
+        extern_paths: &ExternPaths,
+        file: FileDescriptorProto,
+        buf: &mut String,
+    ) {
+        let mut source_info = file
+            .source_code_info
+            .expect("no source code info in request");
+        source_info.location.retain(|location| {
+            let len = location.path.len();
+            len > 0 && len % 2 == 0
+        });
+        source_info
+            .location
+            .sort_by_key(|location| location.path.clone());
+
+        let syntax = match file.syntax.as_ref().map(String::as_str) {
+            None | Some("proto2") => Syntax::Proto2,
+            Some("proto3") => Syntax::Proto3,
+            Some(s) => panic!("unknown syntax: {}", s),
+        };
+
+        let mut code_gen = CodeGenerator {
+            config,
+            package: file.package.unwrap(),
+            source_info,
+            syntax,
+            message_graph,
+            extern_paths,
+            depth: 0,
+            path: Vec::new(),
+            buf,
+        };
+
+        debug!(
+            "file: {:?}, package: {:?}",
+            file.name.as_ref().unwrap(),
+            code_gen.package
+        );
+
+        code_gen.path.push(4);
+        for (idx, message) in file.message_type.into_iter().enumerate() {
+            code_gen.path.push(idx as i32);
+            code_gen.append_message(message);
+            code_gen.path.pop();
+        }
+        code_gen.path.pop();
+
+        code_gen.path.push(5);
+        for (idx, desc) in file.enum_type.into_iter().enumerate() {
+            code_gen.path.push(idx as i32);
+            code_gen.append_enum(desc);
+            code_gen.path.pop();
+        }
+        code_gen.path.pop();
+
+        if code_gen.config.service_generator.is_some() {
+            code_gen.path.push(6);
+            for (idx, service) in file.service.into_iter().enumerate() {
+                code_gen.path.push(idx as i32);
+                code_gen.push_service(service);
+                code_gen.path.pop();
+            }
+
+            if let Some(service_generator) = code_gen.config.service_generator.as_mut() {
+                service_generator.finalize(code_gen.buf);
+            }
+
+            code_gen.path.pop();
+        }
+    }
+
+    fn append_message(&mut self, message: DescriptorProto) {
+        debug!("  message: {:?}", message.name());
+
+        let message_name = message.name().to_string();
+        let fq_message_name = format!(".{}.{}", self.package, message.name());
+
+        // Skip external types.
+        if self.extern_paths.resolve_ident(&fq_message_name).is_some() {
+            return;
+        }
+
+        // Split the nested message types into a vector of normal nested message types, and a map
+        // of the map field entry types. The path index of the nested message types is preserved so
+        // that comments can be retrieved.
+        type NestedTypes = Vec<(DescriptorProto, usize)>;
+        type MapTypes = HashMap<String, (FieldDescriptorProto, FieldDescriptorProto)>;
+        let (nested_types, map_types): (NestedTypes, MapTypes) = message
+            .nested_type
+            .into_iter()
+            .enumerate()
+            .partition_map(|(idx, nested_type)| {
+                if nested_type
+                    .options
+                    .as_ref()
+                    .and_then(|options| options.map_entry)
+                    .unwrap_or(false)
+                {
+                    let key = nested_type.field[0].clone();
+                    let value = nested_type.field[1].clone();
+                    assert_eq!("key", key.name());
+                    assert_eq!("value", value.name());
+
+                    let name = format!("{}.{}", &fq_message_name, nested_type.name());
+                    Either::Right((name, (key, value)))
+                } else {
+                    Either::Left((nested_type, idx))
+                }
+            });
+
+        // Split the fields into a vector of the normal fields, and oneof fields.
+        // Path indexes are preserved so that comments can be retrieved.
+        type Fields = Vec<(FieldDescriptorProto, usize)>;
+        type OneofFields = MultiMap<i32, (FieldDescriptorProto, usize)>;
+        let (fields, mut oneof_fields): (Fields, OneofFields) = message
+            .field
+            .into_iter()
+            .enumerate()
+            .partition_map(|(idx, field)| {
+                if let Some(oneof_index) = field.oneof_index {
+                    Either::Right((oneof_index, (field, idx)))
+                } else {
+                    Either::Left((field, idx))
+                }
+            });
+
+        assert_eq!(oneof_fields.len(), message.oneof_decl.len());
+
+        self.append_doc();
+        self.append_type_attributes(&fq_message_name);
+        self.push_indent();
+        self.buf
+            .push_str("#[derive(Clone, PartialEq, ::prost::Message)]\n");
+        self.push_indent();
+        self.buf.push_str("pub struct ");
+        self.buf.push_str(&to_upper_camel(&message_name));
+        self.buf.push_str(" {\n");
+
+        self.depth += 1;
+        self.path.push(2);
+        for (field, idx) in fields {
+            self.path.push(idx as i32);
+            match field
+                .type_name
+                .as_ref()
+                .and_then(|type_name| map_types.get(type_name))
+            {
+                Some(&(ref key, ref value)) => {
+                    self.append_map_field(&fq_message_name, field, key, value)
+                }
+                None => self.append_field(&fq_message_name, field),
+            }
+            self.path.pop();
+        }
+        self.path.pop();
+
+        self.path.push(8);
+        for (idx, oneof) in message.oneof_decl.iter().enumerate() {
+            let idx = idx as i32;
+            self.path.push(idx);
+            self.append_oneof_field(
+                &message_name,
+                &fq_message_name,
+                oneof,
+                oneof_fields.get_vec(&idx).unwrap(),
+            );
+            self.path.pop();
+        }
+        self.path.pop();
+
+        self.depth -= 1;
+        self.push_indent();
+        self.buf.push_str("}\n");
+
+        if !message.enum_type.is_empty() || !nested_types.is_empty() || !oneof_fields.is_empty() {
+            self.push_mod(&message_name);
+            self.path.push(3);
+            for (nested_type, idx) in nested_types {
+                self.path.push(idx as i32);
+                self.append_message(nested_type);
+                self.path.pop();
+            }
+            self.path.pop();
+
+            self.path.push(4);
+            for (idx, nested_enum) in message.enum_type.into_iter().enumerate() {
+                self.path.push(idx as i32);
+                self.append_enum(nested_enum);
+                self.path.pop();
+            }
+            self.path.pop();
+
+            for (idx, oneof) in message.oneof_decl.into_iter().enumerate() {
+                let idx = idx as i32;
+                self.append_oneof(
+                    &fq_message_name,
+                    oneof,
+                    idx,
+                    oneof_fields.remove(&idx).unwrap(),
+                );
+            }
+
+            self.pop_mod();
+        }
+    }
+
+    fn append_type_attributes(&mut self, msg_name: &str) {
+        assert_eq!(b'.', msg_name.as_bytes()[0]);
+        // TODO: this clone is dirty, but expedious.
+        for (matcher, attribute) in self.config.type_attributes.clone() {
+            if match_ident(&matcher, msg_name, None) {
+                self.push_indent();
+                self.buf.push_str(&attribute);
+                self.buf.push('\n');
+            }
+        }
+    }
+
+    fn append_field_attributes(&mut self, msg_name: &str, field_name: &str) {
+        assert_eq!(b'.', msg_name.as_bytes()[0]);
+        // TODO: this clone is dirty, but expedious.
+        for (matcher, attribute) in self.config.field_attributes.clone() {
+            if match_ident(&matcher, msg_name, Some(field_name)) {
+                self.push_indent();
+                self.buf.push_str(&attribute);
+                self.buf.push('\n');
+            }
+        }
+    }
+
+    fn append_field(&mut self, msg_name: &str, field: FieldDescriptorProto) {
+        let type_ = field.r#type();
+        let repeated = field.label == Some(Label::Repeated as i32);
+        let deprecated = self.deprecated(&field);
+        let optional = self.optional(&field);
+        let ty = self.resolve_type(&field);
+
+        let boxed = !repeated
+            && (type_ == Type::Message || type_ == Type::Group)
+            && self.message_graph.is_nested(field.type_name(), msg_name);
+
+        debug!(
+            "    field: {:?}, type: {:?}, boxed: {}",
+            field.name(),
+            ty,
+            boxed
+        );
+
+        self.append_doc();
+
+        if deprecated {
+            self.push_indent();
+            self.buf.push_str("#[deprecated]\n");
+        }
+
+        self.push_indent();
+        self.buf.push_str("#[prost(");
+        let type_tag = self.field_type_tag(&field);
+        self.buf.push_str(&type_tag);
+
+        match field.label() {
+            Label::Optional => {
+                if optional {
+                    self.buf.push_str(", optional");
+                }
+            }
+            Label::Required => self.buf.push_str(", required"),
+            Label::Repeated => {
+                self.buf.push_str(", repeated");
+                if can_pack(&field)
+                    && !field
+                        .options
+                        .as_ref()
+                        .map_or(self.syntax == Syntax::Proto3, |options| options.packed())
+                {
+                    self.buf.push_str(", packed=\"false\"");
+                }
+            }
+        }
+
+        if boxed {
+            self.buf.push_str(", boxed");
+        }
+        self.buf.push_str(", tag=\"");
+        self.buf.push_str(&field.number().to_string());
+
+        if let Some(ref default) = field.default_value {
+            self.buf.push_str("\", default=\"");
+            if type_ == Type::Bytes {
+                self.buf.push_str("b\\\"");
+                for b in unescape_c_escape_string(default) {
+                    self.buf.extend(
+                        ascii::escape_default(b).flat_map(|c| (c as char).escape_default()),
+                    );
+                }
+                self.buf.push_str("\\\"");
+            } else if type_ == Type::Enum {
+                let enum_value = to_upper_camel(default);
+                let stripped_prefix = if self.config.strip_enum_prefix {
+                    // Field types are fully qualified, so we extract
+                    // the last segment and strip it from the left
+                    // side of the default value.
+                    let enum_type = field
+                        .type_name
+                        .as_ref()
+                        .and_then(|ty| ty.split('.').last())
+                        .unwrap();
+
+                    strip_enum_prefix(&to_upper_camel(&enum_type), &enum_value)
+                } else {
+                    &enum_value
+                };
+                self.buf.push_str(stripped_prefix);
+            } else {
+                // TODO: this is only correct if the Protobuf escaping matches Rust escaping. To be
+                // safer, we should unescape the Protobuf string and re-escape it with the Rust
+                // escaping mechanisms.
+                self.buf.push_str(default);
+            }
+        }
+
+        self.buf.push_str("\")]\n");
+        self.append_field_attributes(msg_name, field.name());
+        self.push_indent();
+        self.buf.push_str("pub ");
+        self.buf.push_str(&to_snake(field.name()));
+        self.buf.push_str(": ");
+        if repeated {
+            self.buf.push_str("::prost::alloc::vec::Vec<");
+        } else if optional {
+            self.buf.push_str("::core::option::Option<");
+        }
+        if boxed {
+            self.buf.push_str("::prost::alloc::boxed::Box<");
+        }
+        self.buf.push_str(&ty);
+        if boxed {
+            self.buf.push_str(">");
+        }
+        if repeated || optional {
+            self.buf.push_str(">");
+        }
+        self.buf.push_str(",\n");
+    }
+
+    fn append_map_field(
+        &mut self,
+        msg_name: &str,
+        field: FieldDescriptorProto,
+        key: &FieldDescriptorProto,
+        value: &FieldDescriptorProto,
+    ) {
+        let key_ty = self.resolve_type(key);
+        let value_ty = self.resolve_type(value);
+
+        debug!(
+            "    map field: {:?}, key type: {:?}, value type: {:?}",
+            field.name(),
+            key_ty,
+            value_ty
+        );
+
+        self.append_doc();
+        self.push_indent();
+
+        let btree_map = self
+            .config
+            .btree_map
+            .iter()
+            .any(|matcher| match_ident(matcher, msg_name, Some(field.name())));
+        let (annotation_ty, lib_name, rust_ty) = if btree_map {
+            ("btree_map", "::prost::alloc::collections", "BTreeMap")
+        } else {
+            ("map", "::std::collections", "HashMap")
+        };
+
+        let key_tag = self.field_type_tag(key);
+        let value_tag = self.map_value_type_tag(value);
+        self.buf.push_str(&format!(
+            "#[prost({}=\"{}, {}\", tag=\"{}\")]\n",
+            annotation_ty,
+            key_tag,
+            value_tag,
+            field.number()
+        ));
+        self.append_field_attributes(msg_name, field.name());
+        self.push_indent();
+        self.buf.push_str(&format!(
+            "pub {}: {}::{}<{}, {}>,\n",
+            to_snake(field.name()),
+            lib_name,
+            rust_ty,
+            key_ty,
+            value_ty
+        ));
+    }
+
+    fn append_oneof_field(
+        &mut self,
+        message_name: &str,
+        fq_message_name: &str,
+        oneof: &OneofDescriptorProto,
+        fields: &[(FieldDescriptorProto, usize)],
+    ) {
+        let name = format!(
+            "{}::{}",
+            to_snake(message_name),
+            to_upper_camel(oneof.name())
+        );
+        self.append_doc();
+        self.push_indent();
+        self.buf.push_str(&format!(
+            "#[prost(oneof=\"{}\", tags=\"{}\")]\n",
+            name,
+            fields
+                .iter()
+                .map(|&(ref field, _)| field.number())
+                .join(", ")
+        ));
+        self.append_field_attributes(fq_message_name, oneof.name());
+        self.push_indent();
+        self.buf.push_str(&format!(
+            "pub {}: ::core::option::Option<{}>,\n",
+            to_snake(oneof.name()),
+            name
+        ));
+    }
+
+    fn append_oneof(
+        &mut self,
+        msg_name: &str,
+        oneof: OneofDescriptorProto,
+        idx: i32,
+        fields: Vec<(FieldDescriptorProto, usize)>,
+    ) {
+        self.path.push(8);
+        self.path.push(idx);
+        self.append_doc();
+        self.path.pop();
+        self.path.pop();
+
+        let oneof_name = format!("{}.{}", msg_name, oneof.name());
+        self.append_type_attributes(&oneof_name);
+        self.push_indent();
+        self.buf
+            .push_str("#[derive(Clone, PartialEq, ::prost::Oneof)]\n");
+        self.push_indent();
+        self.buf.push_str("pub enum ");
+        self.buf.push_str(&to_upper_camel(oneof.name()));
+        self.buf.push_str(" {\n");
+
+        self.path.push(2);
+        self.depth += 1;
+        for (field, idx) in fields {
+            let type_ = field.r#type();
+
+            self.path.push(idx as i32);
+            self.append_doc();
+            self.path.pop();
+
+            self.push_indent();
+            let ty_tag = self.field_type_tag(&field);
+            self.buf.push_str(&format!(
+                "#[prost({}, tag=\"{}\")]\n",
+                ty_tag,
+                field.number()
+            ));
+            self.append_field_attributes(&oneof_name, field.name());
+
+            self.push_indent();
+            let ty = self.resolve_type(&field);
+
+            let boxed = (type_ == Type::Message || type_ == Type::Group)
+                && self.message_graph.is_nested(field.type_name(), msg_name);
+
+            debug!(
+                "    oneof: {:?}, type: {:?}, boxed: {}",
+                field.name(),
+                ty,
+                boxed
+            );
+
+            if boxed {
+                self.buf.push_str(&format!(
+                    "{}(::prost::alloc::boxed::Box<{}>),\n",
+                    to_upper_camel(field.name()),
+                    ty
+                ));
+            } else {
+                self.buf
+                    .push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));
+            }
+        }
+        self.depth -= 1;
+        self.path.pop();
+
+        self.push_indent();
+        self.buf.push_str("}\n");
+    }
+
+    fn location(&self) -> &Location {
+        let idx = self
+            .source_info
+            .location
+            .binary_search_by_key(&&self.path[..], |location| &location.path[..])
+            .unwrap();
+
+        &self.source_info.location[idx]
+    }
+
+    fn append_doc(&mut self) {
+        Comments::from_location(self.location()).append_with_indent(self.depth, &mut self.buf);
+    }
+
+    fn append_enum(&mut self, desc: EnumDescriptorProto) {
+        debug!("  enum: {:?}", desc.name());
+
+        // Skip external types.
+        let enum_name = &desc.name();
+        let enum_values = &desc.value;
+        let fq_enum_name = format!(".{}.{}", self.package, enum_name);
+        if self.extern_paths.resolve_ident(&fq_enum_name).is_some() {
+            return;
+        }
+
+        self.append_doc();
+        self.append_type_attributes(&fq_enum_name);
+        self.push_indent();
+        self.buf.push_str(
+            "#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]\n",
+        );
+        self.push_indent();
+        self.buf.push_str("#[repr(i32)]\n");
+        self.push_indent();
+        self.buf.push_str("pub enum ");
+        self.buf.push_str(&to_upper_camel(desc.name()));
+        self.buf.push_str(" {\n");
+
+        let mut numbers = HashSet::new();
+
+        self.depth += 1;
+        self.path.push(2);
+        for (idx, value) in enum_values.iter().enumerate() {
+            // Skip duplicate enum values. Protobuf allows this when the
+            // 'allow_alias' option is set.
+            if !numbers.insert(value.number()) {
+                continue;
+            }
+
+            self.path.push(idx as i32);
+            let stripped_prefix = if self.config.strip_enum_prefix {
+                Some(to_upper_camel(&enum_name))
+            } else {
+                None
+            };
+            self.append_enum_value(&fq_enum_name, value, stripped_prefix);
+            self.path.pop();
+        }
+        self.path.pop();
+        self.depth -= 1;
+
+        self.push_indent();
+        self.buf.push_str("}\n");
+    }
+
+    fn append_enum_value(
+        &mut self,
+        fq_enum_name: &str,
+        value: &EnumValueDescriptorProto,
+        prefix_to_strip: Option<String>,
+    ) {
+        self.append_doc();
+        self.append_field_attributes(fq_enum_name, &value.name());
+        self.push_indent();
+        let name = to_upper_camel(value.name());
+        let name_unprefixed = match prefix_to_strip {
+            Some(prefix) => strip_enum_prefix(&prefix, &name),
+            None => &name,
+        };
+        self.buf.push_str(name_unprefixed);
+        self.buf.push_str(" = ");
+        self.buf.push_str(&value.number().to_string());
+        self.buf.push_str(",\n");
+    }
+
+    fn push_service(&mut self, service: ServiceDescriptorProto) {
+        let name = service.name().to_owned();
+        debug!("  service: {:?}", name);
+
+        let comments = Comments::from_location(self.location());
+
+        self.path.push(2);
+        let methods = service
+            .method
+            .into_iter()
+            .enumerate()
+            .map(|(idx, mut method)| {
+                debug!("  method: {:?}", method.name());
+                self.path.push(idx as i32);
+                let comments = Comments::from_location(self.location());
+                self.path.pop();
+
+                let name = method.name.take().unwrap();
+                let input_proto_type = method.input_type.take().unwrap();
+                let output_proto_type = method.output_type.take().unwrap();
+                let input_type = self.resolve_ident(&input_proto_type);
+                let output_type = self.resolve_ident(&output_proto_type);
+                let client_streaming = method.client_streaming();
+                let server_streaming = method.server_streaming();
+
+                Method {
+                    name: to_snake(&name),
+                    proto_name: name,
+                    comments,
+                    input_type,
+                    output_type,
+                    input_proto_type,
+                    output_proto_type,
+                    options: method.options.unwrap_or_default(),
+                    client_streaming,
+                    server_streaming,
+                }
+            })
+            .collect();
+        self.path.pop();
+
+        let service = Service {
+            name: to_upper_camel(&name),
+            proto_name: name,
+            package: self.package.clone(),
+            comments,
+            methods,
+            options: service.options.unwrap_or_default(),
+        };
+
+        if let Some(service_generator) = self.config.service_generator.as_mut() {
+            service_generator.generate(service, &mut self.buf)
+        }
+    }
+
+    fn push_indent(&mut self) {
+        for _ in 0..self.depth {
+            self.buf.push_str("    ");
+        }
+    }
+
+    fn push_mod(&mut self, module: &str) {
+        self.push_indent();
+        self.buf.push_str("/// Nested message and enum types in `");
+        self.buf.push_str(module);
+        self.buf.push_str("`.\n");
+
+        self.push_indent();
+        self.buf.push_str("pub mod ");
+        self.buf.push_str(&to_snake(module));
+        self.buf.push_str(" {\n");
+
+        self.package.push_str(".");
+        self.package.push_str(module);
+
+        self.depth += 1;
+    }
+
+    fn pop_mod(&mut self) {
+        self.depth -= 1;
+
+        let idx = self.package.rfind('.').unwrap();
+        self.package.truncate(idx);
+
+        self.push_indent();
+        self.buf.push_str("}\n");
+    }
+
+    fn resolve_type(&self, field: &FieldDescriptorProto) -> String {
+        match field.r#type() {
+            Type::Float => String::from("f32"),
+            Type::Double => String::from("f64"),
+            Type::Uint32 | Type::Fixed32 => String::from("u32"),
+            Type::Uint64 | Type::Fixed64 => String::from("u64"),
+            Type::Int32 | Type::Sfixed32 | Type::Sint32 | Type::Enum => String::from("i32"),
+            Type::Int64 | Type::Sfixed64 | Type::Sint64 => String::from("i64"),
+            Type::Bool => String::from("bool"),
+            Type::String => String::from("::prost::alloc::string::String"),
+            Type::Bytes => String::from("::prost::alloc::vec::Vec<u8>"),
+            Type::Group | Type::Message => self.resolve_ident(field.type_name()),
+        }
+    }
+
+    fn resolve_ident(&self, pb_ident: &str) -> String {
+        // protoc should always give fully qualified identifiers.
+        assert_eq!(".", &pb_ident[..1]);
+
+        if let Some(proto_ident) = self.extern_paths.resolve_ident(pb_ident) {
+            return proto_ident;
+        }
+
+        let mut local_path = self.package.split('.').peekable();
+
+        let mut ident_path = pb_ident[1..].split('.');
+        let ident_type = ident_path.next_back().unwrap();
+        let mut ident_path = ident_path.peekable();
+
+        // Skip path elements in common.
+        while local_path.peek().is_some() && local_path.peek() == ident_path.peek() {
+            local_path.next();
+            ident_path.next();
+        }
+
+        local_path
+            .map(|_| "super".to_string())
+            .chain(ident_path.map(to_snake))
+            .chain(iter::once(to_upper_camel(ident_type)))
+            .join("::")
+    }
+
+    fn field_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
+        match field.r#type() {
+            Type::Float => Cow::Borrowed("float"),
+            Type::Double => Cow::Borrowed("double"),
+            Type::Int32 => Cow::Borrowed("int32"),
+            Type::Int64 => Cow::Borrowed("int64"),
+            Type::Uint32 => Cow::Borrowed("uint32"),
+            Type::Uint64 => Cow::Borrowed("uint64"),
+            Type::Sint32 => Cow::Borrowed("sint32"),
+            Type::Sint64 => Cow::Borrowed("sint64"),
+            Type::Fixed32 => Cow::Borrowed("fixed32"),
+            Type::Fixed64 => Cow::Borrowed("fixed64"),
+            Type::Sfixed32 => Cow::Borrowed("sfixed32"),
+            Type::Sfixed64 => Cow::Borrowed("sfixed64"),
+            Type::Bool => Cow::Borrowed("bool"),
+            Type::String => Cow::Borrowed("string"),
+            Type::Bytes => Cow::Borrowed("bytes"),
+            Type::Group => Cow::Borrowed("group"),
+            Type::Message => Cow::Borrowed("message"),
+            Type::Enum => Cow::Owned(format!(
+                "enumeration={:?}",
+                self.resolve_ident(field.type_name())
+            )),
+        }
+    }
+
+    fn map_value_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
+        match field.r#type() {
+            Type::Enum => Cow::Owned(format!(
+                "enumeration({})",
+                self.resolve_ident(field.type_name())
+            )),
+            _ => self.field_type_tag(field),
+        }
+    }
+
+    fn optional(&self, field: &FieldDescriptorProto) -> bool {
+        if field.label() != Label::Optional {
+            return false;
+        }
+
+        match field.r#type() {
+            Type::Message => true,
+            _ => self.syntax == Syntax::Proto2,
+        }
+    }
+
+    /// Returns `true` if the field options includes the `deprecated` option.
+    fn deprecated(&self, field: &FieldDescriptorProto) -> bool {
+        field
+            .options
+            .as_ref()
+            .map_or(false, FieldOptions::deprecated)
+    }
+}
+
+/// Returns `true` if the repeated field type can be packed.
+fn can_pack(field: &FieldDescriptorProto) -> bool {
+    match field.r#type() {
+        Type::Float
+        | Type::Double
+        | Type::Int32
+        | Type::Int64
+        | Type::Uint32
+        | Type::Uint64
+        | Type::Sint32
+        | Type::Sint64
+        | Type::Fixed32
+        | Type::Fixed64
+        | Type::Sfixed32
+        | Type::Sfixed64
+        | Type::Bool
+        | Type::Enum => true,
+        _ => false,
+    }
+}
+
+/// Based on [`google::protobuf::UnescapeCEscapeString`][1]
+/// [1]: https://github.com/google/protobuf/blob/3.3.x/src/google/protobuf/stubs/strutil.cc#L312-L322
+fn unescape_c_escape_string(s: &str) -> Vec<u8> {
+    let src = s.as_bytes();
+    let len = src.len();
+    let mut dst = Vec::new();
+
+    let mut p = 0;
+
+    while p < len {
+        if src[p] != b'\\' {
+            dst.push(src[p]);
+            p += 1;
+        } else {
+            p += 1;
+            if p == len {
+                panic!(
+                    "invalid c-escaped default binary value ({}): ends with '\'",
+                    s
+                )
+            }
+            match src[p] {
+                b'a' => {
+                    dst.push(0x07);
+                    p += 1;
+                }
+                b'b' => {
+                    dst.push(0x08);
+                    p += 1;
+                }
+                b'f' => {
+                    dst.push(0x0C);
+                    p += 1;
+                }
+                b'n' => {
+                    dst.push(0x0A);
+                    p += 1;
+                }
+                b'r' => {
+                    dst.push(0x0D);
+                    p += 1;
+                }
+                b't' => {
+                    dst.push(0x09);
+                    p += 1;
+                }
+                b'v' => {
+                    dst.push(0x0B);
+                    p += 1;
+                }
+                b'\\' => {
+                    dst.push(0x5C);
+                    p += 1;
+                }
+                b'?' => {
+                    dst.push(0x3F);
+                    p += 1;
+                }
+                b'\'' => {
+                    dst.push(0x27);
+                    p += 1;
+                }
+                b'"' => {
+                    dst.push(0x22);
+                    p += 1;
+                }
+                b'0'..=b'7' => {
+                    eprintln!("another octal: {}, offset: {}", s, &s[p..]);
+                    let mut octal = 0;
+                    for _ in 0..3 {
+                        if p < len && src[p] >= b'0' && src[p] <= b'7' {
+                            eprintln!("\toctal: {}", octal);
+                            octal = octal * 8 + (src[p] - b'0');
+                            p += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    dst.push(octal);
+                }
+                b'x' | b'X' => {
+                    if p + 2 > len {
+                        panic!(
+                            "invalid c-escaped default binary value ({}): incomplete hex value",
+                            s
+                        )
+                    }
+                    match u8::from_str_radix(&s[p + 1..p + 3], 16) {
+                        Ok(b) => dst.push(b),
+                        _ => panic!(
+                            "invalid c-escaped default binary value ({}): invalid hex value",
+                            &s[p..p + 2]
+                        ),
+                    }
+                    p += 3;
+                }
+                _ => panic!(
+                    "invalid c-escaped default binary value ({}): invalid escape",
+                    s
+                ),
+            }
+        }
+    }
+    dst
+}
+
+/// Strip an enum's type name from the prefix of an enum value.
+///
+/// This function assumes that both have been formatted to Rust's
+/// upper camel case naming conventions.
+///
+/// It also tries to handle cases where the stripped name would be
+/// invalid - for example, if it were to begin with a number.
+fn strip_enum_prefix<'a>(prefix: &str, name: &'a str) -> &'a str {
+    let stripped = if name.starts_with(prefix) {
+        &name[prefix.len()..]
+    } else {
+        name
+    };
+    // If the next character after the stripped prefix is not
+    // uppercase, then it means that we didn't have a true prefix -
+    // for example, "Foo" should not be stripped from "Foobar".
+    if stripped
+        .chars()
+        .next()
+        .map(char::is_uppercase)
+        .unwrap_or(false)
+    {
+        stripped
+    } else {
+        name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unescape_c_escape_string() {
+        assert_eq!(
+            &b"hello world"[..],
+            &unescape_c_escape_string("hello world")[..]
+        );
+
+        assert_eq!(&b"\0"[..], &unescape_c_escape_string(r#"\0"#)[..]);
+
+        assert_eq!(
+            &[0o012, 0o156],
+            &unescape_c_escape_string(r#"\012\156"#)[..]
+        );
+        assert_eq!(&[0x01, 0x02], &unescape_c_escape_string(r#"\x01\x02"#)[..]);
+
+        assert_eq!(
+            &b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE"[..],
+            &unescape_c_escape_string(r#"\0\001\a\b\f\n\r\t\v\\\'\"\xfe"#)[..]
+        );
+    }
+
+    #[test]
+    fn test_strip_enum_prefix() {
+        assert_eq!(strip_enum_prefix("Foo", "FooBar"), "Bar");
+        assert_eq!(strip_enum_prefix("Foo", "Foobar"), "Foobar");
+        assert_eq!(strip_enum_prefix("Foo", "Foo"), "Foo");
+        assert_eq!(strip_enum_prefix("Foo", "Bar"), "Bar");
+        assert_eq!(strip_enum_prefix("Foo", "Foo1"), "Foo1");
+    }
+}

--- a/third_party/prost/prost-build/src/code_generator.rs
+++ b/third_party/prost/prost-build/src/code_generator.rs
@@ -715,7 +715,20 @@ impl<'a> CodeGenerator<'a> {
         self.buf.push_str("}\n");
     }
 
+    fn resolve_message_type(&self, field: &FieldDescriptorProto) -> Option<String> {
+        let message_type = self.resolve_ident(&field.options.as_ref()?.message_type.as_ref()?);
+        let direction = match field.type_name() {
+            ".oak.handle.Sender" => Some("Sender"),
+            ".oak.handle.Receiver" => Some("Receiver"),
+            _ => None,
+        }?;
+        Some(format!("::oak::io::{}<{}>", direction, message_type))
+    }
+
     fn resolve_type(&self, field: &FieldDescriptorProto) -> String {
+        if let Some(ty) = self.resolve_message_type(field) {
+            return ty;
+        }
         match field.r#type() {
             Type::Float => String::from("f32"),
             Type::Double => String::from("f64"),

--- a/third_party/prost/prost-build/src/extern_paths.rs
+++ b/third_party/prost/prost-build/src/extern_paths.rs
@@ -1,0 +1,170 @@
+use std::collections::{hash_map, HashMap};
+
+use itertools::Itertools;
+
+use crate::ident::{to_snake, to_upper_camel};
+
+fn validate_proto_path(path: &str) -> Result<(), String> {
+    if path.chars().next().map(|c| c != '.').unwrap_or(true) {
+        return Err(format!(
+            "Protobuf paths must be fully qualified (begin with a leading '.'): {}",
+            path
+        ));
+    }
+    if path.split('.').skip(1).any(str::is_empty) {
+        return Err(format!("invalid fully-qualified Protobuf path: {}", path));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct ExternPaths {
+    extern_paths: HashMap<String, String>,
+}
+
+impl ExternPaths {
+    pub fn new(paths: &[(String, String)], prost_types: bool) -> Result<ExternPaths, String> {
+        let mut extern_paths = ExternPaths {
+            extern_paths: HashMap::new(),
+        };
+
+        for (proto_path, rust_path) in paths {
+            extern_paths.insert(proto_path.clone(), rust_path.clone())?;
+        }
+
+        if prost_types {
+            extern_paths.insert(".google.protobuf".to_string(), "::prost_types".to_string())?;
+            extern_paths.insert(".google.protobuf.BoolValue".to_string(), "bool".to_string())?;
+            extern_paths.insert(
+                ".google.protobuf.BytesValue".to_string(),
+                "::std::vec::Vec<u8>".to_string(),
+            )?;
+            extern_paths.insert(
+                ".google.protobuf.DoubleValue".to_string(),
+                "f64".to_string(),
+            )?;
+            extern_paths.insert(".google.protobuf.Empty".to_string(), "()".to_string())?;
+            extern_paths.insert(".google.protobuf.FloatValue".to_string(), "f32".to_string())?;
+            extern_paths.insert(".google.protobuf.Int32Value".to_string(), "i32".to_string())?;
+            extern_paths.insert(".google.protobuf.Int64Value".to_string(), "i64".to_string())?;
+            extern_paths.insert(
+                ".google.protobuf.StringValue".to_string(),
+                "::std::string::String".to_string(),
+            )?;
+            extern_paths.insert(
+                ".google.protobuf.UInt32Value".to_string(),
+                "u32".to_string(),
+            )?;
+            extern_paths.insert(
+                ".google.protobuf.UInt64Value".to_string(),
+                "u64".to_string(),
+            )?;
+        }
+
+        Ok(extern_paths)
+    }
+
+    fn insert(&mut self, proto_path: String, rust_path: String) -> Result<(), String> {
+        validate_proto_path(&proto_path)?;
+        match self.extern_paths.entry(proto_path) {
+            hash_map::Entry::Occupied(occupied) => {
+                return Err(format!(
+                    "duplicate extern Protobuf path: {}",
+                    occupied.key()
+                ));
+            }
+            hash_map::Entry::Vacant(vacant) => vacant.insert(rust_path),
+        };
+        Ok(())
+    }
+
+    pub fn resolve_ident(&self, pb_ident: &str) -> Option<String> {
+        // protoc should always give fully qualified identifiers.
+        assert_eq!(".", &pb_ident[..1]);
+
+        if let Some(rust_path) = self.extern_paths.get(pb_ident) {
+            return Some(rust_path.clone());
+        }
+
+        // TODO(danburkert): there must be a more efficient way to do this, maybe a trie?
+        for (idx, _) in pb_ident.rmatch_indices('.') {
+            if let Some(rust_path) = self.extern_paths.get(&pb_ident[..idx]) {
+                let mut segments = pb_ident[idx + 1..].split('.');
+                let ident_type = segments.next_back().map(|segment| to_upper_camel(&segment));
+
+                return Some(
+                    rust_path
+                        .split("::")
+                        .chain(segments)
+                        .enumerate()
+                        .map(|(idx, segment)| {
+                            if idx == 0 && segment == "crate" {
+                                // If the first segment of the path is 'crate', then do not escape
+                                // it into a raw identifier, since it's being used as the keyword.
+                                segment.to_owned()
+                            } else {
+                                to_snake(&segment)
+                            }
+                        })
+                        .chain(ident_type.into_iter())
+                        .join("::"),
+                );
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_extern_paths() {
+        let paths = ExternPaths::new(
+            &[
+                (".foo".to_string(), "::foo1".to_string()),
+                (".foo.bar".to_string(), "::foo2".to_string()),
+                (".foo.baz".to_string(), "::foo3".to_string()),
+                (".foo.Fuzz".to_string(), "::foo4::Fuzz".to_string()),
+                (".a.b.c.d.e.f".to_string(), "::abc::def".to_string()),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let case = |proto_ident: &str, resolved_ident: &str| {
+            assert_eq!(paths.resolve_ident(proto_ident).unwrap(), resolved_ident);
+        };
+
+        case(".foo", "::foo1");
+        case(".foo.Foo", "::foo1::Foo");
+        case(".foo.bar", "::foo2");
+        case(".foo.Bas", "::foo1::Bas");
+
+        case(".foo.bar.Bar", "::foo2::Bar");
+        case(".foo.Fuzz.Bar", "::foo4::fuzz::Bar");
+
+        case(".a.b.c.d.e.f", "::abc::def");
+        case(".a.b.c.d.e.f.g.FooBar.Baz", "::abc::def::g::foo_bar::Baz");
+
+        assert!(paths.resolve_ident(".a").is_none());
+        assert!(paths.resolve_ident(".a.b").is_none());
+        assert!(paths.resolve_ident(".a.c").is_none());
+    }
+
+    #[test]
+    fn test_well_known_types() {
+        let paths = ExternPaths::new(&[], true).unwrap();
+
+        let case = |proto_ident: &str, resolved_ident: &str| {
+            assert_eq!(paths.resolve_ident(proto_ident).unwrap(), resolved_ident);
+        };
+
+        case(".google.protobuf.Value", "::prost_types::Value");
+        case(".google.protobuf.Duration", "::prost_types::Duration");
+        case(".google.protobuf.Empty", "()");
+    }
+}

--- a/third_party/prost/prost-build/src/goodbye.proto
+++ b/third_party/prost/prost-build/src/goodbye.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+import "types.proto";
+
+package helloworld;
+
+service Farewell {
+  rpc Goodbye (Message) returns (Response) {}
+}

--- a/third_party/prost/prost-build/src/hello.proto
+++ b/third_party/prost/prost-build/src/hello.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+import "types.proto";
+
+package helloworld;
+
+service Greeting {
+  rpc Hello (Message) returns (Response) {}
+}

--- a/third_party/prost/prost-build/src/ident.rs
+++ b/third_party/prost/prost-build/src/ident.rs
@@ -1,0 +1,236 @@
+//! Utility functions for working with identifiers.
+
+use heck::{CamelCase, SnakeCase};
+
+/// Converts a `camelCase` or `SCREAMING_SNAKE_CASE` identifier to a `lower_snake` case Rust field
+/// identifier.
+pub fn to_snake(s: &str) -> String {
+    let mut ident = s.to_snake_case();
+
+    // Use a raw identifier if the identifier matches a Rust keyword:
+    // https://doc.rust-lang.org/reference/keywords.html.
+    match ident.as_str() {
+        // 2015 strict keywords.
+        | "as" | "break" | "const" | "continue" | "else" | "enum" | "false"
+        | "fn" | "for" | "if" | "impl" | "in" | "let" | "loop" | "match" | "mod" | "move" | "mut"
+        | "pub" | "ref" | "return" | "static" | "struct" | "trait" | "true"
+        | "type" | "unsafe" | "use" | "where" | "while"
+        // 2018 strict keywords.
+        | "dyn"
+        // 2015 reserved keywords.
+        | "abstract" | "become" | "box" | "do" | "final" | "macro" | "override" | "priv" | "typeof"
+        | "unsized" | "virtual" | "yield"
+        // 2018 reserved keywords.
+        | "async" | "await" | "try" => ident.insert_str(0, "r#"),
+        // the following keywords are not supported as raw identifiers and are therefore suffixed with an underscore.
+        "self" | "super" | "extern" | "crate" => ident += "_",
+        _ => (),
+    }
+    ident
+}
+
+/// Converts a `snake_case` identifier to an `UpperCamel` case Rust type identifier.
+pub fn to_upper_camel(s: &str) -> String {
+    let mut ident = s.to_camel_case();
+
+    // Suffix an underscore for the `Self` Rust keyword as it is not allowed as raw identifier.
+    if ident == "Self" {
+        ident += "_";
+    }
+    ident
+}
+
+/// Matches a 'matcher' against a fully qualified identifier.
+pub fn match_ident(matcher: &str, msg: &str, field: Option<&str>) -> bool {
+    assert_eq!(b'.', msg.as_bytes()[0]);
+
+    if matcher.is_empty() {
+        return false;
+    } else if matcher == "." {
+        return true;
+    }
+
+    let match_paths = matcher.split('.').collect::<Vec<_>>();
+    let field_paths = {
+        let mut paths = msg.split('.').collect::<Vec<_>>();
+        if let Some(field) = field {
+            paths.push(field);
+        }
+        paths
+    };
+
+    if &matcher[..1] == "." {
+        // Prefix match.
+        if match_paths.len() > field_paths.len() {
+            false
+        } else {
+            match_paths[..] == field_paths[..match_paths.len()]
+        }
+    // Suffix match.
+    } else if match_paths.len() > field_paths.len() {
+        false
+    } else {
+        match_paths[..] == field_paths[field_paths.len() - match_paths.len()..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #![allow(clippy::cognitive_complexity)]
+
+    use super::*;
+
+    #[test]
+    fn test_to_snake() {
+        assert_eq!("foo_bar", &to_snake("FooBar"));
+        assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
+        assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
+        assert_eq!("xml_http_request", &to_snake("XMLHttpRequest"));
+        assert_eq!("r#while", &to_snake("While"));
+        assert_eq!("fuzz_buster", &to_snake("FUZZ_BUSTER"));
+        assert_eq!("foo_bar_baz", &to_snake("foo_bar_baz"));
+        assert_eq!("fuzz_buster", &to_snake("FUZZ_buster"));
+        assert_eq!("fuzz", &to_snake("_FUZZ"));
+        assert_eq!("fuzz", &to_snake("_fuzz"));
+        assert_eq!("fuzz", &to_snake("_Fuzz"));
+        assert_eq!("fuzz", &to_snake("FUZZ_"));
+        assert_eq!("fuzz", &to_snake("fuzz_"));
+        assert_eq!("fuzz", &to_snake("Fuzz_"));
+        assert_eq!("fuz_z", &to_snake("FuzZ_"));
+
+        // From test_messages_proto3.proto.
+        assert_eq!("fieldname1", &to_snake("fieldname1"));
+        assert_eq!("field_name2", &to_snake("field_name2"));
+        assert_eq!("field_name3", &to_snake("_field_name3"));
+        assert_eq!("field_name4", &to_snake("field__name4_"));
+        assert_eq!("field0name5", &to_snake("field0name5"));
+        assert_eq!("field_0_name6", &to_snake("field_0_name6"));
+        assert_eq!("field_name7", &to_snake("fieldName7"));
+        assert_eq!("field_name8", &to_snake("FieldName8"));
+        assert_eq!("field_name9", &to_snake("field_Name9"));
+        assert_eq!("field_name10", &to_snake("Field_Name10"));
+
+        // TODO(withoutboats/heck#3)
+        //assert_eq!("field_name11", &to_snake("FIELD_NAME11"));
+        assert_eq!("field_name12", &to_snake("FIELD_name12"));
+        assert_eq!("field_name13", &to_snake("__field_name13"));
+        assert_eq!("field_name14", &to_snake("__Field_name14"));
+        assert_eq!("field_name15", &to_snake("field__name15"));
+        assert_eq!("field_name16", &to_snake("field__Name16"));
+        assert_eq!("field_name17", &to_snake("field_name17__"));
+        assert_eq!("field_name18", &to_snake("Field_name18__"));
+    }
+
+    #[test]
+    fn test_to_snake_raw_keyword() {
+        assert_eq!("r#as", &to_snake("as"));
+        assert_eq!("r#break", &to_snake("break"));
+        assert_eq!("r#const", &to_snake("const"));
+        assert_eq!("r#continue", &to_snake("continue"));
+        assert_eq!("r#else", &to_snake("else"));
+        assert_eq!("r#enum", &to_snake("enum"));
+        assert_eq!("r#false", &to_snake("false"));
+        assert_eq!("r#fn", &to_snake("fn"));
+        assert_eq!("r#for", &to_snake("for"));
+        assert_eq!("r#if", &to_snake("if"));
+        assert_eq!("r#impl", &to_snake("impl"));
+        assert_eq!("r#in", &to_snake("in"));
+        assert_eq!("r#let", &to_snake("let"));
+        assert_eq!("r#loop", &to_snake("loop"));
+        assert_eq!("r#match", &to_snake("match"));
+        assert_eq!("r#mod", &to_snake("mod"));
+        assert_eq!("r#move", &to_snake("move"));
+        assert_eq!("r#mut", &to_snake("mut"));
+        assert_eq!("r#pub", &to_snake("pub"));
+        assert_eq!("r#ref", &to_snake("ref"));
+        assert_eq!("r#return", &to_snake("return"));
+        assert_eq!("r#static", &to_snake("static"));
+        assert_eq!("r#struct", &to_snake("struct"));
+        assert_eq!("r#trait", &to_snake("trait"));
+        assert_eq!("r#true", &to_snake("true"));
+        assert_eq!("r#type", &to_snake("type"));
+        assert_eq!("r#unsafe", &to_snake("unsafe"));
+        assert_eq!("r#use", &to_snake("use"));
+        assert_eq!("r#where", &to_snake("where"));
+        assert_eq!("r#while", &to_snake("while"));
+        assert_eq!("r#dyn", &to_snake("dyn"));
+        assert_eq!("r#abstract", &to_snake("abstract"));
+        assert_eq!("r#become", &to_snake("become"));
+        assert_eq!("r#box", &to_snake("box"));
+        assert_eq!("r#do", &to_snake("do"));
+        assert_eq!("r#final", &to_snake("final"));
+        assert_eq!("r#macro", &to_snake("macro"));
+        assert_eq!("r#override", &to_snake("override"));
+        assert_eq!("r#priv", &to_snake("priv"));
+        assert_eq!("r#typeof", &to_snake("typeof"));
+        assert_eq!("r#unsized", &to_snake("unsized"));
+        assert_eq!("r#virtual", &to_snake("virtual"));
+        assert_eq!("r#yield", &to_snake("yield"));
+        assert_eq!("r#async", &to_snake("async"));
+        assert_eq!("r#await", &to_snake("await"));
+        assert_eq!("r#try", &to_snake("try"));
+    }
+
+    #[test]
+    fn test_to_snake_non_raw_keyword() {
+        assert_eq!("self_", &to_snake("self"));
+        assert_eq!("super_", &to_snake("super"));
+        assert_eq!("extern_", &to_snake("extern"));
+        assert_eq!("crate_", &to_snake("crate"));
+    }
+
+    #[test]
+    fn test_to_upper_camel() {
+        assert_eq!("", &to_upper_camel(""));
+        assert_eq!("F", &to_upper_camel("F"));
+        assert_eq!("Foo", &to_upper_camel("FOO"));
+        assert_eq!("FooBar", &to_upper_camel("FOO_BAR"));
+        assert_eq!("FooBar", &to_upper_camel("_FOO_BAR"));
+        assert_eq!("FooBar", &to_upper_camel("FOO_BAR_"));
+        assert_eq!("FooBar", &to_upper_camel("_FOO_BAR_"));
+        assert_eq!("FuzzBuster", &to_upper_camel("fuzzBuster"));
+        assert_eq!("FuzzBuster", &to_upper_camel("FuzzBuster"));
+        assert_eq!("Self_", &to_upper_camel("self"));
+    }
+
+    #[test]
+    fn test_match_ident() {
+        // Prefix matches
+        assert!(match_ident(".", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident(".foo", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident(".foo.bar", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident(".foo.bar.Baz", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident(
+            ".foo.bar.Baz.buzz",
+            ".foo.bar.Baz",
+            Some("buzz")
+        ));
+
+        assert!(!match_ident(".fo", ".foo.bar.Baz", Some("buzz")));
+        assert!(!match_ident(".foo.", ".foo.bar.Baz", Some("buzz")));
+        assert!(!match_ident(".buzz", ".foo.bar.Baz", Some("buzz")));
+        assert!(!match_ident(".Baz.buzz", ".foo.bar.Baz", Some("buzz")));
+
+        // Suffix matches
+        assert!(match_ident("buzz", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident("Baz.buzz", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident("bar.Baz.buzz", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident(
+            "foo.bar.Baz.buzz",
+            ".foo.bar.Baz",
+            Some("buzz")
+        ));
+
+        assert!(!match_ident("buz", ".foo.bar.Baz", Some("buzz")));
+        assert!(!match_ident("uz", ".foo.bar.Baz", Some("buzz")));
+
+        // Type names
+        assert!(match_ident("Baz", ".foo.bar.Baz", None));
+        assert!(match_ident(".", ".foo.bar.Baz", None));
+        assert!(match_ident(".foo.bar", ".foo.bar.Baz", None));
+        assert!(match_ident(".foo.bar.Baz", ".foo.bar.Baz", None));
+        assert!(!match_ident(".fo", ".foo.bar.Baz", None));
+        assert!(!match_ident(".buzz.Baz", ".foo.bar.Baz", None));
+    }
+}

--- a/third_party/prost/prost-build/src/lib.rs
+++ b/third_party/prost/prost-build/src/lib.rs
@@ -1,0 +1,813 @@
+#![doc(html_root_url = "https://docs.rs/prost-build/0.6.1")]
+#![allow(clippy::option_as_ref_deref)]
+
+//! `prost-build` compiles `.proto` files into Rust.
+//!
+//! `prost-build` is designed to be used for build-time code generation as part of a Cargo
+//! build-script.
+//!
+//! ## Example
+//!
+//! Let's create a small crate, `snazzy`, that defines a collection of
+//! snazzy new items in a protobuf file.
+//!
+//! ```bash
+//! $ cargo new snazzy && cd snazzy
+//! ```
+//!
+//! First, add `prost-build`, `prost` and its public dependencies to `Cargo.toml`
+//! (see [crates.io](https://crates.io/crates/prost) for the current versions):
+//!
+//! ```toml
+//! [dependencies]
+//! bytes = <bytes-version>
+//! prost = <prost-version>
+//!
+//! [build-dependencies]
+//! prost-build = { version = <prost-version> }
+//! ```
+//!
+//! Next, add `src/items.proto` to the project:
+//!
+//! ```proto
+//! syntax = "proto3";
+//!
+//! package snazzy.items;
+//!
+//! // A snazzy new shirt!
+//! message Shirt {
+//! enum Size {
+//!     SMALL = 0;
+//!     MEDIUM = 1;
+//!     LARGE = 2;
+//! }
+//!
+//! string color = 1;
+//! Size size = 2;
+//! }
+//! ```
+//!
+//! To generate Rust code from `items.proto`, we use `prost-build` in the crate's
+//! `build.rs` build-script:
+//!
+//! ```rust,no_run
+//! # use std::io::Result;
+//! fn main() -> Result<()> {
+//!   prost_build::compile_protos(&["src/items.proto"], &["src/"])?;
+//!   Ok(())
+//! }
+//! ```
+//!
+//! And finally, in `lib.rs`, include the generated code:
+//!
+//! ```rust,ignore
+//! // Include the `items` module, which is generated from items.proto.
+//! pub mod items {
+//!     include!(concat!(env!("OUT_DIR"), "/snazzy.items.rs"));
+//! }
+//!
+//! pub fn create_large_shirt(color: String) -> items::Shirt {
+//!     let mut shirt = items::Shirt::default();
+//!     shirt.color = color;
+//!     shirt.set_size(items::shirt::Size::Large);
+//!     shirt
+//! }
+//! ```
+//!
+//! That's it! Run `cargo doc` to see documentation for the generated code. The full
+//! example project can be found on [GitHub](https://github.com/danburkert/snazzy).
+//!
+//! ## Sourcing `protoc`
+//!
+//! `prost-build` depends on the Protocol Buffers compiler, `protoc`, to parse `.proto` files into
+//! a representation that can be transformed into Rust. If set, `prost-build` uses the `PROTOC` and
+//! `PROTOC_INCLUDE` environment variables for locating `protoc` and the Protobuf includes
+//! directory. For example, on a macOS system where Protobuf is installed with Homebrew, set the
+//! environment to:
+//!
+//! ```bash
+//! PROTOC=/usr/local/bin/protoc
+//! PROTOC_INCLUDE=/usr/local/include
+//! ```
+//!
+//! and in a typical Linux installation:
+//!
+//! ```bash
+//! PROTOC=/usr/bin/protoc
+//! PROTOC_INCLUDE=/usr/include
+//! ```
+//!
+//! If `PROTOC` is not found in the environment, then a pre-compiled `protoc` binary bundled in
+//! the prost-build crate is used. Pre-compiled `protoc` binaries exist for Linux, macOS, and
+//! Windows systems. If no pre-compiled `protoc` is available for the host platform, then the
+//! `protoc` or `protoc.exe` binary on the `PATH` is used. If `protoc` is not available in any of
+//! these fallback locations, then the build fails.
+//!
+//! If `PROTOC_INCLUDE` is not found in the environment, then the Protobuf include directory bundled
+//! in the prost-build crate is be used.
+
+mod ast;
+mod code_generator;
+mod extern_paths;
+mod ident;
+mod message_graph;
+
+use std::collections::HashMap;
+use std::default;
+use std::env;
+use std::fmt;
+use std::fs;
+use std::io::{Error, ErrorKind, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use log::trace;
+use prost::Message;
+use prost_types::{FileDescriptorProto, FileDescriptorSet};
+
+pub use crate::ast::{Comments, Method, Service};
+use crate::code_generator::CodeGenerator;
+use crate::extern_paths::ExternPaths;
+use crate::ident::to_snake;
+use crate::message_graph::MessageGraph;
+
+type Module = Vec<String>;
+
+/// A service generator takes a service descriptor and generates Rust code.
+///
+/// `ServiceGenerator` can be used to generate application-specific interfaces
+/// or implementations for Protobuf service definitions.
+///
+/// Service generators are registered with a code generator using the
+/// `Config::service_generator` method.
+///
+/// A viable scenario is that an RPC framework provides a service generator. It generates a trait
+/// describing methods of the service and some glue code to call the methods of the trait, defining
+/// details like how errors are handled or if it is asynchronous. Then the user provides an
+/// implementation of the generated trait in the application code and plugs it into the framework.
+///
+/// Such framework isn't part of Prost at present.
+pub trait ServiceGenerator {
+    /// Generates a Rust interface or implementation for a service, writing the
+    /// result to `buf`.
+    fn generate(&mut self, service: Service, buf: &mut String);
+
+    /// Finalizes the generation process.
+    ///
+    /// In case there's something that needs to be output at the end of the generation process, it
+    /// goes here. Similar to [`generate`](#method.generate), the output should be appended to
+    /// `buf`.
+    ///
+    /// An example can be a module or other thing that needs to appear just once, not for each
+    /// service generated.
+    ///
+    /// This still can be called multiple times in a lifetime of the service generator, because it
+    /// is called once per `.proto` file.
+    ///
+    /// The default implementation is empty and does nothing.
+    fn finalize(&mut self, _buf: &mut String) {}
+
+    /// Finalizes the generation process for an entire protobuf package.
+    ///
+    /// This differs from [`finalize`](#method.finalize) by where (and how often) it is called
+    /// during the service generator life cycle. This method is called once per protobuf package,
+    /// making it ideal for grouping services within a single package spread across multiple
+    /// `.proto` files.
+    ///
+    /// The default implementation is empty and does nothing.
+    fn finalize_package(&mut self, _package: &str, _buf: &mut String) {}
+}
+
+/// Configuration options for Protobuf code generation.
+///
+/// This configuration builder can be used to set non-default code generation options.
+pub struct Config {
+    service_generator: Option<Box<dyn ServiceGenerator>>,
+    btree_map: Vec<String>,
+    type_attributes: Vec<(String, String)>,
+    field_attributes: Vec<(String, String)>,
+    prost_types: bool,
+    strip_enum_prefix: bool,
+    out_dir: Option<PathBuf>,
+    extern_paths: Vec<(String, String)>,
+}
+
+impl Config {
+    /// Creates a new code generator configuration with default options.
+    pub fn new() -> Config {
+        Config::default()
+    }
+
+    /// Configure the code generator to generate Rust [`BTreeMap`][1] fields for Protobuf
+    /// [`map`][2] type fields.
+    ///
+    /// # Arguments
+    ///
+    /// **`paths`** - paths to specific fields, messages, or packages which should use a Rust
+    /// `BTreeMap` for Protobuf `map` fields. Paths are specified in terms of the Protobuf type
+    /// name (not the generated Rust type name). Paths with a leading `.` are treated as fully
+    /// qualified names. Paths without a leading `.` are treated as relative, and are suffix
+    /// matched on the fully qualified field name. If a Protobuf map field matches any of the
+    /// paths, a Rust `BTreeMap` field is generated instead of the default [`HashMap`][3].
+    ///
+    /// The matching is done on the Protobuf names, before converting to Rust-friendly casing
+    /// standards.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # let mut config = prost_build::Config::new();
+    /// // Match a specific field in a message type.
+    /// config.btree_map(&[".my_messages.MyMessageType.my_map_field"]);
+    ///
+    /// // Match all map fields in a message type.
+    /// config.btree_map(&[".my_messages.MyMessageType"]);
+    ///
+    /// // Match all map fields in a package.
+    /// config.btree_map(&[".my_messages"]);
+    ///
+    /// // Match all map fields. Expecially useful in `no_std` contexts.
+    /// config.btree_map(&["."]);
+    ///
+    /// // Match all map fields in a nested message.
+    /// config.btree_map(&[".my_messages.MyMessageType.MyNestedMessageType"]);
+    ///
+    /// // Match all fields named 'my_map_field'.
+    /// config.btree_map(&["my_map_field"]);
+    ///
+    /// // Match all fields named 'my_map_field' in messages named 'MyMessageType', regardless of
+    /// // package or nesting.
+    /// config.btree_map(&["MyMessageType.my_map_field"]);
+    ///
+    /// // Match all fields named 'my_map_field', and all fields in the 'foo.bar' package.
+    /// config.btree_map(&["my_map_field", ".foo.bar"]);
+    /// ```
+    ///
+    /// [1]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
+    /// [2]: https://developers.google.com/protocol-buffers/docs/proto3#maps
+    /// [3]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
+    pub fn btree_map<I, S>(&mut self, paths: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.btree_map = paths.into_iter().map(|s| s.as_ref().to_string()).collect();
+        self
+    }
+
+    /// Add additional attribute to matched fields.
+    ///
+    /// # Arguments
+    ///
+    /// **`path`** - a patch matching any number of fields. These fields get the attribute.
+    /// For details about matching fields see [`btree_map`](#method.btree_map).
+    ///
+    /// **`attribute`** - an arbitrary string that'll be placed before each matched field. The
+    /// expected usage are additional attributes, usually in concert with whole-type
+    /// attributes set with [`type_attribute`](method.type_attribute), but it is not
+    /// checked and anything can be put there.
+    ///
+    /// Note that the calls to this method are cumulative ‒ if multiple paths from multiple calls
+    /// match the same field, the field gets all the corresponding attributes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # let mut config = prost_build::Config::new();
+    /// // Prost renames fields named `in` to `in_`. But if serialized through serde,
+    /// // they should as `in`.
+    /// config.field_attribute("in", "#[serde(rename = \"in\")]");
+    /// ```
+    pub fn field_attribute<P, A>(&mut self, path: P, attribute: A) -> &mut Self
+    where
+        P: AsRef<str>,
+        A: AsRef<str>,
+    {
+        self.field_attributes
+            .push((path.as_ref().to_string(), attribute.as_ref().to_string()));
+        self
+    }
+
+    /// Add additional attribute to matched messages, enums and one-ofs.
+    ///
+    /// # Arguments
+    ///
+    /// **`paths`** - a path matching any number of types. It works the same way as in
+    /// [`btree_map`](#method.btree_map), just with the field name omitted.
+    ///
+    /// **`attribute`** - an arbitrary string to be placed before each matched type. The
+    /// expected usage are additional attributes, but anything is allowed.
+    ///
+    /// The calls to this method are cumulative. They don't overwrite previous calls and if a
+    /// type is matched by multiple calls of the method, all relevant attributes are added to
+    /// it.
+    ///
+    /// For things like serde it might be needed to combine with [field
+    /// attributes](#method.field_attribute).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # let mut config = prost_build::Config::new();
+    /// // Nothing around uses floats, so we can derive real `Eq` in addition to `PartialEq`.
+    /// config.type_attribute(".", "#[derive(Eq)]");
+    /// // Some messages want to be serializable with serde as well.
+    /// config.type_attribute("my_messages.MyMessageType",
+    ///                       "#[derive(Serialize)] #[serde(rename-all = \"snake_case\")]");
+    /// config.type_attribute("my_messages.MyMessageType.MyNestedMessageType",
+    ///                       "#[derive(Serialize)] #[serde(rename-all = \"snake_case\")]");
+    /// ```
+    ///
+    /// # Oneof fields
+    ///
+    /// The `oneof` fields don't have a type name of their own inside Protobuf. Therefore, the
+    /// field name can be used both with `type_attribute` and `field_attribute` ‒ the first is
+    /// placed before the `enum` type definition, the other before the field inside corresponding
+    /// message `struct`.
+    ///
+    /// In other words, to place an attribute on the `enum` implementing the `oneof`, the match
+    /// would look like `my_messages.MyMessageType.oneofname`.
+    pub fn type_attribute<P, A>(&mut self, path: P, attribute: A) -> &mut Self
+    where
+        P: AsRef<str>,
+        A: AsRef<str>,
+    {
+        self.type_attributes
+            .push((path.as_ref().to_string(), attribute.as_ref().to_string()));
+        self
+    }
+
+    /// Configures the code generator to use the provided service generator.
+    pub fn service_generator(&mut self, service_generator: Box<dyn ServiceGenerator>) -> &mut Self {
+        self.service_generator = Some(service_generator);
+        self
+    }
+
+    /// Configures the code generator to not use the `prost_types` crate for Protobuf well-known
+    /// types, and instead generate Protobuf well-known types from their `.proto` definitions.
+    pub fn compile_well_known_types(&mut self) -> &mut Self {
+        self.prost_types = false;
+        self
+    }
+
+    /// Declare an externally provided Protobuf package or type.
+    ///
+    /// `extern_path` allows `prost` types in external crates to be referenced in generated code.
+    ///
+    /// When `prost` compiles a `.proto` which includes an import of another `.proto`, it will
+    /// automatically recursively compile the imported file as well. `extern_path` can be used
+    /// to instead substitute types from an external crate.
+    ///
+    /// # Example
+    ///
+    /// As an example, consider a crate, `uuid`, with a `prost`-generated `Uuid` type:
+    ///
+    /// ```proto
+    /// // uuid.proto
+    ///
+    /// syntax = "proto3";
+    /// package uuid;
+    ///
+    /// message Uuid {
+    ///     string uuid_str = 1;
+    /// }
+    /// ```
+    ///
+    /// The `uuid` crate implements some traits for `Uuid`, and publicly exports it:
+    ///
+    /// ```rust,ignore
+    /// // lib.rs in the uuid crate
+    ///
+    /// include!(concat!(env!("OUT_DIR"), "/uuid.rs"));
+    ///
+    /// pub trait DoSomething {
+    ///     fn do_it(&self);
+    /// }
+    ///
+    /// impl DoSomething for Uuid {
+    ///     fn do_it(&self) {
+    ///         println!("Done");
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// A separate crate, `my_application`, uses `prost` to generate message types which reference
+    /// `Uuid`:
+    ///
+    /// ```proto
+    /// // my_application.proto
+    ///
+    /// syntax = "proto3";
+    /// package my_application;
+    ///
+    /// import "uuid.proto";
+    ///
+    /// message MyMessage {
+    ///     uuid.Uuid message_id = 1;
+    ///     string some_payload = 2;
+    /// }
+    /// ```
+    ///
+    /// Additionally, `my_application` depends on the trait impls provided by the `uuid` crate:
+    ///
+    /// ```rust,ignore
+    /// // `main.rs` of `my_application`
+    ///
+    /// use uuid::{DoSomething, Uuid};
+    ///
+    /// include!(concat!(env!("OUT_DIR"), "/my_application.rs"));
+    ///
+    /// pub fn process_message(msg: MyMessage) {
+    ///     if let Some(uuid) = msg.message_id {
+    ///         uuid.do_it();
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Without configuring `uuid` as an external path in `my_application`'s `build.rs`, `prost`
+    /// would compile a completely separate version of the `Uuid` type, and `process_message` would
+    /// fail to compile. However, if `my_application` configures `uuid` as an extern path with a
+    /// call to `.extern_path(".uuid", "::uuid")`, `prost` will use the external type instead of
+    /// compiling a new version of `Uuid`. Note that the configuration could also be specified as
+    /// `.extern_path(".uuid.Uuid", "::uuid::Uuid")` if only the `Uuid` type were externally
+    /// provided, and not the whole `uuid` package.
+    ///
+    /// # Usage
+    ///
+    /// `extern_path` takes a fully-qualified Protobuf path, and the corresponding Rust path that
+    /// it will be substituted with in generated code. The Protobuf path can refer to a package or
+    /// a type, and the Rust path should correspondingly refer to a Rust module or type.
+    ///
+    /// ```rust
+    /// # let mut config = prost_build::Config::new();
+    /// // Declare the `uuid` Protobuf package and all nested packages and types as externally
+    /// // provided by the `uuid` crate.
+    /// config.extern_path(".uuid", "::uuid");
+    ///
+    /// // Declare the `foo.bar.baz` Protobuf package and all nested packages and types as
+    /// // externally provided by the `foo_bar_baz` crate.
+    /// config.extern_path(".foo.bar.baz", "::foo_bar_baz");
+    ///
+    /// // Declare the `uuid.Uuid` Protobuf type (and all nested types) as externally provided
+    /// // by the `uuid` crate's `Uuid` type.
+    /// config.extern_path(".uuid.Uuid", "::uuid::Uuid");
+    /// ```
+    pub fn extern_path<P1, P2>(&mut self, proto_path: P1, rust_path: P2) -> &mut Self
+    where
+        P1: Into<String>,
+        P2: Into<String>,
+    {
+        self.extern_paths
+            .push((proto_path.into(), rust_path.into()));
+        self
+    }
+
+    /// Configures the code generator to not strip the enum name from variant names.
+    ///
+    /// Protobuf enum definitions commonly include the enum name as a prefix of every variant name.
+    /// This style is non-idiomatic in Rust, so by default `prost` strips the enum name prefix from
+    /// variants which include it. Configuring this option prevents `prost` from stripping the
+    /// prefix.
+    pub fn retain_enum_prefix(&mut self) -> &mut Self {
+        self.strip_enum_prefix = false;
+        self
+    }
+
+    /// Configures the output directory where generated Rust files will be written.
+    ///
+    /// If unset, defaults to the `OUT_DIR` environment variable. `OUT_DIR` is set by Cargo when
+    /// executing build scripts, so `out_dir` typically does not need to be configured.
+    pub fn out_dir<P>(&mut self, path: P) -> &mut Self
+    where
+        P: Into<PathBuf>,
+    {
+        self.out_dir = Some(path.into());
+        self
+    }
+
+    /// Compile `.proto` files into Rust files during a Cargo build with additional code generator
+    /// configuration options.
+    ///
+    /// This method is like the `prost_build::compile_protos` function, with the added ability to
+    /// specify non-default code generation options. See that function for more information about
+    /// the arguments and generated outputs.
+    ///
+    /// # Example `build.rs`
+    ///
+    /// ```rust,no_run
+    /// # use std::io::Result;
+    /// fn main() -> Result<()> {
+    ///   let mut prost_build = prost_build::Config::new();
+    ///   prost_build.btree_map(&["."]);
+    ///   prost_build.compile_protos(&["src/frontend.proto", "src/backend.proto"], &["src"])?;
+    ///   Ok(())
+    /// }
+    /// ```
+    pub fn compile_protos<P>(&mut self, protos: &[P], includes: &[P]) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let target: PathBuf = self.out_dir.clone().map(Ok).unwrap_or_else(|| {
+            env::var_os("OUT_DIR")
+                .ok_or_else(|| {
+                    Error::new(ErrorKind::Other, "OUT_DIR environment variable is not set")
+                })
+                .map(Into::into)
+        })?;
+
+        // TODO: This should probably emit 'rerun-if-changed=PATH' directives for cargo, however
+        // according to [1] if any are output then those paths replace the default crate root,
+        // which is undesirable. Figure out how to do it in an additive way; perhaps gcc-rs has
+        // this figured out.
+        // [1]: http://doc.crates.io/build-script.html#outputs-of-the-build-script
+
+        let tmp = tempfile::Builder::new().prefix("prost-build").tempdir()?;
+        let descriptor_set = tmp.path().join("prost-descriptor-set");
+
+        let mut cmd = Command::new(protoc());
+        cmd.arg("--include_imports")
+            .arg("--include_source_info")
+            .arg("-o")
+            .arg(&descriptor_set);
+
+        for include in includes {
+            cmd.arg("-I").arg(include.as_ref());
+        }
+
+        // Set the protoc include after the user includes in case the user wants to
+        // override one of the built-in .protos.
+        cmd.arg("-I").arg(protoc_include());
+
+        for proto in protos {
+            cmd.arg(proto.as_ref());
+        }
+
+        let output = cmd.output()?;
+        if !output.status.success() {
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!("protoc failed: {}", String::from_utf8_lossy(&output.stderr)),
+            ));
+        }
+
+        let buf = fs::read(descriptor_set)?;
+        let descriptor_set = FileDescriptorSet::decode(&*buf).map_err(|error| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                format!("invalid FileDescriptorSet: {}", error.to_string()),
+            )
+        })?;
+
+        let modules = self.generate(descriptor_set.file)?;
+        for (module, content) in modules {
+            let mut filename = module.join(".");
+            filename.push_str(".rs");
+
+            let output_path = target.join(&filename);
+
+            let previous_content = fs::read(&output_path);
+
+            if previous_content
+                .map(|previous_content| previous_content == content.as_bytes())
+                .unwrap_or(false)
+            {
+                trace!("unchanged: {:?}", filename);
+            } else {
+                trace!("writing: {:?}", filename);
+                fs::write(output_path, content)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn generate(&mut self, files: Vec<FileDescriptorProto>) -> Result<HashMap<Module, String>> {
+        let mut modules = HashMap::new();
+        let mut packages = HashMap::new();
+
+        let message_graph = MessageGraph::new(&files)
+            .map_err(|error| Error::new(ErrorKind::InvalidInput, error))?;
+        let extern_paths = ExternPaths::new(&self.extern_paths, self.prost_types)
+            .map_err(|error| Error::new(ErrorKind::InvalidInput, error))?;
+
+        for file in files {
+            let module = self.module(&file);
+
+            // Only record packages that have services
+            if !file.service.is_empty() {
+                packages.insert(module.clone(), file.package().to_string());
+            }
+
+            let mut buf = modules.entry(module).or_insert_with(String::new);
+            CodeGenerator::generate(self, &message_graph, &extern_paths, file, &mut buf);
+        }
+
+        if let Some(ref mut service_generator) = self.service_generator {
+            for (module, package) in packages {
+                let buf = modules.get_mut(&module).unwrap();
+                service_generator.finalize_package(&package, buf);
+            }
+        }
+
+        Ok(modules)
+    }
+
+    fn module(&self, file: &FileDescriptorProto) -> Module {
+        file.package()
+            .split('.')
+            .filter(|s| !s.is_empty())
+            .map(to_snake)
+            .collect()
+    }
+}
+
+impl default::Default for Config {
+    fn default() -> Config {
+        Config {
+            service_generator: None,
+            btree_map: Vec::new(),
+            type_attributes: Vec::new(),
+            field_attributes: Vec::new(),
+            prost_types: true,
+            strip_enum_prefix: true,
+            out_dir: None,
+            extern_paths: Vec::new(),
+        }
+    }
+}
+
+impl fmt::Debug for Config {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Config")
+            .field("btree_map", &self.btree_map)
+            .field("type_attributes", &self.type_attributes)
+            .field("field_attributes", &self.field_attributes)
+            .field("prost_types", &self.prost_types)
+            .field("strip_enum_prefix", &self.strip_enum_prefix)
+            .field("out_dir", &self.out_dir)
+            .field("extern_paths", &self.extern_paths)
+            .finish()
+    }
+}
+
+/// Compile `.proto` files into Rust files during a Cargo build.
+///
+/// The generated `.rs` files are written to the Cargo `OUT_DIR` directory, suitable for use with
+/// the [include!][1] macro. See the [Cargo `build.rs` code generation][2] example for more info.
+///
+/// This function should be called in a project's `build.rs`.
+///
+/// # Arguments
+///
+/// **`protos`** - Paths to `.proto` files to compile. Any transitively [imported][3] `.proto`
+/// files are automatically be included.
+///
+/// **`includes`** - Paths to directories in which to search for imports. Directories are searched
+/// in order. The `.proto` files passed in **`protos`** must be found in one of the provided
+/// include directories.
+///
+/// # Errors
+///
+/// This function can fail for a number of reasons:
+///
+///   - Failure to locate or download `protoc`.
+///   - Failure to parse the `.proto`s.
+///   - Failure to locate an imported `.proto`.
+///   - Failure to compile a `.proto` without a [package specifier][4].
+///
+/// It's expected that this function call be `unwrap`ed in a `build.rs`; there is typically no
+/// reason to gracefully recover from errors during a build.
+///
+/// # Example `build.rs`
+///
+/// ```rust,no_run
+/// # use std::io::Result;
+/// fn main() -> Result<()> {
+///   prost_build::compile_protos(&["src/frontend.proto", "src/backend.proto"], &["src"])?;
+///   Ok(())
+/// }
+/// ```
+///
+/// [1]: https://doc.rust-lang.org/std/macro.include.html
+/// [2]: http://doc.crates.io/build-script.html#case-study-code-generation
+/// [3]: https://developers.google.com/protocol-buffers/docs/proto3#importing-definitions
+/// [4]: https://developers.google.com/protocol-buffers/docs/proto#packages
+pub fn compile_protos<P>(protos: &[P], includes: &[P]) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    Config::new().compile_protos(protos, includes)
+}
+
+/// Returns the path to the `protoc` binary.
+pub fn protoc() -> PathBuf {
+    match env::var_os("PROTOC") {
+        Some(protoc) => PathBuf::from(protoc),
+        None => PathBuf::from(env!("PROTOC")),
+    }
+}
+
+/// Returns the path to the Protobuf include directory.
+pub fn protoc_include() -> PathBuf {
+    match env::var_os("PROTOC_INCLUDE") {
+        Some(include) => PathBuf::from(include),
+        None => PathBuf::from(env!("PROTOC_INCLUDE")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// An example service generator that generates a trait with methods corresponding to the
+    /// service methods.
+    struct ServiceTraitGenerator;
+    impl ServiceGenerator for ServiceTraitGenerator {
+        fn generate(&mut self, service: Service, buf: &mut String) {
+            // Generate a trait for the service.
+            service.comments.append_with_indent(0, buf);
+            buf.push_str(&format!("trait {} {{\n", &service.name));
+
+            // Generate the service methods.
+            for method in service.methods {
+                method.comments.append_with_indent(1, buf);
+                buf.push_str(&format!(
+                    "    fn {}({}) -> {};\n",
+                    method.name, method.input_type, method.output_type
+                ));
+            }
+
+            // Close out the trait.
+            buf.push_str("}\n");
+        }
+        fn finalize(&mut self, buf: &mut String) {
+            // Needs to be present only once, no matter how many services there are
+            buf.push_str("pub mod utils { }\n");
+        }
+    }
+
+    /// Implements `ServiceGenerator` and provides some state for assertions.
+    struct MockServiceGenerator {
+        state: Rc<RefCell<MockState>>,
+    }
+
+    /// Holds state for `MockServiceGenerator`
+    #[derive(Default)]
+    struct MockState {
+        service_names: Vec<String>,
+        package_names: Vec<String>,
+        finalized: u32,
+    }
+
+    impl MockServiceGenerator {
+        fn new(state: Rc<RefCell<MockState>>) -> Self {
+            Self { state }
+        }
+    }
+
+    impl ServiceGenerator for MockServiceGenerator {
+        fn generate(&mut self, service: Service, _buf: &mut String) {
+            let mut state = self.state.borrow_mut();
+            state.service_names.push(service.name);
+        }
+
+        fn finalize(&mut self, _buf: &mut String) {
+            let mut state = self.state.borrow_mut();
+            state.finalized += 1;
+        }
+
+        fn finalize_package(&mut self, package: &str, _buf: &mut String) {
+            let mut state = self.state.borrow_mut();
+            state.package_names.push(package.to_string());
+        }
+    }
+
+    #[test]
+    fn smoke_test() {
+        let _ = env_logger::try_init();
+        Config::new()
+            .service_generator(Box::new(ServiceTraitGenerator))
+            .compile_protos(&["src/smoke_test.proto"], &["src"])
+            .unwrap();
+    }
+
+    #[test]
+    fn finalize_package() {
+        let _ = env_logger::try_init();
+
+        let state = Rc::new(RefCell::new(MockState::default()));
+        let gen = MockServiceGenerator::new(Rc::clone(&state));
+
+        Config::new()
+            .service_generator(Box::new(gen))
+            .compile_protos(&["src/hello.proto", "src/goodbye.proto"], &["src"])
+            .unwrap();
+
+        let state = state.borrow();
+        assert_eq!(&state.service_names, &["Greeting", "Farewell"]);
+        assert_eq!(&state.package_names, &["helloworld"]);
+        assert_eq!(state.finalized, 3);
+    }
+}

--- a/third_party/prost/prost-build/src/message_graph.rs
+++ b/third_party/prost/prost-build/src/message_graph.rs
@@ -1,0 +1,91 @@
+use std::collections::HashMap;
+
+use petgraph::algo::has_path_connecting;
+use petgraph::graph::NodeIndex;
+use petgraph::Graph;
+
+use prost_types::{field_descriptor_proto, DescriptorProto, FileDescriptorProto};
+
+/// `MessageGraph` builds a graph of messages whose edges correspond to nesting.
+/// The goal is to recognize when message types are recursively nested, so
+/// that fields can be boxed when necessary.
+pub struct MessageGraph {
+    index: HashMap<String, NodeIndex>,
+    graph: Graph<String, ()>,
+}
+
+impl MessageGraph {
+    pub fn new(files: &[FileDescriptorProto]) -> Result<MessageGraph, String> {
+        let mut msg_graph = MessageGraph {
+            index: HashMap::new(),
+            graph: Graph::new(),
+        };
+
+        for file in files {
+            let package = format!(
+                ".{}",
+                file.package.as_ref().ok_or_else(|| {
+                    format!(
+                        "prost requires a package specifier in all .proto files \
+                         (https://developers.google.com/protocol-buffers/docs/proto#packages); \
+                         file with missing package specifier: {}",
+                        file.name.as_ref().map_or("(unknown)", String::as_ref),
+                    )
+                })?,
+            );
+            for msg in &file.message_type {
+                msg_graph.add_message(&package, msg);
+            }
+        }
+
+        Ok(msg_graph)
+    }
+
+    fn get_or_insert_index(&mut self, msg_name: String) -> NodeIndex {
+        let MessageGraph {
+            ref mut index,
+            ref mut graph,
+        } = *self;
+        assert_eq!(b'.', msg_name.as_bytes()[0]);
+        *index
+            .entry(msg_name.clone())
+            .or_insert_with(|| graph.add_node(msg_name))
+    }
+
+    /// Adds message to graph IFF it contains a non-repeated field containing another message.
+    /// The purpose of the message graph is detecting recursively nested messages and co-recursively nested messages.
+    /// Because prost does not box message fields, recursively nested messages would not compile in Rust.
+    /// To allow recursive messages, the message graph is used to detect recursion and automatically box the recursive field.
+    /// Since repeated messages are already put in a Vec, boxing them isn’t necessary even if the reference is recursive.
+    fn add_message(&mut self, package: &str, msg: &DescriptorProto) {
+        let msg_name = format!("{}.{}", package, msg.name.as_ref().unwrap());
+        let msg_index = self.get_or_insert_index(msg_name.clone());
+
+        for field in &msg.field {
+            if field.r#type() == field_descriptor_proto::Type::Message
+                && field.label() != field_descriptor_proto::Label::Repeated
+            {
+                let field_index = self.get_or_insert_index(field.type_name.clone().unwrap());
+                self.graph.add_edge(msg_index, field_index, ());
+            }
+        }
+
+        for msg in &msg.nested_type {
+            self.add_message(&msg_name, msg);
+        }
+    }
+
+    /// Returns true if message type `inner` is nested in message type `outer`.
+    pub fn is_nested(&self, outer: &str, inner: &str) -> bool {
+        let outer = match self.index.get(outer) {
+            Some(outer) => *outer,
+            None => return false,
+        };
+        let inner = match self.index.get(inner) {
+            Some(inner) => *inner,
+            None => return false,
+        };
+
+        has_path_connecting(&self.graph, outer, inner, None)
+    }
+}

--- a/third_party/prost/prost-build/src/smoke_test.proto
+++ b/third_party/prost/prost-build/src/smoke_test.proto
@@ -1,0 +1,18 @@
+syntax = "proto2";
+
+package smoke_test;
+
+message SmokeRequest {
+}
+
+message SmokeResponse {
+}
+
+// Just a smoke test service.
+service SmokeService {
+
+    // A detached comment block.
+
+    // Blow some smoke.
+    rpc BlowSmoke(SmokeRequest) returns (SmokeResponse);
+}

--- a/third_party/prost/prost-build/src/types.proto
+++ b/third_party/prost/prost-build/src/types.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package helloworld;
+
+message Message {
+  string say = 1;
+}
+
+message Response {
+  string say = 1;
+}

--- a/third_party/prost/prost-derive/Cargo.toml
+++ b/third_party/prost/prost-derive/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "prost-derive"
+version = "0.6.1"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+license = "Apache-2.0"
+repository = "https://github.com/danburkert/prost"
+documentation = "https://docs.rs/prost-derive"
+readme = "README.md"
+description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
+
+[lib]
+proc_macro = true
+
+[dependencies]
+anyhow = "1"
+itertools = "0.9"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = [ "extra-traits" ] }

--- a/third_party/prost/prost-derive/README.md
+++ b/third_party/prost/prost-derive/README.md
@@ -1,0 +1,16 @@
+[![Documentation](https://docs.rs/prost-derive/badge.svg)](https://docs.rs/prost-derive/)
+[![Crate](https://img.shields.io/crates/v/prost-derive.svg)](https://crates.io/crates/prost-derive)
+
+# prost-derive
+
+`prost-derive` handles generating encoding and decoding implementations for Rust
+types annotated with `prost` annotation. For the most part, users of `prost`
+shouldn't need to interact with `prost-derive` directly.
+
+## License
+
+`prost-derive` is distributed under the terms of the Apache License (Version 2.0).
+
+See [LICENSE](../LICENSE) for details.
+
+Copyright 2017 Dan Burkert

--- a/third_party/prost/prost-derive/src/field/group.rs
+++ b/third_party/prost/prost-derive/src/field/group.rs
@@ -1,0 +1,134 @@
+use anyhow::{bail, Error};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::Meta;
+
+use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};
+
+#[derive(Clone)]
+pub struct Field {
+    pub label: Label,
+    pub tag: u32,
+}
+
+impl Field {
+    pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
+        let mut group = false;
+        let mut label = None;
+        let mut tag = None;
+        let mut boxed = false;
+
+        let mut unknown_attrs = Vec::new();
+
+        for attr in attrs {
+            if word_attr("group", attr) {
+                set_bool(&mut group, "duplicate group attributes")?;
+            } else if word_attr("boxed", attr) {
+                set_bool(&mut boxed, "duplicate boxed attributes")?;
+            } else if let Some(t) = tag_attr(attr)? {
+                set_option(&mut tag, t, "duplicate tag attributes")?;
+            } else if let Some(l) = Label::from_attr(attr) {
+                set_option(&mut label, l, "duplicate label attributes")?;
+            } else {
+                unknown_attrs.push(attr);
+            }
+        }
+
+        if !group {
+            return Ok(None);
+        }
+
+        match unknown_attrs.len() {
+            0 => (),
+            1 => bail!("unknown attribute for group field: {:?}", unknown_attrs[0]),
+            _ => bail!("unknown attributes for group field: {:?}", unknown_attrs),
+        }
+
+        let tag = match tag.or(inferred_tag) {
+            Some(tag) => tag,
+            None => bail!("group field is missing a tag attribute"),
+        };
+
+        Ok(Some(Field {
+            label: label.unwrap_or(Label::Optional),
+            tag,
+        }))
+    }
+
+    pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+        if let Some(mut field) = Field::new(attrs, None)? {
+            if let Some(attr) = attrs.iter().find(|attr| Label::from_attr(attr).is_some()) {
+                bail!(
+                    "invalid attribute for oneof field: {}",
+                    attr.path().into_token_stream()
+                );
+            }
+            field.label = Label::Required;
+            Ok(Some(field))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn encode(&self, ident: TokenStream) -> TokenStream {
+        let tag = self.tag;
+        match self.label {
+            Label::Optional => quote! {
+                if let Some(ref msg) = #ident {
+                    ::prost::encoding::group::encode(#tag, msg, buf);
+                }
+            },
+            Label::Required => quote! {
+                ::prost::encoding::group::encode(#tag, &#ident, buf);
+            },
+            Label::Repeated => quote! {
+                for msg in &#ident {
+                    ::prost::encoding::group::encode(#tag, msg, buf);
+                }
+            },
+        }
+    }
+
+    pub fn merge(&self, ident: TokenStream) -> TokenStream {
+        match self.label {
+            Label::Optional => quote! {
+                ::prost::encoding::group::merge(
+                    tag,
+                    wire_type,
+                    #ident.get_or_insert_with(Default::default),
+                    buf,
+                    ctx,
+                )
+            },
+            Label::Required => quote! {
+                ::prost::encoding::group::merge(tag, wire_type, #ident, buf, ctx)
+            },
+            Label::Repeated => quote! {
+                ::prost::encoding::group::merge_repeated(tag, wire_type, #ident, buf, ctx)
+            },
+        }
+    }
+
+    pub fn encoded_len(&self, ident: TokenStream) -> TokenStream {
+        let tag = self.tag;
+        match self.label {
+            Label::Optional => quote! {
+                #ident.as_ref().map_or(0, |msg| ::prost::encoding::group::encoded_len(#tag, msg))
+            },
+            Label::Required => quote! {
+                ::prost::encoding::group::encoded_len(#tag, &#ident)
+            },
+            Label::Repeated => quote! {
+                ::prost::encoding::group::encoded_len_repeated(#tag, &#ident)
+            },
+        }
+    }
+
+    pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        match self.label {
+            Label::Optional => quote!(#ident = ::core::option::Option::None),
+            Label::Required => quote!(#ident.clear()),
+            Label::Repeated => quote!(#ident.clear()),
+        }
+    }
+}

--- a/third_party/prost/prost-derive/src/field/map.rs
+++ b/third_party/prost/prost-derive/src/field/map.rs
@@ -1,0 +1,394 @@
+use anyhow::{bail, Error};
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{Ident, Lit, Meta, MetaNameValue, NestedMeta};
+
+use crate::field::{scalar, set_option, tag_attr};
+
+#[derive(Clone, Debug)]
+pub enum MapTy {
+    HashMap,
+    BTreeMap,
+}
+
+impl MapTy {
+    fn from_str(s: &str) -> Option<MapTy> {
+        match s {
+            "map" | "hash_map" => Some(MapTy::HashMap),
+            "btree_map" => Some(MapTy::BTreeMap),
+            _ => None,
+        }
+    }
+
+    fn module(&self) -> Ident {
+        match *self {
+            MapTy::HashMap => Ident::new("hash_map", Span::call_site()),
+            MapTy::BTreeMap => Ident::new("btree_map", Span::call_site()),
+        }
+    }
+
+    fn lib(&self) -> TokenStream {
+        match self {
+            MapTy::HashMap => quote! { std },
+            MapTy::BTreeMap => quote! { prost::alloc },
+        }
+    }
+}
+
+fn fake_scalar(ty: scalar::Ty) -> scalar::Field {
+    let kind = scalar::Kind::Plain(scalar::DefaultValue::new(&ty));
+    scalar::Field {
+        ty,
+        kind,
+        tag: 0, // Not used here
+    }
+}
+
+#[derive(Clone)]
+pub struct Field {
+    pub map_ty: MapTy,
+    pub key_ty: scalar::Ty,
+    pub value_ty: ValueTy,
+    pub tag: u32,
+}
+
+impl Field {
+    pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
+        let mut types = None;
+        let mut tag = None;
+
+        for attr in attrs {
+            if let Some(t) = tag_attr(attr)? {
+                set_option(&mut tag, t, "duplicate tag attributes")?;
+            } else if let Some(map_ty) = attr
+                .path()
+                .get_ident()
+                .and_then(|i| MapTy::from_str(&i.to_string()))
+            {
+                let (k, v): (String, String) = match &*attr {
+                    Meta::NameValue(MetaNameValue {
+                        lit: Lit::Str(lit), ..
+                    }) => {
+                        let items = lit.value();
+                        let mut items = items.split(',').map(ToString::to_string);
+                        let k = items.next().unwrap();
+                        let v = match items.next() {
+                            Some(k) => k,
+                            None => bail!("invalid map attribute: must have key and value types"),
+                        };
+                        if items.next().is_some() {
+                            bail!("invalid map attribute: {:?}", attr);
+                        }
+                        (k, v)
+                    }
+                    Meta::List(meta_list) => {
+                        // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
+                        if meta_list.nested.len() != 2 {
+                            bail!("invalid map attribute: must contain key and value types");
+                        }
+                        let k = match &meta_list.nested[0] {
+                            NestedMeta::Meta(Meta::Path(k)) if k.get_ident().is_some() => {
+                                k.get_ident().unwrap().to_string()
+                            }
+                            _ => bail!("invalid map attribute: key must be an identifier"),
+                        };
+                        let v = match &meta_list.nested[1] {
+                            NestedMeta::Meta(Meta::Path(v)) if v.get_ident().is_some() => {
+                                v.get_ident().unwrap().to_string()
+                            }
+                            _ => bail!("invalid map attribute: value must be an identifier"),
+                        };
+                        (k, v)
+                    }
+                    _ => return Ok(None),
+                };
+                set_option(
+                    &mut types,
+                    (map_ty, key_ty_from_str(&k)?, ValueTy::from_str(&v)?),
+                    "duplicate map type attribute",
+                )?;
+            } else {
+                return Ok(None);
+            }
+        }
+
+        Ok(match (types, tag.or(inferred_tag)) {
+            (Some((map_ty, key_ty, value_ty)), Some(tag)) => Some(Field {
+                map_ty,
+                key_ty,
+                value_ty,
+                tag,
+            }),
+            _ => None,
+        })
+    }
+
+    pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+        Field::new(attrs, None)
+    }
+
+    /// Returns a statement which encodes the map field.
+    pub fn encode(&self, ident: TokenStream) -> TokenStream {
+        let tag = self.tag;
+        let key_mod = self.key_ty.module();
+        let ke = quote!(::prost::encoding::#key_mod::encode);
+        let kl = quote!(::prost::encoding::#key_mod::encoded_len);
+        let module = self.map_ty.module();
+        match &self.value_ty {
+            ValueTy::Scalar(scalar::Ty::Enumeration(ty)) => {
+                let default = quote!(#ty::default() as i32);
+                quote! {
+                    ::prost::encoding::#module::encode_with_default(
+                        #ke,
+                        #kl,
+                        ::prost::encoding::int32::encode,
+                        ::prost::encoding::int32::encoded_len,
+                        &(#default),
+                        #tag,
+                        &#ident,
+                        buf,
+                    );
+                }
+            }
+            ValueTy::Scalar(value_ty) => {
+                let val_mod = value_ty.module();
+                let ve = quote!(::prost::encoding::#val_mod::encode);
+                let vl = quote!(::prost::encoding::#val_mod::encoded_len);
+                quote! {
+                    ::prost::encoding::#module::encode(
+                        #ke,
+                        #kl,
+                        #ve,
+                        #vl,
+                        #tag,
+                        &#ident,
+                        buf,
+                    );
+                }
+            }
+            ValueTy::Message => quote! {
+                ::prost::encoding::#module::encode(
+                    #ke,
+                    #kl,
+                    ::prost::encoding::message::encode,
+                    ::prost::encoding::message::encoded_len,
+                    #tag,
+                    &#ident,
+                    buf,
+                );
+            },
+        }
+    }
+
+    /// Returns an expression which evaluates to the result of merging a decoded key value pair
+    /// into the map.
+    pub fn merge(&self, ident: TokenStream) -> TokenStream {
+        let key_mod = self.key_ty.module();
+        let km = quote!(::prost::encoding::#key_mod::merge);
+        let module = self.map_ty.module();
+        match &self.value_ty {
+            ValueTy::Scalar(scalar::Ty::Enumeration(ty)) => {
+                let default = quote!(#ty::default() as i32);
+                quote! {
+                    ::prost::encoding::#module::merge_with_default(
+                        #km,
+                        ::prost::encoding::int32::merge,
+                        #default,
+                        &mut #ident,
+                        buf,
+                        ctx,
+                    )
+                }
+            }
+            ValueTy::Scalar(value_ty) => {
+                let val_mod = value_ty.module();
+                let vm = quote!(::prost::encoding::#val_mod::merge);
+                quote!(::prost::encoding::#module::merge(#km, #vm, &mut #ident, buf, ctx))
+            }
+            ValueTy::Message => quote! {
+                ::prost::encoding::#module::merge(
+                    #km,
+                    ::prost::encoding::message::merge,
+                    &mut #ident,
+                    buf,
+                    ctx,
+                )
+            },
+        }
+    }
+
+    /// Returns an expression which evaluates to the encoded length of the map.
+    pub fn encoded_len(&self, ident: TokenStream) -> TokenStream {
+        let tag = self.tag;
+        let key_mod = self.key_ty.module();
+        let kl = quote!(::prost::encoding::#key_mod::encoded_len);
+        let module = self.map_ty.module();
+        match &self.value_ty {
+            ValueTy::Scalar(scalar::Ty::Enumeration(ty)) => {
+                let default = quote!(#ty::default() as i32);
+                quote! {
+                    ::prost::encoding::#module::encoded_len_with_default(
+                        #kl,
+                        ::prost::encoding::int32::encoded_len,
+                        &(#default),
+                        #tag,
+                        &#ident,
+                    )
+                }
+            }
+            ValueTy::Scalar(value_ty) => {
+                let val_mod = value_ty.module();
+                let vl = quote!(::prost::encoding::#val_mod::encoded_len);
+                quote!(::prost::encoding::#module::encoded_len(#kl, #vl, #tag, &#ident))
+            }
+            ValueTy::Message => quote! {
+                ::prost::encoding::#module::encoded_len(
+                    #kl,
+                    ::prost::encoding::message::encoded_len,
+                    #tag,
+                    &#ident,
+                )
+            },
+        }
+    }
+
+    pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        quote!(#ident.clear())
+    }
+
+    /// Returns methods to embed in the message.
+    pub fn methods(&self, ident: &Ident) -> Option<TokenStream> {
+        if let ValueTy::Scalar(scalar::Ty::Enumeration(ty)) = &self.value_ty {
+            let key_ty = self.key_ty.rust_type();
+            let key_ref_ty = self.key_ty.rust_ref_type();
+
+            let get = Ident::new(&format!("get_{}", ident), Span::call_site());
+            let insert = Ident::new(&format!("insert_{}", ident), Span::call_site());
+            let take_ref = if self.key_ty.is_numeric() {
+                quote!(&)
+            } else {
+                quote!()
+            };
+
+            let get_doc = format!(
+                "Returns the enum value for the corresponding key in `{}`, \
+                 or `None` if the entry does not exist or it is not a valid enum value.",
+                ident,
+            );
+            let insert_doc = format!("Inserts a key value pair into `{}`.", ident);
+            Some(quote! {
+                #[doc=#get_doc]
+                pub fn #get(&self, key: #key_ref_ty) -> ::core::option::Option<#ty> {
+                    self.#ident.get(#take_ref key).cloned().and_then(#ty::from_i32)
+                }
+                #[doc=#insert_doc]
+                pub fn #insert(&mut self, key: #key_ty, value: #ty) -> ::core::option::Option<#ty> {
+                    self.#ident.insert(key, value as i32).and_then(#ty::from_i32)
+                }
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Returns a newtype wrapper around the map, implementing nicer Debug
+    ///
+    /// The Debug tries to convert any enumerations met into the variants if possible, instead of
+    /// outputting the raw numbers.
+    pub fn debug(&self, wrapper_name: TokenStream) -> TokenStream {
+        let type_name = match self.map_ty {
+            MapTy::HashMap => Ident::new("HashMap", Span::call_site()),
+            MapTy::BTreeMap => Ident::new("BTreeMap", Span::call_site()),
+        };
+
+        // A fake field for generating the debug wrapper
+        let key_wrapper = fake_scalar(self.key_ty.clone()).debug(quote!(KeyWrapper));
+        let key = self.key_ty.rust_type();
+        let value_wrapper = self.value_ty.debug();
+        let libname = self.map_ty.lib();
+        let fmt = quote! {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                #key_wrapper
+                #value_wrapper
+                let mut builder = f.debug_map();
+                for (k, v) in self.0 {
+                    builder.entry(&KeyWrapper(k), &ValueWrapper(v));
+                }
+                builder.finish()
+            }
+        };
+        match &self.value_ty {
+            ValueTy::Scalar(ty) => {
+                let value = ty.rust_type();
+                quote! {
+                    struct #wrapper_name<'a>(&'a ::#libname::collections::#type_name<#key, #value>);
+                    impl<'a> ::core::fmt::Debug for #wrapper_name<'a> {
+                        #fmt
+                    }
+                }
+            }
+            ValueTy::Message => quote! {
+                struct #wrapper_name<'a, V: 'a>(&'a ::#libname::collections::#type_name<#key, V>);
+                impl<'a, V> ::core::fmt::Debug for #wrapper_name<'a, V>
+                where
+                    V: ::core::fmt::Debug + 'a,
+                {
+                    #fmt
+                }
+            },
+        }
+    }
+}
+
+fn key_ty_from_str(s: &str) -> Result<scalar::Ty, Error> {
+    let ty = scalar::Ty::from_str(s)?;
+    match ty {
+        scalar::Ty::Int32
+        | scalar::Ty::Int64
+        | scalar::Ty::Uint32
+        | scalar::Ty::Uint64
+        | scalar::Ty::Sint32
+        | scalar::Ty::Sint64
+        | scalar::Ty::Fixed32
+        | scalar::Ty::Fixed64
+        | scalar::Ty::Sfixed32
+        | scalar::Ty::Sfixed64
+        | scalar::Ty::Bool
+        | scalar::Ty::String => Ok(ty),
+        _ => bail!("invalid map key type: {}", s),
+    }
+}
+
+/// A map value type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ValueTy {
+    Scalar(scalar::Ty),
+    Message,
+}
+
+impl ValueTy {
+    fn from_str(s: &str) -> Result<ValueTy, Error> {
+        if let Ok(ty) = scalar::Ty::from_str(s) {
+            Ok(ValueTy::Scalar(ty))
+        } else if s.trim() == "message" {
+            Ok(ValueTy::Message)
+        } else {
+            bail!("invalid map value type: {}", s);
+        }
+    }
+
+    /// Returns a newtype wrapper around the ValueTy for nicer debug.
+    ///
+    /// If the contained value is enumeration, it tries to convert it to the variant. If not, it
+    /// just forwards the implementation.
+    fn debug(&self) -> TokenStream {
+        match self {
+            ValueTy::Scalar(ty) => fake_scalar(ty.clone()).debug(quote!(ValueWrapper)),
+            ValueTy::Message => quote!(
+                fn ValueWrapper<T>(v: T) -> T {
+                    v
+                }
+            ),
+        }
+    }
+}

--- a/third_party/prost/prost-derive/src/field/message.rs
+++ b/third_party/prost/prost-derive/src/field/message.rs
@@ -1,0 +1,134 @@
+use anyhow::{bail, Error};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::Meta;
+
+use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};
+
+#[derive(Clone)]
+pub struct Field {
+    pub label: Label,
+    pub tag: u32,
+}
+
+impl Field {
+    pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
+        let mut message = false;
+        let mut label = None;
+        let mut tag = None;
+        let mut boxed = false;
+
+        let mut unknown_attrs = Vec::new();
+
+        for attr in attrs {
+            if word_attr("message", attr) {
+                set_bool(&mut message, "duplicate message attribute")?;
+            } else if word_attr("boxed", attr) {
+                set_bool(&mut boxed, "duplicate boxed attribute")?;
+            } else if let Some(t) = tag_attr(attr)? {
+                set_option(&mut tag, t, "duplicate tag attributes")?;
+            } else if let Some(l) = Label::from_attr(attr) {
+                set_option(&mut label, l, "duplicate label attributes")?;
+            } else {
+                unknown_attrs.push(attr);
+            }
+        }
+
+        if !message {
+            return Ok(None);
+        }
+
+        match unknown_attrs.len() {
+            0 => (),
+            1 => bail!(
+                "unknown attribute for message field: {:?}",
+                unknown_attrs[0]
+            ),
+            _ => bail!("unknown attributes for message field: {:?}", unknown_attrs),
+        }
+
+        let tag = match tag.or(inferred_tag) {
+            Some(tag) => tag,
+            None => bail!("message field is missing a tag attribute"),
+        };
+
+        Ok(Some(Field {
+            label: label.unwrap_or(Label::Optional),
+            tag,
+        }))
+    }
+
+    pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+        if let Some(mut field) = Field::new(attrs, None)? {
+            if let Some(attr) = attrs.iter().find(|attr| Label::from_attr(attr).is_some()) {
+                bail!(
+                    "invalid attribute for oneof field: {}",
+                    attr.path().into_token_stream()
+                );
+            }
+            field.label = Label::Required;
+            Ok(Some(field))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn encode(&self, ident: TokenStream) -> TokenStream {
+        let tag = self.tag;
+        match self.label {
+            Label::Optional => quote! {
+                if let Some(ref msg) = #ident {
+                    ::prost::encoding::message::encode(#tag, msg, buf);
+                }
+            },
+            Label::Required => quote! {
+                ::prost::encoding::message::encode(#tag, &#ident, buf);
+            },
+            Label::Repeated => quote! {
+                for msg in &#ident {
+                    ::prost::encoding::message::encode(#tag, msg, buf);
+                }
+            },
+        }
+    }
+
+    pub fn merge(&self, ident: TokenStream) -> TokenStream {
+        match self.label {
+            Label::Optional => quote! {
+                ::prost::encoding::message::merge(wire_type,
+                                                 #ident.get_or_insert_with(Default::default),
+                                                 buf,
+                                                 ctx)
+            },
+            Label::Required => quote! {
+                ::prost::encoding::message::merge(wire_type, #ident, buf, ctx)
+            },
+            Label::Repeated => quote! {
+                ::prost::encoding::message::merge_repeated(wire_type, #ident, buf, ctx)
+            },
+        }
+    }
+
+    pub fn encoded_len(&self, ident: TokenStream) -> TokenStream {
+        let tag = self.tag;
+        match self.label {
+            Label::Optional => quote! {
+                #ident.as_ref().map_or(0, |msg| ::prost::encoding::message::encoded_len(#tag, msg))
+            },
+            Label::Required => quote! {
+                ::prost::encoding::message::encoded_len(#tag, &#ident)
+            },
+            Label::Repeated => quote! {
+                ::prost::encoding::message::encoded_len_repeated(#tag, &#ident)
+            },
+        }
+    }
+
+    pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        match self.label {
+            Label::Optional => quote!(#ident = ::core::option::Option::None),
+            Label::Required => quote!(#ident.clear()),
+            Label::Repeated => quote!(#ident.clear()),
+        }
+    }
+}

--- a/third_party/prost/prost-derive/src/field/mod.rs
+++ b/third_party/prost/prost-derive/src/field/mod.rs
@@ -1,0 +1,366 @@
+mod group;
+mod map;
+mod message;
+mod oneof;
+mod scalar;
+
+use std::fmt;
+use std::slice;
+
+use anyhow::{bail, Error};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Attribute, Ident, Lit, LitBool, Meta, MetaList, MetaNameValue, NestedMeta};
+
+#[derive(Clone)]
+pub enum Field {
+    /// A scalar field.
+    Scalar(scalar::Field),
+    /// A message field.
+    Message(message::Field),
+    /// A map field.
+    Map(map::Field),
+    /// A oneof field.
+    Oneof(oneof::Field),
+    /// A group field.
+    Group(group::Field),
+}
+
+impl Field {
+    /// Creates a new `Field` from an iterator of field attributes.
+    ///
+    /// If the meta items are invalid, an error will be returned.
+    /// If the field should be ignored, `None` is returned.
+    pub fn new(attrs: Vec<Attribute>, inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
+        let attrs = prost_attrs(attrs)?;
+
+        // TODO: check for ignore attribute.
+
+        let field = if let Some(field) = scalar::Field::new(&attrs, inferred_tag)? {
+            Field::Scalar(field)
+        } else if let Some(field) = message::Field::new(&attrs, inferred_tag)? {
+            Field::Message(field)
+        } else if let Some(field) = map::Field::new(&attrs, inferred_tag)? {
+            Field::Map(field)
+        } else if let Some(field) = oneof::Field::new(&attrs)? {
+            Field::Oneof(field)
+        } else if let Some(field) = group::Field::new(&attrs, inferred_tag)? {
+            Field::Group(field)
+        } else {
+            bail!("no type attribute");
+        };
+
+        Ok(Some(field))
+    }
+
+    /// Creates a new oneof `Field` from an iterator of field attributes.
+    ///
+    /// If the meta items are invalid, an error will be returned.
+    /// If the field should be ignored, `None` is returned.
+    pub fn new_oneof(attrs: Vec<Attribute>) -> Result<Option<Field>, Error> {
+        let attrs = prost_attrs(attrs)?;
+
+        // TODO: check for ignore attribute.
+
+        let field = if let Some(field) = scalar::Field::new_oneof(&attrs)? {
+            Field::Scalar(field)
+        } else if let Some(field) = message::Field::new_oneof(&attrs)? {
+            Field::Message(field)
+        } else if let Some(field) = map::Field::new_oneof(&attrs)? {
+            Field::Map(field)
+        } else if let Some(field) = group::Field::new_oneof(&attrs)? {
+            Field::Group(field)
+        } else {
+            bail!("no type attribute for oneof field");
+        };
+
+        Ok(Some(field))
+    }
+
+    pub fn tags(&self) -> Vec<u32> {
+        match *self {
+            Field::Scalar(ref scalar) => vec![scalar.tag],
+            Field::Message(ref message) => vec![message.tag],
+            Field::Map(ref map) => vec![map.tag],
+            Field::Oneof(ref oneof) => oneof.tags.clone(),
+            Field::Group(ref group) => vec![group.tag],
+        }
+    }
+
+    /// Returns a statement which encodes the field.
+    pub fn encode(&self, ident: TokenStream) -> TokenStream {
+        match *self {
+            Field::Scalar(ref scalar) => scalar.encode(ident),
+            Field::Message(ref message) => message.encode(ident),
+            Field::Map(ref map) => map.encode(ident),
+            Field::Oneof(ref oneof) => oneof.encode(ident),
+            Field::Group(ref group) => group.encode(ident),
+        }
+    }
+
+    /// Returns an expression which evaluates to the result of merging a decoded
+    /// value into the field.
+    pub fn merge(&self, ident: TokenStream) -> TokenStream {
+        match *self {
+            Field::Scalar(ref scalar) => scalar.merge(ident),
+            Field::Message(ref message) => message.merge(ident),
+            Field::Map(ref map) => map.merge(ident),
+            Field::Oneof(ref oneof) => oneof.merge(ident),
+            Field::Group(ref group) => group.merge(ident),
+        }
+    }
+
+    /// Returns an expression which evaluates to the encoded length of the field.
+    pub fn encoded_len(&self, ident: TokenStream) -> TokenStream {
+        match *self {
+            Field::Scalar(ref scalar) => scalar.encoded_len(ident),
+            Field::Map(ref map) => map.encoded_len(ident),
+            Field::Message(ref msg) => msg.encoded_len(ident),
+            Field::Oneof(ref oneof) => oneof.encoded_len(ident),
+            Field::Group(ref group) => group.encoded_len(ident),
+        }
+    }
+
+    /// Returns a statement which clears the field.
+    pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        match *self {
+            Field::Scalar(ref scalar) => scalar.clear(ident),
+            Field::Message(ref message) => message.clear(ident),
+            Field::Map(ref map) => map.clear(ident),
+            Field::Oneof(ref oneof) => oneof.clear(ident),
+            Field::Group(ref group) => group.clear(ident),
+        }
+    }
+
+    pub fn default(&self) -> TokenStream {
+        match *self {
+            Field::Scalar(ref scalar) => scalar.default(),
+            _ => quote!(::core::default::Default::default()),
+        }
+    }
+
+    /// Produces the fragment implementing debug for the given field.
+    pub fn debug(&self, ident: TokenStream) -> TokenStream {
+        match *self {
+            Field::Scalar(ref scalar) => {
+                let wrapper = scalar.debug(quote!(ScalarWrapper));
+                quote! {
+                    {
+                        #wrapper
+                        ScalarWrapper(&#ident)
+                    }
+                }
+            }
+            Field::Map(ref map) => {
+                let wrapper = map.debug(quote!(MapWrapper));
+                quote! {
+                    {
+                        #wrapper
+                        MapWrapper(&#ident)
+                    }
+                }
+            }
+            _ => quote!(&#ident),
+        }
+    }
+
+    pub fn methods(&self, ident: &Ident) -> Option<TokenStream> {
+        match *self {
+            Field::Scalar(ref scalar) => scalar.methods(ident),
+            Field::Map(ref map) => map.methods(ident),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Label {
+    /// An optional field.
+    Optional,
+    /// A required field.
+    Required,
+    /// A repeated field.
+    Repeated,
+}
+
+impl Label {
+    fn as_str(self) -> &'static str {
+        match self {
+            Label::Optional => "optional",
+            Label::Required => "required",
+            Label::Repeated => "repeated",
+        }
+    }
+
+    fn variants() -> slice::Iter<'static, Label> {
+        const VARIANTS: &[Label] = &[Label::Optional, Label::Required, Label::Repeated];
+        VARIANTS.iter()
+    }
+
+    /// Parses a string into a field label.
+    /// If the string doesn't match a field label, `None` is returned.
+    fn from_attr(attr: &Meta) -> Option<Label> {
+        if let Meta::Path(ref path) = *attr {
+            for &label in Label::variants() {
+                if path.is_ident(label.as_str()) {
+                    return Some(label);
+                }
+            }
+        }
+        None
+    }
+}
+
+impl fmt::Debug for Label {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Display for Label {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Get the items belonging to the 'prost' list attribute, e.g. `#[prost(foo, bar="baz")]`.
+pub(super) fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
+    Ok(attrs
+        .iter()
+        .flat_map(Attribute::parse_meta)
+        .flat_map(|meta| match meta {
+            Meta::List(MetaList { path, nested, .. }) => {
+                if path.is_ident("prost") {
+                    nested.into_iter().collect()
+                } else {
+                    Vec::new()
+                }
+            }
+            _ => Vec::new(),
+        })
+        .flat_map(|attr| -> Result<_, _> {
+            match attr {
+                NestedMeta::Meta(attr) => Ok(attr),
+                NestedMeta::Lit(lit) => bail!("invalid prost attribute: {:?}", lit),
+            }
+        })
+        .collect())
+}
+
+pub fn set_option<T>(option: &mut Option<T>, value: T, message: &str) -> Result<(), Error>
+where
+    T: fmt::Debug,
+{
+    if let Some(ref existing) = *option {
+        bail!("{}: {:?} and {:?}", message, existing, value);
+    }
+    *option = Some(value);
+    Ok(())
+}
+
+pub fn set_bool(b: &mut bool, message: &str) -> Result<(), Error> {
+    if *b {
+        bail!("{}", message);
+    } else {
+        *b = true;
+        Ok(())
+    }
+}
+
+/// Unpacks an attribute into a (key, boolean) pair, returning the boolean value.
+/// If the key doesn't match the attribute, `None` is returned.
+fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
+    if !attr.path().is_ident(key) {
+        return Ok(None);
+    }
+    match *attr {
+        Meta::Path(..) => Ok(Some(true)),
+        Meta::List(ref meta_list) => {
+            // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
+            if meta_list.nested.len() == 1 {
+                if let NestedMeta::Lit(Lit::Bool(LitBool { value, .. })) = meta_list.nested[0] {
+                    return Ok(Some(value));
+                }
+            }
+            bail!("invalid {} attribute", key);
+        }
+        Meta::NameValue(MetaNameValue {
+            lit: Lit::Str(ref lit),
+            ..
+        }) => lit
+            .value()
+            .parse::<bool>()
+            .map_err(Error::from)
+            .map(Option::Some),
+        Meta::NameValue(MetaNameValue {
+            lit: Lit::Bool(LitBool { value, .. }),
+            ..
+        }) => Ok(Some(value)),
+        _ => bail!("invalid {} attribute", key),
+    }
+}
+
+/// Checks if an attribute matches a word.
+fn word_attr(key: &str, attr: &Meta) -> bool {
+    if let Meta::Path(ref path) = *attr {
+        path.is_ident(key)
+    } else {
+        false
+    }
+}
+
+pub(super) fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
+    if !attr.path().is_ident("tag") {
+        return Ok(None);
+    }
+    match *attr {
+        Meta::List(ref meta_list) => {
+            // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
+            if meta_list.nested.len() == 1 {
+                if let NestedMeta::Lit(Lit::Int(ref lit)) = meta_list.nested[0] {
+                    return Ok(Some(lit.base10_parse()?));
+                }
+            }
+            bail!("invalid tag attribute: {:?}", attr);
+        }
+        Meta::NameValue(ref meta_name_value) => match meta_name_value.lit {
+            Lit::Str(ref lit) => lit
+                .value()
+                .parse::<u32>()
+                .map_err(Error::from)
+                .map(Option::Some),
+            Lit::Int(ref lit) => Ok(Some(lit.base10_parse()?)),
+            _ => bail!("invalid tag attribute: {:?}", attr),
+        },
+        _ => bail!("invalid tag attribute: {:?}", attr),
+    }
+}
+
+fn tags_attr(attr: &Meta) -> Result<Option<Vec<u32>>, Error> {
+    if !attr.path().is_ident("tags") {
+        return Ok(None);
+    }
+    match *attr {
+        Meta::List(ref meta_list) => {
+            let mut tags = Vec::with_capacity(meta_list.nested.len());
+            for item in &meta_list.nested {
+                if let NestedMeta::Lit(Lit::Int(ref lit)) = *item {
+                    tags.push(lit.base10_parse()?);
+                } else {
+                    bail!("invalid tag attribute: {:?}", attr);
+                }
+            }
+            Ok(Some(tags))
+        }
+        Meta::NameValue(MetaNameValue {
+            lit: Lit::Str(ref lit),
+            ..
+        }) => lit
+            .value()
+            .split(',')
+            .map(|s| s.trim().parse::<u32>().map_err(Error::from))
+            .collect::<Result<Vec<u32>, _>>()
+            .map(Some),
+        _ => bail!("invalid tag attribute: {:?}", attr),
+    }
+}

--- a/third_party/prost/prost-derive/src/field/oneof.rs
+++ b/third_party/prost/prost-derive/src/field/oneof.rs
@@ -1,0 +1,99 @@
+use anyhow::{bail, Error};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_str, Lit, Meta, MetaNameValue, NestedMeta, Path};
+
+use crate::field::{set_option, tags_attr};
+
+#[derive(Clone)]
+pub struct Field {
+    pub ty: Path,
+    pub tags: Vec<u32>,
+}
+
+impl Field {
+    pub fn new(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+        let mut ty = None;
+        let mut tags = None;
+        let mut unknown_attrs = Vec::new();
+
+        for attr in attrs {
+            if attr.path().is_ident("oneof") {
+                let t = match *attr {
+                    Meta::NameValue(MetaNameValue {
+                        lit: Lit::Str(ref lit),
+                        ..
+                    }) => parse_str::<Path>(&lit.value())?,
+                    Meta::List(ref list) if list.nested.len() == 1 => {
+                        // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
+                        if let NestedMeta::Meta(Meta::Path(ref path)) = list.nested[0] {
+                            if let Some(ident) = path.get_ident() {
+                                Path::from(ident.clone())
+                            } else {
+                                bail!("invalid oneof attribute: item must be an identifier");
+                            }
+                        } else {
+                            bail!("invalid oneof attribute: item must be an identifier");
+                        }
+                    }
+                    _ => bail!("invalid oneof attribute: {:?}", attr),
+                };
+                set_option(&mut ty, t, "duplicate oneof attribute")?;
+            } else if let Some(t) = tags_attr(attr)? {
+                set_option(&mut tags, t, "duplicate tags attributes")?;
+            } else {
+                unknown_attrs.push(attr);
+            }
+        }
+
+        let ty = match ty {
+            Some(ty) => ty,
+            None => return Ok(None),
+        };
+
+        match unknown_attrs.len() {
+            0 => (),
+            1 => bail!(
+                "unknown attribute for message field: {:?}",
+                unknown_attrs[0]
+            ),
+            _ => bail!("unknown attributes for message field: {:?}", unknown_attrs),
+        }
+
+        let tags = match tags {
+            Some(tags) => tags,
+            None => bail!("oneof field is missing a tags attribute"),
+        };
+
+        Ok(Some(Field { ty, tags }))
+    }
+
+    /// Returns a statement which encodes the oneof field.
+    pub fn encode(&self, ident: TokenStream) -> TokenStream {
+        quote! {
+            if let Some(ref oneof) = #ident {
+                oneof.encode(buf)
+            }
+        }
+    }
+
+    /// Returns an expression which evaluates to the result of decoding the oneof field.
+    pub fn merge(&self, ident: TokenStream) -> TokenStream {
+        let ty = &self.ty;
+        quote! {
+            #ty::merge(#ident, tag, wire_type, buf, ctx)
+        }
+    }
+
+    /// Returns an expression which evaluates to the encoded length of the oneof field.
+    pub fn encoded_len(&self, ident: TokenStream) -> TokenStream {
+        let ty = &self.ty;
+        quote! {
+            #ident.as_ref().map_or(0, #ty::encoded_len)
+        }
+    }
+
+    pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        quote!(#ident = ::core::option::Option::None)
+    }
+}

--- a/third_party/prost/prost-derive/src/field/scalar.rs
+++ b/third_party/prost/prost-derive/src/field/scalar.rs
@@ -1,0 +1,787 @@
+use std::convert::TryFrom;
+use std::fmt;
+
+use anyhow::{anyhow, bail, Error};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::{parse_str, Ident, Lit, LitByteStr, Meta, MetaList, MetaNameValue, NestedMeta, Path};
+
+use crate::field::{bool_attr, set_option, tag_attr, Label};
+
+/// A scalar protobuf field.
+#[derive(Clone)]
+pub struct Field {
+    pub ty: Ty,
+    pub kind: Kind,
+    pub tag: u32,
+}
+
+impl Field {
+    pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
+        let mut ty = None;
+        let mut label = None;
+        let mut packed = None;
+        let mut default = None;
+        let mut tag = None;
+
+        let mut unknown_attrs = Vec::new();
+
+        for attr in attrs {
+            if let Some(t) = Ty::from_attr(attr)? {
+                set_option(&mut ty, t, "duplicate type attributes")?;
+            } else if let Some(p) = bool_attr("packed", attr)? {
+                set_option(&mut packed, p, "duplicate packed attributes")?;
+            } else if let Some(t) = tag_attr(attr)? {
+                set_option(&mut tag, t, "duplicate tag attributes")?;
+            } else if let Some(l) = Label::from_attr(attr) {
+                set_option(&mut label, l, "duplicate label attributes")?;
+            } else if let Some(d) = DefaultValue::from_attr(attr)? {
+                set_option(&mut default, d, "duplicate default attributes")?;
+            } else {
+                unknown_attrs.push(attr);
+            }
+        }
+
+        let ty = match ty {
+            Some(ty) => ty,
+            None => return Ok(None),
+        };
+
+        match unknown_attrs.len() {
+            0 => (),
+            1 => bail!("unknown attribute: {:?}", unknown_attrs[0]),
+            _ => bail!("unknown attributes: {:?}", unknown_attrs),
+        }
+
+        let tag = match tag.or(inferred_tag) {
+            Some(tag) => tag,
+            None => bail!("missing tag attribute"),
+        };
+
+        let has_default = default.is_some();
+        let default = default.map_or_else(
+            || Ok(DefaultValue::new(&ty)),
+            |lit| DefaultValue::from_lit(&ty, lit),
+        )?;
+
+        let kind = match (label, packed, has_default) {
+            (None, Some(true), _)
+            | (Some(Label::Optional), Some(true), _)
+            | (Some(Label::Required), Some(true), _) => {
+                bail!("packed attribute may only be applied to repeated fields");
+            }
+            (Some(Label::Repeated), Some(true), _) if !ty.is_numeric() => {
+                bail!("packed attribute may only be applied to numeric types");
+            }
+            (Some(Label::Repeated), _, true) => {
+                bail!("repeated fields may not have a default value");
+            }
+
+            (None, _, _) => Kind::Plain(default),
+            (Some(Label::Optional), _, _) => Kind::Optional(default),
+            (Some(Label::Required), _, _) => Kind::Required(default),
+            (Some(Label::Repeated), packed, false) if packed.unwrap_or_else(|| ty.is_numeric()) => {
+                Kind::Packed
+            }
+            (Some(Label::Repeated), _, false) => Kind::Repeated,
+        };
+
+        Ok(Some(Field { ty, kind, tag }))
+    }
+
+    pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+        if let Some(mut field) = Field::new(attrs, None)? {
+            match field.kind {
+                Kind::Plain(default) => {
+                    field.kind = Kind::Required(default);
+                    Ok(Some(field))
+                }
+                Kind::Optional(..) => bail!("invalid optional attribute on oneof field"),
+                Kind::Required(..) => bail!("invalid required attribute on oneof field"),
+                Kind::Packed | Kind::Repeated => bail!("invalid repeated attribute on oneof field"),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn encode(&self, ident: TokenStream) -> TokenStream {
+        let module = self.ty.module();
+        let encode_fn = match self.kind {
+            Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(encode),
+            Kind::Repeated => quote!(encode_repeated),
+            Kind::Packed => quote!(encode_packed),
+        };
+        let encode_fn = quote!(::prost::encoding::#module::#encode_fn);
+        let tag = self.tag;
+
+        match self.kind {
+            Kind::Plain(ref default) => {
+                let default = default.typed();
+                quote! {
+                    if #ident != #default {
+                        #encode_fn(#tag, &#ident, buf);
+                    }
+                }
+            }
+            Kind::Optional(..) => quote! {
+                if let ::core::option::Option::Some(ref value) = #ident {
+                    #encode_fn(#tag, value, buf);
+                }
+            },
+            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
+                #encode_fn(#tag, &#ident, buf);
+            },
+        }
+    }
+
+    /// Returns an expression which evaluates to the result of merging a decoded
+    /// scalar value into the field.
+    pub fn merge(&self, ident: TokenStream) -> TokenStream {
+        let module = self.ty.module();
+        let merge_fn = match self.kind {
+            Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(merge),
+            Kind::Repeated | Kind::Packed => quote!(merge_repeated),
+        };
+        let merge_fn = quote!(::prost::encoding::#module::#merge_fn);
+
+        match self.kind {
+            Kind::Plain(..) | Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
+                #merge_fn(wire_type, #ident, buf, ctx)
+            },
+            Kind::Optional(..) => quote! {
+                #merge_fn(wire_type,
+                          #ident.get_or_insert_with(Default::default),
+                          buf,
+                          ctx)
+            },
+        }
+    }
+
+    /// Returns an expression which evaluates to the encoded length of the field.
+    pub fn encoded_len(&self, ident: TokenStream) -> TokenStream {
+        let module = self.ty.module();
+        let encoded_len_fn = match self.kind {
+            Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(encoded_len),
+            Kind::Repeated => quote!(encoded_len_repeated),
+            Kind::Packed => quote!(encoded_len_packed),
+        };
+        let encoded_len_fn = quote!(::prost::encoding::#module::#encoded_len_fn);
+        let tag = self.tag;
+
+        match self.kind {
+            Kind::Plain(ref default) => {
+                let default = default.typed();
+                quote! {
+                    if #ident != #default {
+                        #encoded_len_fn(#tag, &#ident)
+                    } else {
+                        0
+                    }
+                }
+            }
+            Kind::Optional(..) => quote! {
+                #ident.as_ref().map_or(0, |value| #encoded_len_fn(#tag, value))
+            },
+            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
+                #encoded_len_fn(#tag, &#ident)
+            },
+        }
+    }
+
+    pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        match self.kind {
+            Kind::Plain(ref default) | Kind::Required(ref default) => {
+                let default = default.typed();
+                match self.ty {
+                    Ty::String | Ty::Bytes => quote!(#ident.clear()),
+                    _ => quote!(#ident = #default),
+                }
+            }
+            Kind::Optional(_) => quote!(#ident = ::core::option::Option::None),
+            Kind::Repeated | Kind::Packed => quote!(#ident.clear()),
+        }
+    }
+
+    /// Returns an expression which evaluates to the default value of the field.
+    pub fn default(&self) -> TokenStream {
+        match self.kind {
+            Kind::Plain(ref value) | Kind::Required(ref value) => value.owned(),
+            Kind::Optional(_) => quote!(::core::option::Option::None),
+            Kind::Repeated | Kind::Packed => quote!(::prost::alloc::vec::Vec::new()),
+        }
+    }
+
+    /// An inner debug wrapper, around the base type.
+    fn debug_inner(&self, wrap_name: TokenStream) -> TokenStream {
+        if let Ty::Enumeration(ref ty) = self.ty {
+            quote! {
+                struct #wrap_name<'a>(&'a i32);
+                impl<'a> ::core::fmt::Debug for #wrap_name<'a> {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                        match #ty::from_i32(*self.0) {
+                            None => ::core::fmt::Debug::fmt(&self.0, f),
+                            Some(en) => ::core::fmt::Debug::fmt(&en, f),
+                        }
+                    }
+                }
+            }
+        } else {
+            quote! {
+                fn #wrap_name<T>(v: T) -> T { v }
+            }
+        }
+    }
+
+    /// Returns a fragment for formatting the field `ident` in `Debug`.
+    pub fn debug(&self, wrapper_name: TokenStream) -> TokenStream {
+        let wrapper = self.debug_inner(quote!(Inner));
+        let inner_ty = self.ty.rust_type();
+        match self.kind {
+            Kind::Plain(_) | Kind::Required(_) => self.debug_inner(wrapper_name),
+            Kind::Optional(_) => quote! {
+                struct #wrapper_name<'a>(&'a ::core::option::Option<#inner_ty>);
+                impl<'a> ::core::fmt::Debug for #wrapper_name<'a> {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                        #wrapper
+                        ::core::fmt::Debug::fmt(&self.0.as_ref().map(Inner), f)
+                    }
+                }
+            },
+            Kind::Repeated | Kind::Packed => {
+                quote! {
+                    struct #wrapper_name<'a>(&'a ::prost::alloc::vec::Vec<#inner_ty>);
+                    impl<'a> ::core::fmt::Debug for #wrapper_name<'a> {
+                        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                            let mut vec_builder = f.debug_list();
+                            for v in self.0 {
+                                #wrapper
+                                vec_builder.entry(&Inner(v));
+                            }
+                            vec_builder.finish()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns methods to embed in the message.
+    pub fn methods(&self, ident: &Ident) -> Option<TokenStream> {
+        let mut ident_str = ident.to_string();
+        if ident_str.starts_with("r#") {
+            ident_str = ident_str[2..].to_owned();
+        }
+
+        if let Ty::Enumeration(ref ty) = self.ty {
+            let set = Ident::new(&format!("set_{}", ident_str), Span::call_site());
+            let set_doc = format!("Sets `{}` to the provided enum value.", ident_str);
+            Some(match self.kind {
+                Kind::Plain(ref default) | Kind::Required(ref default) => {
+                    let get_doc = format!(
+                        "Returns the enum value of `{}`, \
+                         or the default if the field is set to an invalid enum value.",
+                        ident_str,
+                    );
+                    quote! {
+                        #[doc=#get_doc]
+                        pub fn #ident(&self) -> #ty {
+                            #ty::from_i32(self.#ident).unwrap_or(#default)
+                        }
+
+                        #[doc=#set_doc]
+                        pub fn #set(&mut self, value: #ty) {
+                            self.#ident = value as i32;
+                        }
+                    }
+                }
+                Kind::Optional(ref default) => {
+                    let get_doc = format!(
+                        "Returns the enum value of `{}`, \
+                         or the default if the field is unset or set to an invalid enum value.",
+                        ident_str,
+                    );
+                    quote! {
+                        #[doc=#get_doc]
+                        pub fn #ident(&self) -> #ty {
+                            self.#ident.and_then(#ty::from_i32).unwrap_or(#default)
+                        }
+
+                        #[doc=#set_doc]
+                        pub fn #set(&mut self, value: #ty) {
+                            self.#ident = ::core::option::Option::Some(value as i32);
+                        }
+                    }
+                }
+                Kind::Repeated | Kind::Packed => {
+                    let iter_doc = format!(
+                        "Returns an iterator which yields the valid enum values contained in `{}`.",
+                        ident_str,
+                    );
+                    let push = Ident::new(&format!("push_{}", ident_str), Span::call_site());
+                    let push_doc = format!("Appends the provided enum value to `{}`.", ident_str);
+                    quote! {
+                        #[doc=#iter_doc]
+                        pub fn #ident(&self) -> ::core::iter::FilterMap<
+                            ::core::iter::Cloned<::core::slice::Iter<i32>>,
+                            fn(i32) -> ::core::option::Option<#ty>,
+                        > {
+                            self.#ident.iter().cloned().filter_map(#ty::from_i32)
+                        }
+                        #[doc=#push_doc]
+                        pub fn #push(&mut self, value: #ty) {
+                            self.#ident.push(value as i32);
+                        }
+                    }
+                }
+            })
+        } else if let Kind::Optional(ref default) = self.kind {
+            let ty = self.ty.rust_ref_type();
+
+            let match_some = if self.ty.is_numeric() {
+                quote!(::core::option::Option::Some(val) => val,)
+            } else {
+                quote!(::core::option::Option::Some(ref val) => &val[..],)
+            };
+
+            let get_doc = format!(
+                "Returns the value of `{0}`, or the default value if `{0}` is unset.",
+                ident_str,
+            );
+
+            Some(quote! {
+                #[doc=#get_doc]
+                pub fn #ident(&self) -> #ty {
+                    match self.#ident {
+                        #match_some
+                        ::core::option::Option::None => #default,
+                    }
+                }
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// A scalar protobuf field type.
+#[derive(Clone, PartialEq, Eq)]
+pub enum Ty {
+    Double,
+    Float,
+    Int32,
+    Int64,
+    Uint32,
+    Uint64,
+    Sint32,
+    Sint64,
+    Fixed32,
+    Fixed64,
+    Sfixed32,
+    Sfixed64,
+    Bool,
+    String,
+    Bytes,
+    Enumeration(Path),
+}
+
+impl Ty {
+    pub fn from_attr(attr: &Meta) -> Result<Option<Ty>, Error> {
+        let ty = match *attr {
+            Meta::Path(ref name) if name.is_ident("float") => Ty::Float,
+            Meta::Path(ref name) if name.is_ident("double") => Ty::Double,
+            Meta::Path(ref name) if name.is_ident("int32") => Ty::Int32,
+            Meta::Path(ref name) if name.is_ident("int64") => Ty::Int64,
+            Meta::Path(ref name) if name.is_ident("uint32") => Ty::Uint32,
+            Meta::Path(ref name) if name.is_ident("uint64") => Ty::Uint64,
+            Meta::Path(ref name) if name.is_ident("sint32") => Ty::Sint32,
+            Meta::Path(ref name) if name.is_ident("sint64") => Ty::Sint64,
+            Meta::Path(ref name) if name.is_ident("fixed32") => Ty::Fixed32,
+            Meta::Path(ref name) if name.is_ident("fixed64") => Ty::Fixed64,
+            Meta::Path(ref name) if name.is_ident("sfixed32") => Ty::Sfixed32,
+            Meta::Path(ref name) if name.is_ident("sfixed64") => Ty::Sfixed64,
+            Meta::Path(ref name) if name.is_ident("bool") => Ty::Bool,
+            Meta::Path(ref name) if name.is_ident("string") => Ty::String,
+            Meta::Path(ref name) if name.is_ident("bytes") => Ty::Bytes,
+            Meta::NameValue(MetaNameValue {
+                ref path,
+                lit: Lit::Str(ref l),
+                ..
+            }) if path.is_ident("enumeration") => Ty::Enumeration(parse_str::<Path>(&l.value())?),
+            Meta::List(MetaList {
+                ref path,
+                ref nested,
+                ..
+            }) if path.is_ident("enumeration") => {
+                // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
+                if nested.len() == 1 {
+                    if let NestedMeta::Meta(Meta::Path(ref path)) = nested[0] {
+                        Ty::Enumeration(path.clone())
+                    } else {
+                        bail!("invalid enumeration attribute: item must be an identifier");
+                    }
+                } else {
+                    bail!("invalid enumeration attribute: only a single identifier is supported");
+                }
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(ty))
+    }
+
+    pub fn from_str(s: &str) -> Result<Ty, Error> {
+        let enumeration_len = "enumeration".len();
+        let error = Err(anyhow!("invalid type: {}", s));
+        let ty = match s.trim() {
+            "float" => Ty::Float,
+            "double" => Ty::Double,
+            "int32" => Ty::Int32,
+            "int64" => Ty::Int64,
+            "uint32" => Ty::Uint32,
+            "uint64" => Ty::Uint64,
+            "sint32" => Ty::Sint32,
+            "sint64" => Ty::Sint64,
+            "fixed32" => Ty::Fixed32,
+            "fixed64" => Ty::Fixed64,
+            "sfixed32" => Ty::Sfixed32,
+            "sfixed64" => Ty::Sfixed64,
+            "bool" => Ty::Bool,
+            "string" => Ty::String,
+            "bytes" => Ty::Bytes,
+            s if s.len() > enumeration_len && &s[..enumeration_len] == "enumeration" => {
+                let s = &s[enumeration_len..].trim();
+                match s.chars().next() {
+                    Some('<') | Some('(') => (),
+                    _ => return error,
+                }
+                match s.chars().next_back() {
+                    Some('>') | Some(')') => (),
+                    _ => return error,
+                }
+
+                Ty::Enumeration(parse_str::<Path>(s[1..s.len() - 1].trim())?)
+            }
+            _ => return error,
+        };
+        Ok(ty)
+    }
+
+    /// Returns the type as it appears in protobuf field declarations.
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            Ty::Double => "double",
+            Ty::Float => "float",
+            Ty::Int32 => "int32",
+            Ty::Int64 => "int64",
+            Ty::Uint32 => "uint32",
+            Ty::Uint64 => "uint64",
+            Ty::Sint32 => "sint32",
+            Ty::Sint64 => "sint64",
+            Ty::Fixed32 => "fixed32",
+            Ty::Fixed64 => "fixed64",
+            Ty::Sfixed32 => "sfixed32",
+            Ty::Sfixed64 => "sfixed64",
+            Ty::Bool => "bool",
+            Ty::String => "string",
+            Ty::Bytes => "bytes",
+            Ty::Enumeration(..) => "enum",
+        }
+    }
+
+    // TODO: rename to 'owned_type'.
+    pub fn rust_type(&self) -> TokenStream {
+        match *self {
+            Ty::String => quote!(::prost::alloc::string::String),
+            Ty::Bytes => quote!(::prost::alloc::vec::Vec<u8>),
+            _ => self.rust_ref_type(),
+        }
+    }
+
+    // TODO: rename to 'ref_type'
+    pub fn rust_ref_type(&self) -> TokenStream {
+        match *self {
+            Ty::Double => quote!(f64),
+            Ty::Float => quote!(f32),
+            Ty::Int32 => quote!(i32),
+            Ty::Int64 => quote!(i64),
+            Ty::Uint32 => quote!(u32),
+            Ty::Uint64 => quote!(u64),
+            Ty::Sint32 => quote!(i32),
+            Ty::Sint64 => quote!(i64),
+            Ty::Fixed32 => quote!(u32),
+            Ty::Fixed64 => quote!(u64),
+            Ty::Sfixed32 => quote!(i32),
+            Ty::Sfixed64 => quote!(i64),
+            Ty::Bool => quote!(bool),
+            Ty::String => quote!(&str),
+            Ty::Bytes => quote!(&[u8]),
+            Ty::Enumeration(..) => quote!(i32),
+        }
+    }
+
+    pub fn module(&self) -> Ident {
+        match *self {
+            Ty::Enumeration(..) => Ident::new("int32", Span::call_site()),
+            _ => Ident::new(self.as_str(), Span::call_site()),
+        }
+    }
+
+    /// Returns true if the scalar type is length delimited (i.e., `string` or `bytes`).
+    pub fn is_numeric(&self) -> bool {
+        *self != Ty::String && *self != Ty::Bytes
+    }
+}
+
+impl fmt::Debug for Ty {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Display for Ty {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Scalar Protobuf field types.
+#[derive(Clone)]
+pub enum Kind {
+    /// A plain proto3 scalar field.
+    Plain(DefaultValue),
+    /// An optional scalar field.
+    Optional(DefaultValue),
+    /// A required proto2 scalar field.
+    Required(DefaultValue),
+    /// A repeated scalar field.
+    Repeated,
+    /// A packed repeated scalar field.
+    Packed,
+}
+
+/// Scalar Protobuf field default value.
+#[derive(Clone, Debug)]
+pub enum DefaultValue {
+    F64(f64),
+    F32(f32),
+    I32(i32),
+    I64(i64),
+    U32(u32),
+    U64(u64),
+    Bool(bool),
+    String(String),
+    Bytes(Vec<u8>),
+    Enumeration(TokenStream),
+    Path(Path),
+}
+
+impl DefaultValue {
+    pub fn from_attr(attr: &Meta) -> Result<Option<Lit>, Error> {
+        if !attr.path().is_ident("default") {
+            Ok(None)
+        } else if let Meta::NameValue(ref name_value) = *attr {
+            Ok(Some(name_value.lit.clone()))
+        } else {
+            bail!("invalid default value attribute: {:?}", attr)
+        }
+    }
+
+    pub fn from_lit(ty: &Ty, lit: Lit) -> Result<DefaultValue, Error> {
+        let is_i32 = *ty == Ty::Int32 || *ty == Ty::Sint32 || *ty == Ty::Sfixed32;
+        let is_i64 = *ty == Ty::Int64 || *ty == Ty::Sint64 || *ty == Ty::Sfixed64;
+
+        let is_u32 = *ty == Ty::Uint32 || *ty == Ty::Fixed32;
+        let is_u64 = *ty == Ty::Uint64 || *ty == Ty::Fixed64;
+
+        let empty_or_is = |expected, actual: &str| expected == actual || actual.is_empty();
+
+        let default = match lit {
+            Lit::Int(ref lit) if is_i32 && empty_or_is("i32", lit.suffix()) => {
+                DefaultValue::I32(lit.base10_parse()?)
+            }
+            Lit::Int(ref lit) if is_i64 && empty_or_is("i64", lit.suffix()) => {
+                DefaultValue::I64(lit.base10_parse()?)
+            }
+            Lit::Int(ref lit) if is_u32 && empty_or_is("u32", lit.suffix()) => {
+                DefaultValue::U32(lit.base10_parse()?)
+            }
+            Lit::Int(ref lit) if is_u64 && empty_or_is("u64", lit.suffix()) => {
+                DefaultValue::U64(lit.base10_parse()?)
+            }
+
+            Lit::Float(ref lit) if *ty == Ty::Float && empty_or_is("f32", lit.suffix()) => {
+                DefaultValue::F32(lit.base10_parse()?)
+            }
+            Lit::Int(ref lit) if *ty == Ty::Float => DefaultValue::F32(lit.base10_parse()?),
+
+            Lit::Float(ref lit) if *ty == Ty::Double && empty_or_is("f64", lit.suffix()) => {
+                DefaultValue::F64(lit.base10_parse()?)
+            }
+            Lit::Int(ref lit) if *ty == Ty::Double => DefaultValue::F64(lit.base10_parse()?),
+
+            Lit::Bool(ref lit) if *ty == Ty::Bool => DefaultValue::Bool(lit.value),
+            Lit::Str(ref lit) if *ty == Ty::String => DefaultValue::String(lit.value()),
+            Lit::ByteStr(ref lit) if *ty == Ty::Bytes => DefaultValue::Bytes(lit.value()),
+
+            Lit::Str(ref lit) => {
+                let value = lit.value();
+                let value = value.trim();
+
+                if let Ty::Enumeration(ref path) = *ty {
+                    let variant = Ident::new(value, Span::call_site());
+                    return Ok(DefaultValue::Enumeration(quote!(#path::#variant)));
+                }
+
+                // Parse special floating point values.
+                if *ty == Ty::Float {
+                    match value {
+                        "inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::core::f32::INFINITY",
+                            )?));
+                        }
+                        "-inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::core::f32::NEG_INFINITY",
+                            )?));
+                        }
+                        "nan" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::core::f32::NAN")?));
+                        }
+                        _ => (),
+                    }
+                }
+                if *ty == Ty::Double {
+                    match value {
+                        "inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::core::f64::INFINITY",
+                            )?));
+                        }
+                        "-inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::core::f64::NEG_INFINITY",
+                            )?));
+                        }
+                        "nan" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::core::f64::NAN")?));
+                        }
+                        _ => (),
+                    }
+                }
+
+                // Rust doesn't have a negative literals, so they have to be parsed specially.
+                if value.starts_with('-') {
+                    if let Ok(lit) = syn::parse_str::<Lit>(&value[1..]) {
+                        match lit {
+                            Lit::Int(ref lit) if is_i32 && empty_or_is("i32", lit.suffix()) => {
+                                // Initially parse into an i64, so that i32::MIN does not overflow.
+                                let value: i64 = -lit.base10_parse()?;
+                                return Ok(i32::try_from(value).map(DefaultValue::I32)?);
+                            }
+
+                            Lit::Int(ref lit) if is_i64 && empty_or_is("i64", lit.suffix()) => {
+                                // Initially parse into an i128, so that i64::MIN does not overflow.
+                                let value: i128 = -lit.base10_parse()?;
+                                return Ok(i64::try_from(value).map(DefaultValue::I64)?);
+                            }
+
+                            Lit::Float(ref lit)
+                                if *ty == Ty::Float && empty_or_is("f32", lit.suffix()) =>
+                            {
+                                return Ok(DefaultValue::F32(-lit.base10_parse()?));
+                            }
+
+                            Lit::Float(ref lit)
+                                if *ty == Ty::Double && empty_or_is("f64", lit.suffix()) =>
+                            {
+                                return Ok(DefaultValue::F64(-lit.base10_parse()?));
+                            }
+
+                            Lit::Int(ref lit) if *ty == Ty::Float && lit.suffix().is_empty() => {
+                                return Ok(DefaultValue::F32(-lit.base10_parse()?));
+                            }
+
+                            Lit::Int(ref lit) if *ty == Ty::Double && lit.suffix().is_empty() => {
+                                return Ok(DefaultValue::F64(-lit.base10_parse()?));
+                            }
+
+                            _ => (),
+                        }
+                    }
+                }
+                match syn::parse_str::<Lit>(&value) {
+                    Ok(Lit::Str(_)) => (),
+                    Ok(lit) => return DefaultValue::from_lit(ty, lit),
+                    _ => (),
+                }
+                bail!("invalid default value: {}", quote!(#value));
+            }
+            _ => bail!("invalid default value: {}", quote!(#lit)),
+        };
+
+        Ok(default)
+    }
+
+    pub fn new(ty: &Ty) -> DefaultValue {
+        match *ty {
+            Ty::Float => DefaultValue::F32(0.0),
+            Ty::Double => DefaultValue::F64(0.0),
+            Ty::Int32 | Ty::Sint32 | Ty::Sfixed32 => DefaultValue::I32(0),
+            Ty::Int64 | Ty::Sint64 | Ty::Sfixed64 => DefaultValue::I64(0),
+            Ty::Uint32 | Ty::Fixed32 => DefaultValue::U32(0),
+            Ty::Uint64 | Ty::Fixed64 => DefaultValue::U64(0),
+
+            Ty::Bool => DefaultValue::Bool(false),
+            Ty::String => DefaultValue::String(String::new()),
+            Ty::Bytes => DefaultValue::Bytes(Vec::new()),
+            Ty::Enumeration(ref path) => DefaultValue::Enumeration(quote!(#path::default())),
+        }
+    }
+
+    pub fn owned(&self) -> TokenStream {
+        match *self {
+            DefaultValue::String(ref value) if value.is_empty() => {
+                quote!(::prost::alloc::string::String::new())
+            }
+            DefaultValue::String(ref value) => quote!(#value.to_owned()),
+            DefaultValue::Bytes(ref value) if value.is_empty() => {
+                quote!(::prost::alloc::vec::Vec::new())
+            }
+            DefaultValue::Bytes(ref value) => {
+                let lit = LitByteStr::new(value, Span::call_site());
+                quote!(#lit.to_owned())
+            }
+
+            ref other => other.typed(),
+        }
+    }
+
+    pub fn typed(&self) -> TokenStream {
+        if let DefaultValue::Enumeration(_) = *self {
+            quote!(#self as i32)
+        } else {
+            quote!(#self)
+        }
+    }
+}
+
+impl ToTokens for DefaultValue {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match *self {
+            DefaultValue::F64(value) => value.to_tokens(tokens),
+            DefaultValue::F32(value) => value.to_tokens(tokens),
+            DefaultValue::I32(value) => value.to_tokens(tokens),
+            DefaultValue::I64(value) => value.to_tokens(tokens),
+            DefaultValue::U32(value) => value.to_tokens(tokens),
+            DefaultValue::U64(value) => value.to_tokens(tokens),
+            DefaultValue::Bool(value) => value.to_tokens(tokens),
+            DefaultValue::String(ref value) => value.to_tokens(tokens),
+            DefaultValue::Bytes(ref value) => {
+                LitByteStr::new(value, Span::call_site()).to_tokens(tokens)
+            }
+            DefaultValue::Enumeration(ref value) => value.to_tokens(tokens),
+            DefaultValue::Path(ref value) => value.to_tokens(tokens),
+        }
+    }
+}

--- a/third_party/prost/prost-derive/src/lib.rs
+++ b/third_party/prost/prost-derive/src/lib.rs
@@ -1,0 +1,475 @@
+#![doc(html_root_url = "https://docs.rs/prost-derive/0.6.1")]
+// The `quote!` macro requires deep recursion.
+#![recursion_limit = "4096"]
+
+extern crate alloc;
+extern crate proc_macro;
+
+use anyhow::{bail, Error};
+use itertools::Itertools;
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{
+    punctuated::Punctuated, Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, FieldsNamed,
+    FieldsUnnamed, Ident, Variant,
+};
+
+mod field;
+use crate::field::Field;
+
+fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
+    let input: DeriveInput = syn::parse(input)?;
+
+    let ident = input.ident;
+
+    let variant_data = match input.data {
+        Data::Struct(variant_data) => variant_data,
+        Data::Enum(..) => bail!("Message can not be derived for an enum"),
+        Data::Union(..) => bail!("Message can not be derived for a union"),
+    };
+
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
+        bail!("Message may not be derived for generic type");
+    }
+
+    let fields = match variant_data {
+        DataStruct {
+            fields: Fields::Named(FieldsNamed { named: fields, .. }),
+            ..
+        }
+        | DataStruct {
+            fields:
+                Fields::Unnamed(FieldsUnnamed {
+                    unnamed: fields, ..
+                }),
+            ..
+        } => fields.into_iter().collect(),
+        DataStruct {
+            fields: Fields::Unit,
+            ..
+        } => Vec::new(),
+    };
+
+    let mut next_tag: u32 = 1;
+    let mut fields = fields
+        .into_iter()
+        .enumerate()
+        .flat_map(|(idx, field)| {
+            let field_ident = field
+                .ident
+                .unwrap_or_else(|| Ident::new(&idx.to_string(), Span::call_site()));
+            match Field::new(field.attrs, Some(next_tag)) {
+                Ok(Some(field)) => {
+                    next_tag = field.tags().iter().max().map(|t| t + 1).unwrap_or(next_tag);
+                    Some(Ok((field_ident, field)))
+                }
+                Ok(None) => None,
+                Err(err) => Some(Err(
+                    err.context(format!("invalid message field {}.{}", ident, field_ident))
+                )),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // We want Debug to be in declaration order
+    let unsorted_fields = fields.clone();
+
+    // Sort the fields by tag number so that fields will be encoded in tag order.
+    // TODO: This encodes oneof fields in the position of their lowest tag,
+    // regardless of the currently occupied variant, is that consequential?
+    // See: https://developers.google.com/protocol-buffers/docs/encoding#order
+    fields.sort_by_key(|&(_, ref field)| field.tags().into_iter().min().unwrap());
+    let fields = fields;
+
+    let mut tags = fields
+        .iter()
+        .flat_map(|&(_, ref field)| field.tags())
+        .collect::<Vec<_>>();
+    let num_tags = tags.len();
+    tags.sort();
+    tags.dedup();
+    if tags.len() != num_tags {
+        bail!("message {} has fields with duplicate tags", ident);
+    }
+
+    let encoded_len = fields
+        .iter()
+        .map(|&(ref field_ident, ref field)| field.encoded_len(quote!(self.#field_ident)));
+
+    let encode = fields
+        .iter()
+        .map(|&(ref field_ident, ref field)| field.encode(quote!(self.#field_ident)));
+
+    let merge = fields.iter().map(|&(ref field_ident, ref field)| {
+        let merge = field.merge(quote!(value));
+        let tags = field
+            .tags()
+            .into_iter()
+            .map(|tag| quote!(#tag))
+            .intersperse(quote!(|));
+        quote! {
+            #(#tags)* => {
+                let mut value = &mut self.#field_ident;
+                #merge.map_err(|mut error| {
+                    error.push(STRUCT_NAME, stringify!(#field_ident));
+                    error
+                })
+            },
+        }
+    });
+
+    let struct_name = if fields.is_empty() {
+        quote!()
+    } else {
+        quote!(
+            const STRUCT_NAME: &'static str = stringify!(#ident);
+        )
+    };
+
+    // TODO
+    let is_struct = true;
+
+    let clear = fields
+        .iter()
+        .map(|&(ref field_ident, ref field)| field.clear(quote!(self.#field_ident)));
+
+    let default = fields.iter().map(|&(ref field_ident, ref field)| {
+        let value = field.default();
+        quote!(#field_ident: #value,)
+    });
+
+    let methods = fields
+        .iter()
+        .flat_map(|&(ref field_ident, ref field)| field.methods(field_ident))
+        .collect::<Vec<_>>();
+    let methods = if methods.is_empty() {
+        quote!()
+    } else {
+        quote! {
+            #[allow(dead_code)]
+            impl #ident {
+                #(#methods)*
+            }
+        }
+    };
+
+    let debugs = unsorted_fields.iter().map(|&(ref field_ident, ref field)| {
+        let wrapper = field.debug(quote!(self.#field_ident));
+        let call = if is_struct {
+            quote!(builder.field(stringify!(#field_ident), &wrapper))
+        } else {
+            quote!(builder.field(&wrapper))
+        };
+        quote! {
+             let builder = {
+                 let wrapper = #wrapper;
+                 #call
+             };
+        }
+    });
+    let debug_builder = if is_struct {
+        quote!(f.debug_struct(stringify!(#ident)))
+    } else {
+        quote!(f.debug_tuple(stringify!(#ident)))
+    };
+
+    let expanded = quote! {
+        impl ::prost::Message for #ident {
+            #[allow(unused_variables)]
+            fn encode_raw<B>(&self, buf: &mut B) where B: ::prost::bytes::BufMut {
+                #(#encode)*
+            }
+
+            #[allow(unused_variables)]
+            fn merge_field<B>(
+                &mut self,
+                tag: u32,
+                wire_type: ::prost::encoding::WireType,
+                buf: &mut B,
+                ctx: ::prost::encoding::DecodeContext,
+            ) -> ::core::result::Result<(), ::prost::DecodeError>
+            where B: ::prost::bytes::Buf {
+                #struct_name
+                match tag {
+                    #(#merge)*
+                    _ => ::prost::encoding::skip_field(wire_type, tag, buf, ctx),
+                }
+            }
+
+            #[inline]
+            fn encoded_len(&self) -> usize {
+                0 #(+ #encoded_len)*
+            }
+
+            fn clear(&mut self) {
+                #(#clear;)*
+            }
+        }
+
+        impl Default for #ident {
+            fn default() -> #ident {
+                #ident {
+                    #(#default)*
+                }
+            }
+        }
+
+        impl ::core::fmt::Debug for #ident {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                let mut builder = #debug_builder;
+                #(#debugs;)*
+                builder.finish()
+            }
+        }
+
+        #methods
+    };
+
+    Ok(expanded.into())
+}
+
+#[proc_macro_derive(Message, attributes(prost))]
+pub fn message(input: TokenStream) -> TokenStream {
+    try_message(input).unwrap()
+}
+
+fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
+    let input: DeriveInput = syn::parse(input)?;
+    let ident = input.ident;
+
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
+        bail!("Message may not be derived for generic type");
+    }
+
+    let punctuated_variants = match input.data {
+        Data::Enum(DataEnum { variants, .. }) => variants,
+        Data::Struct(_) => bail!("Enumeration can not be derived for a struct"),
+        Data::Union(..) => bail!("Enumeration can not be derived for a union"),
+    };
+
+    // Map the variants into 'fields'.
+    let mut variants: Vec<(Ident, Expr)> = Vec::new();
+    for Variant {
+        ident,
+        fields,
+        discriminant,
+        ..
+    } in punctuated_variants
+    {
+        match fields {
+            Fields::Unit => (),
+            Fields::Named(_) | Fields::Unnamed(_) => {
+                bail!("Enumeration variants may not have fields")
+            }
+        }
+
+        match discriminant {
+            Some((_, expr)) => variants.push((ident, expr)),
+            None => bail!("Enumeration variants must have a disriminant"),
+        }
+    }
+
+    if variants.is_empty() {
+        panic!("Enumeration must have at least one variant");
+    }
+
+    let default = variants[0].0.clone();
+
+    let is_valid = variants
+        .iter()
+        .map(|&(_, ref value)| quote!(#value => true));
+    let from = variants.iter().map(
+        |&(ref variant, ref value)| quote!(#value => ::core::option::Option::Some(#ident::#variant)),
+    );
+
+    let is_valid_doc = format!("Returns `true` if `value` is a variant of `{}`.", ident);
+    let from_i32_doc = format!(
+        "Converts an `i32` to a `{}`, or `None` if `value` is not a valid variant.",
+        ident
+    );
+
+    let expanded = quote! {
+        impl #ident {
+            #[doc=#is_valid_doc]
+            pub fn is_valid(value: i32) -> bool {
+                match value {
+                    #(#is_valid,)*
+                    _ => false,
+                }
+            }
+
+            #[doc=#from_i32_doc]
+            pub fn from_i32(value: i32) -> ::core::option::Option<#ident> {
+                match value {
+                    #(#from,)*
+                    _ => ::core::option::Option::None,
+                }
+            }
+        }
+
+        impl ::core::default::Default for #ident {
+            fn default() -> #ident {
+                #ident::#default
+            }
+        }
+
+        impl ::core::convert::From<#ident> for i32 {
+            fn from(value: #ident) -> i32 {
+                value as i32
+            }
+        }
+    };
+
+    Ok(expanded.into())
+}
+
+#[proc_macro_derive(Enumeration, attributes(prost))]
+pub fn enumeration(input: TokenStream) -> TokenStream {
+    try_enumeration(input).unwrap()
+}
+
+fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
+    let input: DeriveInput = syn::parse(input)?;
+
+    let ident = input.ident;
+
+    let variants = match input.data {
+        Data::Enum(DataEnum { variants, .. }) => variants,
+        Data::Struct(..) => bail!("Oneof can not be derived for a struct"),
+        Data::Union(..) => bail!("Oneof can not be derived for a union"),
+    };
+
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
+        bail!("Message may not be derived for generic type");
+    }
+
+    // Map the variants into 'fields'.
+    let mut fields: Vec<(Ident, Field)> = Vec::new();
+    for Variant {
+        attrs,
+        ident: variant_ident,
+        fields: variant_fields,
+        ..
+    } in variants
+    {
+        let variant_fields = match variant_fields {
+            Fields::Unit => Punctuated::new(),
+            Fields::Named(FieldsNamed { named: fields, .. })
+            | Fields::Unnamed(FieldsUnnamed {
+                unnamed: fields, ..
+            }) => fields,
+        };
+        if variant_fields.len() != 1 {
+            bail!("Oneof enum variants must have a single field");
+        }
+        match Field::new_oneof(attrs)? {
+            Some(field) => fields.push((variant_ident, field)),
+            None => bail!("invalid oneof variant: oneof variants may not be ignored"),
+        }
+    }
+
+    let mut tags = fields
+        .iter()
+        .flat_map(|&(ref variant_ident, ref field)| -> Result<u32, Error> {
+            if field.tags().len() > 1 {
+                bail!(
+                    "invalid oneof variant {}::{}: oneof variants may only have a single tag",
+                    ident,
+                    variant_ident
+                );
+            }
+            Ok(field.tags()[0])
+        })
+        .collect::<Vec<_>>();
+    tags.sort();
+    tags.dedup();
+    if tags.len() != fields.len() {
+        panic!("invalid oneof {}: variants have duplicate tags", ident);
+    }
+
+    let encode = fields.iter().map(|&(ref variant_ident, ref field)| {
+        let encode = field.encode(quote!(*value));
+        quote!(#ident::#variant_ident(ref value) => { #encode })
+    });
+
+    let merge = fields.iter().map(|&(ref variant_ident, ref field)| {
+        let tag = field.tags()[0];
+        let merge = field.merge(quote!(value));
+        quote! {
+            #tag => {
+                match field {
+                    ::core::option::Option::Some(#ident::#variant_ident(ref mut value)) => {
+                        #merge
+                    },
+                    _ => {
+                        let mut owned_value = ::core::default::Default::default();
+                        let value = &mut owned_value;
+                        #merge.map(|_| *field = ::core::option::Option::Some(#ident::#variant_ident(owned_value)))
+                    },
+                }
+            }
+        }
+    });
+
+    let encoded_len = fields.iter().map(|&(ref variant_ident, ref field)| {
+        let encoded_len = field.encoded_len(quote!(*value));
+        quote!(#ident::#variant_ident(ref value) => #encoded_len)
+    });
+
+    let debug = fields.iter().map(|&(ref variant_ident, ref field)| {
+        let wrapper = field.debug(quote!(*value));
+        quote!(#ident::#variant_ident(ref value) => {
+            let wrapper = #wrapper;
+            f.debug_tuple(stringify!(#variant_ident))
+                .field(&wrapper)
+                .finish()
+        })
+    });
+
+    let expanded = quote! {
+        impl #ident {
+            pub fn encode<B>(&self, buf: &mut B) where B: ::prost::bytes::BufMut {
+                match *self {
+                    #(#encode,)*
+                }
+            }
+
+            pub fn merge<B>(
+                field: &mut ::core::option::Option<#ident>,
+                tag: u32,
+                wire_type: ::prost::encoding::WireType,
+                buf: &mut B,
+                ctx: ::prost::encoding::DecodeContext,
+            ) -> ::core::result::Result<(), ::prost::DecodeError>
+            where B: ::prost::bytes::Buf {
+                match tag {
+                    #(#merge,)*
+                    _ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag),
+                }
+            }
+
+            #[inline]
+            pub fn encoded_len(&self) -> usize {
+                match *self {
+                    #(#encoded_len,)*
+                }
+            }
+        }
+
+        impl ::core::fmt::Debug for #ident {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match *self {
+                    #(#debug,)*
+                }
+            }
+        }
+    };
+
+    Ok(expanded.into())
+}
+
+#[proc_macro_derive(Oneof, attributes(prost))]
+pub fn oneof(input: TokenStream) -> TokenStream {
+    try_oneof(input).unwrap()
+}

--- a/third_party/prost/prost-types/Cargo.toml
+++ b/third_party/prost/prost-types/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "prost-types"
+version = "0.6.1"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+license = "Apache-2.0"
+repository = "https://github.com/danburkert/prost"
+documentation = "https://docs.rs/prost-types"
+readme = "README.md"
+description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
+
+[lib]
+doctest = false
+
+[features]
+default = ["std"]
+std = ["prost/std"]
+
+[dependencies]
+bytes = { version = "0.5", default-features = false }
+prost = { version = "0.6.1", path = "..", default-features = false, features = ["prost-derive"] }
+
+[dev-dependencies]
+proptest = "0.9"

--- a/third_party/prost/prost-types/README.md
+++ b/third_party/prost/prost-types/README.md
@@ -1,0 +1,21 @@
+[![Documentation](https://docs.rs/prost-types/badge.svg)](https://docs.rs/prost-types/)
+[![Crate](https://img.shields.io/crates/v/prost-types.svg)](https://crates.io/crates/prost-types)
+
+# `prost-types`
+
+Prost definitions of Protocol Buffers well known types. See the [Protobuf reference][1] for more
+information about well known types.
+
+[1]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
+
+## License
+
+`prost-types` is distributed under the terms of the Apache License (Version 2.0).
+`prost-types` includes code imported from the Protocol Buffers projet, which is
+included under its original ([BSD][2]) license.
+
+[2]: https://github.com/google/protobuf/blob/master/LICENSE
+
+See [LICENSE](..LICENSE) for details.
+
+Copyright 2017 Dan Burkert

--- a/third_party/prost/prost-types/src/compiler.rs
+++ b/third_party/prost/prost-types/src/compiler.rs
@@ -1,0 +1,123 @@
+/// The version number of protocol compiler.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Version {
+    #[prost(int32, optional, tag="1")]
+    pub major: ::core::option::Option<i32>,
+    #[prost(int32, optional, tag="2")]
+    pub minor: ::core::option::Option<i32>,
+    #[prost(int32, optional, tag="3")]
+    pub patch: ::core::option::Option<i32>,
+    /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+    /// be empty for mainline stable releases.
+    #[prost(string, optional, tag="4")]
+    pub suffix: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// An encoded CodeGeneratorRequest is written to the plugin's stdin.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CodeGeneratorRequest {
+    /// The .proto files that were explicitly listed on the command-line.  The
+    /// code generator should generate code only for these files.  Each file's
+    /// descriptor will be included in proto_file, below.
+    #[prost(string, repeated, tag="1")]
+    pub file_to_generate: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// The generator parameter passed on the command-line.
+    #[prost(string, optional, tag="2")]
+    pub parameter: ::core::option::Option<::prost::alloc::string::String>,
+    /// FileDescriptorProtos for all files in files_to_generate and everything
+    /// they import.  The files will appear in topological order, so each file
+    /// appears before any file that imports it.
+    ///
+    /// protoc guarantees that all proto_files will be written after
+    /// the fields above, even though this is not technically guaranteed by the
+    /// protobuf wire format.  This theoretically could allow a plugin to stream
+    /// in the FileDescriptorProtos and handle them one by one rather than read
+    /// the entire set into memory at once.  However, as of this writing, this
+    /// is not similarly optimized on protoc's end -- it will store all fields in
+    /// memory at once before sending them to the plugin.
+    ///
+    /// Type names of fields and extensions in the FileDescriptorProto are always
+    /// fully qualified.
+    #[prost(message, repeated, tag="15")]
+    pub proto_file: ::prost::alloc::vec::Vec<super::FileDescriptorProto>,
+    /// The version number of protocol compiler.
+    #[prost(message, optional, tag="3")]
+    pub compiler_version: ::core::option::Option<Version>,
+}
+/// The plugin writes an encoded CodeGeneratorResponse to stdout.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CodeGeneratorResponse {
+    /// Error message.  If non-empty, code generation failed.  The plugin process
+    /// should exit with status code zero even if it reports an error in this way.
+    ///
+    /// This should be used to indicate errors in .proto files which prevent the
+    /// code generator from generating correct code.  Errors which indicate a
+    /// problem in protoc itself -- such as the input CodeGeneratorRequest being
+    /// unparseable -- should be reported by writing a message to stderr and
+    /// exiting with a non-zero status code.
+    #[prost(string, optional, tag="1")]
+    pub error: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag="15")]
+    pub file: ::prost::alloc::vec::Vec<code_generator_response::File>,
+}
+/// Nested message and enum types in `CodeGeneratorResponse`.
+pub mod code_generator_response {
+    /// Represents a single generated file.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct File {
+        /// The file name, relative to the output directory.  The name must not
+        /// contain "." or ".." components and must be relative, not be absolute (so,
+        /// the file cannot lie outside the output directory).  "/" must be used as
+        /// the path separator, not "\".
+        ///
+        /// If the name is omitted, the content will be appended to the previous
+        /// file.  This allows the generator to break large files into small chunks,
+        /// and allows the generated text to be streamed back to protoc so that large
+        /// files need not reside completely in memory at one time.  Note that as of
+        /// this writing protoc does not optimize for this -- it will read the entire
+        /// CodeGeneratorResponse before writing files to disk.
+        #[prost(string, optional, tag="1")]
+        pub name: ::core::option::Option<::prost::alloc::string::String>,
+        /// If non-empty, indicates that the named file should already exist, and the
+        /// content here is to be inserted into that file at a defined insertion
+        /// point.  This feature allows a code generator to extend the output
+        /// produced by another code generator.  The original generator may provide
+        /// insertion points by placing special annotations in the file that look
+        /// like:
+        ///   @@protoc_insertion_point(NAME)
+        /// The annotation can have arbitrary text before and after it on the line,
+        /// which allows it to be placed in a comment.  NAME should be replaced with
+        /// an identifier naming the point -- this is what other generators will use
+        /// as the insertion_point.  Code inserted at this point will be placed
+        /// immediately above the line containing the insertion point (thus multiple
+        /// insertions to the same point will come out in the order they were added).
+        /// The double-@ is intended to make it unlikely that the generated code
+        /// could contain things that look like insertion points by accident.
+        ///
+        /// For example, the C++ code generator places the following line in the
+        /// .pb.h files that it generates:
+        ///   // @@protoc_insertion_point(namespace_scope)
+        /// This line appears within the scope of the file's package namespace, but
+        /// outside of any particular class.  Another plugin can then specify the
+        /// insertion_point "namespace_scope" to generate additional classes or
+        /// other declarations that should be placed in this scope.
+        ///
+        /// Note that if the line containing the insertion point begins with
+        /// whitespace, the same whitespace will be added to every line of the
+        /// inserted text.  This is useful for languages like Python, where
+        /// indentation matters.  In these languages, the insertion point comment
+        /// should be indented the same amount as any inserted code will need to be
+        /// in order to work correctly in that context.
+        ///
+        /// The code generator that generates the initial file and the one which
+        /// inserts into it must both run as part of a single invocation of protoc.
+        /// Code generators are executed in the order in which they appear on the
+        /// command line.
+        ///
+        /// If |insertion_point| is present, |name| must also be present.
+        #[prost(string, optional, tag="2")]
+        pub insertion_point: ::core::option::Option<::prost::alloc::string::String>,
+        /// The file contents.
+        #[prost(string, optional, tag="15")]
+        pub content: ::core::option::Option<::prost::alloc::string::String>,
+    }
+}

--- a/third_party/prost/prost-types/src/lib.rs
+++ b/third_party/prost/prost-types/src/lib.rs
@@ -1,0 +1,177 @@
+#![doc(html_root_url = "https://docs.rs/prost-types/0.6.1")]
+
+//! Protocol Buffers well-known types.
+//!
+//! Note that the documentation for the types defined in this crate are generated from the Protobuf
+//! definitions, so code examples are not in Rust.
+//!
+//! See the [Protobuf reference][1] for more information about well-known types.
+//!
+//! [1]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use core::convert::TryFrom;
+use core::i32;
+use core::i64;
+use core::time;
+
+include!("protobuf.rs");
+pub mod compiler {
+    include!("compiler.rs");
+}
+
+// The Protobuf `Duration` and `Timestamp` types can't delegate to the standard library equivalents
+// because the Protobuf versions are signed. To make them easier to work with, `From` conversions
+// are defined in both directions.
+
+const NANOS_PER_SECOND: i32 = 1_000_000_000;
+
+impl Duration {
+    /// Normalizes the duration to a canonical format.
+    ///
+    /// Based on [`google::protobuf::util::CreateNormalized`][1].
+    /// [1]: https://github.com/google/protobuf/blob/v3.3.2/src/google/protobuf/util/time_util.cc#L79-L100
+    pub fn normalize(&mut self) {
+        // Make sure nanos is in the range.
+        if self.nanos <= -NANOS_PER_SECOND || self.nanos >= NANOS_PER_SECOND {
+            self.seconds += (self.nanos / NANOS_PER_SECOND) as i64;
+            self.nanos %= NANOS_PER_SECOND;
+        }
+
+        // nanos should have the same sign as seconds.
+        if self.seconds < 0 && self.nanos > 0 {
+            self.seconds += 1;
+            self.nanos -= NANOS_PER_SECOND;
+        } else if self.seconds > 0 && self.nanos < 0 {
+            self.seconds -= 1;
+            self.nanos += NANOS_PER_SECOND;
+        }
+        // TODO: should this be checked?
+        // debug_assert!(self.seconds >= -315_576_000_000 && self.seconds <= 315_576_000_000,
+        //               "invalid duration: {:?}", self);
+    }
+}
+
+/// Converts a `std::time::Duration` to a `Duration`.
+impl From<time::Duration> for Duration {
+    fn from(duration: time::Duration) -> Duration {
+        let seconds = duration.as_secs();
+        let seconds = if seconds > i64::MAX as u64 {
+            i64::MAX
+        } else {
+            seconds as i64
+        };
+        let nanos = duration.subsec_nanos();
+        let nanos = if nanos > i32::MAX as u32 {
+            i32::MAX
+        } else {
+            nanos as i32
+        };
+        let mut duration = Duration { seconds, nanos };
+        duration.normalize();
+        duration
+    }
+}
+
+impl TryFrom<Duration> for time::Duration {
+    type Error = time::Duration;
+
+    /// Converts a `Duration` to a result containing a positive (`Ok`) or negative (`Err`)
+    /// `std::time::Duration`.
+    fn try_from(mut duration: Duration) -> Result<time::Duration, time::Duration> {
+        duration.normalize();
+        if duration.seconds >= 0 {
+            Ok(time::Duration::new(
+                duration.seconds as u64,
+                duration.nanos as u32,
+            ))
+        } else {
+            Err(time::Duration::new(
+                (-duration.seconds) as u64,
+                (-duration.nanos) as u32,
+            ))
+        }
+    }
+}
+
+impl Timestamp {
+    /// Normalizes the timestamp to a canonical format.
+    ///
+    /// Based on [`google::protobuf::util::CreateNormalized`][1].
+    /// [1]: https://github.com/google/protobuf/blob/v3.3.2/src/google/protobuf/util/time_util.cc#L59-L77
+    #[cfg(feature = "std")]
+    pub fn normalize(&mut self) {
+        // Make sure nanos is in the range.
+        if self.nanos <= -NANOS_PER_SECOND || self.nanos >= NANOS_PER_SECOND {
+            self.seconds += (self.nanos / NANOS_PER_SECOND) as i64;
+            self.nanos %= NANOS_PER_SECOND;
+        }
+
+        // For Timestamp nanos should be in the range [0, 999999999].
+        if self.nanos < 0 {
+            self.seconds -= 1;
+            self.nanos += NANOS_PER_SECOND;
+        }
+
+        // TODO: should this be checked?
+        // debug_assert!(self.seconds >= -62_135_596_800 && self.seconds <= 253_402_300_799,
+        //               "invalid timestamp: {:?}", self);
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::time::SystemTime> for Timestamp {
+    fn from(system_time: std::time::SystemTime) -> Timestamp {
+        let (seconds, nanos) = match system_time.duration_since(std::time::UNIX_EPOCH) {
+            Ok(duration) => {
+                let seconds = i64::try_from(duration.as_secs()).unwrap();
+                (seconds, duration.subsec_nanos() as i32)
+            }
+            Err(error) => {
+                let duration = error.duration();
+                let seconds = i64::try_from(duration.as_secs()).unwrap();
+                let nanos = duration.subsec_nanos() as i32;
+                if nanos == 0 {
+                    (-seconds, 0)
+                } else {
+                    (-seconds - 1, 1_000_000_000 - nanos)
+                }
+            }
+        };
+        Timestamp { seconds, nanos }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<Timestamp> for std::time::SystemTime {
+    fn from(mut timestamp: Timestamp) -> std::time::SystemTime {
+        timestamp.normalize();
+        let system_time = if timestamp.seconds >= 0 {
+            std::time::UNIX_EPOCH + time::Duration::from_secs(timestamp.seconds as u64)
+        } else {
+            std::time::UNIX_EPOCH - time::Duration::from_secs((-timestamp.seconds) as u64)
+        };
+
+        system_time + time::Duration::from_nanos(timestamp.nanos as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[cfg(feature = "std")]
+    proptest! {
+        #[test]
+        fn check_system_time_roundtrip(
+            system_time in SystemTime::arbitrary(),
+        ) {
+            prop_assert_eq!(SystemTime::from(Timestamp::from(system_time)), system_time);
+        }
+    }
+}

--- a/third_party/prost/prost-types/src/protobuf.rs
+++ b/third_party/prost/prost-types/src/protobuf.rs
@@ -1,0 +1,1809 @@
+/// The protocol compiler can output a FileDescriptorSet containing the .proto
+/// files it parses.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileDescriptorSet {
+    #[prost(message, repeated, tag="1")]
+    pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
+}
+/// Describes a complete .proto file.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileDescriptorProto {
+    /// file name, relative to root of source tree
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    /// e.g. "foo", "foo.bar", etc.
+    #[prost(string, optional, tag="2")]
+    pub package: ::core::option::Option<::prost::alloc::string::String>,
+    /// Names of files imported by this file.
+    #[prost(string, repeated, tag="3")]
+    pub dependency: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Indexes of the public imported files in the dependency list above.
+    #[prost(int32, repeated, packed="false", tag="10")]
+    pub public_dependency: ::prost::alloc::vec::Vec<i32>,
+    /// Indexes of the weak imported files in the dependency list.
+    /// For Google-internal migration only. Do not use.
+    #[prost(int32, repeated, packed="false", tag="11")]
+    pub weak_dependency: ::prost::alloc::vec::Vec<i32>,
+    /// All top-level definitions in this file.
+    #[prost(message, repeated, tag="4")]
+    pub message_type: ::prost::alloc::vec::Vec<DescriptorProto>,
+    #[prost(message, repeated, tag="5")]
+    pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
+    #[prost(message, repeated, tag="6")]
+    pub service: ::prost::alloc::vec::Vec<ServiceDescriptorProto>,
+    #[prost(message, repeated, tag="7")]
+    pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
+    #[prost(message, optional, tag="8")]
+    pub options: ::core::option::Option<FileOptions>,
+    /// This field contains optional information about the original source code.
+    /// You may safely remove this entire field without harming runtime
+    /// functionality of the descriptors -- the information is needed only by
+    /// development tools.
+    #[prost(message, optional, tag="9")]
+    pub source_code_info: ::core::option::Option<SourceCodeInfo>,
+    /// The syntax of the proto file.
+    /// The supported values are "proto2" and "proto3".
+    #[prost(string, optional, tag="12")]
+    pub syntax: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Describes a message type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag="2")]
+    pub field: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
+    #[prost(message, repeated, tag="6")]
+    pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
+    #[prost(message, repeated, tag="3")]
+    pub nested_type: ::prost::alloc::vec::Vec<DescriptorProto>,
+    #[prost(message, repeated, tag="4")]
+    pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
+    #[prost(message, repeated, tag="5")]
+    pub extension_range: ::prost::alloc::vec::Vec<descriptor_proto::ExtensionRange>,
+    #[prost(message, repeated, tag="8")]
+    pub oneof_decl: ::prost::alloc::vec::Vec<OneofDescriptorProto>,
+    #[prost(message, optional, tag="7")]
+    pub options: ::core::option::Option<MessageOptions>,
+    #[prost(message, repeated, tag="9")]
+    pub reserved_range: ::prost::alloc::vec::Vec<descriptor_proto::ReservedRange>,
+    /// Reserved field names, which may not be used by fields in the same message.
+    /// A given name may only be reserved once.
+    #[prost(string, repeated, tag="10")]
+    pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Nested message and enum types in `DescriptorProto`.
+pub mod descriptor_proto {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ExtensionRange {
+        /// Inclusive.
+        #[prost(int32, optional, tag="1")]
+        pub start: ::core::option::Option<i32>,
+        /// Exclusive.
+        #[prost(int32, optional, tag="2")]
+        pub end: ::core::option::Option<i32>,
+        #[prost(message, optional, tag="3")]
+        pub options: ::core::option::Option<super::ExtensionRangeOptions>,
+    }
+    /// Range of reserved tag numbers. Reserved tag numbers may not be used by
+    /// fields or extension ranges in the same message. Reserved ranges may
+    /// not overlap.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ReservedRange {
+        /// Inclusive.
+        #[prost(int32, optional, tag="1")]
+        pub start: ::core::option::Option<i32>,
+        /// Exclusive.
+        #[prost(int32, optional, tag="2")]
+        pub end: ::core::option::Option<i32>,
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExtensionRangeOptions {
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+/// Describes a field within a message.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FieldDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(int32, optional, tag="3")]
+    pub number: ::core::option::Option<i32>,
+    #[prost(enumeration="field_descriptor_proto::Label", optional, tag="4")]
+    pub label: ::core::option::Option<i32>,
+    /// If type_name is set, this need not be set.  If both this and type_name
+    /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
+    #[prost(enumeration="field_descriptor_proto::Type", optional, tag="5")]
+    pub r#type: ::core::option::Option<i32>,
+    /// For message and enum types, this is the name of the type.  If the name
+    /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+    /// rules are used to find the type (i.e. first the nested types within this
+    /// message are searched, then within the parent, on up to the root
+    /// namespace).
+    #[prost(string, optional, tag="6")]
+    pub type_name: ::core::option::Option<::prost::alloc::string::String>,
+    /// For extensions, this is the name of the type being extended.  It is
+    /// resolved in the same manner as type_name.
+    #[prost(string, optional, tag="2")]
+    pub extendee: ::core::option::Option<::prost::alloc::string::String>,
+    /// For numeric types, contains the original text representation of the value.
+    /// For booleans, "true" or "false".
+    /// For strings, contains the default text contents (not escaped in any way).
+    /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+    /// TODO(kenton):  Base-64 encode?
+    #[prost(string, optional, tag="7")]
+    pub default_value: ::core::option::Option<::prost::alloc::string::String>,
+    /// If set, gives the index of a oneof in the containing type's oneof_decl
+    /// list.  This field is a member of that oneof.
+    #[prost(int32, optional, tag="9")]
+    pub oneof_index: ::core::option::Option<i32>,
+    /// JSON name of this field. The value is set by protocol compiler. If the
+    /// user has set a "json_name" option on this field, that option's value
+    /// will be used. Otherwise, it's deduced from the field's name by converting
+    /// it to camelCase.
+    #[prost(string, optional, tag="10")]
+    pub json_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag="8")]
+    pub options: ::core::option::Option<FieldOptions>,
+}
+/// Nested message and enum types in `FieldDescriptorProto`.
+pub mod field_descriptor_proto {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Type {
+        /// 0 is reserved for errors.
+        /// Order is weird for historical reasons.
+        Double = 1,
+        Float = 2,
+        /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+        /// negative values are likely.
+        Int64 = 3,
+        Uint64 = 4,
+        /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+        /// negative values are likely.
+        Int32 = 5,
+        Fixed64 = 6,
+        Fixed32 = 7,
+        Bool = 8,
+        String = 9,
+        /// Tag-delimited aggregate.
+        /// Group type is deprecated and not supported in proto3. However, Proto3
+        /// implementations should still be able to parse the group wire format and
+        /// treat group fields as unknown fields.
+        Group = 10,
+        /// Length-delimited aggregate.
+        Message = 11,
+        /// New in version 2.
+        Bytes = 12,
+        Uint32 = 13,
+        Enum = 14,
+        Sfixed32 = 15,
+        Sfixed64 = 16,
+        /// Uses ZigZag encoding.
+        Sint32 = 17,
+        /// Uses ZigZag encoding.
+        Sint64 = 18,
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Label {
+        /// 0 is reserved for errors
+        Optional = 1,
+        Required = 2,
+        Repeated = 3,
+    }
+}
+/// Describes a oneof.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OneofDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag="2")]
+    pub options: ::core::option::Option<OneofOptions>,
+}
+/// Describes an enum type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag="2")]
+    pub value: ::prost::alloc::vec::Vec<EnumValueDescriptorProto>,
+    #[prost(message, optional, tag="3")]
+    pub options: ::core::option::Option<EnumOptions>,
+    /// Range of reserved numeric values. Reserved numeric values may not be used
+    /// by enum values in the same enum declaration. Reserved ranges may not
+    /// overlap.
+    #[prost(message, repeated, tag="4")]
+    pub reserved_range: ::prost::alloc::vec::Vec<enum_descriptor_proto::EnumReservedRange>,
+    /// Reserved enum value names, which may not be reused. A given name may only
+    /// be reserved once.
+    #[prost(string, repeated, tag="5")]
+    pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Nested message and enum types in `EnumDescriptorProto`.
+pub mod enum_descriptor_proto {
+    /// Range of reserved numeric values. Reserved values may not be used by
+    /// entries in the same enum. Reserved ranges may not overlap.
+    ///
+    /// Note that this is distinct from DescriptorProto.ReservedRange in that it
+    /// is inclusive such that it can appropriately represent the entire int32
+    /// domain.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct EnumReservedRange {
+        /// Inclusive.
+        #[prost(int32, optional, tag="1")]
+        pub start: ::core::option::Option<i32>,
+        /// Inclusive.
+        #[prost(int32, optional, tag="2")]
+        pub end: ::core::option::Option<i32>,
+    }
+}
+/// Describes a value within an enum.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumValueDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(int32, optional, tag="2")]
+    pub number: ::core::option::Option<i32>,
+    #[prost(message, optional, tag="3")]
+    pub options: ::core::option::Option<EnumValueOptions>,
+}
+/// Describes a service.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ServiceDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag="2")]
+    pub method: ::prost::alloc::vec::Vec<MethodDescriptorProto>,
+    #[prost(message, optional, tag="3")]
+    pub options: ::core::option::Option<ServiceOptions>,
+}
+/// Describes a method of a service.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MethodDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    /// Input and output type names.  These are resolved in the same way as
+    /// FieldDescriptorProto.type_name, but must refer to a message type.
+    #[prost(string, optional, tag="2")]
+    pub input_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="3")]
+    pub output_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag="4")]
+    pub options: ::core::option::Option<MethodOptions>,
+    /// Identifies if client streams multiple client messages
+    #[prost(bool, optional, tag="5", default="false")]
+    pub client_streaming: ::core::option::Option<bool>,
+    /// Identifies if server streams multiple server messages
+    #[prost(bool, optional, tag="6", default="false")]
+    pub server_streaming: ::core::option::Option<bool>,
+}
+// ===================================================================
+// Options
+
+// Each of the definitions above may have "options" attached.  These are
+// just annotations which may cause code to be generated slightly differently
+// or may contain hints for code that manipulates protocol messages.
+//
+// Clients may define custom options as extensions of the *Options messages.
+// These extensions may not yet be known at parsing time, so the parser cannot
+// store the values in them.  Instead it stores them in a field in the *Options
+// message called uninterpreted_option. This field must have the same name
+// across all *Options messages. We then use this field to populate the
+// extensions when we build a descriptor, at which point all protos have been
+// parsed and so all extensions are known.
+//
+// Extension numbers for custom options may be chosen as follows:
+// * For options which will only be used within a single application or
+//   organization, or for experimental options, use field numbers 50000
+//   through 99999.  It is up to you to ensure that you do not use the
+//   same number for multiple options.
+// * For options which will be published and used publicly by multiple
+//   independent entities, e-mail protobuf-global-extension-registry@google.com
+//   to reserve extension numbers. Simply provide your project name (e.g.
+//   Objective-C plugin) and your project website (if available) -- there's no
+//   need to explain how you intend to use them. Usually you only need one
+//   extension number. You can declare multiple options with only one extension
+//   number by putting them in a sub-message. See the Custom Options section of
+//   the docs for examples:
+//   https://developers.google.com/protocol-buffers/docs/proto#options
+//   If this turns out to be popular, a web service will be set up
+//   to automatically assign option numbers.
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileOptions {
+    /// Sets the Java package where classes generated from this .proto will be
+    /// placed.  By default, the proto package is used, but this is often
+    /// inappropriate because proto packages do not normally start with backwards
+    /// domain names.
+    #[prost(string, optional, tag="1")]
+    pub java_package: ::core::option::Option<::prost::alloc::string::String>,
+    /// If set, all the classes from the .proto file are wrapped in a single
+    /// outer class with the given name.  This applies to both Proto1
+    /// (equivalent to the old "--one_java_file" option) and Proto2 (where
+    /// a .proto always translates to a single class, but you may want to
+    /// explicitly choose the class name).
+    #[prost(string, optional, tag="8")]
+    pub java_outer_classname: ::core::option::Option<::prost::alloc::string::String>,
+    /// If set true, then the Java code generator will generate a separate .java
+    /// file for each top-level message, enum, and service defined in the .proto
+    /// file.  Thus, these types will *not* be nested inside the outer class
+    /// named by java_outer_classname.  However, the outer class will still be
+    /// generated to contain the file's getDescriptor() method as well as any
+    /// top-level extensions defined in the file.
+    #[prost(bool, optional, tag="10", default="false")]
+    pub java_multiple_files: ::core::option::Option<bool>,
+    /// This option does nothing.
+    #[deprecated]
+    #[prost(bool, optional, tag="20")]
+    pub java_generate_equals_and_hash: ::core::option::Option<bool>,
+    /// If set true, then the Java2 code generator will generate code that
+    /// throws an exception whenever an attempt is made to assign a non-UTF-8
+    /// byte sequence to a string field.
+    /// Message reflection will do the same.
+    /// However, an extension field still accepts non-UTF-8 byte sequences.
+    /// This option has no effect on when used with the lite runtime.
+    #[prost(bool, optional, tag="27", default="false")]
+    pub java_string_check_utf8: ::core::option::Option<bool>,
+    #[prost(enumeration="file_options::OptimizeMode", optional, tag="9", default="Speed")]
+    pub optimize_for: ::core::option::Option<i32>,
+    /// Sets the Go package where structs generated from this .proto will be
+    /// placed. If omitted, the Go package will be derived from the following:
+    ///   - The basename of the package import path, if provided.
+    ///   - Otherwise, the package statement in the .proto file, if present.
+    ///   - Otherwise, the basename of the .proto file, without extension.
+    #[prost(string, optional, tag="11")]
+    pub go_package: ::core::option::Option<::prost::alloc::string::String>,
+    /// Should generic services be generated in each language?  "Generic" services
+    /// are not specific to any particular RPC system.  They are generated by the
+    /// main code generators in each language (without additional plugins).
+    /// Generic services were the only kind of service generation supported by
+    /// early versions of google.protobuf.
+    ///
+    /// Generic services are now considered deprecated in favor of using plugins
+    /// that generate code specific to your particular RPC system.  Therefore,
+    /// these default to false.  Old code which depends on generic services should
+    /// explicitly set them to true.
+    #[prost(bool, optional, tag="16", default="false")]
+    pub cc_generic_services: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag="17", default="false")]
+    pub java_generic_services: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag="18", default="false")]
+    pub py_generic_services: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag="42", default="false")]
+    pub php_generic_services: ::core::option::Option<bool>,
+    /// Is this file deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for everything in the file, or it will be completely ignored; in the very
+    /// least, this is a formalization for deprecating files.
+    #[prost(bool, optional, tag="23", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// Enables the use of arenas for the proto messages in this file. This applies
+    /// only to generated classes for C++.
+    #[prost(bool, optional, tag="31", default="false")]
+    pub cc_enable_arenas: ::core::option::Option<bool>,
+    /// Sets the objective c class prefix which is prepended to all objective c
+    /// generated classes from this .proto. There is no default.
+    #[prost(string, optional, tag="36")]
+    pub objc_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
+    /// Namespace for generated classes; defaults to the package.
+    #[prost(string, optional, tag="37")]
+    pub csharp_namespace: ::core::option::Option<::prost::alloc::string::String>,
+    /// By default Swift generators will take the proto package and CamelCase it
+    /// replacing '.' with underscore and use that to prefix the types/symbols
+    /// defined. When this options is provided, they will use this value instead
+    /// to prefix the types/symbols defined.
+    #[prost(string, optional, tag="39")]
+    pub swift_prefix: ::core::option::Option<::prost::alloc::string::String>,
+    /// Sets the php class prefix which is prepended to all php generated classes
+    /// from this .proto. Default is empty.
+    #[prost(string, optional, tag="40")]
+    pub php_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
+    /// Use this option to change the namespace of php generated classes. Default
+    /// is empty. When this option is empty, the package name will be used for
+    /// determining the namespace.
+    #[prost(string, optional, tag="41")]
+    pub php_namespace: ::core::option::Option<::prost::alloc::string::String>,
+    /// Use this option to change the namespace of php generated metadata classes.
+    /// Default is empty. When this option is empty, the proto file name will be
+    /// used for determining the namespace.
+    #[prost(string, optional, tag="44")]
+    pub php_metadata_namespace: ::core::option::Option<::prost::alloc::string::String>,
+    /// Use this option to change the package of ruby generated classes. Default
+    /// is empty. When this option is not set, the package name will be used for
+    /// determining the ruby package.
+    #[prost(string, optional, tag="45")]
+    pub ruby_package: ::core::option::Option<::prost::alloc::string::String>,
+    /// The parser stores options it doesn't recognize here.
+    /// See the documentation for the "Options" section above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+/// Nested message and enum types in `FileOptions`.
+pub mod file_options {
+    /// Generated classes can be optimized for speed or code size.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum OptimizeMode {
+        /// Generate complete code for parsing, serialization,
+        Speed = 1,
+        /// etc.
+        ///
+        /// Use ReflectionOps to implement these methods.
+        CodeSize = 2,
+        /// Generate code using MessageLite and the lite runtime.
+        LiteRuntime = 3,
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MessageOptions {
+    /// Set true to use the old proto1 MessageSet wire format for extensions.
+    /// This is provided for backwards-compatibility with the MessageSet wire
+    /// format.  You should not use this for any other reason:  It's less
+    /// efficient, has fewer features, and is more complicated.
+    ///
+    /// The message must be defined exactly as follows:
+    ///   message Foo {
+    ///     option message_set_wire_format = true;
+    ///     extensions 4 to max;
+    ///   }
+    /// Note that the message cannot have any defined fields; MessageSets only
+    /// have extensions.
+    ///
+    /// All extensions of your type must be singular messages; e.g. they cannot
+    /// be int32s, enums, or repeated messages.
+    ///
+    /// Because this is an option, the above two restrictions are not enforced by
+    /// the protocol compiler.
+    #[prost(bool, optional, tag="1", default="false")]
+    pub message_set_wire_format: ::core::option::Option<bool>,
+    /// Disables the generation of the standard "descriptor()" accessor, which can
+    /// conflict with a field of the same name.  This is meant to make migration
+    /// from proto1 easier; new code should avoid fields named "descriptor".
+    #[prost(bool, optional, tag="2", default="false")]
+    pub no_standard_descriptor_accessor: ::core::option::Option<bool>,
+    /// Is this message deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the message, or it will be completely ignored; in the very least,
+    /// this is a formalization for deprecating messages.
+    #[prost(bool, optional, tag="3", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// Whether the message is an automatically generated map entry type for the
+    /// maps field.
+    ///
+    /// For maps fields:
+    ///     map<KeyType, ValueType> map_field = 1;
+    /// The parsed descriptor looks like:
+    ///     message MapFieldEntry {
+    ///         option map_entry = true;
+    ///         optional KeyType key = 1;
+    ///         optional ValueType value = 2;
+    ///     }
+    ///     repeated MapFieldEntry map_field = 1;
+    ///
+    /// Implementations may choose not to generate the map_entry=true message, but
+    /// use a native map in the target language to hold the keys and values.
+    /// The reflection APIs in such implementations still need to work as
+    /// if the field is a repeated message field.
+    ///
+    /// NOTE: Do not set the option in .proto files. Always use the maps syntax
+    /// instead. The option should only be implicitly set by the proto compiler
+    /// parser.
+    #[prost(bool, optional, tag="7")]
+    pub map_entry: ::core::option::Option<bool>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FieldOptions {
+    /// The ctype option instructs the C++ code generator to use a different
+    /// representation of the field than it normally would.  See the specific
+    /// options below.  This option is not yet implemented in the open source
+    /// release -- sorry, we'll try to include it in a future version!
+    #[prost(enumeration="field_options::CType", optional, tag="1", default="String")]
+    pub ctype: ::core::option::Option<i32>,
+    /// The packed option can be enabled for repeated primitive fields to enable
+    /// a more efficient representation on the wire. Rather than repeatedly
+    /// writing the tag and type for each element, the entire array is encoded as
+    /// a single length-delimited blob. In proto3, only explicit setting it to
+    /// false will avoid using packed encoding.
+    #[prost(bool, optional, tag="2")]
+    pub packed: ::core::option::Option<bool>,
+    /// The jstype option determines the JavaScript type used for values of the
+    /// field.  The option is permitted only for 64 bit integral and fixed types
+    /// (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+    /// is represented as JavaScript string, which avoids loss of precision that
+    /// can happen when a large value is converted to a floating point JavaScript.
+    /// Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+    /// use the JavaScript "number" type.  The behavior of the default option
+    /// JS_NORMAL is implementation dependent.
+    ///
+    /// This option is an enum to permit additional types to be added, e.g.
+    /// goog.math.Integer.
+    #[prost(enumeration="field_options::JsType", optional, tag="6", default="JsNormal")]
+    pub jstype: ::core::option::Option<i32>,
+    /// Should this field be parsed lazily?  Lazy applies only to message-type
+    /// fields.  It means that when the outer message is initially parsed, the
+    /// inner message's contents will not be parsed but instead stored in encoded
+    /// form.  The inner message will actually be parsed when it is first accessed.
+    ///
+    /// This is only a hint.  Implementations are free to choose whether to use
+    /// eager or lazy parsing regardless of the value of this option.  However,
+    /// setting this option true suggests that the protocol author believes that
+    /// using lazy parsing on this field is worth the additional bookkeeping
+    /// overhead typically needed to implement it.
+    ///
+    /// This option does not affect the public interface of any generated code;
+    /// all method signatures remain the same.  Furthermore, thread-safety of the
+    /// interface is not affected by this option; const methods remain safe to
+    /// call from multiple threads concurrently, while non-const methods continue
+    /// to require exclusive access.
+    ///
+    ///
+    /// Note that implementations may choose not to check required fields within
+    /// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+    /// may return true even if the inner message has missing required fields.
+    /// This is necessary because otherwise the inner message would have to be
+    /// parsed in order to perform the check, defeating the purpose of lazy
+    /// parsing.  An implementation which chooses not to check required fields
+    /// must be consistent about it.  That is, for any particular sub-message, the
+    /// implementation must either *always* check its required fields, or *never*
+    /// check its required fields, regardless of whether or not the message has
+    /// been parsed.
+    #[prost(bool, optional, tag="5", default="false")]
+    pub lazy: ::core::option::Option<bool>,
+    /// Is this field deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for accessors, or it will be completely ignored; in the very least, this
+    /// is a formalization for deprecating fields.
+    #[prost(bool, optional, tag="3", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// For Google-internal migration only. Do not use.
+    #[prost(bool, optional, tag="10", default="false")]
+    pub weak: ::core::option::Option<bool>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+/// Nested message and enum types in `FieldOptions`.
+pub mod field_options {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum CType {
+        /// Default mode.
+        String = 0,
+        Cord = 1,
+        StringPiece = 2,
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum JsType {
+        /// Use the default type.
+        JsNormal = 0,
+        /// Use JavaScript strings.
+        JsString = 1,
+        /// Use JavaScript numbers.
+        JsNumber = 2,
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OneofOptions {
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumOptions {
+    /// Set this option to true to allow mapping different tag names to the same
+    /// value.
+    #[prost(bool, optional, tag="2")]
+    pub allow_alias: ::core::option::Option<bool>,
+    /// Is this enum deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the enum, or it will be completely ignored; in the very least, this
+    /// is a formalization for deprecating enums.
+    #[prost(bool, optional, tag="3", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumValueOptions {
+    /// Is this enum value deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the enum value, or it will be completely ignored; in the very least,
+    /// this is a formalization for deprecating enum values.
+    #[prost(bool, optional, tag="1", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ServiceOptions {
+    // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
+    //   framework.  We apologize for hoarding these numbers to ourselves, but
+    //   we were already using them long before we decided to release Protocol
+    //   Buffers.
+
+    /// Is this service deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the service, or it will be completely ignored; in the very least,
+    /// this is a formalization for deprecating services.
+    #[prost(bool, optional, tag="33", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MethodOptions {
+    // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
+    //   framework.  We apologize for hoarding these numbers to ourselves, but
+    //   we were already using them long before we decided to release Protocol
+    //   Buffers.
+
+    /// Is this method deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the method, or it will be completely ignored; in the very least,
+    /// this is a formalization for deprecating methods.
+    #[prost(bool, optional, tag="33", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    #[prost(enumeration="method_options::IdempotencyLevel", optional, tag="34", default="IdempotencyUnknown")]
+    pub idempotency_level: ::core::option::Option<i32>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+/// Nested message and enum types in `MethodOptions`.
+pub mod method_options {
+    /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+    /// or neither? HTTP based RPC implementation may choose GET verb for safe
+    /// methods, and PUT verb for idempotent methods instead of the default POST.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum IdempotencyLevel {
+        IdempotencyUnknown = 0,
+        /// implies idempotent
+        NoSideEffects = 1,
+        /// idempotent, but may have side effects
+        Idempotent = 2,
+    }
+}
+/// A message representing a option the parser does not recognize. This only
+/// appears in options protos created by the compiler::Parser class.
+/// DescriptorPool resolves these when building Descriptor objects. Therefore,
+/// options protos in descriptor objects (e.g. returned by Descriptor::options(),
+/// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+/// in them.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UninterpretedOption {
+    #[prost(message, repeated, tag="2")]
+    pub name: ::prost::alloc::vec::Vec<uninterpreted_option::NamePart>,
+    /// The value of the uninterpreted option, in whatever type the tokenizer
+    /// identified it as during parsing. Exactly one of these should be set.
+    #[prost(string, optional, tag="3")]
+    pub identifier_value: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(uint64, optional, tag="4")]
+    pub positive_int_value: ::core::option::Option<u64>,
+    #[prost(int64, optional, tag="5")]
+    pub negative_int_value: ::core::option::Option<i64>,
+    #[prost(double, optional, tag="6")]
+    pub double_value: ::core::option::Option<f64>,
+    #[prost(bytes, optional, tag="7")]
+    pub string_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(string, optional, tag="8")]
+    pub aggregate_value: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Nested message and enum types in `UninterpretedOption`.
+pub mod uninterpreted_option {
+    /// The name of the uninterpreted option.  Each string represents a segment in
+    /// a dot-separated name.  is_extension is true iff a segment represents an
+    /// extension (denoted with parentheses in options specs in .proto files).
+    /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+    /// "foo.(bar.baz).qux".
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct NamePart {
+        #[prost(string, required, tag="1")]
+        pub name_part: ::prost::alloc::string::String,
+        #[prost(bool, required, tag="2")]
+        pub is_extension: bool,
+    }
+}
+// ===================================================================
+// Optional source code info
+
+/// Encapsulates information about the original source file from which a
+/// FileDescriptorProto was generated.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SourceCodeInfo {
+    /// A Location identifies a piece of source code in a .proto file which
+    /// corresponds to a particular definition.  This information is intended
+    /// to be useful to IDEs, code indexers, documentation generators, and similar
+    /// tools.
+    ///
+    /// For example, say we have a file like:
+    ///   message Foo {
+    ///     optional string foo = 1;
+    ///   }
+    /// Let's look at just the field definition:
+    ///   optional string foo = 1;
+    ///   ^       ^^     ^^  ^  ^^^
+    ///   a       bc     de  f  ghi
+    /// We have the following locations:
+    ///   span   path               represents
+    ///   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+    ///   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+    ///   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+    ///   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+    ///   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    ///
+    /// Notes:
+    /// - A location may refer to a repeated field itself (i.e. not to any
+    ///   particular index within it).  This is used whenever a set of elements are
+    ///   logically enclosed in a single code segment.  For example, an entire
+    ///   extend block (possibly containing multiple extension definitions) will
+    ///   have an outer location whose path refers to the "extensions" repeated
+    ///   field without an index.
+    /// - Multiple locations may have the same path.  This happens when a single
+    ///   logical declaration is spread out across multiple places.  The most
+    ///   obvious example is the "extend" block again -- there may be multiple
+    ///   extend blocks in the same scope, each of which will have the same path.
+    /// - A location's span is not always a subset of its parent's span.  For
+    ///   example, the "extendee" of an extension declaration appears at the
+    ///   beginning of the "extend" block and is shared by all extensions within
+    ///   the block.
+    /// - Just because a location's span is a subset of some other location's span
+    ///   does not mean that it is a descendant.  For example, a "group" defines
+    ///   both a type and a field in a single declaration.  Thus, the locations
+    ///   corresponding to the type and field and their components will overlap.
+    /// - Code which tries to interpret locations should probably be designed to
+    ///   ignore those that it doesn't understand, as more types of locations could
+    ///   be recorded in the future.
+    #[prost(message, repeated, tag="1")]
+    pub location: ::prost::alloc::vec::Vec<source_code_info::Location>,
+}
+/// Nested message and enum types in `SourceCodeInfo`.
+pub mod source_code_info {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Location {
+        /// Identifies which part of the FileDescriptorProto was defined at this
+        /// location.
+        ///
+        /// Each element is a field number or an index.  They form a path from
+        /// the root FileDescriptorProto to the place where the definition.  For
+        /// example, this path:
+        ///   [ 4, 3, 2, 7, 1 ]
+        /// refers to:
+        ///   file.message_type(3)  // 4, 3
+        ///       .field(7)         // 2, 7
+        ///       .name()           // 1
+        /// This is because FileDescriptorProto.message_type has field number 4:
+        ///   repeated DescriptorProto message_type = 4;
+        /// and DescriptorProto.field has field number 2:
+        ///   repeated FieldDescriptorProto field = 2;
+        /// and FieldDescriptorProto.name has field number 1:
+        ///   optional string name = 1;
+        ///
+        /// Thus, the above path gives the location of a field name.  If we removed
+        /// the last element:
+        ///   [ 4, 3, 2, 7 ]
+        /// this path refers to the whole field declaration (from the beginning
+        /// of the label to the terminating semicolon).
+        #[prost(int32, repeated, tag="1")]
+        pub path: ::prost::alloc::vec::Vec<i32>,
+        /// Always has exactly three or four elements: start line, start column,
+        /// end line (optional, otherwise assumed same as start line), end column.
+        /// These are packed into a single field for efficiency.  Note that line
+        /// and column numbers are zero-based -- typically you will want to add
+        /// 1 to each before displaying to a user.
+        #[prost(int32, repeated, tag="2")]
+        pub span: ::prost::alloc::vec::Vec<i32>,
+        /// If this SourceCodeInfo represents a complete declaration, these are any
+        /// comments appearing before and after the declaration which appear to be
+        /// attached to the declaration.
+        ///
+        /// A series of line comments appearing on consecutive lines, with no other
+        /// tokens appearing on those lines, will be treated as a single comment.
+        ///
+        /// leading_detached_comments will keep paragraphs of comments that appear
+        /// before (but not connected to) the current element. Each paragraph,
+        /// separated by empty lines, will be one comment element in the repeated
+        /// field.
+        ///
+        /// Only the comment content is provided; comment markers (e.g. //) are
+        /// stripped out.  For block comments, leading whitespace and an asterisk
+        /// will be stripped from the beginning of each line other than the first.
+        /// Newlines are included in the output.
+        ///
+        /// Examples:
+        ///
+        ///   optional int32 foo = 1;  // Comment attached to foo.
+        ///   // Comment attached to bar.
+        ///   optional int32 bar = 2;
+        ///
+        ///   optional string baz = 3;
+        ///   // Comment attached to baz.
+        ///   // Another line attached to baz.
+        ///
+        ///   // Comment attached to qux.
+        ///   //
+        ///   // Another line attached to qux.
+        ///   optional double qux = 4;
+        ///
+        ///   // Detached comment for corge. This is not leading or trailing comments
+        ///   // to qux or corge because there are blank lines separating it from
+        ///   // both.
+        ///
+        ///   // Detached comment for corge paragraph 2.
+        ///
+        ///   optional string corge = 5;
+        ///   /* Block comment attached
+        ///    * to corge.  Leading asterisks
+        ///    * will be removed. */
+        ///   /* Block comment attached to
+        ///    * grault. */
+        ///   optional int32 grault = 6;
+        ///
+        ///   // ignored detached comments.
+        #[prost(string, optional, tag="3")]
+        pub leading_comments: ::core::option::Option<::prost::alloc::string::String>,
+        #[prost(string, optional, tag="4")]
+        pub trailing_comments: ::core::option::Option<::prost::alloc::string::String>,
+        #[prost(string, repeated, tag="6")]
+        pub leading_detached_comments: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    }
+}
+/// Describes the relationship between generated code and its original source
+/// file. A GeneratedCodeInfo message is associated with only one generated
+/// source file, but may contain references to different source .proto files.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GeneratedCodeInfo {
+    /// An Annotation connects some span of text in generated code to an element
+    /// of its generating .proto file.
+    #[prost(message, repeated, tag="1")]
+    pub annotation: ::prost::alloc::vec::Vec<generated_code_info::Annotation>,
+}
+/// Nested message and enum types in `GeneratedCodeInfo`.
+pub mod generated_code_info {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Annotation {
+        /// Identifies the element in the original source .proto file. This field
+        /// is formatted the same as SourceCodeInfo.Location.path.
+        #[prost(int32, repeated, tag="1")]
+        pub path: ::prost::alloc::vec::Vec<i32>,
+        /// Identifies the filesystem path to the original source .proto.
+        #[prost(string, optional, tag="2")]
+        pub source_file: ::core::option::Option<::prost::alloc::string::String>,
+        /// Identifies the starting offset in bytes in the generated code
+        /// that relates to the identified object.
+        #[prost(int32, optional, tag="3")]
+        pub begin: ::core::option::Option<i32>,
+        /// Identifies the ending offset in bytes in the generated code that
+        /// relates to the identified offset. The end offset should be one past
+        /// the last relevant byte (so the length of the text = end - begin).
+        #[prost(int32, optional, tag="4")]
+        pub end: ::core::option::Option<i32>,
+    }
+}
+/// `Any` contains an arbitrary serialized protocol buffer message along with a
+/// URL that describes the type of the serialized message.
+///
+/// Protobuf library provides support to pack/unpack Any values in the form
+/// of utility functions or additional generated methods of the Any type.
+///
+/// Example 1: Pack and unpack a message in C++.
+///
+///     Foo foo = ...;
+///     Any any;
+///     any.PackFrom(foo);
+///     ...
+///     if (any.UnpackTo(&foo)) {
+///       ...
+///     }
+///
+/// Example 2: Pack and unpack a message in Java.
+///
+///     Foo foo = ...;
+///     Any any = Any.pack(foo);
+///     ...
+///     if (any.is(Foo.class)) {
+///       foo = any.unpack(Foo.class);
+///     }
+///
+///  Example 3: Pack and unpack a message in Python.
+///
+///     foo = Foo(...)
+///     any = Any()
+///     any.Pack(foo)
+///     ...
+///     if any.Is(Foo.DESCRIPTOR):
+///       any.Unpack(foo)
+///       ...
+///
+///  Example 4: Pack and unpack a message in Go
+///
+///      foo := &pb.Foo{...}
+///      any, err := ptypes.MarshalAny(foo)
+///      ...
+///      foo := &pb.Foo{}
+///      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+///        ...
+///      }
+///
+/// The pack methods provided by protobuf library will by default use
+/// 'type.googleapis.com/full.type.name' as the type URL and the unpack
+/// methods only use the fully qualified type name after the last '/'
+/// in the type URL, for example "foo.bar.com/x/y.z" will yield type
+/// name "y.z".
+///
+///
+/// JSON
+/// ====
+/// The JSON representation of an `Any` value uses the regular
+/// representation of the deserialized, embedded message, with an
+/// additional field `@type` which contains the type URL. Example:
+///
+///     package google.profile;
+///     message Person {
+///       string first_name = 1;
+///       string last_name = 2;
+///     }
+///
+///     {
+///       "@type": "type.googleapis.com/google.profile.Person",
+///       "firstName": <string>,
+///       "lastName": <string>
+///     }
+///
+/// If the embedded message type is well-known and has a custom JSON
+/// representation, that representation will be embedded adding a field
+/// `value` which holds the custom JSON in addition to the `@type`
+/// field. Example (for message [google.protobuf.Duration][]):
+///
+///     {
+///       "@type": "type.googleapis.com/google.protobuf.Duration",
+///       "value": "1.212s"
+///     }
+///
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Any {
+    /// A URL/resource name that uniquely identifies the type of the serialized
+    /// protocol buffer message. This string must contain at least
+    /// one "/" character. The last segment of the URL's path must represent
+    /// the fully qualified name of the type (as in
+    /// `path/google.protobuf.Duration`). The name should be in a canonical form
+    /// (e.g., leading "." is not accepted).
+    ///
+    /// In practice, teams usually precompile into the binary all types that they
+    /// expect it to use in the context of Any. However, for URLs which use the
+    /// scheme `http`, `https`, or no scheme, one can optionally set up a type
+    /// server that maps type URLs to message definitions as follows:
+    ///
+    /// * If no scheme is provided, `https` is assumed.
+    /// * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+    ///   value in binary format, or produce an error.
+    /// * Applications are allowed to cache lookup results based on the
+    ///   URL, or have them precompiled into a binary to avoid any
+    ///   lookup. Therefore, binary compatibility needs to be preserved
+    ///   on changes to types. (Use versioned type names to manage
+    ///   breaking changes.)
+    ///
+    /// Note: this functionality is not currently available in the official
+    /// protobuf release, and it is not used for type URLs beginning with
+    /// type.googleapis.com.
+    ///
+    /// Schemes other than `http`, `https` (or the empty scheme) might be
+    /// used with implementation specific semantics.
+    ///
+    #[prost(string, tag="1")]
+    pub type_url: ::prost::alloc::string::String,
+    /// Must be a valid serialized protocol buffer of the above specified type.
+    #[prost(bytes, tag="2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+/// `SourceContext` represents information about the source of a
+/// protobuf element, like the file in which it is defined.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SourceContext {
+    /// The path-qualified name of the .proto file that contained the associated
+    /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
+    #[prost(string, tag="1")]
+    pub file_name: ::prost::alloc::string::String,
+}
+/// A protocol buffer message type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Type {
+    /// The fully qualified message name.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// The list of fields.
+    #[prost(message, repeated, tag="2")]
+    pub fields: ::prost::alloc::vec::Vec<Field>,
+    /// The list of types appearing in `oneof` definitions in this type.
+    #[prost(string, repeated, tag="3")]
+    pub oneofs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// The protocol buffer options.
+    #[prost(message, repeated, tag="4")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// The source context.
+    #[prost(message, optional, tag="5")]
+    pub source_context: ::core::option::Option<SourceContext>,
+    /// The source syntax.
+    #[prost(enumeration="Syntax", tag="6")]
+    pub syntax: i32,
+}
+/// A single field of a message type.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Field {
+    /// The field type.
+    #[prost(enumeration="field::Kind", tag="1")]
+    pub kind: i32,
+    /// The field cardinality.
+    #[prost(enumeration="field::Cardinality", tag="2")]
+    pub cardinality: i32,
+    /// The field number.
+    #[prost(int32, tag="3")]
+    pub number: i32,
+    /// The field name.
+    #[prost(string, tag="4")]
+    pub name: ::prost::alloc::string::String,
+    /// The field type URL, without the scheme, for message or enumeration
+    /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
+    #[prost(string, tag="6")]
+    pub type_url: ::prost::alloc::string::String,
+    /// The index of the field type in `Type.oneofs`, for message or enumeration
+    /// types. The first type has index 1; zero means the type is not in the list.
+    #[prost(int32, tag="7")]
+    pub oneof_index: i32,
+    /// Whether to use alternative packed wire representation.
+    #[prost(bool, tag="8")]
+    pub packed: bool,
+    /// The protocol buffer options.
+    #[prost(message, repeated, tag="9")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// The field JSON name.
+    #[prost(string, tag="10")]
+    pub json_name: ::prost::alloc::string::String,
+    /// The string value of the default value of this field. Proto2 syntax only.
+    #[prost(string, tag="11")]
+    pub default_value: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `Field`.
+pub mod field {
+    /// Basic field types.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Kind {
+        /// Field type unknown.
+        TypeUnknown = 0,
+        /// Field type double.
+        TypeDouble = 1,
+        /// Field type float.
+        TypeFloat = 2,
+        /// Field type int64.
+        TypeInt64 = 3,
+        /// Field type uint64.
+        TypeUint64 = 4,
+        /// Field type int32.
+        TypeInt32 = 5,
+        /// Field type fixed64.
+        TypeFixed64 = 6,
+        /// Field type fixed32.
+        TypeFixed32 = 7,
+        /// Field type bool.
+        TypeBool = 8,
+        /// Field type string.
+        TypeString = 9,
+        /// Field type group. Proto2 syntax only, and deprecated.
+        TypeGroup = 10,
+        /// Field type message.
+        TypeMessage = 11,
+        /// Field type bytes.
+        TypeBytes = 12,
+        /// Field type uint32.
+        TypeUint32 = 13,
+        /// Field type enum.
+        TypeEnum = 14,
+        /// Field type sfixed32.
+        TypeSfixed32 = 15,
+        /// Field type sfixed64.
+        TypeSfixed64 = 16,
+        /// Field type sint32.
+        TypeSint32 = 17,
+        /// Field type sint64.
+        TypeSint64 = 18,
+    }
+    /// Whether a field is optional, required, or repeated.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Cardinality {
+        /// For fields with unknown cardinality.
+        Unknown = 0,
+        /// For optional fields.
+        Optional = 1,
+        /// For required fields. Proto2 syntax only.
+        Required = 2,
+        /// For repeated fields.
+        Repeated = 3,
+    }
+}
+/// Enum type definition.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Enum {
+    /// Enum type name.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// Enum value definitions.
+    #[prost(message, repeated, tag="2")]
+    pub enumvalue: ::prost::alloc::vec::Vec<EnumValue>,
+    /// Protocol buffer options.
+    #[prost(message, repeated, tag="3")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// The source context.
+    #[prost(message, optional, tag="4")]
+    pub source_context: ::core::option::Option<SourceContext>,
+    /// The source syntax.
+    #[prost(enumeration="Syntax", tag="5")]
+    pub syntax: i32,
+}
+/// Enum value definition.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumValue {
+    /// Enum value name.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// Enum value number.
+    #[prost(int32, tag="2")]
+    pub number: i32,
+    /// Protocol buffer options.
+    #[prost(message, repeated, tag="3")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+}
+/// A protocol buffer option, which can be attached to a message, field,
+/// enumeration, etc.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Option {
+    /// The option's name. For protobuf built-in options (options defined in
+    /// descriptor.proto), this is the short name. For example, `"map_entry"`.
+    /// For custom options, it should be the fully-qualified name. For example,
+    /// `"google.api.http"`.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// The option's value packed in an Any message. If the value is a primitive,
+    /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
+    /// should be used. If the value is an enum, it should be stored as an int32
+    /// value using the google.protobuf.Int32Value type.
+    #[prost(message, optional, tag="2")]
+    pub value: ::core::option::Option<Any>,
+}
+/// The syntax in which a protocol buffer element is defined.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Syntax {
+    /// Syntax `proto2`.
+    Proto2 = 0,
+    /// Syntax `proto3`.
+    Proto3 = 1,
+}
+/// Api is a light-weight descriptor for an API Interface.
+///
+/// Interfaces are also described as "protocol buffer services" in some contexts,
+/// such as by the "service" keyword in a .proto file, but they are different
+/// from API Services, which represent a concrete implementation of an interface
+/// as opposed to simply a description of methods and bindings. They are also
+/// sometimes simply referred to as "APIs" in other contexts, such as the name of
+/// this message itself. See https://cloud.google.com/apis/design/glossary for
+/// detailed terminology.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Api {
+    /// The fully qualified name of this interface, including package name
+    /// followed by the interface's simple name.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// The methods of this interface, in unspecified order.
+    #[prost(message, repeated, tag="2")]
+    pub methods: ::prost::alloc::vec::Vec<Method>,
+    /// Any metadata attached to the interface.
+    #[prost(message, repeated, tag="3")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// A version string for this interface. If specified, must have the form
+    /// `major-version.minor-version`, as in `1.10`. If the minor version is
+    /// omitted, it defaults to zero. If the entire version field is empty, the
+    /// major version is derived from the package name, as outlined below. If the
+    /// field is not empty, the version in the package name will be verified to be
+    /// consistent with what is provided here.
+    ///
+    /// The versioning schema uses [semantic
+    /// versioning](http://semver.org) where the major version number
+    /// indicates a breaking change and the minor version an additive,
+    /// non-breaking change. Both version numbers are signals to users
+    /// what to expect from different versions, and should be carefully
+    /// chosen based on the product plan.
+    ///
+    /// The major version is also reflected in the package name of the
+    /// interface, which must end in `v<major-version>`, as in
+    /// `google.feature.v1`. For major versions 0 and 1, the suffix can
+    /// be omitted. Zero major versions must only be used for
+    /// experimental, non-GA interfaces.
+    ///
+    ///
+    #[prost(string, tag="4")]
+    pub version: ::prost::alloc::string::String,
+    /// Source context for the protocol buffer service represented by this
+    /// message.
+    #[prost(message, optional, tag="5")]
+    pub source_context: ::core::option::Option<SourceContext>,
+    /// Included interfaces. See [Mixin][].
+    #[prost(message, repeated, tag="6")]
+    pub mixins: ::prost::alloc::vec::Vec<Mixin>,
+    /// The source syntax of the service.
+    #[prost(enumeration="Syntax", tag="7")]
+    pub syntax: i32,
+}
+/// Method represents a method of an API interface.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Method {
+    /// The simple name of this method.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// A URL of the input message type.
+    #[prost(string, tag="2")]
+    pub request_type_url: ::prost::alloc::string::String,
+    /// If true, the request is streamed.
+    #[prost(bool, tag="3")]
+    pub request_streaming: bool,
+    /// The URL of the output message type.
+    #[prost(string, tag="4")]
+    pub response_type_url: ::prost::alloc::string::String,
+    /// If true, the response is streamed.
+    #[prost(bool, tag="5")]
+    pub response_streaming: bool,
+    /// Any metadata attached to the method.
+    #[prost(message, repeated, tag="6")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// The source syntax of this method.
+    #[prost(enumeration="Syntax", tag="7")]
+    pub syntax: i32,
+}
+/// Declares an API Interface to be included in this interface. The including
+/// interface must redeclare all the methods from the included interface, but
+/// documentation and options are inherited as follows:
+///
+/// - If after comment and whitespace stripping, the documentation
+///   string of the redeclared method is empty, it will be inherited
+///   from the original method.
+///
+/// - Each annotation belonging to the service config (http,
+///   visibility) which is not set in the redeclared method will be
+///   inherited.
+///
+/// - If an http annotation is inherited, the path pattern will be
+///   modified as follows. Any version prefix will be replaced by the
+///   version of the including interface plus the [root][] path if
+///   specified.
+///
+/// Example of a simple mixin:
+///
+///     package google.acl.v1;
+///     service AccessControl {
+///       // Get the underlying ACL object.
+///       rpc GetAcl(GetAclRequest) returns (Acl) {
+///         option (google.api.http).get = "/v1/{resource=**}:getAcl";
+///       }
+///     }
+///
+///     package google.storage.v2;
+///     service Storage {
+///       rpc GetAcl(GetAclRequest) returns (Acl);
+///
+///       // Get a data record.
+///       rpc GetData(GetDataRequest) returns (Data) {
+///         option (google.api.http).get = "/v2/{resource=**}";
+///       }
+///     }
+///
+/// Example of a mixin configuration:
+///
+///     apis:
+///     - name: google.storage.v2.Storage
+///       mixins:
+///       - name: google.acl.v1.AccessControl
+///
+/// The mixin construct implies that all methods in `AccessControl` are
+/// also declared with same name and request/response types in
+/// `Storage`. A documentation generator or annotation processor will
+/// see the effective `Storage.GetAcl` method after inherting
+/// documentation and annotations as follows:
+///
+///     service Storage {
+///       // Get the underlying ACL object.
+///       rpc GetAcl(GetAclRequest) returns (Acl) {
+///         option (google.api.http).get = "/v2/{resource=**}:getAcl";
+///       }
+///       ...
+///     }
+///
+/// Note how the version in the path pattern changed from `v1` to `v2`.
+///
+/// If the `root` field in the mixin is specified, it should be a
+/// relative path under which inherited HTTP paths are placed. Example:
+///
+///     apis:
+///     - name: google.storage.v2.Storage
+///       mixins:
+///       - name: google.acl.v1.AccessControl
+///         root: acls
+///
+/// This implies the following inherited HTTP annotation:
+///
+///     service Storage {
+///       // Get the underlying ACL object.
+///       rpc GetAcl(GetAclRequest) returns (Acl) {
+///         option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
+///       }
+///       ...
+///     }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Mixin {
+    /// The fully qualified name of the interface which is included.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// If non-empty specifies a path under which inherited HTTP paths
+    /// are rooted.
+    #[prost(string, tag="2")]
+    pub root: ::prost::alloc::string::String,
+}
+/// A Duration represents a signed, fixed-length span of time represented
+/// as a count of seconds and fractions of seconds at nanosecond
+/// resolution. It is independent of any calendar and concepts like "day"
+/// or "month". It is related to Timestamp in that the difference between
+/// two Timestamp values is a Duration and it can be added or subtracted
+/// from a Timestamp. Range is approximately +-10,000 years.
+///
+/// # Examples
+///
+/// Example 1: Compute Duration from two Timestamps in pseudo code.
+///
+///     Timestamp start = ...;
+///     Timestamp end = ...;
+///     Duration duration = ...;
+///
+///     duration.seconds = end.seconds - start.seconds;
+///     duration.nanos = end.nanos - start.nanos;
+///
+///     if (duration.seconds < 0 && duration.nanos > 0) {
+///       duration.seconds += 1;
+///       duration.nanos -= 1000000000;
+///     } else if (duration.seconds > 0 && duration.nanos < 0) {
+///       duration.seconds -= 1;
+///       duration.nanos += 1000000000;
+///     }
+///
+/// Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+///
+///     Timestamp start = ...;
+///     Duration duration = ...;
+///     Timestamp end = ...;
+///
+///     end.seconds = start.seconds + duration.seconds;
+///     end.nanos = start.nanos + duration.nanos;
+///
+///     if (end.nanos < 0) {
+///       end.seconds -= 1;
+///       end.nanos += 1000000000;
+///     } else if (end.nanos >= 1000000000) {
+///       end.seconds += 1;
+///       end.nanos -= 1000000000;
+///     }
+///
+/// Example 3: Compute Duration from datetime.timedelta in Python.
+///
+///     td = datetime.timedelta(days=3, minutes=10)
+///     duration = Duration()
+///     duration.FromTimedelta(td)
+///
+/// # JSON Mapping
+///
+/// In JSON format, the Duration type is encoded as a string rather than an
+/// object, where the string ends in the suffix "s" (indicating seconds) and
+/// is preceded by the number of seconds, with nanoseconds expressed as
+/// fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+/// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+/// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+/// microsecond should be expressed in JSON format as "3.000001s".
+///
+///
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Duration {
+    /// Signed seconds of the span of time. Must be from -315,576,000,000
+    /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
+    /// 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+    #[prost(int64, tag="1")]
+    pub seconds: i64,
+    /// Signed fractions of a second at nanosecond resolution of the span
+    /// of time. Durations less than one second are represented with a 0
+    /// `seconds` field and a positive or negative `nanos` field. For durations
+    /// of one second or more, a non-zero value for the `nanos` field must be
+    /// of the same sign as the `seconds` field. Must be from -999,999,999
+    /// to +999,999,999 inclusive.
+    #[prost(int32, tag="2")]
+    pub nanos: i32,
+}
+/// `FieldMask` represents a set of symbolic field paths, for example:
+///
+///     paths: "f.a"
+///     paths: "f.b.d"
+///
+/// Here `f` represents a field in some root message, `a` and `b`
+/// fields in the message found in `f`, and `d` a field found in the
+/// message in `f.b`.
+///
+/// Field masks are used to specify a subset of fields that should be
+/// returned by a get operation or modified by an update operation.
+/// Field masks also have a custom JSON encoding (see below).
+///
+/// # Field Masks in Projections
+///
+/// When used in the context of a projection, a response message or
+/// sub-message is filtered by the API to only contain those fields as
+/// specified in the mask. For example, if the mask in the previous
+/// example is applied to a response message as follows:
+///
+///     f {
+///       a : 22
+///       b {
+///         d : 1
+///         x : 2
+///       }
+///       y : 13
+///     }
+///     z: 8
+///
+/// The result will not contain specific values for fields x,y and z
+/// (their value will be set to the default, and omitted in proto text
+/// output):
+///
+///
+///     f {
+///       a : 22
+///       b {
+///         d : 1
+///       }
+///     }
+///
+/// A repeated field is not allowed except at the last position of a
+/// paths string.
+///
+/// If a FieldMask object is not present in a get operation, the
+/// operation applies to all fields (as if a FieldMask of all fields
+/// had been specified).
+///
+/// Note that a field mask does not necessarily apply to the
+/// top-level response message. In case of a REST get operation, the
+/// field mask applies directly to the response, but in case of a REST
+/// list operation, the mask instead applies to each individual message
+/// in the returned resource list. In case of a REST custom method,
+/// other definitions may be used. Where the mask applies will be
+/// clearly documented together with its declaration in the API.  In
+/// any case, the effect on the returned resource/resources is required
+/// behavior for APIs.
+///
+/// # Field Masks in Update Operations
+///
+/// A field mask in update operations specifies which fields of the
+/// targeted resource are going to be updated. The API is required
+/// to only change the values of the fields as specified in the mask
+/// and leave the others untouched. If a resource is passed in to
+/// describe the updated values, the API ignores the values of all
+/// fields not covered by the mask.
+///
+/// If a repeated field is specified for an update operation, new values will
+/// be appended to the existing repeated field in the target resource. Note that
+/// a repeated field is only allowed in the last position of a `paths` string.
+///
+/// If a sub-message is specified in the last position of the field mask for an
+/// update operation, then new value will be merged into the existing sub-message
+/// in the target resource.
+///
+/// For example, given the target message:
+///
+///     f {
+///       b {
+///         d: 1
+///         x: 2
+///       }
+///       c: [1]
+///     }
+///
+/// And an update message:
+///
+///     f {
+///       b {
+///         d: 10
+///       }
+///       c: [2]
+///     }
+///
+/// then if the field mask is:
+///
+///  paths: ["f.b", "f.c"]
+///
+/// then the result will be:
+///
+///     f {
+///       b {
+///         d: 10
+///         x: 2
+///       }
+///       c: [1, 2]
+///     }
+///
+/// An implementation may provide options to override this default behavior for
+/// repeated and message fields.
+///
+/// In order to reset a field's value to the default, the field must
+/// be in the mask and set to the default value in the provided resource.
+/// Hence, in order to reset all fields of a resource, provide a default
+/// instance of the resource and set all fields in the mask, or do
+/// not provide a mask as described below.
+///
+/// If a field mask is not present on update, the operation applies to
+/// all fields (as if a field mask of all fields has been specified).
+/// Note that in the presence of schema evolution, this may mean that
+/// fields the client does not know and has therefore not filled into
+/// the request will be reset to their default. If this is unwanted
+/// behavior, a specific service may require a client to always specify
+/// a field mask, producing an error if not.
+///
+/// As with get operations, the location of the resource which
+/// describes the updated values in the request message depends on the
+/// operation kind. In any case, the effect of the field mask is
+/// required to be honored by the API.
+///
+/// ## Considerations for HTTP REST
+///
+/// The HTTP kind of an update operation which uses a field mask must
+/// be set to PATCH instead of PUT in order to satisfy HTTP semantics
+/// (PUT must only be used for full updates).
+///
+/// # JSON Encoding of Field Masks
+///
+/// In JSON, a field mask is encoded as a single string where paths are
+/// separated by a comma. Fields name in each path are converted
+/// to/from lower-camel naming conventions.
+///
+/// As an example, consider the following message declarations:
+///
+///     message Profile {
+///       User user = 1;
+///       Photo photo = 2;
+///     }
+///     message User {
+///       string display_name = 1;
+///       string address = 2;
+///     }
+///
+/// In proto a field mask for `Profile` may look as such:
+///
+///     mask {
+///       paths: "user.display_name"
+///       paths: "photo"
+///     }
+///
+/// In JSON, the same mask is represented as below:
+///
+///     {
+///       mask: "user.displayName,photo"
+///     }
+///
+/// # Field Masks and Oneof Fields
+///
+/// Field masks treat fields in oneofs just as regular fields. Consider the
+/// following message:
+///
+///     message SampleMessage {
+///       oneof test_oneof {
+///         string name = 4;
+///         SubMessage sub_message = 9;
+///       }
+///     }
+///
+/// The field mask can be:
+///
+///     mask {
+///       paths: "name"
+///     }
+///
+/// Or:
+///
+///     mask {
+///       paths: "sub_message"
+///     }
+///
+/// Note that oneof type names ("test_oneof" in this case) cannot be used in
+/// paths.
+///
+/// ## Field Mask Verification
+///
+/// The implementation of any API method which has a FieldMask type field in the
+/// request should verify the included field paths, and return an
+/// `INVALID_ARGUMENT` error if any path is unmappable.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FieldMask {
+    /// The set of field mask paths.
+    #[prost(string, repeated, tag="1")]
+    pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// `Struct` represents a structured data value, consisting of fields
+/// which map to dynamically typed values. In some languages, `Struct`
+/// might be supported by a native representation. For example, in
+/// scripting languages like JS a struct is represented as an
+/// object. The details of that representation are described together
+/// with the proto support for the language.
+///
+/// The JSON representation for `Struct` is JSON object.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Struct {
+    /// Unordered map of dynamically typed values.
+    #[prost(btree_map="string, message", tag="1")]
+    pub fields: ::prost::alloc::collections::BTreeMap<::prost::alloc::string::String, Value>,
+}
+/// `Value` represents a dynamically typed value which can be either
+/// null, a number, a string, a boolean, a recursive struct value, or a
+/// list of values. A producer of value is expected to set one of that
+/// variants, absence of any variant indicates an error.
+///
+/// The JSON representation for `Value` is JSON value.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Value {
+    /// The kind of value.
+    #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
+    pub kind: ::core::option::Option<value::Kind>,
+}
+/// Nested message and enum types in `Value`.
+pub mod value {
+    /// The kind of value.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Kind {
+        /// Represents a null value.
+        #[prost(enumeration="super::NullValue", tag="1")]
+        NullValue(i32),
+        /// Represents a double value.
+        #[prost(double, tag="2")]
+        NumberValue(f64),
+        /// Represents a string value.
+        #[prost(string, tag="3")]
+        StringValue(::prost::alloc::string::String),
+        /// Represents a boolean value.
+        #[prost(bool, tag="4")]
+        BoolValue(bool),
+        /// Represents a structured value.
+        #[prost(message, tag="5")]
+        StructValue(super::Struct),
+        /// Represents a repeated `Value`.
+        #[prost(message, tag="6")]
+        ListValue(super::ListValue),
+    }
+}
+/// `ListValue` is a wrapper around a repeated field of values.
+///
+/// The JSON representation for `ListValue` is JSON array.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListValue {
+    /// Repeated field of dynamically typed values.
+    #[prost(message, repeated, tag="1")]
+    pub values: ::prost::alloc::vec::Vec<Value>,
+}
+/// `NullValue` is a singleton enumeration to represent the null value for the
+/// `Value` type union.
+///
+///  The JSON representation for `NullValue` is JSON `null`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum NullValue {
+    /// Null value.
+    NullValue = 0,
+}
+/// A Timestamp represents a point in time independent of any time zone or local
+/// calendar, encoded as a count of seconds and fractions of seconds at
+/// nanosecond resolution. The count is relative to an epoch at UTC midnight on
+/// January 1, 1970, in the proleptic Gregorian calendar which extends the
+/// Gregorian calendar backwards to year one.
+///
+/// All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+/// second table is needed for interpretation, using a [24-hour linear
+/// smear](https://developers.google.com/time/smear).
+///
+/// The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+/// restricting to that range, we ensure that we can convert to and from [RFC
+/// 3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+///
+/// # Examples
+///
+/// Example 1: Compute Timestamp from POSIX `time()`.
+///
+///     Timestamp timestamp;
+///     timestamp.set_seconds(time(NULL));
+///     timestamp.set_nanos(0);
+///
+/// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+///
+///     struct timeval tv;
+///     gettimeofday(&tv, NULL);
+///
+///     Timestamp timestamp;
+///     timestamp.set_seconds(tv.tv_sec);
+///     timestamp.set_nanos(tv.tv_usec * 1000);
+///
+/// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+///
+///     FILETIME ft;
+///     GetSystemTimeAsFileTime(&ft);
+///     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+///
+///     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+///     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+///     Timestamp timestamp;
+///     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+///     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+///
+/// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+///
+///     long millis = System.currentTimeMillis();
+///
+///     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+///         .setNanos((int) ((millis % 1000) * 1000000)).build();
+///
+///
+/// Example 5: Compute Timestamp from current time in Python.
+///
+///     timestamp = Timestamp()
+///     timestamp.GetCurrentTime()
+///
+/// # JSON Mapping
+///
+/// In JSON format, the Timestamp type is encoded as a string in the
+/// [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+/// format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+/// where {year} is always expressed using four digits while {month}, {day},
+/// {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+/// seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+/// are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+/// is required. A proto3 JSON serializer should always use UTC (as indicated by
+/// "Z") when printing the Timestamp type and a proto3 JSON parser should be
+/// able to accept both UTC and other timezones (as indicated by an offset).
+///
+/// For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+/// 01:30 UTC on January 15, 2017.
+///
+/// In JavaScript, one can convert a Date object to this format using the
+/// standard
+/// [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+/// method. In Python, a standard `datetime.datetime` object can be converted
+/// to this format using
+/// [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+/// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+/// the Joda Time's [`ISODateTimeFormat.dateTime()`](
+/// http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D
+/// ) to obtain a formatter capable of generating timestamps in this format.
+///
+///
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Timestamp {
+    /// Represents seconds of UTC time since Unix epoch
+    /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+    /// 9999-12-31T23:59:59Z inclusive.
+    #[prost(int64, tag="1")]
+    pub seconds: i64,
+    /// Non-negative fractions of a second at nanosecond resolution. Negative
+    /// second values with fractions must still have non-negative nanos values
+    /// that count forward in time. Must be from 0 to 999,999,999
+    /// inclusive.
+    #[prost(int32, tag="2")]
+    pub nanos: i32,
+}

--- a/third_party/prost/prost-types/src/protobuf.rs
+++ b/third_party/prost/prost-types/src/protobuf.rs
@@ -567,6 +567,9 @@ pub struct FieldOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+    /// Oak `message_type` annotation.
+    #[prost(string, optional, tag="79658")]
+    pub message_type: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `FieldOptions`.
 pub mod field_options {

--- a/third_party/prost/protobuf/Cargo.toml
+++ b/third_party/prost/protobuf/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "protobuf"
+version = "0.0.0"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+publish = false
+edition = "2018"
+
+[dependencies]
+bytes = { version = "0.5", default-features = false }
+prost = { path = ".." }
+prost-types = { path = "../prost-types" }
+
+[build-dependencies]
+anyhow = "1"
+cfg-if = "0.1"
+curl = "0.4"
+flate2 = "1.0"
+prost-build = { path = "../prost-build" }
+tar = "0.4"
+tempfile = "3"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[lib]
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+[[bench]]
+name = "dataset"
+harness = false

--- a/third_party/prost/protobuf/README.md
+++ b/third_party/prost/protobuf/README.md
@@ -1,0 +1,8 @@
+# `protobuf`
+
+`protobuf` is an internal library used by `prost` conformance tests, benchmarks,
+and integration-tests. `protobuf` downloads, compiles, and installs the
+[Protobuf][1] project, including the conformance test runner, `libprotobuf`,
+benchmark data and test and benchmark .protos into the Cargo target directory.
+
+[1]: https://github.com/google/protobuf/

--- a/third_party/prost/protobuf/benches/dataset.rs
+++ b/third_party/prost/protobuf/benches/dataset.rs
@@ -1,0 +1,113 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use prost::Message;
+
+use protobuf::benchmarks::{
+    dataset, google_message3::GoogleMessage3, /*google_message4::GoogleMessage4,*/ proto2,
+    proto3, BenchmarkDataset,
+};
+
+fn load_dataset(dataset: &Path) -> Result<BenchmarkDataset, Box<dyn Error>> {
+    let mut f = File::open(dataset)?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf)?;
+    Ok(BenchmarkDataset::decode(&*buf)?)
+}
+
+fn benchmark_dataset<M>(criterion: &mut Criterion, name: &str, dataset: &'static Path)
+where
+    M: prost::Message + Default + 'static,
+{
+    criterion.bench_function(&format!("dataset/{}/merge", name), move |b| {
+        let dataset = load_dataset(dataset).unwrap();
+        let mut message = M::default();
+        b.iter(|| {
+            for buf in &dataset.payload {
+                message.clear();
+                message.merge(buf.as_slice()).unwrap();
+                criterion::black_box(&message);
+            }
+        });
+    });
+
+    criterion.bench_function(&format!("dataset/{}/encode", name), move |b| {
+        let messages = load_dataset(dataset)
+            .unwrap()
+            .payload
+            .iter()
+            .map(Vec::as_slice)
+            .map(M::decode)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let mut buf = Vec::with_capacity(messages.iter().map(M::encoded_len).sum::<usize>());
+        b.iter(|| {
+            buf.clear();
+            for message in &messages {
+                message.encode(&mut buf).unwrap();
+            }
+            criterion::black_box(&buf);
+        });
+    });
+
+    criterion.bench_function(&format!("dataset/{}/encoded_len", name), move |b| {
+        let messages = load_dataset(dataset)
+            .unwrap()
+            .payload
+            .iter()
+            .map(Vec::as_slice)
+            .map(M::decode)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        b.iter(|| {
+            let encoded_len = messages.iter().map(M::encoded_len).sum::<usize>();
+            criterion::black_box(encoded_len)
+        });
+    });
+}
+
+macro_rules! dataset {
+    ($name: ident, $ty: ty) => {
+        fn $name(criterion: &mut Criterion) {
+            benchmark_dataset::<$ty>(criterion, stringify!($name), dataset::$name());
+        }
+    };
+}
+
+dataset!(google_message1_proto2, proto2::GoogleMessage1);
+dataset!(google_message1_proto3, proto3::GoogleMessage1);
+dataset!(google_message2, proto2::GoogleMessage2);
+//dataset!(google_message3_1, GoogleMessage3);
+dataset!(google_message3_2, GoogleMessage3);
+dataset!(google_message3_3, GoogleMessage3);
+dataset!(google_message3_4, GoogleMessage3);
+//dataset!(google_message3_5, GoogleMessage3);
+//dataset!(google_message4, GoogleMessage4);
+
+criterion_group!(
+    dataset,
+    google_message1_proto2,
+    google_message1_proto3,
+    google_message2,
+);
+
+criterion_group! {
+    name = slow;
+    config = Criterion::default().sample_size(10);
+    targets = google_message3_2, google_message3_4, google_message3_3
+}
+
+// TODO: Criterion now requires a sample_size of 10; figure out a better way to
+// get these tests to run in a reasonable time.
+/*
+criterion_group! {
+    name = extra_slow;
+    config = Criterion::default().sample_size(10);
+    targets = google_message3_1, google_message3_5, google_message4
+}
+*/
+
+criterion_main!(dataset, slow /*, extra_slow*/);

--- a/third_party/prost/protobuf/build.rs
+++ b/third_party/prost/protobuf/build.rs
@@ -1,0 +1,277 @@
+use std::env;
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{ensure, Context, Result};
+use curl::easy::Easy;
+use flate2::bufread::GzDecoder;
+use tar::Archive;
+
+const VERSION: &str = "3.11.2";
+
+static TEST_PROTOS: &[&str] = &[
+    "test_messages_proto2.proto",
+    "test_messages_proto3.proto",
+    "unittest.proto",
+    "unittest_import.proto",
+    "unittest_import_public.proto",
+];
+
+static DATASET_PROTOS: &[&str] = &[
+    "google_message1/proto2/benchmark_message1_proto2.proto",
+    "google_message1/proto3/benchmark_message1_proto3.proto",
+    "google_message2/benchmark_message2.proto",
+    "google_message3/benchmark_message3.proto",
+    "google_message3/benchmark_message3_1.proto",
+    "google_message3/benchmark_message3_2.proto",
+    "google_message3/benchmark_message3_3.proto",
+    "google_message3/benchmark_message3_4.proto",
+    "google_message3/benchmark_message3_5.proto",
+    "google_message3/benchmark_message3_6.proto",
+    "google_message3/benchmark_message3_7.proto",
+    "google_message3/benchmark_message3_8.proto",
+    "google_message4/benchmark_message4.proto",
+    "google_message4/benchmark_message4_1.proto",
+    "google_message4/benchmark_message4_2.proto",
+    "google_message4/benchmark_message4_3.proto",
+];
+
+fn main() -> Result<()> {
+    let out_dir =
+        &PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"));
+    let protobuf_dir = &out_dir.join(format!("protobuf-{}", VERSION));
+
+    if !protobuf_dir.exists() {
+        let tempdir = tempfile::Builder::new()
+            .prefix("protobuf")
+            .tempdir_in(out_dir)
+            .expect("failed to create temporary directory");
+
+        let src_dir = &download_protobuf(tempdir.path())?;
+        let prefix_dir = &src_dir.join("prefix");
+        fs::create_dir(prefix_dir).expect("failed to create prefix directory");
+        install_conformance_test_runner(src_dir, prefix_dir)?;
+        install_protos(src_dir, prefix_dir)?;
+        install_datasets(src_dir, prefix_dir)?;
+        fs::rename(prefix_dir, protobuf_dir).context("failed to move protobuf dir")?;
+    }
+
+    let include_dir = &protobuf_dir.join("include");
+    let benchmarks_include_dir = &include_dir.join("benchmarks");
+    let datasets_include_dir = &benchmarks_include_dir.join("datasets");
+    let mut benchmark_protos = vec![benchmarks_include_dir.join("benchmarks.proto")];
+    benchmark_protos.extend(
+        DATASET_PROTOS
+            .iter()
+            .map(|proto| datasets_include_dir.join(proto)),
+    );
+    prost_build::compile_protos(&benchmark_protos, &[benchmarks_include_dir.to_path_buf()])
+        .unwrap();
+
+    let conformance_include_dir = include_dir.join("conformance");
+    prost_build::compile_protos(
+        &[conformance_include_dir.join("conformance.proto")],
+        &[conformance_include_dir],
+    )
+    .unwrap();
+
+    let test_includes = &include_dir.join("google").join("protobuf");
+
+    // Generate BTreeMap fields for all messages. This forces encoded output to be consistent, so
+    // that encode/decode roundtrips can use encoded output for comparison. Otherwise trying to
+    // compare based on the Rust PartialEq implementations is difficult, due to presence of NaN
+    // values.
+    prost_build::Config::new()
+        .btree_map(&["."])
+        .compile_protos(
+            &[
+                test_includes.join("test_messages_proto2.proto"),
+                test_includes.join("test_messages_proto3.proto"),
+                test_includes.join("unittest.proto"),
+            ],
+            &[include_dir.to_path_buf()],
+        )
+        .unwrap();
+
+    // Emit an environment variable with the path to the build so that it can be located in the
+    // main crate.
+    println!("cargo:rustc-env=PROTOBUF={}", protobuf_dir.display());
+    Ok(())
+}
+
+fn download_tarball(url: &str, out_dir: &Path) -> Result<()> {
+    let mut data = Vec::new();
+    let mut handle = Easy::new();
+
+    // Download the tarball.
+    handle.url(url).context("failed to configure tarball URL")?;
+    handle
+        .follow_location(true)
+        .context("failed to configure follow location")?;
+    {
+        let mut transfer = handle.transfer();
+        transfer
+            .write_function(|new_data| {
+                data.extend_from_slice(new_data);
+                Ok(new_data.len())
+            })
+            .context("failed to write download data")?;
+        transfer.perform().context("failed to download tarball")?;
+    }
+
+    // Unpack the tarball.
+    Archive::new(GzDecoder::new(Cursor::new(data)))
+        .unpack(out_dir)
+        .context("failed to unpack tarball")
+}
+
+/// Downloads and unpacks a Protobuf release tarball to the provided directory.
+fn download_protobuf(out_dir: &Path) -> Result<PathBuf> {
+    download_tarball(
+        &format!(
+            "https://github.com/google/protobuf/archive/v{}.tar.gz",
+            VERSION
+        ),
+        out_dir,
+    )?;
+    let src_dir = out_dir.join(format!("protobuf-{}", VERSION));
+
+    // Apply patches.
+    let mut patch_src = env::current_dir().context("failed to get current working directory")?;
+    patch_src.push("src");
+    patch_src.push("fix-conformance_test_runner-cmake-build.patch");
+
+    let rc = Command::new("patch")
+        .arg("-p1")
+        .arg("-i")
+        .arg(patch_src)
+        .current_dir(&src_dir)
+        .status()
+        .context("failed to apply patch")?;
+    ensure!(rc.success(), "protobuf patch failed");
+
+    Ok(src_dir)
+}
+
+#[cfg(windows)]
+fn install_conformance_test_runner(_: &Path, _: &Path) -> Result<()> {
+    // The conformance test runner does not support Windows [1].
+    // [1]: https://github.com/protocolbuffers/protobuf/tree/master/conformance#portability
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn install_conformance_test_runner(src_dir: &Path, prefix_dir: &Path) -> Result<()> {
+    // Build and install protoc, the protobuf libraries, and the conformance test runner.
+    let rc = Command::new("cmake")
+        .arg("-GNinja")
+        .arg("cmake/")
+        .arg("-DCMAKE_BUILD_TYPE=DEBUG")
+        .arg(&format!("-DCMAKE_INSTALL_PREFIX={}", prefix_dir.display()))
+        .arg("-Dprotobuf_BUILD_CONFORMANCE=ON")
+        .arg("-Dprotobuf_BUILD_TESTS=OFF")
+        .current_dir(&src_dir)
+        .status()
+        .context("failed to execute CMake")?;
+    assert!(rc.success(), "protobuf CMake failed");
+
+    let num_jobs = env::var("NUM_JOBS").context("NUM_JOBS environment variable not set")?;
+
+    let rc = Command::new("ninja")
+        .arg("-j")
+        .arg(&num_jobs)
+        .arg("install")
+        .current_dir(&src_dir)
+        .status()
+        .context("failed to execute ninja protobuf")?;
+    ensure!(rc.success(), "failed to make protobuf");
+
+    // Install the conformance-test-runner binary, since it isn't done automatically.
+    fs::rename(
+        src_dir.join("conformance_test_runner"),
+        prefix_dir.join("bin").join("conformance-test-runner"),
+    )
+    .context("failed to move conformance-test-runner")?;
+
+    Ok(())
+}
+
+fn install_protos(src_dir: &Path, prefix_dir: &Path) -> Result<()> {
+    let include_dir = prefix_dir.join("include");
+
+    // Move test protos to the prefix directory.
+    let test_include_dir = &include_dir.join("google").join("protobuf");
+    fs::create_dir_all(test_include_dir).expect("failed to create test include directory");
+    for proto in TEST_PROTOS {
+        fs::rename(
+            src_dir
+                .join("src")
+                .join("google")
+                .join("protobuf")
+                .join(proto),
+            test_include_dir.join(proto),
+        )
+        .with_context(|| format!("failed to move {}", proto))?;
+    }
+
+    // Move conformance.proto to the install directory.
+    let conformance_include_dir = &include_dir.join("conformance");
+    fs::create_dir(conformance_include_dir)
+        .expect("failed to create conformance include directory");
+    fs::rename(
+        src_dir.join("conformance").join("conformance.proto"),
+        conformance_include_dir.join("conformance.proto"),
+    )
+    .expect("failed to move conformance.proto");
+
+    // Move the benchmark datasets to the install directory.
+    let benchmarks_src_dir = &src_dir.join("benchmarks");
+    let benchmarks_include_dir = &include_dir.join("benchmarks");
+    let datasets_src_dir = &benchmarks_src_dir.join("datasets");
+    let datasets_include_dir = &benchmarks_include_dir.join("datasets");
+    fs::create_dir(benchmarks_include_dir).expect("failed to create benchmarks include directory");
+    fs::rename(
+        benchmarks_src_dir.join("benchmarks.proto"),
+        benchmarks_include_dir.join("benchmarks.proto"),
+    )
+    .expect("failed to move benchmarks.proto");
+    for proto in DATASET_PROTOS.iter().map(Path::new) {
+        let dir = &datasets_include_dir.join(proto.parent().unwrap());
+        fs::create_dir_all(dir)
+            .with_context(|| format!("unable to create directory {}", dir.display()))?;
+        fs::rename(
+            datasets_src_dir.join(proto),
+            datasets_include_dir.join(proto),
+        )
+        .with_context(|| format!("failed to move {}", proto.display()))?;
+    }
+
+    Ok(())
+}
+
+fn install_datasets(src_dir: &Path, prefix_dir: &Path) -> Result<()> {
+    let share_dir = &prefix_dir.join("share");
+    fs::create_dir(share_dir).expect("failed to create share directory");
+    for dataset in &[
+        Path::new("google_message1")
+            .join("proto2")
+            .join("dataset.google_message1_proto2.pb"),
+        Path::new("google_message1")
+            .join("proto3")
+            .join("dataset.google_message1_proto3.pb"),
+        Path::new("google_message2").join("dataset.google_message2.pb"),
+    ] {
+        fs::rename(
+            src_dir.join("benchmarks").join("datasets").join(dataset),
+            share_dir.join(dataset.file_name().unwrap()),
+        )
+        .with_context(|| format!("failed to move {}", dataset.display()))?;
+    }
+
+    download_tarball(
+        "https://storage.googleapis.com/protobuf_opensource_benchmark_data/datasets.tar.gz",
+        share_dir,
+    )
+}

--- a/third_party/prost/protobuf/src/fix-conformance_test_runner-cmake-build.patch
+++ b/third_party/prost/protobuf/src/fix-conformance_test_runner-cmake-build.patch
@@ -1,0 +1,41 @@
+From 104a483fbf3b87d42b0c3381049c72ab45d0f630 Mon Sep 17 00:00:00 2001
+From: Dan Burkert <dan@danburkert.com>
+Date: Sat, 11 Jan 2020 13:44:02 -0800
+Subject: [PATCH] Fix conformance_test_runner CMake build
+
+Makes the conformance_test_runner declared sources in
+cmake/conformance.cmake match the corresponding sources in
+conformance/Makefile.am, which allows the test runner to build
+successfully with CMake.
+---
+ cmake/conformance.cmake | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/conformance.cmake b/cmake/conformance.cmake
+index 82b4cf580..7be713d33 100644
+--- a/cmake/conformance.cmake
++++ b/cmake/conformance.cmake
+@@ -19,14 +19,17 @@ add_custom_command(
+ )
+ 
+ add_executable(conformance_test_runner
+-  ${protobuf_source_dir}/conformance/conformance.pb.cc
++  ${protobuf_source_dir}/conformance/conformance_test.h
+   ${protobuf_source_dir}/conformance/conformance_test.cc
+-  ${protobuf_source_dir}/conformance/binary_json_conformance_main.cc
+-  ${protobuf_source_dir}/conformance/binary_json_conformance_suite.cc
++  ${protobuf_source_dir}/conformance/conformance_test_main.cc
+   ${protobuf_source_dir}/conformance/binary_json_conformance_suite.h
++  ${protobuf_source_dir}/conformance/binary_json_conformance_suite.cc
++  ${protobuf_source_dir}/conformance/text_format_conformance_suite.h
++  ${protobuf_source_dir}/conformance/text_format_conformance_suite.cc
+   ${protobuf_source_dir}/conformance/conformance_test_runner.cc
+   ${protobuf_source_dir}/conformance/third_party/jsoncpp/json.h
+   ${protobuf_source_dir}/conformance/third_party/jsoncpp/jsoncpp.cpp
++  ${protobuf_source_dir}/conformance/conformance.pb.cc
+   ${protobuf_source_dir}/src/google/protobuf/test_messages_proto3.pb.cc
+   ${protobuf_source_dir}/src/google/protobuf/test_messages_proto2.pb.cc
+ )
+-- 
+2.21.1
+

--- a/third_party/prost/protobuf/src/lib.rs
+++ b/third_party/prost/protobuf/src/lib.rs
@@ -1,0 +1,116 @@
+#![allow(clippy::large_enum_variant, clippy::unreadable_literal)]
+
+pub mod benchmarks {
+    include!(concat!(env!("OUT_DIR"), "/benchmarks.rs"));
+
+    pub mod dataset {
+        use std::path::Path;
+
+        pub fn google_message1_proto2() -> &'static Path {
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message1_proto2.pb"
+            ))
+        }
+
+        pub fn google_message1_proto3() -> &'static Path {
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message1_proto3.pb"
+            ))
+        }
+
+        pub fn google_message2() -> &'static Path {
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message2.pb"
+            ))
+        }
+
+        pub fn google_message3_1() -> &'static Path {
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_1.pb"
+            ))
+        }
+
+        pub fn google_message3_2() -> &'static Path {
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_2.pb"
+            ))
+        }
+
+        pub fn google_message3_3() -> &'static Path {
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_3.pb"
+            ))
+        }
+
+        pub fn google_message3_4() -> &'static Path {
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_4.pb"
+            ))
+        }
+
+        pub fn google_message3_5() -> &'static Path {
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_5.pb"
+            ))
+        }
+
+        pub fn google_message4() -> &'static Path {
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message4.pb"
+            ))
+        }
+    }
+
+    pub mod google_message3 {
+        include!(concat!(env!("OUT_DIR"), "/benchmarks.google_message3.rs"));
+    }
+    pub mod google_message4 {
+        include!(concat!(env!("OUT_DIR"), "/benchmarks.google_message4.rs"));
+    }
+    pub mod proto2 {
+        include!(concat!(env!("OUT_DIR"), "/benchmarks.proto2.rs"));
+    }
+    pub mod proto3 {
+        include!(concat!(env!("OUT_DIR"), "/benchmarks.proto3.rs"));
+    }
+}
+
+pub mod conformance {
+    use std::path::Path;
+
+    pub fn test_runner() -> &'static Path {
+        Path::new(concat!(env!("PROTOBUF"), "/bin/conformance-test-runner"))
+    }
+
+    include!(concat!(env!("OUT_DIR"), "/conformance.rs"));
+}
+
+pub mod test_messages {
+    pub mod proto2 {
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/protobuf_test_messages.proto2.rs"
+        ));
+    }
+    pub mod proto3 {
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/protobuf_test_messages.proto3.rs"
+        ));
+    }
+    pub mod protobuf_unittest {
+        include!(concat!(env!("OUT_DIR"), "/protobuf_unittest.rs"));
+    }
+    pub mod protobuf_unittest_import {
+        include!(concat!(env!("OUT_DIR"), "/protobuf_unittest_import.rs"));
+    }
+}

--- a/third_party/prost/publish-release.sh
+++ b/third_party/prost/publish-release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Script which automates publishing a crates.io release of the prost crates.
+
+set -ex
+
+if [ "$#" -ne 0 ]
+then
+  echo "Usage: $0"
+  exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+CRATES=( \
+  "prost-derive" \
+  "." \
+  "prost-types" \
+  "prost-build" \
+)
+
+for CRATE in "${CRATES[@]}"; do
+  pushd "$DIR/$CRATE"
+  cargo publish
+  popd
+done

--- a/third_party/prost/src/encoding.rs
+++ b/third_party/prost/src/encoding.rs
@@ -1,0 +1,1665 @@
+//! Utility functions and types for encoding and decoding Protobuf types.
+//!
+//! Meant to be used only from `Message` implementations.
+
+#![allow(clippy::implicit_hasher, clippy::ptr_arg)]
+
+use alloc::collections::BTreeMap;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::min;
+use core::convert::TryFrom;
+use core::mem;
+use core::str;
+use core::u32;
+use core::usize;
+
+use ::bytes::{buf::ext::BufExt, Buf, BufMut};
+
+use crate::DecodeError;
+use crate::Message;
+
+/// Encodes an integer value into LEB128 variable length format, and writes it to the buffer.
+/// The buffer must have enough remaining space (maximum 10 bytes).
+#[inline]
+pub fn encode_varint<B>(mut value: u64, buf: &mut B)
+where
+    B: BufMut,
+{
+    // Safety notes:
+    //
+    // - advance_mut is unsafe because it could cause uninitialized memory to be
+    //   advanced over. The use here is safe since each byte which is advanced over
+    //   has been written to in the previous loop iteration.
+    let mut i;
+    'outer: loop {
+        i = 0;
+
+        for byte in buf.bytes_mut() {
+            i += 1;
+            if value < 0x80 {
+                *byte = mem::MaybeUninit::new(value as u8);
+                break 'outer;
+            } else {
+                *byte = mem::MaybeUninit::new(((value & 0x7F) | 0x80) as u8);
+                value >>= 7;
+            }
+        }
+
+        unsafe {
+            buf.advance_mut(i);
+        }
+        debug_assert!(buf.has_remaining_mut());
+    }
+
+    unsafe {
+        buf.advance_mut(i);
+    }
+}
+
+/// Decodes a LEB128-encoded variable length integer from the buffer.
+pub fn decode_varint<B>(buf: &mut B) -> Result<u64, DecodeError>
+where
+    B: Buf,
+{
+    let bytes = buf.bytes();
+    let len = bytes.len();
+    if len == 0 {
+        return Err(DecodeError::new("invalid varint"));
+    }
+
+    let byte = unsafe { *bytes.get_unchecked(0) };
+    if byte < 0x80 {
+        buf.advance(1);
+        Ok(u64::from(byte))
+    } else if len > 10 || bytes[len - 1] < 0x80 {
+        let (value, advance) = unsafe { decode_varint_slice(bytes) }?;
+        buf.advance(advance);
+        Ok(value)
+    } else {
+        decode_varint_slow(buf)
+    }
+}
+
+/// Decodes a LEB128-encoded variable length integer from the slice, returning the value and the
+/// number of bytes read.
+///
+/// Based loosely on [`ReadVarint64FromArray`][1].
+///
+/// ## Safety
+///
+/// The caller must ensure that `bytes` is non-empty and either `bytes.len() >= 10` or the last
+/// element in bytes is < `0x80`.
+///
+/// [1]: https://github.com/google/protobuf/blob/3.3.x/src/google/protobuf/io/coded_stream.cc#L365-L406
+#[inline]
+unsafe fn decode_varint_slice(bytes: &[u8]) -> Result<(u64, usize), DecodeError> {
+    // Fully unrolled varint decoding loop. Splitting into 32-bit pieces gives better performance.
+
+    let mut b: u8;
+    let mut part0: u32;
+    b = *bytes.get_unchecked(0);
+    part0 = u32::from(b);
+    if b < 0x80 {
+        return Ok((u64::from(part0), 1));
+    };
+    part0 -= 0x80;
+    b = *bytes.get_unchecked(1);
+    part0 += u32::from(b) << 7;
+    if b < 0x80 {
+        return Ok((u64::from(part0), 2));
+    };
+    part0 -= 0x80 << 7;
+    b = *bytes.get_unchecked(2);
+    part0 += u32::from(b) << 14;
+    if b < 0x80 {
+        return Ok((u64::from(part0), 3));
+    };
+    part0 -= 0x80 << 14;
+    b = *bytes.get_unchecked(3);
+    part0 += u32::from(b) << 21;
+    if b < 0x80 {
+        return Ok((u64::from(part0), 4));
+    };
+    part0 -= 0x80 << 21;
+    let value = u64::from(part0);
+
+    let mut part1: u32;
+    b = *bytes.get_unchecked(4);
+    part1 = u32::from(b);
+    if b < 0x80 {
+        return Ok((value + (u64::from(part1) << 28), 5));
+    };
+    part1 -= 0x80;
+    b = *bytes.get_unchecked(5);
+    part1 += u32::from(b) << 7;
+    if b < 0x80 {
+        return Ok((value + (u64::from(part1) << 28), 6));
+    };
+    part1 -= 0x80 << 7;
+    b = *bytes.get_unchecked(6);
+    part1 += u32::from(b) << 14;
+    if b < 0x80 {
+        return Ok((value + (u64::from(part1) << 28), 7));
+    };
+    part1 -= 0x80 << 14;
+    b = *bytes.get_unchecked(7);
+    part1 += u32::from(b) << 21;
+    if b < 0x80 {
+        return Ok((value + (u64::from(part1) << 28), 8));
+    };
+    part1 -= 0x80 << 21;
+    let value = value + ((u64::from(part1)) << 28);
+
+    let mut part2: u32;
+    b = *bytes.get_unchecked(8);
+    part2 = u32::from(b);
+    if b < 0x80 {
+        return Ok((value + (u64::from(part2) << 56), 9));
+    };
+    part2 -= 0x80;
+    b = *bytes.get_unchecked(9);
+    part2 += u32::from(b) << 7;
+    if b < 0x80 {
+        return Ok((value + (u64::from(part2) << 56), 10));
+    };
+
+    // We have overrun the maximum size of a varint (10 bytes). Assume the data is corrupt.
+    Err(DecodeError::new("invalid varint"))
+}
+
+/// Decodes a LEB128-encoded variable length integer from the buffer, advancing the buffer as
+/// necessary.
+#[inline(never)]
+fn decode_varint_slow<B>(buf: &mut B) -> Result<u64, DecodeError>
+where
+    B: Buf,
+{
+    let mut value = 0;
+    for count in 0..min(10, buf.remaining()) {
+        let byte = buf.get_u8();
+        value |= u64::from(byte & 0x7F) << (count * 7);
+        if byte <= 0x7F {
+            return Ok(value);
+        }
+    }
+
+    Err(DecodeError::new("invalid varint"))
+}
+
+/// Additional information passed to every decode/merge function.
+///
+/// The context should be passed by value and can be freely cloned. When passing
+/// to a function which is decoding a nested object, then use `enter_recursion`.
+#[derive(Clone, Debug)]
+pub struct DecodeContext {
+    /// How many times we can recurse in the current decode stack before we hit
+    /// the recursion limit.
+    ///
+    /// The recursion limit is defined by `RECURSION_LIMIT` and cannot be
+    /// customized. The recursion limit can be ignored by building the Prost
+    /// crate with the `no-recursion-limit` feature.
+    #[cfg(not(feature = "no-recursion-limit"))]
+    recurse_count: u32,
+}
+
+impl Default for DecodeContext {
+    #[cfg(not(feature = "no-recursion-limit"))]
+    #[inline]
+    fn default() -> DecodeContext {
+        DecodeContext {
+            recurse_count: crate::RECURSION_LIMIT,
+        }
+    }
+
+    #[cfg(feature = "no-recursion-limit")]
+    #[inline]
+    fn default() -> DecodeContext {
+        DecodeContext {}
+    }
+}
+
+impl DecodeContext {
+    /// Call this function before recursively decoding.
+    ///
+    /// There is no `exit` function since this function creates a new `DecodeContext`
+    /// to be used at the next level of recursion. Continue to use the old context
+    // at the previous level of recursion.
+    #[cfg(not(feature = "no-recursion-limit"))]
+    #[inline]
+    pub(crate) fn enter_recursion(&self) -> DecodeContext {
+        DecodeContext {
+            recurse_count: self.recurse_count - 1,
+        }
+    }
+
+    #[cfg(feature = "no-recursion-limit")]
+    #[inline]
+    pub(crate) fn enter_recursion(&self) -> DecodeContext {
+        DecodeContext {}
+    }
+
+    /// Checks whether the recursion limit has been reached in the stack of
+    /// decodes described by the `DecodeContext` at `self.ctx`.
+    ///
+    /// Returns `Ok<()>` if it is ok to continue recursing.
+    /// Returns `Err<DecodeError>` if the recursion limit has been reached.
+    #[cfg(not(feature = "no-recursion-limit"))]
+    #[inline]
+    pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
+        if self.recurse_count == 0 {
+            Err(DecodeError::new("recursion limit reached"))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(feature = "no-recursion-limit")]
+    #[inline]
+    pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
+        Ok(())
+    }
+}
+
+/// Returns the encoded length of the value in LEB128 variable length format.
+/// The returned value will be between 1 and 10, inclusive.
+#[inline]
+pub fn encoded_len_varint(value: u64) -> usize {
+    // Based on [VarintSize64][1].
+    // [1]: https://github.com/google/protobuf/blob/3.3.x/src/google/protobuf/io/coded_stream.h#L1301-L1309
+    ((((value | 1).leading_zeros() ^ 63) * 9 + 73) / 64) as usize
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+pub enum WireType {
+    Varint = 0,
+    SixtyFourBit = 1,
+    LengthDelimited = 2,
+    StartGroup = 3,
+    EndGroup = 4,
+    ThirtyTwoBit = 5,
+}
+
+pub const MIN_TAG: u32 = 1;
+pub const MAX_TAG: u32 = (1 << 29) - 1;
+
+impl TryFrom<u64> for WireType {
+    type Error = DecodeError;
+
+    #[inline]
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(WireType::Varint),
+            1 => Ok(WireType::SixtyFourBit),
+            2 => Ok(WireType::LengthDelimited),
+            3 => Ok(WireType::StartGroup),
+            4 => Ok(WireType::EndGroup),
+            5 => Ok(WireType::ThirtyTwoBit),
+            _ => Err(DecodeError::new(format!(
+                "invalid wire type value: {}",
+                value
+            ))),
+        }
+    }
+}
+
+/// Encodes a Protobuf field key, which consists of a wire type designator and
+/// the field tag.
+#[inline]
+pub fn encode_key<B>(tag: u32, wire_type: WireType, buf: &mut B)
+where
+    B: BufMut,
+{
+    debug_assert!(tag >= MIN_TAG && tag <= MAX_TAG);
+    let key = (tag << 3) | wire_type as u32;
+    encode_varint(u64::from(key), buf);
+}
+
+/// Decodes a Protobuf field key, which consists of a wire type designator and
+/// the field tag.
+#[inline(always)]
+pub fn decode_key<B>(buf: &mut B) -> Result<(u32, WireType), DecodeError>
+where
+    B: Buf,
+{
+    let key = decode_varint(buf)?;
+    if key > u64::from(u32::MAX) {
+        return Err(DecodeError::new(format!("invalid key value: {}", key)));
+    }
+    let wire_type = WireType::try_from(key & 0x07)?;
+    let tag = key as u32 >> 3;
+
+    if tag < MIN_TAG {
+        return Err(DecodeError::new("invalid tag value: 0"));
+    }
+
+    Ok((tag, wire_type))
+}
+
+/// Returns the width of an encoded Protobuf field key with the given tag.
+/// The returned width will be between 1 and 5 bytes (inclusive).
+#[inline]
+pub fn key_len(tag: u32) -> usize {
+    encoded_len_varint(u64::from(tag << 3))
+}
+
+/// Checks that the expected wire type matches the actual wire type,
+/// or returns an error result.
+#[inline]
+pub fn check_wire_type(expected: WireType, actual: WireType) -> Result<(), DecodeError> {
+    if expected != actual {
+        return Err(DecodeError::new(format!(
+            "invalid wire type: {:?} (expected {:?})",
+            actual, expected
+        )));
+    }
+    Ok(())
+}
+
+/// Helper function which abstracts reading a length delimiter prefix followed
+/// by decoding values until the length of bytes is exhausted.
+pub fn merge_loop<T, M, B>(
+    value: &mut T,
+    buf: &mut B,
+    ctx: DecodeContext,
+    mut merge: M,
+) -> Result<(), DecodeError>
+where
+    M: FnMut(&mut T, &mut B, DecodeContext) -> Result<(), DecodeError>,
+    B: Buf,
+{
+    let len = decode_varint(buf)?;
+    let remaining = buf.remaining();
+    if len > remaining as u64 {
+        return Err(DecodeError::new("buffer underflow"));
+    }
+
+    let limit = remaining - len as usize;
+    while buf.remaining() > limit {
+        merge(value, buf, ctx.clone())?;
+    }
+
+    if buf.remaining() != limit {
+        return Err(DecodeError::new("delimited length exceeded"));
+    }
+    Ok(())
+}
+
+pub fn skip_field<B>(
+    wire_type: WireType,
+    tag: u32,
+    buf: &mut B,
+    ctx: DecodeContext,
+) -> Result<(), DecodeError>
+where
+    B: Buf,
+{
+    ctx.limit_reached()?;
+    let len = match wire_type {
+        WireType::Varint => decode_varint(buf).map(|_| 0)?,
+        WireType::ThirtyTwoBit => 4,
+        WireType::SixtyFourBit => 8,
+        WireType::LengthDelimited => decode_varint(buf)?,
+        WireType::StartGroup => loop {
+            let (inner_tag, inner_wire_type) = decode_key(buf)?;
+            match inner_wire_type {
+                WireType::EndGroup => {
+                    if inner_tag != tag {
+                        return Err(DecodeError::new("unexpected end group tag"));
+                    }
+                    break 0;
+                }
+                _ => skip_field(inner_wire_type, inner_tag, buf, ctx.enter_recursion())?,
+            }
+        },
+        WireType::EndGroup => return Err(DecodeError::new("unexpected end group tag")),
+    };
+
+    if len > buf.remaining() as u64 {
+        return Err(DecodeError::new("buffer underflow"));
+    }
+
+    buf.advance(len as usize);
+    Ok(())
+}
+
+/// Helper macro which emits an `encode_repeated` function for the type.
+macro_rules! encode_repeated {
+    ($ty:ty) => {
+        pub fn encode_repeated<B>(tag: u32, values: &[$ty], buf: &mut B)
+        where
+            B: BufMut,
+        {
+            for value in values {
+                encode(tag, value, buf);
+            }
+        }
+    };
+}
+
+/// Helper macro which emits a `merge_repeated` function for the numeric type.
+macro_rules! merge_repeated_numeric {
+    ($ty:ty,
+     $wire_type:expr,
+     $merge:ident,
+     $merge_repeated:ident) => {
+        pub fn $merge_repeated<B>(
+            wire_type: WireType,
+            values: &mut Vec<$ty>,
+            buf: &mut B,
+            ctx: DecodeContext,
+        ) -> Result<(), DecodeError>
+        where
+            B: Buf,
+        {
+            if wire_type == WireType::LengthDelimited {
+                // Packed.
+                merge_loop(values, buf, ctx, |values, buf, ctx| {
+                    let mut value = Default::default();
+                    $merge($wire_type, &mut value, buf, ctx)?;
+                    values.push(value);
+                    Ok(())
+                })
+            } else {
+                // Unpacked.
+                check_wire_type($wire_type, wire_type)?;
+                let mut value = Default::default();
+                $merge(wire_type, &mut value, buf, ctx)?;
+                values.push(value);
+                Ok(())
+            }
+        }
+    };
+}
+
+/// Macro which emits a module containing a set of encoding functions for a
+/// variable width numeric type.
+macro_rules! varint {
+    ($ty:ty,
+     $proto_ty:ident) => (
+        varint!($ty,
+                $proto_ty,
+                to_uint64(value) { *value as u64 },
+                from_uint64(value) { value as $ty });
+    );
+
+    ($ty:ty,
+     $proto_ty:ident,
+     to_uint64($to_uint64_value:ident) $to_uint64:expr,
+     from_uint64($from_uint64_value:ident) $from_uint64:expr) => (
+
+         pub mod $proto_ty {
+            use crate::encoding::*;
+
+            pub fn encode<B>(tag: u32, $to_uint64_value: &$ty, buf: &mut B) where B: BufMut {
+                encode_key(tag, WireType::Varint, buf);
+                encode_varint($to_uint64, buf);
+            }
+
+            pub fn merge<B>(wire_type: WireType, value: &mut $ty, buf: &mut B, _ctx: DecodeContext) -> Result<(), DecodeError> where B: Buf {
+                check_wire_type(WireType::Varint, wire_type)?;
+                let $from_uint64_value = decode_varint(buf)?;
+                *value = $from_uint64;
+                Ok(())
+            }
+
+            encode_repeated!($ty);
+
+            pub fn encode_packed<B>(tag: u32, values: &[$ty], buf: &mut B) where B: BufMut {
+                if values.is_empty() { return; }
+
+                encode_key(tag, WireType::LengthDelimited, buf);
+                let len: usize = values.iter().map(|$to_uint64_value| {
+                    encoded_len_varint($to_uint64)
+                }).sum();
+                encode_varint(len as u64, buf);
+
+                for $to_uint64_value in values {
+                    encode_varint($to_uint64, buf);
+                }
+            }
+
+            merge_repeated_numeric!($ty, WireType::Varint, merge, merge_repeated);
+
+            #[inline]
+            pub fn encoded_len(tag: u32, $to_uint64_value: &$ty) -> usize {
+                key_len(tag) + encoded_len_varint($to_uint64)
+            }
+
+            #[inline]
+            pub fn encoded_len_repeated(tag: u32, values: &[$ty]) -> usize {
+                key_len(tag) * values.len() + values.iter().map(|$to_uint64_value| {
+                    encoded_len_varint($to_uint64)
+                }).sum::<usize>()
+            }
+
+            #[inline]
+            pub fn encoded_len_packed(tag: u32, values: &[$ty]) -> usize {
+                if values.is_empty() {
+                    0
+                } else {
+                    let len = values.iter()
+                                    .map(|$to_uint64_value| encoded_len_varint($to_uint64))
+                                    .sum::<usize>();
+                    key_len(tag) + encoded_len_varint(len as u64) + len
+                }
+            }
+
+            #[cfg(test)]
+            mod test {
+                use quickcheck::{quickcheck, TestResult};
+
+                use crate::encoding::$proto_ty::*;
+                use crate::encoding::test::{
+                    check_collection_type,
+                    check_type,
+                };
+
+                quickcheck! {
+                    fn check(value: $ty, tag: u32) -> TestResult {
+                        check_type(value, tag, WireType::Varint,
+                                   encode, merge, encoded_len)
+                    }
+                    fn check_repeated(value: Vec<$ty>, tag: u32) -> TestResult {
+                        check_collection_type(value, tag, WireType::Varint,
+                                              encode_repeated, merge_repeated,
+                                              encoded_len_repeated)
+                    }
+                    fn check_packed(value: Vec<$ty>, tag: u32) -> TestResult {
+                        check_type(value, tag, WireType::LengthDelimited,
+                                   encode_packed, merge_repeated,
+                                   encoded_len_packed)
+                    }
+                }
+            }
+         }
+
+    );
+}
+varint!(bool, bool,
+        to_uint64(value) if *value { 1u64 } else { 0u64 },
+        from_uint64(value) value != 0);
+varint!(i32, int32);
+varint!(i64, int64);
+varint!(u32, uint32);
+varint!(u64, uint64);
+varint!(i32, sint32,
+to_uint64(value) {
+    ((value << 1) ^ (value >> 31)) as u32 as u64
+},
+from_uint64(value) {
+    let value = value as u32;
+    ((value >> 1) as i32) ^ (-((value & 1) as i32))
+});
+varint!(i64, sint64,
+to_uint64(value) {
+    ((value << 1) ^ (value >> 63)) as u64
+},
+from_uint64(value) {
+    ((value >> 1) as i64) ^ (-((value & 1) as i64))
+});
+
+/// Macro which emits a module containing a set of encoding functions for a
+/// fixed width numeric type.
+macro_rules! fixed_width {
+    ($ty:ty,
+     $width:expr,
+     $wire_type:expr,
+     $proto_ty:ident,
+     $put:ident,
+     $get:ident) => {
+        pub mod $proto_ty {
+            use crate::encoding::*;
+
+            pub fn encode<B>(tag: u32, value: &$ty, buf: &mut B)
+            where
+                B: BufMut,
+            {
+                encode_key(tag, $wire_type, buf);
+                buf.$put(*value);
+            }
+
+            pub fn merge<B>(
+                wire_type: WireType,
+                value: &mut $ty,
+                buf: &mut B,
+                _ctx: DecodeContext,
+            ) -> Result<(), DecodeError>
+            where
+                B: Buf,
+            {
+                check_wire_type($wire_type, wire_type)?;
+                if buf.remaining() < $width {
+                    return Err(DecodeError::new("buffer underflow"));
+                }
+                *value = buf.$get();
+                Ok(())
+            }
+
+            encode_repeated!($ty);
+
+            pub fn encode_packed<B>(tag: u32, values: &[$ty], buf: &mut B)
+            where
+                B: BufMut,
+            {
+                if values.is_empty() {
+                    return;
+                }
+
+                encode_key(tag, WireType::LengthDelimited, buf);
+                let len = values.len() as u64 * $width;
+                encode_varint(len as u64, buf);
+
+                for value in values {
+                    buf.$put(*value);
+                }
+            }
+
+            merge_repeated_numeric!($ty, $wire_type, merge, merge_repeated);
+
+            #[inline]
+            pub fn encoded_len(tag: u32, _: &$ty) -> usize {
+                key_len(tag) + $width
+            }
+
+            #[inline]
+            pub fn encoded_len_repeated(tag: u32, values: &[$ty]) -> usize {
+                (key_len(tag) + $width) * values.len()
+            }
+
+            #[inline]
+            pub fn encoded_len_packed(tag: u32, values: &[$ty]) -> usize {
+                if values.is_empty() {
+                    0
+                } else {
+                    let len = $width * values.len();
+                    key_len(tag) + encoded_len_varint(len as u64) + len
+                }
+            }
+
+            #[cfg(test)]
+            mod test {
+                use quickcheck::{quickcheck, TestResult};
+
+                use super::super::test::{check_collection_type, check_type};
+                use super::*;
+
+                quickcheck! {
+                    fn check(value: $ty, tag: u32) -> TestResult {
+                        check_type(value, tag, $wire_type,
+                                   encode, merge, encoded_len)
+                    }
+                    fn check_repeated(value: Vec<$ty>, tag: u32) -> TestResult {
+                        check_collection_type(value, tag, $wire_type,
+                                              encode_repeated, merge_repeated,
+                                              encoded_len_repeated)
+                    }
+                    fn check_packed(value: Vec<$ty>, tag: u32) -> TestResult {
+                        check_type(value, tag, WireType::LengthDelimited,
+                                   encode_packed, merge_repeated,
+                                   encoded_len_packed)
+                    }
+                }
+            }
+        }
+    };
+}
+fixed_width!(
+    f32,
+    4,
+    WireType::ThirtyTwoBit,
+    float,
+    put_f32_le,
+    get_f32_le
+);
+fixed_width!(
+    f64,
+    8,
+    WireType::SixtyFourBit,
+    double,
+    put_f64_le,
+    get_f64_le
+);
+fixed_width!(
+    u32,
+    4,
+    WireType::ThirtyTwoBit,
+    fixed32,
+    put_u32_le,
+    get_u32_le
+);
+fixed_width!(
+    u64,
+    8,
+    WireType::SixtyFourBit,
+    fixed64,
+    put_u64_le,
+    get_u64_le
+);
+fixed_width!(
+    i32,
+    4,
+    WireType::ThirtyTwoBit,
+    sfixed32,
+    put_i32_le,
+    get_i32_le
+);
+fixed_width!(
+    i64,
+    8,
+    WireType::SixtyFourBit,
+    sfixed64,
+    put_i64_le,
+    get_i64_le
+);
+
+/// Macro which emits encoding functions for a length-delimited type.
+macro_rules! length_delimited {
+    ($ty:ty) => {
+        encode_repeated!($ty);
+
+        pub fn merge_repeated<B>(
+            wire_type: WireType,
+            values: &mut Vec<$ty>,
+            buf: &mut B,
+            ctx: DecodeContext,
+        ) -> Result<(), DecodeError>
+        where
+            B: Buf,
+        {
+            check_wire_type(WireType::LengthDelimited, wire_type)?;
+            let mut value = Default::default();
+            merge(wire_type, &mut value, buf, ctx)?;
+            values.push(value);
+            Ok(())
+        }
+
+        #[inline]
+        pub fn encoded_len(tag: u32, value: &$ty) -> usize {
+            key_len(tag) + encoded_len_varint(value.len() as u64) + value.len()
+        }
+
+        #[inline]
+        pub fn encoded_len_repeated(tag: u32, values: &[$ty]) -> usize {
+            key_len(tag) * values.len()
+                + values
+                    .iter()
+                    .map(|value| encoded_len_varint(value.len() as u64) + value.len())
+                    .sum::<usize>()
+        }
+
+        #[cfg(test)]
+        mod test {
+            use quickcheck::{quickcheck, TestResult};
+
+            use super::super::test::{check_collection_type, check_type};
+            use super::*;
+
+            quickcheck! {
+                fn check(value: $ty, tag: u32) -> TestResult {
+                    super::test::check_type(value, tag, WireType::LengthDelimited,
+                                            encode, merge, encoded_len)
+                }
+                fn check_repeated(value: Vec<$ty>, tag: u32) -> TestResult {
+                    super::test::check_collection_type(value, tag, WireType::LengthDelimited,
+                                                       encode_repeated, merge_repeated,
+                                                       encoded_len_repeated)
+                }
+            }
+        }
+    };
+}
+
+pub mod string {
+    use super::*;
+
+    pub fn encode<B>(tag: u32, value: &String, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        encode_key(tag, WireType::LengthDelimited, buf);
+        encode_varint(value.len() as u64, buf);
+        buf.put_slice(value.as_bytes());
+    }
+    pub fn merge<B>(
+        wire_type: WireType,
+        value: &mut String,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        // ## Unsafety
+        //
+        // `string::merge` reuses `bytes::merge`, with an additional check of utf-8
+        // well-formedness. If the utf-8 is not well-formed, or if any other error occurs, then the
+        // string is cleared, so as to avoid leaking a string field with invalid data.
+        //
+        // This implementation uses the unsafe `String::as_mut_vec` method instead of the safe
+        // alternative of temporarily swapping an empty `String` into the field, because it results
+        // in up to 10% better performance on the protobuf message decoding benchmarks.
+        //
+        // It's required when using `String::as_mut_vec` that invalid utf-8 data not be leaked into
+        // the backing `String`. To enforce this, even in the event of a panic in `bytes::merge` or
+        // in the buf implementation, a drop guard is used.
+        unsafe {
+            struct DropGuard<'a>(&'a mut Vec<u8>);
+            impl<'a> Drop for DropGuard<'a> {
+                #[inline]
+                fn drop(&mut self) {
+                    self.0.clear();
+                }
+            }
+
+            let drop_guard = DropGuard(value.as_mut_vec());
+            bytes::merge(wire_type, drop_guard.0, buf, ctx)?;
+            match str::from_utf8(drop_guard.0) {
+                Ok(_) => {
+                    // Success; do not clear the bytes.
+                    mem::forget(drop_guard);
+                    Ok(())
+                }
+                Err(_) => Err(DecodeError::new(
+                    "invalid string value: data is not UTF-8 encoded",
+                )),
+            }
+        }
+    }
+
+    length_delimited!(String);
+}
+
+pub mod bytes {
+    use super::*;
+
+    pub fn encode<B>(tag: u32, value: &Vec<u8>, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        encode_key(tag, WireType::LengthDelimited, buf);
+        encode_varint(value.len() as u64, buf);
+        buf.put_slice(value);
+    }
+
+    pub fn merge<B>(
+        wire_type: WireType,
+        value: &mut Vec<u8>,
+        buf: &mut B,
+        _ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        check_wire_type(WireType::LengthDelimited, wire_type)?;
+        let len = decode_varint(buf)?;
+        if len > buf.remaining() as u64 {
+            return Err(DecodeError::new("buffer underflow"));
+        }
+        let len = len as usize;
+
+        // Clear the existing value. This follows from the following rule in the encoding guide[1]:
+        //
+        // > Normally, an encoded message would never have more than one instance of a non-repeated
+        // > field. However, parsers are expected to handle the case in which they do. For numeric
+        // > types and strings, if the same field appears multiple times, the parser accepts the
+        // > last value it sees.
+        //
+        // [1]: https://developers.google.com/protocol-buffers/docs/encoding#optional
+        value.clear();
+        value.reserve(len);
+        value.put(buf.take(len));
+        Ok(())
+    }
+
+    length_delimited!(Vec<u8>);
+}
+
+pub mod message {
+    use super::*;
+
+    pub fn encode<M, B>(tag: u32, msg: &M, buf: &mut B)
+    where
+        M: Message,
+        B: BufMut,
+    {
+        encode_key(tag, WireType::LengthDelimited, buf);
+        encode_varint(msg.encoded_len() as u64, buf);
+        msg.encode_raw(buf);
+    }
+
+    pub fn merge<M, B>(
+        wire_type: WireType,
+        msg: &mut M,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        M: Message,
+        B: Buf,
+    {
+        check_wire_type(WireType::LengthDelimited, wire_type)?;
+        ctx.limit_reached()?;
+        merge_loop(
+            msg,
+            buf,
+            ctx.enter_recursion(),
+            |msg: &mut M, buf: &mut B, ctx| {
+                let (tag, wire_type) = decode_key(buf)?;
+                msg.merge_field(tag, wire_type, buf, ctx)
+            },
+        )
+    }
+
+    pub fn encode_repeated<M, B>(tag: u32, messages: &[M], buf: &mut B)
+    where
+        M: Message,
+        B: BufMut,
+    {
+        for msg in messages {
+            encode(tag, msg, buf);
+        }
+    }
+
+    pub fn merge_repeated<M, B>(
+        wire_type: WireType,
+        messages: &mut Vec<M>,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        M: Message + Default,
+        B: Buf,
+    {
+        check_wire_type(WireType::LengthDelimited, wire_type)?;
+        let mut msg = M::default();
+        merge(WireType::LengthDelimited, &mut msg, buf, ctx)?;
+        messages.push(msg);
+        Ok(())
+    }
+
+    #[inline]
+    pub fn encoded_len<M>(tag: u32, msg: &M) -> usize
+    where
+        M: Message,
+    {
+        let len = msg.encoded_len();
+        key_len(tag) + encoded_len_varint(len as u64) + len
+    }
+
+    #[inline]
+    pub fn encoded_len_repeated<M>(tag: u32, messages: &[M]) -> usize
+    where
+        M: Message,
+    {
+        key_len(tag) * messages.len()
+            + messages
+                .iter()
+                .map(Message::encoded_len)
+                .map(|len| len + encoded_len_varint(len as u64))
+                .sum::<usize>()
+    }
+}
+
+pub mod group {
+    use super::*;
+
+    pub fn encode<M, B>(tag: u32, msg: &M, buf: &mut B)
+    where
+        M: Message,
+        B: BufMut,
+    {
+        encode_key(tag, WireType::StartGroup, buf);
+        msg.encode_raw(buf);
+        encode_key(tag, WireType::EndGroup, buf);
+    }
+
+    pub fn merge<M, B>(
+        tag: u32,
+        wire_type: WireType,
+        msg: &mut M,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        M: Message,
+        B: Buf,
+    {
+        check_wire_type(WireType::StartGroup, wire_type)?;
+
+        ctx.limit_reached()?;
+        loop {
+            let (field_tag, field_wire_type) = decode_key(buf)?;
+            if field_wire_type == WireType::EndGroup {
+                if field_tag != tag {
+                    return Err(DecodeError::new("unexpected end group tag"));
+                }
+                return Ok(());
+            }
+
+            M::merge_field(msg, field_tag, field_wire_type, buf, ctx.enter_recursion())?;
+        }
+    }
+
+    pub fn encode_repeated<M, B>(tag: u32, messages: &[M], buf: &mut B)
+    where
+        M: Message,
+        B: BufMut,
+    {
+        for msg in messages {
+            encode(tag, msg, buf);
+        }
+    }
+
+    pub fn merge_repeated<M, B>(
+        tag: u32,
+        wire_type: WireType,
+        messages: &mut Vec<M>,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        M: Message + Default,
+        B: Buf,
+    {
+        check_wire_type(WireType::StartGroup, wire_type)?;
+        let mut msg = M::default();
+        merge(tag, WireType::StartGroup, &mut msg, buf, ctx)?;
+        messages.push(msg);
+        Ok(())
+    }
+
+    #[inline]
+    pub fn encoded_len<M>(tag: u32, msg: &M) -> usize
+    where
+        M: Message,
+    {
+        2 * key_len(tag) + msg.encoded_len()
+    }
+
+    #[inline]
+    pub fn encoded_len_repeated<M>(tag: u32, messages: &[M]) -> usize
+    where
+        M: Message,
+    {
+        2 * key_len(tag) * messages.len() + messages.iter().map(Message::encoded_len).sum::<usize>()
+    }
+}
+
+/// Rust doesn't have a `Map` trait, so macros are currently the best way to be
+/// generic over `HashMap` and `BTreeMap`.
+macro_rules! map {
+    ($map_ty:ident) => {
+        use crate::encoding::*;
+        use core::hash::Hash;
+
+        /// Generic protobuf map encode function.
+        pub fn encode<K, V, B, KE, KL, VE, VL>(
+            key_encode: KE,
+            key_encoded_len: KL,
+            val_encode: VE,
+            val_encoded_len: VL,
+            tag: u32,
+            values: &$map_ty<K, V>,
+            buf: &mut B,
+        ) where
+            K: Default + Eq + Hash + Ord,
+            V: Default + PartialEq,
+            B: BufMut,
+            KE: Fn(u32, &K, &mut B),
+            KL: Fn(u32, &K) -> usize,
+            VE: Fn(u32, &V, &mut B),
+            VL: Fn(u32, &V) -> usize,
+        {
+            encode_with_default(
+                key_encode,
+                key_encoded_len,
+                val_encode,
+                val_encoded_len,
+                &V::default(),
+                tag,
+                values,
+                buf,
+            )
+        }
+
+        /// Generic protobuf map merge function.
+        pub fn merge<K, V, B, KM, VM>(
+            key_merge: KM,
+            val_merge: VM,
+            values: &mut $map_ty<K, V>,
+            buf: &mut B,
+            ctx: DecodeContext,
+        ) -> Result<(), DecodeError>
+        where
+            K: Default + Eq + Hash + Ord,
+            V: Default,
+            B: Buf,
+            KM: Fn(WireType, &mut K, &mut B, DecodeContext) -> Result<(), DecodeError>,
+            VM: Fn(WireType, &mut V, &mut B, DecodeContext) -> Result<(), DecodeError>,
+        {
+            merge_with_default(key_merge, val_merge, V::default(), values, buf, ctx)
+        }
+
+        /// Generic protobuf map encode function.
+        pub fn encoded_len<K, V, KL, VL>(
+            key_encoded_len: KL,
+            val_encoded_len: VL,
+            tag: u32,
+            values: &$map_ty<K, V>,
+        ) -> usize
+        where
+            K: Default + Eq + Hash + Ord,
+            V: Default + PartialEq,
+            KL: Fn(u32, &K) -> usize,
+            VL: Fn(u32, &V) -> usize,
+        {
+            encoded_len_with_default(key_encoded_len, val_encoded_len, &V::default(), tag, values)
+        }
+
+        /// Generic protobuf map encode function with an overriden value default.
+        ///
+        /// This is necessary because enumeration values can have a default value other
+        /// than 0 in proto2.
+        pub fn encode_with_default<K, V, B, KE, KL, VE, VL>(
+            key_encode: KE,
+            key_encoded_len: KL,
+            val_encode: VE,
+            val_encoded_len: VL,
+            val_default: &V,
+            tag: u32,
+            values: &$map_ty<K, V>,
+            buf: &mut B,
+        ) where
+            K: Default + Eq + Hash + Ord,
+            V: PartialEq,
+            B: BufMut,
+            KE: Fn(u32, &K, &mut B),
+            KL: Fn(u32, &K) -> usize,
+            VE: Fn(u32, &V, &mut B),
+            VL: Fn(u32, &V) -> usize,
+        {
+            for (key, val) in values.iter() {
+                let skip_key = key == &K::default();
+                let skip_val = val == val_default;
+
+                let len = (if skip_key { 0 } else { key_encoded_len(1, key) })
+                    + (if skip_val { 0 } else { val_encoded_len(2, val) });
+
+                encode_key(tag, WireType::LengthDelimited, buf);
+                encode_varint(len as u64, buf);
+                if !skip_key {
+                    key_encode(1, key, buf);
+                }
+                if !skip_val {
+                    val_encode(2, val, buf);
+                }
+            }
+        }
+
+        /// Generic protobuf map merge function with an overriden value default.
+        ///
+        /// This is necessary because enumeration values can have a default value other
+        /// than 0 in proto2.
+        pub fn merge_with_default<K, V, B, KM, VM>(
+            key_merge: KM,
+            val_merge: VM,
+            val_default: V,
+            values: &mut $map_ty<K, V>,
+            buf: &mut B,
+            ctx: DecodeContext,
+        ) -> Result<(), DecodeError>
+        where
+            K: Default + Eq + Hash + Ord,
+            B: Buf,
+            KM: Fn(WireType, &mut K, &mut B, DecodeContext) -> Result<(), DecodeError>,
+            VM: Fn(WireType, &mut V, &mut B, DecodeContext) -> Result<(), DecodeError>,
+        {
+            let mut key = Default::default();
+            let mut val = val_default;
+            ctx.limit_reached()?;
+            merge_loop(
+                &mut (&mut key, &mut val),
+                buf,
+                ctx.enter_recursion(),
+                |&mut (ref mut key, ref mut val), buf, ctx| {
+                    let (tag, wire_type) = decode_key(buf)?;
+                    match tag {
+                        1 => key_merge(wire_type, key, buf, ctx),
+                        2 => val_merge(wire_type, val, buf, ctx),
+                        _ => skip_field(wire_type, tag, buf, ctx),
+                    }
+                },
+            )?;
+            values.insert(key, val);
+
+            Ok(())
+        }
+
+        /// Generic protobuf map encode function with an overriden value default.
+        ///
+        /// This is necessary because enumeration values can have a default value other
+        /// than 0 in proto2.
+        pub fn encoded_len_with_default<K, V, KL, VL>(
+            key_encoded_len: KL,
+            val_encoded_len: VL,
+            val_default: &V,
+            tag: u32,
+            values: &$map_ty<K, V>,
+        ) -> usize
+        where
+            K: Default + Eq + Hash + Ord,
+            V: PartialEq,
+            KL: Fn(u32, &K) -> usize,
+            VL: Fn(u32, &V) -> usize,
+        {
+            key_len(tag) * values.len()
+                + values
+                    .iter()
+                    .map(|(key, val)| {
+                        let len = (if key == &K::default() {
+                            0
+                        } else {
+                            key_encoded_len(1, key)
+                        }) + (if val == val_default {
+                            0
+                        } else {
+                            val_encoded_len(2, val)
+                        });
+                        encoded_len_varint(len as u64) + len
+                    })
+                    .sum::<usize>()
+        }
+    };
+}
+
+#[cfg(feature = "std")]
+pub mod hash_map {
+    use std::collections::HashMap;
+    map!(HashMap);
+}
+
+pub mod btree_map {
+    map!(BTreeMap);
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::string::ToString;
+    use core::borrow::Borrow;
+    use core::fmt::Debug;
+    use core::u64;
+
+    use ::bytes::{Bytes, BytesMut};
+    use quickcheck::TestResult;
+
+    use crate::encoding::*;
+
+    pub fn check_type<T, B>(
+        value: T,
+        tag: u32,
+        wire_type: WireType,
+        encode: fn(u32, &B, &mut BytesMut),
+        merge: fn(WireType, &mut T, &mut Bytes, DecodeContext) -> Result<(), DecodeError>,
+        encoded_len: fn(u32, &B) -> usize,
+    ) -> TestResult
+    where
+        T: Debug + Default + PartialEq + Borrow<B>,
+        B: ?Sized,
+    {
+        if tag > MAX_TAG || tag < MIN_TAG {
+            return TestResult::discard();
+        }
+
+        let expected_len = encoded_len(tag, value.borrow());
+
+        let mut buf = BytesMut::with_capacity(expected_len);
+        encode(tag, value.borrow(), &mut buf);
+
+        let mut buf = buf.freeze();
+
+        if buf.remaining() != expected_len {
+            return TestResult::error(format!(
+                "encoded_len wrong; expected: {}, actual: {}",
+                expected_len,
+                buf.remaining()
+            ));
+        }
+
+        if !buf.has_remaining() {
+            // Short circuit for empty packed values.
+            return TestResult::passed();
+        }
+
+        let (decoded_tag, decoded_wire_type) = match decode_key(&mut buf) {
+            Ok(key) => key,
+            Err(error) => return TestResult::error(format!("{:?}", error)),
+        };
+
+        if tag != decoded_tag {
+            return TestResult::error(format!(
+                "decoded tag does not match; expected: {}, actual: {}",
+                tag, decoded_tag
+            ));
+        }
+
+        if wire_type != decoded_wire_type {
+            return TestResult::error(format!(
+                "decoded wire type does not match; expected: {:?}, actual: {:?}",
+                wire_type, decoded_wire_type
+            ));
+        }
+
+        match wire_type {
+            WireType::SixtyFourBit if buf.remaining() != 8 => {
+                return TestResult::error(format!(
+                    "64bit wire type illegal remaining: {}, tag: {}",
+                    buf.remaining(),
+                    tag
+                ));
+            }
+            WireType::ThirtyTwoBit if buf.remaining() != 4 => {
+                return TestResult::error(format!(
+                    "32bit wire type illegal remaining: {}, tag: {}",
+                    buf.remaining(),
+                    tag
+                ));
+            }
+            _ => (),
+        }
+
+        let mut roundtrip_value = T::default();
+        if let Err(error) = merge(
+            wire_type,
+            &mut roundtrip_value,
+            &mut buf,
+            DecodeContext::default(),
+        ) {
+            return TestResult::error(error.to_string());
+        };
+
+        if buf.has_remaining() {
+            return TestResult::error(format!(
+                "expected buffer to be empty, remaining: {}",
+                buf.remaining()
+            ));
+        }
+
+        if value == roundtrip_value {
+            TestResult::passed()
+        } else {
+            TestResult::failed()
+        }
+    }
+
+    pub fn check_collection_type<T, B, E, M, L>(
+        value: T,
+        tag: u32,
+        wire_type: WireType,
+        encode: E,
+        mut merge: M,
+        encoded_len: L,
+    ) -> TestResult
+    where
+        T: Debug + Default + PartialEq + Borrow<B>,
+        B: ?Sized,
+        E: FnOnce(u32, &B, &mut BytesMut),
+        M: FnMut(WireType, &mut T, &mut Bytes, DecodeContext) -> Result<(), DecodeError>,
+        L: FnOnce(u32, &B) -> usize,
+    {
+        if tag > MAX_TAG || tag < MIN_TAG {
+            return TestResult::discard();
+        }
+
+        let expected_len = encoded_len(tag, value.borrow());
+
+        let mut buf = BytesMut::with_capacity(expected_len);
+        encode(tag, value.borrow(), &mut buf);
+
+        let mut buf = buf.freeze();
+
+        if buf.remaining() != expected_len {
+            return TestResult::error(format!(
+                "encoded_len wrong; expected: {}, actual: {}",
+                expected_len,
+                buf.remaining()
+            ));
+        }
+
+        let mut roundtrip_value = Default::default();
+        while buf.has_remaining() {
+            let (decoded_tag, decoded_wire_type) = match decode_key(&mut buf) {
+                Ok(key) => key,
+                Err(error) => return TestResult::error(format!("{:?}", error)),
+            };
+
+            if tag != decoded_tag {
+                return TestResult::error(format!(
+                    "decoded tag does not match; expected: {}, actual: {}",
+                    tag, decoded_tag
+                ));
+            }
+
+            if wire_type != decoded_wire_type {
+                return TestResult::error(format!(
+                    "decoded wire type does not match; expected: {:?}, actual: {:?}",
+                    wire_type, decoded_wire_type
+                ));
+            }
+
+            if let Err(error) = merge(
+                wire_type,
+                &mut roundtrip_value,
+                &mut buf,
+                DecodeContext::default(),
+            ) {
+                return TestResult::error(error.to_string());
+            };
+        }
+
+        if value == roundtrip_value {
+            TestResult::passed()
+        } else {
+            TestResult::failed()
+        }
+    }
+
+    #[test]
+    fn string_merge_invalid_utf8() {
+        let mut s = String::new();
+        let buf = b"\x02\x80\x80";
+
+        let r = string::merge(
+            WireType::LengthDelimited,
+            &mut s,
+            &mut &buf[..],
+            DecodeContext::default(),
+        );
+        r.expect_err("must be an error");
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn varint() {
+        fn check(value: u64, mut encoded: &[u8]) {
+            // TODO(rust-lang/rust-clippy#5494)
+            #![allow(clippy::clone_double_ref)]
+
+            // Small buffer.
+            let mut buf = Vec::with_capacity(1);
+            encode_varint(value, &mut buf);
+            assert_eq!(buf, encoded);
+
+            // Large buffer.
+            let mut buf = Vec::with_capacity(100);
+            encode_varint(value, &mut buf);
+            assert_eq!(buf, encoded);
+
+            assert_eq!(encoded_len_varint(value), encoded.len());
+
+            let roundtrip_value = decode_varint(&mut encoded.clone()).expect("decoding failed");
+            assert_eq!(value, roundtrip_value);
+
+            let roundtrip_value = decode_varint_slow(&mut encoded).expect("slow decoding failed");
+            assert_eq!(value, roundtrip_value);
+        }
+
+        check(2u64.pow(0) - 1, &[0x00]);
+        check(2u64.pow(0), &[0x01]);
+
+        check(2u64.pow(7) - 1, &[0x7F]);
+        check(2u64.pow(7), &[0x80, 0x01]);
+        check(300, &[0xAC, 0x02]);
+
+        check(2u64.pow(14) - 1, &[0xFF, 0x7F]);
+        check(2u64.pow(14), &[0x80, 0x80, 0x01]);
+
+        check(2u64.pow(21) - 1, &[0xFF, 0xFF, 0x7F]);
+        check(2u64.pow(21), &[0x80, 0x80, 0x80, 0x01]);
+
+        check(2u64.pow(28) - 1, &[0xFF, 0xFF, 0xFF, 0x7F]);
+        check(2u64.pow(28), &[0x80, 0x80, 0x80, 0x80, 0x01]);
+
+        check(2u64.pow(35) - 1, &[0xFF, 0xFF, 0xFF, 0xFF, 0x7F]);
+        check(2u64.pow(35), &[0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
+
+        check(2u64.pow(42) - 1, &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F]);
+        check(2u64.pow(42), &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
+
+        check(
+            2u64.pow(49) - 1,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+        );
+        check(
+            2u64.pow(49),
+            &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01],
+        );
+
+        check(
+            2u64.pow(56) - 1,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+        );
+        check(
+            2u64.pow(56),
+            &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01],
+        );
+
+        check(
+            2u64.pow(63) - 1,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+        );
+        check(
+            2u64.pow(63),
+            &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01],
+        );
+
+        check(
+            u64::MAX,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01],
+        );
+    }
+
+    /// This big bowl o' macro soup generates a quickcheck encoding test for each
+    /// combination of map type, scalar map key, and value type.
+    /// TODO: these tests take a long time to compile, can this be improved?
+    #[cfg(feature = "std")]
+    macro_rules! map_tests {
+        (keys: $keys:tt,
+         vals: $vals:tt) => {
+            mod hash_map {
+                map_tests!(@private HashMap, hash_map, $keys, $vals);
+            }
+            mod btree_map {
+                map_tests!(@private BTreeMap, btree_map, $keys, $vals);
+            }
+        };
+
+        (@private $map_type:ident,
+                  $mod_name:ident,
+                  [$(($key_ty:ty, $key_proto:ident)),*],
+                  $vals:tt) => {
+            $(
+                mod $key_proto {
+                    use std::collections::$map_type;
+                    use quickcheck::{quickcheck, TestResult};
+
+                    use crate::encoding::*;
+                    use crate::encoding::test::check_collection_type;
+
+                    map_tests!(@private $map_type, $mod_name, ($key_ty, $key_proto), $vals);
+                }
+            )*
+        };
+
+        (@private $map_type:ident,
+                  $mod_name:ident,
+                  ($key_ty:ty, $key_proto:ident),
+                  [$(($val_ty:ty, $val_proto:ident)),*]) => {
+            $(
+                quickcheck! {
+                    fn $val_proto(values: $map_type<$key_ty, $val_ty>, tag: u32) -> TestResult {
+                        check_collection_type(values, tag, WireType::LengthDelimited,
+                                              |tag, values, buf| {
+                                                  $mod_name::encode($key_proto::encode,
+                                                                    $key_proto::encoded_len,
+                                                                    $val_proto::encode,
+                                                                    $val_proto::encoded_len,
+                                                                    tag,
+                                                                    values,
+                                                                    buf)
+                                              },
+                                              |wire_type, values, buf, ctx| {
+                                                  check_wire_type(WireType::LengthDelimited, wire_type)?;
+                                                  $mod_name::merge($key_proto::merge,
+                                                                   $val_proto::merge,
+                                                                   values,
+                                                                   buf,
+                                                                   ctx)
+                                              },
+                                              |tag, values| {
+                                                  $mod_name::encoded_len($key_proto::encoded_len,
+                                                                         $val_proto::encoded_len,
+                                                                         tag,
+                                                                         values)
+                                              })
+                    }
+                }
+             )*
+        };
+    }
+
+    #[cfg(feature = "std")]
+    map_tests!(keys: [
+        (i32, int32),
+        (i64, int64),
+        (u32, uint32),
+        (u64, uint64),
+        (i32, sint32),
+        (i64, sint64),
+        (u32, fixed32),
+        (u64, fixed64),
+        (i32, sfixed32),
+        (i64, sfixed64),
+        (bool, bool),
+        (String, string)
+    ],
+    vals: [
+        (f32, float),
+        (f64, double),
+        (i32, int32),
+        (i64, int64),
+        (u32, uint32),
+        (u64, uint64),
+        (i32, sint32),
+        (i64, sint64),
+        (u32, fixed32),
+        (u64, fixed64),
+        (i32, sfixed32),
+        (i64, sfixed64),
+        (bool, bool),
+        (String, string),
+        (Vec<u8>, bytes)
+    ]);
+}

--- a/third_party/prost/src/error.rs
+++ b/third_party/prost/src/error.rs
@@ -1,0 +1,116 @@
+//! Protobuf encoding and decoding errors.
+
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+
+use core::fmt;
+
+/// A Protobuf message decoding error.
+///
+/// `DecodeError` indicates that the input buffer does not caontain a valid
+/// Protobuf message. The error details should be considered 'best effort': in
+/// general it is not possible to exactly pinpoint why data is malformed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DecodeError {
+    /// A 'best effort' root cause description.
+    description: Cow<'static, str>,
+    /// A stack of (message, field) name pairs, which identify the specific
+    /// message type and field where decoding failed. The stack contains an
+    /// entry per level of nesting.
+    stack: Vec<(&'static str, &'static str)>,
+}
+
+impl DecodeError {
+    /// Creates a new `DecodeError` with a 'best effort' root cause description.
+    ///
+    /// Meant to be used only by `Message` implementations.
+    #[doc(hidden)]
+    pub fn new<S>(description: S) -> DecodeError
+    where
+        S: Into<Cow<'static, str>>,
+    {
+        DecodeError {
+            description: description.into(),
+            stack: Vec::new(),
+        }
+    }
+
+    /// Pushes a (message, field) name location pair on to the location stack.
+    ///
+    /// Meant to be used only by `Message` implementations.
+    #[doc(hidden)]
+    pub fn push(&mut self, message: &'static str, field: &'static str) {
+        self.stack.push((message, field));
+    }
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("failed to decode Protobuf message: ")?;
+        for &(message, field) in &self.stack {
+            write!(f, "{}.{}: ", message, field)?;
+        }
+        f.write_str(&self.description)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DecodeError {}
+
+#[cfg(feature = "std")]
+impl From<DecodeError> for std::io::Error {
+    fn from(error: DecodeError) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, error)
+    }
+}
+
+/// A Protobuf message encoding error.
+///
+/// `EncodeError` always indicates that a message failed to encode because the
+/// provided buffer had insufficient capacity. Message encoding is otherwise
+/// infallible.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct EncodeError {
+    required: usize,
+    remaining: usize,
+}
+
+impl EncodeError {
+    /// Creates a new `EncodeError`.
+    pub(crate) fn new(required: usize, remaining: usize) -> EncodeError {
+        EncodeError {
+            required,
+            remaining,
+        }
+    }
+
+    /// Returns the required buffer capacity to encode the message.
+    pub fn required_capacity(&self) -> usize {
+        self.required
+    }
+
+    /// Returns the remaining length in the provided buffer at the time of encoding.
+    pub fn remaining(&self) -> usize {
+        self.remaining
+    }
+}
+
+impl fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "failed to encode Protobuf messsage; insufficient buffer capacity (required: {}, remaining: {})",
+            self.required, self.remaining
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for EncodeError {}
+
+#[cfg(feature = "std")]
+impl From<EncodeError> for std::io::Error {
+    fn from(error: EncodeError) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, error)
+    }
+}

--- a/third_party/prost/src/lib.rs
+++ b/third_party/prost/src/lib.rs
@@ -1,0 +1,93 @@
+#![doc(html_root_url = "https://docs.rs/prost/0.6.1")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+// Re-export the alloc crate for use within derived code.
+#[doc(hidden)]
+pub extern crate alloc;
+
+// Re-export the bytes crate for use within derived code.
+#[doc(hidden)]
+pub use bytes;
+
+mod error;
+mod message;
+mod types;
+
+#[doc(hidden)]
+pub mod encoding;
+
+pub use crate::error::{DecodeError, EncodeError};
+pub use crate::message::Message;
+
+use bytes::{Buf, BufMut};
+
+use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
+
+// See `encoding::DecodeContext` for more info.
+// 100 is the default recursion limit in the C++ implementation.
+#[cfg(not(feature = "no-recursion-limit"))]
+const RECURSION_LIMIT: u32 = 100;
+
+/// Encodes a length delimiter to the buffer.
+///
+/// See [Message.encode_length_delimited] for more info.
+///
+/// An error will be returned if the buffer does not have sufficient capacity to encode the
+/// delimiter.
+pub fn encode_length_delimiter<B>(length: usize, buf: &mut B) -> Result<(), EncodeError>
+where
+    B: BufMut,
+{
+    let length = length as u64;
+    let required = encoded_len_varint(length);
+    let remaining = buf.remaining_mut();
+    if required > remaining {
+        return Err(EncodeError::new(required, remaining));
+    }
+    encode_varint(length, buf);
+    Ok(())
+}
+
+/// Returns the encoded length of a length delimiter.
+///
+/// Applications may use this method to ensure sufficient buffer capacity before calling
+/// `encode_length_delimiter`. The returned size will be between 1 and 10, inclusive.
+pub fn length_delimiter_len(length: usize) -> usize {
+    encoded_len_varint(length as u64)
+}
+
+/// Decodes a length delimiter from the buffer.
+///
+/// This method allows the length delimiter to be decoded independently of the message, when the
+/// message is encoded with [Message.encode_length_delimited].
+///
+/// An error may be returned in two cases:
+///
+///  * If the supplied buffer contains fewer than 10 bytes, then an error indicates that more
+///    input is required to decode the full delimiter.
+///  * If the supplied buffer contains more than 10 bytes, then the buffer contains an invalid
+///    delimiter, and typically the buffer should be considered corrupt.
+pub fn decode_length_delimiter<B>(mut buf: B) -> Result<usize, DecodeError>
+where
+    B: Buf,
+{
+    let length = decode_varint(&mut buf)?;
+    if length > usize::max_value() as u64 {
+        return Err(DecodeError::new(
+            "length delimiter exceeds maximum usize value",
+        ));
+    }
+    Ok(length as usize)
+}
+
+// Re-export #[derive(Message, Enumeration, Oneof)].
+// Based on serde's equivalent re-export [1], but enabled by default.
+//
+// [1]: https://github.com/serde-rs/serde/blob/v1.0.89/serde/src/lib.rs#L245-L256
+#[cfg(feature = "prost-derive")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate prost_derive;
+#[cfg(feature = "prost-derive")]
+#[doc(hidden)]
+pub use prost_derive::*;

--- a/third_party/prost/src/message.rs
+++ b/third_party/prost/src/message.rs
@@ -1,0 +1,167 @@
+use alloc::boxed::Box;
+use core::fmt::Debug;
+use core::usize;
+
+use bytes::{Buf, BufMut};
+
+use crate::encoding::{
+    decode_key, encode_varint, encoded_len_varint, message, DecodeContext, WireType,
+};
+use crate::DecodeError;
+use crate::EncodeError;
+
+/// A Protocol Buffers message.
+pub trait Message: Debug + Send + Sync {
+    /// Encodes the message to a buffer.
+    ///
+    /// This method will panic if the buffer has insufficient capacity.
+    ///
+    /// Meant to be used only by `Message` implementations.
+    #[doc(hidden)]
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+        Self: Sized;
+
+    /// Decodes a field from a buffer, and merges it into `self`.
+    ///
+    /// Meant to be used only by `Message` implementations.
+    #[doc(hidden)]
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+        Self: Sized;
+
+    /// Returns the encoded length of the message without a length delimiter.
+    fn encoded_len(&self) -> usize;
+
+    /// Encodes the message to a buffer.
+    ///
+    /// An error will be returned if the buffer does not have sufficient capacity.
+    fn encode<B>(&self, buf: &mut B) -> Result<(), EncodeError>
+    where
+        B: BufMut,
+        Self: Sized,
+    {
+        let required = self.encoded_len();
+        let remaining = buf.remaining_mut();
+        if required > buf.remaining_mut() {
+            return Err(EncodeError::new(required, remaining));
+        }
+
+        self.encode_raw(buf);
+        Ok(())
+    }
+
+    /// Encodes the message with a length-delimiter to a buffer.
+    ///
+    /// An error will be returned if the buffer does not have sufficient capacity.
+    fn encode_length_delimited<B>(&self, buf: &mut B) -> Result<(), EncodeError>
+    where
+        B: BufMut,
+        Self: Sized,
+    {
+        let len = self.encoded_len();
+        let required = len + encoded_len_varint(len as u64);
+        let remaining = buf.remaining_mut();
+        if required > remaining {
+            return Err(EncodeError::new(required, remaining));
+        }
+        encode_varint(len as u64, buf);
+        self.encode_raw(buf);
+        Ok(())
+    }
+
+    /// Decodes an instance of the message from a buffer.
+    ///
+    /// The entire buffer will be consumed.
+    fn decode<B>(mut buf: B) -> Result<Self, DecodeError>
+    where
+        B: Buf,
+        Self: Default,
+    {
+        let mut message = Self::default();
+        Self::merge(&mut message, &mut buf).map(|_| message)
+    }
+
+    /// Decodes a length-delimited instance of the message from the buffer.
+    fn decode_length_delimited<B>(buf: B) -> Result<Self, DecodeError>
+    where
+        B: Buf,
+        Self: Default,
+    {
+        let mut message = Self::default();
+        message.merge_length_delimited(buf)?;
+        Ok(message)
+    }
+
+    /// Decodes an instance of the message from a buffer, and merges it into `self`.
+    ///
+    /// The entire buffer will be consumed.
+    fn merge<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+        Self: Sized,
+    {
+        let ctx = DecodeContext::default();
+        while buf.has_remaining() {
+            let (tag, wire_type) = decode_key(&mut buf)?;
+            self.merge_field(tag, wire_type, &mut buf, ctx.clone())?;
+        }
+        Ok(())
+    }
+
+    /// Decodes a length-delimited instance of the message from buffer, and
+    /// merges it into `self`.
+    fn merge_length_delimited<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+        Self: Sized,
+    {
+        message::merge(
+            WireType::LengthDelimited,
+            self,
+            &mut buf,
+            DecodeContext::default(),
+        )
+    }
+
+    /// Clears the message, resetting all fields to their default.
+    fn clear(&mut self);
+}
+
+impl<M> Message for Box<M>
+where
+    M: Message,
+{
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        (**self).encode_raw(buf)
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        (**self).merge_field(tag, wire_type, buf, ctx)
+    }
+    fn encoded_len(&self) -> usize {
+        (**self).encoded_len()
+    }
+    fn clear(&mut self) {
+        (**self).clear()
+    }
+}

--- a/third_party/prost/src/types.rs
+++ b/third_party/prost/src/types.rs
@@ -1,0 +1,386 @@
+//! Protocol Buffers well-known wrapper types.
+//!
+//! This module provides implementations of `Message` for Rust standard library types which
+//! correspond to a Protobuf well-known wrapper type. The remaining well-known types are defined in
+//! the `prost-types` crate in order to avoid a cyclic dependency between `prost` and
+//! `prost-build`.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use ::bytes::{Buf, BufMut};
+
+use crate::{
+    encoding::{
+        bool, bytes, double, float, int32, int64, skip_field, string, uint32, uint64,
+        DecodeContext, WireType,
+    },
+    DecodeError, Message,
+};
+
+/// `google.protobuf.BoolValue`
+impl Message for bool {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if *self {
+            bool::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            bool::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if *self {
+            2
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        *self = false;
+    }
+}
+
+/// `google.protobuf.UInt32Value`
+impl Message for u32 {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if *self != 0 {
+            uint32::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            uint32::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if *self != 0 {
+            uint32::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        *self = 0;
+    }
+}
+
+/// `google.protobuf.UInt64Value`
+impl Message for u64 {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if *self != 0 {
+            uint64::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            uint64::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if *self != 0 {
+            uint64::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        *self = 0;
+    }
+}
+
+/// `google.protobuf.Int32Value`
+impl Message for i32 {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if *self != 0 {
+            int32::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            int32::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if *self != 0 {
+            int32::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        *self = 0;
+    }
+}
+
+/// `google.protobuf.Int64Value`
+impl Message for i64 {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if *self != 0 {
+            int64::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            int64::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if *self != 0 {
+            int64::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        *self = 0;
+    }
+}
+
+/// `google.protobuf.FloatValue`
+impl Message for f32 {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if *self != 0.0 {
+            float::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            float::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if *self != 0.0 {
+            float::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        *self = 0.0;
+    }
+}
+
+/// `google.protobuf.DoubleValue`
+impl Message for f64 {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if *self != 0.0 {
+            double::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            double::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if *self != 0.0 {
+            double::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        *self = 0.0;
+    }
+}
+
+/// `google.protobuf.StringValue`
+impl Message for String {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if !self.is_empty() {
+            string::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            string::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if !self.is_empty() {
+            string::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        self.clear();
+    }
+}
+
+/// `google.protobuf.BytesValue`
+impl Message for Vec<u8> {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if !self.is_empty() {
+            bytes::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            bytes::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if !self.is_empty() {
+            bytes::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        self.clear();
+    }
+}
+
+/// `google.protobuf.Empty`
+impl Message for () {
+    fn encode_raw<B>(&self, _buf: &mut B)
+    where
+        B: BufMut,
+    {
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        skip_field(wire_type, tag, buf, ctx)
+    }
+    fn encoded_len(&self) -> usize {
+        0
+    }
+    fn clear(&mut self) {}
+}

--- a/third_party/prost/tests-2015/Cargo.toml
+++ b/third_party/prost/tests-2015/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "tests-2015"
+version = "0.0.0"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+publish = false
+edition = "2015"
+
+build = "../tests/src/build.rs"
+
+[lib]
+doctest = false
+path = "../tests/src/lib.rs"
+
+[features]
+default = ["edition-2015", "std"]
+edition-2015 = []
+std = []
+
+[dependencies]
+anyhow = "1"
+bytes = "0.5"
+cfg-if = "0.1"
+prost = { path = ".." }
+prost-types = { path = "../prost-types" }
+protobuf = { path = "../protobuf" }
+
+[dev-dependencies]
+diff = "0.1"
+prost-build = { path = "../prost-build" }
+tempfile = "3"
+
+[build-dependencies]
+cfg-if = "0.1"
+env_logger = { version = "0.7", default-features = false }
+prost-build = { path = "../prost-build" }
+protobuf = { path = "../protobuf" }

--- a/third_party/prost/tests-no-std/Cargo.toml
+++ b/third_party/prost/tests-no-std/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "tests-no-std"
+version = "0.0.0"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+publish = false
+edition = "2018"
+
+build = "../tests/src/build.rs"
+
+[lib]
+doctest = false
+path = "../tests/src/lib.rs"
+
+# Compile the `tests` crate *without* the std feature, which is implicitly
+# omitted from the default crate features. It would be easier to do something
+# like `cargo test -p tests --no-default-features`, but that currently does not
+# do the right thing (see [1] for more context).
+# [1]: https://github.com/rust-lang/cargo/pull/8074
+
+[dependencies]
+anyhow = { version = "1", default-features = false }
+bytes = { version = "0.5", default-features = false }
+cfg-if = "0.1"
+prost = { path = "..", default-features = false, features = ["prost-derive"] }
+prost-types = { path = "../prost-types", default-features = false }
+protobuf = { path = "../protobuf" }
+
+[dev-dependencies]
+diff = "0.1"
+prost-build = { path = "../prost-build" }
+tempfile = "3"
+
+[build-dependencies]
+cfg-if = "0.1"
+env_logger = { version = "0.7", default-features = false }
+prost-build = { path = "../prost-build" }
+protobuf = { path = "../protobuf" }

--- a/third_party/prost/tests/Cargo.toml
+++ b/third_party/prost/tests/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "tests"
+version = "0.0.0"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+publish = false
+edition = "2018"
+
+build = "src/build.rs"
+
+[lib]
+doctest = false
+
+[features]
+default = ["std"]
+std = []
+
+[dependencies]
+anyhow = "1"
+bytes = "0.5"
+cfg-if = "0.1"
+prost = { path = ".." }
+prost-types = { path = "../prost-types" }
+protobuf = { path = "../protobuf" }
+
+[dev-dependencies]
+diff = "0.1"
+prost-build = { path = "../prost-build" }
+tempfile = "3"
+
+[build-dependencies]
+cfg-if = "0.1"
+env_logger = { version = "0.7", default-features = false }
+prost-build = { path = "../prost-build" }
+protobuf = { path = "../protobuf" }

--- a/third_party/prost/tests/src/bootstrap.rs
+++ b/third_party/prost/tests/src/bootstrap.rs
@@ -1,0 +1,95 @@
+// protoc on Windows outputs \r\n line endings.
+#![cfg(not(target_os = "windows"))]
+#![cfg(feature = "std")]
+
+use std::fs;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+
+use prost_build;
+use tempfile;
+
+/// Test which bootstraps protobuf.rs and compiler.rs from the .proto definitions in the Protobuf
+/// repo. Ensures that the checked-in compiled versions are up-to-date.
+#[test]
+fn bootstrap() {
+    let protobuf = prost_build::protoc_include()
+        .join("google")
+        .join("protobuf");
+
+    let tempdir = tempfile::Builder::new()
+        .prefix("prost-types-bootstrap")
+        .tempdir()
+        .unwrap();
+
+    prost_build::Config::new()
+        .compile_well_known_types()
+        .btree_map(&["."])
+        .out_dir(tempdir.path())
+        .compile_protos(
+            &[
+                // Protobuf Plugins.
+                protobuf.join("descriptor.proto"),
+                protobuf.join("compiler").join("plugin.proto"),
+                // Well-known Types (except wrapper.proto, whose types are substituted
+                // for the corresponding standard library types).
+                protobuf.join("any.proto"),
+                protobuf.join("api.proto"),
+                protobuf.join("duration.proto"),
+                protobuf.join("field_mask.proto"),
+                protobuf.join("source_context.proto"),
+                protobuf.join("struct.proto"),
+                protobuf.join("timestamp.proto"),
+                protobuf.join("type.proto"),
+            ],
+            &[],
+        )
+        .unwrap();
+
+    let mut bootstrapped_protobuf = String::new();
+    fs::File::open(tempdir.path().join("google.protobuf.rs"))
+        .unwrap()
+        .read_to_string(&mut bootstrapped_protobuf)
+        .unwrap();
+
+    let mut bootstrapped_compiler = String::new();
+    fs::File::open(tempdir.path().join("google.protobuf.compiler.rs"))
+        .unwrap()
+        .read_to_string(&mut bootstrapped_compiler)
+        .unwrap();
+
+    let src = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("no parent")
+        .join("prost-types")
+        .join("src");
+
+    let mut protobuf = String::new();
+    fs::File::open(src.join("protobuf.rs"))
+        .unwrap()
+        .read_to_string(&mut protobuf)
+        .unwrap();
+
+    let mut compiler = String::new();
+    fs::File::open(src.join("compiler.rs"))
+        .unwrap()
+        .read_to_string(&mut compiler)
+        .unwrap();
+
+    if protobuf != bootstrapped_protobuf {
+        fs::File::create(src.join("protobuf.rs"))
+            .unwrap()
+            .write_all(bootstrapped_protobuf.as_bytes())
+            .unwrap();
+    }
+    if compiler != bootstrapped_compiler {
+        fs::File::create(src.join("compiler.rs"))
+            .unwrap()
+            .write_all(bootstrapped_compiler.as_bytes())
+            .unwrap();
+    }
+
+    assert_eq!(protobuf, bootstrapped_protobuf);
+    assert_eq!(compiler, bootstrapped_compiler);
+}

--- a/third_party/prost/tests/src/build.rs
+++ b/third_party/prost/tests/src/build.rs
@@ -1,0 +1,124 @@
+#[macro_use]
+extern crate cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "edition-2015")] {
+        extern crate env_logger;
+        extern crate prost_build;
+    }
+}
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    env_logger::init();
+
+    // The source directory. The indirection is necessary in order to support the tests-2015 crate,
+    // which sets the current directory to tests-2015 during build script evaluation.
+    let src = PathBuf::from("../tests/src");
+    let includes = &[src.clone()];
+
+    // Generate BTreeMap fields for all messages. This forces encoded output to be consistent, so
+    // that encode/decode roundtrips can use encoded output for comparison. Otherwise trying to
+    // compare based on the Rust PartialEq implementations is difficult, due to presence of NaN
+    // values.
+    let mut config = prost_build::Config::new();
+    config.btree_map(&["."]);
+    // Tests for custom attributes
+    config.type_attribute("Foo.Bar_Baz.Foo_barBaz", "#[derive(Eq, PartialOrd, Ord)]");
+    config.type_attribute(
+        "Foo.Bar_Baz.Foo_barBaz.fuzz_buster",
+        "#[derive(Eq, PartialOrd, Ord)]",
+    );
+    config.type_attribute("Foo.Custom.Attrs.Msg", "#[allow(missing_docs)]");
+    config.type_attribute("Foo.Custom.Attrs.Msg.field", "/// Oneof docs");
+    config.type_attribute("Foo.Custom.Attrs.AnEnum", "#[allow(missing_docs)]");
+    config.type_attribute("Foo.Custom.Attrs.AnotherEnum", "/// Oneof docs");
+    config.type_attribute(
+        "Foo.Custom.OneOfAttrs.Msg.field",
+        "#[derive(Eq, PartialOrd, Ord)]",
+    );
+    config.field_attribute("Foo.Custom.Attrs.AnotherEnum.C", "/// The C docs");
+    config.field_attribute("Foo.Custom.Attrs.AnotherEnum.D", "/// The D docs");
+    config.field_attribute("Foo.Custom.Attrs.Msg.field.a", "/// Oneof A docs");
+    config.field_attribute("Foo.Custom.Attrs.Msg.field.b", "/// Oneof B docs");
+
+    config
+        .compile_protos(&[src.join("ident_conversion.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("nesting.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("recursive_oneof.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("custom_attributes.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("oneof_attributes.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("no_unused_results.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("default_enum_value.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("groups.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("deprecated_field.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("well_known_types.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(
+            &[src.join("packages/widget_factory.proto")],
+            &[src.join("packages")],
+        )
+        .unwrap();
+
+    // Check that attempting to compile a .proto without a package declaration results in an error.
+    config
+        .compile_protos(&[src.join("no_package.proto")], includes)
+        .err()
+        .unwrap();
+
+    let out_dir =
+        &PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"))
+            .join("extern_paths");
+    fs::create_dir_all(out_dir).expect("failed to create prefix directory");
+    config.out_dir(out_dir);
+
+    // Compile some of the module examples as an extern path. The extern path syntax is edition
+    // specific, since the way crate-internal fully qualified paths has changed.
+    cfg_if! {
+        if #[cfg(feature = "edition-2015")] {
+            const EXTERN_PATH: &str = "::packages::gizmo";
+        } else {
+            const EXTERN_PATH: &str = "crate::packages::gizmo";
+        }
+    };
+    config.extern_path(".packages.gizmo", EXTERN_PATH);
+
+    config
+        .compile_protos(
+            &[src.join("packages").join("widget_factory.proto")],
+            &[src.join("packages")],
+        )
+        .unwrap();
+}

--- a/third_party/prost/tests/src/custom_attributes.proto
+++ b/third_party/prost/tests/src/custom_attributes.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package Foo.Custom.Attrs;
+
+message Msg {
+}
+
+enum AnEnum {
+	A = 0;
+	B = 1;
+}
+
+enum AnotherEnum {
+	C = 0;
+	D = 2;
+}

--- a/third_party/prost/tests/src/debug.rs
+++ b/third_party/prost/tests/src/debug.rs
@@ -1,0 +1,96 @@
+//! Tests for our own Debug implementation.
+//!
+//! The tests check against expected output. This may be a bit fragile, but it is likely OK for
+//! actual use.
+
+use prost::alloc::{format, string::String};
+
+// Borrow some types from other places.
+#[cfg(feature = "std")]
+use crate::message_encoding::Basic;
+use crate::message_encoding::BasicEnumeration;
+
+/// Some real-life message
+#[test]
+#[cfg(feature = "std")]
+fn basic() {
+    let mut basic = Basic::default();
+    assert_eq!(
+        format!("{:?}", basic),
+        "Basic { \
+         int32: 0, \
+         bools: [], \
+         string: \"\", \
+         optional_string: None, \
+         enumeration: ZERO, \
+         enumeration_map: {}, \
+         string_map: {}, \
+         enumeration_btree_map: {}, \
+         string_btree_map: {}, \
+         oneof: None \
+         }"
+    );
+    basic
+        .enumeration_map
+        .insert(0, BasicEnumeration::TWO as i32);
+    basic.enumeration = 42;
+    assert_eq!(
+        format!("{:?}", basic),
+        "Basic { \
+         int32: 0, \
+         bools: [], \
+         string: \"\", \
+         optional_string: None, \
+         enumeration: 42, \
+         enumeration_map: {0: TWO}, \
+         string_map: {}, \
+         enumeration_btree_map: {}, \
+         string_btree_map: {}, \
+         oneof: None \
+         }"
+    );
+}
+
+/*
+TODO(danburkert/prost#56):
+
+/// A special case with a tuple struct
+#[test]
+fn tuple_struct() {
+    #[derive(Clone, PartialEq, Message)]
+    struct NewType(
+        #[prost(enumeration="BasicEnumeration", tag="5")]
+        i32,
+    );
+    assert_eq!(format!("{:?}", NewType(BasicEnumeration::TWO as i32)), "NewType(TWO)");
+    assert_eq!(format!("{:?}", NewType(42)), "NewType(42)");
+}
+*/
+
+#[derive(Clone, PartialEq, prost::Oneof)]
+pub enum OneofWithEnum {
+    #[prost(int32, tag = "8")]
+    Int(i32),
+    #[prost(string, tag = "9")]
+    String(String),
+    #[prost(enumeration = "BasicEnumeration", tag = "10")]
+    Enumeration(i32),
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct MessageWithOneof {
+    #[prost(oneof = "OneofWithEnum", tags = "8, 9, 10")]
+    of: Option<OneofWithEnum>,
+}
+
+/// Enumerations inside oneofs
+#[test]
+fn oneof_with_enum() {
+    let msg = MessageWithOneof {
+        of: Some(OneofWithEnum::Enumeration(BasicEnumeration::TWO as i32)),
+    };
+    assert_eq!(
+        format!("{:?}", msg),
+        "MessageWithOneof { of: Some(Enumeration(TWO)) }"
+    );
+}

--- a/third_party/prost/tests/src/default_enum_value.proto
+++ b/third_party/prost/tests/src/default_enum_value.proto
@@ -1,0 +1,26 @@
+// From https://github.com/danburkert/prost/issues/118
+
+syntax = "proto2";
+
+package default_enum_value;
+
+enum PrivacyLevel {
+  PRIVACY_LEVEL_ONE = 1;
+  PRIVACY_LEVEL_TWO = 2;
+  PRIVACY_LEVEL_PRIVACY_LEVEL_THREE = 3;
+  PRIVACY_LEVELPRIVACY_LEVEL_FOUR = 4;
+}
+
+message Test {
+  optional PrivacyLevel privacy_level_1 = 1 [default = PRIVACY_LEVEL_ONE];
+  optional PrivacyLevel privacy_level_3 = 2 [default = PRIVACY_LEVEL_PRIVACY_LEVEL_THREE];
+  optional PrivacyLevel privacy_level_4 = 3 [default = PRIVACY_LEVELPRIVACY_LEVEL_FOUR];
+}
+
+// danburkert/prost#310
+enum ERemoteClientBroadcastMsg {
+    k_ERemoteClientBroadcastMsgDiscovery = 0;
+}
+message CMsgRemoteClientBroadcastHeader {
+    optional ERemoteClientBroadcastMsg msg_type = 2 [default = k_ERemoteClientBroadcastMsgDiscovery];
+}

--- a/third_party/prost/tests/src/deprecated_field.proto
+++ b/third_party/prost/tests/src/deprecated_field.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package deprecated_field;
+
+message Test {
+  string not_outdated = 1;
+  string outdated = 2 [deprecated = true];
+}

--- a/third_party/prost/tests/src/deprecated_field.rs
+++ b/third_party/prost/tests/src/deprecated_field.rs
@@ -1,0 +1,29 @@
+use alloc::string::ToString;
+
+mod deprecated_field {
+    // #![deny(unused_results)]
+    include!(concat!(env!("OUT_DIR"), "/deprecated_field.rs"));
+}
+
+#[test]
+fn test_warns_when_using_fields_with_deprecated_field() {
+    #[allow(deprecated)]
+    let message = deprecated_field::Test {
+        not_outdated: ".ogg".to_string(),
+        outdated: ".wav".to_string(),
+    };
+    // This test relies on the `#[allow(deprecated)]` attribute to ignore the warning that should
+    // be raised by the compiler.
+    // This test has a shortcoming since it doesn't explicitly check for the presence of the
+    // `deprecated` attribute since it doesn't exist at runtime. If complied without the `allow`
+    // attribute the following warning would be raised:
+    //
+    //    warning: use of deprecated item 'deprecated_field::deprecated_field::Test::outdated'
+    //      --> tests/src/deprecated_field.rs:11:9
+    //       |
+    //    11 |         outdated: ".wav".to_string(),
+    //       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //       |
+    //       = note: `#[warn(deprecated)]` on by default
+    drop(message);
+}

--- a/third_party/prost/tests/src/extern_paths.rs
+++ b/third_party/prost/tests/src/extern_paths.rs
@@ -1,0 +1,45 @@
+//! Tests nested packages with `extern_path`.
+
+include!(concat!(env!("OUT_DIR"), "/extern_paths/packages.rs"));
+
+pub mod widget {
+    include!(concat!(env!("OUT_DIR"), "/extern_paths/packages.widget.rs"));
+    pub mod factory {
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/extern_paths/packages.widget.factory.rs"
+        ));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::packages::gizmo;
+    use crate::packages::DoIt;
+    use prost::Message;
+
+    let mut widget_factory = widget::factory::WidgetFactory::default();
+    assert_eq!(0, widget_factory.encoded_len());
+
+    widget_factory.inner = Some(widget::factory::widget_factory::Inner {});
+    assert_eq!(2, widget_factory.encoded_len());
+
+    widget_factory.root = Some(Root {});
+    assert_eq!(4, widget_factory.encoded_len());
+
+    widget_factory.root_inner = Some(root::Inner {});
+    assert_eq!(6, widget_factory.encoded_len());
+
+    widget_factory.widget = Some(widget::Widget {});
+    assert_eq!(8, widget_factory.encoded_len());
+
+    widget_factory.widget_inner = Some(widget::widget::Inner {});
+    assert_eq!(10, widget_factory.encoded_len());
+
+    widget_factory.gizmo = Some(gizmo::Gizmo {});
+    assert_eq!(12, widget_factory.encoded_len());
+    widget_factory.gizmo.as_ref().map(DoIt::do_it);
+
+    widget_factory.gizmo_inner = Some(gizmo::gizmo::Inner {});
+    assert_eq!(14, widget_factory.encoded_len());
+}

--- a/third_party/prost/tests/src/groups.proto
+++ b/third_party/prost/tests/src/groups.proto
@@ -1,0 +1,57 @@
+syntax = "proto2";
+
+package groups;
+
+message Test1 {
+    optional group GroupA = 1 {
+        optional int32 i2 = 2;
+    }
+}
+
+message Test2 {
+    optional int32 i14 = 4;
+    repeated group GroupB = 5 {
+        optional int32 i16 = 6;
+    }
+    optional int32 i17 = 7;
+}
+
+message OneofGroup {
+    optional int32 i1 = 1;
+
+    oneof field {
+        group G = 2 {
+            optional int32 i2 = 1;
+            required string s1 = 2;
+            optional Test1 t1 = 3;
+        }
+
+        string s2 = 3;
+    }
+}
+
+message NestedGroup {
+    optional group OptionalGroup = 1 {
+        optional NestedGroup nested_group = 1;
+    }
+
+    required group RequiredGroup = 2 {
+        required NestedGroup nested_group = 1;
+    }
+
+    repeated group RepeatedGroup = 3 {
+        repeated NestedGroup nested_groups = 1;
+    }
+
+    oneof o {
+        group G = 4 {
+            optional NestedGroup nested_group = 1;
+        }
+    }
+}
+
+message NestedGroup2 {
+    optional group OptionalGroup = 1 {
+        optional NestedGroup2 nested_group = 1;
+    }
+}

--- a/third_party/prost/tests/src/ident_conversion.proto
+++ b/third_party/prost/tests/src/ident_conversion.proto
@@ -1,0 +1,81 @@
+syntax = "proto3";
+
+package Foo.Bar_Baz;
+
+// Test that ident conversion works correctly on message and field names.
+message Foo_barBaz {
+
+  int32 fooBar_baz = 1;
+
+  repeated fuzz_buster fuzz_busters = 2;
+
+  StrawberryRhubarbPIE p_iE = 3;
+
+  // Rust Keywords:
+  int32 as = 4;
+  int32 break = 5;
+  int32 const = 6;
+  int32 continue = 7;
+  int32 else = 8;
+  int32 enum = 9;
+  int32 false = 10;
+  int32 fn = 11;
+  int32 for = 12;
+  int32 if = 13;
+  int32 impl = 14;
+  int32 in = 15;
+  int32 let = 16;
+  int32 loop = 17;
+  int32 match = 18;
+  int32 mod = 19;
+  int32 move = 20;
+  int32 mut = 21;
+  int32 pub = 22;
+  int32 ref = 23;
+  int32 return = 24;
+  int32 static = 25;
+  int32 struct = 26;
+  int32 trait = 27;
+  int32 true = 28;
+  int32 type = 29;
+  int32 unsafe = 30;
+  int32 use = 31;
+  int32 where = 32;
+  int32 while = 33;
+  int32 dyn = 34;
+  int32 abstract = 35;
+  int32 become = 36;
+  int32 box = 37;
+  int32 do = 38;
+  int32 final = 39;
+  int32 macro = 40;
+  int32 override = 41;
+  int32 priv = 42;
+  int32 typeof = 43;
+  int32 unsized = 44;
+  int32 virtual = 45;
+  int32 yield = 46;
+  int32 async = 47;
+  int32 await = 48;
+  int32 try = 49;
+  int32 self = 50;
+  int32 super = 51;
+  int32 extern = 52;
+  int32 crate = 53;
+
+  message Self {
+  }
+
+  message fuzz_buster {
+    map<int32, Foo_barBaz> t = 1;
+    fuzz_buster NestedSelf = 2;
+  }
+
+  enum StrawberryRhubarbPIE {
+    foo = 0;
+    BAR = 1;
+    foo_bar = 2;
+    fuzzBUSTER = 3;
+    NormalRustEnumCase = 4;
+  }
+}

--- a/third_party/prost/tests/src/lib.rs
+++ b/third_party/prost/tests/src/lib.rs
@@ -1,0 +1,582 @@
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::module_inception,
+    clippy::unreadable_literal
+)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate cfg_if;
+
+extern crate alloc;
+
+cfg_if! {
+    if #[cfg(feature = "edition-2015")] {
+        extern crate anyhow;
+        extern crate bytes;
+        extern crate core;
+        extern crate prost;
+        extern crate prost_types;
+        extern crate protobuf;
+        #[cfg(test)]
+        extern crate prost_build;
+        #[cfg(test)]
+        extern crate tempfile;
+    }
+}
+
+pub mod extern_paths;
+pub mod packages;
+pub mod unittest;
+
+#[cfg(test)]
+mod bootstrap;
+#[cfg(test)]
+mod debug;
+#[cfg(test)]
+mod deprecated_field;
+#[cfg(test)]
+mod message_encoding;
+#[cfg(test)]
+mod no_unused_results;
+#[cfg(test)]
+mod well_known_types;
+
+pub mod foo {
+    pub mod bar_baz {
+        include!(concat!(env!("OUT_DIR"), "/foo.bar_baz.rs"));
+    }
+}
+
+pub mod nesting {
+    include!(concat!(env!("OUT_DIR"), "/nesting.rs"));
+}
+
+pub mod recursive_oneof {
+    include!(concat!(env!("OUT_DIR"), "/recursive_oneof.rs"));
+}
+
+/// This tests the custom attributes support by abusing docs.
+///
+/// Docs really are full-blown attributes. So we use them to ensure we can place them on everything
+/// we need. If they aren't put onto something or allowed not to be there (by the generator),
+/// compilation fails.
+#[deny(missing_docs)]
+pub mod custom_attributes {
+    include!(concat!(env!("OUT_DIR"), "/foo.custom.attrs.rs"));
+}
+
+/// Also for testing custom attributes, but on oneofs.
+///
+/// Unfortunately, an OneOf field generates a companion module in the .rs file. There's no
+/// reasonable way to place a doc comment on that, so we do the test with `derive(Ord)` and have it
+/// in a separate file.
+pub mod oneof_attributes {
+    include!(concat!(env!("OUT_DIR"), "/foo.custom.one_of_attrs.rs"));
+}
+
+/// Issue https://github.com/danburkert/prost/issues/118
+///
+/// When a message contains an enum field with a default value, we
+/// must ensure that the appropriate name conventions are used.
+pub mod default_enum_value {
+    include!(concat!(env!("OUT_DIR"), "/default_enum_value.rs"));
+}
+
+pub mod groups {
+    include!(concat!(env!("OUT_DIR"), "/groups.rs"));
+}
+
+use alloc::format;
+use alloc::vec::Vec;
+
+use anyhow::anyhow;
+use bytes::Buf;
+
+use prost::Message;
+
+pub enum RoundtripResult {
+    /// The roundtrip succeeded.
+    Ok(Vec<u8>),
+    /// The data could not be decoded. This could indicate a bug in prost,
+    /// or it could indicate that the input was bogus.
+    DecodeError(prost::DecodeError),
+    /// Re-encoding or validating the data failed.  This indicates a bug in `prost`.
+    Error(anyhow::Error),
+}
+
+impl RoundtripResult {
+    /// Unwrap the roundtrip result.
+    pub fn unwrap(self) -> Vec<u8> {
+        match self {
+            RoundtripResult::Ok(buf) => buf,
+            RoundtripResult::DecodeError(error) => {
+                panic!("failed to decode the roundtrip data: {}", error)
+            }
+            RoundtripResult::Error(error) => panic!("failed roundtrip: {}", error),
+        }
+    }
+
+    /// Unwrap the roundtrip result. Panics if the result was a validation or re-encoding error.
+    pub fn unwrap_error(self) -> Result<Vec<u8>, prost::DecodeError> {
+        match self {
+            RoundtripResult::Ok(buf) => Ok(buf),
+            RoundtripResult::DecodeError(error) => Err(error),
+            RoundtripResult::Error(error) => panic!("failed roundtrip: {}", error),
+        }
+    }
+}
+
+/// Tests round-tripping a message type. The message should be compiled with `BTreeMap` fields,
+/// otherwise the comparison may fail due to inconsistent `HashMap` entry encoding ordering.
+pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult
+where
+    M: Message + Default,
+{
+    // Try to decode a message from the data. If decoding fails, continue.
+    let all_types = match M::decode(data) {
+        Ok(all_types) => all_types,
+        Err(error) => return RoundtripResult::DecodeError(error),
+    };
+
+    let encoded_len = all_types.encoded_len();
+
+    // TODO: Reenable this once sign-extension in negative int32s is figured out.
+    // assert!(encoded_len <= data.len(), "encoded_len: {}, len: {}, all_types: {:?}",
+    //         encoded_len, data.len(), all_types);
+
+    let mut buf1 = Vec::new();
+    if let Err(error) = all_types.encode(&mut buf1) {
+        return RoundtripResult::Error(error.into());
+    }
+    if encoded_len != buf1.len() {
+        return RoundtripResult::Error(anyhow!(
+            "expected encoded len ({}) did not match actual encoded len ({})",
+            encoded_len,
+            buf1.len()
+        ));
+    }
+
+    let roundtrip = match M::decode(&*buf1) {
+        Ok(roundtrip) => roundtrip,
+        Err(error) => return RoundtripResult::Error(anyhow::Error::new(error)),
+    };
+
+    let mut buf2 = Vec::new();
+    if let Err(error) = roundtrip.encode(&mut buf2) {
+        return RoundtripResult::Error(error.into());
+    }
+
+    /*
+    // Useful for debugging:
+    eprintln!(" data: {:?}", data.iter().map(|x| format!("0x{:x}", x)).collect::<Vec<_>>());
+    eprintln!(" buf1: {:?}", buf1.iter().map(|x| format!("0x{:x}", x)).collect::<Vec<_>>());
+    eprintln!("a: {:?}\nb: {:?}", all_types, roundtrip);
+    */
+
+    if buf1 != buf2 {
+        return RoundtripResult::Error(anyhow!("roundtripped encoded buffers do not match"));
+    }
+
+    RoundtripResult::Ok(buf1)
+}
+
+/// Generic rountrip serialization check for messages.
+pub fn check_message<M>(msg: &M)
+where
+    M: Message + Default + PartialEq,
+{
+    let expected_len = msg.encoded_len();
+
+    let mut buf = Vec::with_capacity(18);
+    msg.encode(&mut buf).unwrap();
+    assert_eq!(expected_len, buf.len());
+
+    let mut buf = &*buf;
+    let roundtrip = M::decode(&mut buf).unwrap();
+
+    if buf.has_remaining() {
+        panic!("expected buffer to be empty: {}", buf.remaining());
+    }
+
+    assert_eq!(msg, &roundtrip);
+}
+
+/// Serialize from A should equal Serialize from B
+pub fn check_serialize_equivalent<M, N>(msg_a: &M, msg_b: &N)
+where
+    M: Message + Default + PartialEq,
+    N: Message + Default + PartialEq,
+{
+    let mut buf_a = Vec::new();
+    msg_a.encode(&mut buf_a).unwrap();
+    let mut buf_b = Vec::new();
+    msg_b.encode(&mut buf_b).unwrap();
+    assert_eq!(buf_a, buf_b);
+}
+
+#[cfg(test)]
+mod tests {
+
+    use alloc::borrow::ToOwned;
+    use alloc::boxed::Box;
+    use alloc::collections::{BTreeMap, BTreeSet};
+    use alloc::string::ToString;
+    use alloc::vec;
+
+    use super::*;
+
+    use protobuf::test_messages::proto3::TestAllTypesProto3;
+
+    #[test]
+    fn test_all_types_proto3() {
+        // Some selected encoded messages, mostly collected from failed fuzz runs.
+        let msgs: &[&[u8]] = &[
+            &[0x28, 0x28, 0x28, 0xFF, 0xFF, 0xFF, 0xFF, 0x68],
+            &[0x92, 0x01, 0x00, 0x92, 0xF4, 0x01, 0x02, 0x00, 0x00],
+            &[0x5d, 0xff, 0xff, 0xff, 0xff, 0x28, 0xff, 0xff, 0x21],
+            &[0x98, 0x04, 0x02, 0x08, 0x0B, 0x98, 0x04, 0x02, 0x08, 0x02],
+            // optional_int32: -1
+            &[0x08, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x08],
+            // repeated_bool: [true, true]
+            &[0xDA, 0x02, 0x02, 0x2A, 0x03],
+            // oneof_double: nan
+            &[0xb1, 0x07, 0xf6, 0x3d, 0xf5, 0xff, 0x27, 0x3d, 0xf5, 0xff],
+            // optional_float: -0.0
+            &[0xdd, 0x00, 0x00, 0x00, 0x00, 0x80],
+            // optional_value: nan
+            &[
+                0xE2, 0x13, 0x1B, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+                0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF, 0x08, 0xFF, 0x0E,
+            ],
+        ];
+
+        for msg in msgs {
+            roundtrip::<TestAllTypesProto3>(msg).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_ident_conversions() {
+        let msg = foo::bar_baz::FooBarBaz {
+            foo_bar_baz: 42,
+            fuzz_busters: vec![foo::bar_baz::foo_bar_baz::FuzzBuster {
+                t: BTreeMap::<i32, foo::bar_baz::FooBarBaz>::new(),
+                nested_self: None,
+            }],
+            p_i_e: 0,
+            r#as: 4,
+            r#break: 5,
+            r#const: 6,
+            r#continue: 7,
+            r#else: 8,
+            r#enum: 9,
+            r#false: 10,
+            r#fn: 11,
+            r#for: 12,
+            r#if: 13,
+            r#impl: 14,
+            r#in: 15,
+            r#let: 16,
+            r#loop: 17,
+            r#match: 18,
+            r#mod: 19,
+            r#move: 20,
+            r#mut: 21,
+            r#pub: 22,
+            r#ref: 23,
+            r#return: 24,
+            r#static: 25,
+            r#struct: 26,
+            r#trait: 27,
+            r#true: 28,
+            r#type: 29,
+            r#unsafe: 30,
+            r#use: 31,
+            r#where: 32,
+            r#while: 33,
+            r#dyn: 34,
+            r#abstract: 35,
+            r#become: 36,
+            r#box: 37,
+            r#do: 38,
+            r#final: 39,
+            r#macro: 40,
+            r#override: 41,
+            r#priv: 42,
+            r#typeof: 43,
+            r#unsized: 44,
+            r#virtual: 45,
+            r#yield: 46,
+            r#async: 47,
+            r#await: 48,
+            r#try: 49,
+            self_: 50,
+            super_: 51,
+            extern_: 52,
+            crate_: 53,
+        };
+
+        let _ = foo::bar_baz::foo_bar_baz::Self_ {};
+
+        // Test enum ident conversion.
+        let _ = foo::bar_baz::foo_bar_baz::StrawberryRhubarbPie::Foo;
+        let _ = foo::bar_baz::foo_bar_baz::StrawberryRhubarbPie::Bar;
+        let _ = foo::bar_baz::foo_bar_baz::StrawberryRhubarbPie::FooBar;
+        let _ = foo::bar_baz::foo_bar_baz::StrawberryRhubarbPie::FuzzBuster;
+        let _ = foo::bar_baz::foo_bar_baz::StrawberryRhubarbPie::NormalRustEnumCase;
+
+        let mut buf = Vec::new();
+        msg.encode(&mut buf).expect("encode");
+        roundtrip::<foo::bar_baz::FooBarBaz>(&buf).unwrap();
+    }
+
+    #[test]
+    fn test_custom_type_attributes() {
+        // We abuse the ident conversion protobuf for the custom attribute additions. We placed
+        // `Ord` on the FooBarBaz (which is not implemented by ordinary messages).
+        let mut set1 = BTreeSet::new();
+        let msg1 = foo::bar_baz::FooBarBaz::default();
+        set1.insert(msg1);
+        // Similar, but for oneof fields
+        let mut set2 = BTreeSet::new();
+        let msg2 = oneof_attributes::Msg::default();
+        set2.insert(msg2.field);
+    }
+
+    #[test]
+    fn test_nesting() {
+        use crate::nesting::{A, B};
+        let _ = A {
+            a: Some(Box::new(A::default())),
+            repeated_a: Vec::<A>::new(),
+            map_a: BTreeMap::<i32, A>::new(),
+            b: Some(Box::new(B::default())),
+            repeated_b: Vec::<B>::new(),
+            map_b: BTreeMap::<i32, B>::new(),
+        };
+    }
+
+    #[test]
+    fn test_deep_nesting() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::nesting::A;
+
+            let mut a = Box::new(A::default());
+            for _ in 0..depth {
+                let mut next = Box::new(A::default());
+                next.a = Some(a);
+                a = next;
+            }
+
+            let mut buf = Vec::new();
+            a.encode(&mut buf).unwrap();
+            A::decode(&*buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(100).is_ok());
+        assert!(build_and_roundtrip(101).is_err());
+    }
+
+    #[test]
+    fn test_deep_nesting_oneof() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::recursive_oneof::{a, A, C};
+
+            let mut a = Box::new(A {
+                kind: Some(a::Kind::C(C {})),
+            });
+            for _ in 0..depth {
+                a = Box::new(A {
+                    kind: Some(a::Kind::A(a)),
+                });
+            }
+
+            let mut buf = Vec::new();
+            a.encode(&mut buf).unwrap();
+            A::decode(&*buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(99).is_ok());
+        assert!(build_and_roundtrip(100).is_err());
+    }
+
+    #[test]
+    fn test_deep_nesting_group() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::groups::{nested_group2::OptionalGroup, NestedGroup2};
+
+            let mut a = NestedGroup2::default();
+            for _ in 0..depth {
+                a = NestedGroup2 {
+                    optionalgroup: Some(Box::new(OptionalGroup {
+                        nested_group: Some(a),
+                    })),
+                };
+            }
+
+            let mut buf = Vec::new();
+            a.encode(&mut buf).unwrap();
+            NestedGroup2::decode(&*buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(50).is_ok());
+        assert!(build_and_roundtrip(51).is_err());
+    }
+
+    #[test]
+    fn test_deep_nesting_repeated() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::nesting::C;
+
+            let mut c = C::default();
+            for _ in 0..depth {
+                let mut next = C::default();
+                next.r.push(c);
+                c = next;
+            }
+
+            let mut buf = Vec::new();
+            c.encode(&mut buf).unwrap();
+            C::decode(&*buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(100).is_ok());
+        assert!(build_and_roundtrip(101).is_err());
+    }
+
+    #[test]
+    fn test_deep_nesting_map() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::nesting::D;
+
+            let mut d = D::default();
+            for _ in 0..depth {
+                let mut next = D::default();
+                next.m.insert("foo".to_owned(), d);
+                d = next;
+            }
+
+            let mut buf = Vec::new();
+            d.encode(&mut buf).unwrap();
+            D::decode(&*buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(50).is_ok());
+        assert!(build_and_roundtrip(51).is_err());
+    }
+
+    #[test]
+    fn test_recursive_oneof() {
+        use crate::recursive_oneof::{a, A, B, C};
+        let _ = A {
+            kind: Some(a::Kind::B(Box::new(B {
+                a: Some(Box::new(A {
+                    kind: Some(a::Kind::C(C {})),
+                })),
+            }))),
+        };
+    }
+
+    #[test]
+    fn test_267_regression() {
+        // Checks that skip_field will error appropriately when given a big stack of StartGroup
+        // tags. When the no-recursion-limit feature is enabled this results in stack overflow.
+        //
+        // https://github.com/danburkert/prost/issues/267
+        let buf = vec![b'C'; 1 << 20];
+        <() as Message>::decode(&buf[..]).err().unwrap();
+    }
+
+    #[test]
+    fn test_default_enum() {
+        let msg = default_enum_value::Test::default();
+        assert_eq!(msg.privacy_level_1(), default_enum_value::PrivacyLevel::One);
+        assert_eq!(
+            msg.privacy_level_3(),
+            default_enum_value::PrivacyLevel::PrivacyLevelThree
+        );
+        assert_eq!(
+            msg.privacy_level_4(),
+            default_enum_value::PrivacyLevel::PrivacyLevelprivacyLevelFour
+        );
+    }
+
+    #[test]
+    fn test_group() {
+        // optional group
+        let msg1_bytes = &[0x0B, 0x10, 0x20, 0x0C];
+
+        let msg1 = groups::Test1 {
+            groupa: Some(groups::test1::GroupA { i2: Some(32) }),
+        };
+
+        let mut bytes = Vec::new();
+        msg1.encode(&mut bytes).unwrap();
+        assert_eq!(&bytes, msg1_bytes);
+
+        // skip group while decoding
+        let data: &[u8] = &[
+            0x0B, // start group (tag=1)
+            0x30, 0x01, // unused int32 (tag=6)
+            0x2B, 0x30, 0xFF, 0x01, 0x2C, // unused group (tag=5)
+            0x10, 0x20, // int32 (tag=2)
+            0x0C, // end group (tag=1)
+        ];
+        assert_eq!(groups::Test1::decode(data), Ok(msg1));
+
+        // repeated group
+        let msg2_bytes: &[u8] = &[
+            0x20, 0x40, 0x2B, 0x30, 0xFF, 0x01, 0x2C, 0x2B, 0x30, 0x01, 0x2C, 0x38, 0x64,
+        ];
+
+        let msg2 = groups::Test2 {
+            i14: Some(64),
+            groupb: vec![
+                groups::test2::GroupB { i16: Some(255) },
+                groups::test2::GroupB { i16: Some(1) },
+            ],
+            i17: Some(100),
+        };
+
+        let mut bytes = Vec::new();
+        msg2.encode(&mut bytes).unwrap();
+        assert_eq!(&*bytes, msg2_bytes);
+
+        assert_eq!(groups::Test2::decode(msg2_bytes), Ok(msg2));
+    }
+
+    #[test]
+    fn test_group_oneof() {
+        let msg = groups::OneofGroup {
+            i1: Some(42),
+            field: Some(groups::oneof_group::Field::S2("foo".to_string())),
+        };
+        check_message(&msg);
+
+        let msg = groups::OneofGroup {
+            i1: Some(42),
+            field: Some(groups::oneof_group::Field::G(groups::oneof_group::G {
+                i2: None,
+                s1: "foo".to_string(),
+                t1: None,
+            })),
+        };
+        check_message(&msg);
+
+        let msg = groups::OneofGroup {
+            i1: Some(42),
+            field: Some(groups::oneof_group::Field::G(groups::oneof_group::G {
+                i2: Some(99),
+                s1: "foo".to_string(),
+                t1: Some(groups::Test1 {
+                    groupa: Some(groups::test1::GroupA { i2: None }),
+                }),
+            })),
+        };
+        check_message(&msg);
+
+        check_message(&groups::OneofGroup::default());
+    }
+}

--- a/third_party/prost/tests/src/message_encoding.rs
+++ b/third_party/prost/tests/src/message_encoding.rs
@@ -1,0 +1,370 @@
+use prost::alloc::{borrow::ToOwned, string::String, vec, vec::Vec};
+use prost::{Enumeration, Message, Oneof};
+
+use crate::check_message;
+use crate::check_serialize_equivalent;
+
+#[derive(Clone, PartialEq, Message)]
+pub struct RepeatedFloats {
+    #[prost(float, tag = "11")]
+    pub single_float: f32,
+    #[prost(float, repeated, packed = "true", tag = "41")]
+    pub repeated_float: Vec<f32>,
+}
+
+#[test]
+fn check_repeated_floats() {
+    check_message(&RepeatedFloats {
+        single_float: 0.0,
+        repeated_float: vec![
+            0.1,
+            340282300000000000000000000000000000000.0,
+            0.000000000000000000000000000000000000011754944,
+        ],
+    });
+}
+
+#[test]
+fn check_scalar_types() {
+    check_message(&ScalarTypes::default());
+}
+
+/// A protobuf message which contains all scalar types.
+#[derive(Clone, PartialEq, Message)]
+pub struct ScalarTypes {
+    #[prost(int32, tag = "001")]
+    pub int32: i32,
+    #[prost(int64, tag = "002")]
+    pub int64: i64,
+    #[prost(uint32, tag = "003")]
+    pub uint32: u32,
+    #[prost(uint64, tag = "004")]
+    pub uint64: u64,
+    #[prost(sint32, tag = "005")]
+    pub sint32: i32,
+    #[prost(sint64, tag = "006")]
+    pub sint64: i64,
+    #[prost(fixed32, tag = "007")]
+    pub fixed32: u32,
+    #[prost(fixed64, tag = "008")]
+    pub fixed64: u64,
+    #[prost(sfixed32, tag = "009")]
+    pub sfixed32: i32,
+    #[prost(sfixed64, tag = "010")]
+    pub sfixed64: i64,
+    #[prost(float, tag = "011")]
+    pub float: f32,
+    #[prost(double, tag = "012")]
+    pub double: f64,
+    #[prost(bool, tag = "013")]
+    pub _bool: bool,
+    #[prost(string, tag = "014")]
+    pub string: String,
+    #[prost(bytes, tag = "015")]
+    pub bytes: Vec<u8>,
+
+    #[prost(int32, required, tag = "101")]
+    pub required_int32: i32,
+    #[prost(int64, required, tag = "102")]
+    pub required_int64: i64,
+    #[prost(uint32, required, tag = "103")]
+    pub required_uint32: u32,
+    #[prost(uint64, required, tag = "104")]
+    pub required_uint64: u64,
+    #[prost(sint32, required, tag = "105")]
+    pub required_sint32: i32,
+    #[prost(sint64, required, tag = "106")]
+    pub required_sint64: i64,
+    #[prost(fixed32, required, tag = "107")]
+    pub required_fixed32: u32,
+    #[prost(fixed64, required, tag = "108")]
+    pub required_fixed64: u64,
+    #[prost(sfixed32, required, tag = "109")]
+    pub required_sfixed32: i32,
+    #[prost(sfixed64, required, tag = "110")]
+    pub required_sfixed64: i64,
+    #[prost(float, required, tag = "111")]
+    pub required_float: f32,
+    #[prost(double, required, tag = "112")]
+    pub required_double: f64,
+    #[prost(bool, required, tag = "113")]
+    pub required_bool: bool,
+    #[prost(string, required, tag = "114")]
+    pub required_string: String,
+    #[prost(bytes, required, tag = "115")]
+    pub required_bytes: Vec<u8>,
+
+    #[prost(int32, optional, tag = "201")]
+    pub optional_int32: Option<i32>,
+    #[prost(int64, optional, tag = "202")]
+    pub optional_int64: Option<i64>,
+    #[prost(uint32, optional, tag = "203")]
+    pub optional_uint32: Option<u32>,
+    #[prost(uint64, optional, tag = "204")]
+    pub optional_uint64: Option<u64>,
+    #[prost(sint32, optional, tag = "205")]
+    pub optional_sint32: Option<i32>,
+    #[prost(sint64, optional, tag = "206")]
+    pub optional_sint64: Option<i64>,
+
+    #[prost(fixed32, optional, tag = "207")]
+    pub optional_fixed32: Option<u32>,
+    #[prost(fixed64, optional, tag = "208")]
+    pub optional_fixed64: Option<u64>,
+    #[prost(sfixed32, optional, tag = "209")]
+    pub optional_sfixed32: Option<i32>,
+    #[prost(sfixed64, optional, tag = "210")]
+    pub optional_sfixed64: Option<i64>,
+    #[prost(float, optional, tag = "211")]
+    pub optional_float: Option<f32>,
+    #[prost(double, optional, tag = "212")]
+    pub optional_double: Option<f64>,
+    #[prost(bool, optional, tag = "213")]
+    pub optional_bool: Option<bool>,
+    #[prost(string, optional, tag = "214")]
+    pub optional_string: Option<String>,
+    #[prost(bytes, optional, tag = "215")]
+    pub optional_bytes: Option<Vec<u8>>,
+
+    #[prost(int32, repeated, packed = "false", tag = "301")]
+    pub repeated_int32: Vec<i32>,
+    #[prost(int64, repeated, packed = "false", tag = "302")]
+    pub repeated_int64: Vec<i64>,
+    #[prost(uint32, repeated, packed = "false", tag = "303")]
+    pub repeated_uint32: Vec<u32>,
+    #[prost(uint64, repeated, packed = "false", tag = "304")]
+    pub repeated_uint64: Vec<u64>,
+    #[prost(sint32, repeated, packed = "false", tag = "305")]
+    pub repeated_sint32: Vec<i32>,
+    #[prost(sint64, repeated, packed = "false", tag = "306")]
+    pub repeated_sint64: Vec<i64>,
+    #[prost(fixed32, repeated, packed = "false", tag = "307")]
+    pub repeated_fixed32: Vec<u32>,
+    #[prost(fixed64, repeated, packed = "false", tag = "308")]
+    pub repeated_fixed64: Vec<u64>,
+    #[prost(sfixed32, repeated, packed = "false", tag = "309")]
+    pub repeated_sfixed32: Vec<i32>,
+    #[prost(sfixed64, repeated, packed = "false", tag = "310")]
+    pub repeated_sfixed64: Vec<i64>,
+    #[prost(float, repeated, packed = "false", tag = "311")]
+    pub repeated_float: Vec<f32>,
+    #[prost(double, repeated, packed = "false", tag = "312")]
+    pub repeated_double: Vec<f64>,
+    #[prost(bool, repeated, packed = "false", tag = "313")]
+    pub repeated_bool: Vec<bool>,
+    #[prost(string, repeated, packed = "false", tag = "315")]
+    pub repeated_string: Vec<String>,
+    #[prost(bytes, repeated, packed = "false", tag = "316")]
+    pub repeated_bytes: Vec<Vec<u8>>,
+
+    #[prost(int32, repeated, tag = "401")]
+    pub packed_int32: Vec<i32>,
+    #[prost(int64, repeated, tag = "402")]
+    pub packed_int64: Vec<i64>,
+    #[prost(uint32, repeated, tag = "403")]
+    pub packed_uint32: Vec<u32>,
+    #[prost(uint64, repeated, tag = "404")]
+    pub packed_uint64: Vec<u64>,
+    #[prost(sint32, repeated, tag = "405")]
+    pub packed_sint32: Vec<i32>,
+    #[prost(sint64, repeated, tag = "406")]
+    pub packed_sint64: Vec<i64>,
+    #[prost(fixed32, repeated, tag = "407")]
+    pub packed_fixed32: Vec<u32>,
+
+    #[prost(fixed64, repeated, tag = "408")]
+    pub packed_fixed64: Vec<u64>,
+    #[prost(sfixed32, repeated, tag = "409")]
+    pub packed_sfixed32: Vec<i32>,
+    #[prost(sfixed64, repeated, tag = "410")]
+    pub packed_sfixed64: Vec<i64>,
+    #[prost(float, repeated, tag = "411")]
+    pub packed_float: Vec<f32>,
+    #[prost(double, repeated, tag = "412")]
+    pub packed_double: Vec<f64>,
+    #[prost(bool, repeated, tag = "413")]
+    pub packed_bool: Vec<bool>,
+    #[prost(string, repeated, tag = "415")]
+    pub packed_string: Vec<String>,
+    #[prost(bytes, repeated, tag = "416")]
+    pub packed_bytes: Vec<Vec<u8>>,
+}
+
+#[test]
+fn check_tags_inferred() {
+    check_message(&TagsInferred::default());
+    check_serialize_equivalent(&TagsInferred::default(), &TagsQualified::default());
+
+    let tags_inferred = TagsInferred {
+        one: true,
+        two: Some(42),
+        three: vec![0.0, 1.0, 1.0],
+        skip_to_nine: "nine".to_owned(),
+        ten: 0,
+        eleven: ::alloc::collections::BTreeMap::new(),
+        back_to_five: vec![1, 0, 1],
+        six: Basic::default(),
+    };
+    check_message(&tags_inferred);
+
+    let tags_qualified = TagsQualified {
+        one: true,
+        two: Some(42),
+        three: vec![0.0, 1.0, 1.0],
+        five: vec![1, 0, 1],
+        six: Basic::default(),
+        nine: "nine".to_owned(),
+        ten: 0,
+        eleven: ::alloc::collections::BTreeMap::new(),
+    };
+    check_serialize_equivalent(&tags_inferred, &tags_qualified);
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct TagsInferred {
+    #[prost(bool)]
+    pub one: bool,
+    #[prost(int32, optional)]
+    pub two: Option<i32>,
+    #[prost(float, repeated)]
+    pub three: Vec<f32>,
+
+    #[prost(tag = "9", string, required)]
+    pub skip_to_nine: String,
+    #[prost(enumeration = "BasicEnumeration", default = "ONE")]
+    pub ten: i32,
+    #[prost(btree_map = "string, string")]
+    pub eleven: ::alloc::collections::BTreeMap<String, String>,
+
+    #[prost(tag = "5", bytes)]
+    pub back_to_five: Vec<u8>,
+    #[prost(message, required)]
+    pub six: Basic,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct TagsQualified {
+    #[prost(tag = "1", bool)]
+    pub one: bool,
+    #[prost(tag = "2", int32, optional)]
+    pub two: Option<i32>,
+    #[prost(tag = "3", float, repeated)]
+    pub three: Vec<f32>,
+
+    #[prost(tag = "5", bytes)]
+    pub five: Vec<u8>,
+    #[prost(tag = "6", message, required)]
+    pub six: Basic,
+
+    #[prost(tag = "9", string, required)]
+    pub nine: String,
+    #[prost(tag = "10", enumeration = "BasicEnumeration", default = "ONE")]
+    pub ten: i32,
+    #[prost(tag = "11", btree_map = "string, string")]
+    pub eleven: ::alloc::collections::BTreeMap<String, String>,
+}
+
+/// A prost message with default value.
+#[derive(Clone, PartialEq, Message)]
+pub struct DefaultValues {
+    #[prost(int32, tag = "1", default = "42")]
+    pub int32: i32,
+
+    #[prost(int32, optional, tag = "2", default = "88")]
+    pub optional_int32: Option<i32>,
+
+    #[prost(string, tag = "3", default = "fourty two")]
+    pub string: String,
+
+    #[prost(enumeration = "BasicEnumeration", tag = "4", default = "ONE")]
+    pub enumeration: i32,
+
+    #[prost(enumeration = "BasicEnumeration", optional, tag = "5", default = "TWO")]
+    pub optional_enumeration: Option<i32>,
+
+    #[prost(enumeration = "BasicEnumeration", repeated, tag = "6")]
+    pub repeated_enumeration: Vec<i32>,
+}
+
+#[test]
+fn check_default_values() {
+    let default = DefaultValues::default();
+    assert_eq!(default.int32, 42);
+    assert_eq!(default.optional_int32, None);
+    assert_eq!(&default.string, "fourty two");
+    assert_eq!(default.enumeration, BasicEnumeration::ONE as i32);
+    assert_eq!(default.optional_enumeration, None);
+    assert_eq!(&default.repeated_enumeration, &[]);
+    assert_eq!(0, default.encoded_len());
+}
+
+/// A protobuf enum.
+#[derive(Clone, Copy, Debug, PartialEq, Enumeration)]
+pub enum BasicEnumeration {
+    ZERO = 0,
+    ONE = 1,
+    TWO = 2,
+    THREE = 3,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct Basic {
+    #[prost(int32, tag = "1")]
+    pub int32: i32,
+
+    #[prost(bool, repeated, packed = "false", tag = "2")]
+    pub bools: Vec<bool>,
+
+    #[prost(string, tag = "3")]
+    pub string: String,
+
+    #[prost(string, optional, tag = "4")]
+    pub optional_string: Option<String>,
+
+    #[prost(enumeration = "BasicEnumeration", tag = "5")]
+    pub enumeration: i32,
+
+    #[prost(map = "int32, enumeration(BasicEnumeration)", tag = "6")]
+    #[cfg(feature = "std")]
+    pub enumeration_map: ::std::collections::HashMap<i32, i32>,
+
+    #[prost(hash_map = "string, string", tag = "7")]
+    #[cfg(feature = "std")]
+    pub string_map: ::std::collections::HashMap<String, String>,
+
+    #[prost(btree_map = "int32, enumeration(BasicEnumeration)", tag = "10")]
+    pub enumeration_btree_map: prost::alloc::collections::BTreeMap<i32, i32>,
+
+    #[prost(btree_map = "string, string", tag = "11")]
+    pub string_btree_map: prost::alloc::collections::BTreeMap<String, String>,
+
+    #[prost(oneof = "BasicOneof", tags = "8, 9")]
+    pub oneof: Option<BasicOneof>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct Compound {
+    #[prost(message, optional, tag = "1")]
+    pub optional_message: Option<Basic>,
+
+    #[prost(message, required, tag = "2")]
+    pub required_message: Basic,
+
+    #[prost(message, repeated, tag = "3")]
+    pub repeated_message: Vec<Basic>,
+
+    #[prost(map = "sint32, message", tag = "4")]
+    #[cfg(feature = "std")]
+    pub message_map: ::std::collections::HashMap<i32, Basic>,
+
+    #[prost(btree_map = "sint32, message", tag = "5")]
+    pub message_btree_map: prost::alloc::collections::BTreeMap<i32, Basic>,
+}
+
+#[derive(Clone, PartialEq, Oneof)]
+pub enum BasicOneof {
+    #[prost(int32, tag = "8")]
+    Int(i32),
+    #[prost(string, tag = "9")]
+    String(String),
+}

--- a/third_party/prost/tests/src/nesting.proto
+++ b/third_party/prost/tests/src/nesting.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package nesting;
+
+message A {
+    A a = 1;
+    repeated A repeated_a = 2;
+    map<int32, A> map_a = 3;
+
+    B b = 4;
+    repeated B repeated_b = 5;
+    map<int32, B> map_b = 6;
+}
+
+message B {
+    A a = 1;
+}
+
+message C {
+    repeated C r = 1;
+}
+
+message D {
+    map<string, D> m = 1;
+}

--- a/third_party/prost/tests/src/no_package.proto
+++ b/third_party/prost/tests/src/no_package.proto
@@ -1,0 +1,1 @@
+syntax = "proto3";

--- a/third_party/prost/tests/src/no_unused_results.proto
+++ b/third_party/prost/tests/src/no_unused_results.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package no_unused_results;
+
+message Test {
+    string dummy_field = 1;
+}

--- a/third_party/prost/tests/src/no_unused_results.rs
+++ b/third_party/prost/tests/src/no_unused_results.rs
@@ -1,0 +1,7 @@
+mod should_compile_successfully {
+    #![deny(unused_results)]
+    include!(concat!(env!("OUT_DIR"), "/no_unused_results.rs"));
+}
+
+#[test]
+fn dummy() {}

--- a/third_party/prost/tests/src/oneof_attributes.proto
+++ b/third_party/prost/tests/src/oneof_attributes.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+// Testing oneof custom attributes (separately from the other ones, since oneof
+// fields create their own companion module and our trick with abusing
+// deny(missing_docs) doesn't work on that.
+
+package Foo.Custom.OneOfAttrs;
+
+message Msg {
+    oneof field {
+        string a = 1;
+        bytes b = 2;
+    }
+}

--- a/third_party/prost/tests/src/packages/gizmo.proto
+++ b/third_party/prost/tests/src/packages/gizmo.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package packages.gizmo;
+
+message Gizmo {
+  message Inner {
+  }
+}

--- a/third_party/prost/tests/src/packages/mod.rs
+++ b/third_party/prost/tests/src/packages/mod.rs
@@ -1,0 +1,52 @@
+//! Tests nested packages.
+
+include!(concat!(env!("OUT_DIR"), "/packages.rs"));
+
+pub mod gizmo {
+    include!(concat!(env!("OUT_DIR"), "/packages.gizmo.rs"));
+}
+
+pub mod widget {
+    include!(concat!(env!("OUT_DIR"), "/packages.widget.rs"));
+    pub mod factory {
+        include!(concat!(env!("OUT_DIR"), "/packages.widget.factory.rs"));
+    }
+}
+
+// Trait used in extern_paths.rs.
+pub trait DoIt {
+    fn do_it(&self);
+}
+
+impl DoIt for gizmo::Gizmo {
+    fn do_it(&self) {}
+}
+
+#[test]
+fn test() {
+    use prost::Message;
+
+    let mut widget_factory = widget::factory::WidgetFactory::default();
+    assert_eq!(0, widget_factory.encoded_len());
+
+    widget_factory.inner = Some(widget::factory::widget_factory::Inner {});
+    assert_eq!(2, widget_factory.encoded_len());
+
+    widget_factory.root = Some(Root {});
+    assert_eq!(4, widget_factory.encoded_len());
+
+    widget_factory.root_inner = Some(root::Inner {});
+    assert_eq!(6, widget_factory.encoded_len());
+
+    widget_factory.widget = Some(widget::Widget {});
+    assert_eq!(8, widget_factory.encoded_len());
+
+    widget_factory.widget_inner = Some(widget::widget::Inner {});
+    assert_eq!(10, widget_factory.encoded_len());
+
+    widget_factory.gizmo = Some(gizmo::Gizmo {});
+    assert_eq!(12, widget_factory.encoded_len());
+
+    widget_factory.gizmo_inner = Some(gizmo::gizmo::Inner {});
+    assert_eq!(14, widget_factory.encoded_len());
+}

--- a/third_party/prost/tests/src/packages/root.proto
+++ b/third_party/prost/tests/src/packages/root.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package packages;
+
+message Root {
+  message Inner {
+  }
+}

--- a/third_party/prost/tests/src/packages/widget.proto
+++ b/third_party/prost/tests/src/packages/widget.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package packages.widget;
+
+message Widget {
+  message Inner {
+  }
+
+  enum Type {
+    A = 0;
+    B = 1;
+    C = 2;
+  }
+}

--- a/third_party/prost/tests/src/packages/widget_factory.proto
+++ b/third_party/prost/tests/src/packages/widget_factory.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package packages.widget.factory;
+
+import "root.proto";
+import "gizmo.proto";
+import "widget.proto";
+
+message WidgetFactory {
+  message Inner {
+  }
+
+  Inner inner = 1;
+
+  Root root = 2;
+  Root.Inner root_inner = 3;
+
+  Widget widget = 4;
+  Widget.Inner widget_inner = 5;
+  Widget.Type widget_type = 8;
+
+  gizmo.Gizmo gizmo = 6;
+  gizmo.Gizmo.Inner gizmo_inner = 7;
+}

--- a/third_party/prost/tests/src/recursive_oneof.proto
+++ b/third_party/prost/tests/src/recursive_oneof.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package recursive_oneof;
+
+message A {
+    oneof kind {
+        A a = 1;
+        B b = 2;
+        C c = 3;
+    }
+}
+
+message B {
+    A a = 1;
+}
+
+message C {}

--- a/third_party/prost/tests/src/unittest.rs
+++ b/third_party/prost/tests/src/unittest.rs
@@ -1,0 +1,48 @@
+#![cfg(test)]
+#![allow(clippy::float_cmp)]
+
+use core::{f32, f64};
+
+use protobuf::test_messages::protobuf_unittest;
+
+#[test]
+fn extreme_default_values() {
+    let pb = protobuf_unittest::TestExtremeDefaultValues::default();
+
+    assert_eq!(
+        b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE",
+        pb.escaped_bytes()
+    );
+
+    assert_eq!(0xFFFFFFFF, pb.large_uint32());
+    assert_eq!(0xFFFFFFFFFFFFFFFF, pb.large_uint64());
+    assert_eq!(-0x7FFFFFFF, pb.small_int32());
+    assert_eq!(-0x7FFFFFFFFFFFFFFF, pb.small_int64());
+    assert_eq!(-0x80000000, pb.really_small_int32());
+    assert_eq!(-0x8000000000000000, pb.really_small_int64());
+
+    assert_eq!(pb.utf8_string(), "\u{1234}");
+
+    assert_eq!(0.0, pb.zero_float());
+    assert_eq!(1.0, pb.one_float());
+    assert_eq!(1.5, pb.small_float());
+    assert_eq!(-1.0, pb.negative_one_float());
+    assert_eq!(-1.5, pb.negative_float());
+    assert_eq!(2E8, pb.large_float());
+    assert_eq!(-8e-28, pb.small_negative_float());
+
+    assert_eq!(f64::INFINITY, pb.inf_double());
+    assert_eq!(f64::NEG_INFINITY, pb.neg_inf_double());
+    assert_ne!(pb.nan_double(), pb.nan_double());
+    assert_eq!(f32::INFINITY, pb.inf_float());
+    assert_eq!(f32::NEG_INFINITY, pb.neg_inf_float());
+    assert_ne!(pb.nan_float(), pb.nan_float());
+
+    assert_eq!("? ? ?? ?? ??? ??/ ??-", pb.cpp_trigraph());
+
+    assert_eq!("hel\0lo", pb.string_with_zero());
+    assert_eq!(b"wor\0ld", pb.bytes_with_zero());
+    assert_eq!("ab\0c", pb.string_piece_with_zero());
+    assert_eq!("12\03", pb.cord_with_zero());
+    assert_eq!("${unknown}", pb.replacement_string());
+}

--- a/third_party/prost/tests/src/well_known_types.proto
+++ b/third_party/prost/tests/src/well_known_types.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+package well_known_types;
+
+message Foo {
+    // enum
+    google.protobuf.NullValue null = 1;
+    // message
+    google.protobuf.Timestamp timestamp = 2;
+}

--- a/third_party/prost/tests/src/well_known_types.rs
+++ b/third_party/prost/tests/src/well_known_types.rs
@@ -1,0 +1,14 @@
+include!(concat!(env!("OUT_DIR"), "/well_known_types.rs"));
+
+#[test]
+fn test_well_known_types() {
+    let msg = Foo {
+        null: ::prost_types::NullValue::NullValue.into(),
+        timestamp: Some(::prost_types::Timestamp {
+            seconds: 99,
+            nanos: 42,
+        }),
+    };
+
+    crate::check_message(&msg);
+}


### PR DESCRIPTION
Vendors https://github.com/danburkert/prost into `third_party` and applies a patch that will help pass handles in protobuf messages. for context, see #673.

This PR also includes a script that can be used to vendor prost and apply the patch to make it easier to maintain.

This is the first of a set of PRs that together provide the same functionality as https://github.com/project-oak/oak/pull/1108, but introduced in smaller portions.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
