### PR TITLE
Provide example client rust target override on runner command line

### DIFF
--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -66,21 +66,37 @@ pub struct RunExamples {
     )]
     pub example_name: Option<String>,
     #[structopt(flatten)]
+    pub build_client: BuildClient,
+    #[structopt(flatten)]
     pub build_server: BuildServer,
     #[structopt(long, help = "run server [default: true]")]
     pub run_server: Option<bool>,
-    #[structopt(
-        long,
-        help = "client variant: [all, rust, cpp, go, nodejs, none] [default: all]",
-        default_value = "all"
-    )]
-    pub client_variant: String,
     #[structopt(long, help = "additional arguments to pass to clients")]
     pub client_additional_args: Vec<String>,
     #[structopt(long, help = "additional arguments to pass to server")]
     pub server_additional_args: Vec<String>,
     #[structopt(long, help = "build a Docker image for the examples")]
     pub build_docker: bool,
+}
+
+#[derive(StructOpt, Clone)]
+pub struct BuildClient {
+    #[structopt(
+        long,
+        help = "client variant: [all, rust, cpp, go, nodejs, none] [default: all]",
+        default_value = "all"
+    )]
+    pub client_variant: String,
+    #[structopt(
+        long,
+        help = "rust toolchain override to use for the client compilation [e.g. stable, nightly, stage2]"
+    )]
+    pub client_rust_toolchain: Option<String>,
+    #[structopt(
+        long,
+        help = "rust target to use for the client compilation [e.g. x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, x86_64-apple-darwin]"
+    )]
+    pub client_rust_target: Option<String>,
 }
 
 #[derive(StructOpt, Clone)]


### PR DESCRIPTION
This adds the option '--client-rust-target' to the runner,
following the pattern from the '--server-rust-target'.
In addition in the case of heterogeneous builds, the framework
is in place to add '--client-rust-toolchain' at a later date.

Issues: 1349

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
