### PR TITLE
Automate possibilistic_ni proof and prove no_steps_from_empty

### DIFF
--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -70,7 +70,7 @@ Local Ltac logical_simplify :=
          | H : exists _, _ |- _ => destruct H
          | H1 : ?P, H2 : ?P -> _ |- _ =>
            (* only proceed if P is a Prop; if H1 is a nat, for instance, P
-              would be a type, and we don't want to specialize foralls. *)
+              would be a Type, and we don't want to specialize foralls. *)
            match type of P with Prop => idtac end;
            specialize (H2 H1)
          | H : ?x = ?x |- _ => clear H

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -68,7 +68,11 @@ Local Ltac logical_simplify :=
   repeat match goal with
          | H : _ /\ _ |- _ => destruct H
          | H : exists _, _ |- _ => destruct H
-         | H1 : ?P, H2 : ?P -> _ |- _ => specialize (H2 H1)
+         | H1 : ?P, H2 : ?P -> _ |- _ =>
+           (* only proceed if P is a Prop; if H1 is a nat, for instance, P
+              would be a type, and we don't want to specialize foralls. *)
+           match type of P with Prop => idtac end;
+           specialize (H2 H1)
          | H : ?x = ?x |- _ => clear H
          end.
 

--- a/experimental/ni_coq/vfiles/TraceTheorems.v
+++ b/experimental/ni_coq/vfiles/TraceTheorems.v
@@ -27,8 +27,7 @@ Local Ltac crush := repeat crush_step.
 
 Theorem no_steps_from_empty: forall t,
     ~(step_system_ev_t [] t).
-Proof.
-Admitted. (* WIP *)
+Proof. inversion 1; crush. Qed.
 
 (* This vestige is kept for now
 * because it was referenced in the old P..NI.v *)


### PR DESCRIPTION
I put together some tactics and used them to automate the `possibilistic_ni` proof. Also proves a small admit in `TraceTheorems.v`. The proof structure here is actually pretty similar to before; it's just that the tactics are handling manipulations like plugging one hypothesis into the other.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
