### PR TITLE
Revert "LICENSE: fill in copyright placeholder (#967)"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 The Project Oak Authors.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This reverts commit 1f67e3b602f5ad2f72aa2be1c88412fcccedef33.

See updated (2020-07-08) advice at:
https://opensource.google/docs/releasing/preparing/#Apache-header

