### PR TITLE
Add time-of-day, and fail/pass status to each log line of `runner`

### DIFF
--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -142,6 +142,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +639,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +866,7 @@ version = "0.1.0"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "chrono",
  "clap",
  "colored",
  "futures",
@@ -1102,6 +1133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 async-recursion = "*"
 async-trait = "*"
+chrono = "*"
 clap = "*"
 colored = "*"
 futures = "*"

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -101,7 +101,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Command::Completion => panic!("should have been handled above"),
         };
         // TODO(#396): Add support for running individual commands via command line flags.
-        run_step(&Context::root(&opt), steps).await
+        let remaining_steps = steps.len();
+        run_step(&Context::root(&opt), steps, Status::new(remaining_steps)).await
     };
 
     if watch {


### PR DESCRIPTION
* Adds time-of-day (UTC) in the `%H:%M:%S` format to each log line
* Adds run status in the `E:<error-count>,O:<ok-count>,R:<remaining-count>`
  format to each log line

Example log line:
```
[11:43:59; E:0,O:6,R:3]:  ❯ ci ❯ examples ❯ aggregator ❯ run ❯ background server ❯ run clients ❯ cpp } ⊢ [OK] [3s]
```

This change can hopefully address some of the issues raised in #1283 and #1291.