### PR TITLE
Move from BigInts to strings for simplicity

### DIFF
--- a/oak_runtime/introspection_browser_client/components/ApplicationStateOverview/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/ApplicationStateOverview/index.tsx
@@ -30,10 +30,10 @@ export default function ApplicationStateOverview({
       <p>{applicationState.nodeInfos.size} Nodes:</p>
       <ul>
         {[...applicationState.nodeInfos.entries()].map(([id, nodeInfo]) => (
-          <li key={id.toString()}>
+          <li key={id}>
             <dl>
               <dt>ID:</dt>
-              <dd>{id.toString()}</dd>
+              <dd>{id}</dd>
               <dt>Name:</dt>
               <dd>{nodeInfo.name}</dd>
               <dt>Labels:</dt>
@@ -43,9 +43,8 @@ export default function ApplicationStateOverview({
                 <ul>
                   {[...nodeInfo.abiHandles.entries()].map(
                     ([handle, channelHalf]) => (
-                      <li key={handle.toString()}>
-                        {handle.toString()} pointing to channel{' '}
-                        {channelHalf.channelId.toString()}{' '}
+                      <li key={handle}>
+                        {handle} pointing to channel {channelHalf.channelId}{' '}
                         {channelHalf.direction}
                       </li>
                     )

--- a/oak_runtime/introspection_browser_client/components/ChannelDetails/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/ChannelDetails/index.tsx
@@ -30,7 +30,7 @@ export default function ChannelDetails({
   applicationState,
 }: ChannelDetailsProps) {
   const { channelId } = useParams<ParamTypes>();
-  const channel = applicationState.channels.get(BigInt(channelId));
+  const channel = applicationState.channels.get(channelId);
 
   if (channel === undefined) {
     return <p>A channel with the ID: {channelId} does not exist.</p>;

--- a/oak_runtime/introspection_browser_client/components/HandleDetails/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/HandleDetails/index.tsx
@@ -31,13 +31,13 @@ export default function HandleDetails({
   applicationState,
 }: HandleDetailsProps) {
   const { nodeId, handle } = useParams<ParamTypes>();
-  const node = applicationState.nodeInfos.get(BigInt(nodeId));
+  const node = applicationState.nodeInfos.get(nodeId);
 
   if (node === undefined) {
     return <p>A node with the ID: {node} does not exist.</p>;
   }
 
-  const channelHalf = node.abiHandles.get(BigInt(handle));
+  const channelHalf = node.abiHandles.get(handle);
 
   if (channelHalf === undefined) {
     return (
@@ -50,7 +50,7 @@ export default function HandleDetails({
   return (
     <p>
       The handle {handle} of the node {nodeId} maps to channel{' '}
-      {channelHalf.channelId.toString()} {channelHalf.direction}
+      {channelHalf.channelId} {channelHalf.direction}
     </p>
   );
 }

--- a/oak_runtime/introspection_browser_client/components/NodeDetails/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/NodeDetails/index.tsx
@@ -28,7 +28,7 @@ interface ParamTypes {
 
 export default function NodeDetails({ applicationState }: NodeDetailsProps) {
   const { nodeId } = useParams<ParamTypes>();
-  const node = applicationState.nodeInfos.get(BigInt(nodeId));
+  const node = applicationState.nodeInfos.get(nodeId);
 
   if (node === undefined) {
     return <p>A node with the ID: {nodeId} does not exist.</p>;

--- a/oak_runtime/introspection_browser_client/components/StateGraph/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/StateGraph/index.tsx
@@ -29,13 +29,12 @@ import {
 
 // Generate a Graphviz dot graph that shows the shape of the Nodes and Channels
 function getGraphFromState(applicationState: OakApplicationState) {
-  const getNodeDotId = (nodeId: NodeId) => `node${nodeId.toString()}`;
-  const getChannelDotId = (channelId: ChannelID) =>
-    `channel${channelId.toString()}`;
+  const getNodeDotId = (nodeId: NodeId) => `node${nodeId}`;
+  const getChannelDotId = (channelId: ChannelID) => `channel${channelId}`;
   const getHandleDotId = (nodeId: NodeId, handle: AbiHandle) =>
-    `node${nodeId.toString()}_${handle.toString()}`;
+    `node${nodeId}_${handle}`;
   const getMessageDotId = (channelId: ChannelID, messageIndex: number) =>
-    `msg${channelId.toString()}_${messageIndex}`;
+    `msg${channelId}_${messageIndex}`;
 
   const oakNodes = [...applicationState.nodeInfos.entries()].map(
     ([nodeId, nodeInfo]) =>


### PR DESCRIPTION
These will be rendered as strings either way, there's little value in converting handles/channels/nodes from protobuf strings to BigInts and then back to strings for rendering. 

I used BigInts for accuracy (and since it would be correct for `google-protobuf` to return them for 64 bit integers) but it seems best to be pragmatic. ^^ 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
