### PR TITLE
Write call single-step, single-thread unwind

### DIFF
--- a/experimental/ni_coq/Makefile.conf
+++ b/experimental/ni_coq/Makefile.conf
@@ -8,7 +8,7 @@
 #                                                                             #
 ###############################################################################
 
-COQMF_VFILES = vfiles/Lattice.v vfiles/Parameters.v vfiles/GenericMap.v vfiles/RuntimeModel.v vfiles/LowEquivalences.v vfiles/Events.v vfiles/TraceTheorems.v vfiles/EvAugSemantics.v vfiles/PossibilisticNI.v
+COQMF_VFILES = vfiles/Lattice.v vfiles/Parameters.v vfiles/GenericMap.v vfiles/RuntimeModel.v vfiles/LowEquivalences.v vfiles/Events.v vfiles/TraceTheorems.v vfiles/EvAugSemantics.v vfiles/NIUtilTheorems.v vfiles/Unwind.v vfiles/PossibilisticNI.v
 COQMF_MLIFILES = 
 COQMF_MLFILES = 
 COQMF_MLGFILES = 

--- a/experimental/ni_coq/_CoqProject
+++ b/experimental/ni_coq/_CoqProject
@@ -7,4 +7,6 @@ vfiles/LowEquivalences.v
 vfiles/Events.v
 vfiles/TraceTheorems.v
 vfiles/EvAugSemantics.v
+vfiles/NIUtilTheorems.v
+vfiles/Unwind.v
 vfiles/PossibilisticNI.v

--- a/experimental/ni_coq/vfiles/LowEquivalences.v
+++ b/experimental/ni_coq/vfiles/LowEquivalences.v
@@ -26,6 +26,8 @@ Inductive chan_low_eq: level -> channel -> channel -> Prop :=
     | ChNoFlow ell ch1 ch2
         (* if the level is not high enough to read either channel,
         * they both look the same to observers at this level *)
+        (Hlbl_eq: ch1.(clbl) = ch2.(clbl))  
+                (* Hlbl_eq makes the labels of channels publicly observable *)
         (H1: ~(ch1.(clbl) <<L ell))
         (H2: ~(ch2.(clbl) <<L ell)):
         chan_low_eq ell ch1 ch2.
@@ -33,12 +35,12 @@ Inductive chan_low_eq: level -> channel -> channel -> Prop :=
 Inductive node_low_eq: level -> node -> node -> Prop :=
     | NodeEq ell n1 n2 (H: n1 = n2): node_low_eq ell n1 n2
     | NodeNoFlow ell n1 n2
+        (Hlbl_eq: n1.(nlbl) = n2.(nlbl))
+                (* Hlbl_eq makes the labels of nodes publicly observable *)
         (H1: ~(n1.(nlbl) <<L ell))
         (H2: ~(n2.(nlbl) <<L ell)):
         node_low_eq ell n1 n2.
 
-(* Is there may a better way to write these using the finset / finmap
-* libs *)
 Definition chan_state_low_eq (ell: level)(chs1 chs2: chan_state): Prop :=
     forall h, (match (chs1 .[?h]), (chs2 .[?h]) with
         | None, None => True

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -1,68 +1,146 @@
 From OakIFC Require Import
-        RuntimeModel
         Parameters
+        RuntimeModel
+        EvAugSemantics
+        Events
         LowEquivalences
-        GenericMap.
+        Lattice.
 Require Import Coq.Lists.List.
 Import ListNotations.
+From mathcomp Require Import all_ssreflect finmap.
+From RecordUpdate Require Import RecordSet.
+Import RecordSetNotations.
 
-Theorem chan_upd_preserves_nodes: forall h ch s,
-    (state_upd_chan h ch s).(nodes) = s.(nodes).
+
+Theorem trace_leq_imples_head_st_leq: forall ell t1 t2 s1 s2,
+    (head_st t1 = Some s1) ->
+    (head_st t2 = Some s2) ->
+    (trace_low_eq ell t1 t2) ->
+    (state_low_eq ell s1 s2).
 Proof.
-    intros; simpl; reflexivity.
+    inversion 3. 
+    - 
+        exfalso. rewrite <- H3 in H. inversion H.
+    - 
+        assert (xs = s1). {
+            assert (head_st ((xs, xe) :: t0 ) = Some xs).
+            reflexivity. congruence.
+        }
+        assert (ys = s2). {
+            assert (head_st ((ys, ye) :: t3 ) = Some ys).
+            reflexivity. congruence.
+        }
+    congruence.
 Qed.
 
-Theorem chan_append_unwind: forall ell m ch1 ch2,
-    (chan_low_eq ell ch1 ch2) ->
-    (chan_low_eq ell (chan_append ch1 m) (chan_append ch2 m)). 
+Theorem state_leq_and_flowsto_to_node_eq: forall ell s1 s2 id n1 n2,
+    (nodes s1).[? id] = Some n1 ->
+    (nodes s2).[? id] = Some n2 ->
+    (state_low_eq ell s1 s2) -> 
+    (nlbl n1 <<L ell) ->
+    n1 = n2.
 Proof.
-    intros. inversion H. 
-    constructor. rewrite H0. reflexivity.
-    constructor 2.
-    apply H1. apply H2.
-Qed. 
+    inversion 3. specialize (H2 id). rewrite H H0 in H2.
+    inversion H2. subst. reflexivity. contradiction.
+Qed.
 
-Theorem leq_ch_upd_preserves_sleq: forall (ell: level)
-    (h:handle)(ch1 ch2: channel)(s1 s2:state),
-    (chan_low_eq ell ch1 ch2) ->
-    (state_low_eq ell s1 s2) ->
-    (state_low_eq ell 
-        (state_upd_chan h ch1 s1)
-        (state_upd_chan h ch2 s2)).
+Theorem state_upd_chan_preserves_node_state_leq:
+    forall ell s1 s2 han1 ch1 han2 ch2,
+    node_state_low_eq ell (nodes s1) (nodes s2) ->
+    node_state_low_eq ell
+        (nodes (state_upd_chan han1 ch1 s1))
+        (nodes (state_upd_chan han2 ch2 s2)).
+Proof.
+Admitted. (* WIP // TODO *)
+
+Theorem state_upd_node_preserves_chan_state_leq:
+    forall ell s1 s2 id1 id2 n1 n2,
+    chan_state_low_eq ell (chans s1) (chans s2) ->
+    chan_state_low_eq ell
+        (chans (state_upd_node id1 n1 s1))
+        (chans (state_upd_node id2 n2 s2)).
+Proof.
+Admitted. (* WIP // TODO *)
+
+Theorem leq_node_updates_preserve_node_state_leq:
+    forall ell s1 s2 n1 n2 id,
+    node_state_low_eq ell (nodes s1) (nodes s2) ->
+    node_low_eq ell n1 n2 ->
+    node_state_low_eq ell
+        (nodes (state_upd_node id n1 s1)) (nodes (state_upd_node id n2 s2)).
+Proof.
+Admitted. (* WIP // TODO *)
+
+Theorem leq_chan_updates_preserve_chan_state_leq:
+    forall ell s1 s2 ch1 ch2 han,
+    chan_state_low_eq ell (chans s1) (chans s2) ->
+    chan_low_eq ell ch1 ch2 ->
+    chan_state_low_eq ell
+        (chans (state_upd_chan han ch1 s1)) (chans (state_upd_chan han ch2 s2)).
+Proof.
+Admitted. (* WIP // TODO *)
+
+Theorem node_low_eq_reflexive:
+    forall ell n, node_low_eq ell n n.
+Proof.
+Admitted. (* WIP // TODO *)
+
+Theorem other_chan_exists_from_chans_leq: forall ell s1 s2 han ch1,
+    chan_state_low_eq ell (chans s1) (chans s2) ->
+    (chans s1).[? han] = Some ch1 ->
+    exists ch2, ((chans s2).[? han ] = Some ch2) /\
+        (chan_low_eq ell ch1 ch2).
+Proof.
+Admitted. (* WIP // TODO *)
+
+Theorem state_upd_node_eq: forall id n s,
+    (state_upd_node id n s).(nodes).[? id] = Some n.
+intros.
+rewrite fnd_set. 
+rewrite (introT (@eqP node_id id id)); congruence.
+Qed.
+
+Theorem state_upd_node_neq: forall id id' n s,
+    id' <> id ->
+    (state_upd_node id n s).(nodes).[?id'] = s.(nodes).[?id'].
+intros.
+rewrite fnd_set. 
+specialize (Bool.ReflectF (id' = id) H) as H1.
+Admitted. (* WIP *) (* I am stuck with this one. Come back to it later. *)
+
+Theorem trace_loweq_to_deref_node: forall ell t1 t2 id s1 n1,
+(* If two traces are low-equivalent and in the first trace:
+    - the head element has some state (it's not an emty trace)
+    - and in the head state, id can be dereferenced to some node
+    then:
+    - there must be some head state in the other trace (s2)
+    - and we must be able to also dereference id in s2 to some node 
+Mostly, this is just a consequence of the def of trace-low-equivalence.
+*)
+    (trace_low_eq ell t1 t2) ->
+    (head_st t1 = Some s1) ->
+    ((nodes s1).[? id] = Some n1) ->
+    (exists s2 n2,
+        head_st t2 = Some s2 /\ 
+        (nodes s2).[? id] = Some n2 ).
 Proof.
     intros.
-    inversion H.
-        (* ch1 = ch2 *)
-        - rewrite H1. unfold state_low_eq. split.
-            (* node_state *)
-            rewrite chan_upd_preserves_nodes.
-            rewrite chan_upd_preserves_nodes.
-            apply H0.
-            (* chan_state *)
-            unfold chan_state_low_eq. intros.
-            destruct (dec_eq_h h h0).
-                (* h = h0 *)
-                + rewrite e. unfold state_upd_chan.
-                simpl. rewrite upd_eq. rewrite upd_eq.
-                constructor. reflexivity.
-                (* h <> h0 *)
-                + unfold state_upd_chan. simpl. 
-                rewrite upd_neq. rewrite upd_neq.
-                apply H0. apply n. apply n.
-        (* ~(ch1.l flowsTo ell) /\ ~(ch2.l flowsTo ell) *)
-        - unfold state_low_eq. split.
-            (* node_state *)
-            rewrite chan_upd_preserves_nodes.
-            rewrite chan_upd_preserves_nodes.
-            apply H0.
-            (* chan_state *)
-            unfold chan_state_low_eq. intros. destruct (dec_eq_h h h0).
-                (* h = h0 *)
-                + rewrite e. unfold state_upd_chan. simpl.
-                rewrite upd_eq. rewrite upd_eq.
-                constructor 2. apply H1. apply H2.
-                (* h <> h0 *)
-                + unfold state_upd_chan. simpl. 
-                rewrite upd_neq. rewrite upd_neq.
-                apply H0. apply n. apply n.
+    destruct (head_st t2) eqn:Ht2head.
+    - (* some s *)
+        destruct (nodes s).[? id] eqn:Hsid.
+            + (* some n *)
+                exists s. exists n.
+                split; (reflexivity || assumption).
+            + (* none *)
+                inversion H; subst.
+                * (* t1 = [] and t2 = [] *) discriminate H0.
+                * exfalso. inversion H4; subst. simpl in Ht2head.
+                 unfold node_state_low_eq in H5.
+                 inversion Ht2head. rewrite H8 in H5. specialize (H5 id).
+                 rewrite Hsid in H5. simpl in H0. inversion H0.
+                 rewrite H9 in H5. rewrite H1 in H5. assumption.
+    - (* none *)
+        inversion H; subst. 
+            + discriminate H0.
+            + inversion Ht2head.
 Qed.

--- a/experimental/ni_coq/vfiles/Unwind.v
+++ b/experimental/ni_coq/vfiles/Unwind.v
@@ -1,0 +1,105 @@
+Require Import Coq.Lists.List.
+Import ListNotations.
+From OakIFC Require Import
+    Parameters
+    RuntimeModel
+    EvAugSemantics
+    Events
+    LowEquivalences
+    Lattice
+    NIUtilTheorems.
+From mathcomp Require Import all_ssreflect finmap.
+From RecordUpdate Require Import RecordSet.
+Import RecordSetNotations.
+
+(*============================================================================
+ Unwinding Theorems
+============================================================================*)
+(*
+This file contains theorems that prove "the unwinding condition" for 
+various single pure functions. An unwinding condition is a single step of
+noninterference.
+*)
+
+(*
+It might be better to write them using something like this in the future:
+
+Definition state_unwind (f: state -> state):
+    forall ell s1 s2, 
+        state_low_eq ell s1 s2 ->
+        state_low_eq ell (f s1) (fs 2)
+
+but we have to fix the way the definitions are curried.
+*)
+
+Theorem chan_append_unwind:
+    forall ell ch1 ch2 msg,
+    chan_low_eq ell ch1 ch2 ->
+    chan_low_eq ell (chan_append ch1 msg) (chan_append ch2 msg).
+Proof.
+Admitted. (* WIP // TODO *)
+
+Theorem state_upd_unwind_from_leqn:
+    forall ell id n1 n2 s1 s2,
+    node_low_eq ell n1 n2 ->
+    state_low_eq ell s1 s2 ->
+    state_low_eq ell (state_upd_node id n1 s1) (state_upd_node id n2 s2).
+Proof.
+    intros. inversion H0. 
+    split.
+    - (* nodes *) 
+        intros id'. destruct (id' =P id). 
+        + (* eq *) 
+            rewrite e;
+            rewrite !state_upd_node_eq; assumption.
+        + (* neq *) 
+            rewrite !state_upd_node_neq.
+            apply (H1 id');  assumption.
+    - (* chans *)
+        assumption. assumption. apply H2.
+Qed.
+
+Theorem set_call_unwind: forall ell id c s1 s2,
+    state_low_eq ell s1 s2 ->
+    state_low_eq ell (s_set_call s1 id c) (s_set_call s2 id c).
+Proof.
+    intros. inversion H; subst.
+    unfold s_set_call.
+    destruct (s1.(nodes).[? id]) eqn:E1; destruct (s2.(nodes).[? id]) eqn:E2.
+    - (* some, some *)
+        assert (E: node_low_eq ell 
+            (n <| ncall ::= (fun=> c) |>)
+            (n0 <| ncall ::= (fun=> c) |>)).
+        {
+            specialize (H0 id). rewrite E1 E2 in H0.
+            inversion H0; subst.
+            constructor; reflexivity.
+            constructor 2; assumption.
+        }
+        eapply state_upd_unwind_from_leqn; assumption.
+    - (* some, none *)
+        exfalso. specialize (H0 id).
+        rewrite E1 E2 in H0.
+        assumption.
+    - (* none, some *)
+        exfalso. specialize (H0 id).
+        rewrite E1 E2 in H0.
+        assumption.
+    - split; assumption.
+Qed.
+
+Theorem call_havoc_unwind: forall ell id c t1 t2 t1' t2',
+    (trace_low_eq ell t1 t2) ->
+    (t1' = head_set_call t1 id c) ->
+    (t2' = head_set_call t2 id c) ->
+    (trace_low_eq ell t1' t2').
+Proof.
+    intros.
+    destruct t1, t2; simpl in *; subst.
+    - (* nil, nil *) constructor.
+    - (* nil, not nil *) inversion H.
+    - (* not nil, nil *) inversion H.
+    - destruct p. destruct p0. inversion H; subst.
+    constructor 2; try assumption.
+    eapply set_call_unwind; assumption.
+Qed.


### PR DESCRIPTION
This commit finishes a proof of the single-step, single-threaded
unwinding condition for just the write call and just in the case where
the label of the node making the call does flow to the label of the
observer. Several new smaller theorems are introduced but admitted for
now. They should be relatively simple. The files are reorganized a bit.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
