### PR TITLE
Fix oak_loader being compiled on each runner run

### DIFF
--- a/oak_runtime/introspection_browser_client/.gitignore
+++ b/oak_runtime/introspection_browser_client/.gitignore
@@ -1,4 +1,5 @@
 # Build output
 /dist
+/dist-tmp
 # Programmatically generated code from protobufs
 /protoc_out

--- a/oak_runtime/introspection_browser_client/package.json
+++ b/oak_runtime/introspection_browser_client/package.json
@@ -12,6 +12,7 @@
     "@types/d3-graphviz": "^2.6.3",
     "compression-webpack-plugin": "^5.0.2",
     "copy-webpack-plugin": "^6.0.3",
+    "rimraf": "^3.0.2",
     "ts-loader": "^8.0.3",
     "ts-protoc-gen": "^0.12.0",
     "typescript": "^4.0.2",


### PR DESCRIPTION
Addresses (one half of) https://github.com/project-oak/oak/issues/1456:

Background: The introspection client is built on each run, changing the timestamp on output assets, even if the resulting file is identical. Cargo checks this timestamp to determine if these files have changed. Since timestamps are different on each run, cargo recompiles each binary that includes these files, on every run. This patches this via a webpack plugin that ensures that the timestamp of the introspection assets only changes if the contents changed.  

Reduces the time spent on the `build server` step from ~55s to <1s on subsequent runs. 

Next up I'll look into some optimizations to cache/skip build steps of the introspection client to speed up that step as well. (Currently ~30s on every run)

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
