### PR TITLE
Create Oak Chrome extension skeleton

### DIFF
--- a/chrome_extension/README.md
+++ b/chrome_extension/README.md
@@ -1,0 +1,44 @@
+# Oak Chrome Extension
+
+The Oak Chrome Extension is a proof of concept to show how Oak may be used as
+part of web applications.
+
+A regular web page may at any point enter Oak private mode, which means that
+from that point onwards it will be able to communicate exclusively with an Oak
+application that can enforce that any data it receives is kept private for the
+current session. This is similar to "incognito mode" but for the server-side
+parts of an application.
+
+A web page enters Oak private mode by invoking the following Javascript code:
+
+```javascript
+window.postMessage('oak_enter');
+```
+
+This is an irreversible process: at this point, the Oak extension takes full
+control of all the communication initiated by that particular tab, blocks any
+non-Oak requests (including any static assets, which the application should take
+care to load before entering Oak mode), attaches an appropriate label to any Oak
+requests, and authenticates against a remote Oak application.
+
+Note that there is no way of getting out of Oak mode for a tab; if there were,
+it may be used to leak potentially confidential data from the current tab. The
+only way out of Oak mode is to manually close the tab, and then create a new
+one. Again, this is similar to how it is not possible to take a Chrome incognito
+tab and turn it back into a regular tab.
+
+Note: for now, it seems that closing a tab and then re-opening the last closed
+tab actually re-creates a tab with the same URL but outside of Oak mode.
+
+## Installation
+
+In order to install the Chrome extension locally for development:
+
+- navigate to `chrome://extensions`
+- turn on "Developer mode"
+- click on the "Load unpacked" button
+- select the `chrome_extension` folder (the one containing the `manifest.json`
+  file) and click "Open"
+
+After the extension is installed, in order to reload it from disk, it is
+sufficient to click on the refresh arrow button next to the extension.

--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// TODO(#1492): Generate an ECDSA key pair, and use the private key for authentication and the
+// public key as Oak label.
+//
+// See https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign
+
+// Ids of tabs that have entered Oak mode.
+const enabledTabs = new Set();
+
+// Intercept outgoing requests, and block them if they are coming from a tab that has entered Oak
+// mode.
+//
+// TODO(#1492): This only intercepts new WebSocket connections, but not individual messages on
+// previously established connections. e.g. https://www.websocket.org/echo.html.
+//
+// TODO(#1492): This does not catch cases in which a tab opens another tab via JavaScript, e.g.
+// `window.open('https://google.com/?q=123');`.
+chrome.webRequest.onBeforeRequest.addListener(
+  (details) => {
+    const tabId = details.tabId;
+    const oakMode = enabledTabs.has(tabId);
+    console.log(
+      'request from tab ' + tabId + ': ' + (oakMode ? 'blocked' : 'allowed')
+    );
+    // For now, we just cancel all outgoing requests once a tab has entered Oak mode, which is not
+    // particularly meaningful (and in fact quite annoying, since it is irreversible). But this serves
+    // as a proof of concepts that we can intercept requests and block them with arbitrary logic.
+    //
+    // TODO(#1492): Instead of just cancelling all requests, we should allow Oak requests through,
+    // and attach authentication credentials and labels to them. For this, we need to determine
+    // which ones are legitimate Oak requests though.
+    return { cancel: oakMode };
+  },
+  // filters
+  { urls: ['<all_urls>'] },
+  // extraInfoSpec
+  ['blocking']
+);
+
+// Listen for messages from `content.js` that signal whether to enable Oak mode for a specific tab.
+chrome.runtime.onMessage.addListener((message, sender) => {
+  console.log('message received', message, sender);
+  if (message == 'oak_enter') {
+    const tabId = sender.tab.id;
+    console.log('entering Oak mode for tab ' + tabId);
+    enabledTabs.add(tabId);
+  }
+});

--- a/chrome_extension/content.js
+++ b/chrome_extension/content.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// The extension id assigned by Chrome to this extension.
+const extensionId = 'nimjbbjddomejdcjaobokgnfmjgjefcc';
+
+// Listen for messages from the top frame of the current tab.
+//
+// This may be sent with something similar to the following:
+//
+// ```
+// window.postMessage('oak_enter');
+// ```
+//
+// Once this content script receives such message, then it sends in turn a message to the background
+// script of the extension.
+window.addEventListener(
+  'message',
+  (event) => {
+    console.log('message received', event);
+    if (event.data == 'oak_enter') {
+      chrome.runtime.sendMessage(extensionId, 'oak_enter');
+    }
+  },
+  false
+);

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 2,
+  "name": "Oak",
+  "version": "0.0.0",
+  "permissions": [
+    "activeTab",
+    "webRequest",
+    "webRequestBlocking",
+    "https://*/*",
+    "http://*/*",
+    "ws://*/*",
+    "wss://*/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["https://*/*"],
+      "js": ["content.js"]
+    }
+  ],
+  "background": {
+    "scripts": ["background.js"]
+  }
+}


### PR DESCRIPTION
This is a very experimental placeholder, which exposes an API for tabs
to switch to "Oak private mode", allowing the extension to then
intercept and block requests.

Ref #1492

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.
