### PR TITLE
Implement introspection events 

### DIFF
--- a/oak/server/rust/oak_runtime/src/runtime/channel.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/channel.rs
@@ -47,7 +47,7 @@ type WaitingThreads = Mutex<HashMap<ThreadId, Weak<Thread>>>;
 /// is included in the `reader_count` or `writer_count`.
 pub struct Channel {
     // An internal identifier for this channel. Purely for disambiguation in debugging output.
-    id: ChannelId,
+    pub id: ChannelId,
 
     pub messages: RwLock<Messages>,
 
@@ -85,6 +85,11 @@ impl std::fmt::Debug for Channel {
 
 /// A reference to one half of a [`Channel`].
 pub struct ChannelHalf {
+    // Make the associated channel public for introspection
+    #[cfg(feature = "oak_debug")]
+    pub channel: Arc<Channel>,
+    // Ensure the associated channel is private
+    #[cfg(not(feature = "oak_debug"))]
     channel: Arc<Channel>,
     pub direction: ChannelHalfDirection,
 }

--- a/oak/server/rust/oak_runtime/src/runtime/channel.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/channel.rs
@@ -47,7 +47,7 @@ type WaitingThreads = Mutex<HashMap<ThreadId, Weak<Thread>>>;
 /// is included in the `reader_count` or `writer_count`.
 pub struct Channel {
     // An internal identifier for this channel. Purely for disambiguation in debugging output.
-    pub id: ChannelId,
+    id: ChannelId,
 
     pub messages: RwLock<Messages>,
 
@@ -85,11 +85,6 @@ impl std::fmt::Debug for Channel {
 
 /// A reference to one half of a [`Channel`].
 pub struct ChannelHalf {
-    // Make the associated channel public for introspection
-    #[cfg(feature = "oak_debug")]
-    pub channel: Arc<Channel>,
-    // Ensure the associated channel is private
-    #[cfg(not(feature = "oak_debug"))]
     channel: Arc<Channel>,
     pub direction: ChannelHalfDirection,
 }
@@ -103,6 +98,12 @@ impl ChannelHalf {
             ChannelHalfDirection::Read => channel.inc_reader_count(),
         };
         ChannelHalf { channel, direction }
+    }
+
+    /// Get the ID of the underlying channel.  For debugging/introspection
+    /// purposes.
+    pub fn get_id(&self) -> u64 {
+        self.channel.id
     }
 
     /// Get read-only access to the channel's messages.  For debugging/introspection

--- a/oak/server/rust/oak_runtime/src/runtime/channel.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/channel.rs
@@ -102,7 +102,7 @@ impl ChannelHalf {
 
     /// Get the ID of the underlying channel.  For debugging/introspection
     /// purposes.
-    pub fn get_id(&self) -> u64 {
+    pub fn get_channel_id(&self) -> u64 {
         self.channel.id
     }
 

--- a/oak/server/rust/oak_runtime/src/runtime/introspection_events.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/introspection_events.rs
@@ -16,16 +16,11 @@
 
 use crate::{
     proto::oak::introspection_events::{event::EventDetails, Event},
-    runtime::{NodeId, Runtime},
+    runtime::Runtime,
 };
 use log::info;
 use prost_types::Timestamp;
 use std::time::{SystemTime, UNIX_EPOCH};
-
-pub fn node_id_to_primitive(node_id: NodeId) -> u64 {
-    let NodeId(node_id_as_primitive) = node_id;
-    node_id_as_primitive
-}
 
 fn current_timestamp() -> Timestamp {
     let duration_since_unix_epoch = SystemTime::now()

--- a/oak/server/rust/oak_runtime/src/runtime/introspection_events.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/introspection_events.rs
@@ -16,11 +16,16 @@
 
 use crate::{
     proto::oak::introspection_events::{event::EventDetails, Event},
-    runtime::Runtime,
+    runtime::{NodeId, Runtime},
 };
 use log::info;
 use prost_types::Timestamp;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn node_id_to_primitive(node_id: NodeId) -> u64 {
+    let NodeId(node_id_as_primitive) = node_id;
+    node_id_as_primitive
+}
 
 fn current_timestamp() -> Timestamp {
     let duration_since_unix_epoch = SystemTime::now()

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     metrics::Metrics,
     node,
     proto::oak::introspection_events::{
-        event::EventDetails, ChannelCreated, HandleCreated, NodeCreated,
+        event::EventDetails, ChannelCreated, HandleCreated, NodeCreated, NodeDestroyed,
     },
     runtime::channel::{with_reader_channel, with_writer_channel, Channel},
     GrpcConfiguration,
@@ -924,6 +924,16 @@ impl Runtime {
             .remove(&node_id)
             .expect("remove_node_id: Node didn't exist!");
         self.update_nodes_count_metric();
+
+        {
+            // Fire NodeDestroyed introspection event
+            let NodeId(node_id_as_primitive) = node_id;
+            let event_details = NodeDestroyed {
+                node_id: node_id_as_primitive,
+            };
+
+            self.introspection_event(EventDetails::NodeDestroyed(event_details));
+        }
     }
 
     /// Add an [`NodeId`] [`NodeInfo`] pair to the [`Runtime`]. This method temporarily holds the

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     message::{Message, NodeMessage},
     metrics::Metrics,
     node,
-    proto::oak::introspection_events::{event::EventDetails, NodeCreated},
+    proto::oak::introspection_events::{event::EventDetails, ChannelCreated, NodeCreated},
     runtime::channel::{with_reader_channel, with_writer_channel, Channel},
     GrpcConfiguration,
 };
@@ -595,6 +595,18 @@ impl Runtime {
             write_handle,
             read_handle,
         );
+
+        {
+            // Fire ChannelCreated introspection event
+            let NodeId(node_id_as_primitive) = node_id;
+            let event_details = ChannelCreated {
+                node_id: node_id_as_primitive,
+                channel_id,
+            };
+
+            self.introspection_event(EventDetails::ChannelCreated(event_details));
+        }
+
         Ok((write_handle, read_handle))
     }
 

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     message::{Message, NodeMessage},
     metrics::Metrics,
     node,
+    proto::oak::introspection_events::{event::EventDetails, NodeCreated},
     runtime::channel::{with_reader_channel, with_writer_channel, Channel},
     GrpcConfiguration,
 };
@@ -986,6 +987,16 @@ impl Runtime {
         // Insert the now running instance to the list of running instances (by moving it), so that
         // `Node::stop` will be called on it eventually.
         self.add_node_stopper(new_node_id, node_stopper);
+
+        {
+            // Fire NodeCreated introspection event
+            let NodeId(node_id_as_primitive) = new_node_id;
+            let event_details = NodeCreated {
+                node_id: node_id_as_primitive,
+            };
+
+            self.introspection_event(EventDetails::NodeCreated(event_details));
+        }
 
         Ok(())
     }

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -52,7 +52,6 @@ pub mod graph;
 #[cfg(feature = "oak_debug")]
 mod introspect;
 mod introspection_events;
-use introspection_events::node_id_to_primitive;
 mod proxy;
 #[cfg(test)]
 pub mod tests;
@@ -276,7 +275,7 @@ impl Runtime {
                 );
 
                 let event_details = HandleCreated {
-                    node_id: node_id_to_primitive(node_id),
+                    node_id: node_id.0,
                     handle: candidate,
                     channel_id: half.get_id(),
                 };
@@ -295,7 +294,7 @@ impl Runtime {
         let node_info = node_infos.get_mut(&node_id).expect("Invalid node_id");
 
         let event_details = HandleDestroyed {
-            node_id: node_id_to_primitive(node_id),
+            node_id: node_id.0,
             handle,
             channel_id: node_info
                 .abi_handles
@@ -629,7 +628,7 @@ impl Runtime {
         );
 
         self.introspection_event(EventDetails::ChannelCreated(ChannelCreated {
-            node_id: node_id_to_primitive(node_id),
+            node_id: node_id.0,
             channel_id,
         }));
 
@@ -933,7 +932,7 @@ impl Runtime {
         self.update_nodes_count_metric();
 
         self.introspection_event(EventDetails::NodeDestroyed(NodeDestroyed {
-            node_id: node_id_to_primitive(node_id),
+            node_id: node_id.0,
         }))
     }
 
@@ -1031,7 +1030,7 @@ impl Runtime {
         self.add_node_stopper(new_node_id, node_stopper);
 
         self.introspection_event(EventDetails::NodeCreated(NodeCreated {
-            node_id: node_id_to_primitive(node_id),
+            node_id: node_id.0,
         }));
 
         Ok(())

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -52,6 +52,7 @@ pub mod graph;
 #[cfg(feature = "oak_debug")]
 mod introspect;
 mod introspection_events;
+use introspection_events::node_id_to_primitive;
 mod proxy;
 #[cfg(test)]
 pub mod tests;
@@ -281,9 +282,8 @@ impl Runtime {
 
                 {
                     // Fire HandleCreated introspection event
-                    let NodeId(node_id_as_primitive) = node_id;
                     let event_details = HandleCreated {
-                        node_id: node_id_as_primitive,
+                        node_id: node_id_to_primitive(node_id),
                         handle: candidate,
                         channel_id,
                     };
@@ -300,15 +300,14 @@ impl Runtime {
         let mut node_infos = self.node_infos.write().unwrap();
         let node_info = node_infos.get_mut(&node_id).expect("Invalid node_id");
 
-        let NodeId(node_id_as_primitive) = node_id;
-        let half = node_info
-            .abi_handles
-            .get(&handle)
-            .ok_or(OakStatus::ErrBadHandle)?;
         let event_details = HandleDestroyed {
-            node_id: node_id_as_primitive,
+            node_id: node_id_to_primitive(node_id),
             handle,
-            channel_id: half.get_id(),
+            channel_id: node_info
+                .abi_handles
+                .get(&handle)
+                .ok_or(OakStatus::ErrBadHandle)?
+                .get_id(),
         };
 
         let result = node_info
@@ -640,9 +639,8 @@ impl Runtime {
 
         {
             // Fire ChannelCreated introspection event
-            let NodeId(node_id_as_primitive) = node_id;
             let event_details = ChannelCreated {
-                node_id: node_id_as_primitive,
+                node_id: node_id_to_primitive(node_id),
                 channel_id,
             };
 
@@ -950,9 +948,8 @@ impl Runtime {
 
         {
             // Fire NodeDestroyed introspection event
-            let NodeId(node_id_as_primitive) = node_id;
             let event_details = NodeDestroyed {
-                node_id: node_id_as_primitive,
+                node_id: node_id_to_primitive(node_id),
             };
 
             self.introspection_event(EventDetails::NodeDestroyed(event_details));
@@ -1054,9 +1051,8 @@ impl Runtime {
 
         {
             // Fire NodeCreated introspection event
-            let NodeId(node_id_as_primitive) = new_node_id;
             let event_details = NodeCreated {
-                node_id: node_id_as_primitive,
+                node_id: node_id_to_primitive(node_id),
             };
 
             self.introspection_event(EventDetails::NodeCreated(event_details));

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -275,7 +275,7 @@ impl Runtime {
                 );
 
                 // Copy the channel_id for introspection before moving the half.
-                let channel_id = half.channel.id;
+                let channel_id = half.get_id();
 
                 node_info.abi_handles.insert(candidate, half);
 
@@ -305,11 +305,10 @@ impl Runtime {
             .abi_handles
             .get(&handle)
             .ok_or(OakStatus::ErrBadHandle)?;
-        let channel_id = half.channel.id;
         let event_details = HandleDestroyed {
             node_id: node_id_as_primitive,
             handle,
-            channel_id,
+            channel_id: half.get_id(),
         };
 
         let result = node_info

--- a/oak/server/rust/oak_runtime/src/runtime/mod.rs
+++ b/oak/server/rust/oak_runtime/src/runtime/mod.rs
@@ -277,7 +277,7 @@ impl Runtime {
                 let event_details = HandleCreated {
                     node_id: node_id.0,
                     handle: candidate,
-                    channel_id: half.get_id(),
+                    channel_id: half.get_channel_id(),
                 };
 
                 node_info.abi_handles.insert(candidate, half);
@@ -300,7 +300,7 @@ impl Runtime {
                 .abi_handles
                 .get(&handle)
                 .ok_or(OakStatus::ErrBadHandle)?
-                .get_id(),
+                .get_channel_id(),
         };
 
         let result = node_info
@@ -309,9 +309,8 @@ impl Runtime {
             .ok_or(OakStatus::ErrBadHandle)
             .map(|_half| ());
 
-        match result {
-            Ok(()) => self.introspection_event(EventDetails::HandleDestroyed(event_details)),
-            Err(_status) => (),
+        if result.is_ok() {
+            self.introspection_event(EventDetails::HandleDestroyed(event_details))
         };
 
         result


### PR DESCRIPTION
Implements `ChannelCreated`, `HandleCreated`, `HandleDestroyed`, `NodeCreated`, `NodeDestroyed`

Omits the `ChannelDestroyed` event for now, for reasons explained here: https://github.com/project-oak/oak/issues/913#issuecomment-661794936

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
