### PR TITLE
Run Rust TIR client with runner

### DIFF
--- a/examples/trusted_information_retrieval/example.toml
+++ b/examples/trusted_information_retrieval/example.toml
@@ -18,6 +18,10 @@ module_0 = { Cargo = { cargo_manifest = "examples/trusted_information_retrieval/
 module_1 = { Cargo = { cargo_manifest = "examples/trusted_information_retrieval/module_1/rust/Cargo.toml" } }
 
 [clients]
+rust = { Cargo = { cargo_manifest = "examples/trusted_information_retrieval/client/rust/Cargo.toml" }, additional_args = [
+  "--root-tls-certificate=examples/certs/local/ca.pem",
+  "--id=1",
+] }
 cpp = { Bazel = { bazel_target = "//examples/trusted_information_retrieval/client:client" }, additional_args = [
   "--id=1",
 ] }


### PR DESCRIPTION
This change adds a Rust TIR client in the `example.toml`.

Fixes https://github.com/project-oak/oak/issues/1285

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have checked that these tests are run by [Cloudbuild](/cloudbuild.yaml)
