### PR TITLE
Small clean-up of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ RUN curl --location "${bazel_url}" > bazel.deb \
 ARG emscripten_version=1.39.17
 ARG emscripten_node_version=12.9.1_64bit
 ARG emscripten_sha256=925dd5ca7dd783d0b367386e81847eaf680d54ae86017c4b5846dea951e17dc9
+
 ARG emscripten_dir=/usr/local/emsdk
 ARG emscripten_temp=/tmp/emscripten.zip
 RUN mkdir --parents ${emscripten_dir} \
@@ -98,6 +99,8 @@ ENV EM_CACHE "${emscripten_dir}/.emscripten_cache"
 ENV PATH "${emscripten_dir}:${emscripten_dir}/node/${emscripten_node_version}/bin:${PATH}"
 # We need to allow a non-root Docker container to write into the directory
 RUN chmod --recursive go+wx "${emscripten_dir}"
+# Emscripten brings Node with it, we need to allow non-root access to temp folders
+RUN mkdir "/.npm" && chmod a+rwx "/.npm"
 
 # Install Go.
 ARG golang_version=1.14.4

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -164,21 +164,21 @@ steps:
 
   - name: 'gcr.io/oak-ci/oak:latest'
     id: check_formatting
-    waitFor: ['git_check_diff', 'build_android_image']
+    waitFor: ['git_init', 'build_android_image']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/check_formatting']
 
   - name: 'gcr.io/oak-ci/oak:latest'
     id: check_cargo_deny
-    waitFor: ['check_formatting']
+    waitFor: ['check_formatting', 'git_check_diff']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/check_cargo_deny']
 
   - name: 'gcr.io/oak-ci/oak:latest'
     id: check_docs
-    waitFor: ['check_formatting']
+    waitFor: ['check_formatting', 'git_check_diff']
     timeout: 30m
     entrypoint: 'bash'
     args: ['./scripts/check_docs']

--- a/docs/INSTALL-OSX.md
+++ b/docs/INSTALL-OSX.md
@@ -39,11 +39,9 @@ RUN rustup target add wasm32-unknown-unknown
 # Install musl target for Rust (for statically linked binaries).
 RUN rustup target add x86_64-unknown-linux-musl
 
-# Install rustfmt, clippy, and the Rust Language Server.
+# Install rustfmt and clippy.
 RUN rustup component add \
   clippy \
-  rls \
-  rust-analysis \
   rust-src \
   rustfmt
 ```

--- a/oak/module/placeholders.h
+++ b/oak/module/placeholders.h
@@ -36,28 +36,12 @@
 
 extern "C" {
 
-PLACEHOLDER(int, __syscall5, int, int)
-PLACEHOLDER(int, __syscall192, int, int)
-PLACEHOLDER(int, __syscall194, int, int)
-
 PLACEHOLDER(int, fstat, int, struct stat*)
 PLACEHOLDER(ssize_t, lgetxattr, const char*, const char*, void*, size_t)
 PLACEHOLDER(ssize_t, listxattr, const char*, char*, size_t)
 
 PLACEHOLDER(void*, dlopen, const char*, int)
 PLACEHOLDER(void*, dlsym, void*, const char*)
-PLACEHOLDER(long, sysconf, int)
-
-PLACEHOLDER(int, clock_gettime, clockid_t, struct timespec*)
-PLACEHOLDER(int, nanosleep, const struct timespec*, struct timespec*)
-
-PLACEHOLDER(int, pthread_cond_destroy, pthread_cond_t*)
-PLACEHOLDER(int, pthread_cond_init, pthread_cond_t*, const pthread_condattr_t*)
-PLACEHOLDER(int, pthread_create, pthread_t*, const pthread_attr_t*, void* (*)(void*), void*)
-PLACEHOLDER(int, pthread_equal, pthread_t, pthread_t)
-PLACEHOLDER(void, pthread_exit, void*)
-PLACEHOLDER(int, pthread_join, pthread_t, void**)
-PLACEHOLDER(int, pthread_setcancelstate, int, int*)
 
 double round(double x) { return __builtin_round(x); }
 float roundf(float x) { return __builtin_roundf(x); }

--- a/toolchain/emcc.sh
+++ b/toolchain/emcc.sh
@@ -16,5 +16,7 @@ if [[ -n "${EM_CACHE}" ]]; then
   export EM_EXCLUSIVE_CACHE_ACCESS=1
 fi
 export EMCC_WASM_BACKEND=1
+export EMCC_FORCE_STDLIBS=libc-wasm,libc++,libc++abi,libmalloc,libc_rt_wasm
+export EMCC_ONLY_FORCED_STDLIBS=1
 
 external/emsdk/emsdk/upstream/emscripten/emcc "$@"

--- a/toolchain/emcc.sh
+++ b/toolchain/emcc.sh
@@ -16,7 +16,5 @@ if [[ -n "${EM_CACHE}" ]]; then
   export EM_EXCLUSIVE_CACHE_ACCESS=1
 fi
 export EMCC_WASM_BACKEND=1
-export EMCC_FORCE_STDLIBS=libc-wasm,libc++,libc++abi,libmalloc,libc_rt_wasm
-export EMCC_ONLY_FORCED_STDLIBS=1
 
 external/emsdk/emsdk/upstream/emscripten/emcc "$@"


### PR DESCRIPTION
I've tried to remove unused stuff and reuse existing binaries where possible.
This shaves about 1 GB from the image size, according to my local docker image ls and hopefully makes building the whole image faster.

I've also changed the order for GCB, to run the spellchecking first.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
