### PR TITLE
Update prettier to version 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ RUN go get github.com/raviqqe/liche@f57a5d1 \
 # This will use the Node version installed by emscripten.
 # https://prettier.io/
 # https://github.com/igorshubovych/markdownlint-cli
-ARG prettier_version=1.19.1
+ARG prettier_version=2.1.1
 ARG prettier_plugin_toml_version=0.3.1
 ARG markdownlint_version=0.22.0
 RUN npm install --global \

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -262,6 +262,7 @@ name = "hello_world"
 [modules]
 app = { path = "examples/hello_world/bin/hello_world.wasm" }
 translator = { path = "examples/hello_world/bin/translator.wasm" }
+
 ```
 
 All these steps are implemented as a part of the
@@ -278,6 +279,7 @@ name = "hello_world"
 [modules]
 app = { external = { url = "https://storage.googleapis.com/oak-modules/hello_world/57ba0bcebf2c01389d0413736b0a3bb261312bcf0d6e87181359e402df751d50", sha256 = "57ba0bcebf2c01389d0413736b0a3bb261312bcf0d6e87181359e402df751d50" } }
 translator = { path = "examples/hello_world/bin/translator.wasm" }
+
 ```
 
 It is also possible to save compiled Wasm modules to Google Cloud Storage using

--- a/examples/hello_world/client/nodejs/index.js
+++ b/examples/hello_world/client/nodejs/index.js
@@ -36,7 +36,7 @@ async function main() {
     // Hence we use grpcProtoLoader for gRPC services, and protobufjs
     // for all other protos.
     protobufjs.load(OAK_LABEL_PROTO_PATH),
-    grpcProtoLoader.load(SERVICE_PROTO_PATH)
+    grpcProtoLoader.load(SERVICE_PROTO_PATH),
   ]);
 
   function getGrpcMetadata() {

--- a/oak_runtime/introspection_browser_client/components/ApplicationStateOverview/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/ApplicationStateOverview/index.tsx
@@ -22,7 +22,7 @@ type ApplicationStateOverviewProps = {
 };
 
 export default function ApplicationStateOverview({
-  applicationState
+  applicationState,
 }: ApplicationStateOverviewProps) {
   return (
     <section>

--- a/oak_runtime/introspection_browser_client/components/Root/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/Root/index.tsx
@@ -56,7 +56,7 @@ interface NodeInfo {
 type ChannelID = number;
 enum ChannelHalfDirection {
   Read,
-  Write
+  Write,
 }
 interface ChannelHalf {
   channelId: ChannelID;
@@ -82,7 +82,7 @@ function eventReducer(
   switch (eventType) {
     case EventDetailsCase.NODE_CREATED:
       applicationState.nodeInfos.set(event!.getNodeCreated()!.getNodeId(), {
-        abiHandles: new Map()
+        abiHandles: new Map(),
       });
 
       break;
@@ -102,7 +102,7 @@ function eventReducer(
         const channelId = event!.getChannelCreated()!.getChannelId();
         applicationState.channels.set(channelId, {
           id: channelId,
-          messages: []
+          messages: [],
         });
       }
 
@@ -134,7 +134,7 @@ function eventReducer(
           channelId: details!.getChannelId(),
           // TODO(#913): Add a direction property in the introspection
           // event and use the real value here.
-          direction: 0
+          direction: 0,
         });
       }
 
@@ -202,7 +202,7 @@ export default function Root() {
     (): OakApplicationState =>
       events.reduce(eventReducer, {
         nodeInfos: new Map(),
-        channels: new Map()
+        channels: new Map(),
       }),
     [events]
   );

--- a/oak_runtime/introspection_browser_client/webpack.config.js
+++ b/oak_runtime/introspection_browser_client/webpack.config.js
@@ -17,35 +17,35 @@
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 
-module.exports = env => ({
+module.exports = (env) => ({
   entry: './index.tsx',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'index.js'
+    filename: 'index.js',
   },
   plugins: [
     new CopyPlugin({
-      patterns: [{ from: 'static' }]
-    })
+      patterns: [{ from: 'static' }],
+    }),
   ],
   module: {
     rules: [
       {
         test: /\.tsx?$/,
         use: 'ts-loader',
-        exclude: /node_modules/
-      }
-    ]
+        exclude: /node_modules/,
+      },
+    ],
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],
     alias: {
-      '~': path.resolve(__dirname)
-    }
+      '~': path.resolve(__dirname),
+    },
   },
   mode: env.NODE_ENV || 'none',
   devServer: {
     inline: true,
-    liveReload: false
-  }
+    liveReload: false,
+  },
 });


### PR DESCRIPTION
See: https://prettier.io/blog/2020/03/21/2.0.0.html

Matches the major version of the Prettier VSCode plugin, thereby avoiding formatting inconsistencies between that & our format script.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
