### PR TITLE
Ensure NodeCreated is fired for the initial node

### DIFF
--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -1150,13 +1150,6 @@ impl Runtime {
             OakStatus::ErrInvalidArgs
         })?;
 
-        // TODO(#913): Add automated tests that verify that NodeCreated is
-        // always fired prior to any other introspection events related to the
-        // node.
-        self.introspection_event(EventDetails::NodeCreated(NodeCreated {
-            node_id: node_id.0,
-        }));
-
         let node_privilege = instance.get_privilege();
 
         self.node_configure_instance(new_node_id, &new_node_name, label, &node_privilege);
@@ -1229,6 +1222,13 @@ impl Runtime {
         label: &Label,
         privilege: &NodePrivilege,
     ) {
+        // TODO(#913): Add automated tests that verify that NodeCreated is
+        // always fired prior to any other introspection events related to the
+        // node.
+        self.introspection_event(EventDetails::NodeCreated(NodeCreated {
+            node_id: node_id.0,
+        }));
+
         self.add_node_info(
             node_id,
             NodeInfo {


### PR DESCRIPTION
Moves the `NodeCreated` introspection event from being fired in the `Runtime.node_create` method to the `Runtime.node_configure_instance` method. This is done since the first node (`implicit.initial`) is created directly in `RuntimeProxy.create_runtime` and does not go through `Runtime.node_create`.

# Checklist

- [X] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
