### PR TITLE
Create dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/oak_loader"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This should allow us to receive notifications for updates to Rust crates we depend on (from the `oak_loader` crate only for now).

See https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically

Once set up, updates should show up here: https://github.com/project-oak/oak/network/updates

I am not sure how useful it will be in practice, but we can give it a try and see whether we want to keep it or not.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
