### PR TITLE
Use idiomatic HTTP types in the SDK

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -743,7 +743,6 @@ version = "0.1.0"
 dependencies = [
  "http",
  "log",
- "maplit",
  "oak",
  "oak_abi",
  "oak_services",
@@ -1187,6 +1186,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "fmt",
+ "http",
  "log",
  "oak_abi",
  "oak_derive",
@@ -1277,7 +1277,9 @@ dependencies = [
 name = "oak_services"
 version = "0.1.0"
 dependencies = [
+ "http",
  "log",
+ "maplit",
  "oak_abi",
  "oak_io",
  "oak_utils",

--- a/examples/http_server/module/Cargo.toml
+++ b/examples/http_server/module/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 http = "*"
 log = "*"
-maplit = "*"
 oak = "=0.1.0"
 oak_abi = "=0.1.0"
 oak_services = "=0.1.0"

--- a/examples/http_server/module/src/lib.rs
+++ b/examples/http_server/module/src/lib.rs
@@ -17,9 +17,7 @@
 //! Simple example starting an Oak Application serving a static page over HTTP.
 
 use log::{info, warn};
-use maplit::hashmap;
-use oak::{http::Invocation, Node, OakError};
-use oak_services::proto::oak::encap::{HeaderValue, HttpResponse};
+use oak::{http::Invocation, Node, OakError, OakStatus};
 
 oak::entrypoint!(oak_main => |_in_channel| {
     oak::logger::init_default();
@@ -37,35 +35,21 @@ impl Node<Invocation> for StaticHttpServer {
     fn handle_command(&mut self, invocation: Invocation) -> Result<(), OakError> {
         let request = invocation.receive()?;
 
-        info!("Handling a request to {}.", request.uri);
+        info!("Handling a request to {}.", request.uri());
 
-        // Workaround for https://rust-lang.github.io/rust-clippy/master/index.html#borrow_interior_mutable_const.
-        static CONTENT_TYPE: http::header::HeaderName = http::header::CONTENT_TYPE;
-
-        let response = match request.uri.parse::<http::Uri>() {
-            Ok(uri) => match uri.path().as_ref() {
-                "/" => HttpResponse {
-                    body: include_bytes!("../static/index.html").to_vec(),
-                    status: http::StatusCode::OK.as_u16() as i32,
-                    headers: hashmap! {
-                        CONTENT_TYPE.as_str().to_string() => HeaderValue { values: vec!["text/html; charset=UTF-8".to_string().into_bytes()] },
-                    },
-                },
-                _ => HttpResponse {
-                    body: "not found".to_string().into_bytes(),
-                    status: http::StatusCode::NOT_FOUND.as_u16() as i32,
-                    headers: hashmap! {},
-                },
-            },
-            Err(err) => {
-                warn!("could not parse URI: {}", err);
-                HttpResponse {
-                    body: "invalid URI".to_string().into_bytes(),
-                    status: http::StatusCode::BAD_REQUEST.as_u16() as i32,
-                    headers: hashmap! {},
-                }
-            }
+        let response = match request.uri().path().as_ref() {
+            "/" => http::response::Builder::new()
+                .status(http::StatusCode::OK)
+                .header(http::header::CONTENT_TYPE, "text/html; charset=UTF-8")
+                .body(include_bytes!("../static/index.html").to_vec()),
+            _ => http::response::Builder::new()
+                .status(http::StatusCode::NOT_FOUND)
+                .body("not found".to_string().into_bytes()),
         };
+        let response = response.map_err(|err| {
+            warn!("Could not build response: {}", err);
+            OakError::OakStatus(OakStatus::ErrInternal)
+        })?;
 
         let res = invocation.send(&response);
         invocation.close_channels();

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -825,7 +825,9 @@ dependencies = [
 name = "oak_services"
 version = "0.1.0"
 dependencies = [
+ "http",
  "log",
+ "maplit",
  "oak_abi",
  "oak_io",
  "oak_utils",

--- a/oak_runtime/Cargo.lock
+++ b/oak_runtime/Cargo.lock
@@ -819,7 +819,9 @@ dependencies = [
 name = "oak_services"
 version = "0.1.0"
 dependencies = [
+ "http",
  "log",
+ "maplit",
  "oak_abi",
  "oak_io",
  "oak_utils",

--- a/oak_runtime/src/node/http/tests.rs
+++ b/oak_runtime/src/node/http/tests.rs
@@ -219,7 +219,9 @@ fn oak_node_simulator(runtime: &RuntimeProxy, invocation_receiver: oak_abi::Hand
         let resp = HttpResponse {
             body: vec![],
             status: http::status::StatusCode::OK.as_u16() as i32,
-            headers: hashmap! {},
+            headers: Some(HeaderMap {
+                headers: hashmap! {},
+            }),
         };
         invocation
             .sender

--- a/oak_services/Cargo.lock
+++ b/oak_services/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +72,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +100,12 @@ checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "libc"
@@ -147,7 +170,9 @@ dependencies = [
 name = "oak_services"
 version = "0.1.0"
 dependencies = [
+ "http",
  "log",
+ "maplit",
  "oak_abi",
  "oak_io",
  "oak_utils",

--- a/oak_services/Cargo.toml
+++ b/oak_services/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+http = "*"
 log = "*"
+maplit = "*"
 prost = { path = "../third_party/prost" }
 prost-types = { path = "../third_party/prost/prost-types" }
 oak_abi = { path = "../oak_abi" }

--- a/oak_services/proto/http_encap.proto
+++ b/oak_services/proto/http_encap.proto
@@ -27,7 +27,7 @@ message HttpRequest {
   // The body of the request.
   bytes body = 3;
   // The HTTP request headers.
-  map<string, HeaderValue> headers = 4;
+  HeaderMap headers = 4;
 }
 
 // Protocol buffer encoding representing an HTTP response.
@@ -37,7 +37,12 @@ message HttpResponse {
   // The HTTP status code.
   int32 status = 2;
   // The HTTP response headers.
-  map<string, HeaderValue> headers = 3;
+  HeaderMap headers = 3;
+}
+
+// Wrapper around a HashMap representing the headers in HttpRequest and HttpResponse.
+message HeaderMap {
+  map<string, HeaderValue> headers = 1;
 }
 
 // Each header name in an HTTP request or HTTP response may correspond to more

--- a/oak_services/src/http/mod.rs
+++ b/oak_services/src/http/mod.rs
@@ -1,0 +1,102 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::proto::oak::encap::{HeaderMap, HeaderValue, HttpRequest, HttpResponse};
+use http::{Request, Response};
+use log::warn;
+use maplit::hashmap;
+use oak_abi::OakStatus;
+
+impl From<&Response<Vec<u8>>> for HttpResponse {
+    fn from(response: &Response<Vec<u8>>) -> Self {
+        HttpResponse {
+            body: response.body().to_owned(),
+            status: response.status().as_u16() as i32,
+            headers: Some(HeaderMap::from(response.headers().to_owned())),
+        }
+    }
+}
+
+impl std::convert::TryFrom<HttpRequest> for Request<Vec<u8>> {
+    type Error = OakStatus;
+    fn try_from(request: HttpRequest) -> Result<Self, Self::Error> {
+        let mut builder = Request::builder()
+            .method(request.method.as_bytes())
+            .uri(request.uri);
+        if let Some(headers) = request.headers {
+            for (header_name, header_value) in headers.iter() {
+                builder = builder.header(header_name, header_value);
+            }
+        }
+        builder.body(request.body).map_err(|err| {
+            warn!("Could not create request: {}", err);
+            OakStatus::ErrInternal
+        })
+    }
+}
+
+impl From<http::header::HeaderMap<http::header::HeaderValue>> for HeaderMap {
+    fn from(http_headers: http::header::HeaderMap<http::header::HeaderValue>) -> Self {
+        let mut headers = hashmap! {};
+        for (header_name, header_value) in &http_headers {
+            headers
+                .entry(header_name.to_string())
+                .or_insert_with(Vec::new)
+                .push(header_value.as_bytes().to_vec())
+        }
+        let headers = headers
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.to_owned(),
+                    HeaderValue {
+                        values: value.to_owned(),
+                    },
+                )
+            })
+            .collect();
+
+        HeaderMap { headers }
+    }
+}
+
+impl HeaderMap {
+    /// Flatten the headers into an iterator of tuples (String, http::header::HeaderValue).
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = (http::header::HeaderName, http::header::HeaderValue)> + '_ {
+        self.headers
+            .iter()
+            .flat_map(|(name, value)| {
+                value.values.iter().filter_map(move |val| {
+                    let name_value_pair = || -> Result<(http::header::HeaderName, http::header::HeaderValue), OakStatus>  {
+                        let header_name = http::header::HeaderName::from_bytes(name.as_bytes())
+                            .map_err(|err| {
+                                warn!("Error when parsing header name: {}", err);
+                                OakStatus::ErrInternal
+                            })?;
+                        let header_value =
+                            http::header::HeaderValue::from_bytes(val).map_err(|err| {
+                                warn!("Error when parsing header value: {}", err);
+                                OakStatus::ErrInternal
+                            })?;
+                        Ok((header_name, header_value))
+                    };
+                    name_value_pair().ok()
+                })
+            })
+    }
+}

--- a/oak_services/src/lib.rs
+++ b/oak_services/src/lib.rs
@@ -18,4 +18,5 @@
 //! binary interface (ABI).
 
 pub mod grpc;
+pub mod http;
 pub mod proto;

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -810,6 +810,7 @@ dependencies = [
  "assert_matches",
  "byteorder",
  "fmt",
+ "http",
  "log",
  "oak_abi",
  "oak_derive",
@@ -920,7 +921,9 @@ dependencies = [
 name = "oak_services"
 version = "0.1.0"
 dependencies = [
+ "http",
  "log",
+ "maplit",
  "oak_abi",
  "oak_io",
  "oak_utils",

--- a/sdk/rust/oak/Cargo.toml
+++ b/sdk/rust/oak/Cargo.toml
@@ -13,6 +13,7 @@ oak_services = "=0.1.0"
 prost = "*"
 prost-types = "*"
 fmt = "*"
+http = "*"
 log = { version = "*", features = ["std"] }
 byteorder = "*"
 rand_core = { version = "*", features = ["std"] }


### PR DESCRIPTION
Fixes #1459 

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)

