### PR TITLE
Split node creation logic into separate trait

### DIFF
--- a/oak_runtime/src/introspect.rs
+++ b/oak_runtime/src/introspect.rs
@@ -209,7 +209,7 @@ fn handle_request(
 async fn make_server(
     port: u16,
     runtime: Arc<Runtime>,
-    termination_notificiation_receiver: tokio::sync::oneshot::Receiver<()>,
+    termination_notification_receiver: tokio::sync::oneshot::Receiver<()>,
 ) {
     // Initialize SocketAddr to listen on.
     let addr = SocketAddr::from((std::net::Ipv6Addr::UNSPECIFIED, port));
@@ -233,7 +233,7 @@ async fn make_server(
     let server = Server::bind(&addr).serve(make_service);
     let graceful = server.with_graceful_shutdown(async {
         // Treat notification failure the same as a notification.
-        let _ = termination_notificiation_receiver.await;
+        let _ = termination_notification_receiver.await;
     });
 
     // Run until asked to terminate.

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -61,9 +61,6 @@ impl RuntimeProxy {
         signature_table: &SignatureTable,
     ) -> RuntimeProxy {
         let runtime = Arc::new(Runtime {
-            application_configuration: application_configuration.clone(),
-            secure_server_configuration: secure_server_configuration.clone(),
-            signature_table: signature_table.clone(),
             terminating: AtomicBool::new(false),
             next_channel_id: AtomicU64::new(0),
             node_infos: RwLock::new(HashMap::new()),
@@ -71,6 +68,11 @@ impl RuntimeProxy {
             aux_servers: Mutex::new(Vec::new()),
             introspection_event_queue: Mutex::new(VecDeque::new()),
             metrics_data: Metrics::new(),
+            node_factory: crate::node::ServerNodeFactory {
+                application_configuration: application_configuration.clone(),
+                secure_server_configuration: secure_server_configuration.clone(),
+                signature_table: signature_table.clone(),
+            },
         });
         let proxy = runtime.proxy_for_new_node();
         proxy.runtime.node_configure_instance(
@@ -96,6 +98,7 @@ impl RuntimeProxy {
     ) -> Result<oak_abi::Handle, OakStatus> {
         let node_configuration = self
             .runtime
+            .node_factory
             .application_configuration
             .initial_node_configuration
             .as_ref()


### PR DESCRIPTION
This decouples the Runtime object from the details of how specific nodes
are created, which may vary based on platform or purpose in which the
Runtime is instantiated.

Ref #1497

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
