### PR TITLE
Render oakApplicationState with graphviz

### DIFF
--- a/oak_runtime/introspection_browser_client/components/Root/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/Root/index.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import ApplicationStateOverview from '~/components/ApplicationStateOverview';
+import StateGraph from '~/components/StateGraph';
 import EventList from '~/components/EventList';
 import introspectionEventsProto, {
   DirectionMap,
@@ -49,8 +50,8 @@ export interface OakApplicationState {
   channels: Channels;
 }
 
-type NodeId = number;
-type AbiHandle = number;
+export type NodeId = number;
+export type AbiHandle = number;
 type NodeInfos = Map<NodeId, NodeInfo>;
 interface NodeInfo {
   name: string;
@@ -58,8 +59,8 @@ interface NodeInfo {
   label: Label;
 }
 
-type ChannelID = number;
-enum ChannelHalfDirection {
+export type ChannelID = number;
+export enum ChannelHalfDirection {
   Read = 'READ',
   Write = 'WRITE',
 }
@@ -236,6 +237,7 @@ export default function Root() {
   return (
     <>
       <ApplicationStateOverview applicationState={applicationState} />
+      <StateGraph applicationState={applicationState} />
       <EventList events={events} />
     </>
   );

--- a/oak_runtime/introspection_browser_client/components/StateGraph/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/StateGraph/index.tsx
@@ -15,6 +15,7 @@
 //
 
 import React from 'react';
+import { graphviz } from 'd3-graphviz';
 import {
   OakApplicationState,
   ChannelHalfDirection,
@@ -22,10 +23,6 @@ import {
   ChannelID,
   AbiHandle,
 } from '~/components/Root';
-
-type StateGraphProps = {
-  applicationState: OakApplicationState;
-};
 
 // Generate a Graphviz dot graph that shows the shape of the Nodes and Channels
 function getGraphFromState(applicationState: OakApplicationState) {
@@ -91,14 +88,16 @@ function getGraphFromState(applicationState: OakApplicationState) {
   `;
 }
 
+type StateGraphProps = {
+  applicationState: OakApplicationState;
+};
+
 export default function StateGraph({ applicationState }: StateGraphProps) {
-  return (
-    <section
-      dangerouslySetInnerHTML={{
-        __html: getGraphFromState(applicationState)
-          .replace(/ /g, '&nbsp;')
-          .replace(/\n/g, '<br/>'),
-      }}
-    ></section>
-  );
+  const ref = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const dotGraph = getGraphFromState(applicationState);
+    graphviz(ref.current).renderDot(dotGraph);
+  }, [applicationState]);
+
+  return <div ref={ref} />;
 }

--- a/oak_runtime/introspection_browser_client/components/StateGraph/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/StateGraph/index.tsx
@@ -1,0 +1,104 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import React from 'react';
+import {
+  OakApplicationState,
+  ChannelHalfDirection,
+  NodeId,
+  ChannelID,
+  AbiHandle,
+} from '~/components/Root';
+
+type StateGraphProps = {
+  applicationState: OakApplicationState;
+};
+
+// Generate a Graphviz dot graph that shows the shape of the Nodes and Channels
+function getGraphFromState(applicationState: OakApplicationState) {
+  const getNodeDotId = (nodeId: NodeId) => `node${nodeId}`;
+  const getChannelDotId = (channelId: ChannelID) => `channel${channelId}`;
+  const getHandleDotId = (nodeId: NodeId, handle: AbiHandle) =>
+    `node${nodeId}_${handle}`;
+
+  const oakNodes = [...applicationState.nodeInfos.entries()].map(
+    ([nodeId, nodeInfo]) => `${getNodeDotId(nodeId)} [label="${nodeInfo.name}"]`
+  );
+  const oakHandles = [...applicationState.nodeInfos.entries()]
+    .map(([nodeId, nodeInfo]) =>
+      [...nodeInfo.abiHandles.entries()].map(
+        ([handle]) =>
+          `${getHandleDotId(nodeId, handle)} [label="${nodeId}:${handle}"]`
+      )
+    )
+    .flat();
+  const oakChannels = [
+    ...applicationState.channels.entries(),
+  ].map(([channelId]) => getChannelDotId(channelId));
+  const connections = [...applicationState.nodeInfos.entries()]
+    .map(([nodeId, nodeInfo]) =>
+      [...nodeInfo.abiHandles.entries()].map(([handle, channelHalf]) => {
+        switch (channelHalf.direction) {
+          case ChannelHalfDirection.Write:
+            return `${getNodeDotId(nodeId)} -> ${getHandleDotId(
+              nodeId,
+              handle
+            )} -> ${getChannelDotId(channelHalf.channelId)}`;
+
+          case ChannelHalfDirection.Read:
+            return `${getChannelDotId(
+              channelHalf.channelId
+            )} -> ${getHandleDotId(nodeId, handle)} -> ${getNodeDotId(nodeId)}`;
+
+          default:
+            // This should never happen
+            throw new Error(
+              `Encountered unhandled direction value ${channelHalf.direction}`
+            );
+        }
+      })
+    )
+    .flat();
+
+  return `digraph Runtime {
+    {
+      node [shape=box style=filled fillcolor=red fontsize=24]
+      ${oakNodes.join('\n      ')}
+    }
+    {
+      node [shape=hexagon style=filled fillcolor=orange]
+      ${oakHandles.join('\n      ')}
+    }
+    {
+      node [shape=ellipse style=filled fillcolor=green]
+      ${oakChannels.join('\n      ')}
+    }
+    ${connections.join('\n    ')}
+  }
+  `;
+}
+
+export default function StateGraph({ applicationState }: StateGraphProps) {
+  return (
+    <section
+      dangerouslySetInnerHTML={{
+        __html: getGraphFromState(applicationState)
+          .replace(/ /g, '&nbsp;')
+          .replace(/\n/g, '<br/>'),
+      }}
+    ></section>
+  );
+}

--- a/oak_runtime/introspection_browser_client/package-lock.json
+++ b/oak_runtime/introspection_browser_client/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@hpcc-js/wasm": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-0.3.13.tgz",
+      "integrity": "sha512-cnhBOjxa2RCb/0phDmjy9u1+GEMyDKFtf1uXbtYFlm9XcyLZEDKFOzYjeb9iXM4mF0dDhS0P3iRmy4U9orIasA=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -37,6 +42,57 @@
       "dev": true,
       "requires": {
         "mkdirp": "^1.0.4"
+      }
+    },
+    "@types/d3-color": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.2.tgz",
+      "integrity": "sha512-6pBxzJ8ZP3dYEQ4YjQ+NVbQaOflfgXq/JbDiS99oLobM2o72uAST4q6yPxHv6FOTCRC/n35ktuo8pvw/S4M7sw==",
+      "dev": true
+    },
+    "@types/d3-graphviz": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-graphviz/-/d3-graphviz-2.6.3.tgz",
+      "integrity": "sha512-K8q9ZBmE2Xbqh+eRbNhjN7NNUWtnoIHzFnPZ+ulHonvgnv5qL2Hzppx/fg2ZFa9V2OUUbzoOS0H28FtVCVsQ5w==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "@types/d3-interpolate": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.3.1.tgz",
+      "integrity": "sha512-z8Zmi08XVwe8e62vP6wcA+CNuRhpuUU5XPEfqpG0hRypDE5BWNthQHB1UNWWDB7ojCbGaN4qBdsWp5kWxhT1IQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-color": "*"
+      }
+    },
+    "@types/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-ksY8UxvTXpzD91Dy3D9zZg98yF2ZEPMKJd8ZQJlZt1QH3Xxr08s6fESEdC2l0Kbe6Xd9VhaoJX06cRaMR1lEnA==",
+      "dev": true
+    },
+    "@types/d3-transition": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.1.6.tgz",
+      "integrity": "sha512-/F+O2r4oz4G9ATIH3cuSCMGphAnl7VDx7SbENEK0NlI/FE8Jx2oiIrv0uTrpg7yF/AmuWbqp7AGdEHAPIh24Gg==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-zoom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.7.4.tgz",
+      "integrity": "sha512-5jnFo/itYhJeB2khO/lKe730kW/h2EbKMOvY0uNp3+7NdPm4w63DwPEMxifQZ7n902xGYK5DdU67FmToSoy4VA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
       }
     },
     "@types/glob": {
@@ -1343,6 +1399,99 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
+    },
+    "d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+    },
+    "d3-drag": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "requires": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
+    "d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "d3-graphviz": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-3.1.0.tgz",
+      "integrity": "sha512-OcVBBvpj2QR1waw+rhQitZshUrS4I/zScsm+LWXowg96hGccsjWF6YGaU3p9pnZQu45yxpji2Zt9y2Zne4wE9Q==",
+      "requires": {
+        "@hpcc-js/wasm": "0.3.13",
+        "d3-dispatch": "^1.0.6",
+        "d3-format": "^1.4.3",
+        "d3-interpolate": "^1.4.0",
+        "d3-path": "^1.0.9",
+        "d3-selection": "^1.4.1",
+        "d3-timer": "^1.0.10",
+        "d3-transition": "^1.3.2",
+        "d3-zoom": "1.7.3"
+      }
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
+    },
+    "d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "d3-transition": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
+      "integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
+      "requires": {
+        "d3-color": "1",
+        "d3-dispatch": "1",
+        "d3-ease": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "^1.1.0",
+        "d3-timer": "1"
+      }
+    },
+    "d3-zoom": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.3.tgz",
+      "integrity": "sha512-xEBSwFx5Z9T3/VrwDkMt+mr0HCzv7XjpGURJ8lWmIC8wxe32L39eWHIasEe/e7Ox8MPU4p1hvH8PKN2olLzIBg==",
+      "requires": {
+        "d3-dispatch": "1",
+        "d3-drag": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "1",
+        "d3-transition": "1"
+      }
     },
     "debug": {
       "version": "2.6.9",

--- a/oak_runtime/introspection_browser_client/package.json
+++ b/oak_runtime/introspection_browser_client/package.json
@@ -8,6 +8,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/d3-graphviz": "^2.6.3",
     "compression-webpack-plugin": "^5.0.2",
     "copy-webpack-plugin": "^6.0.3",
     "ts-loader": "^8.0.3",
@@ -20,6 +21,7 @@
   "dependencies": {
     "@types/react": "^16.9.47",
     "@types/react-dom": "^16.9.8",
+    "d3-graphviz": "^3.1.0",
     "google-protobuf": "^3.13.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/oak_runtime/introspection_browser_client/tsconfig.json
+++ b/oak_runtime/introspection_browser_client/tsconfig.json
@@ -3,6 +3,7 @@
     "outDir": "./dist/",
     "module": "ES2015",
     "target": "ES2015",
+    "lib": ["ES2020", "DOM"],
     "jsx": "react",
     "esModuleInterop": true,
     "noImplicitAny": true,

--- a/oak_runtime/introspection_browser_client/webpack.config.js
+++ b/oak_runtime/introspection_browser_client/webpack.config.js
@@ -26,7 +26,13 @@ module.exports = (env) => ({
   },
   plugins: [
     new CopyPlugin({
-      patterns: [{ from: 'static' }],
+      patterns: [
+        { from: './static', to: './' },
+        {
+          from: './node_modules/@hpcc-js/wasm/dist/graphvizlib.wasm',
+          to: './',
+        },
+      ],
     }),
     ...(env.NODE_ENV === 'production'
       ? [new CompressionPlugin({ deleteOriginalAssets: true })]

--- a/oak_runtime/src/introspect.rs
+++ b/oak_runtime/src/introspect.rs
@@ -119,6 +119,10 @@ fn find_client_file(path: &str) -> Option<(Vec<u8>, String)> {
             include_bytes!("../introspection_browser_client/dist/index.js.gz").to_vec(),
             "application/javascript".to_string(),
         )),
+        "graphvizlib.wasm" => Some((
+            include_bytes!("../introspection_browser_client/dist/graphvizlib.wasm.gz").to_vec(),
+            "application/wasm".to_string(),
+        )),
         _ => None,
     }
 }


### PR DESCRIPTION
Replicates the behavior of Rust introspection by rendering the application state as a graph

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
