### PR TITLE
abitest: add slow methods for parallel tests

### DIFF
--- a/examples/abitest/client/BUILD
+++ b/examples/abitest/client/BUILD
@@ -34,6 +34,7 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@cpp_httplib//:httplib",
     ],
@@ -47,6 +48,8 @@ cc_library(
         "//examples/abitest/proto:abitest_cc_grpc",
         "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
     ],
 )
 
@@ -58,5 +61,6 @@ cc_library(
         "//examples/abitest/proto:abitest_cc_grpc",
         "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/time",
     ],
 )

--- a/examples/abitest/client/abitest.cc
+++ b/examples/abitest/client/abitest.cc
@@ -20,6 +20,7 @@
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
+#include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"

--- a/examples/abitest/client/grpc_test_server.cc
+++ b/examples/abitest/client/grpc_test_server.cc
@@ -16,6 +16,8 @@
 
 #include "examples/abitest/client/grpc_test_server.h"
 
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "glog/logging.h"
 
 using ::oak::examples::abitest::GrpcTestRequest;
@@ -94,6 +96,34 @@ grpc::Status GrpcTestServer::BidiStreamingMethod(
     stream->Write(rsp);
   }
   LOG(INFO) << "BidiStreamingMethod -> OK";
+  return grpc::Status::OK;
+}
+
+grpc::Status GrpcTestServer::SlowUnaryMethod(grpc::ServerContext* context,
+                                             const GrpcTestRequest* req, GrpcTestResponse* rsp) {
+  LOG(INFO) << "UnaryMethod ...";
+  absl::SleepFor(absl::Seconds(5));
+  rsp->set_text("sloow");
+  LOG(INFO) << "UnaryMethod ... -> Ok('" << rsp->text() << "')";
+  return grpc::Status::OK;
+}
+
+grpc::Status GrpcTestServer::SlowStreamingMethod(grpc::ServerContext* context,
+                                                 const GrpcTestRequest* req,
+                                                 grpc::ServerWriter<GrpcTestResponse>* writer) {
+  // Write two responses to exercise streaming.
+  GrpcTestResponse rsp;
+  rsp.set_text("sloow");
+  LOG(INFO) << "ServerStreamingMethod...";
+  absl::SleepFor(absl::Seconds(3));
+  writer->Write(rsp);
+  LOG(INFO) << "ServerStreamingMethod... -> '" << req->ok_text() << "'";
+
+  LOG(INFO) << "ServerStreamingMethod...";
+  absl::SleepFor(absl::Seconds(3));
+  writer->Write(rsp);
+  LOG(INFO) << "ServerStreamingMethod... -> '" << req->ok_text() << "'";
+  LOG(INFO) << "ServerStreamingMethod -> OK";
   return grpc::Status::OK;
 }
 

--- a/examples/abitest/client/grpc_test_server.h
+++ b/examples/abitest/client/grpc_test_server.h
@@ -49,6 +49,14 @@ class GrpcTestServer final : public ::oak::examples::abitest::OakABITestService:
       ::grpc::ServerContext* context,
       grpc::ServerReaderWriter<oak::examples::abitest::GrpcTestResponse,
                                oak::examples::abitest::GrpcTestRequest>* stream) override;
+
+  grpc::Status SlowUnaryMethod(grpc::ServerContext* context,
+                               const oak::examples::abitest::GrpcTestRequest* req,
+                               oak::examples::abitest::GrpcTestResponse* rsp) override;
+
+  grpc::Status SlowStreamingMethod(
+      grpc::ServerContext* context, const oak::examples::abitest::GrpcTestRequest* req,
+      grpc::ServerWriter<oak::examples::abitest::GrpcTestResponse>* writer) override;
 };
 
 }  // namespace test

--- a/examples/abitest/client/grpctest.h
+++ b/examples/abitest/client/grpctest.h
@@ -35,5 +35,7 @@ bool test_client_streaming_method_ok(oak::examples::abitest::OakABITestService::
 bool test_client_streaming_method_err(oak::examples::abitest::OakABITestService::Stub* stub);
 bool test_bidi_streaming_method_ok(oak::examples::abitest::OakABITestService::Stub* stub);
 bool test_bidi_streaming_method_err(oak::examples::abitest::OakABITestService::Stub* stub);
+bool test_slow_unary_method(oak::examples::abitest::OakABITestService::Stub* stub);
+bool test_slow_streaming_method(oak::examples::abitest::OakABITestService::Stub* stub);
 
 #endif  // EXAMPLES_ABITEST_CLIENT_GRPCTEST_H

--- a/examples/abitest/proto/abitest.proto
+++ b/examples/abitest/proto/abitest.proto
@@ -67,4 +67,9 @@ service OakABITestService {
   rpc ServerStreamingMethod(GrpcTestRequest) returns (stream GrpcTestResponse);
   rpc ClientStreamingMethod(stream GrpcTestRequest) returns (GrpcTestResponse);
   rpc BidiStreamingMethod(stream GrpcTestRequest) returns (stream GrpcTestResponse);
+
+  // The following methods perform an operation that takes some time server-side;
+  // this allows testing of parallel requests.
+  rpc SlowUnaryMethod(GrpcTestRequest) returns (GrpcTestResponse);
+  rpc SlowStreamingMethod(GrpcTestRequest) returns (stream GrpcTestResponse);
 }


### PR DESCRIPTION
Add SlowUnaryMethod and SlowStreamingMethod to the gRPC service
definition for abitest.

Implement these methods in the C++ client application (which also acts
as a gRPC server) by just sleeping before sending a response.

Implement these methods in the Oak Node by forwarding on to a gRPC
client pseudo-Node, which will connect back to the gRPC service inside
the abitest C++ client application, and so will hit the sleeps
described above.

Add simple test cases for --test_grpc=true which just invoke these
slow methods.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
