### PR TITLE
Add an option to compile release Wasm in tests

### DIFF
--- a/examples/abitest/module_0/rust/tests/integration_test.rs
+++ b/examples/abitest/module_0/rust/tests/integration_test.rs
@@ -37,8 +37,8 @@ const BACKEND_MODULE_WASM_FILE_NAME: &str = "abitest_1_backend.wasm";
 
 fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
-        FRONTEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, FRONTEND_MODULE_WASM_FILE_NAME).context("could not compile frontend module")?,
-        BACKEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(BACKEND_MANIFEST, BACKEND_MODULE_WASM_FILE_NAME).context("could not compile backend module")?,
+        FRONTEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, FRONTEND_MODULE_WASM_FILE_NAME, false).context("could not compile frontend module")?,
+        BACKEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(BACKEND_MANIFEST, BACKEND_MODULE_WASM_FILE_NAME, false).context("could not compile backend module")?,
     })
 }
 

--- a/examples/abitest/module_0/rust/tests/integration_test.rs
+++ b/examples/abitest/module_0/rust/tests/integration_test.rs
@@ -37,8 +37,8 @@ const BACKEND_MODULE_WASM_FILE_NAME: &str = "abitest_1_backend.wasm";
 
 fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
-        FRONTEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, FRONTEND_MODULE_WASM_FILE_NAME, false).context("could not compile frontend module")?,
-        BACKEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(BACKEND_MANIFEST, BACKEND_MODULE_WASM_FILE_NAME, false).context("could not compile backend module")?,
+        FRONTEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, FRONTEND_MODULE_WASM_FILE_NAME, oak_tests::Profile::Debug).context("could not compile frontend module")?,
+        BACKEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(BACKEND_MANIFEST, BACKEND_MODULE_WASM_FILE_NAME, oak_tests::Profile::Debug).context("could not compile backend module")?,
     })
 }
 

--- a/examples/trusted_database/module/rust/tests/integration_test.rs
+++ b/examples/trusted_database/module/rust/tests/integration_test.rs
@@ -94,7 +94,7 @@ const XML_DATABASE: &str = r#"<?xml version="1.0" encoding="utf-8"?><stations la
 
 fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
-        MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, MAIN_MODULE_WASM_FILE_NAME, false).context("Couldn't compile main module")?,
+        MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, MAIN_MODULE_WASM_FILE_NAME, oak_tests::Profile::Debug).context("Couldn't compile main module")?,
     })
 }
 

--- a/examples/trusted_database/module/rust/tests/integration_test.rs
+++ b/examples/trusted_database/module/rust/tests/integration_test.rs
@@ -94,7 +94,7 @@ const XML_DATABASE: &str = r#"<?xml version="1.0" encoding="utf-8"?><stations la
 
 fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
-        MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, MAIN_MODULE_WASM_FILE_NAME).context("Couldn't compile main module")?,
+        MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, MAIN_MODULE_WASM_FILE_NAME, false).context("Couldn't compile main module")?,
     })
 }
 

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -64,16 +64,6 @@ pub fn compile_rust_wasm(
     }
 
     Command::new("cargo")
-        // .args(&[
-        //     "build",
-        //     &format!(
-        //         "--target-dir={}",
-        //         target_dir.to_str().expect("invalid target dir")
-        //     ),
-        //     &format!("{}", if let Profile::Release = profile { "--release" } else { "" }),
-        //     "--target=wasm32-unknown-unknown",
-        //     &format!("--manifest-path={}", cargo_path),
-        // ])
         .args(args)
         .env_remove("RUSTFLAGS")
         .spawn()

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -36,7 +36,7 @@ use tonic::{
 // TODO(#544): re-enable unit tests of SDK functionality
 
 /// Uses cargo to compile a Rust manifest to Wasm bytes.
-pub fn compile_rust_wasm(cargo_path: &str, module_wasm_file_name: &str) -> anyhow::Result<Vec<u8>> {
+pub fn compile_rust_wasm(cargo_path: &str, module_wasm_file_name: &str, release: bool) -> anyhow::Result<Vec<u8>> {
     // Use a separate target dir for Wasm build artifacts. The precise name is not relevant, but it
     // should end with `target` so that it gets automatically ignored by our `.gitignore`.
     let target_dir = PathBuf::from("oak_tests/target");
@@ -48,6 +48,7 @@ pub fn compile_rust_wasm(cargo_path: &str, module_wasm_file_name: &str) -> anyho
                 "--target-dir={}",
                 target_dir.to_str().expect("invalid target dir")
             ),
+            &format!("{}", if release { "--release" } else { "" }),
             "--target=wasm32-unknown-unknown",
             &format!("--manifest-path={}", cargo_path),
         ])
@@ -116,7 +117,7 @@ pub fn runtime_config(
 ) -> oak_runtime::RuntimeConfiguration {
     let wasm: HashMap<String, Vec<u8>> = [(
         DEFAULT_MODULE_NAME.to_string(),
-        compile_rust_wasm(DEFAULT_MODULE_MANIFEST, module_wasm_file_name)
+        compile_rust_wasm(DEFAULT_MODULE_MANIFEST, module_wasm_file_name, false)
             .expect("failed to build wasm module"),
     )]
     .iter()

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -59,8 +59,9 @@ pub fn compile_rust_wasm(
         "--target=wasm32-unknown-unknown".to_string(),
         format!("--manifest-path={}", cargo_path),
     ];
-    if let Profile::Release = profile {
-        args.push("--release".to_string());
+    match profile {
+        Profile::Release => args.push("--release".to_string()),
+        Profile::Debug => (),
     }
 
     Command::new("cargo")


### PR DESCRIPTION
This change adds an option to compile release Wasm in tests (necessary for benchmarking).