### PR TITLE
Add ABI support for node and channel labels

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -238,6 +238,55 @@ If creating the specified Node would violate
 - `param[4]: usize`: Handle to channel
 - `result[0]: u32`: Status of operation
 
+### `node_label`
+
+Returns the label for the calling Node, as a serialized
+[`Label`](/oak/proto/label.proto) protobuf message.
+
+If the provided space for label data (`param[0]` and `param[1]`) is not large
+enough, the function returns `BUFFER_TOO_SMALL` and the required size is written
+in the space provided by `param[2]`.
+
+- `param[0]: usize`: Destination buffer
+- `param[1]: usize`: Destination buffer size in bytes
+- `param[2]: usize`: Address of a 4-byte location that will receive the number
+  of bytes in the label (as a little-endian u32) if the provided buffer is not
+  large enough.
+- `result[0]: u32`: Status of operation
+
+### `channel_label`
+
+Returns the label for the specified channel, as a serialized
+[`Label`](/oak/proto/label.proto) protobuf message.
+
+If the provided space for label data (`param[1]` and `param[2]`) is not large
+enough, the function returns `BUFFER_TOO_SMALL` and the required size is written
+in the space provided by `param[3]`.
+
+- `param[0]: u64`: Handle to channel
+- `param[1]: usize`: Destination buffer
+- `param[2]: usize`: Destination buffer size in bytes
+- `param[3]: usize`: Address of a 4-byte location that will receive the number
+  of bytes in the label (as a little-endian u32) if the provided buffer is not
+  large enough.
+- `result[0]: u32`: Status of operation
+
+### `node_privilege`
+
+Returns a label indicating the downgrade privilege of the calling Node, as a
+serialized [`Label`](/oak/proto/label.proto) protobuf message.
+
+If the provided space for label data (`param[0]` and `param[1]`) is not large
+enough, the function returns `BUFFER_TOO_SMALL` and the required size is written
+in the space provided by `param[2]`.
+
+- `param[0]: usize`: Destination buffer
+- `param[1]: usize`: Destination buffer size in bytes
+- `param[2]: usize`: Address of a 4-byte location that will receive the number
+  of bytes in the label (as a little-endian u32) if the provided buffer is not
+  large enough.
+- `result[0]: u32`: Status of operation
+
 ### `random_get`
 
 Fills a buffer with random bytes.

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -238,7 +238,7 @@ If creating the specified Node would violate
 - `param[4]: usize`: Handle to channel
 - `result[0]: u32`: Status of operation
 
-### `node_label`
+### `node_label_read`
 
 Returns the label for the calling Node, as a serialized
 [`Label`](/oak/proto/label.proto) protobuf message.
@@ -254,7 +254,7 @@ in the space provided by `param[2]`.
   large enough.
 - `result[0]: u32`: Status of operation
 
-### `channel_label`
+### `channel_label_read`
 
 Returns the label for the specified channel, as a serialized
 [`Label`](/oak/proto/label.proto) protobuf message.
@@ -271,7 +271,7 @@ in the space provided by `param[3]`.
   large enough.
 - `result[0]: u32`: Status of operation
 
-### `node_privilege`
+### `node_privilege_read`
 
 Returns a label indicating the downgrade privilege of the calling Node, as a
 serialized [`Label`](/oak/proto/label.proto) protobuf message.

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -1467,17 +1467,24 @@ impl FrontendNode {
     }
 
     fn test_node_privilege(&mut self) -> TestResult {
-        let privilege = oak::node_label();
+        let privilege = oak::node_privilege();
         expect_matches!(privilege, Ok(_));
         let confidentiality_tags = privilege.unwrap().confidentiality_tags.to_vec();
         expect_eq!(1, confidentiality_tags.len());
-        let tag = confidentiality_tags[0];
+        let tag = confidentiality_tags[0].tag.clone().unwrap();
         expect_matches!(
             tag,
             oak_abi::proto::oak::label::tag::Tag::WebAssemblyModuleTag(_)
         );
-        let oak_abi::proto::oak::label::tag::Tag::WebAssemblyModuleTag(module_tag) = tag;
-        expect_eq!(32, module_tag.web_assembly_module_hash_sha_256.len());
+        match tag {
+            oak_abi::proto::oak::label::tag::Tag::WebAssemblyModuleTag(module_tag) => {
+                expect_eq!(32, module_tag.web_assembly_module_hash_sha_256.len())
+            }
+            _ => {
+                error!("Unreachable code reached.");
+                unreachable!();
+            }
+        };
         Ok(())
     }
 

--- a/oak/module/oak_abi.h
+++ b/oak/module/oak_abi.h
@@ -54,6 +54,13 @@ WASM_IMPORT("oak")
 oak_abi::OakStatus channel_create(oak_abi::Handle* write_handle, oak_abi::Handle* read_handle,
                                   uint8_t* label_buf, size_t label_size);
 WASM_IMPORT("oak")
+oak_abi::OakStatus channel_label(oak_abi::Handle handle, uint8_t* label_buf, size_t label_size,
+                                 uint32_t* actual_size);
+WASM_IMPORT("oak")
+oak_abi::OakStatus node_label(uint8_t* label_buf, size_t label_size, uint32_t* actual_size);
+WASM_IMPORT("oak")
+oak_abi::OakStatus node_privilege(uint8_t* label_buf, size_t label_size, uint32_t* actual_size);
+WASM_IMPORT("oak")
 oak_abi::OakStatus node_create(uint8_t* config_buf, size_t config_size, uint8_t* label_buf,
                                size_t label_size, oak_abi::Handle handle);
 WASM_IMPORT("oak")

--- a/oak/module/oak_abi.h
+++ b/oak/module/oak_abi.h
@@ -54,12 +54,13 @@ WASM_IMPORT("oak")
 oak_abi::OakStatus channel_create(oak_abi::Handle* write_handle, oak_abi::Handle* read_handle,
                                   uint8_t* label_buf, size_t label_size);
 WASM_IMPORT("oak")
-oak_abi::OakStatus channel_label(oak_abi::Handle handle, uint8_t* label_buf, size_t label_size,
-                                 uint32_t* actual_size);
+oak_abi::OakStatus channel_label_read(oak_abi::Handle handle, uint8_t* label_buf, size_t label_size,
+                                      uint32_t* actual_size);
 WASM_IMPORT("oak")
-oak_abi::OakStatus node_label(uint8_t* label_buf, size_t label_size, uint32_t* actual_size);
+oak_abi::OakStatus node_label_read(uint8_t* label_buf, size_t label_size, uint32_t* actual_size);
 WASM_IMPORT("oak")
-oak_abi::OakStatus node_privilege(uint8_t* label_buf, size_t label_size, uint32_t* actual_size);
+oak_abi::OakStatus node_privilege_read(uint8_t* label_buf, size_t label_size,
+                                       uint32_t* actual_size);
 WASM_IMPORT("oak")
 oak_abi::OakStatus node_create(uint8_t* config_buf, size_t config_size, uint8_t* label_buf,
                                size_t label_size, oak_abi::Handle handle);

--- a/oak_abi/src/lib.rs
+++ b/oak_abi/src/lib.rs
@@ -168,7 +168,7 @@ extern "C" {
     ///
     /// [`ErrBufferTooSmall`]: crate::OakStatus::ErrBufferTooSmall
     /// [`Label`]: crate::label::Label
-    pub fn channel_label(
+    pub fn channel_label_read(
         handle: u64,
         label_buf: *mut u8,
         label_size: usize,
@@ -188,7 +188,7 @@ extern "C" {
     ///
     /// [`ErrBufferTooSmall`]: crate::OakStatus::ErrBufferTooSmall
     /// [`Label`]: crate::label::Label
-    pub fn node_label(label_buf: *mut u8, label_size: usize, actual_size: *mut u32) -> u32;
+    pub fn node_label_read(label_buf: *mut u8, label_size: usize, actual_size: *mut u32) -> u32;
 
     /// Returns a label indicating the downgrade privilege of the current calling node.
     ///
@@ -203,7 +203,8 @@ extern "C" {
     ///
     /// [`ErrBufferTooSmall`]: crate::OakStatus::ErrBufferTooSmall
     /// [`Label`]: crate::label::Label
-    pub fn node_privilege(label_buf: *mut u8, label_size: usize, actual_size: *mut u32) -> u32;
+    pub fn node_privilege_read(label_buf: *mut u8, label_size: usize, actual_size: *mut u32)
+        -> u32;
 
     /// Creates a new Node instance running code identified by a serialized [`NodeConfiguration`].
     ///

--- a/oak_abi/src/lib.rs
+++ b/oak_abi/src/lib.rs
@@ -155,6 +155,56 @@ extern "C" {
     /// [`OakStatus`]: crate::OakStatus
     pub fn channel_close(handle: u64) -> u32;
 
+    /// Returns the label for the channel identified by `handle`.
+    ///
+    /// The label is stored into `label_buf` as a serialized [`Label`] protobuf message. The actual
+    /// size of the serialized message is indicated by `actual_size`.
+    ///
+    /// If the provided space for the label is too small (`label_buf` and `label_size`), then no
+    /// data will be stored in `label_buf` and [`ErrBufferTooSmall`] returned. The required size
+    /// will be returned in the space provided by `actual_size`.
+    ///
+    /// Returns the status of the operation, as an [`OakStatus`] value.
+    ///
+    /// [`ErrBufferTooSmall`]: crate::OakStatus::ErrBufferTooSmall
+    /// [`Label`]: crate::label::Label
+    pub fn channel_label(
+        handle: u64,
+        label_buf: *mut u8,
+        label_size: usize,
+        actual_size: *mut u32,
+    ) -> u32;
+
+    /// Returns the label of the current calling node.
+    ///
+    /// The label is stored into `label_buf` as a serialized [`Label`] protobuf message. The actual
+    /// size of the serialized message is indicated by `actual_size`.
+    ///
+    /// If the provided space for the label is too small (`label_buf` and `label_size`), then no
+    /// data will be stored in `label_buf` and [`ErrBufferTooSmall`] returned. The required size
+    /// will be returned in the space provided by `actual_size`.
+    ///
+    /// Returns the status of the operation, as an [`OakStatus`] value.
+    ///
+    /// [`ErrBufferTooSmall`]: crate::OakStatus::ErrBufferTooSmall
+    /// [`Label`]: crate::label::Label
+    pub fn node_label(label_buf: *mut u8, label_size: usize, actual_size: *mut u32) -> u32;
+
+    /// Returns a label indicating the downgrade privilege of the current calling node.
+    ///
+    /// The label is stored into `label_buf` as a serialized [`Label`] protobuf message. The actual
+    /// size of the serialized message is indicated by `actual_size`.
+    ///
+    /// If the provided space for the label is too small (`label_buf` and `label_size`), then no
+    /// data will be stored in `label_buf` and [`ErrBufferTooSmall`] returned. The required size
+    /// will be returned in the space provided by `actual_size`.
+    ///
+    /// Returns the status of the operation, as an [`OakStatus`] value.
+    ///
+    /// [`ErrBufferTooSmall`]: crate::OakStatus::ErrBufferTooSmall
+    /// [`Label`]: crate::label::Label
+    pub fn node_privilege(label_buf: *mut u8, label_size: usize, actual_size: *mut u32) -> u32;
+
     /// Creates a new Node instance running code identified by a serialized [`NodeConfiguration`].
     ///
     /// The serialized configuration object is provided in the memory area given by `config_buf` and

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -277,7 +277,7 @@ impl std::fmt::Debug for NodeInfo {
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, PartialOrd, Ord)]
 pub struct NodeId(pub u64);
 
-/// Helper types to indicate whether a channel read operation has succeed or has failed with not
+/// Helper types to indicate whether a channel read operation has succeeded or has failed with not
 /// enough `bytes_capacity` and/or `handles_capacity`.
 #[derive(Debug)]
 pub enum NodeReadStatus {
@@ -288,7 +288,7 @@ pub enum ReadStatus {
     Success(Message),
     NeedsCapacity(usize, usize),
 }
-/// Helper type to indicate whether retrieving a serialized label has succeed or has failed with
+/// Helper type to indicate whether retrieving a serialized label has succeeded or has failed with
 /// not enough capacity.
 #[derive(Debug)]
 pub enum LabelSerializationStatus {

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -676,7 +676,7 @@ impl Runtime {
         if size > capacity {
             Ok(LabelSerializationStatus::NeedsCapacity(size))
         } else {
-            let mut encoded = Vec::new();
+            let mut encoded = Vec::with_capacity(size);
             match label.encode(&mut encoded) {
                 Err(error) => {
                     warn!("Could not encode label: {}", error);
@@ -701,7 +701,7 @@ impl Runtime {
         if size > capacity {
             Ok(LabelSerializationStatus::NeedsCapacity(size))
         } else {
-            let mut encoded = Vec::new();
+            let mut encoded = Vec::with_capacity(size);
             match label.encode(&mut encoded) {
                 Err(error) => {
                     warn!("Could not encode label: {}", error);
@@ -727,7 +727,7 @@ impl Runtime {
         if size > capacity {
             Ok(LabelSerializationStatus::NeedsCapacity(size))
         } else {
-            let mut encoded = Vec::new();
+            let mut encoded = Vec::with_capacity(size);
             match label.encode(&mut encoded) {
                 Err(error) => {
                     warn!("Could not encode label: {}", error);

--- a/oak_runtime/src/node/wasm/mod.rs
+++ b/oak_runtime/src/node/wasm/mod.rs
@@ -524,7 +524,7 @@ impl WasmInterface {
                         self.pretty_name, err
                     );
                     OakStatus::ErrInvalidArgs
-                })?;
+                })
             }
             LabelSerializationStatus::NeedsCapacity(_) => Err(OakStatus::ErrBufferTooSmall),
         }
@@ -576,7 +576,7 @@ impl WasmInterface {
                         self.pretty_name, err
                     );
                     OakStatus::ErrInvalidArgs
-                })?;
+                })
             }
             LabelSerializationStatus::NeedsCapacity(_) => Err(OakStatus::ErrBufferTooSmall),
         }
@@ -628,7 +628,7 @@ impl WasmInterface {
                         self.pretty_name, err
                     );
                     OakStatus::ErrInvalidArgs
-                })?;
+                })
             }
             LabelSerializationStatus::NeedsCapacity(_) => Err(OakStatus::ErrBufferTooSmall),
         }

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -18,8 +18,8 @@
 //! context of a specific Node or pseudo-Node.
 
 use crate::{
-    metrics::Metrics, AuxServer, ChannelHalfDirection, NodeId, NodeMessage, NodePrivilege,
-    NodeReadStatus, Runtime, SecureServerConfiguration, SignatureTable,
+    metrics::Metrics, AuxServer, ChannelHalfDirection, LabelSerializationStatus, NodeId,
+    NodeMessage, NodePrivilege, NodeReadStatus, Runtime, SecureServerConfiguration, SignatureTable,
 };
 use core::sync::atomic::{AtomicBool, AtomicU64};
 use log::debug;
@@ -280,6 +280,64 @@ impl RuntimeProxy {
         debug!(
             "{:?}: channel_try_read({}, bytes_capacity={}, handles_capacity={}) -> {:?}",
             self.node_id, read_handle, bytes_capacity, handles_capacity, result
+        );
+        result
+    }
+
+    /// See [`Runtime::get_serialized_channel_label`].
+    pub fn get_serialized_channel_label(
+        &self,
+        handle: oak_abi::Handle,
+        capacity: usize,
+    ) -> Result<LabelSerializationStatus, OakStatus> {
+        debug!(
+            "{:?}: get_serialized_channel_label({}, capacity={})",
+            self.node_id, handle, capacity
+        );
+        let result = self
+            .runtime
+            .get_serialized_channel_label(self.node_id, handle, capacity);
+        debug!(
+            "{:?}: get_serialized_channel_label({}, capacity={}) -> {:?}",
+            self.node_id, handle, capacity, result
+        );
+        result
+    }
+
+    /// See [`Runtime::get_serialized_node_label`].
+    pub fn get_serialized_node_label(
+        &self,
+        capacity: usize,
+    ) -> Result<LabelSerializationStatus, OakStatus> {
+        debug!(
+            "{:?}: get_serialized_node_label(capacity={})",
+            self.node_id, capacity
+        );
+        let result = self
+            .runtime
+            .get_serialized_node_label(self.node_id, capacity);
+        debug!(
+            "{:?}: get_serialized_node_label(capacity={}) -> {:?}",
+            self.node_id, capacity, result
+        );
+        result
+    }
+
+    /// See [`Runtime::get_serialized_node_privilege`].
+    pub fn get_serialized_node_privilege(
+        &self,
+        capacity: usize,
+    ) -> Result<LabelSerializationStatus, OakStatus> {
+        debug!(
+            "{:?}: get_serialized_node_privilege(capacity={})",
+            self.node_id, capacity
+        );
+        let result = self
+            .runtime
+            .get_serialized_node_privilege(self.node_id, capacity);
+        debug!(
+            "{:?}: get_serialized_node_privilege(capacity={}) -> {:?}",
+            self.node_id, capacity, result
         );
         result
     }

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -18,8 +18,8 @@
 //! context of a specific Node or pseudo-Node.
 
 use crate::{
-    metrics::Metrics, AuxServer, ChannelHalfDirection, LabelSerializationStatus, NodeId,
-    NodeMessage, NodePrivilege, NodeReadStatus, Runtime, SecureServerConfiguration, SignatureTable,
+    metrics::Metrics, AuxServer, ChannelHalfDirection, LabelReadStatus, NodeId, NodeMessage,
+    NodePrivilege, NodeReadStatus, Runtime, SecureServerConfiguration, SignatureTable,
 };
 use core::sync::atomic::{AtomicBool, AtomicU64};
 use log::debug;
@@ -289,7 +289,7 @@ impl RuntimeProxy {
         &self,
         handle: oak_abi::Handle,
         capacity: usize,
-    ) -> Result<LabelSerializationStatus, OakStatus> {
+    ) -> Result<LabelReadStatus, OakStatus> {
         debug!(
             "{:?}: get_serialized_channel_label({}, capacity={})",
             self.node_id, handle, capacity
@@ -305,10 +305,7 @@ impl RuntimeProxy {
     }
 
     /// See [`Runtime::get_serialized_node_label`].
-    pub fn get_serialized_node_label(
-        &self,
-        capacity: usize,
-    ) -> Result<LabelSerializationStatus, OakStatus> {
+    pub fn get_serialized_node_label(&self, capacity: usize) -> Result<LabelReadStatus, OakStatus> {
         debug!(
             "{:?}: get_serialized_node_label(capacity={})",
             self.node_id, capacity
@@ -327,7 +324,7 @@ impl RuntimeProxy {
     pub fn get_serialized_node_privilege(
         &self,
         capacity: usize,
-    ) -> Result<LabelSerializationStatus, OakStatus> {
+    ) -> Result<LabelReadStatus, OakStatus> {
         debug!(
             "{:?}: get_serialized_node_privilege(capacity={})",
             self.node_id, capacity

--- a/oak_services/proto/http_encap.proto
+++ b/oak_services/proto/http_encap.proto
@@ -40,7 +40,6 @@ message HttpResponse {
   map<string, HeaderValue> headers = 3;
 }
 
-
 // Each header name in an HTTP request or HTTP response may correspond to more
 // than one header values. This protocol buffer represents such header values.
 message HeaderValue {

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -300,138 +300,68 @@ pub fn node_create_with_label(
 }
 
 /// Get the [`Label`] for the channel associated with the `handle`.
-pub fn channel_label(handle: Handle) -> Result<Label, OakStatus> {
-    let mut bytes = Vec::with_capacity(1024);
-    for resized in &[false, true] {
-        let mut actual_size: u32 = 0;
-        let status = OakStatus::from_i32(unsafe {
-            oak_abi::channel_label(
-                handle,
-                bytes.as_mut_ptr(),
-                bytes.capacity(),
-                &mut actual_size,
-            ) as i32
-        });
-        match status {
-            Some(s) => match s {
-                OakStatus::Ok => {
-                    unsafe {
-                        // The serialized label was successfully fetched, so set the length to the
-                        // actual length.
-                        bytes.set_len(actual_size as usize);
-                    }
-                    return Ok(Label::deserialize(&bytes).expect("Could not deserialize label."));
-                }
-
-                OakStatus::ErrBufferTooSmall if !(*resized) => {
-                    // Extend the vector to be large enough for the serialized label.
-                    debug!(
-                        "Got space for {} bytes, need {}",
-                        bytes.capacity(),
-                        actual_size
-                    );
-                    bytes.reserve((actual_size as usize) - bytes.capacity());
-
-                    // Try again with a buffer resized to cope with expected size of data.
-                    continue;
-                }
-
-                s => {
-                    return Err(s);
-                }
-            },
-            None => {
-                return Err(OakStatus::ErrInternal);
-            }
-        }
-    }
-    error!("unreachable code reached");
-    Err(OakStatus::ErrInternal)
+pub fn channel_label_read(handle: Handle) -> Result<Label, OakStatus> {
+    read_label_with(|bytes, actual_size| unsafe {
+        oak_abi::channel_label_read(
+            handle,
+            bytes.as_mut_ptr(),
+            bytes.capacity(),
+            &mut *actual_size,
+        ) as i32
+    })
 }
 
 /// Get the [`Label`] for the current node.
-pub fn node_label() -> Result<Label, OakStatus> {
-    let mut bytes = Vec::with_capacity(1024);
-    for resized in &[false, true] {
-        let mut actual_size: u32 = 0;
-        let status = OakStatus::from_i32(unsafe {
-            oak_abi::node_label(bytes.as_mut_ptr(), bytes.capacity(), &mut actual_size) as i32
-        });
-        match status {
-            Some(s) => match s {
-                OakStatus::Ok => {
-                    unsafe {
-                        // The serialized label was successfully fetched, so set the length to the
-                        // actual length.
-                        bytes.set_len(actual_size as usize);
-                    }
-                    return Ok(Label::deserialize(&bytes).expect("Could not deserialize label."));
-                }
-
-                OakStatus::ErrBufferTooSmall if !(*resized) => {
-                    // Extend the vector to be large enough for the serialized label.
-                    debug!(
-                        "Got space for {} bytes, need {}",
-                        bytes.capacity(),
-                        actual_size
-                    );
-                    bytes.reserve((actual_size as usize) - bytes.capacity());
-
-                    // Try again with a buffer resized to cope with expected size of data.
-                    continue;
-                }
-
-                s => {
-                    return Err(s);
-                }
-            },
-            None => {
-                return Err(OakStatus::ErrInternal);
-            }
-        }
-    }
-    error!("unreachable code reached");
-    Err(OakStatus::ErrInternal)
+pub fn node_label_read() -> Result<Label, OakStatus> {
+    read_label_with(|bytes, actual_size| unsafe {
+        oak_abi::node_label_read(bytes.as_mut_ptr(), bytes.capacity(), &mut *actual_size) as i32
+    })
 }
 
 /// Get the downgrade privilege for the current node represented as a [`Label`].
-pub fn node_privilege() -> Result<Label, OakStatus> {
+pub fn node_privilege_read() -> Result<Label, OakStatus> {
+    read_label_with(|bytes, actual_size| unsafe {
+        oak_abi::node_privilege_read(bytes.as_mut_ptr(), bytes.capacity(), &mut *actual_size) as i32
+    })
+}
+
+/// Helper function to read a label using `label_fetcher`.
+///
+/// If the buffer is too small, it will resize the buffer to the `actual_size` and try again.
+fn read_label_with<F>(label_fetcher: F) -> Result<Label, OakStatus>
+where
+    F: Fn(&mut Vec<u8>, &mut u32) -> i32,
+{
     let mut bytes = Vec::with_capacity(1024);
     for resized in &[false, true] {
         let mut actual_size: u32 = 0;
-        let status = OakStatus::from_i32(unsafe {
-            oak_abi::node_privilege(bytes.as_mut_ptr(), bytes.capacity(), &mut actual_size) as i32
-        });
+        let status = OakStatus::from_i32(label_fetcher(&mut bytes, &mut actual_size))
+            .ok_or(OakStatus::ErrInternal)?;
         match status {
-            Some(s) => match s {
-                OakStatus::Ok => {
-                    unsafe {
-                        // The serialized label was successfully fetched, so set the length to the
-                        // actual length.
-                        bytes.set_len(actual_size as usize);
-                    }
-                    return Ok(Label::deserialize(&bytes).expect("Could not deserialize label."));
+            OakStatus::Ok => {
+                unsafe {
+                    // The serialized label was successfully fetched, so set the length to the
+                    // actual length.
+                    bytes.set_len(actual_size as usize);
                 }
+                return Ok(Label::deserialize(&bytes).expect("Could not deserialize label."));
+            }
 
-                OakStatus::ErrBufferTooSmall if !(*resized) => {
-                    // Extend the vector to be large enough for the serialized label.
-                    debug!(
-                        "Got space for {} bytes, need {}",
-                        bytes.capacity(),
-                        actual_size
-                    );
-                    bytes.reserve((actual_size as usize) - bytes.capacity());
+            OakStatus::ErrBufferTooSmall if !(*resized) => {
+                // Extend the vector to be large enough for the serialized label.
+                debug!(
+                    "Got space for {} bytes, need {}",
+                    bytes.capacity(),
+                    actual_size
+                );
+                bytes.reserve((actual_size as usize) - bytes.capacity());
 
-                    // Try again with a buffer resized to cope with expected size of data.
-                    continue;
-                }
+                // Try again with a buffer resized to cope with expected size of data.
+                continue;
+            }
 
-                s => {
-                    return Err(s);
-                }
-            },
-            None => {
-                return Err(OakStatus::ErrInternal);
+            s => {
+                return Err(s);
             }
         }
     }

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -305,7 +305,12 @@ pub fn channel_label(handle: Handle) -> Result<Label, OakStatus> {
     for resized in &[false, true] {
         let mut actual_size: u32 = 0;
         let status = OakStatus::from_i32(unsafe {
-            oak_abi::channel_label(handle, bytes.as_mut_ptr(), bytes.len(), &mut actual_size) as i32
+            oak_abi::channel_label(
+                handle,
+                bytes.as_mut_ptr(),
+                bytes.capacity(),
+                &mut actual_size,
+            ) as i32
         });
         match status {
             Some(s) => match s {
@@ -325,7 +330,7 @@ pub fn channel_label(handle: Handle) -> Result<Label, OakStatus> {
                         bytes.capacity(),
                         actual_size
                     );
-                    bytes.reserve((actual_size as usize) - bytes.len());
+                    bytes.reserve((actual_size as usize) - bytes.capacity());
 
                     // Try again with a buffer resized to cope with expected size of data.
                     continue;
@@ -350,7 +355,7 @@ pub fn node_label() -> Result<Label, OakStatus> {
     for resized in &[false, true] {
         let mut actual_size: u32 = 0;
         let status = OakStatus::from_i32(unsafe {
-            oak_abi::node_label(bytes.as_mut_ptr(), bytes.len(), &mut actual_size) as i32
+            oak_abi::node_label(bytes.as_mut_ptr(), bytes.capacity(), &mut actual_size) as i32
         });
         match status {
             Some(s) => match s {
@@ -370,7 +375,7 @@ pub fn node_label() -> Result<Label, OakStatus> {
                         bytes.capacity(),
                         actual_size
                     );
-                    bytes.reserve((actual_size as usize) - bytes.len());
+                    bytes.reserve((actual_size as usize) - bytes.capacity());
 
                     // Try again with a buffer resized to cope with expected size of data.
                     continue;
@@ -395,7 +400,7 @@ pub fn node_privilege() -> Result<Label, OakStatus> {
     for resized in &[false, true] {
         let mut actual_size: u32 = 0;
         let status = OakStatus::from_i32(unsafe {
-            oak_abi::node_privilege(bytes.as_mut_ptr(), bytes.len(), &mut actual_size) as i32
+            oak_abi::node_privilege(bytes.as_mut_ptr(), bytes.capacity(), &mut actual_size) as i32
         });
         match status {
             Some(s) => match s {
@@ -415,7 +420,7 @@ pub fn node_privilege() -> Result<Label, OakStatus> {
                         bytes.capacity(),
                         actual_size
                     );
-                    bytes.reserve((actual_size as usize) - bytes.len());
+                    bytes.reserve((actual_size as usize) - bytes.capacity());
 
                     // Try again with a buffer resized to cope with expected size of data.
                     continue;

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -299,6 +299,141 @@ pub fn node_create_with_label(
     result_from_status(status as i32, ())
 }
 
+/// Get the [`Label`] for the channel associated with the `handle`.
+pub fn channel_label(handle: Handle) -> Result<Label, OakStatus> {
+    let mut bytes = Vec::with_capacity(1024);
+    for resized in &[false, true] {
+        let mut actual_size: u32 = 0;
+        let status = OakStatus::from_i32(unsafe {
+            oak_abi::channel_label(handle, bytes.as_ptr(), bytes.len(), &mut actual_size)
+        });
+        match status {
+            Some(s) => match s {
+                OakStatus::Ok => {
+                    unsafe {
+                        // The serialized label was successfully fetched, so set the length to the
+                        // actual length.
+                        bytes.set_len(actual_size as usize);
+                    }
+                    return Ok(Label::deserialize(&bytes).expect("Could not deserialize label."));
+                }
+
+                OakStatus::ErrBufferTooSmall if !(*resized) => {
+                    // Extend the vector to be large enough for the serialized label.
+                    debug!(
+                        "Got space for {} bytes, need {}",
+                        bytes.capacity(),
+                        actual_size
+                    );
+                    bytes.reserve((actual_size as usize) - bytes.len());
+
+                    // Try again with a buffer resized to cope with expected size of data.
+                    continue;
+                }
+
+                s => {
+                    return Err(s);
+                }
+            },
+            None => {
+                return Err(OakStatus::ErrInternal);
+            }
+        }
+    }
+    error!("unreachable code reached");
+    Err(OakStatus::ErrInternal)
+}
+
+/// Get the [`Label`] for the current node.
+pub fn node_label() -> Result<Label, OakStatus> {
+    let mut bytes = Vec::with_capacity(1024);
+    for resized in &[false, true] {
+        let mut actual_size: u32 = 0;
+        let status = OakStatus::from_i32(unsafe {
+            oak_abi::node_label(bytes.as_ptr(), bytes.len(), &mut actual_size)
+        });
+        match status {
+            Some(s) => match s {
+                OakStatus::Ok => {
+                    unsafe {
+                        // The serialized label was successfully fetched, so set the length to the
+                        // actual length.
+                        bytes.set_len(actual_size as usize);
+                    }
+                    return Ok(Label::deserialize(&bytes).expect("Could not deserialize label."));
+                }
+
+                OakStatus::ErrBufferTooSmall if !(*resized) => {
+                    // Extend the vector to be large enough for the serialized label.
+                    debug!(
+                        "Got space for {} bytes, need {}",
+                        bytes.capacity(),
+                        actual_size
+                    );
+                    bytes.reserve((actual_size as usize) - bytes.len());
+
+                    // Try again with a buffer resized to cope with expected size of data.
+                    continue;
+                }
+
+                s => {
+                    return Err(s);
+                }
+            },
+            None => {
+                return Err(OakStatus::ErrInternal);
+            }
+        }
+    }
+    error!("unreachable code reached");
+    Err(OakStatus::ErrInternal)
+}
+
+/// Get the downgrade privilege for the current node represented as a [`Label`].
+pub fn node_privilege() -> Result<Label, OakStatus> {
+    let mut bytes = Vec::with_capacity(1024);
+    for resized in &[false, true] {
+        let mut actual_size: u32 = 0;
+        let status = OakStatus::from_i32(unsafe {
+            oak_abi::node_privilege(bytes.as_ptr(), bytes.len(), &mut actual_size)
+        });
+        match status {
+            Some(s) => match s {
+                OakStatus::Ok => {
+                    unsafe {
+                        // The serialized label was successfully fetched, so set the length to the
+                        // actual length.
+                        bytes.set_len(actual_size as usize);
+                    }
+                    return Ok(Label::deserialize(&bytes).expect("Could not deserialize label."));
+                }
+
+                OakStatus::ErrBufferTooSmall if !(*resized) => {
+                    // Extend the vector to be large enough for the serialized label.
+                    debug!(
+                        "Got space for {} bytes, need {}",
+                        bytes.capacity(),
+                        actual_size
+                    );
+                    bytes.reserve((actual_size as usize) - bytes.len());
+
+                    // Try again with a buffer resized to cope with expected size of data.
+                    continue;
+                }
+
+                s => {
+                    return Err(s);
+                }
+            },
+            None => {
+                return Err(OakStatus::ErrInternal);
+            }
+        }
+    }
+    error!("unreachable code reached");
+    Err(OakStatus::ErrInternal)
+}
+
 /// Fill a buffer with random data.
 pub fn random_get(buf: &mut [u8]) -> Result<(), OakStatus> {
     let status = unsafe { oak_abi::random_get(buf.as_mut_ptr(), buf.len()) };

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -305,7 +305,7 @@ pub fn channel_label(handle: Handle) -> Result<Label, OakStatus> {
     for resized in &[false, true] {
         let mut actual_size: u32 = 0;
         let status = OakStatus::from_i32(unsafe {
-            oak_abi::channel_label(handle, bytes.as_ptr(), bytes.len(), &mut actual_size)
+            oak_abi::channel_label(handle, bytes.as_mut_ptr(), bytes.len(), &mut actual_size) as i32
         });
         match status {
             Some(s) => match s {
@@ -350,7 +350,7 @@ pub fn node_label() -> Result<Label, OakStatus> {
     for resized in &[false, true] {
         let mut actual_size: u32 = 0;
         let status = OakStatus::from_i32(unsafe {
-            oak_abi::node_label(bytes.as_ptr(), bytes.len(), &mut actual_size)
+            oak_abi::node_label(bytes.as_mut_ptr(), bytes.len(), &mut actual_size) as i32
         });
         match status {
             Some(s) => match s {
@@ -395,7 +395,7 @@ pub fn node_privilege() -> Result<Label, OakStatus> {
     for resized in &[false, true] {
         let mut actual_size: u32 = 0;
         let status = OakStatus::from_i32(unsafe {
-            oak_abi::node_privilege(bytes.as_ptr(), bytes.len(), &mut actual_size)
+            oak_abi::node_privilege(bytes.as_mut_ptr(), bytes.len(), &mut actual_size) as i32
         });
         match status {
             Some(s) => match s {

--- a/sdk/rust/oak/src/stubs.rs
+++ b/sdk/rust/oak/src/stubs.rs
@@ -76,6 +76,31 @@ pub extern "C" fn node_create(_config_buf: *const u8, _config_len: usize, _handl
     panic!("stub function invoked!");
 }
 #[no_mangle]
+pub extern "C" fn channel_label(
+    _handle: u64,
+    _label_buf: *mut u8,
+    _label_size: usize,
+    _actual_size: *mut u32,
+) -> u32 {
+    panic!("stub function invoked!");
+}
+#[no_mangle]
+pub extern "C" fn node_label(
+    _label_buf: *mut u8,
+    _label_size: usize,
+    _actual_size: *mut u32,
+) -> u32 {
+    panic!("stub function invoked!");
+}
+#[no_mangle]
+pub extern "C" fn node_privilege(
+    _label_buf: *mut u8,
+    _label_size: usize,
+    _actual_size: *mut u32,
+) -> u32 {
+    panic!("stub function invoked!");
+}
+#[no_mangle]
 pub extern "C" fn random_get(_buf: *mut u8, _len: usize) -> u32 {
     panic!("stub function invoked!");
 }

--- a/sdk/rust/oak/src/stubs.rs
+++ b/sdk/rust/oak/src/stubs.rs
@@ -76,7 +76,7 @@ pub extern "C" fn node_create(_config_buf: *const u8, _config_len: usize, _handl
     panic!("stub function invoked!");
 }
 #[no_mangle]
-pub extern "C" fn channel_label(
+pub extern "C" fn channel_label_read(
     _handle: u64,
     _label_buf: *mut u8,
     _label_size: usize,
@@ -85,7 +85,7 @@ pub extern "C" fn channel_label(
     panic!("stub function invoked!");
 }
 #[no_mangle]
-pub extern "C" fn node_label(
+pub extern "C" fn node_label_read(
     _label_buf: *mut u8,
     _label_size: usize,
     _actual_size: *mut u32,
@@ -93,7 +93,7 @@ pub extern "C" fn node_label(
     panic!("stub function invoked!");
 }
 #[no_mangle]
-pub extern "C" fn node_privilege(
+pub extern "C" fn node_privilege_read(
     _label_buf: *mut u8,
     _label_size: usize,
     _actual_size: *mut u32,


### PR DESCRIPTION
This PR adds functionality to allow WASM nodes to view their labels and downgrading privilege, and the labels associated with channel handles.

The ABI documentation changes were copied from #1137

Fixes #1406

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [x] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
