### PR TITLE
Clean up cargo-deny warnings

### DIFF
--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -1,0 +1,26 @@
+# Configuration used for dependency checking with cargo-deny.
+#
+# For further details on all configuration options see:
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+targets = [
+  { triple = "wasm32-unknown-unknown" },
+  { triple = "x86_64-unknown-linux-musl" },
+]
+
+# List of allowed licenses.
+# For more detailsinformation see http://go/thirdpartylicenses
+[licenses]
+allow = [
+  "Apache-2.0",
+  "MPL-2.0",
+  "ISC",
+  "MIT",
+  "OpenSSL",
+]
+copyleft = "deny"
+
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 3171872035 }]

--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -7,16 +7,42 @@ targets = [
   { triple = "x86_64-unknown-linux-musl" },
 ]
 
-# List of allowed licenses.
-# For more detailsinformation see http://go/thirdpartylicenses
-[licenses]
-allow = [
-  "Apache-2.0",
-  "MPL-2.0",
-  "ISC",
-  "MIT",
-  "OpenSSL",
+# Deny all advisories unless explicitly ignored.
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+  # TODO(#1267): Remove when mio no longer depends on net2.
+  "RUSTSEC-2020-0016",
+  # TODO(#1268): Remove when ring and prometheus no longer depends on spin.
+  "RUSTSEC-2019-0031",
 ]
+
+# Deny multiple versions unless explicitly skipped.
+[bans]
+multiple-versions = "deny"
+
+# TODO(#1270): Remove when no longer needed by tonic, jsonwebtoken and rustls.
+[[bans.skip]]
+name = "base64"
+version = "=0.11.0"
+
+# TODO(#1270): Remove when rusty-machine no longer depends on old version.
+[[bans.skip]]
+name = "rand"
+version = "=0.3.23"
+
+# TODO(#1270): Remove when rusty-machine no longer depends on old version.
+[[bans.skip]]
+name = "rand"
+version = "=0.4.6"
+
+# List of allowed licenses.
+# For more detailed information see http://go/thirdpartylicenses.
+[licenses]
+allow = ["Apache-2.0", "MPL-2.0", "ISC", "MIT", "OpenSSL"]
 copyleft = "deny"
 
 [[licenses.clarify]]

--- a/experimental/deny.toml
+++ b/experimental/deny.toml
@@ -2,19 +2,29 @@
 #
 # For further details on all configuration options see:
 # https://embarkstudios.github.io/cargo-deny/checks/cfg.html
-targets = [
-  { triple = "x86_64-unknown-linux-musl" },
+targets = [{ triple = "x86_64-unknown-linux-musl" }]
+
+# Deny all advisories unless explicitly ignored.
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+  # TODO(#1267): Remove when mio no longer depends on net2.
+  "RUSTSEC-2020-0016",
+  # TODO(#1268): Remove when ring and prometheus no longer depends on spin.
+  "RUSTSEC-2019-0031",
 ]
 
+# Deny multiple versions unless explicitly skipped.
+[bans]
+multiple-versions = "deny"
+
 # List of allowed licenses.
-# For more detailsinformation see http://go/thirdpartylicenses
+# For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = [
-  "Apache-2.0",
-  "ISC",
-  "MIT",
-  "OpenSSL",
-]
+allow = ["Apache-2.0", "ISC", "MIT", "OpenSSL"]
 copyleft = "deny"
 
 [[licenses.clarify]]

--- a/experimental/deny.toml
+++ b/experimental/deny.toml
@@ -1,0 +1,24 @@
+# Configuration used for dependency checking with cargo-deny.
+#
+# For further details on all configuration options see:
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+targets = [
+  { triple = "x86_64-unknown-linux-musl" },
+]
+
+# List of allowed licenses.
+# For more detailsinformation see http://go/thirdpartylicenses
+[licenses]
+allow = [
+  "Apache-2.0",
+  "ISC",
+  "MIT",
+  "OpenSSL",
+]
+copyleft = "deny"
+
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 3171872035 }]

--- a/oak/server/deny.toml
+++ b/oak/server/deny.toml
@@ -2,12 +2,32 @@
 #
 # For further details on all configuration options see:
 # https://embarkstudios.github.io/cargo-deny/checks/cfg.html
-targets = [
-  { triple = "x86_64-unknown-linux-musl" },
+targets = [{ triple = "x86_64-unknown-linux-musl" }]
+
+# Deny all advisories unless explicitly ignored.
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+  # TODO(#1267): Remove when mio no longer depends on net2.
+  "RUSTSEC-2020-0016",
+  # TODO(#1268): Remove when ring and prometheus no longer depends on spin.
+  "RUSTSEC-2019-0031",
 ]
 
+# Deny multiple versions unless explicitly skipped.
+[bans]
+multiple-versions = "deny"
+
+# TODO(#1270): Remove when no longer needed by tonic, jsonwebtoken and rustls.
+[[bans.skip]]
+name = "base64"
+version = "=0.11.0"
+
 # List of allowed licenses.
-# For more detailsinformation see http://go/thirdpartylicenses
+# For more detailed information see http://go/thirdpartylicenses.
 [licenses]
 allow = [
   "Apache-2.0",

--- a/oak/server/deny.toml
+++ b/oak/server/deny.toml
@@ -1,0 +1,26 @@
+# Configuration used for dependency checking with cargo-deny.
+#
+# For further details on all configuration options see:
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+targets = [
+  { triple = "x86_64-unknown-linux-musl" },
+]
+
+# List of allowed licenses.
+# For more detailsinformation see http://go/thirdpartylicenses
+[licenses]
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "MPL-2.0",
+  "ISC",
+  "MIT",
+  "OpenSSL",
+]
+copyleft = "deny"
+
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 3171872035 }]

--- a/oak_abi/deny.toml
+++ b/oak_abi/deny.toml
@@ -12,18 +12,6 @@ targets = [
 [licenses]
 allow = [
   "Apache-2.0",
-  "Apache-2.0 WITH LLVM-exception",
-  "BSD-2-Clause",
-  "CC0-1.0",
-  "MPL-2.0",
-  "ISC",
   "MIT",
-  "OpenSSL",
-  "Zlib",
 ]
-
-[[licenses.clarify]]
-name = "ring"
-version = "*"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 3171872035 }]
+copyleft = "deny"

--- a/oak_abi/deny.toml
+++ b/oak_abi/deny.toml
@@ -7,11 +7,19 @@ targets = [
   { triple = "x86_64-unknown-linux-musl" },
 ]
 
+# Deny all advisories unless explicitly ignored.
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+
+# Deny multiple versions unless explicitly skipped.
+[bans]
+multiple-versions = "deny"
+
 # List of allowed licenses.
-# For more detailsinformation see http://go/thirdpartylicenses
+# For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = [
-  "Apache-2.0",
-  "MIT",
-]
+allow = ["Apache-2.0", "MIT"]
 copyleft = "deny"

--- a/oak_utils/deny.toml
+++ b/oak_utils/deny.toml
@@ -2,15 +2,21 @@
 #
 # For further details on all configuration options see:
 # https://embarkstudios.github.io/cargo-deny/checks/cfg.html
-targets = [
-  { triple = "x86_64-unknown-linux-musl" },
-]
+targets = [{ triple = "x86_64-unknown-linux-musl" }]
+
+# Deny all advisories unless explicitly ignored.
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+
+# Deny multiple versions unless explicitly skipped.
+[bans]
+multiple-versions = "deny"
 
 # List of allowed licenses.
 # For more detailsinformation see http://go/thirdpartylicenses
 [licenses]
-allow = [
-  "Apache-2.0",
-  "MIT",
-]
+allow = ["Apache-2.0", "MIT"]
 copyleft = "deny"

--- a/oak_utils/deny.toml
+++ b/oak_utils/deny.toml
@@ -1,0 +1,16 @@
+# Configuration used for dependency checking with cargo-deny.
+#
+# For further details on all configuration options see:
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+targets = [
+  { triple = "x86_64-unknown-linux-musl" },
+]
+
+# List of allowed licenses.
+# For more detailsinformation see http://go/thirdpartylicenses
+[licenses]
+allow = [
+  "Apache-2.0",
+  "MIT",
+]
+copyleft = "deny"

--- a/runner/deny.toml
+++ b/runner/deny.toml
@@ -2,12 +2,47 @@
 #
 # For further details on all configuration options see:
 # https://embarkstudios.github.io/cargo-deny/checks/cfg.html
-targets = [
-  { triple = "x86_64-unknown-linux-musl" },
+targets = [{ triple = "x86_64-unknown-linux-musl" }]
+
+# Deny all advisories unless explicitly ignored.
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+  # TODO(#1267): Remove when mio no longer depends on net2.
+  "RUSTSEC-2020-0016",
+  # TODO(#1269): Remove when spinner no longer depends on term.
+  "RUSTSEC-2018-0015",
 ]
 
+# Deny multiple versions unless explicitly skipped.
+[bans]
+multiple-versions = "deny"
+
+# TODO(#1270): Remove when no longer needed by spinners.
+[[bans.skip]]
+name = "ansi_term"
+version = "=0.7.5"
+
+# TODO(#1270): Remove when no longer needed by spinners.
+[[bans.skip]]
+name = "quote"
+version = "=0.3.15"
+
+# TODO(#1270): Remove when no longer needed by spinners.
+[[bans.skip]]
+name = "syn"
+version = "=0.11.11"
+
+# TODO(#1270): Remove when no longer needed by spinners.
+[[bans.skip]]
+name = "unicode-xid"
+version = "=0.0.4"
+
 # List of allowed licenses.
-# For more detailsinformation see http://go/thirdpartylicenses
+# For more detailed information see http://go/thirdpartylicenses.
 [licenses]
 allow = [
   "Apache-2.0",

--- a/runner/deny.toml
+++ b/runner/deny.toml
@@ -1,0 +1,22 @@
+# Configuration used for dependency checking with cargo-deny.
+#
+# For further details on all configuration options see:
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+targets = [
+  { triple = "x86_64-unknown-linux-musl" },
+]
+
+# List of allowed licenses.
+# For more detailsinformation see http://go/thirdpartylicenses
+[licenses]
+allow = [
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "CC0-1.0",
+  # TODO(#1266): Check whether LGPL is OK.
+  "LGPL-3.0",
+  "MPL-2.0",
+  "ISC",
+  "MIT",
+]
+copyleft = "deny"

--- a/sdk/deny.toml
+++ b/sdk/deny.toml
@@ -7,17 +7,32 @@ targets = [
   { triple = "x86_64-unknown-linux-musl" },
 ]
 
-# List of allowed licenses.
-# For more detailsinformation see http://go/thirdpartylicenses
-[licenses]
-allow = [
-  "Apache-2.0",
-  "MPL-2.0",
-  "ISC",
-  "MIT",
-  "OpenSSL",
-  "Zlib",
+# Deny all advisories unless explicitly ignored.
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+  # TODO(#1267): Remove when mio no longer depends on net2.
+  "RUSTSEC-2020-0016",
+  # TODO(#1268): Remove when ring no longer depends on spin.
+  "RUSTSEC-2019-0031",
 ]
+
+# Deny multiple versions unless explicitly skipped.
+[bans]
+multiple-versions = "deny"
+
+# TODO(#1270): Remove when no longer needed by tonic and rustls.
+[[bans.skip]]
+name = "base64"
+version = "=0.11.0"
+
+# List of allowed licenses.
+# For more detailed information see http://go/thirdpartylicenses.
+[licenses]
+allow = ["Apache-2.0", "MPL-2.0", "ISC", "MIT", "OpenSSL", "Zlib"]
 copyleft = "deny"
 
 [[licenses.clarify]]

--- a/sdk/deny.toml
+++ b/sdk/deny.toml
@@ -1,0 +1,27 @@
+# Configuration used for dependency checking with cargo-deny.
+#
+# For further details on all configuration options see:
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+targets = [
+  { triple = "wasm32-unknown-unknown" },
+  { triple = "x86_64-unknown-linux-musl" },
+]
+
+# List of allowed licenses.
+# For more detailsinformation see http://go/thirdpartylicenses
+[licenses]
+allow = [
+  "Apache-2.0",
+  "MPL-2.0",
+  "ISC",
+  "MIT",
+  "OpenSSL",
+  "Zlib",
+]
+copyleft = "deny"
+
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 3171872035 }]


### PR DESCRIPTION
# Add a corresponding deny.toml for every cargo workspace
All workspaces shared a single global deny.toml which led to many unnecessary warnings. This change also removes the global deny.toml file to ensure cargo deny does not automatically fall back to it when new workspaces are added.

# Convert cargo-deny warnings to errors
Warnings raised by cargo-deny during CI was also being ignored. This change converts warnings realted to advisories and duplicate crate versions to errors to ensure these would block CI in future.

It also contains explicit exclusions to allow CI to still pass for the current state with TODOs to remove these in future when these exceptions are no longer required.

Fixes #933, as individual issues have been created to remove explicit exclusions when feasible.