### PR TITLE
Remove SDK `Handle` struct

### DIFF
--- a/examples/abitest/module_1/rust/src/lib.rs
+++ b/examples/abitest/module_1/rust/src/lib.rs
@@ -43,9 +43,7 @@ pub extern "C" fn backend_oak_main(in_handle: u64) {
 
 fn inner_main(in_handle: u64) -> Result<(), oak::OakStatus> {
     oak::logger::init(log::Level::Debug).expect("Couldn't initialize logging node!");
-    let in_channel = oak::ReadHandle {
-        handle: oak::Handle::from_raw(in_handle),
-    };
+    let in_channel = oak::ReadHandle { handle: in_handle };
 
     // We expect a single empty message holding a reply channel to already
     // be waiting on the channel.

--- a/sdk/rust/oak/src/io/decodable.rs
+++ b/sdk/rust/oak/src/io/decodable.rs
@@ -24,7 +24,7 @@ pub trait Decodable: Sized {
 impl<T: crate::handle::HandleVisit + prost::Message + Default> Decodable for T {
     fn decode(message: &Message) -> Result<Self, OakError> {
         let mut value = T::decode(message.bytes.as_slice())?;
-        let handles: Vec<u64> = message.handles.iter().map(|h| h.id).collect();
+        let handles: Vec<u64> = message.handles.to_vec();
         crate::handle::inject_handles(&mut value, &handles)?;
         Ok(value)
     }

--- a/sdk/rust/oak/src/io/encodable.rs
+++ b/sdk/rust/oak/src/io/encodable.rs
@@ -24,10 +24,7 @@ pub trait Encodable {
 impl<T: crate::handle::HandleVisit + prost::Message + Clone> Encodable for T {
     fn encode(&self) -> Result<Message, OakError> {
         let mut msg = self.clone();
-        let handles = crate::handle::extract_handles(&mut msg)
-            .into_iter()
-            .map(crate::Handle::from_raw)
-            .collect();
+        let handles = crate::handle::extract_handles(&mut msg);
         let mut bytes = Vec::new();
         self.encode(&mut bytes)?;
         Ok(crate::io::Message { bytes, handles })

--- a/sdk/rust/oak/src/io/receiver.rs
+++ b/sdk/rust/oak/src/io/receiver.rs
@@ -130,8 +130,8 @@ impl<T: Decodable> Receiver<T> {
 }
 
 impl<T: Decodable> crate::handle::HandleVisit for Receiver<T> {
-    fn visit<F: FnMut(&mut crate::handle::Handle)>(&mut self, mut visitor: F) -> F {
-        visitor(&mut self.handle.handle.id);
+    fn visit<F: FnMut(&mut crate::Handle)>(&mut self, mut visitor: F) -> F {
+        visitor(&mut self.handle.handle);
         visitor
     }
 }
@@ -139,7 +139,7 @@ impl<T: Decodable> crate::handle::HandleVisit for Receiver<T> {
 impl<T: Decodable> Receiver<T> {
     pub fn as_proto_handle(&self) -> crate::handle::Receiver {
         crate::handle::Receiver {
-            id: self.handle.handle.id,
+            id: self.handle.handle,
         }
     }
 }
@@ -151,7 +151,7 @@ impl<T: Send + Sync + core::fmt::Debug + Decodable> prost::Message for Receiver<
     }
 
     fn clear(&mut self) {
-        self.handle.handle.id = 0;
+        self.handle.handle = crate::handle::invalid();
     }
 
     fn encode_raw<B: BufMut>(&self, buf: &mut B) {
@@ -167,7 +167,7 @@ impl<T: Send + Sync + core::fmt::Debug + Decodable> prost::Message for Receiver<
     ) -> Result<(), prost::DecodeError> {
         let mut proto = self.as_proto_handle();
         proto.merge_field(tag, wire_type, buf, ctx)?;
-        self.handle.handle.id = proto.id;
+        self.handle.handle = proto.id;
         Ok(())
     }
 }
@@ -175,7 +175,7 @@ impl<T: Send + Sync + core::fmt::Debug + Decodable> prost::Message for Receiver<
 impl<T: Decodable> Default for Receiver<T> {
     fn default() -> Receiver<T> {
         Receiver::new(ReadHandle {
-            handle: crate::Handle::invalid(),
+            handle: crate::handle::invalid(),
         })
     }
 }

--- a/sdk/rust/oak/src/io/sender.rs
+++ b/sdk/rust/oak/src/io/sender.rs
@@ -65,8 +65,8 @@ impl<T: Encodable> Sender<T> {
 }
 
 impl<T: Encodable> crate::handle::HandleVisit for Sender<T> {
-    fn visit<F: FnMut(&mut crate::handle::Handle)>(&mut self, mut visitor: F) -> F {
-        visitor(&mut self.handle.handle.id);
+    fn visit<F: FnMut(&mut crate::Handle)>(&mut self, mut visitor: F) -> F {
+        visitor(&mut self.handle.handle);
         visitor
     }
 }
@@ -74,7 +74,7 @@ impl<T: Encodable> crate::handle::HandleVisit for Sender<T> {
 impl<T: Encodable> Sender<T> {
     pub fn as_proto_handle(&self) -> crate::handle::Sender {
         crate::handle::Sender {
-            id: self.handle.handle.id,
+            id: self.handle.handle,
         }
     }
 }
@@ -86,7 +86,7 @@ impl<T: Send + Sync + core::fmt::Debug + Encodable> prost::Message for Sender<T>
     }
 
     fn clear(&mut self) {
-        self.handle.handle.id = 0;
+        self.handle.handle = crate::handle::invalid();
     }
 
     fn encode_raw<B: BufMut>(&self, buf: &mut B) {
@@ -102,7 +102,7 @@ impl<T: Send + Sync + core::fmt::Debug + Encodable> prost::Message for Sender<T>
     ) -> Result<(), prost::DecodeError> {
         let mut proto = self.as_proto_handle();
         proto.merge_field(tag, wire_type, buf, ctx)?;
-        self.handle.handle.id = proto.id;
+        self.handle.handle = proto.id;
         Ok(())
     }
 }
@@ -110,7 +110,7 @@ impl<T: Send + Sync + core::fmt::Debug + Encodable> prost::Message for Sender<T>
 impl<T: Encodable> Default for Sender<T> {
     fn default() -> Sender<T> {
         Sender::new(WriteHandle {
-            handle: crate::Handle::invalid(),
+            handle: crate::handle::invalid(),
         })
     }
 }

--- a/sdk/rust/oak/tests/handle_extract_inject.rs
+++ b/sdk/rust/oak/tests/handle_extract_inject.rs
@@ -271,15 +271,11 @@ fn roundtrip() {
 }
 
 fn sender<T: oak::io::Encodable>(id: u64) -> Sender<T> {
-    Sender::new(oak::WriteHandle {
-        handle: oak::Handle::from_raw(id),
-    })
+    Sender::new(oak::WriteHandle { handle: id })
 }
 
 fn receiver<T: oak::io::Decodable>(id: u64) -> Receiver<T> {
-    Receiver::new(oak::ReadHandle {
-        handle: oak::Handle::from_raw(id),
-    })
+    Receiver::new(oak::ReadHandle { handle: id })
 }
 
 // Dummy hashing utilities to make the order of elements returned from a HashMap deterministic

--- a/sdk/rust/oak_derive/src/lib.rs
+++ b/sdk/rust/oak_derive/src/lib.rs
@@ -56,7 +56,7 @@ fn struct_impls(name: &Ident, data: &syn::DataStruct) -> TokenStream {
 
     quote! {
         impl ::oak::handle::HandleVisit for #name {
-            fn visit<F: FnMut(&mut ::oak::handle::Handle)>(&mut self, visitor: F) -> F {
+            fn visit<F: FnMut(&mut ::oak::Handle)>(&mut self, visitor: F) -> F {
                 #body
             }
         }
@@ -67,7 +67,7 @@ fn enum_impls(name: &Ident, data: &syn::DataEnum) -> TokenStream {
     let variants: Vec<TokenStream> = data.variants.iter().map(variant_impl).collect();
     quote! {
         impl ::oak::handle::HandleVisit for #name {
-            fn visit<F: FnMut(&mut ::oak::handle::Handle)>(&mut self, visitor: F) -> F {
+            fn visit<F: FnMut(&mut ::oak::Handle)>(&mut self, visitor: F) -> F {
                 match self {
                     #(
                         #name::#variants,

--- a/sdk/rust/oak_derive/tests/visit.rs
+++ b/sdk/rust/oak_derive/tests/visit.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use oak::handle::{Handle, HandleVisit};
+use oak::{handle::HandleVisit, Handle};
 
 #[derive(Default)]
 struct Visited(Handle);


### PR DESCRIPTION
This PR removes the `Handle` struct from the SDK and uses the ABI `Handle` type alias directly. It is another step towards harmonising similar data structures between the Runtime and SDK with the end-goal of enabling automatic serialisation of handles in protobufs in the Oak runtime.

This is a follow-up to #1330 and #1331, and an additional step towards resolving #1224, #1249, and #1324.

An associated PR (to follow) will add `ReadHandle` and `WriteHandle` support to the Runtime.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
