### PR TITLE
Make http_server example client actually log

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -760,6 +760,7 @@ name = "https_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "env_logger",
  "hyper",
  "hyper-rustls",
  "log",

--- a/examples/http_server/client/Cargo.toml
+++ b/examples/http_server/client/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "*"
+env_logger = "*"
 hyper = "*"
 hyper-rustls = { version = "*", default-features = false, features = [
   "webpki-tokio"

--- a/examples/http_server/client/src/main.rs
+++ b/examples/http_server/client/src/main.rs
@@ -31,6 +31,7 @@ pub struct Opt {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
     // Send a request, and wait for the response
     let label = oak_abi::label::Label::public_untrusted();
     let label_bytes = serde_json::to_string(&label)
@@ -68,6 +69,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .expect("Error while awaiting response");
 
-    log::info!("Got response: {:?}", resp);
+    log::info!("response: {:?}", resp);
+    log::info!(
+        "response body: {:?}",
+        hyper::body::to_bytes(resp.into_body())
+            .await
+            .expect("could not read response body")
+    );
     Ok(())
 }


### PR DESCRIPTION
It should help debugging the issue described in https://github.com/project-oak/oak/pull/1461#discussion_r486658233

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
