### PR TITLE
Downgrade error on gRPC client node invocation channel closure

### DIFF
--- a/oak/server/rust/oak_runtime/src/node/grpc/client.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/client.rs
@@ -90,10 +90,10 @@ impl GrpcClientNode {
             debug!("Waiting for gRPC invocation");
             // Read a gRPC invocation from the [`Receiver`].
             let invocation = receiver.receive(&runtime).map_err(|error| {
-                if error == OakStatus::ErrTerminated {
-                    debug!("gRPC client node is terminating.");
-                } else {
-                    error!("Couldn't receive the invocation: {:?}", error);
+                match error {
+                    OakStatus::ErrTerminated => debug!("gRPC client node is terminating."),
+                    OakStatus::ErrChannelClosed => info!("gRPC invocation channel closed"),
+                    _ => error!("Couldn't receive the invocation: {:?}", error),
                 }
                 error
             })?;


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
