### PR TITLE
Introspection client: Get state from events

### DIFF
--- a/oak_runtime/introspection_browser_client/index.tsx
+++ b/oak_runtime/introspection_browser_client/index.tsx
@@ -45,6 +45,104 @@ function loadSerializedEvents(): Promise<Uint8Array> {
   });
 }
 
+interface OakApplicationState {
+  nodeInfos: NodeInfos;
+  channels: Channels;
+}
+
+type NodeId = number;
+type AbiHandle = number;
+type NodeInfos = Map<NodeId, NodeInfo>;
+interface NodeInfo {
+  abiHandles: Map<AbiHandle, ChannelHalf>;
+}
+
+type ChannelID = number;
+enum ChannelHalfDirection {
+  Read,
+  Write,
+}
+interface ChannelHalf {
+  channelId: ChannelID;
+  direction: ChannelHalfDirection;
+}
+interface Message {
+  data: Uint8Array;
+  channels: ChannelHalf[];
+}
+interface Channel {
+  id: ChannelID;
+  messages: Message[];
+}
+type Channels = Map<ChannelID, Channel>;
+
+function eventReducer(
+  applicationState: OakApplicationState,
+  event: introspectionEventsProto.Event
+) {
+  const eventType = event.getEventDetailsCase();
+  const { EventDetailsCase } = introspectionEventsProto.Event;
+
+  switch (eventType) {
+    case EventDetailsCase.NODE_CREATED:
+      applicationState.nodeInfos.set(event.getNodeCreated().getNodeId(), {
+        abiHandles: new Map(),
+      });
+
+      break;
+    case EventDetailsCase.NODE_DESTROYED:
+      applicationState.nodeInfos.delete(event.getNodeDestroyed().getNodeId());
+
+      break;
+    case EventDetailsCase.CHANNEL_CREATED:
+      {
+        const channelId = event.getChannelCreated().getChannelId();
+        applicationState.channels.set(channelId, {
+          id: channelId,
+          messages: [],
+        });
+      }
+
+      break;
+    case EventDetailsCase.CHANNEL_DESTROYED:
+      applicationState.channels.delete(
+        event.getChannelDestroyed().getChannelId()
+      );
+
+      break;
+    case EventDetailsCase.HANDLE_CREATED:
+      {
+        const details = event.getHandleCreated();
+        applicationState.nodeInfos
+          .get(details.getNodeId())
+          .abiHandles.set(details.getHandle(), {
+            channelId: details.getChannelId(),
+            direction: 0,
+          });
+      }
+      break;
+    case EventDetailsCase.HANDLE_DESTROYED:
+      {
+        const details = event.getHandleDestroyed();
+        applicationState.nodeInfos
+          .get(details.getNodeId())
+          .abiHandles.delete(details.getHandle());
+      }
+      break;
+    case EventDetailsCase.MESSAGE_ENQUEUED:
+      // TODO(#913): Add support for displaying messages
+      break;
+    case EventDetailsCase.MESSAGE_DEQUEUED:
+      // TODO(#913): Add support for displaying messages
+      break;
+    default:
+      // This should never happen
+      throw new Error(`Encountered unhandled event of type ${eventType}`);
+  }
+
+  return applicationState;
+}
+
 const EventList = () => {
   const [events, setEvents] = React.useState<introspectionEventsProto.Event[]>(
     []
@@ -60,16 +158,55 @@ const EventList = () => {
 
     loadEvents();
   }, []);
+  const applicationState = React.useMemo(
+    (): OakApplicationState =>
+      events.reduce(eventReducer, {
+        nodeInfos: new Map(),
+        channels: new Map(),
+      }),
+    [events]
+  );
 
   return (
-    <ol>
-      {events.map((event, index) => (
-        // Usually it's not advisable to use the index as a key. However since
-        // the list of events is append-only it's fine in this case.
-        // Ref: https://reactjs.org/docs/lists-and-keys.html#keys
-        <li key={index}>{JSON.stringify(event.toObject())}</li>
-      ))}
-    </ol>
+    <>
+      <section>
+        <strong>Application State</strong>
+        <p>{applicationState.nodeInfos.size} Nodes:</p>
+        <ul>
+          {[...applicationState.nodeInfos.entries()].map(([id, nodeInfo]) => (
+            <li key={id}>
+              <dl>
+                <dt>ID:</dt>
+                <dd>{id}</dd>
+                <dt>Handles:</dt>
+                <dd>
+                  <ul>
+                    {[...nodeInfo.abiHandles.entries()].map(
+                      ([handle, channelHalf]) => (
+                        <li key={handle}>
+                          {handle} pointing to channel {channelHalf.channelId}
+                        </li>
+                      )
+                    )}
+                  </ul>
+                </dd>
+              </dl>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <strong>Events List</strong>
+        <ol>
+          {events.map((event, index) => (
+            // Usually it's not advisable to use the index as a key. However since
+            // the list of events is append-only it's fine in this case.
+            // Ref: https://reactjs.org/docs/lists-and-keys.html#keys
+            <li key={index}>{JSON.stringify(event.toObject())}</li>
+          ))}
+        </ol>
+      </section>
+    </>
   );
 };
 

--- a/oak_runtime/introspection_browser_client/index.tsx
+++ b/oak_runtime/introspection_browser_client/index.tsx
@@ -60,7 +60,7 @@ interface NodeInfo {
 type ChannelID = number;
 enum ChannelHalfDirection {
   Read,
-  Write,
+  Write
 }
 interface ChannelHalf {
   channelId: ChannelID;
@@ -86,7 +86,7 @@ function eventReducer(
   switch (eventType) {
     case EventDetailsCase.NODE_CREATED:
       applicationState.nodeInfos.set(event.getNodeCreated().getNodeId(), {
-        abiHandles: new Map(),
+        abiHandles: new Map()
       });
 
       break;
@@ -99,7 +99,7 @@ function eventReducer(
         const channelId = event.getChannelCreated().getChannelId();
         applicationState.channels.set(channelId, {
           id: channelId,
-          messages: [],
+          messages: []
         });
       }
 
@@ -117,7 +117,7 @@ function eventReducer(
           .get(details.getNodeId())
           .abiHandles.set(details.getHandle(), {
             channelId: details.getChannelId(),
-            direction: 0,
+            direction: 0
           });
       }
       break;
@@ -162,7 +162,7 @@ const EventList = () => {
     (): OakApplicationState =>
       events.reduce(eventReducer, {
         nodeInfos: new Map(),
-        channels: new Map(),
+        channels: new Map()
       }),
     [events]
   );

--- a/oak_runtime/introspection_browser_client/index.tsx
+++ b/oak_runtime/introspection_browser_client/index.tsx
@@ -60,7 +60,7 @@ interface NodeInfo {
 type ChannelID = number;
 enum ChannelHalfDirection {
   Read,
-  Write
+  Write,
 }
 interface ChannelHalf {
   channelId: ChannelID;
@@ -86,7 +86,7 @@ function eventReducer(
   switch (eventType) {
     case EventDetailsCase.NODE_CREATED:
       applicationState.nodeInfos.set(event.getNodeCreated().getNodeId(), {
-        abiHandles: new Map()
+        abiHandles: new Map(),
       });
 
       break;
@@ -99,7 +99,7 @@ function eventReducer(
         const channelId = event.getChannelCreated().getChannelId();
         applicationState.channels.set(channelId, {
           id: channelId,
-          messages: []
+          messages: [],
         });
       }
 
@@ -117,9 +117,10 @@ function eventReducer(
           .get(details.getNodeId())
           .abiHandles.set(details.getHandle(), {
             channelId: details.getChannelId(),
-            direction: 0
+            direction: 0,
           });
       }
+
       break;
     case EventDetailsCase.HANDLE_DESTROYED:
       {
@@ -128,12 +129,15 @@ function eventReducer(
           .get(details.getNodeId())
           .abiHandles.delete(details.getHandle());
       }
+
       break;
     case EventDetailsCase.MESSAGE_ENQUEUED:
       // TODO(#913): Add support for displaying messages
+
       break;
     case EventDetailsCase.MESSAGE_DEQUEUED:
       // TODO(#913): Add support for displaying messages
+
       break;
     default:
       // This should never happen
@@ -162,7 +166,7 @@ const EventList = () => {
     (): OakApplicationState =>
       events.reduce(eventReducer, {
         nodeInfos: new Map(),
-        channels: new Map()
+        channels: new Map(),
       }),
     [events]
   );

--- a/oak_runtime/introspection_browser_client/index.tsx
+++ b/oak_runtime/introspection_browser_client/index.tsx
@@ -117,6 +117,8 @@ function eventReducer(
           .get(details.getNodeId())
           .abiHandles.set(details.getHandle(), {
             channelId: details.getChannelId(),
+            // TODO(#913): Add a direction property in the introspection
+            // event and use the real value here.
             direction: 0,
           });
       }

--- a/oak_runtime/introspection_browser_client/index.tsx
+++ b/oak_runtime/introspection_browser_client/index.tsx
@@ -85,14 +85,14 @@ function eventReducer(
 
   switch (eventType) {
     case EventDetailsCase.NODE_CREATED:
-      applicationState.nodeInfos.set(event.getNodeCreated().getNodeId(), {
+      applicationState.nodeInfos.set(event!.getNodeCreated()!.getNodeId(), {
         abiHandles: new Map(),
       });
 
       break;
     case EventDetailsCase.NODE_DESTROYED:
       {
-        const nodeId = event.getNodeDestroyed().getNodeId();
+        const nodeId = event!.getNodeDestroyed()!.getNodeId();
         if (applicationState.nodeInfos.delete(nodeId) === false) {
           throw new Error(
             `Couldn't delete Node with id "${nodeId}", as it does not exist.`
@@ -103,7 +103,7 @@ function eventReducer(
       break;
     case EventDetailsCase.CHANNEL_CREATED:
       {
-        const channelId = event.getChannelCreated().getChannelId();
+        const channelId = event!.getChannelCreated()!.getChannelId();
         applicationState.channels.set(channelId, {
           id: channelId,
           messages: [],
@@ -113,7 +113,7 @@ function eventReducer(
       break;
     case EventDetailsCase.CHANNEL_DESTROYED:
       {
-        const channelId = event.getChannelDestroyed().getChannelId();
+        const channelId = event!.getChannelDestroyed()!.getChannelId();
         if (applicationState.channels.delete(channelId) === false) {
           throw new Error(
             `Couldn't delete Channel with id "${channelId}", as it does not exist.`
@@ -125,7 +125,7 @@ function eventReducer(
     case EventDetailsCase.HANDLE_CREATED:
       {
         const details = event.getHandleCreated();
-        const nodeId = details.getNodeId();
+        const nodeId = details!.getNodeId();
         const node = applicationState.nodeInfos.get(nodeId);
 
         if (node === undefined) {
@@ -134,8 +134,8 @@ function eventReducer(
           );
         }
 
-        node.abiHandles.set(details.getHandle(), {
-          channelId: details.getChannelId(),
+        node.abiHandles.set(details!.getHandle(), {
+          channelId: details!.getChannelId(),
           // TODO(#913): Add a direction property in the introspection
           // event and use the real value here.
           direction: 0,
@@ -146,7 +146,7 @@ function eventReducer(
     case EventDetailsCase.HANDLE_DESTROYED:
       {
         const details = event.getHandleDestroyed();
-        const nodeId = details.getNodeId();
+        const nodeId = details!.getNodeId();
         const node = applicationState.nodeInfos.get(nodeId);
 
         if (node === undefined) {
@@ -155,7 +155,7 @@ function eventReducer(
           );
         }
 
-        const handle = details.getHandle();
+        const handle = details!.getHandle();
 
         if (node.abiHandles.delete(handle) === false) {
           throw new Error(

--- a/oak_runtime/introspection_browser_client/index.tsx
+++ b/oak_runtime/introspection_browser_client/index.tsx
@@ -60,7 +60,7 @@ interface NodeInfo {
 type ChannelID = number;
 enum ChannelHalfDirection {
   Read,
-  Write,
+  Write
 }
 interface ChannelHalf {
   channelId: ChannelID;
@@ -86,7 +86,7 @@ function eventReducer(
   switch (eventType) {
     case EventDetailsCase.NODE_CREATED:
       applicationState.nodeInfos.set(event!.getNodeCreated()!.getNodeId(), {
-        abiHandles: new Map(),
+        abiHandles: new Map()
       });
 
       break;
@@ -106,7 +106,7 @@ function eventReducer(
         const channelId = event!.getChannelCreated()!.getChannelId();
         applicationState.channels.set(channelId, {
           id: channelId,
-          messages: [],
+          messages: []
         });
       }
 
@@ -138,7 +138,7 @@ function eventReducer(
           channelId: details!.getChannelId(),
           // TODO(#913): Add a direction property in the introspection
           // event and use the real value here.
-          direction: 0,
+          direction: 0
         });
       }
 
@@ -200,7 +200,7 @@ const EventList = () => {
     (): OakApplicationState =>
       events.reduce(eventReducer, {
         nodeInfos: new Map(),
-        channels: new Map(),
+        channels: new Map()
       }),
     [events]
   );

--- a/oak_runtime/introspection_browser_client/tsconfig.json
+++ b/oak_runtime/introspection_browser_client/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "ES2015",
     "jsx": "react",
     "esModuleInterop": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
Implements the logic to deduct the state of an Oak application from a list of events describing state mutations. "Time traveling" to view a past state then becomes as easy as calculating the state from a subset of the present event list.

The UI currently isn't very pretty and shows only the current state. I'll be working with a designer to create a more beautiful and useful version.

![image](https://user-images.githubusercontent.com/8875406/92164562-73164600-ee2d-11ea-9de9-59074dc76c0c.png)


# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
