### PR TITLE
Ensure introspection events are logged in the right order

### DIFF
--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -1072,6 +1072,10 @@ impl Runtime {
             OakStatus::ErrInvalidArgs
         })?;
 
+        self.introspection_event(EventDetails::NodeCreated(NodeCreated {
+            node_id: node_id.0,
+        }));
+
         let node_privilege = instance.get_privilege();
 
         self.node_configure_instance(new_node_id, &new_node_name, label, &node_privilege);
@@ -1093,10 +1097,6 @@ impl Runtime {
         // Insert the now running instance to the list of running instances (by moving it), so that
         // `Node::stop` will be called on it eventually.
         self.add_node_stopper(new_node_id, node_stopper);
-
-        self.introspection_event(EventDetails::NodeCreated(NodeCreated {
-            node_id: node_id.0,
-        }));
 
         Ok(())
     }

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -667,6 +667,9 @@ impl Runtime {
             write_half,
             read_half,
         );
+
+        self.introspection_event(EventDetails::ChannelCreated(ChannelCreated { channel_id }));
+
         // Insert them into the handle table and return the ABI handles to the caller.
         let write_handle = self.new_abi_handle(node_id, write_half);
         let read_handle = self.new_abi_handle(node_id, read_half);
@@ -676,8 +679,6 @@ impl Runtime {
             write_handle,
             read_handle,
         );
-
-        self.introspection_event(EventDetails::ChannelCreated(ChannelCreated { channel_id }));
 
         Ok((write_handle, read_handle))
     }

--- a/oak/server/rust/oak_runtime/src/lib.rs
+++ b/oak/server/rust/oak_runtime/src/lib.rs
@@ -668,6 +668,9 @@ impl Runtime {
             read_half,
         );
 
+        // TODO(#913): Add automated tests that verify that ChannelCreated is
+        // always fired prior to any other introspection events related to the
+        // channel.
         self.introspection_event(EventDetails::ChannelCreated(ChannelCreated { channel_id }));
 
         // Insert them into the handle table and return the ABI handles to the caller.
@@ -1073,6 +1076,9 @@ impl Runtime {
             OakStatus::ErrInvalidArgs
         })?;
 
+        // TODO(#913): Add automated tests that verify that NodeCreated is
+        // always fired prior to any other introspection events related to the
+        // node.
         self.introspection_event(EventDetails::NodeCreated(NodeCreated {
             node_id: node_id.0,
         }));


### PR DESCRIPTION
`NodeCreated` should always be logged prior to any events related to the node, such as `HandleCreated`.
`ChannelCreated` should always be logged prior to any events related to the channel, such as `HandleCreated`.

I'd like to write an integration test to ensure this is always the case, but not sure how testing currently works in our codebase.

Ideally the test would involve starting an Oak application (hello_world works), and then running a small script that iterates over the built up `introspection_event_queue` and ensures the events are in the valid order.

Ref: is #913

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
