### PR TITLE
Move back to GenericMap

### DIFF
--- a/experimental/ni_coq/vfiles/EvAugSemantics.v
+++ b/experimental/ni_coq/vfiles/EvAugSemantics.v
@@ -15,6 +15,7 @@ Arguments Ensembles.Singleton {U}.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
 
+Local Open Scope map_scope.
 (*
 The top-level security condition compares traces involving both states (as
 in "state" in RuntimeModel.v) and events. This file augments the semantics 
@@ -45,9 +46,11 @@ so the call is a piece of state that probably does not matter at the moment)
  and a downgrade event.
 *)
 
-Notation "n '--->' msg":= (EvL (OutEv msg) n.(nlbl)) (at level 10).
-Notation "n '<---' msg":= (EvL (InEv msg) n.(nlbl)) (at level 10).
-Notation "n '---'":= (EvL NilEv n.(nlbl)) (at level 10).
+Declare Scope aug_scope.
+Local Open Scope aug_scope.
+Notation "n '--->' msg":= (EvL (OutEv msg) n.(nlbl)) (at level 10) : aug_scope.
+Notation "n '<---' msg":= (EvL (InEv msg) n.(nlbl)) (at level 10) : aug_scope.
+Notation "n '---'":= (EvL NilEv n.(nlbl)) (at level 10) : aug_scope.
 
 
 Definition head_st (t: trace) :=
@@ -118,3 +121,4 @@ Inductive step_system_ev_multi: trace -> trace -> Prop :=
         step_system_ev t2 t3 ->
         step_system_ev_multi t1 t2 ->
         step_system_ev_multi t1 t3.
+

--- a/experimental/ni_coq/vfiles/EvAugSemantics.v
+++ b/experimental/ni_coq/vfiles/EvAugSemantics.v
@@ -3,9 +3,9 @@ Require Import List.
 From OakIFC Require Import
     Lattice
     Parameters
+    GenericMap
     RuntimeModel
     Events.
-From mathcomp Require Import all_ssreflect finmap.
 Import ListNotations.
 
 Arguments Ensembles.In {U}.

--- a/experimental/ni_coq/vfiles/GenericMap.v
+++ b/experimental/ni_coq/vfiles/GenericMap.v
@@ -37,10 +37,12 @@ Definition tg_fmap {KT: KeyT}{VT: Type}
     (f: VT -> VT)(m: tg_map KT VT): tg_map KT VT :=
     fun k => (f (m k)).
 
+Declare Scope map_scope.
 Notation "'_' '!->' v" := (tg_empty v)
-  (at level 100, right associativity).
+  (at level 100, right associativity) : map_scope.
 Notation "x '!->' v ';' m" := (tg_update m x v)
-  (at level 100, v at next level, right associativity).
+  (at level 100, v at next level, right associativity) : map_scope.
+Open Scope map_scope.
 
 Theorem upd_eq {KT: KeyT}{VT: Type}: forall (m: tg_map KT VT) k v,
     (k !-> v; m) k = v.
@@ -73,15 +75,16 @@ Definition pg_fmap {KT: KeyT}{VT: Type}
     end.
 
 Notation "x '|->' v ';' m" := (pg_update m x v)
-  (at level 100, v at next level, right associativity).
+  (at level 100, v at next level, right associativity) : map_scope.
 Notation "x '|->' v" := (pg_update pg_empty x v)
-  (at level 100).
+  (at level 100) : map_scope.
 
 (* Make the notation compatible with ssreflect finmap to 
 * deal with laziness of me *)
 Notation "m '.[' k '<-' v ']'" := (pg_update m k v)
-  (at level 100).
+  (at level 100) : map_scope.
 Definition fnd {KT: KeyT}{VT: Type} (m: (pg_map KT VT)) k :=  (m k).
 Notation "m '.[?' k ']'" := (fnd m k) 
-(at level 2, k at level 200, format "m .[?  k ]").
+(at level 2, k at level 200, format "m .[?  k ]") : map_scope.
 
+Close Scope map_scope.

--- a/experimental/ni_coq/vfiles/GenericMap.v
+++ b/experimental/ni_coq/vfiles/GenericMap.v
@@ -76,7 +76,12 @@ Notation "x '|->' v ';' m" := (pg_update m x v)
   (at level 100, v at next level, right associativity).
 Notation "x '|->' v" := (pg_update pg_empty x v)
   (at level 100).
-Notation "m '[' k '-->' v ']'" := (pg_update m k v)
-  (at level 100).
 
-(* undoubtedly theorems *)
+(* Make the notation compatible with ssreflect finmap to 
+* deal with laziness of me *)
+Notation "m '.[' k '<-' v ']'" := (pg_update m k v)
+  (at level 100).
+Definition fnd {KT: KeyT}{VT: Type} (m: (pg_map KT VT)) k :=  (m k).
+Notation "m '.[?' k ']'" := (fnd m k) 
+(at level 2, k at level 200, format "m .[?  k ]").
+

--- a/experimental/ni_coq/vfiles/LowEquivalences.v
+++ b/experimental/ni_coq/vfiles/LowEquivalences.v
@@ -1,9 +1,9 @@
 Require Import Coq.Lists.List.
 Import ListNotations.
-From mathcomp Require Import all_ssreflect finmap.
 From OakIFC Require Import
     RuntimeModel
-    Parameters.
+    Parameters
+    GenericMap.
 
 (*=============================================================================
 * Low Equivalences

--- a/experimental/ni_coq/vfiles/LowEquivalences.v
+++ b/experimental/ni_coq/vfiles/LowEquivalences.v
@@ -5,6 +5,7 @@ From OakIFC Require Import
     Parameters
     GenericMap.
 
+Local Open Scope map_scope.
 (*=============================================================================
 * Low Equivalences
 =============================================================================*)

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -1,13 +1,13 @@
 From OakIFC Require Import
+        Lattice
         Parameters
+        GenericMap
         RuntimeModel
         EvAugSemantics
         Events
-        LowEquivalences
-        Lattice.
+        LowEquivalences.
 Require Import Coq.Lists.List.
 Import ListNotations.
-From mathcomp Require Import all_ssreflect finmap.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
 
@@ -40,7 +40,9 @@ Theorem state_leq_and_flowsto_to_node_eq: forall ell s1 s2 id n1 n2,
     (nlbl n1 <<L ell) ->
     n1 = n2.
 Proof.
-    inversion 3. specialize (H2 id). rewrite H H0 in H2.
+    inversion 3. specialize (H2 id).
+    (* hmmm, I used to be able to do rewrite H H0 in H2 as one tactic here *)
+    rewrite H in H2. rewrite H0 in H2.
     inversion H2. subst. reflexivity. contradiction.
 Qed.
 
@@ -95,18 +97,16 @@ Admitted. (* WIP // TODO *)
 
 Theorem state_upd_node_eq: forall id n s,
     (state_upd_node id n s).(nodes).[? id] = Some n.
-intros.
-rewrite fnd_set. 
-rewrite (introT (@eqP node_id id id)); congruence.
+Proof.
+    intros. eapply upd_eq.
 Qed.
 
-Theorem state_upd_node_neq: forall id id' n s,
+Theorem state_upd_node_neq: forall (id id': node_id) n s,
     id' <> id ->
     (state_upd_node id n s).(nodes).[?id'] = s.(nodes).[?id'].
-intros.
-rewrite fnd_set. 
-specialize (Bool.ReflectF (id' = id) H) as H1.
-Admitted. (* WIP *) (* I am stuck with this one. Come back to it later. *)
+Proof.
+    intros. eapply upd_neq. congruence.
+Qed.
 
 Theorem trace_loweq_to_deref_node: forall ell t1 t2 id s1 n1,
 (* If two traces are low-equivalent and in the first trace:

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -41,8 +41,7 @@ Theorem state_leq_and_flowsto_to_node_eq: forall ell s1 s2 id n1 n2,
     n1 = n2.
 Proof.
     inversion 3. specialize (H2 id).
-    (* hmmm, I used to be able to do rewrite H H0 in H2 as one tactic here *)
-    rewrite H in H2. rewrite H0 in H2.
+    rewrite H, H0 in H2.
     inversion H2. subst. reflexivity. contradiction.
 Qed.
 

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -11,6 +11,7 @@ Import ListNotations.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
 
+Local Open Scope map_scope.
 
 Theorem trace_leq_imples_head_st_leq: forall ell t1 t2 s1 s2,
     (head_st t1 = Some s1) ->
@@ -137,7 +138,7 @@ Proof.
                  unfold node_state_low_eq in H5.
                  inversion Ht2head. rewrite H8 in H5. specialize (H5 id).
                  rewrite Hsid in H5. simpl in H0. inversion H0.
-                 rewrite H9 in H5. rewrite H1 in H5. assumption.
+                 rewrite H9, H1 in H5. assumption.
     - (* none *)
         inversion H; subst. 
             + discriminate H0.

--- a/experimental/ni_coq/vfiles/Parameters.v
+++ b/experimental/ni_coq/vfiles/Parameters.v
@@ -1,4 +1,3 @@
-From mathcomp Require Import fintype eqtype.
 Require Import OakIFC.Lattice.
 
 (*
@@ -10,11 +9,14 @@ In this case, labels are syntactic objects and levels are the security domains.
 
 Class params := {
     (* Assumed types, most with decidable equality *)
-    level: finType; 
-    data: finType;      (* this is a generic piece of data, for example the
-                            bytes sent over a channel *)
-    node_id: finType;
-    handle: finType;
+    level: Type; 
+    dec_eq_lev: forall x y: level, {x=y} + {x <> y};
+    data: Type;
+    dec_eq_msg: forall x y: data, {x=y} + {x <> y};
+    node_id: Type;
+    dec_eq_nid: forall x y: node_id, {x=y} + {x <> y};
+    handle: Type;
+    dec_eq_h: forall x y: handle, {x=y} + {x <> y};
 }.
 (* these things need to be ssreflect.fintype for compatability with
    ssreflect.finmap. finTypes have decidable equality which you can get

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -13,7 +13,8 @@ From OakIFC Require Import
     Unwind.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
-
+Local Open Scope map_scope.
+Local Open Scope aug_scope.
 
 (*
 This is the top-level candidate security condition. This is a
@@ -132,7 +133,7 @@ Proof.
                 eapply state_upd_node_preserves_chan_state_leq. apply Hsleq_s1s2.
                 assert (ch1' = chan_append ch1 msg) by
                     (destruct (chan_append ch1 msg ); reflexivity).
-                rewrite H9. rewrite Heqch2'.
+                rewrite H9, Heqch2'.
                 eapply chan_append_unwind.
                     (* chan_low_eq ell ch1 ch2 *) (* TODO make theorem*)
                 inversion Hsleq_s1s2. specialize (H16 han).

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -3,6 +3,7 @@ Import ListNotations.
 From OakIFC Require Import
     Lattice
     Parameters
+    GenericMap
     RuntimeModel
     EvAugSemantics
     Events
@@ -10,7 +11,6 @@ From OakIFC Require Import
     TraceTheorems
     NIUtilTheorems
     Unwind.
-From mathcomp Require Import all_ssreflect finmap.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
 
@@ -132,16 +132,13 @@ Proof.
                 eapply state_upd_node_preserves_chan_state_leq. apply Hsleq_s1s2.
                 assert (ch1' = chan_append ch1 msg) by
                     (destruct (chan_append ch1 msg ); reflexivity).
-                rewrite H9 Heqch2'.
+                rewrite H9. rewrite Heqch2'.
                 eapply chan_append_unwind.
                     (* chan_low_eq ell ch1 ch2 *) (* TODO make theorem*)
                 inversion Hsleq_s1s2. specialize (H16 han).
                     rewrite H13 in H16. rewrite Hch2 in H16. assumption.
         + (* NOT flows *)
 Admitted. (* WIP *)
-
-
-
  
 Theorem possibilistic_ni_1step: forall ell t1 t2 t1',
     (trace_low_eq ell t1 t2) ->

--- a/experimental/ni_coq/vfiles/RuntimeModel.v
+++ b/experimental/ni_coq/vfiles/RuntimeModel.v
@@ -12,6 +12,7 @@ From OakIFC Require Import
 * changes goals back to normal Coq built-in record updates *)
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
+Local Open Scope map_scope.
 
 (* This file is the top-level model of the Oak runtime *)
 

--- a/experimental/ni_coq/vfiles/RuntimeModel.v
+++ b/experimental/ni_coq/vfiles/RuntimeModel.v
@@ -3,12 +3,9 @@ Import ListNotations.
 Require Import Coq.Sets.Ensembles.
 From OakIFC Require Import
     Lattice
-    Parameters.
-(* finmap is a library for finite maps.
-* it comes with nice notations and some built-in theorems.
-* Since this is all that is used from ssreflect, we could cut ssreflect
-* if it becomes too much trouble*)
-From mathcomp Require Import all_ssreflect finmap.
+    Parameters
+    GenericMap.
+
 (* RecordUpdate is a conveninece feature that provides functional updates for
 * records with notation: https://github.com/tchajed/coq-record-update *)
 (* To work with record updates from this library in proofs "unfold set" quickly
@@ -26,10 +23,6 @@ Arguments Ensembles.Singleton {U}.
 Arguments Ensembles.Union {U}.
 Arguments Ensembles.Setminus{U}.
 Arguments Ensembles.Included{U}.
-
-(* Needed for most finite map notation *)
-Open Scope fmap_scope.
-Open Scope fset_scope.
 
 (*============================================================================
  Commands, State, Etc.
@@ -86,8 +79,16 @@ Record node := Node {
 Instance etanode: Settable _ :=
     settable! Node<nlbl; read_handles; write_handles; ncall>.
 
-Definition node_state := {fmap node_id -> node}.
-Definition chan_state := {fmap handle -> channel}.
+Instance Knid: KeyT := {
+    t := node_id; 
+    eq_dec := dec_eq_nid;
+}.
+Instance Khandle: KeyT := {
+    t := handle;
+    eq_dec := dec_eq_h;
+}.
+Definition node_state := pg_map Knid node.
+Definition chan_state := pg_map Khandle channel.
 Record state := State {
     nodes: node_state;
     chans: chan_state

--- a/experimental/ni_coq/vfiles/Unwind.v
+++ b/experimental/ni_coq/vfiles/Unwind.v
@@ -11,7 +11,7 @@ From OakIFC Require Import
     NIUtilTheorems.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
-
+Local Open Scope map_scope.
 (*============================================================================
  Unwinding Theorems
 ============================================================================*)
@@ -80,11 +80,11 @@ Proof.
         eapply state_upd_unwind_from_leqn; assumption.
     - (* some, none *)
         exfalso. specialize (H0 id).
-        rewrite E1 in H0. rewrite E2 in H0.
+        rewrite E1, E2 in H0.
         assumption.
     - (* none, some *)
         exfalso. specialize (H0 id).
-        rewrite E1 in H0. rewrite E2 in H0.
+        rewrite E1, E2 in H0.
         assumption.
     - split; assumption.
 Qed.

--- a/experimental/ni_coq/vfiles/Unwind.v
+++ b/experimental/ni_coq/vfiles/Unwind.v
@@ -1,14 +1,14 @@
 Require Import Coq.Lists.List.
 Import ListNotations.
 From OakIFC Require Import
+    Lattice
     Parameters
+    GenericMap
     RuntimeModel
     EvAugSemantics
     Events
     LowEquivalences
-    Lattice
     NIUtilTheorems.
-From mathcomp Require Import all_ssreflect finmap.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
 
@@ -48,7 +48,7 @@ Proof.
     intros. inversion H0. 
     split.
     - (* nodes *) 
-        intros id'. destruct (id' =P id). 
+        intros id'. destruct (dec_eq_nid id' id).
         + (* eq *) 
             rewrite e;
             rewrite !state_upd_node_eq; assumption.
@@ -68,10 +68,11 @@ Proof.
     destruct (s1.(nodes).[? id]) eqn:E1; destruct (s2.(nodes).[? id]) eqn:E2.
     - (* some, some *)
         assert (E: node_low_eq ell 
-            (n <| ncall ::= (fun=> c) |>)
-            (n0 <| ncall ::= (fun=> c) |>)).
+            (n <| ncall ::= (fun x=> c) |>)
+            (n0 <| ncall ::= (fun x=> c) |>)).
         {
-            specialize (H0 id). rewrite E1 E2 in H0.
+            specialize (H0 id). rewrite E1 in H0.
+            rewrite E2 in H0.
             inversion H0; subst.
             constructor; reflexivity.
             constructor 2; assumption.
@@ -79,11 +80,11 @@ Proof.
         eapply state_upd_unwind_from_leqn; assumption.
     - (* some, none *)
         exfalso. specialize (H0 id).
-        rewrite E1 E2 in H0.
+        rewrite E1 in H0. rewrite E2 in H0.
         assumption.
     - (* none, some *)
         exfalso. specialize (H0 id).
-        rewrite E1 E2 in H0.
+        rewrite E1 in H0. rewrite E2 in H0.
         assumption.
     - split; assumption.
 Qed.


### PR DESCRIPTION
Following discussion with @jadephilipoom,  this commit removes the ssreflect
finmap in favor of using the old simpler GenericMap.v implementation of
finite maps. SSReflect is a fairly complicated library that turns out to
be closer to a whole new dialect of coq. Given that the only use for it
was finite maps and we are not doing computation on maps, it seems
best to just use simpler maps.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
