### PR TITLE
Generate bash completions in runner

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -4,6 +4,7 @@
 - [Meta-Advice](#meta-advice)
 - [Docker vs. Native](#docker-vs-native)
 - [Prerequisites](#prerequisites)
+- [Runner](#runner)
 - [Run Example Application](#run-example-application)
   - [Build Application](#build-application)
   - [Build Runtime Server](#build-runtime-server)
@@ -111,6 +112,21 @@ A full development environment for the project also includes various extra
 tools, for example for linting and synchronizing documentation. As ever, the
 [`Dockerfile`](/Dockerfile) holds the details, but the scripts under
 [`scripts/`](/scripts) also indicate what's needed for different steps.
+
+## Runner
+
+`runner` is a utility binary to perform a number of common tasks within the Oak
+repository. It can be run by invoking `./scripts/runner` from the root of the
+repository, and it has a number of flags and sub-commands available, which
+should be self-explanatory.
+
+For convenience, the following commands install a `runner` alias and bash
+autocompletion:
+
+```bash
+alias runner=./scripts/runner
+source <(runner completion)
+```
 
 ## Run Example Application
 

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -809,6 +809,7 @@ version = "0.1.0"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "clap",
  "colored",
  "futures",
  "maplit",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 async-recursion = "*"
 async-trait = "*"
+clap = "*"
 colored = "*"
 futures = "*"
 maplit = "*"

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -47,6 +47,8 @@ pub enum Command {
     RunTests,
     RunTestsTsan,
     RunCi,
+    #[structopt(about = "generate bash completion script to stdout")]
+    Completion,
 }
 
 #[derive(StructOpt, Clone)]

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -80,6 +80,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let opt = Opt::from_args();
 
+    if let Command::Completion = opt.cmd {
+        Opt::clap().gen_completions_to("runner", clap::Shell::Bash, &mut std::io::stdout());
+        std::process::exit(0);
+    };
+
     let watch = opt.watch;
 
     let run = async move || {
@@ -91,6 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Command::Format => format(),
             Command::CheckFormat => check_format(),
             Command::RunCi => run_ci(),
+            Command::Completion => panic!("should have been handled above"),
         };
         // TODO(#396): Add support for running individual commands via command line flags.
         run_step(&Context::root(&opt), steps).await


### PR DESCRIPTION
Can be installed with the following commands:

```bash
alias runner=./scripts/runner
source <(runner completion)
```