### PR TITLE
Add documentation on passing handles in Protobuf.

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -477,6 +477,37 @@ handle for the _write_ half of a different channel, which is then used for
 responses &ndash; so the new Node has a way of _sending_ externally, as well as
 receiving.
 
+For nodes that communicate by exchanging messages that are serialized protocol
+buffer messages, the Oak SDK allows encoding channel handles into protobuf
+messages:
+
+<!-- prettier-ignore-start -->
+[embedmd]:# (../examples/injection/proto/injection.proto Protobuf /^message BlobStoreSender/ /^}$/)
+```Protobuf
+message BlobStoreSender {
+  oak.handle.Sender sender = 1 [(oak.handle.message_type) = ".oak.examples.injection.BlobResponse"];
+}
+```
+<!-- prettier-ignore-end -->
+
+The `message_type` field option provided by the SDK specifies the fully
+qualified (with leading dot) name of the protobuf message passed over the
+channel.
+
+The above protobuf definition generates the following Rust data type:
+
+```Rust
+struct BlobStoreSender {
+  sender: ::oak::io::Sender<BlobResponse>,
+}
+```
+
+An `oak.handle.Receiver` type is also available for read handles.
+
+The generated struct is fully type safe, encoding the direction of the handle
+(`Sender` or `Receiver`) as well as the type of the message that is sent or
+received using `message_type`.
+
 ## Persistent Storage
 
 TODO: describe use of storage


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

This adds a short section on handles in Protocol Buffers to the documentation. 

It feels a bit short to me, so feel free to suggest more things to touch upon here 😄. I would put an example where a message is received and then the handle is used immediately afterwards, but I don't think we have such a snippet in our codebase currently 😅.