### PR TITLE
Add missing introspection event for channel_try_read_message

### DIFF
--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -987,11 +987,6 @@ impl Runtime {
     ) -> Result<Option<NodeReadStatus>, OakStatus> {
         let half = self.abi_to_read_half(node_id, handle)?;
         self.validate_can_read_from_channel(node_id, &half)?;
-        self.introspection_event(EventDetails::MessageDequeued(MessageDequeued {
-            node_id: node_id.0,
-            channel_id: half.get_channel_id(),
-            acquired_handles: vec![],
-        }));
         let result = with_reader_channel(&half, |channel| {
             let mut messages = channel.messages.write().unwrap();
             match messages.front() {


### PR DESCRIPTION
An introspection event already existed for `channel_read`, but was missing when reading messages via this message.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
