### PR TITLE
Fix protobuf silently losing precision for 64 bit integers in JS

### DIFF
--- a/oak_runtime/introspection_browser_client/components/ApplicationStateOverview/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/ApplicationStateOverview/index.tsx
@@ -30,10 +30,10 @@ export default function ApplicationStateOverview({
       <p>{applicationState.nodeInfos.size} Nodes:</p>
       <ul>
         {[...applicationState.nodeInfos.entries()].map(([id, nodeInfo]) => (
-          <li key={id}>
+          <li key={id.toString()}>
             <dl>
               <dt>ID:</dt>
-              <dd>{id}</dd>
+              <dd>{id.toString()}</dd>
               <dt>Name:</dt>
               <dd>{nodeInfo.name}</dd>
               <dt>Labels:</dt>
@@ -43,8 +43,9 @@ export default function ApplicationStateOverview({
                 <ul>
                   {[...nodeInfo.abiHandles.entries()].map(
                     ([handle, channelHalf]) => (
-                      <li key={handle}>
-                        {handle} pointing to channel {channelHalf.channelId}{' '}
+                      <li key={handle.toString()}>
+                        {handle.toString()} pointing to channel{' '}
+                        {channelHalf.channelId.toString()}{' '}
                         {channelHalf.direction}
                       </li>
                     )

--- a/oak_runtime/introspection_browser_client/components/Root/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/Root/index.tsx
@@ -50,8 +50,8 @@ export interface OakApplicationState {
   channels: Channels;
 }
 
-export type NodeId = number;
-export type AbiHandle = number;
+export type NodeId = bigint;
+export type AbiHandle = bigint;
 type NodeInfos = Map<NodeId, NodeInfo>;
 interface NodeInfo {
   name: string;
@@ -59,7 +59,7 @@ interface NodeInfo {
   label: Label;
 }
 
-export type ChannelID = number;
+export type ChannelID = bigint;
 export enum ChannelHalfDirection {
   Read = 'READ',
   Write = 'WRITE',
@@ -104,16 +104,19 @@ function eventReducer(
 
   switch (eventType) {
     case EventDetailsCase.NODE_CREATED:
-      applicationState.nodeInfos.set(event!.getNodeCreated()!.getNodeId(), {
-        name: event!.getNodeCreated()!.getName(),
-        abiHandles: new Map(),
-        label: event!.getNodeCreated()!.getLabel()!,
-      });
+      applicationState.nodeInfos.set(
+        BigInt(event!.getNodeCreated()!.getNodeId()),
+        {
+          name: event!.getNodeCreated()!.getName(),
+          abiHandles: new Map(),
+          label: event!.getNodeCreated()!.getLabel()!,
+        }
+      );
 
       break;
     case EventDetailsCase.NODE_DESTROYED:
       {
-        const nodeId = event!.getNodeDestroyed()!.getNodeId();
+        const nodeId = BigInt(event!.getNodeDestroyed()!.getNodeId());
         if (applicationState.nodeInfos.delete(nodeId) === false) {
           throw new Error(
             `Couldn't delete Node with id "${nodeId}", as it does not exist.`
@@ -125,7 +128,7 @@ function eventReducer(
     case EventDetailsCase.CHANNEL_CREATED:
       {
         const channel = event!.getChannelCreated()!;
-        const channelId = channel.getChannelId();
+        const channelId = BigInt(channel.getChannelId());
         applicationState.channels.set(channelId, {
           id: channelId,
           messages: [],
@@ -136,7 +139,7 @@ function eventReducer(
       break;
     case EventDetailsCase.CHANNEL_DESTROYED:
       {
-        const channelId = event!.getChannelDestroyed()!.getChannelId();
+        const channelId = BigInt(event!.getChannelDestroyed()!.getChannelId());
         if (applicationState.channels.delete(channelId) === false) {
           throw new Error(
             `Couldn't delete Channel with id "${channelId}", as it does not exist.`
@@ -148,7 +151,7 @@ function eventReducer(
     case EventDetailsCase.HANDLE_CREATED:
       {
         const details = event.getHandleCreated();
-        const nodeId = details!.getNodeId();
+        const nodeId = BigInt(details!.getNodeId());
         const node = applicationState.nodeInfos.get(nodeId);
 
         if (node === undefined) {
@@ -157,8 +160,8 @@ function eventReducer(
           );
         }
 
-        const direction = node.abiHandles.set(details!.getHandle(), {
-          channelId: details!.getChannelId(),
+        const direction = node.abiHandles.set(BigInt(details!.getHandle()), {
+          channelId: BigInt(details!.getChannelId()),
           direction: protoDirectionToChannelHalfDirection(
             details!.getDirection()
           ),
@@ -169,7 +172,7 @@ function eventReducer(
     case EventDetailsCase.HANDLE_DESTROYED:
       {
         const details = event.getHandleDestroyed();
-        const nodeId = details!.getNodeId();
+        const nodeId = BigInt(details!.getNodeId());
         const node = applicationState.nodeInfos.get(nodeId);
 
         if (node === undefined) {
@@ -178,7 +181,7 @@ function eventReducer(
           );
         }
 
-        const handle = details!.getHandle();
+        const handle = BigInt(details!.getHandle());
 
         if (node.abiHandles.delete(handle) === false) {
           throw new Error(

--- a/oak_runtime/introspection_browser_client/components/StateGraph/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/StateGraph/index.tsx
@@ -26,10 +26,11 @@ import {
 
 // Generate a Graphviz dot graph that shows the shape of the Nodes and Channels
 function getGraphFromState(applicationState: OakApplicationState) {
-  const getNodeDotId = (nodeId: NodeId) => `node${nodeId}`;
-  const getChannelDotId = (channelId: ChannelID) => `channel${channelId}`;
+  const getNodeDotId = (nodeId: NodeId) => `node${nodeId.toString()}`;
+  const getChannelDotId = (channelId: ChannelID) =>
+    `channel${channelId.toString()}`;
   const getHandleDotId = (nodeId: NodeId, handle: AbiHandle) =>
-    `node${nodeId}_${handle}`;
+    `node${nodeId.toString()}_${handle.toString()}`;
 
   const oakNodes = [...applicationState.nodeInfos.entries()].map(
     ([nodeId, nodeInfo]) => `${getNodeDotId(nodeId)} [label="${nodeInfo.name}"]`

--- a/proto/introspection_events.proto
+++ b/proto/introspection_events.proto
@@ -44,7 +44,12 @@ message Event {
 }
 
 message NodeCreated {
-  uint64 node_id = 1;
+  // By default the generated JavaScript code converts all 64bit integer types
+  // to the JS `number` type. A potentially lossy conversion since `number` only
+  // supports integers up to 2^53 - 1. This is remedied via the [jstype =
+  // JS_STRING] annotation. Ref:
+  // https://github.com/protocolbuffers/protobuf/issues/3666
+  uint64 node_id = 1 [jstype = JS_STRING];
 
   string name = 2;
 
@@ -52,17 +57,17 @@ message NodeCreated {
 }
 
 message NodeDestroyed {
-  uint64 node_id = 1;
+  uint64 node_id = 1 [jstype = JS_STRING];
 }
 
 message ChannelCreated {
-  uint64 channel_id = 1;
+  uint64 channel_id = 1 [jstype = JS_STRING];
 
   oak.label.Label label = 2;
 }
 
 message ChannelDestroyed {
-  uint64 channel_id = 1;
+  uint64 channel_id = 1 [jstype = JS_STRING];
 }
 
 enum Direction {
@@ -71,35 +76,46 @@ enum Direction {
 }
 
 message HandleCreated {
-  uint64 node_id = 1;
+  uint64 node_id = 1 [jstype = JS_STRING];
 
-  uint64 channel_id = 2;
+  uint64 channel_id = 2 [jstype = JS_STRING];
 
-  uint64 handle = 3;
+  uint64 handle = 3 [jstype = JS_STRING];
 
   Direction direction = 4;
 }
 
 message HandleDestroyed {
-  uint64 node_id = 1;
+  uint64 node_id = 1 [jstype = JS_STRING];
 
-  uint64 channel_id = 2;
+  uint64 channel_id = 2 [jstype = JS_STRING];
 
-  uint64 handle = 3;
+  uint64 handle = 3 [jstype = JS_STRING];
 }
 
 message MessageEnqueued {
-  uint64 node_id = 1;
+  uint64 node_id = 1 [jstype = JS_STRING];
 
-  uint64 channel_id = 2;
+  uint64 channel_id = 2 [jstype = JS_STRING];
 
-  repeated uint64 included_handles = 3;
+  // These fields must be explicitly marked as packed = false, since depending
+  // on being interpreted as either standard uint64 vs as a string type they
+  // are respectively packed and not packed by default.
+  // Ref: https://developers.google.com/protocol-buffers/docs/encoding#packed
+  // If these are not explicitly set as not packed, the the JS parser
+  // (google-protobuf) will produce an error when interpreting the packed
+  // integer field as a non packed string field. This is since it seems
+  // to not have implemented the protobuf parser spec of being able to
+  // "parse repeated fields that were compiled as packed as if they were not
+  // packed, and vice versa". Ref:
+  // https://github.com/protocolbuffers/protobuf/issues/3571#issuecomment-575543049
+  repeated uint64 included_handles = 3 [jstype = JS_STRING, packed = false];
 }
 
 message MessageDequeued {
-  uint64 node_id = 1;
+  uint64 node_id = 1 [jstype = JS_STRING];
 
-  uint64 channel_id = 2;
+  uint64 channel_id = 2 [jstype = JS_STRING];
 
-  repeated uint64 acquired_handles = 3;
+  repeated uint64 acquired_handles = 3 [jstype = JS_STRING, packed = false];
 }


### PR DESCRIPTION
Good times. :) 

In the generated JavaScript code, the Google protobuf compiler converts `uint64` to the JavaScript `number`  type though that one only supports integers up to 2^53 - 1 .

This remedies this by appending `[jstype = JS_STRING]` to these fields and converting them to `BigInt`s on the client. 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
