### PR TITLE
Event for node creation. Prune old things. A TODO

### DIFF
--- a/experimental/ni_coq/vfiles/Events.v
+++ b/experimental/ni_coq/vfiles/Events.v
@@ -10,7 +10,8 @@ Import ListNotations.
 Inductive event: Type :=
     | NilEv: event
     | InEv (m: message): event
-    | OutEv (m: message): event.
+    | OutEv (m: message): event
+    | NCreateEv (n: node): event.
 (* note that messages include the bytes and handles sent via channels *)
 (* eventually, downgrades will also be represented by events *)
 

--- a/experimental/ni_coq/vfiles/TraceTheorems.v
+++ b/experimental/ni_coq/vfiles/TraceTheorems.v
@@ -25,19 +25,6 @@ Local Ltac crush_step :=
 (* General-purpose tactic that simplifies and solves simple goals. *)
 Local Ltac crush := repeat crush_step.
 
-Lemma head_set_call_preserves_len: forall t t' id c,
-    head_set_call t id c = t' ->
-    length t = length t'.
-Proof. cbv [head_set_call]. crush. Qed.
-
-Theorem head_set_call_not_nil: forall t id c,
-    t <> nil -> (head_set_call t id c) <> nil.
-Proof. cbv [head_set_call]. crush. Qed.
-
-Lemma head_set_call_preserves_tail: forall t id c,
-    tl (head_set_call t id c) = tl t.
-Proof. cbv [head_set_call]. crush. Qed.
-
 Theorem no_steps_from_empty: forall t,
     ~(step_system_ev_t [] t).
 Proof.

--- a/experimental/ni_coq/vfiles/Unwind.v
+++ b/experimental/ni_coq/vfiles/Unwind.v
@@ -85,19 +85,3 @@ Proof.
         *)
     - admit. (* split; assumption *)
 Admitted.
-
-Theorem call_havoc_unwind: forall ell id c t1 t2 t1' t2',
-    (trace_low_eq ell t1 t2) ->
-    (t1' = head_set_call t1 id c) ->
-    (t2' = head_set_call t2 id c) ->
-    (trace_low_eq ell t1' t2').
-Proof.
-    intros.
-    destruct t1, t2; simpl in *; subst.
-    - (* nil, nil *) constructor.
-    - (* nil, not nil *) inversion H.
-    - (* not nil, nil *) inversion H.
-    - destruct p. destruct p0. inversion H; subst.
-    constructor 2; try assumption.
-    eapply set_call_unwind; assumption.
-Qed.


### PR DESCRIPTION
In EvAugSemantics, an event for node creation is added. I think this is
more accurate because presumably an attacker can tell whether or not a
node gets created.

I think it still does not make sense to add an event for node creation
because node creation can only be observed indirectly (i.e., an attacker
writes code that tries to read or write from a channel to see if the channel
exists). The events for read/write will capture these potential indirect
leaks.

Things to do with changing the call in the last node to execute when
constructing traces are removed. These are no longer needed now that
there is a single step semantics on just states and traces are built
separately.

A note about connecting system_step and system_step_ev are added.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
