### PR TITLE
Add a flag for rerunning server for each client

### DIFF
--- a/examples/private_set_intersection/example.toml
+++ b/examples/private_set_intersection/example.toml
@@ -1,4 +1,5 @@
 name = "private_set_intersection"
+rerun_server_for_each_client = true
 
 [applications]
 


### PR DESCRIPTION
This change adds a `rerun_server_for_each_client` flag for rerunning server for each client.

# Checklist
- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have checked that these tests are run by [Cloudbuild](/cloudbuild.yaml)
