### PR TITLE
Enhance Private Set Intersection

### DIFF
--- a/examples/private_set_intersection/module/rust/src/lib.rs
+++ b/examples/private_set_intersection/module/rust/src/lib.rs
@@ -63,7 +63,7 @@ impl PrivateSetIntersection for Node {
         if self.fixed {
             return Err(grpc::build_status(
                 grpc::Code::InvalidArgument,
-                "Set contributions are now longer available",
+                "Set contributions are no longer available",
             ));
         }
 

--- a/examples/private_set_intersection/module/rust/src/lib.rs
+++ b/examples/private_set_intersection/module/rust/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! Clients invoke the module by providing their own private set, and the module keeps track of the
 //! intersection of all the provided sets from all the clients that have interacted with it.
-//! The number of contributed private sets is limited and defined by [`CONTRIBUTION_THRESHOLD`].
+//! The number of contributed private sets is limited and defined by [`SET_THRESHOLD`].
 //!
 //! The (common) intersection can then be retrieved by each client by a separate invocation.
 //! After the first client retrieves the intersection it becomes locked, and new contributions are

--- a/examples/private_set_intersection/module/rust/tests/integration_test.rs
+++ b/examples/private_set_intersection/module/rust/tests/integration_test.rs
@@ -44,11 +44,25 @@ async fn test_set_intersection() {
     let result = client.submit_set(req).await;
     assert_matches!(result, Ok(_));
 
+    // Send more sets than threshold.
+    let req = SubmitSetRequest {
+        values: vec!["c".to_string()],
+    };
+    let result = client.submit_set(req).await;
+    assert_matches!(result, Err(_));
+
     let result = client.get_intersection(()).await;
     assert_matches!(result, Ok(_));
     let got = HashSet::<String>::from_iter(result.unwrap().into_inner().values.to_vec());
     let want: HashSet<String> = ["b".to_string(), "c".to_string()].iter().cloned().collect();
     assert_eq!(got, want);
+
+    // Send a new set after the intersection was requested.
+    let req = SubmitSetRequest {
+        values: vec!["c".to_string()],
+    };
+    let result = client.submit_set(req).await;
+    assert_matches!(result, Err(_));
 
     runtime.stop();
 }

--- a/examples/private_set_intersection/proto/private_set_intersection.proto
+++ b/examples/private_set_intersection/proto/private_set_intersection.proto
@@ -29,6 +29,10 @@ message GetIntersectionResponse {
 }
 
 service PrivateSetIntersection {
+  // Submit a private set that will be contributed to the set intersection.
+  // The number of submissions is limited.
   rpc SubmitSet(SubmitSetRequest) returns (google.protobuf.Empty);
+  // Request the final private set intersection.
+  // Once the intersection is requested it becomes locked, and new contributions are discarded.
   rpc GetIntersection(google.protobuf.Empty) returns (GetIntersectionResponse);
 }


### PR DESCRIPTION
This change enhances Private Set Intersection example:
- Limits number of clients
- Freezes set after first query

Fixes https://github.com/project-oak/oak/issues/747

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
