### PR TITLE
cloudbuild failing rerun example

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,6 +7,11 @@ steps:
     waitFor: ['-']
     timeout: 10m
     args: ['pull', 'gcr.io/oak-ci/oak:latest']
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: list_working_dir_files
+    entrypoint: 'ls'
+    args: ['-la', '/workspace']
   # Build Docker image based on current Dockerfile, if necessary.
   - name: 'gcr.io/cloud-builders/docker'
     id: build_image
@@ -20,74 +25,78 @@ steps:
         '--tag=gcr.io/oak-ci/oak:latest',
         '.',
       ]
+
+  - name: 'gcr.io/oak-ci/oak:latest'
+    id: git_check_diff
+    waitFor: ['build_image']
+    timeout: 5m
+    entrypoint: 'bash'
+    # Intentionally mispell this script to cause a failure
+    args: ['./scripts/git_check_dif']
+
   # Run next build steps inside the newly created Docker image.
   # See: https://cloud.google.com/cloud-build/docs/create-custom-build-steps
   # Init .git repository used by check_generated
   # Workaround for https://github.com/GoogleCloudPlatform/cloud-builders/issues/236
-  - name: 'gcr.io/oak-ci/oak:latest'
-    id: git_init
-    entrypoint: 'bash'
-    waitFor: ['build_image']
-    timeout: 5m
-    args: ['./scripts/git_init']
-
-  - name: 'gcr.io/oak-ci/oak:latest'
-    id: cargo_crev
-    entrypoint: 'bash'
-    waitFor: ['git_init']
-    timeout: 5m
-    args: ['./scripts/run_cargo_crev']
-
-  - name: 'gcr.io/oak-ci/oak:latest'
-    id: runner_ci
-    waitFor: ['git_init']
-    timeout: 60m
-    entrypoint: 'bash'
-    args: ['./scripts/runner', '--commands', 'run-ci']
-
-  - name: 'gcr.io/oak-ci/oak:latest'
-    id: generate_root_ca_certs
-    waitFor: ['git_init']
-    timeout: 5m
-    entrypoint: 'bash'
-    args: ['./scripts/generate_root_ca_certs']
-
+  #- name: 'gcr.io/oak-ci/oak:latest'
+  #  id: git_init
+  #  entrypoint: 'bash'
+  #  waitFor: ['build_image']
+  #  timeout: 5m
+  #  args: ['./scripts/git_init']
+  #- name: 'gcr.io/oak-ci/oak:latest'
+  # id: cargo_crev
+  #  entrypoint: 'bash'
+  #  waitFor: ['git_init']
+  #  timeout: 5m
+  #  args: ['./scripts/run_cargo_crev']
+  # - name: 'gcr.io/oak-ci/oak:latest'
+  #   id: runner_ci
+  #   waitFor: ['git_init']
+  #   timeout: 60m
+  #   entrypoint: 'bash'
+  #   args: ['./scripts/runner', '--commands', 'run-ci']
+  #     - name: 'gcr.io/oak-ci/oak:latest'
+  #       id: generate_root_ca_certs
+  #       waitFor: ['git_init']
+  #      timeout: 5m
+  #       entrypoint: 'bash'
+  #       args: ['./scripts/generate_root_ca_certs']
   # Check whether any of the previous steps resulted in file diffs that were not checked in or
   # ignored by git.
-  - name: 'gcr.io/oak-ci/oak:latest'
-    id: git_check_diff
-    waitFor: ['git_init', 'runner_ci', 'generate_root_ca_certs']
-    timeout: 5m
-    entrypoint: 'bash'
-    args: ['./scripts/git_check_diff']
-
+  #- name: 'gcr.io/oak-ci/oak:latest'
+  #  id: git_check_diff
+  #  waitFor: ['git_init', 'generate_root_ca_certs']
+  #  timeout: 5m
+  #  entrypoint: 'bash'
+  #  args: ['./scripts/git_check_diff']
   # Pull Android Docker image.
-  - name: 'gcr.io/cloud-builders/docker'
-    id: pull_android_image
-    waitFor: ['-']
-    timeout: 10m
-    args: ['pull', 'gcr.io/oak-ci/oak-android:latest']
+  # - name: 'gcr.io/cloud-builders/docker'
+  #   id: pull_android_image
+  #   waitFor: ['-']
+  #   timeout: 10m
+  #   args: ['pull', 'gcr.io/oak-ci/oak-android:latest']
   # Build Docker image based for Android SDK.
-  - name: 'gcr.io/cloud-builders/docker'
-    id: build_android_image
-    waitFor: ['pull_android_image']
-    timeout: 60m
-    args:
-      [
-        'build',
-        '--pull',
-        '--cache-from=gcr.io/oak-ci/oak-android:latest',
-        '--tag=gcr.io/oak-ci/oak-android:latest',
-        '--file=android.Dockerfile',
-        '.',
-      ]
+  # - name: 'gcr.io/cloud-builders/docker'
+  #   id: build_android_image
+  #   waitFor: ['pull_android_image']
+  #   timeout: 60m
+  #   args:
+  #     [
+  #       'build',
+  #       '--pull',
+  #       '--cache-from=gcr.io/oak-ci/oak-android:latest',
+  #       '--tag=gcr.io/oak-ci/oak-android:latest',
+  #       '--file=android.Dockerfile',
+  #       '.',
+  #     ]
   # Build Android Hello-World application.
-  - name: 'gcr.io/oak-ci/oak-android:latest'
-    id: build_examples_android
-    waitFor: ['build_android_image']
-    timeout: 60m
-    entrypoint: 'bash'
-    args: ['./scripts/build_examples_android']
+  # - name: 'gcr.io/oak-ci/oak-android:latest'
+  #   id: build_examples_android
+  #   waitFor: ['build_android_image']
+  #   timeout: 60m
+  #   entrypoint: 'bash'
+  #   args: ['./scripts/build_examples_android']
 
 # Copy compiled enclave binary to Google Cloud Storage.
 # See:


### PR DESCRIPTION
First build, triggered by pushing a commit builds the docker image successfully, except for the intentional failure in the last step: https://pantheon.corp.google.com/cloud-build/builds/3fe2738a-26ec-4d3a-8c5d-14643db1c988;step=3?project=oak-ci

Second build, triggered by clicking re-run on GitHub fails to build the docker image, shows an empty working directory: https://pantheon.corp.google.com/cloud-build/builds/29c4c441-a472-4e13-99ff-534c0d2a3ef1;step=2?project=oak-ci

-----

Largely based of #1305, with further simplifications. The force push is unrelated to the GCP behvaiour. 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
