### PR TITLE
Remove cargo run from runner

### DIFF
--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -291,48 +291,63 @@ fn build_wasm_module(name: &str, target: &Target, example_name: &str) -> Step {
 
 fn build_server(opt: &BuildServer) -> Step {
     match opt.server_variant.as_str() {
-        "base" | "logless" => Step::Single {
-            name: format!("build server ({})", opt.server_variant),
-            command: Cmd::new_with_env(
-                "cargo",
-                spread![
-                    ...match &opt.server_rust_toolchain {
-                        // This overrides the toolchain used by `rustup` to invoke the actual
-                        // `cargo` binary.
-                        // See https://github.com/rust-lang/rustup#toolchain-override-shorthand
-                        Some(server_rust_toolchain) => vec![format!("+{}", server_rust_toolchain)],
-                        None => vec![],
-                    },
-                    "build".to_string(),
-                    // If building in coverage mode, use the default target from the host, and build
-                    // in debug mode.
-                    ...if opt.coverage {
-                        vec![]
-                    } else {
-                        vec![
-                            format!("--target={}", opt.server_rust_target.as_deref().unwrap_or(DEFAULT_SERVER_RUST_TARGET)),
-                            "--release".to_string(),
-                        ]
-                    },
-                    "--manifest-path=oak/server/rust/oak_loader/Cargo.toml".to_string(),
-                    ...if opt.server_variant == "logless" {
-                        vec!["--no-default-features".to_string()]
-                    } else {
-                        vec![]
-                    },
-                ],
-                &if opt.coverage {
-                    hashmap! {
-                        // Build the Runtime server in coverage mode, as per https://github.com/mozilla/grcov
-                        "CARGO_INCREMENTAL".to_string() => "0".to_string(),
-                        "RUSTDOCFLAGS".to_string() => "-Cpanic=abort".to_string(),
-                        // grcov instructions suggest also including `-Cpanic=abort` in RUSTFLAGS, but this causes our build.rs scripts to fail.
-                        "RUSTFLAGS".to_string() => "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic-abort_tests".to_string(),
-                    }
-                } else {
-                    hashmap! {}
+        "base" | "logless" => Step::Multiple {
+            name: "server".to_string(),
+            steps: vec![
+                Step::Single {
+                    name: "create bin folder".to_string(),
+                    command: Cmd::new(
+                        "mkdir",
+                        vec!["--parent".to_string(), "oak/server/bin".to_string()],
+                    ),
                 },
-            ),
+                Step::Single {
+                    name: format!("build server ({})", opt.server_variant),
+                    command: Cmd::new_with_env(
+                        "cargo",
+                        spread![
+                            ...match &opt.server_rust_toolchain {
+                                // This overrides the toolchain used by `rustup` to invoke the actual
+                                // `cargo` binary.
+                                // See https://github.com/rust-lang/rustup#toolchain-override-shorthand
+                                Some(server_rust_toolchain) => vec![format!("+{}", server_rust_toolchain)],
+                                None => vec![],
+                            },
+                            "build".to_string(),
+                            // If building in coverage mode, use the default target from the host, and build
+                            // in debug mode.
+                            ...if opt.coverage {
+                                vec![]
+                            } else {
+                                vec![
+                                    format!("--target={}", opt.server_rust_target.as_deref().unwrap_or(DEFAULT_SERVER_RUST_TARGET)),
+                                    "--release".to_string(),
+                                ]
+                            },
+                            "--manifest-path=oak/server/rust/oak_loader/Cargo.toml".to_string(),
+                            "--out-dir=oak/server/bin".to_string(),
+                            // `--out-dir` is unstable and requires `-Zunstable-options`.
+                            "-Zunstable-options".to_string(),
+                            ...if opt.server_variant == "logless" {
+                                vec!["--no-default-features".to_string()]
+                            } else {
+                                vec![]
+                            },
+                        ],
+                        &if opt.coverage {
+                            hashmap! {
+                                // Build the Runtime server in coverage mode, as per https://github.com/mozilla/grcov
+                                "CARGO_INCREMENTAL".to_string() => "0".to_string(),
+                                "RUSTDOCFLAGS".to_string() => "-Cpanic=abort".to_string(),
+                                // grcov instructions suggest also including `-Cpanic=abort` in RUSTFLAGS, but this causes our build.rs scripts to fail.
+                                "RUSTFLAGS".to_string() => "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic-abort_tests".to_string(),
+                            }
+                        } else {
+                            hashmap! {}
+                        },
+                    ),
+                },
+            ],
         },
         v => panic!("unknown server variant: {}", v),
     }
@@ -439,28 +454,8 @@ fn run_example_server(
     application_file: &str,
 ) -> Box<dyn Runnable> {
     Cmd::new_with_env(
-        "cargo",
+        "oak/server/bin/oak_loader",
         spread![
-            ...match &opt.server_rust_toolchain {
-                // This overrides the toolchain used by `rustup` to invoke the actual `cargo`
-                // binary.
-                // See https://github.com/rust-lang/rustup#toolchain-override-shorthand
-                Some(server_rust_toolchain) => vec![format!("+{}", server_rust_toolchain)],
-                None => vec![],
-            },
-            "run".to_string(),
-            // If building in coverage mode, use the default target from the host, and build in
-            // debug mode.
-            ...if opt.coverage {
-                vec![]
-            } else {
-                vec![
-                    format!("--target={}", opt.server_rust_target.as_deref().unwrap_or(DEFAULT_SERVER_RUST_TARGET)),
-                    "--release".to_string(),
-                ]
-            },
-            "--manifest-path=oak/server/rust/oak_loader/Cargo.toml".to_string(),
-            "--".to_string(),
             "--grpc-tls-private-key=./examples/certs/local/local.key".to_string(),
             "--grpc-tls-certificate=./examples/certs/local/local.pem".to_string(),
             // TODO(#396): Add `--oidc-client` support.

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -298,7 +298,7 @@ fn build_server(opt: &BuildServer) -> Step {
                     name: "create bin folder".to_string(),
                     command: Cmd::new(
                         "mkdir",
-                        vec!["--parent".to_string(), "oak/server/bin".to_string()],
+                        vec!["-p".to_string(), "oak/server/bin".to_string()],
                     ),
                 },
                 Step::Single {


### PR DESCRIPTION
This change:
- Removes `cargo run` from `runner`
- Copies `oak_loader` into `bin` and use it to run Oak server

Fixes https://github.com/project-oak/oak/issues/1252

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have checked that these tests are run by [Cloudbuild](/cloudbuild.yaml)
