### PR TITLE
Apply all constructors first to automatically construct new state

### DIFF
--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -179,7 +179,17 @@ Proof.
                 do 2 eexists; split_ands; [ | | reflexivity ].
                 1:apply_all_constructors;
                   solve [eauto using state_hidx_to_proj_state_hidx with flowsto].
-                subst_lets. eauto 7 with unwind.
+                subst_lets.
+                eapply set_call_unwind.
+                eapply state_upd_chan_unwind.
+                eapply chan_append_unwind.
+                symmetry.
+                (* eauto with unwind can't seem to figure this part out: *)
+                eapply chan_low_proj_loweq.
+                (* in this spot, could also do:
+                eapply chan_low_proj_idempotent.
+                 *)
+                eauto with unwind.
             + (* ReadChannel *)
                 pose proof (state_hidx_to_proj_state_hidx ell _ _ _
                     ltac:(eauto)) as Hch_hidx_s1proj.

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -131,6 +131,8 @@ Hint Extern 4 (chan_low_eq _ _ _) => reflexivity : unwind.
 (* meant to be case where we have (cleq ch (proj ch) ) and want to swap order *)
 Hint Extern 4 (chan_low_eq _ _ (chan_low_proj _ _)) => symmetry : unwind.
 Hint Extern 4 (state_low_eq _ _ (state_low_proj _ _)) => symmetry : unwind.
+Hint Extern 2 (chan_low_proj _ _ = chan_low_proj _ _)
+=> simple eapply chan_low_proj_loweq : unwind.
 
 Hint Extern 4 (_ <<L clbl (chan_low_proj _ _))
 => (rewrite chan_projection_preserves_lbl) : flowsto.
@@ -179,17 +181,7 @@ Proof.
                 do 2 eexists; split_ands; [ | | reflexivity ].
                 1:apply_all_constructors;
                   solve [eauto using state_hidx_to_proj_state_hidx with flowsto].
-                subst_lets.
-                eapply set_call_unwind.
-                eapply state_upd_chan_unwind.
-                eapply chan_append_unwind.
-                symmetry.
-                (* eauto with unwind can't seem to figure this part out: *)
-                eapply chan_low_proj_loweq.
-                (* in this spot, could also do:
-                eapply chan_low_proj_idempotent.
-                 *)
-                eauto with unwind.
+                subst_lets. eauto 7 with unwind.
             + (* ReadChannel *)
                 pose proof (state_hidx_to_proj_state_hidx ell _ _ _
                     ltac:(eauto)) as Hch_hidx_s1proj.


### PR DESCRIPTION
Based on conversation with @aferr, this change implements a tactic that applies all the system/node constructors before any of the generated subgoals are solved. That way, we can use `eexists` instead of manually repeating the new state based on the constructor, which should help the proof keep pace with future changes. ~Also, it seems to help out `eauto with unwind`, which now solves the subgoal it was struggling with before!~ ~(Edit: never mind, CI says no so fixing)~ (Edit again: I accidentally deleted a `Hint Extern`, now it works again!)

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
