### PR TITLE
Create a minimal Rust only example

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -89,6 +89,35 @@ steps:
     entrypoint: 'bash'
     args: ['./scripts/build_examples_android']
 
+  # Pull Minimal Docker image.
+  - name: 'gcr.io/cloud-builders/docker'
+    id: pull_minimal_image
+    waitFor: ['-']
+    timeout: 10m
+    args: ['pull', 'gcr.io/oak-ci/oak-minimal:latest']
+  # Build Docker image for Minimal setup.
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build_minimal_image
+    waitFor: ['pull_minimal_image']
+    timeout: 60m
+    args:
+      [
+        'build',
+        '--pull',
+        '--cache-from=gcr.io/oak-ci/oak-minimal:latest',
+        '--tag=gcr.io/oak-ci/oak-minimal:latest',
+        '--file=minimal.Dockerfile',
+        '.',
+      ]
+
+  # Run Minimal example.
+  - name: 'gcr.io/oak-ci/oak-minimal:latest'
+    id: run_example_minimal
+    waitFor: ['build_minimal_image']
+    timeout: 60m
+    entrypoint: 'bash'
+    args: ['./scripts/runner', 'run-examples', '--example-name=minimal']
+
 # Copy compiled enclave binary to Google Cloud Storage.
 # See:
 # - https://pantheon.corp.google.com/storage/browser/artifacts.oak-ci.appspot.com/test/?project=oak-ci

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -951,6 +951,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "env_logger",
+ "log",
+ "minimal_client",
+ "oak",
+ "oak_runtime",
+ "oak_tests",
+ "oak_utils",
+ "prost",
+ "tokio",
+]
+
+[[package]]
+name = "minimal_client"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "log",
+ "oak_abi",
+ "oak_utils",
+ "prost",
+ "structopt",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
 name = "mio"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,6 +25,8 @@ members = [
   "translator/grpc",
   "translator/common",
   "translator/module/rust",
+  "minimal/client/rust",
+  "minimal/module/rust",
 ]
 
 # Patch dependencies on oak crates so that they refer to the versions within this same repository.
@@ -50,6 +52,7 @@ running_average_grpc = { path = "running_average/grpc" }
 translator_common = { path = "translator/common" }
 translator_grpc = { path = "translator/grpc" }
 trusted_information_retrieval_client = { path = "trusted_information_retrieval/client/rust" }
+minimal_client = { path = "minimal/client/rust" }
 # Third party.
 expect = { path = "../third_party/expect" }
 roughenough = { path = "../third_party/roughenough" }

--- a/examples/minimal/client/rust/Cargo.toml
+++ b/examples/minimal/client/rust/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "minimal_client"
+version = "0.1.0"
+authors = ["Ionut-Victor Anghelcovici <iovi@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+name = "minimal_client"
+path = "src/lib.rs"
+
+[[bin]]
+name = "minimal_client_bin"
+path = "src/main.rs"
+
+[dependencies]
+env_logger = "*"
+log = "*"
+oak_abi = "=0.1.0"
+prost = "*"
+structopt = "*"
+tokio = { version = "*", features = ["fs", "macros", "sync", "stream"] }
+tonic = { version = "*", features = ["tls"] }
+
+[build-dependencies]
+oak_utils = "*"

--- a/examples/minimal/client/rust/build.rs
+++ b/examples/minimal/client/rust/build.rs
@@ -1,0 +1,29 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    generate_grpc_code(
+        "../../proto",
+        &["minimal.proto"],
+        CodegenOptions {
+            build_client: true,
+            ..Default::default()
+        },
+    )?;
+    Ok(())
+}

--- a/examples/minimal/client/rust/src/lib.rs
+++ b/examples/minimal/client/rust/src/lib.rs
@@ -1,0 +1,19 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub mod proto {
+    tonic::include_proto!("oak.examples.minimal");
+}

--- a/examples/minimal/client/rust/src/main.rs
+++ b/examples/minimal/client/rust/src/main.rs
@@ -1,0 +1,96 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! This is a minimal Rust client. It does a simple request, containing a string
+// to an Oak application and expects a response with a string in it.
+//
+
+use log::info;
+use minimal_client::proto::{minimal_client::MinimalClient, MinimalRequest};
+use oak_abi::label::Label;
+use prost::Message;
+use structopt::StructOpt;
+use tonic::{
+    metadata::MetadataValue,
+    transport::{Certificate, Channel, ClientTlsConfig},
+    Request,
+};
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "Minimal Client")]
+pub struct Opt {
+    #[structopt(
+        long,
+        help = "URI of the Oak application to connect to",
+        default_value = "https://localhost:8080"
+    )]
+    uri: String,
+    #[structopt(
+        long,
+        help = "PEM encoded X.509 TLS root certificate file used by gRPC client"
+    )]
+    root_tls_certificate: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    info!("Initialising and reading args");
+    env_logger::init();
+    let opt = Opt::from_args();
+
+    let uri = opt.uri.parse().expect("Error parsing URI");
+    let root_tls_certificate = tokio::fs::read(&opt.root_tls_certificate)
+        .await
+        .expect("Could not load certificate file");
+
+    info!("Connecting to Oak Application: {:?}", uri);
+    let tls_config =
+        ClientTlsConfig::new().ca_certificate(Certificate::from_pem(root_tls_certificate));
+    let channel = Channel::builder(uri)
+        .tls_config(tls_config)
+        .connect()
+        .await
+        .expect("Could not connect to Oak Application");
+
+    // TODO(#1097): Turn the following logic into a proper reusable client library.
+    info!("Generating public label");
+    let mut label = Vec::new();
+    Label::public_untrusted()
+        .encode(&mut label)
+        .expect("Error encoding label");
+
+    info!("Creating client");
+    let mut client = MinimalClient::with_interceptor(channel, move |mut request: Request<()>| {
+        request.metadata_mut().insert_bin(
+            oak_abi::OAK_LABEL_GRPC_METADATA_KEY,
+            MetadataValue::from_bytes(label.as_ref()),
+        );
+        Ok(request)
+    });
+
+    let request = Request::new(MinimalRequest {
+        request: String::from("Ferris"),
+    });
+    info!("Sending request: {:?}", request);
+
+    let response = client
+        .knock(request)
+        .await
+        .expect("Could not receive response");
+    info!("Received response: {:?}", response);
+
+    Ok(())
+}

--- a/examples/minimal/config/config.toml
+++ b/examples/minimal/config/config.toml
@@ -1,0 +1,4 @@
+name = "minimal"
+
+[modules]
+app = { path = "examples/minimal/bin/minimal.wasm" }

--- a/examples/minimal/example.toml
+++ b/examples/minimal/example.toml
@@ -1,0 +1,13 @@
+name = "minimal"
+
+[application]
+manifest = "examples/minimal/config/config.toml"
+out = "examples/minimal/bin/config.bin"
+
+[modules]
+app = { Cargo = { cargo_manifest = "examples/minimal/module/rust/Cargo.toml" } }
+
+[clients]
+rust = { Cargo = { cargo_manifest = "examples/minimal/client/rust/Cargo.toml" }, additional_args = [
+  "--root-tls-certificate=./examples/certs/local/ca.pem",
+] }

--- a/examples/minimal/module/rust/Cargo.toml
+++ b/examples/minimal/module/rust/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "minimal"
+version = "0.1.0"
+authors = ["Ionut-Victor Anghelcovici <iovi@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+log = "*"
+oak = "=0.1.0"
+prost = "*"
+
+[dev-dependencies]
+assert_matches = "*"
+env_logger = "*"
+log = "*"
+oak_runtime = "=0.1.0"
+oak_tests = "=0.1.0"
+tokio = { version = "*", features = ["macros", "rt-threaded", "stream"] }
+minimal_client = "=0.1.0"
+
+[build-dependencies]
+oak_utils = "*"

--- a/examples/minimal/module/rust/build.rs
+++ b/examples/minimal/module/rust/build.rs
@@ -1,0 +1,22 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+fn main() {
+    oak_utils::compile_protos(
+        &["../../proto/minimal.proto"],
+        &["../../proto", "../../../../third_party"],
+    );
+}

--- a/examples/minimal/module/rust/src/lib.rs
+++ b/examples/minimal/module/rust/src/lib.rs
@@ -1,0 +1,43 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/oak.examples.minimal.rs"));
+}
+
+use log::info;
+use oak::grpc;
+use proto::{Minimal, MinimalDispatcher, MinimalReply, MinimalRequest};
+
+oak::entrypoint!(oak_main => |_in_channel| {
+    oak::logger::init_default();
+    let node = Node {};
+    let dispatcher = MinimalDispatcher::new(node);
+    let grpc_channel =
+        oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
+    oak::run_event_loop(dispatcher, grpc_channel);
+});
+
+struct Node {}
+
+impl Minimal for Node {
+    fn knock(&mut self, req: MinimalRequest) -> grpc::Result<MinimalReply> {
+        info!("{} is knocking", req.request);
+        let mut res = MinimalReply::default();
+        res.reply = format!("Hello {}!", req.request);
+        Ok(res)
+    }
+}

--- a/examples/minimal/proto/minimal.proto
+++ b/examples/minimal/proto/minimal.proto
@@ -1,0 +1,31 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.examples.minimal;
+
+message MinimalRequest {
+  string request = 1;
+}
+
+message MinimalReply {
+  string reply = 1;
+}
+
+service Minimal {
+  rpc knock(MinimalRequest) returns (MinimalReply);
+}

--- a/minimal.Dockerfile
+++ b/minimal.Dockerfile
@@ -1,0 +1,63 @@
+# Use fixed snapshot of Debian to create a deterministic environment.
+# Snapshot tags can be found at https://hub.docker.com/r/debian/snapshot/tags
+ARG debian_snapshot=buster-20200327
+FROM debian/snapshot:${debian_snapshot}
+
+# Set the SHELL option -o pipefail before RUN with a pipe in.
+# See https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Uncomment the RUN below if the default snapshot package manager is slow.
+# Please not that this might cause issues and affects reproducible builds,
+# so only use for development.
+# RUN echo \
+#  deb [arch=amd64] http://ukdebian.mirror.anlx.net/debian buster main non-free contrib\
+# > /etc/apt/sources.list
+
+RUN apt-get --yes update \
+  && apt-get install --no-install-recommends --yes \
+  build-essential \
+  ca-certificates \
+  curl \
+  libssl-dev \
+  pkg-config \
+  unzip \
+  # Cleanup
+  && apt-get clean \
+  && rm --recursive --force /var/lib/apt/lists/*
+
+# Install Protobuf compiler.
+ARG protobuf_version=3.11.4
+ARG protobuf_sha256=6d0f18cd84b918c7b3edd0203e75569e0c8caecb1367bbbe409b45e28514f5be
+ARG protobuf_dir=/usr/local/protobuf
+ARG protobuf_temp=/tmp/protobuf.zip
+ENV PATH "${protobuf_dir}/bin:${PATH}"
+RUN curl --location https://github.com/protocolbuffers/protobuf/releases/download/v${protobuf_version}/protoc-${protobuf_version}-linux-x86_64.zip > ${protobuf_temp} \
+  && sha256sum --binary ${protobuf_temp} && echo "${protobuf_sha256} *${protobuf_temp}" | sha256sum --check \
+  && unzip ${protobuf_temp} -d ${protobuf_dir} \
+  && rm ${protobuf_temp} \
+  && protoc --version
+
+# Install rustup.
+ARG rustup_dir=/usr/local/cargo
+ENV RUSTUP_HOME ${rustup_dir}
+ENV CARGO_HOME ${rustup_dir}
+ENV PATH "${rustup_dir}/bin:${PATH}"
+RUN curl --location https://sh.rustup.rs > /tmp/rustup \
+  && sh /tmp/rustup -y --default-toolchain=none \
+  && chmod a+rwx ${rustup_dir} \
+  && rustup --version
+
+# Install Rust toolchain.
+# We currently need the nightly version in order to be able to compile some of the examples.
+# See https://rust-lang.github.io/rustup-components-history/ for how to pick a version that supports
+# the appropriate set of components.
+ARG rust_version=nightly-2020-06-10
+RUN rustup toolchain install ${rust_version} \
+  && rustup default ${rust_version}
+
+# Install WebAssembly target for Rust.
+RUN rustup target add wasm32-unknown-unknown
+
+# Install musl target for Rust (for statically linked binaries).
+RUN rustup target add x86_64-unknown-linux-musl


### PR DESCRIPTION
I wanted to have a very simple Rust only example (client & module code in Rust). I think hello_world is a bit more complex now, due to the multitude of clients/modules and I wanted something very simple instead.

This is also an attempt to create a "Quick Start" example. It appears that we have just a few things we need to install for this type of applications.

I don't like the client code, as it is too complicated now, but we have #1097 to track that.


# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
