### PR TITLE
Use IPv6 in oak_loader

### DIFF
--- a/oak/server/rust/oak_runtime/src/introspect.rs
+++ b/oak/server/rust/oak_runtime/src/introspect.rs
@@ -146,7 +146,7 @@ async fn make_server(
     termination_notificiation_receiver: tokio::sync::oneshot::Receiver<()>,
 ) {
     // Initialize SocketAddr to listen on.
-    let addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], port));
+    let addr = SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, port));
     info!("starting introspection server on {:?}", addr);
 
     // Initialize MakeService to handle each connection.

--- a/oak/server/rust/oak_runtime/src/introspect.rs
+++ b/oak/server/rust/oak_runtime/src/introspect.rs
@@ -146,7 +146,7 @@ async fn make_server(
     termination_notificiation_receiver: tokio::sync::oneshot::Receiver<()>,
 ) {
     // Initialize SocketAddr to listen on.
-    let addr = SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, port));
+    let addr = SocketAddr::from((std::net::Ipv6Addr::UNSPECIFIED, port));
     info!("starting introspection server on {:?}", addr);
 
     // Initialize MakeService to handle each connection.

--- a/oak/server/rust/oak_runtime/src/introspect.rs
+++ b/oak/server/rust/oak_runtime/src/introspect.rs
@@ -145,11 +145,11 @@ async fn make_server(
     runtime: Arc<Runtime>,
     termination_notificiation_receiver: tokio::sync::oneshot::Receiver<()>,
 ) {
-    // Construct our SocketAddr to listen on...
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    // Initialize SocketAddr to listen on.
+    let addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], port));
     info!("starting introspection server on {:?}", addr);
 
-    // And a MakeService to handle each connection...
+    // Initialize MakeService to handle each connection.
     let make_service = make_service_fn(move |_| {
         // The `Arc<Runtime>` is moved into this closure, but needs to be cloned
         // because this closure is called for every connection.
@@ -163,14 +163,14 @@ async fn make_server(
         }
     });
 
-    // Then bind and serve...
+    // Bind an address and serve incoming connections.
     let server = Server::bind(&addr).serve(make_service);
     let graceful = server.with_graceful_shutdown(async {
         // Treat notification failure the same as a notification.
         let _ = termination_notificiation_receiver.await;
     });
 
-    // And run until asked to terminate...
+    // Run until asked to terminate.
     let result = graceful.await;
     info!("introspection server terminated with {:?}", result);
 }

--- a/oak/server/rust/oak_runtime/src/introspect.rs
+++ b/oak/server/rust/oak_runtime/src/introspect.rs
@@ -151,8 +151,8 @@ async fn make_server(
 
     // Initialize MakeService to handle each connection.
     let make_service = make_service_fn(move |_| {
-        // The `Arc<Runtime>` is moved into this closure, but needs to be cloned
-        // because this closure is called for every connection.
+        // The `Arc<Runtime>` is moved into this closure, but it needs to be
+        // cloned because this closure is called for every connection.
         let runtime = runtime.clone();
 
         async move {

--- a/oak/server/rust/oak_runtime/src/metrics/server.rs
+++ b/oak/server/rust/oak_runtime/src/metrics/server.rs
@@ -79,7 +79,7 @@ async fn make_server(
     runtime: Arc<Runtime>,
     termination_notificiation_receiver: tokio::sync::oneshot::Receiver<()>,
 ) {
-    let addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], port));
+    let addr = SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, port));
 
     // A `Service` is needed for every connection, so this
     // creates one from the `serve_metrics` function.

--- a/oak/server/rust/oak_runtime/src/metrics/server.rs
+++ b/oak/server/rust/oak_runtime/src/metrics/server.rs
@@ -79,7 +79,7 @@ async fn make_server(
     runtime: Arc<Runtime>,
     termination_notificiation_receiver: tokio::sync::oneshot::Receiver<()>,
 ) {
-    let addr = SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, port));
+    let addr = SocketAddr::from((std::net::Ipv6Addr::UNSPECIFIED, port));
 
     // A `Service` is needed for every connection, so this
     // creates one from the `serve_metrics` function.

--- a/oak/server/rust/oak_runtime/src/metrics/server.rs
+++ b/oak/server/rust/oak_runtime/src/metrics/server.rs
@@ -79,7 +79,7 @@ async fn make_server(
     runtime: Arc<Runtime>,
     termination_notificiation_receiver: tokio::sync::oneshot::Receiver<()>,
 ) {
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], port));
 
     // A `Service` is needed for every connection, so this
     // creates one from the `serve_metrics` function.


### PR DESCRIPTION
This change updates IP addresses used by `oak_loader` and makes them IPv6.

Fixes https://github.com/project-oak/oak/issues/1314

# Checklist
- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
