### PR TITLE
IFC docs: Reorder sections a bit

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -197,25 +197,20 @@ compares both confidentiality and integrity:
 - the **integrity** check ensures that the value sent is trusted by the
   destination
 
+Intuitively, data can only flow from a source to a destination if:
+
+- the destination is **at least as secret** as the source
+- the source is **at least as trusted** as the destination
+
+> Notably, the integrity part of the check is "flipped" by convention (see
+> "Integrity Considerations for Secure Computer Systems" below). More
+> fundamental than adhering to convention, by flipping the integrity order in
+> this way, we can retain the intuitive meaning behind integrity tags as
+> representing trust by a principal (trust by a user, trust on a subject, etc.).
+
 More concretely, if `L_a = (C_a, I_a)` (where `C_a` and `I_a` are the
 confidentiality and integrity components respectively), and `L_b = (C_b, I_b)`
-then `L_a ⊑ L_b` iff `C_a ⊆ C_b` and `I_a ⊇ I_b`. Notably, the integrity part of
-the check is "flipped" by convention (see "Integrity Considerations for Secure
-Computer Systems" below). More fundamental than adhering to convention, by
-flipping the integrity order in this way, we can retain the intuitive meaning
-behind integrity tags as representing trust by a principal (trust by a user,
-trust on a subject, etc.).
-
-Intuitively, data can only flow from `a` to `b` if:
-
-- `b` is **at least as secret** as `a`
-- `a` is **at least as trusted** as `b`
-
-The least privileged label is usually referred to as "public untrusted" (and
-represented as `⊥`, pronounced "bottom"), which corresponds to a Node or Channel
-which has only observed public data, and its inputs are not endorsed with any
-level of integrity; in this label, both confidentiality and integrity components
-are empty sets.
+then `L_a ⊑ L_b` iff `C_a ⊆ C_b` and `I_a ⊇ I_b`.
 
 As an example, if the `a`'s confidentiality is `{c_0, c_1}`, and `a`'s integrity
 is `{i_0, i_1}`, then:
@@ -252,6 +247,12 @@ It follows that bi-directional communication between Nodes `a` and `b` is only
 allowed (via two uni-directional Channels) if
 `(L_a ⊑ L_b) ∧ (L_b ⊑ L_a) ⇒ L_a = L_b`, i.e. if `a` and `b` have identical
 confidentiality and integrity.
+
+The least privileged label is usually referred to as "public untrusted" (and
+represented as `⊥`, pronounced "bottom"), which corresponds to a Node or Channel
+which has only observed public data, and its inputs are not endorsed with any
+level of integrity; in this label, both confidentiality and integrity components
+are empty sets.
 
 #### Node and Channel Creation
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -202,11 +202,11 @@ Intuitively, data can only flow from a source to a destination if:
 - the destination is **at least as secret** as the source
 - the source is **at least as trusted** as the destination
 
-> Notably, the integrity part of the check is "flipped" by convention (see
-> "Integrity Considerations for Secure Computer Systems" below). More
-> fundamental than adhering to convention, by flipping the integrity order in
-> this way, we can retain the intuitive meaning behind integrity tags as
-> representing trust by a principal (trust by a user, trust on a subject, etc.).
+Notably, the integrity part of the check is "flipped" by convention (see
+"Integrity Considerations for Secure Computer Systems" below). More fundamental
+than adhering to convention, by flipping the integrity order in this way, we can
+retain the intuitive meaning behind integrity tags as representing trust by a
+principal (trust by a user, trust on a subject, etc.).
 
 More concretely, if `L_a = (C_a, I_a)` (where `C_a` and `I_a` are the
 confidentiality and integrity components respectively), and `L_b = (C_b, I_b)`


### PR DESCRIPTION
Proposing these changes in small PRs so they can be reviewed carefully.

Reorders the paragraphs a bit, so they go from "high level" to "concrete examples" 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
