### PR TITLE
Improve dev container support in VS code 

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,9 +1,12 @@
 // See https://code.visualstudio.com/docs/remote/containers for details.
 {
-  "dockerFile": "Dockerfile",
+  "image": "gcr.io/oak-ci/oak:latest",
   "extensions": [
     "bazelbuild.vscode-bazel",
-    "xaver.clang-format",
-    "rust-lang.rust"
+    "bodil.prettier-toml",
+    "bungcip.better-toml",
+    "esbenp.prettier-vscode",
+    "matklad.rust-analyzer",
+    "xaver.clang-format"
   ]
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,16 +10,10 @@ steps:
   # Build Docker image based on current Dockerfile, if necessary.
   - name: 'gcr.io/cloud-builders/docker'
     id: build_image
+    entrypoint: 'bash'
     waitFor: ['pull_image']
     timeout: 20m
-    args:
-      [
-        'build',
-        '--pull',
-        '--cache-from=gcr.io/oak-ci/oak:latest',
-        '--tag=gcr.io/oak-ci/oak:latest',
-        '.',
-      ]
+    args: ['./scripts/docker_build']
   # Run next build steps inside the newly created Docker image.
   # See: https://cloud.google.com/cloud-build/docs/create-custom-build-steps
   # Init .git repository used by check_generated

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,6 +40,39 @@ The remainder of this document explores what's going on under the covers here,
 allowing individual stages to be built and run independently, and allowing
 builds that don't have to rely on a Docker environment.
 
+## VS Code Dev Container
+
+The simplest way to get up and running with a development environment that
+contains all the required tools is to use
+[VS Code](https://code.visualstudio.com/) with the
+[Remote-Containers](https://code.visualstudio.com/docs/remote/containers)
+extension. After this is installed, and VS Code is running and pointing to the
+root of the Oak repository, from a separate terminal build the Docker image, if
+you haven't already:
+
+```bash
+./scripts/docker_pull
+./scripts/docker_build
+```
+
+Then from VS Code click on the Remote-Containers button in the bottom left
+corner of the status bar:
+
+![Remote-Containers status bar](https://code.visualstudio.com/assets/docs/remote/common/remote-dev-status-bar.png)
+
+and then select "Remote-Containers: Reopen in Container".
+
+This should attach VS Code to an instance of the Docker container with all the
+dev tools installed, and configured with most linters and Rust tools.
+
+The Rust-Analyzer extension may prompt you to download the rust-analyzer server,
+in which case allow that by clicking on "Download now" in the notification.
+
+To test that things work correctly, open a Rust file, start typing `std::`
+somewhere, and autocomplete results should start showing up. Note that it may
+take a while for the `rust-analyzer` extension to go through all the local code
+and build its index.
+
 ## Meta-Advice
 
 For any open-source project, the best way of figuring out what prerequisites and

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+readonly SCRIPTS_DIR="$(dirname "$0")"
+# shellcheck source=scripts/common
+source "$SCRIPTS_DIR/common"
+
+# The default user for a Docker container has uid 0 (root). To avoid creating
+# root-owned files in the build directory we tell Docker to use the current user
+# ID, if known.
+# See
+# https://github.com/googleapis/google-cloud-cpp/blob/a186208b79d900b4ec71c6f9df3acf7638f01dc6/ci/kokoro/docker/build.sh#L147-L152
+readonly DOCKER_UID="${UID:-0}"
+readonly DOCKER_GID="$(id -g)"
+readonly DOCKER_USER="${USER:-root}"
+
+docker build \
+  --cache-from="$DOCKER_IMAGE_NAME:latest" \
+  --tag="$DOCKER_IMAGE_NAME:latest" \
+  --build-arg=USERNAME="$DOCKER_USER" \
+  --build-arg=USER_UID="$DOCKER_UID" \
+  --build-arg=USER_GID="$DOCKER_GID" \
+  . 1>&2

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -9,14 +9,8 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-# The default user for a Docker container has uid 0 (root). To avoid creating
-# root-owned files in the build directory we tell Docker to use the current user
-# ID, if known.
-# See
-# https://github.com/googleapis/google-cloud-cpp/blob/a186208b79d900b4ec71c6f9df3acf7638f01dc6/ci/kokoro/docker/build.sh#L147-L152
-readonly DOCKER_UID="${UID:-0}"
-readonly DOCKER_GID="${GID:-0}"
-readonly DOCKER_USER="${USER:-root}"
+"$SCRIPTS_DIR/docker_build"
+
 # In order for the docker-cli inside the container to use the host dockerd,
 # we need permissions for the user with the same gid as the host
 if [[ "${OSTYPE}" == "darwin"*  ]]; then
@@ -28,16 +22,9 @@ fi
 mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 
-docker build \
-  --cache-from="$DOCKER_IMAGE_NAME:latest" \
-  --tag="$DOCKER_IMAGE_NAME:latest" \
-  . 1>&2
-
 docker_run_flags=(
   '--interactive'
   '--rm'
-  "--user=$DOCKER_UID:$DOCKER_GID"
-  "--env=USER=$DOCKER_USER"
   '--env=BAZEL_REMOTE_CACHE_ENABLED'
   '--env=BAZEL_GOOGLE_CREDENTIALS'
   "--volume=$PWD/bazel-cache:/.cache/bazel"


### PR DESCRIPTION
Split Docker image build and run steps

Create script for docker build, and use it in cloud build too

Create user as part of the docker build step, so that it is a real user
with a proper $HOME and most tools work as expected

Add instructions on how to get things up and running on VS Code using
the remote container extension
