### PR TITLE
Support "spread" operator via macro

### DIFF
--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -373,3 +373,68 @@ impl Running {
         }
     }
 }
+
+/// Similar to the `vec!` macro, but also allows a "spread" operator syntax (`...`) to inline and
+/// expand nested iterable values.
+///
+/// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax.
+#[macro_export]
+macro_rules! spread [
+    // Empty case.
+    () => (
+        vec![].iter()
+    );
+    // Spread value base case.
+    (...$vv:expr) => (
+        $vv.iter()
+    );
+    // Spread value recursive case.
+    (...$vv:expr, $($rest:tt)*) => (
+        $vv.iter().chain( spread![$($rest)*] )
+    );
+    // Single value base case.
+    ($v:expr) => (
+        vec![$v].iter()
+    );
+    // Single value recursive case.
+    ($v:expr, $($rest:tt)*) => (
+        vec![$v].iter().chain( spread![$($rest)*] )
+    );
+];
+
+#[test]
+fn test_spread() {
+    assert_eq!(vec![1], spread![1].cloned().collect::<Vec<i32>>());
+    assert_eq!(vec![1, 2], spread![1, 2].cloned().collect::<Vec<i32>>());
+    assert_eq!(
+        vec![1, 2, 3, 4],
+        spread![1, 2, 3, 4].cloned().collect::<Vec<i32>>()
+    );
+    assert_eq!(
+        vec![1, 2, 3, 4],
+        spread![...vec![1, 2], 3, 4].cloned().collect::<Vec<i32>>()
+    );
+    assert_eq!(
+        vec![1, 2, 3, 4],
+        spread![1, ...vec![2, 3], 4].cloned().collect::<Vec<i32>>()
+    );
+    assert_eq!(
+        vec![1, 2, 3, 4],
+        spread![1, 2, ...vec![3, 4]].cloned().collect::<Vec<i32>>()
+    );
+    assert_eq!(
+        vec![1, 2, 3, 4],
+        spread![...vec![1, 2], ...vec![3, 4]]
+            .cloned()
+            .collect::<Vec<i32>>()
+    );
+    assert_eq!(
+        vec![1, 2, 3, 4],
+        spread![...vec![1, 2, 3, 4]].cloned().collect::<Vec<i32>>()
+    );
+
+    assert_eq!(
+        vec!["foo", "bar"],
+        spread!["foo", "bar"].cloned().collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
This allows removing a layer of nesting in various places where we used
to use `flatten` instead.

A common case is for lists of flags, which sometimes contain other lists
of flags, which need to be expanded in line.

The implementation is not very efficient and has some corner cases (e.g.
still requires calls to `to_string` to make things work sometimes).

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
