### PR TITLE
Introspection: Persist state across links & page refreshes

### DIFF
--- a/oak_runtime/introspection_browser_client/components/Event/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/Event/index.tsx
@@ -44,7 +44,7 @@ export default function Event({
 }: {
   event: introspectionEventsProto.Event;
 }) {
-  const eventTime: string = event.getTimestamp().toDate().toISOString();
+  const eventTime: string = event.getTimestamp()!.toDate().toISOString();
   const [eventType, eventDetails] = getEventDetails(event);
 
   return (

--- a/oak_runtime/introspection_browser_client/components/Root/index.tsx
+++ b/oak_runtime/introspection_browser_client/components/Root/index.tsx
@@ -309,14 +309,13 @@ export default function Root() {
 
   const classes = useStyles();
 
-  // Subset of events representing the inspected point in time
-  const events = totalEvents.slice(0, presentEventIndex + 1);
-
   // Application state based of the current point in time
-  const applicationState: OakApplicationState = events.reduce(eventReducer, {
-    nodeInfos: new Map(),
-    channels: new Map(),
-  });
+  const applicationState: OakApplicationState = totalEvents
+    .slice(0, presentEventIndex + 1)
+    .reduce(eventReducer, {
+      nodeInfos: new Map(),
+      channels: new Map(),
+    });
 
   return (
     <>

--- a/oak_runtime/introspection_browser_client/package-lock.json
+++ b/oak_runtime/introspection_browser_client/package-lock.json
@@ -206,6 +206,12 @@
         "@types/node": "*"
       }
     },
+    "@types/google-protobuf": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.7.3.tgz",
+      "integrity": "sha512-FRwj40euE2bYkG+0X5w2nEA8yAzgJRcEa7RBd0Gsdkb9/tPM2pctVVAvnOUTbcXo2VmIHPo0Ae94Gl9vRHfKzg==",
+      "dev": true
+    },
     "@types/history": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",

--- a/oak_runtime/introspection_browser_client/package.json
+++ b/oak_runtime/introspection_browser_client/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@types/d3-ease": "^1.0.9",
     "@types/d3-graphviz": "^2.6.3",
+    "@types/google-protobuf": "^3.7.3",
     "@types/react-router-dom": "^5.1.5",
     "cache-loader": "^4.1.0",
     "compression-webpack-plugin": "^5.0.2",


### PR DESCRIPTION
Uses [session storage](https://developer.mozilla.org/en/docs/Web/API/Window/sessionStorage) to persist application state across page refreshes & links. 

Prevents state from resetting when navigating via native links etc

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
