### PR TITLE
Drop node_id from channel introspection events

### DIFF
--- a/oak/proto/introspection_events.proto
+++ b/oak/proto/introspection_events.proto
@@ -47,15 +47,11 @@ message NodeDestroyed {
 }
 
 message ChannelCreated {
-  uint64 node_id = 1;
-
-  uint64 channel_id = 2;
+  uint64 channel_id = 1;
 }
 
 message ChannelDestroyed {
-  uint64 node_id = 1;
-
-  uint64 channel_id = 2;
+  uint64 channel_id = 1;
 }
 
 message HandleCreated {

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -674,10 +674,7 @@ impl Runtime {
             read_handle,
         );
 
-        self.introspection_event(EventDetails::ChannelCreated(ChannelCreated {
-            node_id: node_id.0,
-            channel_id,
-        }));
+        self.introspection_event(EventDetails::ChannelCreated(ChannelCreated { channel_id }));
 
         Ok((write_handle, read_handle))
     }


### PR DESCRIPTION
As suggested by @daviddrysdale: https://project-oak.slack.com/archives/CHE9E13C3/p1595049790239800?thread_ts=1594995744.232500&cid=CHE9E13C3

Imho this makes sense conceptually, since channels aren't tied to Nodes, but connected to them via handles. 

See the related issue #913

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
