### PR TITLE
Use Docker BuildKit for the CI and docker_script

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     id: pull_image
     waitFor: ['-']
     timeout: 10m
-    args: ['pull', 'gcr.io/oak-ci/oak:latest']
+    args: ['pull', 'gcr.io/oak-ci/oak:latest_buildkit']
   # Build Docker image based on current Dockerfile, if necessary.
   - name: 'gcr.io/cloud-builders/docker'
     id: build_image
@@ -18,28 +18,28 @@ steps:
   # See: https://cloud.google.com/cloud-build/docs/create-custom-build-steps
   # Init .git repository used by check_generated
   # Workaround for https://github.com/GoogleCloudPlatform/cloud-builders/issues/236
-  - name: 'gcr.io/oak-ci/oak:latest'
+  - name: 'gcr.io/oak-ci/oak:latest_buildkit'
     id: git_init
     entrypoint: 'bash'
     waitFor: ['build_image']
     timeout: 5m
     args: ['./scripts/git_init']
 
-  - name: 'gcr.io/oak-ci/oak:latest'
+  - name: 'gcr.io/oak-ci/oak:latest_buildkit'
     id: cargo_crev
     entrypoint: 'bash'
     waitFor: ['git_init']
     timeout: 5m
     args: ['./scripts/run_cargo_crev']
 
-  - name: 'gcr.io/oak-ci/oak:latest'
+  - name: 'gcr.io/oak-ci/oak:latest_buildkit'
     id: runner_ci
     waitFor: ['git_init']
     timeout: 90m
     entrypoint: 'bash'
     args: ['./scripts/runner', '--commands', 'run-ci']
 
-  - name: 'gcr.io/oak-ci/oak:latest'
+  - name: 'gcr.io/oak-ci/oak:latest_buildkit'
     id: generate_root_ca_certs
     waitFor: ['git_init']
     timeout: 5m
@@ -48,7 +48,7 @@ steps:
 
   # Check whether any of the previous steps resulted in file diffs that were not checked in or
   # ignored by git.
-  - name: 'gcr.io/oak-ci/oak:latest'
+  - name: 'gcr.io/oak-ci/oak:latest_buildkit'
     id: git_check_diff
     waitFor: ['git_init', 'runner_ci', 'generate_root_ca_certs']
     timeout: 5m

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -12,10 +12,13 @@ source "$SCRIPTS_DIR/common"
 readonly DOCKER_UID="${UID:-0}"
 readonly DOCKER_GID="$(id -g)"
 readonly DOCKER_USER="${USER:-root}"
+# Use the Docker BuildKit backend: Useful for quicker builds, and multi-arch 
+# builds, as it expands the automatic variables available to the container.
+declare -x DOCKER_BUILDKIT=1
 
 docker build \
-  --cache-from="$DOCKER_IMAGE_NAME:latest" \
-  --tag="$DOCKER_IMAGE_NAME:latest" \
+  --cache-from="$DOCKER_IMAGE_NAME:latest_buildkit" \
+  --tag="$DOCKER_IMAGE_NAME:latest_buildkit" \
   --build-arg=USERNAME="$DOCKER_USER" \
   --build-arg=USER_UID="$DOCKER_UID" \
   --build-arg=USER_GID="$DOCKER_GID" \

--- a/scripts/docker_pull
+++ b/scripts/docker_pull
@@ -8,4 +8,4 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-docker pull "$DOCKER_IMAGE_NAME:latest"
+docker pull "$DOCKER_IMAGE_NAME:latest_buildkit"

--- a/scripts/docker_push
+++ b/scripts/docker_push
@@ -14,4 +14,4 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-docker push "$DOCKER_IMAGE_NAME:latest"
+docker push "$DOCKER_IMAGE_NAME:latest_buildkit"

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -45,7 +45,7 @@ fi
 
 if [[ "$1" == '--detach' ]]; then
   docker_run_flags+=('--detach')
-  docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_NAME:latest" "${@:2}"
+  docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_NAME:latest_buildkit" "${@:2}"
 else
-  docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_NAME:latest" "$@"
+  docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_NAME:latest_buildkit" "$@"
 fi


### PR DESCRIPTION
Docker BuildKit has a number of advanages over the tradiditonal
Docker back end - it's potentially quicker as it can make use of
parallel jobs when multi-stage Dockerfiles are used, and it also
enables the use of automatically set target/host ARGs, such as
TARGETARCH. This is especially useful when working with multiple
target architectures.

(This PR is primarily created to check the functionality of integration with GCP)

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
