### PR TITLE
Introspection: Patch incorrect event order in the Event List tab

### DIFF
--- a/oak_runtime/introspection_browser_client/components/EventList/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/EventList/index.tsx
@@ -19,16 +19,35 @@ import introspectionEventsProto from '~/protoc_out/proto/introspection_events_pb
 
 type EventListProps = { events: introspectionEventsProto.Event[] };
 
+// Array of events in reverse chronological order
+type ReversedEvents = {
+  // The event index, in the order of event creation
+  eventIndex: number;
+  // The actual event
+  event: introspectionEventsProto.Event;
+}[];
+
 export default function EventList({ events }: EventListProps) {
+  // Reverse the array of events (while storing the orginal index) to render
+  // events in a reverse chronological order.
+  const reversedEvents = React.useMemo(
+    () =>
+      events.reduce((acc, event, eventIndex) => {
+        acc.unshift({ eventIndex, event });
+        return acc;
+      }, [] as ReversedEvents),
+    events
+  );
+
   return (
     <section>
       <strong>Events List</strong>
       <ol reversed>
-        {events.map((event, index) => (
+        {reversedEvents.map(({ eventIndex, event }) => (
           // Usually it's not advisable to use the index as a key. However since
           // the list of events is append-only it's fine in this case.
           // Ref: https://reactjs.org/docs/lists-and-keys.html#keys
-          <li key={index}>{JSON.stringify(event.toObject())}</li>
+          <li key={eventIndex}>{JSON.stringify(event.toObject())}</li>
         ))}
       </ol>
     </section>


### PR DESCRIPTION
In #1472 I added the `reversed` tag to the HTML list, but neglected to reverse the array of events to match it.

Before:
![image](https://user-images.githubusercontent.com/8875406/93895269-8d826780-fce7-11ea-8e6f-db1561fcbe67.png)

After:
![image](https://user-images.githubusercontent.com/8875406/93895189-76437a00-fce7-11ea-8a00-dca62bdd7db6.png)


# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
