### PR TITLE
Update docs on Wasm cache

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -250,6 +250,26 @@ translator = { path = "examples/hello_world/bin/translator.wasm" }
 All these steps are implemented as a part of the
 `./scripts/runner run-examples --example-name=hello_world` script.
 
+Oak Config Serializer also allows to download Wasm modules from
+[Google Cloud Storage](https://cloud.google.com/storage). In order to do this,
+the application configuration file should include `external` as a module
+location:
+
+```toml
+name = "hello_world"
+
+[modules]
+app = { external = { url = "https://storage.googleapis.com/oak-modules/hello_world/57ba0bcebf2c01389d0413736b0a3bb261312bcf0d6e87181359e402df751d50", sha256 = "57ba0bcebf2c01389d0413736b0a3bb261312bcf0d6e87181359e402df751d50" } }
+translator = { path = "examples/hello_world/bin/translator.wasm" }
+```
+
+It is also possible to save compiled Wasm modules to Google Cloud Storage using
+the following script:
+
+```bash
+./scripts/push_example -e hello_world
+```
+
 ### Starting the Oak Application
 
 The Oak Application is then started using the Oak Loader:

--- a/examples/aggregator/config.toml
+++ b/examples/aggregator/config.toml
@@ -1,4 +1,4 @@
 name = "aggregator"
 
 [modules]
-app = { path = "examples/aggregator/bin/aggregator.wasm" }
+app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/f2c6e041a2b1771800fa5657d62885ac9f2334cecc3d839b047dc6d16ec82e1c", sha256 = "f2c6e041a2b1771800fa5657d62885ac9f2334cecc3d839b047dc6d16ec82e1c" } }


### PR DESCRIPTION
This change:
- Makes `aggregator` example download Wasm module form cloud
- Updates docs

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have updated [documentation](/docs/) accordingly.
