### PR TITLE
Introspection: (Re)add missing include_bytes! call

### DIFF
--- a/oak_runtime/src/introspect.rs
+++ b/oak_runtime/src/introspect.rs
@@ -40,11 +40,11 @@ mod introspection_client {
     use hyper::header::CONTENT_ENCODING;
 
     fn static_file(
-        file: &str,
+        file: Vec<u8>,
         content_type: &str,
         content_encoding: Option<&str>,
     ) -> Response<Body> {
-        let mut response = Response::new(Body::from(file.to_string()));
+        let mut response = Response::new(Body::from(file));
         let headers = response.headers_mut();
         headers.insert(CONTENT_TYPE, content_type.parse().unwrap());
         // If the served file is compressed, add a header instructing the
@@ -72,24 +72,24 @@ mod introspection_client {
 
         match subpath {
             "/index.js" => Some(static_file(
-                "../introspection_browser_client/dist/index.js.gz",
+                include_bytes!("../introspection_browser_client/dist/index.js.gz").to_vec(),
                 "application/javascript",
                 Some("gzip"),
             )),
             "/graphvizlib.wasm" => Some(static_file(
-                "../introspection_browser_client/dist/graphvizlib.wasm.gz",
+                include_bytes!("../introspection_browser_client/dist/graphvizlib.wasm.gz").to_vec(),
                 "application/wasm",
                 Some("gzip"),
             )),
             "/favicon.png" => Some(static_file(
-                "../introspection_browser_client/dist/favicon.png",
+                include_bytes!("../introspection_browser_client/dist/favicon.png").to_vec(),
                 "image/png",
                 None,
             )),
             // Serve index.html for all other paths under /dynamic, enabling
             // client-side routing
             _ => Some(static_file(
-                "../introspection_browser_client/dist/index.html.gz",
+                include_bytes!("../introspection_browser_client/dist/index.html.gz").to_vec(),
                 "text/html",
                 Some("gzip"),
             )),

--- a/oak_runtime/src/introspect.rs
+++ b/oak_runtime/src/introspect.rs
@@ -40,7 +40,7 @@ mod introspection_client {
     use hyper::header::CONTENT_ENCODING;
 
     fn static_file(
-        file: Vec<u8>,
+        file: &'static [u8],
         content_type: &str,
         content_encoding: Option<&str>,
     ) -> Response<Body> {
@@ -72,24 +72,24 @@ mod introspection_client {
 
         match subpath {
             "/index.js" => Some(static_file(
-                include_bytes!("../introspection_browser_client/dist/index.js.gz").to_vec(),
+                include_bytes!("../introspection_browser_client/dist/index.js.gz"),
                 "application/javascript",
                 Some("gzip"),
             )),
             "/graphvizlib.wasm" => Some(static_file(
-                include_bytes!("../introspection_browser_client/dist/graphvizlib.wasm.gz").to_vec(),
+                include_bytes!("../introspection_browser_client/dist/graphvizlib.wasm.gz"),
                 "application/wasm",
                 Some("gzip"),
             )),
             "/favicon.png" => Some(static_file(
-                include_bytes!("../introspection_browser_client/dist/favicon.png").to_vec(),
+                include_bytes!("../introspection_browser_client/dist/favicon.png"),
                 "image/png",
                 None,
             )),
             // Serve index.html for all other paths under /dynamic, enabling
             // client-side routing
             _ => Some(static_file(
-                include_bytes!("../introspection_browser_client/dist/index.html.gz").to_vec(),
+                include_bytes!("../introspection_browser_client/dist/index.html.gz"),
                 "text/html",
                 Some("gzip"),
             )),


### PR DESCRIPTION
Fixes a bug introduced in #1560 that led to serving the string file path instead of the actual file. 😬

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
