### PR TITLE
Add abitests for HTTP server pseudo-node

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "env_logger",
  "expect",
  "hex",
+ "http_server",
  "log",
  "maplit",
  "oak",

--- a/examples/abitest/client/cpp/BUILD
+++ b/examples/abitest/client/cpp/BUILD
@@ -26,6 +26,8 @@ cc_binary(
     deps = [
         ":grpc_test_server",
         ":grpctest",
+        ":httplib_config",
+        ":httptest",
         "//examples/abitest/proto:abitest_cc_grpc",
         "//oak/client:application_client",
         "//oak/server/storage:memory_provider",
@@ -35,6 +37,13 @@ cc_binary(
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "httplib_config",
+    hdrs = ["httplib_config.h"],
+    deps = [
         "@cpp_httplib//:httplib",
     ],
 )
@@ -47,6 +56,17 @@ cc_library(
         "//examples/abitest/proto:abitest_cc_grpc",
         "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
+    ],
+)
+
+cc_library(
+    name = "httptest",
+    srcs = ["httptest.cc"],
+    hdrs = ["httptest.h"],
+    deps = [
+        ":httplib_config",
+        "//oak/common:label",
+        "@com_github_google_glog//:glog",
     ],
 )
 

--- a/examples/abitest/client/cpp/httplib_config.h
+++ b/examples/abitest/client/cpp/httplib_config.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Wrapper include file for httplib.h with all configured options in one place
+// (so builds are consistent).
+#define CPPHTTPLIB_OPENSSL_SUPPORT 1
+#include "httplib.h"

--- a/examples/abitest/client/cpp/httptest.cc
+++ b/examples/abitest/client/cpp/httptest.cc
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "examples/abitest/client/cpp/httptest.h"
+
+#include "glog/logging.h"
+#include "httplib_config.h"
+#include "oak_abi/proto/label.pb.h"
+
+const char* CA_CERT_PATH = "../../../../../../../../../examples/certs/local/ca.pem";
+const int PORT = 8383;
+
+// Simple manual test case registry.
+const std::map<std::string, HttpTestFn> http_tests = {
+    {"HttpsWithJsonLabelOk", test_https_with_json_label_ok},
+    {"HttpsWithProtobufLabelOk", test_https_with_protobuf_label_ok},
+    {"HttpsWithoutLabelErrBadRequest", test_https_without_label_err_bad_request},
+    {"UnsecureHttpErr", test_unsecure_http_err},
+};
+
+bool test_https_with_json_label_ok() {
+  httplib::SSLClient cli("localhost", PORT);
+  cli.set_ca_cert_path(CA_CERT_PATH);
+  cli.enable_server_certificate_verification(true);
+  httplib::Headers headers = {{"oak-label", "{\"confidentialityTags\":[],\"integrityTags\":[]}"}};
+
+  auto res = cli.Get("/", headers);
+  return res && res->status == 200;
+}
+
+bool test_https_with_protobuf_label_ok() {
+  oak::label::Label label;
+  std::string label_str = label.SerializeAsString();
+  httplib::SSLClient cli("localhost", PORT);
+  cli.set_ca_cert_path(CA_CERT_PATH);
+  cli.enable_server_certificate_verification(true);
+  httplib::Headers headers = {{"oak-label-bin", label_str}};
+
+  auto res = cli.Get("/", headers);
+  return res && res->status == 200;
+}
+
+bool test_https_without_label_err_bad_request() {
+  httplib::SSLClient cli("localhost", PORT);
+  cli.set_ca_cert_path(CA_CERT_PATH);
+  cli.enable_server_certificate_verification(true);
+
+  auto res = cli.Get("/");
+  return res && res->status == 400;
+}
+
+bool test_unsecure_http_err() {
+  httplib::Client cli("localhost", PORT);
+  httplib::Headers headers = {{"oak-label", "{\"confidentialityTags\":[],\"integrityTags\":[]}"}};
+
+  auto res = cli.Get("/", headers);
+  // The server should reject the request, since the request is not being sent over a TLS
+  // connection.
+  return !res;
+}

--- a/examples/abitest/client/cpp/httptest.h
+++ b/examples/abitest/client/cpp/httptest.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EXAMPLES_ABITEST_CLIENT_HTTPTEST_H
+#define EXAMPLES_ABITEST_CLIENT_HTTPTEST_H
+
+#include <map>
+#include <string>
+
+// Test functions return true on success, false on failure.
+typedef bool (*HttpTestFn)();
+extern const std::map<std::string, HttpTestFn> http_tests;
+
+bool test_https_with_json_label_ok();
+bool test_https_with_protobuf_label_ok();
+bool test_https_without_label_err_bad_request();
+bool test_unsecure_http_err();
+
+#endif  // EXAMPLES_ABITEST_CLIENT_HTTPTEST_H

--- a/examples/abitest/module_0/rust/Cargo.toml
+++ b/examples/abitest/module_0/rust/Cargo.toml
@@ -14,6 +14,7 @@ byteorder = "*"
 chrono = "*"
 expect = { path = "../../../../third_party/expect" }
 hex = "*"
+http_server = { path = "../../../http_server/module" }
 log = "*"
 oak = "=0.1.0"
 oak_abi = "=0.1.0"

--- a/examples/http_server/example.toml
+++ b/examples/http_server/example.toml
@@ -9,12 +9,6 @@ out = "examples/http_server/bin/http_server.oak"
 [applications.rust.modules]
 module = { Cargo = { cargo_manifest = "examples/http_server/module/Cargo.toml" } }
 
-[server]
-additional_args = [
-  "--http-tls-certificate=./examples/certs/local/local.pem",
-  "--http-tls-private-key=./examples/certs/local/local.key",
-]
-
 [clients]
 rust = { Cargo = { cargo_manifest = "examples/http_server/client/rust/Cargo.toml" }, additional_args = [
   "--ca-cert=./examples/certs/local/ca.pem"

--- a/examples/http_server/module/src/lib.rs
+++ b/examples/http_server/module/src/lib.rs
@@ -29,7 +29,10 @@ oak::entrypoint!(oak_main => |_in_channel| {
     oak::run_event_loop(node, http_channel);
 });
 
-struct StaticHttpServer;
+/// A simple HTTP server that responds with `OK` (200) to every request sent to `/`, and with
+/// `NOT_FOUND` (400) to any other request. It is used in the `abitest`. So its functionality
+/// should be modified with care!
+pub struct StaticHttpServer;
 
 impl Node<Invocation> for StaticHttpServer {
     fn handle_command(&mut self, invocation: Invocation) -> Result<(), OakError> {

--- a/oak_runtime/src/node/http/mod.rs
+++ b/oak_runtime/src/node/http/mod.rs
@@ -161,7 +161,10 @@ impl HttpServerNode {
 
         // Run until asked to terminate...
         let result = graceful_server.await;
-        info!("HTTP server pseudo-node terminated with {:?}", result);
+        info!(
+            "HTTP server pseudo-node on addr {:?} terminated with {:?}",
+            self.address, result
+        );
     }
 
     /// Build a server that checks incoming TCP connections for TLS handshake.

--- a/oak_runtime/src/tls.rs
+++ b/oak_runtime/src/tls.rs
@@ -17,7 +17,6 @@
 use std::{
     fs::File,
     io::{self, BufReader},
-    path::Path,
     sync::Arc,
 };
 use tokio_rustls::rustls::{
@@ -34,12 +33,12 @@ pub struct TlsConfig {
 
 impl TlsConfig {
     pub fn new(cert_path: &str, key_path: &str) -> Option<Self> {
-        let certs = match load_certs(&Path::new(cert_path)) {
+        let certs = match load_certs(cert_path) {
             Ok(certs) => certs,
             Err(_) => return None,
         };
 
-        let keys = match load_keys(&Path::new(key_path)) {
+        let keys = match load_keys(key_path) {
             Ok(keys) => keys,
             Err(_) => return None,
         };
@@ -59,12 +58,12 @@ pub(crate) fn to_server_config(tls_config: TlsConfig) -> Arc<ServerConfig> {
     Arc::new(cfg)
 }
 
-fn load_certs(path: &Path) -> io::Result<Vec<Certificate>> {
+fn load_certs(path: &str) -> io::Result<Vec<Certificate>> {
     certs(&mut BufReader::new(File::open(path)?))
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid cert"))
 }
 
-fn load_keys(path: &Path) -> io::Result<Vec<PrivateKey>> {
+fn load_keys(path: &str) -> io::Result<Vec<PrivateKey>> {
     rsa_private_keys(&mut BufReader::new(File::open(path)?))
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid key"))
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -528,8 +528,10 @@ fn run_example_server(
     Cmd::new_with_env(
         "oak_loader/bin/oak_loader",
         spread![
-            "--grpc-tls-private-key=./examples/certs/local/local.key".to_string(),
             "--grpc-tls-certificate=./examples/certs/local/local.pem".to_string(),
+            "--grpc-tls-private-key=./examples/certs/local/local.key".to_string(),
+            "--http-tls-certificate=./examples/certs/local/local.pem".to_string(),
+            "--http-tls-private-key=./examples/certs/local/local.key".to_string(),
             // TODO(#396): Add `--oidc-client` support.
             format!("--application={}", application_file),
             ...match opt.server_variant {


### PR DESCRIPTION
Fixes #1334.

The uncovered code is error checking logic that would be very difficult to simulate in the tests. 