### PR TITLE
Choose client variants in runner

### DIFF
--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build examples
         run: |
-          ./scripts/docker_run ./scripts/runner run-examples --run-clients=false --run-server=false
+          ./scripts/docker_run ./scripts/runner run-examples --client-variant=none --run-server=false
 
       # Generate an index of the hashes of the reproducible artifacts.
       - name: Generate Reproducibility Index

--- a/docs/INSTALL-OSX.md
+++ b/docs/INSTALL-OSX.md
@@ -66,14 +66,14 @@ The Oak Runtime and its dependencies are built with the following script:
 Build a particular example, say `hello_world`, with:
 
 ```bash
-./scripts/runner run-examples --run-server=false --run-clients=false --example-name=hello_world
+./scripts/runner run-examples --run-server=false --client-variant=none --example-name=hello_world
 ```
 
 Note that the Runtime server requires a particular Oak Application to run, and
 so relies on the previous section.
 
 ```bash
-./scripts/runner run-examples --run-clients=false --example-name=hello_world
+./scripts/runner run-examples --client-variant=none --example-name=hello_world
 ```
 
 In a separate terminal, run an example client that connects to the Oak Runtime

--- a/docs/development.md
+++ b/docs/development.md
@@ -170,7 +170,7 @@ to a WebAssembly module and then serializes it into a binary application
 configuration file to be loaded to the Oak Server:
 
 ```bash
-./scripts/runner run-examples --run-server=false --run-clients=false --example-name=hello_world
+./scripts/runner run-examples --run-server=false --client-variant=none --example-name=hello_world
 ```
 
 This binary application configuration file includes the compiled Wasm code for
@@ -201,7 +201,7 @@ Oak Application (which must already have been compiled into WebAssembly and
 built into a serialized configuration, as [described above](#build-application).
 
 ```bash
-./scripts/runner run-examples --run-clients=false --example-name=hello_world
+./scripts/runner run-examples --client-variant=none --example-name=hello_world
 ```
 
 In the end, you should end up with an Oak server running, end with log output

--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -37,7 +37,7 @@ a Sparse Vector - a dictionary with integer keys.
 Build and run the Aggregator with the following command:
 
 ```bash
-./scripts/runner run-examples --run-clients=false --example-name=aggregator
+./scripts/runner run-examples --client-variant=none --example-name=aggregator
 ```
 
 Aggregator code is in `common` and `module` directories (where `common` defines

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -18,7 +18,7 @@ as bearer tokens:
 Initially, the chat example needs to be built, and the server started:
 
 ```bash
-./scripts/runner --logs run-examples --run-clients=false --example-name=chat
+./scripts/runner --logs run-examples --client-variant=none --example-name=chat
 ```
 
 After this, one can run the first client, which connects to the Oak Application

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -69,8 +69,12 @@ pub struct RunExamples {
     pub build_server: BuildServer,
     #[structopt(long, help = "run server [default: true]")]
     pub run_server: Option<bool>,
-    #[structopt(long, help = "run clients [default: true]")]
-    pub run_clients: Option<bool>,
+    #[structopt(
+        long,
+        help = "client variant: [all, rust, cpp, go, nodejs, none] [default: all]",
+        default_value = "all"
+    )]
+    pub client_variant: String,
     #[structopt(long, help = "additional arguments to pass to clients")]
     pub client_additional_args: Vec<String>,
     #[structopt(long, help = "additional arguments to pass to server")]

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -61,6 +61,8 @@ const DEFAULT_EXAMPLE_BACKEND_RUST_TARGET: &str = "x86_64-apple-darwin";
 const DEFAULT_EXAMPLE_BACKEND_RUST_TARGET: &str = "x86_64-unknown-linux-gnu";
 
 static PROCESSES: Lazy<Mutex<Vec<i32>>> = Lazy::new(|| Mutex::new(Vec::new()));
+const ALL_CLIENTS: &str = "all";
+const NO_CLIENTS: &str = "none";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -448,7 +450,7 @@ fn run_ci() -> Step {
                 application_variant: "rust".to_string(),
                 example_name: None,
                 run_server: None,
-                client_variant: "all".to_string(),
+                client_variant: ALL_CLIENTS.to_string(),
                 client_additional_args: Vec::new(),
                 server_additional_args: Vec::new(),
                 build_docker: false,
@@ -463,7 +465,7 @@ fn run_ci() -> Step {
                 application_variant: "cpp".to_string(),
                 example_name: None,
                 run_server: None,
-                client_variant: "all".to_string(),
+                client_variant: ALL_CLIENTS.to_string(),
                 client_additional_args: Vec::new(),
                 server_additional_args: Vec::new(),
                 build_docker: false,
@@ -479,7 +481,7 @@ fn run_ci() -> Step {
                 application_variant: "rust".to_string(),
                 example_name: Some("hello_world".to_string()),
                 run_server: Some(false),
-                client_variant: "none".to_string(),
+                client_variant: NO_CLIENTS.to_string(),
                 client_additional_args: Vec::new(),
                 server_additional_args: Vec::new(),
                 build_docker: true,
@@ -602,7 +604,7 @@ fn run_example(opt: &RunExamples, example: &Example) -> Step {
             .clients
             .iter()
             .filter(|(name, _)| match opt.client_variant.as_str() {
-                "all" => true,
+                ALL_CLIENTS => true,
                 client => *name == client,
             })
             .map(|(name, client)| run_client(name, &client, opt.client_additional_args.clone()))
@@ -618,7 +620,7 @@ fn run_example(opt: &RunExamples, example: &Example) -> Step {
     // clients in the foreground.
     #[allow(clippy::collapsible_if)]
     let run_backend_server_clients: Step = if opt.run_server.unwrap_or(true) {
-        let run_server_clients = if opt.client_variant != "none" {
+        let run_server_clients = if opt.client_variant != NO_CLIENTS {
             Step::WithBackground {
                 name: "background server".to_string(),
                 background: run_server,
@@ -639,7 +641,7 @@ fn run_example(opt: &RunExamples, example: &Example) -> Step {
             None => run_server_clients,
         }
     } else {
-        if opt.client_variant != "none" {
+        if opt.client_variant != NO_CLIENTS {
             run_clients
         } else {
             Step::Multiple {


### PR DESCRIPTION
This change adds a `client_variant` parameter to `runner` (replaces `run_clients`).

Fixes https://github.com/project-oak/oak/issues/1294

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have checked that these tests are run by [Cloudbuild](/cloudbuild.yaml)
