### PR TITLE
Make runner ignore (some) generated files

### DIFF
--- a/runner/src/check_license.rs
+++ b/runner/src/check_license.rs
@@ -34,8 +34,7 @@ impl Runnable for CheckLicense {
     }
 
     fn run(self: Box<Self>, _opt: &Opt) -> Box<dyn Running> {
-        let file_content = std::fs::read_to_string(&self.path).expect("could not read file");
-        let result_value = if file_content.contains("Apache License") {
+        let result_value = if file_contains(&self.path.into(), "Apache License") {
             StatusResultValue::Ok
         } else {
             StatusResultValue::Error


### PR DESCRIPTION
Fix #1362

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
