### PR TITLE
Rename `Node` to `CommandHandler`.

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -64,7 +64,7 @@ oak::entrypoint!(grpc_oak_main => |_in_channel| {
     };
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_event_loop(node, grpc_channel);
+    oak::run_command_loop(node, grpc_channel);
 });
 ```
 <!-- prettier-ignore-end -->
@@ -112,7 +112,7 @@ oak::entrypoint!(grpc_oak_main => |_in_channel| {
     let dispatcher = TranslatorDispatcher::new(Node);
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_event_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel);
 }
 ```
 <!-- prettier-ignore-end -->
@@ -144,7 +144,7 @@ pub extern "C" fn frontend_oak_main(_in_handle: u64) {
         let dispatcher = OakAbiTestServiceDispatcher::new(node);
         let grpc_channel =
             oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-        oak::run_event_loop(dispatcher, grpc_channel);
+        oak::run_command_loop(dispatcher, grpc_channel);
     });
 }
 ```

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -159,7 +159,7 @@ pub extern "C" fn frontend_oak_main(_in_handle: u64) {
         let dispatcher = OakAbiTestServiceDispatcher::new(node);
         let grpc_channel =
             oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-        oak::run_event_loop(dispatcher, grpc_channel);
+        oak::run_command_loop(dispatcher, grpc_channel);
     });
 }
 
@@ -2373,11 +2373,11 @@ pub extern "C" fn channel_loser(_handle: u64) {
 pub extern "C" fn http_oak_main(http_channel: u64) {
     oak::logger::init_default();
     let node = http_server::StaticHttpServer {};
-    oak::run_event_loop(
+    oak::run_command_loop(
         node,
-        oak::io::Receiver::new(oak_io::handle::ReadHandle {
+        oak_io::handle::ReadHandle {
             handle: http_channel,
-        }),
+        },
     );
 }
 

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -163,7 +163,7 @@ impl Aggregator for AggregatorNode {
 oak::entrypoint!(grpc_worker => |in_channel| {
     oak::logger::init_default();
     let dispatcher = AggregatorDispatcher::new(AggregatorNode::new());
-    oak::run_event_loop(dispatcher, oak::io::Receiver::<grpc::Invocation>::new(in_channel));
+    oak::run_command_loop(dispatcher, in_channel);
 });
 
 #[derive(Debug, serde::Deserialize)]

--- a/examples/chat/module/rust/src/backend.rs
+++ b/examples/chat/module/rust/src/backend.rs
@@ -19,11 +19,11 @@ use crate::proto::{
     Command, Message,
 };
 use log::{info, warn};
-use oak::Node;
+use oak::CommandHandler;
 
 oak::entrypoint!(backend_oak_main => |in_channel| {
     oak::logger::init_default();
-    oak::run_event_loop(Room::default(), oak::io::Receiver::<Command>::new(in_channel));
+    oak::run_command_loop(Room::default(), in_channel);
 });
 
 #[derive(Default)]
@@ -32,7 +32,7 @@ struct Room {
     clients: Vec<oak::grpc::ChannelResponseWriter>,
 }
 
-impl Node<Command> for Room {
+impl CommandHandler<Command> for Room {
     fn handle_command(&mut self, command: Command) -> Result<(), oak::OakError> {
         match command.command {
             Some(JoinRoom(sender)) => {

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -44,7 +44,7 @@ oak::entrypoint!(grpc_oak_main => |_in_channel| {
     let dispatcher = ChatDispatcher::new(Node::default());
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_event_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel);
 });
 
 struct Room {

--- a/examples/hello_world/module/rust/src/lib.rs
+++ b/examples/hello_world/module/rust/src/lib.rs
@@ -31,7 +31,7 @@ oak::entrypoint!(oak_main => |_in_channel| {
     let dispatcher = HelloWorldDispatcher::new(node);
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_event_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel);
 });
 
 struct Node {

--- a/examples/http_server/module/src/lib.rs
+++ b/examples/http_server/module/src/lib.rs
@@ -17,16 +17,16 @@
 //! Simple example starting an Oak Application serving a static page over HTTP.
 
 use log::{info, warn};
-use oak::{http::Invocation, Node, OakError, OakStatus};
+use oak::{http::Invocation, CommandHandler, OakError, OakStatus};
 
 oak::entrypoint!(oak_main => |_in_channel| {
     oak::logger::init_default();
-    let node = StaticHttpServer{};
+    let node = StaticHttpServer;
     info!("Starting HTTP server pseudo-node on port 8080.");
     let http_channel =
         oak::http::init("[::]:8080").expect("Could not create HTTP server pseudo-Node!");
 
-    oak::run_event_loop(node, http_channel);
+    oak::run_command_loop(node, http_channel);
 });
 
 /// A simple HTTP server that responds with `OK` (200) to every request sent to `/`, and with
@@ -34,7 +34,7 @@ oak::entrypoint!(oak_main => |_in_channel| {
 /// should be modified with care!
 pub struct StaticHttpServer;
 
-impl Node<Invocation> for StaticHttpServer {
+impl CommandHandler<Invocation> for StaticHttpServer {
     fn handle_command(&mut self, invocation: Invocation) -> Result<(), OakError> {
         let request = invocation.receive()?;
 

--- a/examples/machine_learning/module/rust/src/lib.rs
+++ b/examples/machine_learning/module/rust/src/lib.rs
@@ -154,7 +154,7 @@ oak::entrypoint!(oak_main => |in_channel| {
         config: None,
         model: NaiveBayes::new(),
     };
-    oak::run_event_loop(node, oak::io::Receiver::<grpc::Invocation>::new(in_channel));
+    oak::run_command_loop(node, in_channel);
 });
 
 oak::entrypoint!(grpc_oak_main => |_in_channel| {
@@ -167,7 +167,7 @@ oak::entrypoint!(grpc_oak_main => |_in_channel| {
     };
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_event_loop(node, grpc_channel);
+    oak::run_command_loop(node, grpc_channel);
 });
 
 struct Node {

--- a/examples/private_set_intersection/module/rust/src/lib.rs
+++ b/examples/private_set_intersection/module/rust/src/lib.rs
@@ -42,7 +42,7 @@ oak::entrypoint!(oak_main => |_in_channel| {
     let dispatcher = PrivateSetIntersectionDispatcher::new(Node::default());
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_event_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel);
 });
 
 /// Maximum number of contributed private sets.

--- a/examples/running_average/module/rust/src/lib.rs
+++ b/examples/running_average/module/rust/src/lib.rs
@@ -33,7 +33,7 @@ oak::entrypoint!(oak_main => |_in_channel| {
     let dispatcher = RunningAverageDispatcher::new(Node::default());
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_event_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel);
 });
 
 #[derive(Default)]

--- a/examples/translator/module/rust/src/lib.rs
+++ b/examples/translator/module/rust/src/lib.rs
@@ -26,7 +26,7 @@ use translator_common::proto::{
 oak::entrypoint!(oak_main => |in_channel| {
     oak::logger::init_default();
     let dispatcher = TranslatorDispatcher::new(Node);
-    oak::run_event_loop(dispatcher, oak::io::Receiver::<grpc::Invocation>::new(in_channel));
+    oak::run_command_loop(dispatcher, in_channel);
 });
 
 // The `grpc_oak_main` entrypoint is used when the Translator acts as a standalone Oak
@@ -38,7 +38,7 @@ oak::entrypoint!(grpc_oak_main => |_in_channel| {
     let dispatcher = TranslatorDispatcher::new(Node);
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_event_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel);
 });
 
 struct Node;

--- a/examples/trusted_database/module/rust/src/handler.rs
+++ b/examples/trusted_database/module/rust/src/handler.rs
@@ -124,5 +124,5 @@ oak::entrypoint!(handler_oak_main => |in_channel| {
     let dispatcher = TrustedDatabaseDispatcher::new(node);
     let invocation_receiver = receiver.receiver.expect("Empty gRPC invocation receiver");
     // The event loop only runs once because the `Main` Node sends a single invocation.
-    oak::run_event_loop(dispatcher, invocation_receiver);
+    oak::run_command_loop(dispatcher, invocation_receiver);
 });

--- a/examples/trusted_database/module/rust/src/lib.rs
+++ b/examples/trusted_database/module/rust/src/lib.rs
@@ -57,7 +57,9 @@ mod tests;
 
 use database::load_database;
 use log::{debug, error};
-use oak::{grpc, io::SenderExt, proto::oak::invocation::GrpcInvocationReceiver, Node, OakError};
+use oak::{
+    grpc, io::SenderExt, proto::oak::invocation::GrpcInvocationReceiver, CommandHandler, OakError,
+};
 use proto::oak::examples::trusted_database::{PointOfInterest, TrustedDatabaseCommand};
 
 /// Oak Node that contains an in-memory database.
@@ -65,7 +67,7 @@ pub struct TrustedDatabaseNode {
     points_of_interest: Vec<PointOfInterest>,
 }
 
-impl Node<grpc::Invocation> for TrustedDatabaseNode {
+impl CommandHandler<grpc::Invocation> for TrustedDatabaseNode {
     fn handle_command(&mut self, invocation: grpc::Invocation) -> Result<(), OakError> {
         // Create a client request handler Node.
         debug!("Creating handler Node");
@@ -133,5 +135,5 @@ oak::entrypoint!(oak_main => |in_channel| {
     let points_of_interest = load_database(config_map).expect("Couldn't load database");
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("Couldn't create gRPC server pseudo-Node");
-    oak::run_event_loop(TrustedDatabaseNode { points_of_interest }, grpc_channel);
+    oak::run_command_loop(TrustedDatabaseNode { points_of_interest }, grpc_channel);
 });

--- a/examples/trusted_information_retrieval/module_0/rust/src/lib.rs
+++ b/examples/trusted_information_retrieval/module_0/rust/src/lib.rs
@@ -82,5 +82,5 @@ oak::entrypoint!(oak_main => |in_channel| {
     });
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("Couldn't create gRPC server pseudo-Node");
-    oak::run_event_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel);
 });

--- a/examples/trusted_information_retrieval/module_1/rust/src/lib.rs
+++ b/examples/trusted_information_retrieval/module_1/rust/src/lib.rs
@@ -150,7 +150,7 @@ impl DatabaseProxy for DatabaseProxyNode {
 oak::entrypoint!(database_proxy_main => |in_channel| {
     oak::logger::init_default();
     let dispatcher = DatabaseProxyDispatcher::new(DatabaseProxyNode::default());
-    oak::run_event_loop(dispatcher, oak::io::Receiver::<grpc::Invocation>::new(in_channel));
+    oak::run_command_loop(dispatcher, in_channel);
 });
 
 oak::entrypoint!(grpc_database_proxy_main => |_in_channel| {
@@ -158,5 +158,5 @@ oak::entrypoint!(grpc_database_proxy_main => |_in_channel| {
     let dispatcher = DatabaseProxyDispatcher::new(DatabaseProxyNode::default());
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("Couldn't create gRPC server pseudo-Node");
-    oak::run_event_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel);
 });

--- a/oak_io/src/handle.rs
+++ b/oak_io/src/handle.rs
@@ -32,6 +32,12 @@ impl std::fmt::Debug for ReadHandle {
     }
 }
 
+impl From<Handle> for ReadHandle {
+    fn from(handle: Handle) -> Self {
+        ReadHandle { handle }
+    }
+}
+
 /// Wrapper for a handle to the send half of a channel.
 ///
 /// For use when the underlying [`Handle`] is known to be for a send half.
@@ -43,6 +49,12 @@ pub struct WriteHandle {
 impl std::fmt::Debug for WriteHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "WriteHandle({})", self.handle)
+    }
+}
+
+impl From<Handle> for WriteHandle {
+    fn from(handle: Handle) -> Self {
+        WriteHandle { handle }
     }
 }
 

--- a/oak_io/src/receiver.rs
+++ b/oak_io/src/receiver.rs
@@ -52,6 +52,12 @@ impl<T: Decodable> Receiver<T> {
     }
 }
 
+impl<T: Decodable> From<ReadHandle> for Receiver<T> {
+    fn from(handle: ReadHandle) -> Self {
+        Receiver::new(handle)
+    }
+}
+
 impl<T: Decodable> crate::handle::HandleVisit for Receiver<T> {
     fn visit<F: FnMut(&mut crate::Handle)>(&mut self, mut visitor: F) -> F {
         visitor(&mut self.handle.handle);

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -131,13 +131,13 @@ impl ChannelResponseWriter {
 
 /// Trait for Oak Nodes that act as a gRPC services.
 ///
-/// A `ServerNode` instance is normally passed to [`oak::run_event_loop`], to
+/// A `ServerNode` instance is normally passed to [`oak::run_command_loop`], to
 /// allow repeated invocation of its `invoke()` method.
 ///
 /// You can choose to implement this trait yourself, or use the convenient
 /// `Dispatcher` created by the gRPC code generator.
 ///
-/// [`oak::run_event_loop`]: ../../oak/fn.run_event_loop.html
+/// [`oak::run_command_loop`]: ../../oak/fn.run_command_loop.html
 pub trait ServerNode {
     /// Process a single gRPC method invocation.
     ///
@@ -147,7 +147,7 @@ pub trait ServerNode {
     fn invoke(&mut self, method: &str, req: &[u8], writer: ChannelResponseWriter);
 }
 
-impl<T: ServerNode> crate::Node<Invocation> for T {
+impl<T: ServerNode> crate::CommandHandler<Invocation> for T {
     /// Handle incoming gRPC events for a [`ServerNode`].
     ///
     /// Invoking the given `node`'s [`invoke`] method for each incoming request that


### PR DESCRIPTION
This makes more sense as the command handling logic is only potentially
part of a Node, but not a Node per se.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
