### PR TITLE
Docker: chmod a+rwx "/.config" to remove npm warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,8 +99,9 @@ ENV EM_CACHE "${emscripten_dir}/.emscripten_cache"
 ENV PATH "${emscripten_dir}:${emscripten_dir}/node/${emscripten_node_version}/bin:${PATH}"
 # We need to allow a non-root Docker container to write into the directory
 RUN chmod --recursive go+wx "${emscripten_dir}"
-# Emscripten brings Node with it, we need to allow non-root access to temp folders
-RUN mkdir "/.npm" && chmod a+rwx "/.npm"
+# Emscripten brings Node with it, we need to allow non-root access to temp and
+# config folders
+RUN mkdir -p "/.npm" && chmod a+rwx "/.npm" & mkdir -p "/.config" && chmod a+rwx "/.config"
 
 # Install Go.
 ARG golang_version=1.14.4


### PR DESCRIPTION
NPM uses the `~/.config` folder to check for its intended version and to suggest updates. 

Given it access to it patches the warning highlighted by @benlaurie on slack: https://project-oak.slack.com/archives/CHE9E13C3/p1595603416335400

`chmod a+rwx` is what we used so far to patch permission issues in our docker setup, but if there's concerns regarding this specific folder (the entirety of `/.config` after all) I'm happy to suggest less aggressive solutions. 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
