### PR TITLE
Runner: Remove invalid CLI flag

### DIFF
--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -524,7 +524,7 @@ fn run_example_server(
             // TODO(#396): Add `--oidc-client` support.
             format!("--application={}", application_file),
             ...if opt.server_variant == "logless" {
-                vec!["--no-default-features".to_string()]
+                vec![]
             } else {
                 vec!["--root-tls-certificate=./examples/certs/local/ca.pem".to_string()]
             },


### PR DESCRIPTION
`./scripts/runner --logs run-examples --client-variant=none --server-variant=logless --example-name=hello_world` fails with:
<img width="1141" alt="Screenshot at Aug 28 4-12-39 pm" src="https://user-images.githubusercontent.com/8875406/91583786-95015b80-e949-11ea-8d50-e2d8eab57918.png">

This seems to be the `--no-default-features` cargo flag, which is already passed during compilation: 
https://github.com/project-oak/oak/blob/e174def0a34f1e975d1c0d9cd905cf05c856b4f4/runner/src/main.rs#L351

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
