### PR TITLE
cloudbuild: allow for longer runner stage

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
   - name: 'gcr.io/oak-ci/oak:latest'
     id: runner_ci
     waitFor: ['git_init']
-    timeout: 60m
+    timeout: 90m
     entrypoint: 'bash'
     args: ['./scripts/runner', '--commands', 'run-ci']
 


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
