### PR TITLE
Specify the host triple as the target

### DIFF
--- a/examples/aggregator/scripts/run_backend
+++ b/examples/aggregator/scripts/run_backend
@@ -4,6 +4,6 @@ readonly GLOBAL_SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")/../../../scripts/"
 # shellcheck source=scripts/common
 source "${GLOBAL_SCRIPTS_DIR}/common"
 
-exec cargo run --release --manifest-path=examples/aggregator/backend/Cargo.toml -- \
+exec cargo run --release --target="${RUST_HOST_TARGET}" --manifest-path=examples/aggregator/backend/Cargo.toml -- \
   --grpc-tls-private-key="${GLOBAL_SCRIPTS_DIR}/../examples/certs/local/local.key" \
   --grpc-tls-certificate="${GLOBAL_SCRIPTS_DIR}/../examples/certs/local/local.pem"

--- a/scripts/build_example
+++ b/scripts/build_example
@@ -125,7 +125,7 @@ for client_variant in ${client_variants}
 do
   case "${client_variant}" in
     cargo)
-      cargo build --release "--manifest-path=./examples/${EXAMPLE}/client/rust/Cargo.toml"
+      cargo build --release --target="${RUST_HOST_TARGET}" "--manifest-path=./examples/${EXAMPLE}/client/rust/Cargo.toml"
       ;;
     bazel)
       bazel_build_flags+=(

--- a/scripts/run_example
+++ b/scripts/run_example
@@ -115,7 +115,7 @@ do
   case "${client_variant}" in
     cargo)
       rust_client_manifest="${SCRIPTS_DIR}/../examples/${EXAMPLE}/client/rust/Cargo.toml"
-          cargo run --release --manifest-path="${rust_client_manifest}" -- \
+          cargo run --release --target="${RUST_HOST_TARGET}" --manifest-path="${rust_client_manifest}" -- \
             --root-tls-certificate="${SCRIPTS_DIR}/../examples/certs/local/ca.pem" \
             "${CLIENT_ARGS[@]-}"
       ;;


### PR DESCRIPTION
The same way the host triple is explicitly specified as the target when
building the backend components, it should be specified using the
`--target` flag when building the clients, to avoid cache invalidation.

The CI-build takes 6-7 minutes less after this change. 

Ref #971 