### PR TITLE
Spawn a thread per-invocation in gRPC server processing

### DIFF
--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -39,12 +39,6 @@ struct Node {
     rooms: HashMap<RoomId, Room>,
 }
 
-oak::entrypoint!(oak_main => |in_channel| {
-    oak::logger::init_default();
-    let dispatcher = ChatDispatcher::new(Node::default());
-    oak::run_event_loop(dispatcher, oak::io::Receiver::<grpc::Invocation>::new(in_channel));
-});
-
 oak::entrypoint!(grpc_oak_main => |_in_channel| {
     oak::logger::init_default();
     let dispatcher = ChatDispatcher::new(Node::default());


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
