### PR TITLE
Compress introspection client files with gzip

### DIFF
--- a/oak_runtime/introspection_browser_client/package-lock.json
+++ b/oak_runtime/introspection_browser_client/package-lock.json
@@ -1084,6 +1084,19 @@
         "vary": "~1.1.2"
       }
     },
+    "compression-webpack-plugin": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-5.0.2.tgz",
+      "integrity": "sha512-F2G4cQfsMZ6CiPlG22Q5EDUCqnfyZqTjyJP5cMgNYUbBg/dUzV3hto8yTFFIogDCTWooVbePHQE0qL6FrJUSsA==",
+      "dev": true,
+      "requires": {
+        "cacache": "^15.0.5",
+        "find-cache-dir": "^3.3.1",
+        "schema-utils": "^2.7.0",
+        "serialize-javascript": "^4.0.0",
+        "webpack-sources": "^1.4.3"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/oak_runtime/introspection_browser_client/package.json
+++ b/oak_runtime/introspection_browser_client/package.json
@@ -8,6 +8,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "compression-webpack-plugin": "^5.0.2",
     "copy-webpack-plugin": "^6.0.3",
     "ts-loader": "^8.0.3",
     "ts-protoc-gen": "^0.12.0",

--- a/oak_runtime/introspection_browser_client/webpack.config.js
+++ b/oak_runtime/introspection_browser_client/webpack.config.js
@@ -16,6 +16,7 @@
 
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
+const CompressionPlugin = require('compression-webpack-plugin');
 
 module.exports = (env) => ({
   entry: './index.tsx',
@@ -27,6 +28,9 @@ module.exports = (env) => ({
     new CopyPlugin({
       patterns: [{ from: 'static' }],
     }),
+    ...(env.NODE_ENV === 'production'
+      ? [new CompressionPlugin({ deleteOriginalAssets: true })]
+      : []),
   ],
   module: {
     rules: [


### PR DESCRIPTION
Cuts the size of the generated JS bundle in half, so this seems sensible. 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
