### PR TITLE
[RFC] Configuration-based generic planner node

### DIFF
--- a/rfcs/1440_generic_planner_node.md
+++ b/rfcs/1440_generic_planner_node.md
@@ -451,7 +451,7 @@ applications through static analysis tools that can help detect common problems:
 - Check that all nodes can read from handles they receive
 - Check that the node graph manifest does not violate defense-in-depth
   restritcions
-- Hihglight points where data is declassified to `Public`
+- Highlight points where data is declassified to `Public`
 - Find nodes that can never receive data (unneeded nodes)
 - Find nodes where data will get stuck (dead ends)
 - Find risky patterns (e.g. diamond shaped graph with declassification in each

--- a/rfcs/1440_generic_planner_node.md
+++ b/rfcs/1440_generic_planner_node.md
@@ -40,14 +40,14 @@ expanded over time to support more complex scenarios.
 
 The planner node will be responsible for creating nodes, creating channels,
 sending channel handles to the created nodes to ensure that the full node graph
-is created on start-up. It will will also act as a message router, which would
-route HTTP- and GRPC invocations to other nodes based on the associated labels.
+is created on start-up. It will also act as a message router, which would route
+HTTP- and GRPC invocations to other nodes based on the associated labels.
 
 ## Detailed Design
 
 ### Planner Node
 
-The planner node will the the initial node created for an application. The
+The planner node will be the initial node created for an application. The
 manifest file will be passed to the planner node as part of the application's
 `ConfigMap`.
 
@@ -69,8 +69,8 @@ recipient for a specific label.
 
 ### Manifest File
 
-The manifest file will be will be passed to the application as part of the
-initial configuration map as a TOML file. The file will be deserialised into the
+The manifest file will be passed to the application as part of the initial
+configuration map as a TOML file. The file will be deserialised into the
 following structure:
 
 ```rust

--- a/rfcs/1440_generic_planner_node.md
+++ b/rfcs/1440_generic_planner_node.md
@@ -105,6 +105,7 @@ name:
 ```toml
 [node_template]
 name = "user_{base64($user_id)}"
+
 ```
 
 The initial impementation of dynamic node creation will focus only on support
@@ -152,8 +153,8 @@ user-specific gRPC confidentiality tag and extracting the byte-array content of
 the tag as a parameter named user_id:
 
 ```toml
-
 [[label_template.confidentiality_tags]]
+
 [label_template.confidentiality_tags.tag.grpc_tag_template]
 user_id_parameter_name = "user_id"
 

--- a/rfcs/1440_generic_planner_node.md
+++ b/rfcs/1440_generic_planner_node.md
@@ -1,0 +1,74 @@
+# RFC#1440: Configuration-based Generic Planner Node
+
+## Objective
+
+Make the node graph easier to set up, reason about and amenable to static
+analysis.
+
+## Background
+
+An Oak application creates an initial node and calls the entry point on that
+node. A typical pattern is to use this initial node as a "Planner Node",
+responsible for creating all other nodes and channels. The creation of the nodes
+an channels is done through code. For simple cases it is easy to figure out what
+the graph can look like by inspecting the code, but it becomes increasingly
+difficult as the complexity of the logic of the planner node increases to cope
+with more complex node graphs. Another drawback of the code-based dynamic node
+creation is that we have to run the code to use the introspection mechanism to
+visualise the node graph.
+
+Generating the node graph automatically based on a configuration/manifest file
+should simplify this. It should be easier to figure out what the node graph will
+look like through inspecting a manifest file (assuming it has an easily
+understandable format). Additional benefits of configuration-based node creation
+include:
+
+- It would be easier to build tools to visualise the node graph without running
+  the application.
+- It would be easier to build tools to perform static analysis of the node graph
+  to detect potential problems.
+- It would usualy be easier to reason about the security of a static node graph.
+
+Moving all node and channel creation to a configuration-based mechanism is a
+significant and potentially disruptive change. This RFC proposes a more gradual
+approach by implementing a re-usable WASM-based planner node that uses a
+manifest file to do the node and channel creation. The functionality can be
+expanded over time to support more complex scenarios.
+
+## Overview
+
+The
+
+## Detailed Design
+
+### Planner node
+
+### Manifest File
+
+### Initialising New Nodes
+
+### Accessing Channels
+
+## Planning
+
+The initial implementation will be done as a `planner` example. It will create
+multiple test nodes and channels and connect these together. The example will
+also expose a gRPC method to the client so the client can request the manifest
+file. The client will compare the manifest file to the introspection data to
+test that the nodes were created as expected.
+
+Once the intial implementation is done, some of the common reusable code will be
+moved to the SDK. The fist example of such reusable code is support for node to
+accept an `init` proto that contains a list of `Sender`s and `Receiver`s that
+wrap the handles for channels that should be available to the node.
+
+The next step would be to update the existing examples to reuse the
+configuration-based `planner` node.
+
+## Future Work
+
+### Static analysis tools
+
+### Dynamic sub-graph creation
+
+### Declaration of supported message types


### PR DESCRIPTION
This is the draft version of the RFC for creating a generic planner node that will construct the node graph for an application based on a manifest file and also route invocation based on labels.