### PR TITLE
Grant TLS tag privilege to gRPC client pseudo-node

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,8 +19,8 @@ again.
 
 All submissions, including submissions by project members, require review. We
 use GitHub Pull Requests (PR) for this purpose. Consult
-[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
-information on using PRs.
+[GitHub Help](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
+for more information on using PRs.
 
 For a new review, the author works on a new branch on their own fork of the
 repository (we don't create additional branches on the main repository).
@@ -41,14 +41,14 @@ commits will most likely be squashed just before merging, and only the message
 of the original commit will be kept.
 
 It is _not_ recommended to use the
-["Applying suggested changes"](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request#applying-suggested-changes)
+["Applying suggested changes"](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request#applying-suggested-changes)
 functionality in the GitHub UI, as this may result in the changes being
 associated with the wrong user email address, and it also creates a separate
 commit, which is not necessarily what we want.
 
 In most cases the author expects a single commit out of a PR; once approved, the
 PR is merged via the
-["Squash and merge"](https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits)
+["Squash and merge"](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits)
 button in the GitHub UI. The UI will suggest a final commit message composed of
 the PR title, and individual commit messages as a bullet point list; the author
 should then reword the final commit message in the UI, usually discarding the
@@ -56,7 +56,7 @@ message of any additional fixup commit.
 
 In some cases the author intends to keep multiple commits as part of the same
 PR, in which case they would use the
-["Rebase and merge"](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits)
+["Rebase and merge"](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits)
 button. Note in this case it is up to the author to make sure that any fixups
 are squashed against the correct commit if necessary.
 

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -498,7 +498,7 @@ framework via the Oak Runtime:
 async fn test_say_hello() {
     env_logger::init();
 
-    let runtime = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
+    let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::channel_and_interceptor().await;

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6,6 +6,7 @@ version = "0.1.0"
 dependencies = [
  "abitest_common",
  "abitest_grpc",
+ "anyhow",
  "assert_matches",
  "byteorder",
  "chrono",
@@ -1148,6 +1149,7 @@ dependencies = [
 name = "oak_tests"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "lazy_static",
  "log",

--- a/examples/abitest/module_0/rust/Cargo.toml
+++ b/examples/abitest/module_0/rust/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "*"
 oak_utils = "*"
 
 [dev-dependencies]
+anyhow = "*"
 abitest_grpc = "=0.1.0"
 assert_matches = "*"
 env_logger = "*"

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -1747,19 +1747,19 @@ impl FrontendNode {
         // Create a second gRPC server Node on a different port.
         let result = oak::grpc::server::init("[::]:8181");
         expect_matches!(result, Ok(_));
-        let handle = result.unwrap();
+        let invocation_receiver = result.unwrap();
         // Close the only read-handle for the invocation handle, which should
         // trigger the gRPC server pseudo-Node to terminate (but we can't
         // check that here).
-        expect_eq!(Ok(()), oak::channel_close(handle.handle));
+        expect_eq!(Ok(()), invocation_receiver.close());
         Ok(())
     }
 
     fn test_grpc_server_invalid_address(&mut self) -> TestResult {
         // Attempt to create an additional gRPC server with an invalid local address.
         expect_eq!(
-            Err(OakStatus::ErrInvalidArgs),
-            oak::grpc::server::init("10 Downing Street")
+            Some(OakStatus::ErrInvalidArgs),
+            oak::grpc::server::init("10 Downing Street").err()
         );
         Ok(())
     }

--- a/examples/abitest/module_0/rust/tests/integration_test.rs
+++ b/examples/abitest/module_0/rust/tests/integration_test.rs
@@ -15,6 +15,7 @@
 //
 
 use abitest_grpc::proto::{oak_abi_test_service_client::OakAbiTestServiceClient, AbiTestRequest};
+use anyhow::Context;
 use assert_matches::assert_matches;
 use log::{debug, error, info};
 use maplit::hashmap;
@@ -34,13 +35,13 @@ const FRONTEND_ENTRYPOINT_NAME: &str = "frontend_oak_main";
 const FRONTEND_MANIFEST: &str = "../../module_0/rust/Cargo.toml";
 const BACKEND_MANIFEST: &str = "../../module_1/rust/Cargo.toml";
 
-const FRONTEND_WASM_NAME: &str = "abitest_0_frontend.wasm";
-const BACKEND_WASM_NAME: &str = "abitest_1_backend.wasm";
+const FRONTEND_MODULE_WASM_FILE_NAME: &str = "abitest_0_frontend.wasm";
+const BACKEND_MODULE_WASM_FILE_NAME: &str = "abitest_1_backend.wasm";
 
-fn build_wasm() -> std::io::Result<HashMap<String, Vec<u8>>> {
+fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
-        FRONTEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, FRONTEND_WASM_NAME)?,
-        BACKEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(BACKEND_MANIFEST, BACKEND_WASM_NAME)?,
+        FRONTEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, FRONTEND_MODULE_WASM_FILE_NAME).context("could not compile frontend module")?,
+        BACKEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(BACKEND_MANIFEST, BACKEND_MODULE_WASM_FILE_NAME).context("could not compile backend module")?,
     })
 }
 

--- a/examples/aggregator/client/aggregator.cc
+++ b/examples/aggregator/client/aggregator.cc
@@ -103,8 +103,10 @@ int main(int argc, char** argv) {
     values.push_back(value);
   }
 
-  // Submit data sample.
-  submit_sample(stub.get(), bucket, indices, values);
+  // Submit data sample as many times as it takes to reach the hardcoded threshold.
+  for (int i = 0; i < 5; i++) {
+    submit_sample(stub.get(), bucket, indices, values);
+  }
 
   return EXIT_SUCCESS;
 }

--- a/examples/aggregator/module/rust/tests/integration_test.rs
+++ b/examples/aggregator/module/rust/tests/integration_test.rs
@@ -24,7 +24,7 @@ use std::{
     convert::{From, TryFrom},
 };
 
-const MODULE_CONFIG_NAME: &str = "aggregator";
+const MODULE_WASM_FILE_NAME: &str = "aggregator.wasm";
 
 async fn submit_sample(
     client: &mut AggregatorClient<tonic::transport::Channel>,
@@ -43,7 +43,7 @@ async fn submit_sample(
 async fn test_aggregator() {
     env_logger::init();
 
-    let runtime = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
+    let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::channel_and_interceptor().await;

--- a/examples/chat/module/rust/src/backend.rs
+++ b/examples/chat/module/rust/src/backend.rs
@@ -21,7 +21,7 @@ use prost::Message as _;
 
 oak::entrypoint!(backend_oak_main => |in_channel| {
     oak::logger::init_default();
-    oak::run_event_loop(Room::default(), in_channel);
+    oak::run_event_loop(Room::default(), oak::io::Receiver::<Command>::new(in_channel));
 });
 
 #[derive(Default)]

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -41,7 +41,7 @@ struct Node {
 oak::entrypoint!(oak_main => |in_channel| {
     oak::logger::init_default();
     let dispatcher = ChatDispatcher::new(Node::default());
-    oak::run_event_loop(dispatcher, in_channel);
+    oak::run_event_loop(dispatcher, oak::io::Receiver::<grpc::Invocation>::new(in_channel));
 });
 
 oak::entrypoint!(grpc_oak_main => |_in_channel| {

--- a/examples/hello_world/module/rust/tests/integration_test.rs
+++ b/examples/hello_world/module/rust/tests/integration_test.rs
@@ -18,14 +18,14 @@ use assert_matches::assert_matches;
 use hello_world_grpc::proto::{hello_world_client::HelloWorldClient, HelloRequest};
 use log::info;
 
-const MODULE_CONFIG_NAME: &str = "hello_world";
+const MODULE_WASM_FILE_NAME: &str = "hello_world.wasm";
 
 // Test invoking the SayHello Node service method via the Oak runtime.
 #[tokio::test(core_threads = 2)]
 async fn test_say_hello() {
     env_logger::init();
 
-    let runtime = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
+    let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::channel_and_interceptor().await;

--- a/examples/machine_learning/module/rust/src/lib.rs
+++ b/examples/machine_learning/module/rust/src/lib.rs
@@ -154,7 +154,7 @@ oak::entrypoint!(oak_main => |in_channel| {
         config: None,
         model: NaiveBayes::new(),
     };
-    oak::run_event_loop(node, in_channel);
+    oak::run_event_loop(node, oak::io::Receiver::<grpc::Invocation>::new(in_channel));
 });
 
 oak::entrypoint!(grpc_oak_main => |_in_channel| {

--- a/examples/private_set_intersection/module/rust/tests/integration_test.rs
+++ b/examples/private_set_intersection/module/rust/tests/integration_test.rs
@@ -20,13 +20,13 @@ use private_set_intersection_grpc::proto::{
 };
 use std::{collections::HashSet, iter::FromIterator};
 
-const MODULE_CONFIG_NAME: &str = "private_set_intersection";
+const MODULE_WASM_FILE_NAME: &str = "private_set_intersection.wasm";
 
 #[tokio::test(core_threads = 2)]
 async fn test_set_intersection() {
     env_logger::init();
 
-    let runtime = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
+    let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::channel_and_interceptor().await;

--- a/examples/running_average/module/rust/tests/integration_test.rs
+++ b/examples/running_average/module/rust/tests/integration_test.rs
@@ -19,7 +19,7 @@ use running_average_grpc::proto::{
     running_average_client::RunningAverageClient, SubmitSampleRequest,
 };
 
-const MODULE_CONFIG_NAME: &str = "running_average";
+const MODULE_WASM_FILE_NAME: &str = "running_average.wasm";
 
 async fn submit_sample(client: &mut RunningAverageClient<tonic::transport::Channel>, value: u64) {
     let req = SubmitSampleRequest { value };
@@ -31,7 +31,7 @@ async fn submit_sample(client: &mut RunningAverageClient<tonic::transport::Chann
 async fn test_running_average() {
     env_logger::init();
 
-    let runtime = oak_tests::run_single_module_default(MODULE_CONFIG_NAME)
+    let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::channel_and_interceptor().await;

--- a/examples/translator/module/rust/src/lib.rs
+++ b/examples/translator/module/rust/src/lib.rs
@@ -26,7 +26,7 @@ use translator_common::proto::{
 oak::entrypoint!(oak_main => |in_channel| {
     oak::logger::init_default();
     let dispatcher = TranslatorDispatcher::new(Node);
-    oak::run_event_loop(dispatcher, in_channel);
+    oak::run_event_loop(dispatcher, oak::io::Receiver::<grpc::Invocation>::new(in_channel));
 });
 
 // The `grpc_oak_main` entrypoint is used when the Translator acts as a standalone Oak

--- a/examples/translator/module/rust/tests/integration_test.rs
+++ b/examples/translator/module/rust/tests/integration_test.rs
@@ -18,13 +18,13 @@ use assert_matches::assert_matches;
 use log::info;
 use translator_grpc::proto::{translator_client::TranslatorClient, TranslateRequest};
 
-const MODULE_CONFIG_NAME: &str = "translator";
+const MODULE_WASM_FILE_NAME: &str = "translator.wasm";
 
 #[tokio::test(core_threads = 2)]
 async fn test_translate() {
     env_logger::init();
 
-    let runtime = oak_tests::run_single_module(MODULE_CONFIG_NAME, "grpc_oak_main")
+    let runtime = oak_tests::run_single_module(MODULE_WASM_FILE_NAME, "grpc_oak_main")
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::channel_and_interceptor().await;

--- a/examples/trusted_information_retrieval/module_0/rust/tests/integration_test.rs
+++ b/examples/trusted_information_retrieval/module_0/rust/tests/integration_test.rs
@@ -22,7 +22,7 @@ use trusted_information_retrieval_client::proto::{
     GetPointOfInterestRequest, GetPointOfInterestResponse,
 };
 
-const MODULE_CONFIG_NAME: &str = "trusted_information_retrieval";
+const MODULE_WASM_FILE_NAME: &str = "trusted_information_retrieval.wasm";
 const ENTRYPOINT_NAME: &str = "oak_main";
 
 const CONFIG_FILE: &str = r#"
@@ -45,9 +45,12 @@ async fn test_trusted_information_retrieval_for_unavailable_database() {
     let config_map = ConfigMap {
         items: hashmap! {"config".to_string() => CONFIG_FILE.as_bytes().to_vec()},
     };
-    let runtime =
-        oak_tests::run_single_module_with_config(MODULE_CONFIG_NAME, ENTRYPOINT_NAME, config_map)
-            .expect("Unable to configure runtime with test wasm!");
+    let runtime = oak_tests::run_single_module_with_config(
+        MODULE_WASM_FILE_NAME,
+        ENTRYPOINT_NAME,
+        config_map,
+    )
+    .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
     let mut client = TrustedInformationRetrievalClient::with_interceptor(channel, interceptor);

--- a/examples/trusted_information_retrieval/module_1/rust/src/lib.rs
+++ b/examples/trusted_information_retrieval/module_1/rust/src/lib.rs
@@ -42,15 +42,15 @@ use proto::{
     GetDatabaseEntryResponse, ListDatabaseEntriesRequest,
 };
 
-const MODULE_CONFIG_NAME: &str = "database_proxy";
-const MODULE_ENTRYPOINT_NAME: &str = "database_proxy_main";
+const NODE_MODULE_NAME: &str = "database_proxy";
+const NODE_ENTRYPOINT_NAME: &str = "database_proxy_main";
 
 /// Expected number of database entries per request.
 const DATABASE_PAGE_SIZE: u32 = 5;
 
 pub fn get_database_entry(id: &str, database_url: &str) -> grpc::Result<DatabaseEntry> {
     let client = oak::grpc::client::Client::new_with_label(
-        &oak::node_config::wasm(MODULE_CONFIG_NAME, MODULE_ENTRYPOINT_NAME),
+        &oak::node_config::wasm(NODE_MODULE_NAME, NODE_ENTRYPOINT_NAME),
         &Label::public_untrusted(),
     )
     .map(DatabaseProxyClient)
@@ -151,7 +151,7 @@ impl DatabaseProxy for DatabaseProxyNode {
 oak::entrypoint!(database_proxy_main => |in_channel| {
     oak::logger::init_default();
     let dispatcher = DatabaseProxyDispatcher::new(DatabaseProxyNode::default());
-    oak::run_event_loop(dispatcher, in_channel);
+    oak::run_event_loop(dispatcher, oak::io::Receiver::<grpc::Invocation>::new(in_channel));
 });
 
 oak::entrypoint!(grpc_database_proxy_main => |_in_channel| {

--- a/examples/trusted_information_retrieval/module_1/rust/tests/integration_test.rs
+++ b/examples/trusted_information_retrieval/module_1/rust/tests/integration_test.rs
@@ -19,7 +19,7 @@ use trusted_information_retrieval_client::proto::{
     database_proxy_client::DatabaseProxyClient, GetDatabaseEntryRequest, GetDatabaseEntryResponse,
 };
 
-const MODULE_CONFIG_NAME: &str = "database_proxy";
+const MODULE_WASM_FILE_NAME: &str = "database_proxy.wasm";
 const MODULE_ENTRYPOINT_NAME: &str = "grpc_database_proxy_main";
 
 const DATABASE_URL: &str = "https://localhost:8888";
@@ -40,7 +40,7 @@ async fn get_database_entry(
 async fn test_database_proxy_for_unavailable_database() {
     env_logger::init();
 
-    let runtime = oak_tests::run_single_module(MODULE_CONFIG_NAME, MODULE_ENTRYPOINT_NAME)
+    let runtime = oak_tests::run_single_module(MODULE_WASM_FILE_NAME, MODULE_ENTRYPOINT_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::channel_and_interceptor().await;

--- a/oak/common/label.cc
+++ b/oak/common/label.cc
@@ -59,6 +59,13 @@ oak::label::Label WebAssemblyModuleLabel(const std::string& web_assembly_module_
   return label;
 }
 
+oak::label::Label TlsEndpointLabel(const std::string& authority) {
+  oak::label::Label label;
+  auto* confidentiality_tag = label.add_confidentiality_tags();
+  confidentiality_tag->mutable_tls_endpoint_tag()->set_authority(authority);
+  return label;
+}
+
 oak::label::Label PublicUntrustedLabel() {
   oak::label::Label label;
   return label;

--- a/oak/common/label.h
+++ b/oak/common/label.h
@@ -50,6 +50,9 @@ oak::label::Label AuthorizationBearerTokenLabel(const std::string& authorization
 // Creates a label having as principal the provided WebAssembly module SHA-256 hash.
 oak::label::Label WebAssemblyModuleLabel(const std::string& web_asesemblymodule_hash_sha_256);
 
+// Creates a label having as principal the provided TLS authority (host:port).
+oak::label::Label TlsEndpointLabel(const std::string& authority);
+
 // Creates a public untrusted label, which is the least confidential and least trusted label and
 // applies no confidentiality restrictions to the data contained in the request.
 oak::label::Label PublicUntrustedLabel();

--- a/oak/proto/application.proto
+++ b/oak/proto/application.proto
@@ -107,9 +107,6 @@ message GrpcClientConfiguration {
   // The URI component of a gRPC server endpoint. Must contain the "Host"
   // element. https://docs.rs/tonic/0.2.1/tonic/transport/struct.Uri.html
   string uri = 1;
-  // The endpoint address of the external gRPC service.
-  // `address` is represented as an "ip_address:tcp_port" string.
-  string address = 2;
 }
 
 // RoughtimeClientConfiguration describes the configuration of a Roughtime

--- a/oak/proto/label.proto
+++ b/oak/proto/label.proto
@@ -66,16 +66,7 @@ message WebAssemblyModuleTag {
 //
 // Applies to both the HTTP and gRPC client pseudo-nodes.
 message TlsEndpointTag {
-  // The Subject Alternative Name (SAN) of a certificate that a remote endpoint must be able to
-  // present in order to be allowed to receive data with this confidentiality tag.
-  //
-  // In general a certificate may have multiple SANs; an HTTP or gRPC client pseudo-node connected
-  // to a remote endpoint with multiple SANs is able to declassify data with a TlsEndpointTag
-  // referring to any of these SANs.
-  //
-  // The certificate is validated by the Oak Runtime using the set of Certificate Authorities (CA)
-  // that are available to it.
-  //
-  // See https://tools.ietf.org/html/rfc5280#section-4.2.1.6
-  string certificate_subject_alternative_name = 1;
+  // The TLS authority (host:port) of the remote endpoint, which is validated by the Oak Runtime
+  // using the set of Certificate Authorities (CA) that are available to it.
+  string authority = 1;
 }

--- a/oak/server/rust/oak_runtime/src/node/grpc/server/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/server/mod.rs
@@ -108,6 +108,7 @@ impl GrpcServerNode {
                 OakStatus::ErrInternal
             })?;
 
+        // TODO(#389): Automatically generate this code.
         let invocation_channel = if read_status[0] == ChannelReadStatus::ReadReady {
             runtime
                 .channel_read(startup_handle)

--- a/oak_abi/src/label/mod.rs
+++ b/oak_abi/src/label/mod.rs
@@ -92,3 +92,14 @@ pub fn web_assembly_module_tag(web_assembly_module_hash_sha_256: &[u8]) -> Tag {
         })),
     }
 }
+
+/// Creates a [`Tag`] having as principal the provided TLS authority.
+///
+/// See https://github.com/project-oak/oak/blob/main/oak/proto/label.proto
+pub fn tls_endpoint_tag(authority: &str) -> Tag {
+    Tag {
+        tag: Some(tag::Tag::TlsEndpointTag(TlsEndpointTag {
+            authority: authority.to_string(),
+        })),
+    }
+}

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
 name = "oak_tests"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "lazy_static",
  "log",

--- a/sdk/rust/oak/src/grpc/server.rs
+++ b/sdk/rust/oak/src/grpc/server.rs
@@ -16,27 +16,68 @@
 
 //! Functionality to help Oak Nodes create gRPC server pseudo-Nodes.
 
-use crate::{OakStatus, ReadHandle};
+use crate::{grpc::Invocation, io::Receiver, OakStatus};
+
+struct GrpcServerInit {
+    invocation_sender: crate::io::Sender<Invocation>,
+}
+
+// TODO(#389): Automatically generate this code.
+impl crate::io::Encodable for GrpcServerInit {
+    fn encode(&self) -> Result<crate::io::Message, crate::OakError> {
+        let bytes = vec![];
+        let handles = vec![self.invocation_sender.handle.handle];
+        Ok(crate::io::Message { bytes, handles })
+    }
+}
+
+// TODO(#389): Automatically generate this code.
+impl crate::io::Decodable for GrpcServerInit {
+    fn decode(message: &crate::io::Message) -> Result<Self, crate::OakError> {
+        if !message.bytes.is_empty() {
+            panic!(
+                "incorrect number of bytes received: {} (expected: 0)",
+                message.bytes.len()
+            );
+        }
+        if message.handles.len() != 1 {
+            panic!(
+                "incorrect number of handles received: {} (expected: 1)",
+                message.handles.len()
+            );
+        }
+        Ok(GrpcServerInit {
+            invocation_sender: crate::io::Sender::new(crate::WriteHandle {
+                handle: message.handles[0],
+            }),
+        })
+    }
+}
 
 /// Initializes a gRPC server pseudo-Node listening on the provided address.
 ///
-/// Returns a [`ReadHandle`] to read invocations from.
-///
-/// [`ReadHandle`]: crate::ReadHandle
-pub fn init(address: &str) -> std::result::Result<ReadHandle, OakStatus> {
-    // Create a channel and pass the read half to a new gRPC pseudo-Node.
-    let (write_handle, read_handle) = crate::channel_create().expect("Couldn't create a channel");
+/// Returns a [`Receiver`] to read gRPC [`Invocation`]s from.
+pub fn init(address: &str) -> Result<Receiver<Invocation>, OakStatus> {
+    // Create a channel and pass the read half to a new gRPC server pseudo-Node.
+    let (init_sender, init_receiver) = crate::io::channel_create::<GrpcServerInit>()
+        .expect("Couldn't create init channel to gRPC server pseudo-node");
     let config = crate::node_config::grpc_server(address);
-    crate::node_create(&config, read_handle)?;
-    crate::channel_close(read_handle.handle).expect("Couldn't close a channel");
+    crate::node_create(&config, init_receiver.handle)?;
+    init_receiver
+        .close()
+        .expect("Couldn't close init channel to gRPC server pseudo-node");
 
     // Create a separate channel for receiving invocations and pass it to a gRPC pseudo-Node.
-    let (invocation_write_handle, invocation_read_handle) =
-        crate::channel_create().expect("Couldn't create a channel");
-    crate::channel_write(write_handle, &[], &[invocation_write_handle.handle])
-        .expect("Couldn't write to a channel");
-    crate::channel_close(write_handle.handle).expect("Couldn't close a channel");
-    crate::channel_close(invocation_write_handle.handle).expect("Couldn't close a channel");
+    let (invocation_sender, invocation_receiver) =
+        crate::io::channel_create::<Invocation>().expect("Couldn't create gRPC invocation channel");
 
-    Ok(invocation_read_handle)
+    let grpc_server_init = GrpcServerInit { invocation_sender };
+    init_sender
+        .send(&grpc_server_init)
+        .expect("Could not send init message to gRPC server pseudo-node");
+    init_sender
+        .close()
+        .expect("Couldn't close init message channel to gRPC server pseudo-node");
+
+    Ok(invocation_receiver)
 }

--- a/sdk/rust/oak/src/io/receiver.rs
+++ b/sdk/rust/oak/src/io/receiver.rs
@@ -24,10 +24,21 @@ use serde::{Deserialize, Serialize};
 /// For use when the underlying [`Handle`] is known to be for a receive half.
 ///
 /// [`Handle`]: crate::Handle
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Receiver<T: Decodable> {
     pub handle: ReadHandle,
     phantom: std::marker::PhantomData<T>,
+}
+
+/// Manual implementation of [`std::fmt::Debug`] for any `T`.
+///
+/// The automatically derived implementation would only cover types `T` that are themselves
+/// `Display`, but we do not care about that bound, since there is never an actual element of type
+/// `T` to display.
+impl<T: Decodable> std::fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "Receiver({:?})", self.handle)
+    }
 }
 
 impl<T: Decodable> Receiver<T> {

--- a/sdk/rust/oak/src/node_config.rs
+++ b/sdk/rust/oak/src/node_config.rs
@@ -25,7 +25,6 @@ pub fn grpc_client(address: &str) -> NodeConfiguration {
     NodeConfiguration {
         name: "grpc_client".to_string(),
         config_type: Some(ConfigType::GrpcClientConfig(GrpcClientConfiguration {
-            address: address.to_string(),
             uri: address.to_string(),
         })),
     }

--- a/sdk/rust/oak_tests/Cargo.toml
+++ b/sdk/rust/oak_tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+anyhow = "*"
 byteorder = "*"
 lazy_static = "*"
 log = { version = "*", features = ["std"] }


### PR DESCRIPTION
Replace the certificate SAN name field in the label, with a field that
represents the authority (host:port) of the remote endpoint instead.

Make `run_event_loop` more type safe by passing in a `Reciever<T>` where
`T` is the same type of the `Node<T>` that actually handles the
messages.

Create an explicit `GrpcServerInit` message to pass to a gRPC server
pseudo-node, instead of manually passing handles to it in an
unstructured way.

Remove unused `address` field from `GrpcClientConfiguration` protobuf
message.

Split aggregator example in two nodes, so that the gRPC worker node may
be assigned a different label in the future, to reflect the fact that it
is handling non-public data.

Add explicit scheme to gRPC client URL in aggregator example (not sure
how / whether it worked previously, Tonic complains).

Make aggregator client submit a meaningful number of samples in order to
reach the aggregation threshold, instead of just one.

Ref #814

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
