### PR TITLE
Add async channel stream

### DIFF
--- a/experimental/Cargo.lock
+++ b/experimental/Cargo.lock
@@ -550,6 +550,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "fmt",
+ "http",
  "log",
  "oak_abi",
  "oak_derive",
@@ -608,7 +609,9 @@ dependencies = [
 name = "oak_services"
 version = "0.1.0"
 dependencies = [
+ "http",
  "log",
+ "maplit",
  "oak_abi",
  "oak_io",
  "oak_utils",

--- a/experimental/oak_async/src/io.rs
+++ b/experimental/oak_async/src/io.rs
@@ -75,9 +75,9 @@ impl<T: Decodable> Drop for ChannelRead<T> {
 
 /// `Stream` representing a sequence of asynchronous reads from a channel.
 pub struct ChannelReadStream<T: Decodable>(
-    // Note: `Stream` could be implemented directly on the `ChannelRead` type. Unfortunately the
-    // `Future` and `Stream` extension traits have some methods that overlap, such as `map`. This
-    // would make it impossible for the compiler to figure out what a call like
+    // Note: `Stream` could be implemented directly on the `ChannelRead` type, but unfortunately
+    // the `Future` and `Stream` extension traits have some methods that overlap, such as
+    // `map`. This would make it impossible for the compiler to figure out what a call like
     // `my_channel_read.map(..)`  should do, so instead the stream is wrapped in its own type to
     // avoid any confusion.
     ChannelRead<T>,
@@ -123,7 +123,9 @@ pub trait ReceiverAsync {
     /// Asynchronously receive multiple messages.
     ///
     /// Each item received from this `Stream` resolves to either a message or an `OakError`
-    fn receive_stream(&self) -> ChannelReadStream<Self::Message>;
+    fn receive_stream(&self) -> ChannelReadStream<Self::Message> {
+        ChannelReadStream(self.receive_async())
+    }
 }
 
 impl<T: Decodable + Send> ReceiverAsync for oak::io::Receiver<T> {
@@ -131,9 +133,5 @@ impl<T: Decodable + Send> ReceiverAsync for oak::io::Receiver<T> {
 
     fn receive_async(&self) -> ChannelRead<Self::Message> {
         ChannelRead::new(self.handle)
-    }
-
-    fn receive_stream(&self) -> ChannelReadStream<Self::Message> {
-        ChannelReadStream(self.receive_async())
     }
 }

--- a/experimental/oak_async/src/lib.rs
+++ b/experimental/oak_async/src/lib.rs
@@ -18,4 +18,4 @@ mod executor;
 mod io;
 
 pub use executor::block_on;
-pub use io::{ChannelRead, ReceiverAsync};
+pub use io::{ChannelRead, ChannelReadStream, ReceiverAsync};

--- a/experimental/oak_async/tests/tests.rs
+++ b/experimental/oak_async/tests/tests.rs
@@ -291,7 +291,7 @@ fn many_reads_parallel() {
 // Stream functionality relies heavily on the implementation of `Future`, so we only need minimal
 // tests for the `Stream` impl.
 #[test]
-fn stream_immediate() {
+fn stream_read_multiple() {
     init();
 
     let mut data_sent_count = 0;


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.

Adds a `ChannelReadStream` type implementing [`Stream`](https://docs.rs/futures/0.3.5/futures/stream/trait.Stream.html) to the async sdk.

This PR builds on top of #1466.

For more background, please see the [RFC#01391](
https://github.com/project-oak/oak/blob/main/rfcs/01391_async_sdk.md).