### PR TITLE
Adds TLS support for HTTP server pseudo-node

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -832,10 +832,10 @@ dependencies = [
  "hyper",
  "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
+ "webpki-roots 0.20.0",
 ]
 
 [[package]]
@@ -1116,8 +1116,8 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 0.4.4",
- "security-framework-sys 0.4.3",
+ "security-framework",
+ "security-framework-sys",
  "tempfile",
 ]
 
@@ -1265,7 +1265,6 @@ dependencies = [
  "hex",
  "http",
  "hyper",
- "hyper-rustls",
  "itertools",
  "jsonwebtoken",
  "lazy_static",
@@ -1285,7 +1284,6 @@ dependencies = [
  "reqwest",
  "roughenough",
  "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",
@@ -1837,7 +1835,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.19.0",
  "winreg",
 ]
 
@@ -1928,18 +1926,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
-dependencies = [
- "openssl-probe",
- "rustls",
- "schannel",
- "security-framework 1.0.0",
-]
-
-[[package]]
 name = "rusty-machine"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,20 +1998,7 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "libc",
- "security-framework-sys 0.4.3",
-]
-
-[[package]]
-name = "security-framework"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys 1.0.0",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -2033,16 +2006,6 @@ name = "security-framework-sys"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2975,6 +2938,15 @@ name = "webpki-roots"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
 dependencies = [
  "webpki",
 ]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1285,6 +1285,7 @@ dependencies = [
  "reqwest",
  "roughenough",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -383,6 +383,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c8e13110a84b6315df212c045be706af261fd364791cad863285439ebba672e"
+dependencies = [
+ "sct",
+]
+
+[[package]]
 name = "database_proxy"
 version = "0.1.0"
 dependencies = [
@@ -765,6 +774,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
+name = "https_client"
+version = "0.1.0"
+dependencies = [
+ "hyper",
+ "hyper-rustls",
+ "log",
+ "oak_abi",
+ "prost",
+ "rustls",
+ "structopt",
+ "tokio",
+]
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,10 +827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
  "bytes",
+ "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
@@ -1091,8 +1116,8 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
- "security-framework-sys",
+ "security-framework 0.4.4",
+ "security-framework-sys 0.4.3",
  "tempfile",
 ]
 
@@ -1240,6 +1265,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "hyper-rustls",
  "itertools",
  "jsonwebtoken",
  "lazy_static",
@@ -1263,6 +1289,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "tokio-rustls",
  "tonic",
  "wasmi",
 ]
@@ -1900,6 +1927,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework 1.0.0",
+]
+
+[[package]]
 name = "rusty-machine"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,7 +2011,20 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "libc",
- "security-framework-sys",
+ "security-framework-sys 0.4.3",
+]
+
+[[package]]
+name = "security-framework"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys 1.0.0",
 ]
 
 [[package]]
@@ -1980,6 +2032,16 @@ name = "security-framework-sys"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "hello_world/client/rust",
   "hello_world/module/rust",
   "http_server/module",
+  "http_server/client",
   "injection/module/rust",
   "machine_learning/module/rust",
   "trusted_information_retrieval/backend",

--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -47,6 +47,10 @@ version = "=0.13.1"
 name = "rustls"
 version = "=0.17.0"
 
+[[bans.skip]]
+name = "webpki-roots"
+version = "=0.19.0"
+
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]

--- a/examples/http_server/client/Cargo.toml
+++ b/examples/http_server/client/Cargo.toml
@@ -7,7 +7,9 @@ license = "Apache-2.0"
 
 [dependencies]
 hyper = "*"
-hyper-rustls = "*"
+hyper-rustls = { version = "*", default-features = false, features = [
+  "webpki-tokio"
+] }
 log = "*"
 oak_abi = "=0.1.0"
 prost = "*"

--- a/examples/http_server/client/Cargo.toml
+++ b/examples/http_server/client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "https_client"
+version = "0.1.0"
+authors = ["Razieh Behjati <razieh@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+hyper = "*"
+hyper-rustls = "*"
+log = "*"
+oak_abi = "=0.1.0"
+prost = "*"
+rustls = "*"
+structopt = "*"
+tokio = { version = "*", features = ["fs", "macros", "sync", "stream"] }

--- a/examples/http_server/client/client
+++ b/examples/http_server/client/client
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+set -o xtrace
 
-curl localhost:8080
+cert_path="../../certs/local/ca.pem"
+curl --cacert "${cert_path}" https://localhost:8080

--- a/examples/http_server/client/src/main.rs
+++ b/examples/http_server/client/src/main.rs
@@ -34,7 +34,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Send a request, and wait for the response
     let label = oak_abi::label::Label::public_untrusted();
     let mut label_bytes = vec![];
-    let _ = label.encode(&mut label_bytes);
+    label
+        .encode(&mut label_bytes)
+        .expect("could not serialize label to bytes");
     let opt = Opt::from_args();
 
     let path = &opt.ca_cert;

--- a/examples/http_server/client/src/main.rs
+++ b/examples/http_server/client/src/main.rs
@@ -1,0 +1,72 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use prost::Message;
+use std::{fs, io};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "HTTPS server pseudo-Node Client Example.")]
+pub struct Opt {
+    #[structopt(
+        long,
+        help = "Path to the PEM-encoded CA root certificate.",
+        default_value = "../../certs/local/ca.pem"
+    )]
+    ca_cert: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Send a request, and wait for the response
+    let label = oak_abi::label::Label::public_untrusted();
+    let mut label_bytes = vec![];
+    let _ = label.encode(&mut label_bytes);
+    let opt = Opt::from_args();
+
+    let path = &opt.ca_cert;
+    let ca_file = fs::File::open(path).unwrap_or_else(|e| panic!("failed to open {}: {}", path, e));
+    let mut ca = io::BufReader::new(ca_file);
+
+    // Build an HTTP connector which supports HTTPS too.
+    let mut http = hyper::client::HttpConnector::new();
+    http.enforce_http(false);
+    // Build a TLS client, using the custom CA store for lookups.
+    let mut tls = rustls::ClientConfig::new();
+    tls.root_store
+        .add_pem_file(&mut ca)
+        .expect("failed to load custom CA store");
+    // Join the above part into an HTTPS connector.
+    let https = hyper_rustls::HttpsConnector::from((http, tls));
+
+    let client: hyper::client::Client<_, hyper::Body> =
+        hyper::client::Client::builder().build(https);
+
+    let request = hyper::Request::builder()
+        .method("get")
+        .uri("https://localhost:8080")
+        .header(oak_abi::OAK_LABEL_HTTP_KEY, label_bytes)
+        .body(hyper::Body::empty())
+        .unwrap();
+
+    let resp = client
+        .request(request)
+        .await
+        .expect("Error while awaiting response");
+
+    log::info!("Got response: {:?}", resp);
+    Ok(())
+}

--- a/examples/http_server/example.toml
+++ b/examples/http_server/example.toml
@@ -9,5 +9,15 @@ out = "examples/http_server/bin/http_server.oak"
 [applications.rust.modules]
 module = { Cargo = { cargo_manifest = "examples/http_server/module/Cargo.toml" } }
 
+[server]
+additional_args = [
+  "--http-tls-certificate=./examples/certs/local/local.pem",
+  "--http-tls-private-key=./examples/certs/local/local.key",
+]
+
 [clients]
-shell = { Shell = { script = "examples/http_server/client/client" } }
+rust = { Cargo = { cargo_manifest = "examples/http_server/client/Cargo.toml" }, additional_args = [
+  "--ca-cert=./examples/certs/local/ca.pem"
+] }
+# TODO: uncomment when we can pass labels as text/json
+# shell = { Shell = { script = "examples/http_server/client/client" } }

--- a/examples/http_server/example.toml
+++ b/examples/http_server/example.toml
@@ -19,5 +19,5 @@ additional_args = [
 rust = { Cargo = { cargo_manifest = "examples/http_server/client/Cargo.toml" }, additional_args = [
   "--ca-cert=./examples/certs/local/ca.pem"
 ] }
-# TODO: uncomment when we can pass labels as text/json
+# TODO(#1279): uncomment when we can pass labels as text/json
 # shell = { Shell = { script = "examples/http_server/client/client" } }

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -157,6 +157,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +186,15 @@ checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "ct-logs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c8e13110a84b6315df212c045be706af261fd364791cad863285439ebba672e"
+dependencies = [
+ "sct",
 ]
 
 [[package]]
@@ -488,10 +513,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
  "bytes",
+ "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
@@ -812,6 +839,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "hyper-rustls",
  "itertools",
  "jsonwebtoken",
  "lazy_static",
@@ -835,6 +863,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "tokio-rustls",
  "tonic",
  "wasmi",
 ]
@@ -878,6 +907,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "parity-wasm"
@@ -1245,6 +1280,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1304,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1278,6 +1335,29 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -157,22 +157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,15 +170,6 @@ checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "ct-logs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8e13110a84b6315df212c045be706af261fd364791cad863285439ebba672e"
-dependencies = [
- "sct",
 ]
 
 [[package]]
@@ -513,12 +488,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
  "bytes",
- "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
@@ -839,7 +812,6 @@ dependencies = [
  "hex",
  "http",
  "hyper",
- "hyper-rustls",
  "itertools",
  "jsonwebtoken",
  "lazy_static",
@@ -859,7 +831,6 @@ dependencies = [
  "reqwest",
  "roughenough",
  "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",
@@ -908,12 +879,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "parity-wasm"
@@ -1281,18 +1246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
-dependencies = [
- "openssl-probe",
- "rustls",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,16 +1258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1336,29 +1279,6 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -859,6 +859,7 @@ dependencies = [
  "reqwest",
  "roughenough",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",

--- a/oak_runtime/Cargo.lock
+++ b/oak_runtime/Cargo.lock
@@ -127,6 +127,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +156,15 @@ checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "ct-logs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c8e13110a84b6315df212c045be706af261fd364791cad863285439ebba672e"
+dependencies = [
+ "sct",
 ]
 
 [[package]]
@@ -458,10 +483,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
  "bytes",
+ "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
@@ -768,6 +795,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "hyper-rustls",
  "itertools",
  "jsonwebtoken",
  "lazy_static",
@@ -787,10 +815,12 @@ dependencies = [
  "reqwest",
  "roughenough",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",
  "tokio",
+ "tokio-rustls",
  "tonic",
  "wasmi",
  "wat",
@@ -835,6 +865,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "parity-wasm"
@@ -1178,6 +1214,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1238,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1211,6 +1269,29 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/oak_runtime/Cargo.lock
+++ b/oak_runtime/Cargo.lock
@@ -127,22 +127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,10 +472,10 @@ dependencies = [
  "hyper",
  "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
+ "webpki-roots 0.20.0",
 ]
 
 [[package]]
@@ -815,7 +799,6 @@ dependencies = [
  "reqwest",
  "roughenough",
  "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",
@@ -865,12 +848,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "parity-wasm"
@@ -1161,7 +1138,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.19.0",
  "winreg",
 ]
 
@@ -1214,18 +1191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
-dependencies = [
- "openssl-probe",
- "rustls",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,16 +1203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1269,29 +1224,6 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2024,6 +1956,15 @@ name = "webpki-roots"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
 dependencies = [
  "webpki",
 ]

--- a/oak_runtime/Cargo.toml
+++ b/oak_runtime/Cargo.toml
@@ -24,7 +24,7 @@ futures-core = "*"
 futures-util = "*"
 hex = "*"
 http = "*"
-hyper = { version = "0.13.0", default-features = false }
+hyper = "*"
 itertools = "*"
 jsonwebtoken = "*"
 lazy_static = "*"
@@ -44,7 +44,7 @@ regex = { version = "1", optional = true }
 reqwest = { version = "*", default-features = false, features = ["rustls-tls"] }
 roughenough = { path = "../third_party/roughenough" }
 rustls = "*"
-rustls-native-certs = { version = "0.4.0", optional = true }
+rustls-native-certs = "*"
 serde = "*"
 serde_json = "*"
 sha2 = "*"

--- a/oak_runtime/Cargo.toml
+++ b/oak_runtime/Cargo.toml
@@ -24,7 +24,7 @@ futures-core = "*"
 futures-util = "*"
 hex = "*"
 http = "*"
-hyper = "*"
+hyper = { version = "0.13.0", default-features = false }
 itertools = "*"
 jsonwebtoken = "*"
 lazy_static = "*"
@@ -44,6 +44,7 @@ regex = { version = "1", optional = true }
 reqwest = { version = "*", default-features = false, features = ["rustls-tls"] }
 roughenough = { path = "../third_party/roughenough" }
 rustls = "*"
+rustls-native-certs = { version = "0.4.0", optional = true }
 serde = "*"
 serde_json = "*"
 sha2 = "*"
@@ -55,6 +56,8 @@ tokio = { version = "*", features = [
   "time",
   "udp"
 ] }
+tokio-rustls = "*"
+hyper-rustls = "*"
 tonic = { version = "*", features = ["tls"] }
 wasmi = { version = "*", default-features = false, features = ["core"] }
 

--- a/oak_runtime/Cargo.toml
+++ b/oak_runtime/Cargo.toml
@@ -44,7 +44,6 @@ regex = { version = "1", optional = true }
 reqwest = { version = "*", default-features = false, features = ["rustls-tls"] }
 roughenough = { path = "../third_party/roughenough" }
 rustls = "*"
-rustls-native-certs = "*"
 serde = "*"
 serde_json = "*"
 sha2 = "*"
@@ -57,12 +56,14 @@ tokio = { version = "*", features = [
   "udp"
 ] }
 tokio-rustls = "*"
-hyper-rustls = "*"
 tonic = { version = "*", features = ["tls"] }
 wasmi = { version = "*", default-features = false, features = ["core"] }
 
 [dev-dependencies]
 env_logger = "*"
+hyper-rustls = { version = "*", default-features = false, features = [
+  "webpki-tokio"
+] }
 minisign = "*"
 regex = "*"
 wat = "*"

--- a/oak_runtime/deny.toml
+++ b/oak_runtime/deny.toml
@@ -26,6 +26,10 @@ multiple-versions = "deny"
 name = "base64"
 version = "=0.11.0"
 
+[[bans.skip]]
+name = "webpki-roots"
+version = "=0.19.0"
+
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]

--- a/oak_runtime/src/config.rs
+++ b/oak_runtime/src/config.rs
@@ -28,8 +28,11 @@ use tonic::transport::Certificate;
 /// send messages into the Runtime. Creating a new channel and passing the write [`oak_abi::Handle`]
 /// into the runtime will enable messages to be read back out from the [`RuntimeProxy`].
 pub fn configure_and_run(config: RuntimeConfiguration) -> Result<Arc<Runtime>, OakError> {
-    let proxy =
-        RuntimeProxy::create_runtime(&config.app_config, &config.grpc_config, &config.sign_table);
+    let proxy = RuntimeProxy::create_runtime(
+        &config.app_config,
+        &config.secure_server_configuration,
+        &config.sign_table,
+    );
     let config_map = config.config_map.clone();
     let handle = proxy.start_runtime(config)?;
 

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -77,6 +77,7 @@ mod proxy;
 #[cfg(test)]
 mod tests;
 pub mod time;
+pub mod tls;
 
 /// Configuration options that govern the behaviour of the Runtime and the Oak Application running
 /// inside it.
@@ -87,7 +88,7 @@ pub struct RuntimeConfiguration {
     /// Port to run an introspection server on, if provided.
     pub introspect_port: Option<u16>,
     /// gRPC-specific options.
-    pub grpc_config: GrpcConfiguration,
+    pub secure_server_configuration: SecureServerConfiguration,
     /// Application configuration.
     pub app_config: ApplicationConfiguration,
     /// Table that contains signatures and public keys corresponding to Oak modules.
@@ -128,6 +129,22 @@ pub struct Signature {
 pub struct SignatureTable {
     /// Keys in the table are Oak module hashes.
     pub values: HashMap<String, Vec<Signature>>,
+}
+
+/// Configuration options related to HTTP pseudo-Nodes.
+///
+/// `Debug` is intentionally not implemented in order to avoid accidentally logging secrets.
+#[derive(Default, Clone)]
+pub struct HttpConfiguration {
+    /// TLS identity to use for all HTTP Server Nodes.
+    pub tls_config: crate::tls::TlsConfig,
+}
+
+/// Configuration options for secure HTTP and gRPC pseudo-Nodes.
+#[derive(Default, Clone)]
+pub struct SecureServerConfiguration {
+    pub grpc_config: Option<GrpcConfiguration>,
+    pub http_config: Option<HttpConfiguration>,
 }
 
 struct NodeStopper {
@@ -306,7 +323,9 @@ impl Drop for AuxServer {
 /// Runtime structure for configuring and running a set of Oak Nodes.
 pub struct Runtime {
     application_configuration: ApplicationConfiguration,
-    grpc_configuration: GrpcConfiguration,
+
+    secure_server_configuration: SecureServerConfiguration,
+
     signature_table: SignatureTable,
 
     terminating: AtomicBool,
@@ -1123,7 +1142,7 @@ impl Runtime {
         let instance = node::create_node(
             &self.application_configuration,
             config,
-            &self.grpc_configuration,
+            &self.secure_server_configuration,
             &self.signature_table,
         )
         .map_err(|err| {

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -87,7 +87,7 @@ pub struct RuntimeConfiguration {
     pub metrics_port: Option<u16>,
     /// Port to run an introspection server on, if provided.
     pub introspect_port: Option<u16>,
-    /// gRPC-specific options.
+    /// Security options for server pseudo-nodes.
     pub secure_server_configuration: SecureServerConfiguration,
     /// Application configuration.
     pub app_config: ApplicationConfiguration,

--- a/oak_runtime/src/node/http/mod.rs
+++ b/oak_runtime/src/node/http/mod.rs
@@ -234,11 +234,13 @@ impl HttpServerNode {
 
         let incoming_tls_stream = tcp
             .incoming()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Incoming failed: {:?}", e)))
-            .and_then(move |s| {
-                tls_acceptor.accept(s).map_err(|e| {
-                    log::error!("Client-connection error: {:?}", e);
-                    io::Error::new(io::ErrorKind::Other, format!("TLS Error: {:?}", e))
+            .map_err(|err| {
+                io::Error::new(io::ErrorKind::Other, format!("Incoming failed: {:?}", err))
+            })
+            .and_then(move |stream| {
+                tls_acceptor.accept(stream).map_err(|err| {
+                    log::error!("Client-connection error: {:?}", err);
+                    io::Error::new(io::ErrorKind::Other, format!("TLS Error: {:?}", err))
                 })
             })
             .boxed();

--- a/oak_runtime/src/node/http/mod.rs
+++ b/oak_runtime/src/node/http/mod.rs
@@ -24,6 +24,8 @@ use crate::{
     node::{ConfigurationError, Node},
     ChannelHalfDirection, RuntimeProxy,
 };
+use core::task::{Context, Poll};
+use futures_util::stream::Stream;
 use hyper::{
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server, StatusCode,
@@ -38,8 +40,18 @@ use oak_io::{
 };
 use oak_services::proto::oak::encap::{HttpRequest, HttpResponse};
 use prost::Message;
-use std::{future::Future, net::SocketAddr, pin::Pin};
-use tokio::sync::oneshot;
+use std::{io, net::SocketAddr, pin::Pin};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::oneshot,
+};
+use tokio_rustls::server::TlsStream;
+
+use futures_util::{
+    future::TryFutureExt,
+    stream::{StreamExt, TryStreamExt},
+};
+use tokio_rustls::TlsAcceptor;
 
 #[cfg(test)]
 pub mod tests;
@@ -53,12 +65,32 @@ fn check_port(address: &SocketAddr) -> Result<(), ConfigurationError> {
     }
 }
 
+/// Asynchronously accept incoming TLS connections.
+pub struct TlsServer<'a> {
+    acceptor: Pin<Box<dyn Stream<Item = Result<TlsStream<TcpStream>, io::Error>> + 'a>>,
+}
+
+impl hyper::server::accept::Accept for TlsServer<'_> {
+    type Conn = TlsStream<TcpStream>;
+    type Error = io::Error;
+
+    /// Poll to accept the next connection.
+    fn poll_accept(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        Pin::new(&mut self.acceptor).poll_next(cx)
+    }
+}
+
 /// Struct that represents an HTTP server pseudo-Node.
 pub struct HttpServerNode {
     /// Pseudo-Node name.
     node_name: String,
     /// Server address to listen client requests on.
     address: SocketAddr,
+    /// TLS certificate and private key for establishing secure connections.
+    tls_config: crate::tls::TlsConfig,
 }
 
 impl HttpServerNode {
@@ -66,12 +98,14 @@ impl HttpServerNode {
     pub fn new(
         node_name: &str,
         config: HttpServerConfiguration,
+        tls_config: crate::tls::TlsConfig,
     ) -> Result<Self, ConfigurationError> {
         let address = config.address.parse()?;
         check_port(&address)?;
         Ok(Self {
             node_name: node_name.to_string(),
             address,
+            tls_config,
         })
     }
 
@@ -154,21 +188,23 @@ impl HttpServerNode {
     ) {
         // A `Service` is needed for every connection, so this
         // creates one from the `request_handler`.
-        let make_service = make_service_fn(move |_conn| {
+        let service = make_service_fn(move |_conn| {
             let handler = request_handler.clone();
             async move {
                 Ok::<_, hyper::Error>(service_fn(move |req| {
                     let handler = handler.clone();
-
-                    async move {
-                        let http_request = HttpServerNode::map_to_http_request(req).await;
-                        handler.handle(http_request).await
-                    }
+                    async move { handler.handle(req).await }
                 }))
             }
         });
 
-        let server = Server::bind(&self.address).serve(make_service);
+        // Low-level server creation is needed, to be able to validate TLS streams.
+        let mut tcp = TcpListener::bind(&self.address)
+            .await
+            .expect("Could not create TCP listener.");
+        let tls_server = self.build_tls_server(&mut tcp).await;
+        let server = Server::builder(tls_server).serve(service);
+
         let graceful_server = server.with_graceful_shutdown(async {
             // Treat notification failure the same as a notification.
             let _ = notify_receiver.await;
@@ -180,8 +216,36 @@ impl HttpServerNode {
         );
 
         // Run until asked to terminate...
-        let result = graceful_server.await;
+        let result = graceful_server
+            // Terminate the server only if a shutdown signal is received.
+            // In case of errors, only log them instead of terminating the server.
+            .or_else(|e| async move {
+                log::error!("server error: {}", e);
+                Ok::<_, hyper::Error>(())
+            })
+            .await;
         info!("HTTP server pseudo-node terminated with {:?}", result);
+    }
+
+    /// Build a server that checks incoming TCP connections for TLS handshake.
+    async fn build_tls_server<'a>(&'a self, tcp: &'a mut TcpListener) -> TlsServer<'a> {
+        let tls_cfg = crate::tls::to_server_config(self.tls_config.clone());
+        let tls_acceptor = TlsAcceptor::from(tls_cfg);
+
+        let incoming_tls_stream = tcp
+            .incoming()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Incoming failed: {:?}", e)))
+            .and_then(move |s| {
+                tls_acceptor.accept(s).map_err(|e| {
+                    log::error!("Client-connection error: {:?}", e);
+                    io::Error::new(io::ErrorKind::Other, format!("TLS Error: {:?}", e))
+                })
+            })
+            .boxed();
+
+        TlsServer {
+            acceptor: incoming_tls_stream,
+        }
     }
 
     // Create an instance of HttpRequest, from the given Request.
@@ -287,28 +351,21 @@ struct HttpRequestHandler {
 }
 
 impl HttpRequestHandler {
-    fn handle(
-        &self,
-        request: HttpRequest,
-    ) -> Pin<Box<dyn Future<Output = Result<Response<Body>, OakStatus>> + Send + Sync>> {
-        let handler = self.clone();
-        let future = async move {
-            let oak_label = get_oak_label(&request)?;
-            info!(
-                "Handling HTTP request; request size: {} bytes, label: {:?}",
-                request.body.len(),
-                oak_label
-            );
+    async fn handle(&self, req: Request<Body>) -> Result<Response<Body>, OakStatus> {
+        let request = HttpServerNode::map_to_http_request(req).await;
+        let oak_label = get_oak_label(&request)?;
+        info!(
+            "Handling HTTP request; request size: {} bytes, label: {:?}",
+            request.body.len(),
+            oak_label
+        );
 
-            debug!("Inject the request into the Oak Node");
-            let response = handler
-                .inject_http_request(request, &oak_label)
-                .map_err(|_| OakStatus::ErrInternal)?;
+        debug!("Inject the request into the Oak Node");
+        let response = self
+            .inject_http_request(request, &oak_label)
+            .map_err(|_| OakStatus::ErrInternal)?;
 
-            Ok(response.to_response())
-        };
-
-        Box::pin(future)
+        Ok(response.to_response())
     }
 
     fn inject_http_request(
@@ -430,8 +487,8 @@ fn get_oak_label(req: &HttpRequest) -> Result<Label, OakStatus> {
             OakStatus::ErrInvalidArgs
         }),
         None => {
-            warn!("No HTTP label found: using public_untrusted.");
-            Ok(Label::public_untrusted())
+            warn!("No HTTP label found.");
+            Err(OakStatus::ErrInvalidArgs)
         }
     }
 }
@@ -464,9 +521,7 @@ impl HttpResponseIterator {
             }
             Err(status) => {
                 error!("Could not read response: {}", status);
-                *response.status_mut() =
-                    StatusCode::from_u16(http::status::StatusCode::INTERNAL_SERVER_ERROR.as_u16())
-                        .expect("Error when creating internal error (500) status code.");
+                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
             }
         }
         response

--- a/oak_runtime/src/node/wasm/tests.rs
+++ b/oak_runtime/src/node/wasm/tests.rs
@@ -15,7 +15,7 @@
 //
 
 use super::*;
-use crate::{GrpcConfiguration, RuntimeProxy};
+use crate::{RuntimeProxy, SecureServerConfiguration};
 use maplit::hashmap;
 use oak_abi::{
     label::Label,
@@ -43,7 +43,7 @@ fn start_node(
     };
     let proxy = RuntimeProxy::create_runtime(
         &application_configuration,
-        &GrpcConfiguration::default(),
+        &SecureServerConfiguration::default(),
         &signature_table,
     );
     let (_write_handle, read_handle) = proxy.channel_create(&Label::public_untrusted())?;

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -18,8 +18,8 @@
 //! context of a specific Node or pseudo-Node.
 
 use crate::{
-    metrics::Metrics, AuxServer, ChannelHalfDirection, GrpcConfiguration, NodeId, NodeMessage,
-    NodePrivilege, NodeReadStatus, Runtime, SignatureTable,
+    metrics::Metrics, AuxServer, ChannelHalfDirection, NodeId, NodeMessage, NodePrivilege,
+    NodeReadStatus, Runtime, SecureServerConfiguration, SignatureTable,
 };
 use core::sync::atomic::{AtomicBool, AtomicU64};
 use log::debug;
@@ -57,12 +57,12 @@ impl RuntimeProxy {
     /// Creates a [`Runtime`] instance with a single initial Node configured, and no channels.
     pub fn create_runtime(
         application_configuration: &ApplicationConfiguration,
-        grpc_configuration: &GrpcConfiguration,
+        secure_server_configuration: &SecureServerConfiguration,
         signature_table: &SignatureTable,
     ) -> RuntimeProxy {
         let runtime = Arc::new(Runtime {
             application_configuration: application_configuration.clone(),
-            grpc_configuration: grpc_configuration.clone(),
+            secure_server_configuration: secure_server_configuration.clone(),
             signature_table: signature_table.clone(),
             terminating: AtomicBool::new(false),
             next_channel_id: AtomicU64::new(0),

--- a/oak_runtime/src/tests.rs
+++ b/oak_runtime/src/tests.rs
@@ -44,7 +44,7 @@ fn run_node_body(node_label: &Label, node_privilege: &NodePrivilege, node_body: 
     info!("Create runtime for test");
     let proxy = crate::RuntimeProxy::create_runtime(
         &configuration,
-        &GrpcConfiguration::default(),
+        &SecureServerConfiguration::default(),
         &signature_table,
     );
 

--- a/oak_runtime/src/tls.rs
+++ b/oak_runtime/src/tls.rs
@@ -51,9 +51,9 @@ pub(crate) fn to_server_config(tls_config: TlsConfig) -> Arc<ServerConfig> {
     let mut cfg = ServerConfig::new(NoClientAuth::new());
     // Select a certificate to use.
     let private_key = tls_config.keys[0].clone();
-    let _ = cfg
-        .set_single_cert(tls_config.certs, private_key)
-        .map_err(|e| log::error!("{}", e));
+    if let Err(error) = cfg.set_single_cert(tls_config.certs, private_key) {
+        log::warn!("{}", error);
+    };
     // Configure ALPN to accept HTTP/2, HTTP/1.1 in that order.
     cfg.set_protocols(&[b"h2".to_vec(), b"http/1.1".to_vec()]);
     Arc::new(cfg)

--- a/oak_runtime/src/tls.rs
+++ b/oak_runtime/src/tls.rs
@@ -25,6 +25,7 @@ use tokio_rustls::rustls::{
     Certificate, NoClientAuth, PrivateKey, ServerConfig,
 };
 
+/// Represents TLS identity to use for HTTP server pseudo-nodes.
 #[derive(Default, Clone)]
 pub struct TlsConfig {
     certs: Vec<Certificate>,

--- a/oak_runtime/src/tls.rs
+++ b/oak_runtime/src/tls.rs
@@ -1,0 +1,69 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::{
+    fs::File,
+    io::{self, BufReader},
+    path::Path,
+    sync::Arc,
+};
+use tokio_rustls::rustls::{
+    internal::pemfile::{certs, rsa_private_keys},
+    Certificate, NoClientAuth, PrivateKey, ServerConfig,
+};
+
+#[derive(Default, Clone)]
+pub struct TlsConfig {
+    certs: Vec<Certificate>,
+    keys: Vec<PrivateKey>,
+}
+
+impl TlsConfig {
+    pub fn new(cert_path: &str, key_path: &str) -> Option<Self> {
+        let certs = match load_certs(&Path::new(cert_path)) {
+            Ok(certs) => certs,
+            Err(_) => return None,
+        };
+
+        let keys = match load_keys(&Path::new(key_path)) {
+            Ok(keys) => keys,
+            Err(_) => return None,
+        };
+        Some(TlsConfig { certs, keys })
+    }
+}
+
+pub(crate) fn to_server_config(tls_config: TlsConfig) -> Arc<ServerConfig> {
+    let mut cfg = ServerConfig::new(NoClientAuth::new());
+    // Select a certificate to use.
+    let private_key = tls_config.keys[0].clone();
+    let _ = cfg
+        .set_single_cert(tls_config.certs, private_key)
+        .map_err(|e| log::error!("{}", e));
+    // Configure ALPN to accept HTTP/2, HTTP/1.1 in that order.
+    cfg.set_protocols(&[b"h2".to_vec(), b"http/1.1".to_vec()]);
+    Arc::new(cfg)
+}
+
+fn load_certs(path: &Path) -> io::Result<Vec<Certificate>> {
+    certs(&mut BufReader::new(File::open(path)?))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid cert"))
+}
+
+fn load_keys(path: &Path) -> io::Result<Vec<PrivateKey>> {
+    rsa_private_keys(&mut BufReader::new(File::open(path)?))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid key"))
+}

--- a/oak_runtime/tests/integration_test.rs
+++ b/oak_runtime/tests/integration_test.rs
@@ -37,7 +37,7 @@ mod common {
         WebAssemblyConfiguration,
     };
     use oak_io::OakError;
-    use oak_runtime::{config, GrpcConfiguration, Runtime, SignatureTable};
+    use oak_runtime::{config, Runtime, SecureServerConfiguration, SignatureTable};
     use std::sync::Arc;
     use wat::parse_str;
 
@@ -70,7 +70,7 @@ mod common {
         config::configure_and_run(oak_runtime::RuntimeConfiguration {
             metrics_port: Some(crate::METRICS_PORT),
             introspect_port: None,
-            grpc_config: GrpcConfiguration::default(),
+            secure_server_configuration: SecureServerConfiguration::default(),
             app_config: application_configuration,
             sign_table: SignatureTable::default(),
             config_map: ConfigMap::default(),

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -946,6 +946,7 @@ dependencies = [
  "reqwest",
  "roughenough",
  "rustls 0.17.0",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -198,6 +198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
+dependencies = [
+ "sct",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,10 +547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
  "bytes",
+ "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls 0.17.0",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.13.1",
  "webpki",
@@ -915,6 +926,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "hyper-rustls",
  "itertools",
  "jsonwebtoken",
  "lazy_static",
@@ -938,6 +950,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "tokio-rustls 0.13.1",
  "tonic",
  "wasmi",
 ]
@@ -1426,6 +1439,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.17.0",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -198,15 +198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
-dependencies = [
- "sct",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,12 +538,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
  "bytes",
- "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls 0.17.0",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.13.1",
  "webpki",
@@ -926,7 +915,6 @@ dependencies = [
  "hex",
  "http",
  "hyper",
- "hyper-rustls",
  "itertools",
  "jsonwebtoken",
  "lazy_static",
@@ -946,7 +934,6 @@ dependencies = [
  "reqwest",
  "roughenough",
  "rustls 0.17.0",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",
@@ -1440,18 +1427,6 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
-dependencies = [
- "openssl-probe",
- "rustls 0.17.0",
- "schannel",
- "security-framework",
 ]
 
 [[package]]

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -137,15 +137,19 @@ pub fn runtime_config_wasm(
     oak_runtime::RuntimeConfiguration {
         metrics_port: Some(9090),
         introspect_port: Some(1909),
-        grpc_config: oak_runtime::GrpcConfiguration {
-            grpc_server_tls_identity: Some(Identity::from_pem(
-                include_str!("../certs/local.pem"),
-                include_str!("../certs/local.key"),
-            )),
-            grpc_client_root_tls_certificate: Some(
-                oak_runtime::config::load_certificate(&include_str!("../certs/ca.pem")).unwrap(),
-            ),
-            oidc_client_info: None,
+        secure_server_configuration: oak_runtime::SecureServerConfiguration {
+            grpc_config: Some(oak_runtime::GrpcConfiguration {
+                grpc_server_tls_identity: Some(Identity::from_pem(
+                    include_str!("../certs/local.pem"),
+                    include_str!("../certs/local.key"),
+                )),
+                grpc_client_root_tls_certificate: Some(
+                    oak_runtime::config::load_certificate(&include_str!("../certs/ca.pem"))
+                        .unwrap(),
+                ),
+                oidc_client_info: None,
+            }),
+            http_config: None,
         },
         app_config: ApplicationConfiguration {
             wasm_modules,


### PR DESCRIPTION
- Adds TLS support for HTTP server pseudo-node
- Adds new flags optional to `oak_loader` for HTTP tls configuration
- Adds a Rust client for the `http_server` example

Fixes #1345 

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
