### PR TITLE
Move Sender and Receiver runtime functionality

### DIFF
--- a/oak/server/rust/oak_runtime/src/config.rs
+++ b/oak/server/rust/oak_runtime/src/config.rs
@@ -16,7 +16,7 @@
 
 //! Functionality covering configuration of a Runtime instance.
 
-use crate::{Runtime, RuntimeConfiguration, RuntimeProxy};
+use crate::{io::SenderExt, Runtime, RuntimeConfiguration, RuntimeProxy};
 use log::{error, info};
 use oak_abi::OakStatus;
 use std::sync::Arc;

--- a/oak/server/rust/oak_runtime/src/node/grpc/client.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/client.rs
@@ -17,7 +17,7 @@
 //! gRPC client pseudo-Node functionality.
 
 use crate::{
-    io::Receiver,
+    io::{Receiver, ReceiverExt},
     metrics::Metrics,
     node::{
         grpc::{codec::VecCodec, invocation::Invocation},

--- a/oak/server/rust/oak_runtime/src/node/grpc/invocation.rs
+++ b/oak/server/rust/oak_runtime/src/node/grpc/invocation.rs
@@ -17,7 +17,7 @@
 //! Functionality for handling gRPC method invocations.
 
 use crate::{
-    io::{Decodable, Receiver, Sender},
+    io::{Decodable, Receiver, ReceiverExt, Sender, SenderExt},
     NodeMessage, RuntimeProxy,
 };
 use log::error;

--- a/oak/server/rust/oak_runtime/src/node/http/mod.rs
+++ b/oak/server/rust/oak_runtime/src/node/http/mod.rs
@@ -20,6 +20,7 @@
 //! asynchronously.
 
 use crate::{
+    io::{ReceiverExt, SenderExt},
     node::{ConfigurationError, Node},
     ChannelHalfDirection, RuntimeProxy,
 };

--- a/oak/server/rust/oak_runtime/src/node/roughtime.rs
+++ b/oak/server/rust/oak_runtime/src/node/roughtime.rs
@@ -17,7 +17,7 @@
 //! Roughtime client pseudo-Node functionality.
 
 use crate::{
-    io::Receiver,
+    io::{Receiver, ReceiverExt},
     node::grpc::invocation::Invocation,
     time::{
         get_default_servers, RoughtimeClient, RoughtimeServer, DEFAULT_MAX_RADIUS_MICROSECONDS,


### PR DESCRIPTION
Move the runtime-specific implementations from the Sender and Receiver structs into extension traits.

This is a step towards implementing #1224, #1249, and #1324. It is the `oak_runtime` counterpart to #1330.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
