### PR TITLE
Move implementations from SDK Sender and Receiver

### DIFF
--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -174,9 +174,8 @@ oak::entrypoint!(oak_main => |_in_channel| {
         &oak::node_config::wasm("app", "grpc_worker"),
         invocation_receiver.handle,
     ).expect("could not create gRPC worker node");
-    while let Ok(invocation) = grpc_channel.receive() {
-        invocation_sender
-            .send(&invocation)
+    while let Ok(invocation) = oak::io::receive(&grpc_channel) {
+        oak::io::send(&invocation_sender, &invocation)
             .expect("could not send invocation to worker node");
     }
 });

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -30,7 +30,10 @@ pub mod proto {
 use aggregator_common::ThresholdAggregator;
 use data::SparseVector;
 use log::{debug, error};
-use oak::grpc;
+use oak::{
+    grpc,
+    io::{ReceiverExt, SenderExt},
+};
 use oak_abi::label::Label;
 use proto::{Aggregator, AggregatorClient, AggregatorDispatcher, Sample};
 use std::{collections::HashMap, convert::TryFrom};
@@ -174,8 +177,9 @@ oak::entrypoint!(oak_main => |_in_channel| {
         &oak::node_config::wasm("app", "grpc_worker"),
         invocation_receiver.handle,
     ).expect("could not create gRPC worker node");
-    while let Ok(invocation) = oak::io::receive(&grpc_channel) {
-        oak::io::send(&invocation_sender, &invocation)
+    while let Ok(invocation) = grpc_channel.receive() {
+        invocation_sender
+            .send(&invocation)
             .expect("could not send invocation to worker node");
     }
 });

--- a/examples/injection/module/rust/src/lib.rs
+++ b/examples/injection/module/rust/src/lib.rs
@@ -66,7 +66,7 @@ mod proto {
 
 use oak::{
     grpc,
-    io::{Receiver, Sender},
+    io::{close_receiver, close_sender, receive, send, Receiver, Sender},
 };
 
 use proto::{
@@ -84,8 +84,8 @@ oak::entrypoint!(grpc_fe => |_in_channel| {
         .expect("Failed to create provider");
     oak::channel_close(to_provider_read_handle.handle).expect("Failed to close channel");
 
-    Sender::new(to_provider_write_handle)
-        .send(&BlobStoreProviderSender { sender: Some(Sender::new(from_provider_write_handle)) })
+    let sender = Sender::new(to_provider_write_handle);
+    send(&sender, &BlobStoreProviderSender { sender: Some(Sender::new(from_provider_write_handle)) })
         .expect("Failed to send handle to provider");
     oak::channel_close(from_provider_write_handle.handle).expect("Failed to close channel");
 
@@ -101,8 +101,9 @@ oak::entrypoint!(grpc_fe => |_in_channel| {
 
 oak::entrypoint!(provider => |frontend_read| {
     oak::logger::init_default();
+    let frontend_receiver = Receiver::<BlobStoreProviderSender>::new(frontend_read);
     let frontend_sender =
-        Receiver::<BlobStoreProviderSender>::new(frontend_read).receive()
+        receive(&frontend_receiver)
             .expect("Did not receive a decodable message")
             .sender
             .expect("No sender in received message");
@@ -112,8 +113,9 @@ oak::entrypoint!(provider => |frontend_read| {
 
 oak::entrypoint!(store => |reader| {
     oak::logger::init_default();
+    let receiver = Receiver::<BlobStoreSender>::new(reader);
     let sender =
-        Receiver::<BlobStoreSender>::new(reader).receive()
+        receive(&receiver)
             .expect("Did not receive a write handle")
             .sender
             .expect("No write handle in received message");
@@ -146,15 +148,11 @@ impl BlobStoreFrontend {
     fn get_interface(&mut self) -> &BlobStoreInterface {
         // Make sure it is cached
         if let BlobStoreAccess::BlobStoreProvider { sender, receiver } = &self.store {
-            sender
-                .send(&BlobStoreRequest {})
-                .expect("Failed to send BlobStoreRequest");
-            sender.close().expect("Failed to close sender");
+            send(&sender, &BlobStoreRequest {}).expect("Failed to send BlobStoreRequest");
+            close_sender(&sender).expect("Failed to close sender");
 
-            let iface = receiver
-                .receive()
-                .expect("Failed to receive BlobStoreInterface");
-            receiver.close().expect("Failed to close receiver");
+            let iface = receive(&receiver).expect("Failed to receive BlobStoreInterface");
+            close_receiver(&receiver).expect("Failed to close receiver");
 
             self.store = BlobStoreAccess::BlobStore(iface);
         };
@@ -167,18 +165,21 @@ impl BlobStoreFrontend {
 
     fn send(&mut self, request: &BlobRequest) -> BlobResponse {
         let iface = self.get_interface();
-        iface
-            .sender
-            .as_ref()
-            .expect("No sender present on interface")
-            .send(request)
-            .expect("Could not send request");
-        iface
-            .receiver
-            .as_ref()
-            .expect("No receiver present on interface")
-            .receive()
-            .expect("Could not receive response")
+        send(
+            iface
+                .sender
+                .as_ref()
+                .expect("No sender present on interface"),
+            request,
+        )
+        .expect("Could not send request");
+        receive(
+            iface
+                .receiver
+                .as_ref()
+                .expect("No receiver present on interface"),
+        )
+        .expect("Could not receive response")
     }
 }
 
@@ -217,15 +218,21 @@ impl oak::Node<BlobStoreRequest> for BlobStoreProvider {
         )?;
         oak::channel_close(to_store_read_handle.handle).expect("Failed to close channel");
 
-        Sender::new(to_store_write_handle).send(&BlobStoreSender {
-            sender: Some(Sender::new(from_store_write_handle)),
-        })?;
+        send(
+            &Sender::new(to_store_write_handle),
+            &BlobStoreSender {
+                sender: Some(Sender::new(from_store_write_handle)),
+            },
+        )?;
         oak::channel_close(from_store_write_handle.handle).expect("Failed to close channel");
 
-        self.sender.send(&BlobStoreInterface {
-            sender: Some(Sender::new(to_store_write_handle)),
-            receiver: Some(Receiver::new(from_store_read_handle)),
-        })
+        send(
+            &self.sender,
+            &BlobStoreInterface {
+                sender: Some(Sender::new(to_store_write_handle)),
+                receiver: Some(Receiver::new(from_store_read_handle)),
+            },
+        )
     }
 }
 
@@ -284,6 +291,6 @@ impl oak::Node<BlobRequest> for BlobStoreImpl {
             Some(Request::Put(req)) => self.put_blob(req),
             None => panic!("No inner request"),
         };
-        self.sender.send(&response)
+        send(&self.sender, &response)
     }
 }

--- a/sdk/rust/oak/src/grpc/client.rs
+++ b/sdk/rust/oak/src/grpc/client.rs
@@ -41,9 +41,7 @@ impl Client {
         let (invocation_sender, invocation_receiver) =
             crate::io::channel_create().expect("failed to create channel");
         let status = crate::node_create_with_label(config, label, invocation_receiver.handle);
-        invocation_receiver
-            .close()
-            .expect("failed to close channel");
+        crate::io::close_receiver(&invocation_receiver).expect("failed to close channel");
         match status {
             Ok(_) => {
                 info!(
@@ -63,7 +61,7 @@ impl Client {
 impl Drop for Client {
     fn drop(&mut self) {
         info!("Closing Client channel {:?}", self.invocation_sender.handle);
-        if let Err(status) = self.invocation_sender.close() {
+        if let Err(status) = crate::io::close_sender(&self.invocation_sender) {
             warn!(
                 "Failed to close Client channel {:?}: {:?}",
                 self.invocation_sender.handle, status

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -16,7 +16,10 @@
 
 //! Functionality to help Oak Nodes interact with gRPC.
 
-use crate::OakError;
+use crate::{
+    io::{close_receiver, close_sender, receive, send},
+    OakError,
+};
 use log::{error, warn};
 use oak_abi::proto::google::rpc;
 pub use oak_abi::proto::{
@@ -88,9 +91,9 @@ impl ChannelResponseWriter {
                 WriteMode::Close => true,
             },
         };
-        self.sender.send(&grpc_rsp)?;
+        send(&self.sender, &grpc_rsp)?;
         if mode == WriteMode::Close {
-            self.sender.close()?;
+            close_sender(&self.sender)?;
         }
         Ok(())
     }
@@ -106,9 +109,9 @@ impl ChannelResponseWriter {
                 WriteMode::Close => true,
             },
         };
-        self.sender.send(&grpc_rsp)?;
+        send(&self.sender, &grpc_rsp)?;
         if mode == WriteMode::Close {
-            self.sender.close()?;
+            close_sender(&self.sender)?;
         }
         Ok(())
     }
@@ -122,8 +125,8 @@ impl ChannelResponseWriter {
         if let Err(status) = result {
             grpc_rsp.status = Some(status);
         }
-        self.sender.send(&grpc_rsp)?;
-        self.sender.close()?;
+        send(&self.sender, &grpc_rsp)?;
+        close_sender(&self.sender)?;
         Ok(())
     }
 }
@@ -159,7 +162,7 @@ impl<T: ServerNode> crate::Node<Invocation> for T {
         let response_writer = ChannelResponseWriter::new(invocation.response_sender);
 
         // Read a single encapsulated request message from the read half.
-        let req: GrpcRequest = invocation.request_receiver.receive().map_err(|err| {
+        let req: GrpcRequest = receive(&invocation.request_receiver).map_err(|err| {
             // TODO(#1078): If it's clear that the issue is caused by a too restrictive label
             // (permission denied), then return a more specific error to the gRPC client.
             warn!(
@@ -186,7 +189,7 @@ impl<T: ServerNode> crate::Node<Invocation> for T {
 
         // Since we are expecting a single message, close the channel immediately.
         // This will change when we implement client streaming (#97).
-        invocation.request_receiver.close()?;
+        close_receiver(&invocation.request_receiver)?;
         if !req.last {
             // TODO(#97): Implement client streaming.
             panic!("Support for streaming requests not yet implemented");
@@ -232,8 +235,8 @@ where
     // message channel.
     let req =
         oak_abi::grpc::encap_request(req, method_name).expect("failed to serialize GrpcRequest");
-    req_sender.send(&req).expect("failed to write to channel");
-    req_sender.close().expect("failed to close channel");
+    send(&req_sender, &req).expect("failed to write to channel");
+    close_sender(&req_sender).expect("failed to close channel");
 
     // Create a new channel for responses to arrive on.
     let (rsp_sender, rsp_receiver) =
@@ -245,11 +248,9 @@ where
         request_receiver: req_receiver.clone(),
         response_sender: rsp_sender.clone(),
     };
-    invocation_channel
-        .send(&invocation)
-        .expect("failed to write invocation to channel");
-    req_receiver.close().expect("failed to close channel");
-    rsp_sender.close().expect("failed to close channel");
+    send(&invocation_channel, &invocation).expect("failed to write invocation to channel");
+    close_receiver(&req_receiver).expect("failed to close channel");
+    close_sender(&rsp_sender).expect("failed to close channel");
 
     Ok(rsp_receiver)
 }
@@ -268,8 +269,8 @@ where
 {
     let rsp_receiver = invoke_grpc_method_stream(method_name, req, invocation_channel)?;
     // Read a single encapsulated response.
-    let result = rsp_receiver.receive();
-    rsp_receiver.close().expect("failed to close channel");
+    let result = receive(&rsp_receiver);
+    close_receiver(&rsp_receiver).expect("failed to close channel");
     let grpc_rsp = result.map_err(|status| {
         error!("failed to receive response: {:?}", status);
         build_status(

--- a/sdk/rust/oak/src/io/mod.rs
+++ b/sdk/rust/oak/src/io/mod.rs
@@ -16,8 +16,7 @@
 
 //! Wrappers for Oak SDK types to allow their use with [`std::io`].
 
-use crate::{ChannelReadStatus, OakError, OakStatus};
-use log::error;
+use crate::OakStatus;
 use oak_abi::label::Label;
 use std::io;
 
@@ -28,8 +27,8 @@ mod sender;
 
 pub use decodable::Decodable;
 pub use encodable::Encodable;
-pub use receiver::Receiver;
-pub use sender::Sender;
+pub use receiver::{Receiver, ReceiverExt};
+pub use sender::{Sender, SenderExt};
 
 /// Create a new channel for transmission of `Encodable` and `Decodable` types.
 pub fn channel_create<T: Encodable + Decodable>() -> Result<(Sender<T>, Receiver<T>), OakStatus> {
@@ -49,75 +48,6 @@ pub fn channel_create_with_label<T: Encodable + Decodable>(
 pub struct Message {
     pub bytes: Vec<u8>,
     pub handles: Vec<crate::Handle>,
-}
-
-/// Close the underlying channel used by the sender.
-pub fn close_sender<T: Encodable>(sender: &Sender<T>) -> Result<(), OakStatus> {
-    crate::channel_close(sender.handle.handle)
-}
-
-/// Attempt to send a value on the sender.
-pub fn send<T: Encodable>(sender: &Sender<T>, t: &T) -> Result<(), OakError> {
-    let message = t.encode()?;
-    crate::channel_write(sender.handle, &message.bytes, &message.handles)?;
-    Ok(())
-}
-
-/// Close the underlying channel used by the receiver.
-pub fn close_receiver<T: Decodable>(receiver: &Receiver<T>) -> Result<(), OakStatus> {
-    crate::channel_close(receiver.handle.handle)
-}
-
-/// Attempt to wait for a value on the receiver, blocking if necessary.
-pub fn receive<T: Decodable>(receiver: &Receiver<T>) -> Result<T, OakError> {
-    wait(receiver)?;
-    try_receive(receiver)
-}
-
-/// Attempt to read a value from the receiver, without blocking.
-pub fn try_receive<T: Decodable>(receiver: &Receiver<T>) -> Result<T, OakError> {
-    let mut bytes = Vec::with_capacity(1024);
-    let mut handles = Vec::with_capacity(16);
-    crate::channel_read(receiver.handle, &mut bytes, &mut handles)?;
-    // `bytes` and `handles` are moved into `Message`, so there is no extra copy happening here.
-    let message = crate::io::Message { bytes, handles };
-    T::decode(&message)
-}
-
-/// Wait for a value to be available from the receiver.
-///
-/// Returns [`ChannelReadStatus`] of the wrapped handle, or `Err(OakStatus::ErrTerminated)` if
-/// the Oak Runtime is terminating.
-pub fn wait<T: Decodable>(receiver: &Receiver<T>) -> Result<ChannelReadStatus, OakStatus> {
-    // TODO(#500): Consider creating the handle notification space once and for all in `new`.
-    let read_handles = vec![receiver.handle];
-    let mut space = crate::new_handle_space(&read_handles);
-    crate::prep_handle_space(&mut space);
-    let status =
-        unsafe { oak_abi::wait_on_channels(space.as_mut_ptr(), read_handles.len() as u32) };
-
-    match crate::result_from_status(status as i32, ()) {
-        Ok(()) => space
-            .get(oak_abi::SPACE_BYTES_PER_HANDLE - 1)
-            .cloned()
-            .map(i32::from)
-            .and_then(ChannelReadStatus::from_i32)
-            .ok_or_else(|| {
-                error!(
-                    "Should never get here. `wait_on_channels` always yields a valid `ChannelReadStatus` if the returned status is not Err(OakStatus::ErrTerminated)."
-                );
-                OakStatus::ErrInternal
-            }),
-        Err(OakStatus::ErrTerminated) => Err(OakStatus::ErrTerminated),
-        Err(OakStatus::ErrInvalidArgs) => {
-            error!("Should never get here. `ErrInvalidArgs` here indicates that `space` is corrupted.");
-            Err(OakStatus::ErrInternal)
-        }
-        Err(status) => {
-            error!("Should never get here. `wait_on_channels` should never return {:?}.", status);
-            Err(OakStatus::ErrInternal)
-        }
-    }
 }
 
 /// Map a non-OK [`OakStatus`] value to the nearest available [`std::io::Error`].

--- a/sdk/rust/oak/src/io/mod.rs
+++ b/sdk/rust/oak/src/io/mod.rs
@@ -16,7 +16,8 @@
 
 //! Wrappers for Oak SDK types to allow their use with [`std::io`].
 
-use crate::OakStatus;
+use crate::{ChannelReadStatus, OakError, OakStatus};
+use log::error;
 use oak_abi::label::Label;
 use std::io;
 
@@ -48,6 +49,75 @@ pub fn channel_create_with_label<T: Encodable + Decodable>(
 pub struct Message {
     pub bytes: Vec<u8>,
     pub handles: Vec<crate::Handle>,
+}
+
+/// Close the underlying channel used by the sender.
+pub fn close_sender<T: Encodable>(sender: &Sender<T>) -> Result<(), OakStatus> {
+    crate::channel_close(sender.handle.handle)
+}
+
+/// Attempt to send a value on the sender.
+pub fn send<T: Encodable>(sender: &Sender<T>, t: &T) -> Result<(), OakError> {
+    let message = t.encode()?;
+    crate::channel_write(sender.handle, &message.bytes, &message.handles)?;
+    Ok(())
+}
+
+/// Close the underlying channel used by the receiver.
+pub fn close_receiver<T: Decodable>(receiver: &Receiver<T>) -> Result<(), OakStatus> {
+    crate::channel_close(receiver.handle.handle)
+}
+
+/// Attempt to wait for a value on the receiver, blocking if necessary.
+pub fn receive<T: Decodable>(receiver: &Receiver<T>) -> Result<T, OakError> {
+    wait(receiver)?;
+    try_receive(receiver)
+}
+
+/// Attempt to read a value from the receiver, without blocking.
+pub fn try_receive<T: Decodable>(receiver: &Receiver<T>) -> Result<T, OakError> {
+    let mut bytes = Vec::with_capacity(1024);
+    let mut handles = Vec::with_capacity(16);
+    crate::channel_read(receiver.handle, &mut bytes, &mut handles)?;
+    // `bytes` and `handles` are moved into `Message`, so there is no extra copy happening here.
+    let message = crate::io::Message { bytes, handles };
+    T::decode(&message)
+}
+
+/// Wait for a value to be available from the receiver.
+///
+/// Returns [`ChannelReadStatus`] of the wrapped handle, or `Err(OakStatus::ErrTerminated)` if
+/// the Oak Runtime is terminating.
+pub fn wait<T: Decodable>(receiver: &Receiver<T>) -> Result<ChannelReadStatus, OakStatus> {
+    // TODO(#500): Consider creating the handle notification space once and for all in `new`.
+    let read_handles = vec![receiver.handle];
+    let mut space = crate::new_handle_space(&read_handles);
+    crate::prep_handle_space(&mut space);
+    let status =
+        unsafe { oak_abi::wait_on_channels(space.as_mut_ptr(), read_handles.len() as u32) };
+
+    match crate::result_from_status(status as i32, ()) {
+        Ok(()) => space
+            .get(oak_abi::SPACE_BYTES_PER_HANDLE - 1)
+            .cloned()
+            .map(i32::from)
+            .and_then(ChannelReadStatus::from_i32)
+            .ok_or_else(|| {
+                error!(
+                    "Should never get here. `wait_on_channels` always yields a valid `ChannelReadStatus` if the returned status is not Err(OakStatus::ErrTerminated)."
+                );
+                OakStatus::ErrInternal
+            }),
+        Err(OakStatus::ErrTerminated) => Err(OakStatus::ErrTerminated),
+        Err(OakStatus::ErrInvalidArgs) => {
+            error!("Should never get here. `ErrInvalidArgs` here indicates that `space` is corrupted.");
+            Err(OakStatus::ErrInternal)
+        }
+        Err(status) => {
+            error!("Should never get here. `wait_on_channels` should never return {:?}.", status);
+            Err(OakStatus::ErrInternal)
+        }
+    }
 }
 
 /// Map a non-OK [`OakStatus`] value to the nearest available [`std::io::Error`].

--- a/sdk/rust/oak/src/io/receiver.rs
+++ b/sdk/rust/oak/src/io/receiver.rs
@@ -14,8 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{io::Decodable, ChannelReadStatus, OakError, OakStatus, ReadHandle};
-use log::error;
+use crate::{io::Decodable, ReadHandle};
 use prost::{
     bytes::{Buf, BufMut},
     encoding::{DecodeContext, WireType},
@@ -49,71 +48,6 @@ impl<T: Decodable> Receiver<T> {
         Receiver {
             handle,
             phantom: std::marker::PhantomData,
-        }
-    }
-
-    /// Close the underlying channel used by this receiver.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn close(&self) -> Result<(), OakStatus> {
-        crate::channel_close(self.handle.handle)
-    }
-
-    /// Attempt to wait for a value on this receiver, blocking if necessary.
-    ///
-    /// See https://doc.rust-lang.org/std/sync/mpsc/struct.Receiver.html#method.recv
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn receive(&self) -> Result<T, OakError> {
-        self.wait()?;
-        self.try_receive()
-    }
-
-    /// Attempt to read a value from this receiver, without blocking.
-    ///
-    /// See https://doc.rust-lang.org/std/sync/mpsc/struct.Receiver.html#method.try_recv
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn try_receive(&self) -> Result<T, OakError> {
-        let mut bytes = Vec::with_capacity(1024);
-        let mut handles = Vec::with_capacity(16);
-        crate::channel_read(self.handle, &mut bytes, &mut handles)?;
-        // `bytes` and `handles` are moved into `Message`, so there is no extra copy happening here.
-        let message = crate::io::Message { bytes, handles };
-        T::decode(&message)
-    }
-
-    /// Wait for a value to be available from this receiver.
-    ///
-    /// Returns [`ChannelReadStatus`] of the wrapped handle, or `Err(OakStatus::ErrTerminated)` if
-    /// the Oak Runtime is terminating.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn wait(&self) -> Result<ChannelReadStatus, OakStatus> {
-        // TODO(#500): Consider creating the handle notification space once and for all in `new`.
-        let read_handles = vec![self.handle];
-        let mut space = crate::new_handle_space(&read_handles);
-        crate::prep_handle_space(&mut space);
-        let status =
-            unsafe { oak_abi::wait_on_channels(space.as_mut_ptr(), read_handles.len() as u32) };
-
-        match crate::result_from_status(status as i32, ()) {
-            Ok(()) => space
-                .get(oak_abi::SPACE_BYTES_PER_HANDLE - 1)
-                .cloned()
-                .map(i32::from)
-                .and_then(ChannelReadStatus::from_i32)
-                .ok_or_else(|| {
-                    error!(
-                        "Should never get here. `wait_on_channels` always yields a valid `ChannelReadStatus` if the returned status is not Err(OakStatus::ErrTerminated)."
-                    );
-                    OakStatus::ErrInternal
-                }),
-            Err(OakStatus::ErrTerminated) => Err(OakStatus::ErrTerminated),
-            Err(OakStatus::ErrInvalidArgs) => {
-                error!("Should never get here. `ErrInvalidArgs` here indicates that `space` is corrupted.");
-                Err(OakStatus::ErrInternal)
-            }
-            Err(status) => {
-                error!("Should never get here. `wait_on_channels` should never return {:?}.", status);
-                Err(OakStatus::ErrInternal)
-            }
         }
     }
 }

--- a/sdk/rust/oak/src/io/receiver.rs
+++ b/sdk/rust/oak/src/io/receiver.rs
@@ -14,7 +14,8 @@
 // limitations under the License.
 //
 
-use crate::{io::Decodable, ReadHandle};
+use crate::{io::Decodable, ChannelReadStatus, OakError, OakStatus, ReadHandle};
+use log::error;
 use prost::{
     bytes::{Buf, BufMut},
     encoding::{DecodeContext, WireType},
@@ -30,6 +31,82 @@ use prost::{
 pub struct Receiver<T: Decodable> {
     pub handle: ReadHandle,
     phantom: std::marker::PhantomData<T>,
+}
+
+pub trait ReceiverExt<T> {
+    /// Close the underlying channel used by the receiver.
+    fn close(&self) -> Result<(), OakStatus>;
+
+    /// Attempt to wait for a value on the receiver, blocking if necessary.
+    fn receive(&self) -> Result<T, OakError>;
+
+    /// Attempt to read a value from the receiver, without blocking.
+    fn try_receive(&self) -> Result<T, OakError>;
+
+    /// Wait for a value to be available from the receiver.
+    ///
+    /// Returns [`ChannelReadStatus`] of the wrapped handle, or `Err(OakStatus::ErrTerminated)` if
+    /// the Oak Runtime is terminating.
+    fn wait(&self) -> Result<ChannelReadStatus, OakStatus>;
+}
+
+impl<T: Decodable> ReceiverExt<T> for Receiver<T> {
+    /// Close the underlying channel used by the receiver.
+    fn close(&self) -> Result<(), OakStatus> {
+        crate::channel_close(self.handle.handle)
+    }
+
+    /// Attempt to wait for a value on the receiver, blocking if necessary.
+    fn receive(&self) -> Result<T, OakError> {
+        self.wait()?;
+        self.try_receive()
+    }
+
+    /// Attempt to read a value from the receiver, without blocking.
+    fn try_receive(&self) -> Result<T, OakError> {
+        let mut bytes = Vec::with_capacity(1024);
+        let mut handles = Vec::with_capacity(16);
+        crate::channel_read(self.handle, &mut bytes, &mut handles)?;
+        // `bytes` and `handles` are moved into `Message`, so there is no extra copy happening here.
+        let message = crate::io::Message { bytes, handles };
+        T::decode(&message)
+    }
+
+    /// Wait for a value to be available from the receiver.
+    ///
+    /// Returns [`ChannelReadStatus`] of the wrapped handle, or `Err(OakStatus::ErrTerminated)` if
+    /// the Oak Runtime is terminating.
+    fn wait(&self) -> Result<ChannelReadStatus, OakStatus> {
+        // TODO(#500): Consider creating the handle notification space once and for all in `new`.
+        let read_handles = vec![self.handle];
+        let mut space = crate::new_handle_space(&read_handles);
+        crate::prep_handle_space(&mut space);
+        let status =
+            unsafe { oak_abi::wait_on_channels(space.as_mut_ptr(), read_handles.len() as u32) };
+
+        match crate::result_from_status(status as i32, ()) {
+            Ok(()) => space
+                .get(oak_abi::SPACE_BYTES_PER_HANDLE - 1)
+                .cloned()
+                .map(i32::from)
+                .and_then(ChannelReadStatus::from_i32)
+                .ok_or_else(|| {
+                    error!(
+                        "Should never get here. `wait_on_channels` always yields a valid `ChannelReadStatus` if the returned status is not Err(OakStatus::ErrTerminated)."
+                    );
+                    OakStatus::ErrInternal
+                }),
+            Err(OakStatus::ErrTerminated) => Err(OakStatus::ErrTerminated),
+            Err(OakStatus::ErrInvalidArgs) => {
+                error!("Should never get here. `ErrInvalidArgs` here indicates that `space` is corrupted.");
+                Err(OakStatus::ErrInternal)
+            }
+            Err(status) => {
+                error!("Should never get here. `wait_on_channels` should never return {:?}.", status);
+                Err(OakStatus::ErrInternal)
+            }
+        }
+    }
 }
 
 /// Manual implementation of [`std::fmt::Debug`] for any `T`.

--- a/sdk/rust/oak/src/io/sender.rs
+++ b/sdk/rust/oak/src/io/sender.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{io::Encodable, OakError, OakStatus, WriteHandle};
+use crate::{io::Encodable, WriteHandle};
 use prost::{
     bytes::{Buf, BufMut},
     encoding::{DecodeContext, WireType},
@@ -38,22 +38,6 @@ impl<T: Encodable> Sender<T> {
             handle,
             phantom: std::marker::PhantomData,
         }
-    }
-
-    /// Close the underlying channel used by this sender.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn close(&self) -> Result<(), OakStatus> {
-        crate::channel_close(self.handle.handle)
-    }
-
-    /// Attempt to send a value on this sender.
-    ///
-    /// See https://doc.rust-lang.org/std/sync/mpsc/struct.Sender.html#method.send
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn send(&self, t: &T) -> Result<(), OakError> {
-        let message = t.encode()?;
-        crate::channel_write(self.handle, &message.bytes, &message.handles)?;
-        Ok(())
     }
 }
 

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -433,8 +433,8 @@ pub trait Node<T: crate::io::Decodable> {
 /// initial channel.
 pub fn app_config_map(initial_handle: ReadHandle) -> Result<ConfigMap, OakError> {
     let receiver = crate::io::Receiver::new(initial_handle);
-    let result = receiver.receive();
-    if let Err(err) = receiver.close() {
+    let result = crate::io::receive(&receiver);
+    if let Err(err) = crate::io::close_receiver(&receiver) {
         error!("Failed to close initial channel: {:?}", err);
     }
     result
@@ -466,7 +466,7 @@ pub fn run_event_loop<T: crate::io::Decodable, N: Node<T>>(
         // will return `ErrTerminated`, which indicates that the event loop should be terminated.
         // For any other error raised while waiting is logged, we try and determine whether it is
         // transient or not, and then continue or terminate the event loop, respectively.
-        match receiver.wait() {
+        match crate::io::wait(&receiver) {
             Err(status) => {
                 use crate::OakStatus::*;
                 match status {
@@ -505,7 +505,7 @@ pub fn run_event_loop<T: crate::io::Decodable, N: Node<T>>(
                 }
             },
         }
-        match receiver.try_receive() {
+        match crate::io::try_receive(&receiver) {
             Ok(command) => {
                 info!("{:?}: received command", receiver);
                 if let Err(err) = node.handle_command(command) {

--- a/sdk/rust/oak/src/logger/mod.rs
+++ b/sdk/rust/oak/src/logger/mod.rs
@@ -21,6 +21,7 @@
 
 // TODO(#544)
 
+use crate::io::SenderExt;
 use log::{Level, Log, Metadata, Record, SetLoggerError};
 
 struct OakChannelLogger {
@@ -41,7 +42,7 @@ impl Log for OakChannelLogger {
             level: map_level(record.level()) as i32,
             message: format!("{}", record.args()),
         };
-        match crate::io::send(&self.channel, &log_msg) {
+        match self.channel.send(&log_msg) {
             Ok(()) => (),
             Err(crate::OakError::OakStatus(crate::OakStatus::ErrTerminated)) => (),
             Err(e) => panic!("could not send log message over log channel: {}", e),

--- a/sdk/rust/oak/src/logger/mod.rs
+++ b/sdk/rust/oak/src/logger/mod.rs
@@ -41,7 +41,7 @@ impl Log for OakChannelLogger {
             level: map_level(record.level()) as i32,
             message: format!("{}", record.args()),
         };
-        match self.channel.send(&log_msg) {
+        match crate::io::send(&self.channel, &log_msg) {
             Ok(()) => (),
             Err(crate::OakError::OakStatus(crate::OakStatus::ErrTerminated)) => (),
             Err(e) => panic!("could not send log message over log channel: {}", e),


### PR DESCRIPTION
Move the context-dependent implementations from the SDK's `Sender` and `Receiver` structs into extension traits.

This is a first step towards implementing #1224, #1249, #1324, and generally making it possible to serialise handles in protos in the runtime pseudo nodes as well. This requires harmonising the `Sender` and `Receiver` structs between the SDK and runtime. Some of the functions are incompatible between the runtime and SDK, so have to be moved out of the implementation of the struct itself. The next step is to do something similar for the runtime versions of these structs.

- `SenderExt`
  - `send`
  - `close`
- `ReceiverExt`
  - `receive`
  - `wait`
  - `try_receive`
  - `close`

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
