### PR TITLE
Allow both JSON and protobuf labels in HTTP requests

### DIFF
--- a/examples/http_server/client/src/main.rs
+++ b/examples/http_server/client/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let request = hyper::Request::builder()
         .method("get")
         .uri("https://localhost:8080")
-        .header(oak_abi::OAK_LABEL_HTTP_KEY, label_bytes)
+        .header(oak_abi::OAK_LABEL_HTTP_JSON_KEY, label_bytes)
         .body(hyper::Body::empty())
         .unwrap();
 

--- a/oak_abi/src/lib.rs
+++ b/oak_abi/src/lib.rs
@@ -38,8 +38,11 @@ impl std::error::Error for OakStatus {}
 /// Keep in sync with /oak/common/label.cc.
 pub const OAK_LABEL_GRPC_METADATA_KEY: &str = "x-oak-label-bin";
 
-/// The header key used for encoded Labels in HTTP requests.
-pub const OAK_LABEL_HTTP_KEY: &str = "oak-label";
+/// The header key used for JSON formatted Labels in HTTP requests.
+pub const OAK_LABEL_HTTP_JSON_KEY: &str = "oak-label";
+
+/// The header key used for protobuf encoded Labels in HTTP requests.
+pub const OAK_LABEL_HTTP_PROTOBUF_KEY: &str = "oak-label-bin";
 
 /// Handle used to identify read or write channel halves.
 ///


### PR DESCRIPTION
Ref [this comment](https://github.com/project-oak/oak/pull/1398#discussion_r478527779).