### PR TITLE
Create 'unwind' hint db for eauto

### DIFF
--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -92,6 +92,11 @@ Theorem step_implies_lowproj_steps_leq: forall ell s1 s1' e1,
 Proof.
 Admitted. (* WIP *)
 
+(* Hints for [eauto with unwind] *)
+Hint Resolve state_upd_chan_unwind chan_append_unwind chan_low_proj_loweq
+     state_upd_node_unwind : unwind.
+Hint Extern 4 (node_low_eq _ _ _) => reflexivity : unwind.
+
 Theorem low_proj_steps_implies_leq_step: forall ell s s1' e1,
     (step_system_ev (state_low_proj ell s) s1' e1) ->
     (exists s2' e2,
@@ -133,9 +138,7 @@ Proof.
                 (* s1'' =L s2'' *)
                 (* This part looks tactic-able to me *)
                 subst. unfold s1''. eapply set_call_unwind. unfold ch'.
-                eapply state_upd_chan_unwind. eapply chan_append_unwind. 
-                eapply chan_low_proj_loweq. eapply state_upd_node_unwind.
-                reflexivity. eapply state_low_proj_loweq.
+                eauto with unwind.
             + (* ReadChannel *)
                 admit.
             + (* CreateChannel *)


### PR DESCRIPTION
Follow-up to discussion here: https://github.com/project-oak/oak/pull/1535#discussion_r499647876

The reason the plain `Hint Resolve`s weren't working was that `state_upd_node_unwind` produces a `node_low_eq` subgoal, and there's no declared `Reflexive` instance for that definition. Using an explicit `Hint Extern` tells `eauto` to unfold the definition until it finds an equality underneath. So I was wrong to suspect in the previous discussion that it was an `eapply` unfolding things more aggressively than `eauto` does; it was actually `reflexivity`!

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
