### PR TITLE
Remove need for step_system_multi_backwards admit

### DIFF
--- a/experimental/ni_coq/vfiles/EvAugSemantics.v
+++ b/experimental/ni_coq/vfiles/EvAugSemantics.v
@@ -115,6 +115,6 @@ Inductive step_system_ev_multi: trace -> trace -> Prop :=
         step_system_ev t t' ->
         step_system_ev_multi t t'
     | multi_system_ev_tran t1 t2 t3:
-        step_system_ev t1 t2 ->
-        step_system_ev_multi t2 t3 ->
+        step_system_ev t2 t3 ->
+        step_system_ev_multi t1 t2 ->
         step_system_ev_multi t1 t3.

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -175,12 +175,13 @@ induction t1n.
             (a::t1n) Hinit_tleq H) as [t2n [E1 E2]].
             exists t2n. split. constructor. assumption. assumption.
         + rename Ht1_mstep_t1n into Ht1_mstep_at1n.
-        specialize (step_system_multi_backwards t2 t1n a H0) as E.
-        assert (H': step_system_ev_multi t1_init t2) by
-            (constructor; assumption).
-        specialize (IHt1n (step_system_transitive t1_init t2 t1n H' E))
+          match goal with
+            H : _ |- _ =>
+            apply step_system_ev_uncons in H end.
+          cbn [tl] in *; subst.
+          specialize (IHt1n ltac:(assumption))
             as [t2n [Hm_t2_init_t2n Hleq_t1n_t2n]].
-        specialize (step_system_multi_extends t2 t1n a H0) as E2.
+        specialize (step_system_multi_extends _ (a::t1n) ltac:(eauto)) as E2.
         specialize (possibilistic_ni_1step ell t1n t2n (a::t1n) Hleq_t1n_t2n E2)
             as [t2n' [Hs_t2n_t2n' Hleq_at1n_t2n']].
         exists t2n'. split.

--- a/experimental/ni_coq/vfiles/TraceTheorems.v
+++ b/experimental/ni_coq/vfiles/TraceTheorems.v
@@ -127,7 +127,7 @@ Proof.
     rewrite E in H. assumption.
 Qed.
 
-Lemma step_system_ev_uncons: forall t1 t2,
+Theorem step_system_ev_uncons: forall t1 t2,
     step_system_ev t1 t2 ->
     t1 = tl t2.
 Proof.

--- a/experimental/ni_coq/vfiles/TraceTheorems.v
+++ b/experimental/ni_coq/vfiles/TraceTheorems.v
@@ -48,16 +48,25 @@ Proof.
     unfold not. intros. inversion H.
 Qed.
 
+Lemma system_no_steps_to_empty: forall t,
+    ~(step_system_ev t []).
+Proof.
+  intros. intro Hstep.
+  remember ([]: trace) as emp eqn:R.
+  inversion Hstep.
+  cbv [head_set_call] in *.
+  destruct t'; subst.
+  - inversion H0.
+  - destruct p; congruence.
+Qed.
+
 Theorem no_steps_to_empty: forall t, 
     ~(step_system_ev_multi t []).
     unfold not. intros.
     remember ([]: trace) as emp eqn:R.
-    induction H; subst.
-        - (* refl *) inversion H; subst. destruct t'.
-            + inversion H2. 
-            + apply head_set_call_not_nil in H0. assumption.
-            unfold not. intros. generalize dependent H4. apply nil_cons_rev.
-        - apply IHstep_system_ev_multi. reflexivity.
+    inversion H; subst.
+    - eapply system_no_steps_to_empty; eauto.
+    - eapply system_no_steps_to_empty; eauto.
 Qed.
 
 Theorem step_system_transitive: forall t1 t2 t3,
@@ -65,10 +74,9 @@ Theorem step_system_transitive: forall t1 t2 t3,
     step_system_ev_multi t2 t3 ->
     step_system_ev_multi t1 t3.
 Proof.
-    intros.
-    induction H.
-        - apply (multi_system_ev_tran t t' t3); assumption.
-        - apply IHstep_system_ev_multi in H0.
+    induction 2; intros.
+        - apply (multi_system_ev_tran t1 t t'); assumption.
+        - apply IHstep_system_ev_multi in H.
         apply (multi_system_ev_tran t1 t2 t3); assumption.
 Qed.
 
@@ -119,20 +127,18 @@ Proof.
     rewrite E in H. assumption.
 Qed.
 
-Theorem step_system_multi_extends: forall t t' a,
-    step_system_ev_multi t (a :: t') ->
-    step_system_ev t' (a :: t').
+Lemma step_system_ev_uncons: forall t1 t2,
+    step_system_ev t1 t2 ->
+    t1 = tl t2.
 Proof.
-    intros. remember (a::t') as t1 eqn:Ht1.
-    induction H; subst.
-        - apply (step_system_extends t t' a); assumption.
-        - apply IHstep_system_ev_multi. reflexivity.
+  induction 1; intros; subst.
+  inversion H3; subst; reflexivity.
 Qed.
 
-Theorem step_system_multi_backwards: forall t t' a,
-    step_system_ev_multi t (a :: t') ->
-    step_system_ev_multi t t'.
+Theorem step_system_multi_extends: forall t t',
+    step_system_ev_multi t t' ->
+    step_system_ev (tl t') t'.
 Proof.
-Admitted. (* WIP *)
-
-
+  inversion 1; intros; subst;
+    erewrite <-step_system_ev_uncons; eauto.
+Qed.


### PR DESCRIPTION
This PR, instead of proving the admitted lemma `step_system_multi_backwards`, removes the need for it by:
- flipping the order of transitivity in multi-step semantics so that forward steps are more natural
- replacing the use of `step_system_multi_backwards` with simpler reasoning based on the new semantics

Essentially, the change to the multi-step semantics made it so that, when constructing an inductive that proves there exists a sequence of valid steps starting with trace `t1` and ending with trace `t2`, we increase the sequence length by *adding events to `t2`*, rather than *removing them from `t1`*.

Most of the line-by-line changes are slight adjustments to the `TraceTheorems.v` proofs to match them with the new transitivity order.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
