### PR TITLE
Build without mathcomp-finmap installed

### DIFF
--- a/experimental/ni_coq/README.md
+++ b/experimental/ni_coq/README.md
@@ -21,7 +21,6 @@ is in vfiles/RuntimeModel.v. Both are evolving.
 The following are dependencies of this project:
 
 - coq (8.11.0)
-- coq-mathcomp-finmap (1.5.0)
 - coq-record-update (0.2.0)
 
 All of the above may be installed with [opam](https://opam.ocaml.org/), and the

--- a/experimental/ni_coq/vfiles/Events.v
+++ b/experimental/ni_coq/vfiles/Events.v
@@ -5,7 +5,6 @@ From OakIFC Require Import
     LowEquivalences.
 Require Import Coq.Lists.List.
 Import ListNotations.
-From mathcomp Require Import fintype.
 
 (* This file contains  *)
 

--- a/experimental/ni_coq/vfiles/Unwind.v
+++ b/experimental/ni_coq/vfiles/Unwind.v
@@ -53,10 +53,10 @@ Proof.
             rewrite e;
             rewrite !state_upd_node_eq; assumption.
         + (* neq *) 
-            rewrite !state_upd_node_neq.
+            rewrite !state_upd_node_neq; try assumption.
             apply (H1 id');  assumption.
     - (* chans *)
-        assumption. assumption. apply H2.
+        assumption.
 Qed.
 
 Theorem set_call_unwind: forall ell id c s1 s2,


### PR DESCRIPTION
Follow-up to  af58235b7a8bd441c639b2b9ae093c0f563f99d7

Since I've swapped out my laptop, I was building without `mathcomp-finmap` installed, and found one lingering import that apparently affected the behavior of one proof. This PR:
- removes the lingering import
- fixes the single affected proof
- removes the line on the README saying mathcomp-finmap is a dependency

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
