### PR TITLE
Update docs about the use of labels with HTTP requests

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -322,6 +322,28 @@ represented by a message containing two Channels handles:
     connection itself; this represents the actual authority of the caller.
   - an empty integrity component.
 
+### HTTP and user labels
+
+Similar to gRPC requests, each incoming HTTP request must have a label
+specifying the confidentiality guarantees that the caller wants to impose on the
+request message. The label is either provided as a JSON formatted header named
+`oak-label` or a [protobuf message](/oak_abi/proto/label.proto) in a header
+named `oak-label-bin`. JSON formatted labels must conform to the
+[canonical encoding of Proto3 to JSON](https://developers.google.com/protocol-buffers/docs/proto3#json).
+
+Internally, each incoming HTTP invocation is represented by a message containing
+two Channel handles:
+
+- a "request receiver" read handle to a Channel whose label has a
+  confidentiality component explicitly set to the confidentiality component of
+  the label provided as a header (i.e., `oak-label` or `oak-label-bin`) in the
+  HTTP request. This represents the confidentiality guarantees that the caller
+  wants to impose on the request message.
+
+- a "response sender" write handle to a Channel. To avoid any accidental data
+  leaks, the label of the Channel is set to have a confidentiality component set
+  based on the identity of the user, and an empty integrity component.
+
 ### Signature labels
 
 Oak Wasm modules can be signed using [Ed25519](https://ed25519.cr.yp.to/)

--- a/oak_abi/proto/application.proto
+++ b/oak_abi/proto/application.proto
@@ -137,8 +137,8 @@ message HttpClientConfiguration {
   // The authority supported by this client. The authority must match the label of the HTTP Client
   // pseudo-Node. If the authority is non-empty, only HTTPS requests with the same authority
   // component in their URIs can be handled. If the authority is empty, the client must be public
-  // and it may handle arbitrary requests to any HTTP or HTTPS services. The authority is also used to
-  // set the privilege of the node.
+  // and it may handle arbitrary requests to any HTTP or HTTPS services. The authority is also used
+  // to set the privilege of the node.
   string authority = 1;
 }
 


### PR DESCRIPTION
* Adds json schema files for IFC labels, generated using [protoc-gen-jsonschema](https://github.com/chrusty/protoc-gen-jsonschema)
* Updates documentation about the use of IFC labels with HTTP requests