### PR TITLE
Possibilistic single-step for system transition

### DIFF
--- a/experimental/ni_coq/vfiles/EvAugSemantics.v
+++ b/experimental/ni_coq/vfiles/EvAugSemantics.v
@@ -94,6 +94,13 @@ Definition trace_upd_head_state (t: trace) (s: state) :=
         | (s', e) :: t' => (s, e) :: t'
     end.
 
+Definition head_set_call t id c: trace :=
+    match t with 
+        | nil => nil (* this case never happens in the 
+                context where this is used *)
+        | (s, e) :: t' => (s_set_call s id c, e) :: t'
+    end.
+
 Inductive step_system_ev: trace -> trace -> Prop :=
     | ValidStep id n c c' s t s' t':
         head_st t  = Some s ->
@@ -101,8 +108,7 @@ Inductive step_system_ev: trace -> trace -> Prop :=
         s.(nodes) .[?id] = Some n ->
         n.(ncall) = c ->
         step_node_ev id c t t' ->
-        step_system_ev t (trace_upd_head_state t' (state_upd_node id
-            (n<| ncall := c'|>) s')).
+        step_system_ev t (head_set_call t' id c').
 
 Inductive step_system_ev_multi: trace -> trace -> Prop :=
     | multi_system_ev_refl t t':

--- a/experimental/ni_coq/vfiles/Parameters.v
+++ b/experimental/ni_coq/vfiles/Parameters.v
@@ -29,6 +29,7 @@ Context {lat: Lattice level}.
 Infix "⊔" := join (at level 40, left associativity).
 Infix "⊓" := meet (at level 40, left associativity).
 Infix "<<L" := ord (at level 50).
+Infix "<<?" := ord_dec (at level 50).
 
 Notation "'LETOPT' x <== e1 'IN' e2"
    := (match e1 with

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -7,6 +7,9 @@ From OakIFC Require Import
     Events
     LowEquivalences
     TraceTheorems.
+From mathcomp Require Import all_ssreflect finmap.
+From RecordUpdate Require Import RecordSet.
+Import RecordSetNotations.
 
 
 (*
@@ -66,16 +69,100 @@ Definition conjecture_possibilistic_ni := forall ell t1_init t2_init t1n,
         (step_system_ev_multi t2_init t2n) /\
         (trace_low_eq ell t1n t2n)).
 
+Theorem possibilistic_ni_1step_node: forall ell id t1 t2 s1 s2 n1 n2 t1',
+    (head_st t1 = Some s1) ->
+    (head_st t2 = Some s2) ->
+    (s1.(nodes) .[?id] = Some n1) ->
+    (s2.(nodes) .[?id] = Some n2) ->
+    (trace_low_eq ell t1 t2) ->
+    (step_node_ev id (ncall n1) t1 t1') ->
+    (exists t2',
+        (step_node_ev id (ncall n2) t2 t2') /\
+        (trace_low_eq ell t1' t2')).
+Proof.
+Admitted. (* WIP *)
+
+Theorem call_havoc_unwind: forall ell id c t1 t2 t1' t2',
+    (trace_low_eq ell t1 t2) ->
+    (t1' = head_set_call t1 id c) ->
+    (t2' = head_set_call t2 id c) ->
+    (trace_low_eq ell t1' t2').
+Proof.
+Admitted. (* WIP *)
+
+Theorem trace_loweq_to_deref_node: forall ell t1 t2 id s1 n1,
+(* If two traces are low-equivalent and in the first trace:
+    - the head element has some state (it's not an emty trace)
+    - and in the head state, id can be dereferenced to some node
+    then:
+    - there must be some head state in the other trace (s2)
+    - and we must be able to also dereference id in s2 to some node 
+Mostly, this is just a consequence of the def of trace-low-equivalence.
+*)
+    (trace_low_eq ell t1 t2) ->
+    (head_st t1 = Some s1) ->
+    ((nodes s1).[? id] = Some n1) ->
+    (exists s2 n2,
+        head_st t2 = Some s2 /\ 
+        (nodes s2).[? id] = Some n2 ).
+Proof.
+    intros.
+    destruct (head_st t2) eqn:Ht2head.
+    - (* some s *)
+        destruct (nodes s).[? id] eqn:Hsid.
+            + (* some n *)
+                exists s. exists n.
+                split; (reflexivity || assumption).
+            + (* none *)
+                inversion H; subst.
+                * (* t1 = [] and t2 = [] *) discriminate H0.
+                * exfalso. inversion H4; subst. simpl in Ht2head.
+                 unfold node_state_low_eq in H5.
+                 inversion Ht2head. rewrite H8 in H5. specialize (H5 id).
+                 rewrite Hsid in H5. simpl in H0. inversion H0.
+                 rewrite H9 in H5. rewrite H1 in H5. assumption.
+    - (* none *)
+        inversion H; subst. 
+            + discriminate H0.
+            + inversion Ht2head.
+Qed.
+ 
 Theorem possibilistic_ni_1step: forall ell t1 t2 t1',
     (trace_low_eq ell t1 t2) ->
     (step_system_ev t1 t1') ->
     (exists t2',
         (step_system_ev t2 t2') /\
         (trace_low_eq ell t1' t2')).
-Admitted. (* NOTE: work in progress *)
+Proof.
+    intros.
+    inversion H0; subst.
+    rename t' into t1_sn. rename s into s1. rename s' into s1'. rename n into n1.
+    specialize (trace_loweq_to_deref_node ell t1 t2 id s1 n1
+        H H1 H3) as [s2 [n2 [Ht2s2 Hs2n2]]].
+    specialize (possibilistic_ni_1step_node ell id
+        t1 t2 s1 s2 n1 n2 t1_sn  H1 Ht2s2 H3 Hs2n2 H H5)
+            as [t2_sn [Hnstep2 Hnstep_leq]].
+    assert (Hs2': exists s2', head_st t2_sn = Some s2'). {
+        (* this assertion is essentially re-stating node_no_steps_to_empty
+        in a way that gives us a particular head state of t2_sn *)
+        destruct t2_sn; subst.
+        - exfalso. apply (node_no_steps_to_empty t2 id (ncall n2)). assumption.
+        - exists (fst p). simpl. destruct p. reflexivity.
+    }
+    destruct Hs2' as [s2' Hs2']. 
+    remember (head_set_call t2_sn id c') as t2'.
+    exists t2'. split.
+    +  (* can step from t2_sn to t2' *)
+        subst. apply (ValidStep id n2 (ncall n2) c' s2 t2 s2' t2_sn);
+            (assumption || reflexivity).
+    + (* low-equiv t1' t2' *)
+        remember (head_set_call t1_sn id c') as t1' eqn:Ht1'.
+        apply (call_havoc_unwind ell id c' t1_sn t2_sn t1' t2');
+            (assumption || reflexivity).
+Qed. 
 
-
-Theorem possibilistic_ni: conjecture_possibilistic_ni. Proof.
+Theorem possibilistic_ni: conjecture_possibilistic_ni.
+Proof.
 unfold conjecture_possibilistic_ni.
 intros ell t1_init t2_init t1n [Hinit_tleq [Ht1_init [Ht2_init Ht1_mstep_t1n]]].
 remember ([]: trace) as emp eqn:R.
@@ -84,31 +171,19 @@ induction t1n.
         exfalso. apply (no_steps_to_empty t1_init Ht1_mstep_t1n).
     - (* inductive case *)
     inversion Ht1_mstep_t1n ; subst.
-        + assert (E: exists t2n,
-            (step_system_ev t2_init t2n) /\
-            (trace_low_eq ell (a::t1n) t2n)) by
-            apply (possibilistic_ni_1step ell t1_init t2_init
-                (a::t1n) Hinit_tleq H).
-            destruct E as [t2n [E1 E2]].
+        + specialize (possibilistic_ni_1step ell t1_init t2_init
+            (a::t1n) Hinit_tleq H) as [t2n [E1 E2]].
             exists t2n. split. constructor. assumption. assumption.
         + rename Ht1_mstep_t1n into Ht1_mstep_at1n.
-        assert (E: step_system_ev_multi t2 t1n)
-            by apply (step_system_multi_backwards t2 t1n a H0).
+        specialize (step_system_multi_backwards t2 t1n a H0) as E.
         assert (H': step_system_ev_multi t1_init t2) by
             (constructor; assumption).
-        assert (Ht1_mstep_t1n: step_system_ev_multi t1_init t1n)
-            by apply (step_system_transitive t1_init t2 t1n H' E).
-        apply IHt1n in Ht1_mstep_t1n as [t2n [Hm_t2_init_t2n Hleq_t1n_t2n]].
-        assert (E2: step_system_ev t1n (a::t1n))
-            by apply (step_system_multi_extends t2 t1n a H0).
-            (*need to get non-multi from E2.  *)
-        assert (E3: exists t2n',
-            (step_system_ev t2n t2n') /\
-            (trace_low_eq ell (a::t1n) t2n')) by
-            apply (possibilistic_ni_1step ell t1n t2n (a::t1n) Hleq_t1n_t2n E2).
-            destruct E3 as [t2n' [Hs_t2n_t2n' Hleq_at1n_t2n']].
-        exists t2n'.
-        split.
-        + apply (step_system_transitive t2_init t2n t2n'). assumption.
+        specialize (IHt1n (step_system_transitive t1_init t2 t1n H' E))
+            as [t2n [Hm_t2_init_t2n Hleq_t1n_t2n]].
+        specialize (step_system_multi_extends t2 t1n a H0) as E2.
+        specialize (possibilistic_ni_1step ell t1n t2n (a::t1n) Hleq_t1n_t2n E2)
+            as [t2n' [Hs_t2n_t2n' Hleq_at1n_t2n']].
+        exists t2n'. split.
+        apply (step_system_transitive t2_init t2n t2n'). assumption.
         constructor. assumption. assumption.
 Qed.

--- a/experimental/ni_coq/vfiles/RuntimeModel.v
+++ b/experimental/ni_coq/vfiles/RuntimeModel.v
@@ -150,6 +150,11 @@ Definition nid_fresh (s: state)(nid: node_id): Prop :=
 Definition new_chan (lbl: level): channel :=
     {| clbl := lbl; ms := [] |}.
 
+Definition s_set_call s id c :=
+    match s.(nodes).[?id] with
+        | None => s
+        | Some n => state_upd_node id (n <|ncall := c|>) s
+    end.
 
 (*============================================================================
 * Single Call Semantics
@@ -229,10 +234,11 @@ than the ABI calls is modeled as simply returning an arbitrary continuation
 (* Errors might later be modeled by choosing a different continuation based
 on whether or not a call was successful, in this case, the resulting
 continuation likely needs to be moved into the local transition relation *)
+
 Inductive step_system: state -> state -> Prop :=
     (* possibly also a termination case *)
     | ValidStep id n c c' s s':
         s.(nodes) .[?id] = Some n ->
         n.(ncall) = c ->
         step_node id c s s' ->
-        step_system s (state_upd_node id (n <|ncall := c'|>) s').
+        step_system s (s_set_call s id c').


### PR DESCRIPTION
This commit includes a proof of possibilistic_ni_1step in
PossibilisticNI.v, which is the unwinding condition. However, it still
depends on several theorems are still admitted, but should be true. The
definition for havocking calls for nodes that have just executed has
also been fixed in the system-wide state transition relation.
Previously, the call havocking part of the definition assumed that the
contents of the node have not changed as a result of the node's
execution, but clearly that is wrong. Now it properly updates the
(possibly changed) node that is pointed to by the node id that was
executed.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
