### PR TITLE
sdk: don't leak gRPC channel handle

### DIFF
--- a/sdk/rust/oak/src/grpc/server.rs
+++ b/sdk/rust/oak/src/grpc/server.rs
@@ -42,6 +42,7 @@ pub fn init(address: &str) -> Result<Receiver<Invocation>, OakStatus> {
     // Create a separate channel for receiving invocations and pass it to a gRPC pseudo-Node.
     let (invocation_sender, invocation_receiver) =
         crate::io::channel_create::<Invocation>().expect("Couldn't create gRPC invocation channel");
+    let local_invocation_sender = invocation_sender.handle;
 
     let grpc_server_init = ServerInvocationChannel::new(invocation_sender);
     init_sender
@@ -50,6 +51,8 @@ pub fn init(address: &str) -> Result<Receiver<Invocation>, OakStatus> {
     init_sender
         .close()
         .expect("Couldn't close init message channel to gRPC server pseudo-node");
+    crate::channel_close(local_invocation_sender.handle)
+        .expect("Couldn't close invocation send channel copy");
 
     Ok(invocation_receiver)
 }

--- a/sdk/rust/oak/src/io/sender.rs
+++ b/sdk/rust/oak/src/io/sender.rs
@@ -35,10 +35,10 @@ pub struct Sender<T: Encodable> {
 /// Trait for context-dependent functionality on a `Sender`.
 pub trait SenderExt<T> {
     /// Close the underlying channel used by the sender.
-    fn send(&self, t: &T) -> Result<(), OakError>;
+    fn close(&self) -> Result<(), OakStatus>;
 
     /// Attempt to send a value on the sender.
-    fn close(&self) -> Result<(), OakStatus>;
+    fn send(&self, t: &T) -> Result<(), OakError>;
 }
 
 impl<T: Encodable> SenderExt<T> for Sender<T> {


### PR DESCRIPTION
This would be better as something integrated with the `ServerInvocationChannel`
and `Sender` types, but works for now.

Fixes #1358

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
