### PR TITLE
Turn off PR comments from codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,10 +14,7 @@ parsers:
       method: no
       macro: no
 
-comment:
-  layout: "reach,diff,flags,tree"
-  behavior: default
-  require_changes: no
+comment: false
 
 ignore:
   - "examples/"    # Just track Rust->host compiled code


### PR DESCRIPTION
At the moment they're not helpful.  If we sort out the oddly-low
reported numbers from codecov (cf. #1187) we can always re-enable
later.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
