### PR TITLE
Move client proto generation to oak_utils

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 name = "abitest_grpc"
 version = "0.1.0"
 dependencies = [
+ "oak_utils",
  "prost",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -89,11 +89,11 @@ dependencies = [
  "futures-core",
  "futures-util",
  "log",
+ "oak_utils",
  "prost",
  "structopt",
  "tokio",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -104,9 +104,9 @@ version = "0.1.0"
 name = "aggregator_grpc"
 version = "0.1.0"
 dependencies = [
+ "oak_utils",
  "prost",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -191,12 +191,12 @@ dependencies = [
  "futures-util",
  "hyper",
  "log",
+ "oak_utils",
  "open",
  "prost",
  "structopt",
  "tokio",
  "tonic",
- "tonic-build",
  "url",
 ]
 
@@ -650,9 +650,9 @@ dependencies = [
 name = "hello_world_grpc"
 version = "0.1.0"
 dependencies = [
+ "oak_utils",
  "prost",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -1141,7 +1141,6 @@ dependencies = [
  "sha2",
  "tokio",
  "tonic",
- "tonic-build",
  "wasmi",
 ]
 
@@ -1170,6 +1169,7 @@ dependencies = [
  "prost-build",
  "quote",
  "tempfile",
+ "tonic-build",
  "walkdir",
 ]
 
@@ -1348,9 +1348,9 @@ dependencies = [
 name = "private_set_intersection_grpc"
 version = "0.1.0"
 dependencies = [
+ "oak_utils",
  "prost",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -1731,9 +1731,9 @@ dependencies = [
 name = "running_average_grpc"
 version = "0.1.0"
 dependencies = [
+ "oak_utils",
  "prost",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -2433,9 +2433,9 @@ dependencies = [
 name = "translator_grpc"
 version = "0.1.0"
 dependencies = [
+ "oak_utils",
  "prost",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -2472,6 +2472,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "log",
+ "oak_utils",
  "prost",
  "quick-xml",
  "reqwest",
@@ -2479,7 +2480,6 @@ dependencies = [
  "structopt",
  "tokio",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -2494,7 +2494,6 @@ dependencies = [
  "structopt",
  "tokio",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]

--- a/examples/abitest/grpc/Cargo.toml
+++ b/examples/abitest/grpc/Cargo.toml
@@ -10,4 +10,4 @@ prost = "*"
 tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]
-tonic-build = "*"
+oak_utils = "*"

--- a/examples/abitest/grpc/build.rs
+++ b/examples/abitest/grpc/build.rs
@@ -14,22 +14,7 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO(#1093): drop this client crate and move all proto generation to common crate.
-    let proto_path = Path::new("../proto");
-    let file_path = proto_path.join("abitest.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path.display());
-
-    // Generate the normal (non-Oak) server and client code for the gRPC service,
-    // along with the Rust types corresponding to the message definitions.
-    tonic_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile(&[file_path.as_path()], &[proto_path])?;
+    oak_utils::compile_client_proto("../proto", "abitest.proto")?;
     Ok(())
 }

--- a/examples/abitest/grpc/build.rs
+++ b/examples/abitest/grpc/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &["abitest.proto"],
         CodegenOptions {
             build_client: true,
-            build_server: false,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/examples/abitest/grpc/build.rs
+++ b/examples/abitest/grpc/build.rs
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_client_proto("../proto", "abitest.proto")?;
+    generate_grpc_code(
+        "../proto",
+        &["abitest.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: false,
+        },
+    )?;
     Ok(())
 }

--- a/examples/aggregator/backend/Cargo.toml
+++ b/examples/aggregator/backend/Cargo.toml
@@ -16,4 +16,4 @@ tokio = { version = "*", features = ["fs", "macros", "sync", "stream"] }
 tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]
-tonic-build = "*"
+oak_utils = "*"

--- a/examples/aggregator/backend/build.rs
+++ b/examples/aggregator/backend/build.rs
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_server_proto("../../../examples/aggregator/proto", "aggregator.proto")?;
+    generate_grpc_code(
+        "../proto",
+        &["aggregator.proto"],
+        CodegenOptions {
+            build_client: false,
+            build_server: true,
+        },
+    )?;
     Ok(())
 }

--- a/examples/aggregator/backend/build.rs
+++ b/examples/aggregator/backend/build.rs
@@ -14,19 +14,7 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_path = Path::new("../../../examples/aggregator/proto");
-    let file_path = proto_path.join("aggregator.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path.display());
-
-    tonic_build::configure()
-        .build_client(false)
-        .build_server(true)
-        .compile(&[file_path.as_path()], &[proto_path])?;
+    oak_utils::compile_server_proto("../../../examples/aggregator/proto", "aggregator.proto")?;
     Ok(())
 }

--- a/examples/aggregator/backend/build.rs
+++ b/examples/aggregator/backend/build.rs
@@ -21,8 +21,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "../proto",
         &["aggregator.proto"],
         CodegenOptions {
-            build_client: false,
             build_server: true,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/examples/aggregator/grpc/Cargo.toml
+++ b/examples/aggregator/grpc/Cargo.toml
@@ -10,4 +10,4 @@ prost = "*"
 tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]
-tonic-build = "*"
+oak_utils = "*"

--- a/examples/aggregator/grpc/build.rs
+++ b/examples/aggregator/grpc/build.rs
@@ -14,22 +14,7 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO(#1093): drop this client crate and move all proto generation to common crate.
-    let proto_path = Path::new("../proto");
-    let file_path = proto_path.join("aggregator.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path.display());
-
-    // Generate the normal (non-Oak) server and client code for the gRPC service,
-    // along with the Rust types corresponding to the message definitions.
-    tonic_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile(&[file_path.as_path()], &[proto_path])?;
+    oak_utils::compile_client_proto("../proto", "aggregator.proto")?;
     Ok(())
 }

--- a/examples/aggregator/grpc/build.rs
+++ b/examples/aggregator/grpc/build.rs
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_client_proto("../proto", "aggregator.proto")?;
+    generate_grpc_code(
+        "../proto",
+        &["aggregator.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: false,
+        },
+    )?;
     Ok(())
 }

--- a/examples/aggregator/grpc/build.rs
+++ b/examples/aggregator/grpc/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &["aggregator.proto"],
         CodegenOptions {
             build_client: true,
-            build_server: false,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/examples/authentication/client/Cargo.toml
+++ b/examples/authentication/client/Cargo.toml
@@ -20,4 +20,4 @@ tonic = { version = "*", features = ["tls"] }
 url = "*"
 
 [build-dependencies]
-tonic-build = "*"
+oak_utils = "*"

--- a/examples/authentication/client/build.rs
+++ b/examples/authentication/client/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &["authentication.proto"],
         CodegenOptions {
             build_client: true,
-            build_server: false,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/examples/authentication/client/build.rs
+++ b/examples/authentication/client/build.rs
@@ -14,19 +14,7 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_path = Path::new("../../../oak/proto");
-    let file_path = proto_path.join("authentication.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path.display());
-
-    tonic_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile(&[file_path.as_path()], &[proto_path])?;
+    oak_utils::compile_client_proto("../../../oak/proto", "authentication.proto")?;
     Ok(())
 }

--- a/examples/authentication/client/build.rs
+++ b/examples/authentication/client/build.rs
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_client_proto("../../../oak/proto", "authentication.proto")?;
+    generate_grpc_code(
+        "../../../oak/proto",
+        &["authentication.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: false,
+        },
+    )?;
     Ok(())
 }

--- a/examples/hello_world/grpc/Cargo.toml
+++ b/examples/hello_world/grpc/Cargo.toml
@@ -10,4 +10,4 @@ prost = "*"
 tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]
-tonic-build = "*"
+oak_utils = "*"

--- a/examples/hello_world/grpc/build.rs
+++ b/examples/hello_world/grpc/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &["hello_world.proto"],
         CodegenOptions {
             build_client: true,
-            build_server: false,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/examples/hello_world/grpc/build.rs
+++ b/examples/hello_world/grpc/build.rs
@@ -14,22 +14,7 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO(#1093): drop this client crate and move all proto generation to common crate.
-    let proto_path = Path::new("../proto");
-    let file_path = proto_path.join("hello_world.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path.display());
-
-    // Generate the normal (non-Oak) server and client code for the gRPC service,
-    // along with the Rust types corresponding to the message definitions.
-    tonic_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile(&[file_path.as_path()], &[proto_path])?;
+    oak_utils::compile_client_proto("../proto", "hello_world.proto")?;
     Ok(())
 }

--- a/examples/hello_world/grpc/build.rs
+++ b/examples/hello_world/grpc/build.rs
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_client_proto("../proto", "hello_world.proto")?;
+    generate_grpc_code(
+        "../proto",
+        &["hello_world.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: false,
+        },
+    )?;
     Ok(())
 }

--- a/examples/private_set_intersection/grpc/Cargo.toml
+++ b/examples/private_set_intersection/grpc/Cargo.toml
@@ -10,4 +10,4 @@ prost = "*"
 tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]
-tonic-build = "*"
+oak_utils = "*"

--- a/examples/private_set_intersection/grpc/build.rs
+++ b/examples/private_set_intersection/grpc/build.rs
@@ -14,22 +14,7 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO(#1093): drop this client crate and move all proto generation to common crate.
-    let proto_path = Path::new("../proto");
-    let file_path = proto_path.join("private_set_intersection.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path.display());
-
-    // Generate the normal (non-Oak) server and client code for the gRPC service,
-    // along with the Rust types corresponding to the message definitions.
-    tonic_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile(&[file_path.as_path()], &[proto_path])?;
+    oak_utils::compile_client_proto("../proto", "private_set_intersection.proto")?;
     Ok(())
 }

--- a/examples/private_set_intersection/grpc/build.rs
+++ b/examples/private_set_intersection/grpc/build.rs
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_client_proto("../proto", "private_set_intersection.proto")?;
+    generate_grpc_code(
+        "../proto",
+        &["private_set_intersection.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: false,
+        },
+    )?;
     Ok(())
 }

--- a/examples/private_set_intersection/grpc/build.rs
+++ b/examples/private_set_intersection/grpc/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &["private_set_intersection.proto"],
         CodegenOptions {
             build_client: true,
-            build_server: false,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/examples/running_average/grpc/Cargo.toml
+++ b/examples/running_average/grpc/Cargo.toml
@@ -10,4 +10,4 @@ prost = "*"
 tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]
-tonic-build = "*"
+oak_utils = "*"

--- a/examples/running_average/grpc/build.rs
+++ b/examples/running_average/grpc/build.rs
@@ -14,22 +14,7 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO(#1093): drop this client crate and move all proto generation to common crate.
-    let proto_path = Path::new("../proto");
-    let file_path = proto_path.join("running_average.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path.display());
-
-    // Generate the normal (non-Oak) server and client code for the gRPC service,
-    // along with the Rust types corresponding to the message definitions.
-    tonic_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile(&[file_path.as_path()], &[proto_path])?;
+    oak_utils::compile_client_proto("../proto", "running_average.proto")?;
     Ok(())
 }

--- a/examples/running_average/grpc/build.rs
+++ b/examples/running_average/grpc/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &["running_average.proto"],
         CodegenOptions {
             build_client: true,
-            build_server: false,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/examples/running_average/grpc/build.rs
+++ b/examples/running_average/grpc/build.rs
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_client_proto("../proto", "running_average.proto")?;
+    generate_grpc_code(
+        "../proto",
+        &["running_average.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: false,
+        },
+    )?;
     Ok(())
 }

--- a/examples/translator/grpc/Cargo.toml
+++ b/examples/translator/grpc/Cargo.toml
@@ -10,4 +10,4 @@ prost = "*"
 tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]
-tonic-build = "*"
+oak_utils = "*"

--- a/examples/translator/grpc/build.rs
+++ b/examples/translator/grpc/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &["translator.proto"],
         CodegenOptions {
             build_client: true,
-            build_server: false,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/examples/translator/grpc/build.rs
+++ b/examples/translator/grpc/build.rs
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_client_proto("../proto", "translator.proto")?;
+    generate_grpc_code(
+        "../proto",
+        &["translator.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: false,
+        },
+    )?;
     Ok(())
 }

--- a/examples/translator/grpc/build.rs
+++ b/examples/translator/grpc/build.rs
@@ -14,22 +14,7 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO(#1093): drop this client crate and move all proto generation to common crate.
-    let proto_path = Path::new("../proto");
-    let file_path = proto_path.join("translator.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path.display());
-
-    // Generate the normal (non-Oak) server and client code for the gRPC service,
-    // along with the Rust types corresponding to the message definitions.
-    tonic_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile(&[file_path.as_path()], &[proto_path])?;
+    oak_utils::compile_client_proto("../proto", "translator.proto")?;
     Ok(())
 }

--- a/examples/trusted_information_retrieval/backend/Cargo.toml
+++ b/examples/trusted_information_retrieval/backend/Cargo.toml
@@ -30,4 +30,4 @@ quick-xml = { version = "*", features = ["serialize"] }
 assert_matches = "*"
 
 [build-dependencies]
-tonic-build = "*"
+oak_utils = "*"

--- a/examples/trusted_information_retrieval/backend/build.rs
+++ b/examples/trusted_information_retrieval/backend/build.rs
@@ -14,14 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_server_proto(
-        "../../../examples/trusted_information_retrieval/proto",
-        "trusted_information_retrieval.proto",
-    )?;
-    oak_utils::compile_server_proto(
-        "../../../examples/trusted_information_retrieval/proto",
-        "database.proto",
+    generate_grpc_code(
+        "../proto",
+        &["trusted_information_retrieval.proto", "database.proto"],
+        CodegenOptions {
+            build_client: false,
+            build_server: true,
+        },
     )?;
     Ok(())
 }

--- a/examples/trusted_information_retrieval/backend/build.rs
+++ b/examples/trusted_information_retrieval/backend/build.rs
@@ -21,8 +21,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "../proto",
         &["trusted_information_retrieval.proto", "database.proto"],
         CodegenOptions {
-            build_client: false,
             build_server: true,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/examples/trusted_information_retrieval/backend/build.rs
+++ b/examples/trusted_information_retrieval/backend/build.rs
@@ -14,30 +14,14 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_path = Path::new("../../../examples/trusted_information_retrieval/proto");
-    let trusted_information_retrieval_path = proto_path.join("trusted_information_retrieval.proto");
-    let database_path = proto_path.join("database.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!(
-        "cargo:rerun-if-changed={}",
-        trusted_information_retrieval_path.display()
-    );
-    println!("cargo:rerun-if-changed={}", database_path.display());
-
-    tonic_build::configure()
-        .build_client(false)
-        .build_server(true)
-        .compile(
-            &[
-                trusted_information_retrieval_path.as_path(),
-                database_path.as_path(),
-            ],
-            &[proto_path],
-        )?;
+    oak_utils::compile_server_proto(
+        "../../../examples/trusted_information_retrieval/proto",
+        "trusted_information_retrieval.proto",
+    )?;
+    oak_utils::compile_server_proto(
+        "../../../examples/trusted_information_retrieval/proto",
+        "database.proto",
+    )?;
     Ok(())
 }

--- a/examples/trusted_information_retrieval/client/rust/Cargo.toml
+++ b/examples/trusted_information_retrieval/client/rust/Cargo.toml
@@ -24,4 +24,3 @@ tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]
 oak_utils = "*"
-tonic-build = "*"

--- a/examples/trusted_information_retrieval/client/rust/build.rs
+++ b/examples/trusted_information_retrieval/client/rust/build.rs
@@ -14,8 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    oak_utils::compile_client_proto("../../proto", "trusted_information_retrieval.proto")?;
-    oak_utils::compile_client_proto("../../proto", "database.proto")?;
+    generate_grpc_code(
+        "../../proto",
+        &["trusted_information_retrieval.proto", "database.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: false,
+        },
+    )?;
     Ok(())
 }

--- a/examples/trusted_information_retrieval/client/rust/build.rs
+++ b/examples/trusted_information_retrieval/client/rust/build.rs
@@ -14,31 +14,8 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO(#1120): Add Rust client library function for building Protobuf.
-    let proto_path = Path::new("../../proto");
-    let trusted_information_retrieval_path = proto_path.join("trusted_information_retrieval.proto");
-    let database_path = proto_path.join("database.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!(
-        "cargo:rerun-if-changed={}",
-        trusted_information_retrieval_path.display()
-    );
-    println!("cargo:rerun-if-changed={}", database_path.display());
-
-    tonic_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile(
-            &[
-                trusted_information_retrieval_path.as_path(),
-                database_path.as_path(),
-            ],
-            &[proto_path],
-        )?;
+    oak_utils::compile_client_proto("../../proto", "trusted_information_retrieval.proto")?;
+    oak_utils::compile_client_proto("../../proto", "database.proto")?;
     Ok(())
 }

--- a/examples/trusted_information_retrieval/client/rust/build.rs
+++ b/examples/trusted_information_retrieval/client/rust/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &["trusted_information_retrieval.proto", "database.proto"],
         CodegenOptions {
             build_client: true,
-            build_server: false,
+            ..Default::default()
         },
     )?;
     Ok(())

--- a/oak/server/Cargo.lock
+++ b/oak/server/Cargo.lock
@@ -722,7 +722,6 @@ dependencies = [
  "sha2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wat 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -737,6 +736,7 @@ dependencies = [
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/oak/server/rust/oak_runtime/Cargo.toml
+++ b/oak/server/rust/oak_runtime/Cargo.toml
@@ -60,9 +60,3 @@ wat = "*"
 [build-dependencies]
 oak_utils = "*"
 prost-build = "*"
-# Disable the `rustfmt` feature, as it requires `rustfmt` which may not be supported for custom
-# toolchains.
-tonic-build = { version = "*", default-features = false, features = [
-  "prost",
-  "transport"
-] }

--- a/oak/server/rust/oak_runtime/build.rs
+++ b/oak/server/rust/oak_runtime/build.rs
@@ -21,8 +21,8 @@ fn main() {
         "../../../../oak/proto",
         &["authentication.proto"],
         CodegenOptions {
-            build_client: false,
             build_server: true,
+            ..Default::default()
         },
     )
     .expect("Proto compilation failed.");

--- a/oak/server/rust/oak_runtime/build.rs
+++ b/oak/server/rust/oak_runtime/build.rs
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() {
-    oak_utils::compile_server_proto("../../../../oak/proto", "authentication.proto")
-        .expect("Proto compilation failed.");
+    generate_grpc_code(
+        "../../../../oak/proto",
+        &["authentication.proto"],
+        CodegenOptions {
+            build_client: false,
+            build_server: true,
+        },
+    )
+    .expect("Proto compilation failed.");
 }

--- a/oak/server/rust/oak_runtime/build.rs
+++ b/oak/server/rust/oak_runtime/build.rs
@@ -14,21 +14,7 @@
 // limitations under the License.
 //
 
-use std::path::Path;
-
 fn main() {
-    let proto_path = Path::new("../../../../oak/proto");
-    let file_path = proto_path.join("authentication.proto");
-
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    println!("cargo:rerun-if-changed={}", file_path.display());
-
-    // Build `authentication.proto` with `tonic-build` rather than `oak_utils` as it runs directly
-    // as a tonic service inside the gRPC server node rather than in a separate Wasm Node.
-    tonic_build::configure()
-        .build_client(false)
-        .build_server(true)
-        .compile(&[file_path.as_path()], &[proto_path])
+    oak_utils::compile_server_proto("../../../../oak/proto", "authentication.proto")
         .expect("Proto compilation failed.");
 }

--- a/oak_abi/Cargo.lock
+++ b/oak_abi/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "prost-build",
  "quote",
  "tempfile",
+ "tonic-build",
  "walkdir",
 ]
 
@@ -298,6 +299,18 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/oak_utils/Cargo.lock
+++ b/oak_utils/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "prost-build",
  "quote",
  "tempfile",
+ "tonic-build",
  "walkdir",
 ]
 
@@ -287,6 +288,18 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/oak_utils/Cargo.toml
+++ b/oak_utils/Cargo.toml
@@ -15,3 +15,9 @@ quote = "*"
 walkdir = "*"
 prost-build = "*"
 proc-macro2 = "*"
+# Disable the `rustfmt` feature, as it requires `rustfmt` which may not be supported for custom
+# toolchains.
+tonic-build = { version = "*", default-features = false, features = [
+  "prost",
+  "transport"
+] }

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -748,7 +748,6 @@ dependencies = [
  "sha2",
  "tokio",
  "tonic",
- "tonic-build",
  "wasmi",
 ]
 
@@ -777,6 +776,7 @@ dependencies = [
  "prost-build",
  "quote",
  "tempfile",
+ "tonic-build",
  "walkdir",
 ]
 


### PR DESCRIPTION
This change moves Protobuf generation function to `oak_utils`.

Fixes https://github.com/project-oak/oak/issues/1120
Ref https://github.com/project-oak/oak/issues/1093

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
