### PR TITLE
Add support for IFC labels as json

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -778,12 +778,14 @@ checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 name = "https_client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "hyper",
  "hyper-rustls",
  "log",
  "oak_abi",
  "prost",
  "rustls",
+ "serde_json",
  "structopt",
  "tokio",
 ]
@@ -1233,6 +1235,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "serde",
 ]
 
 [[package]]

--- a/examples/http_server/client/Cargo.toml
+++ b/examples/http_server/client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+anyhow = "*"
 hyper = "*"
 hyper-rustls = { version = "*", default-features = false, features = [
   "webpki-tokio"
@@ -14,5 +15,6 @@ log = "*"
 oak_abi = "=0.1.0"
 prost = "*"
 rustls = "*"
+serde_json = "*"
 structopt = "*"
 tokio = { version = "*", features = ["fs", "macros", "sync", "stream"] }

--- a/examples/http_server/client/client
+++ b/examples/http_server/client/client
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -o xtrace
 
-cert_path="../../certs/local/ca.pem"
-curl --cacert "${cert_path}" https://localhost:8080
+cert_path='./examples/certs/local/ca.pem'
+curl --cacert "${cert_path}" --header 'oak-label: {"confidentialityTags":[],"integrityTags":[]}' https://localhost:8080

--- a/examples/http_server/client/src/main.rs
+++ b/examples/http_server/client/src/main.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use prost::Message;
+use anyhow::Context;
 use std::{fs, io};
 use structopt::StructOpt;
 
@@ -33,10 +33,9 @@ pub struct Opt {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Send a request, and wait for the response
     let label = oak_abi::label::Label::public_untrusted();
-    let mut label_bytes = vec![];
-    label
-        .encode(&mut label_bytes)
-        .expect("could not serialize label to bytes");
+    let label_bytes = serde_json::to_string(&label)
+        .context("Could not serialize public/untrusted label to JSON.")?
+        .into_bytes();
     let opt = Opt::from_args();
 
     let path = &opt.ca_cert;

--- a/examples/http_server/example.toml
+++ b/examples/http_server/example.toml
@@ -19,5 +19,4 @@ additional_args = [
 rust = { Cargo = { cargo_manifest = "examples/http_server/client/Cargo.toml" }, additional_args = [
   "--ca-cert=./examples/certs/local/ca.pem"
 ] }
-# TODO(#1279): uncomment when we can pass labels as text/json
-# shell = { Shell = { script = "examples/http_server/client/client" } }
+shell = { Shell = { script = "examples/http_server/client/client" } }

--- a/oak_abi/Cargo.lock
+++ b/oak_abi/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "serde",
 ]
 
 [[package]]
@@ -276,6 +277,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/oak_abi/Cargo.toml
+++ b/oak_abi/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 prost = { path = "../third_party/prost" }
 prost-types = { path = "../third_party/prost/prost-types" }
+serde = { version = "*", features = ["derive"] }
 
 [build-dependencies]
 oak_utils = { path = "../oak_utils" }

--- a/oak_io/Cargo.lock
+++ b/oak_io/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "serde",
 ]
 
 [[package]]
@@ -297,6 +298,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -757,6 +757,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "serde",
 ]
 
 [[package]]

--- a/oak_runtime/Cargo.lock
+++ b/oak_runtime/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "serde",
 ]
 
 [[package]]

--- a/oak_runtime/src/node/http/tests.rs
+++ b/oak_runtime/src/node/http/tests.rs
@@ -17,6 +17,7 @@
 use super::*;
 use maplit::hashmap;
 use oak_abi::{label::Label, proto::oak::application::ApplicationConfiguration};
+use prost::Message;
 use std::{fs, option::Option, thread::JoinHandle};
 
 struct HttpServerTester {
@@ -202,8 +203,9 @@ fn oak_node_simulator(runtime: &RuntimeProxy, invocation_receiver: oak_abi::Hand
 async fn send_request(uri: &str) -> Result<http::response::Response<hyper::Body>, hyper::Error> {
     // Send a request, and wait for the response
     let label = oak_abi::label::Label::public_untrusted();
-    let mut label_bytes = vec![];
-    let _ = label.encode(&mut label_bytes);
+    let label_bytes = serde_json::to_string(&label)
+        .expect("Could not serialize the label to JSON")
+        .into_bytes();
 
     let path = "../examples/certs/local/ca.pem";
     let ca_file = fs::File::open(path).unwrap_or_else(|e| panic!("failed to open {}: {}", path, e));

--- a/oak_services/Cargo.lock
+++ b/oak_services/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "serde",
 ]
 
 [[package]]
@@ -310,6 +311,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/oak_utils/src/lib.rs
+++ b/oak_utils/src/lib.rs
@@ -238,6 +238,11 @@ where
         // We require label-related types to be comparable and hashable so that they can be used in
         // hash-based collections.
         .type_attribute(".oak.label", "#[derive(Eq, Hash)]")
+        .type_attribute(
+            ".oak.label",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(".oak.label", "#[serde(rename_all = \"camelCase\")]")
         .compile_protos(inputs, includes)
         .expect("could not run prost-build");
 }

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "serde",
 ]
 
 [[package]]


### PR DESCRIPTION
* Allows serializing and deserializing IFC labels to and from json
* Updates HTTP server examples and tests accordingly

Fixes #1279 

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
