### PR TITLE
Expose label methods from sender and receiver

### DIFF
--- a/sdk/rust/oak/src/io/receiver.rs
+++ b/sdk/rust/oak/src/io/receiver.rs
@@ -16,22 +16,25 @@
 
 use crate::{
     io::{Decodable, Receiver},
-    ChannelReadStatus, OakError, OakStatus,
+    ChannelReadStatus, Label, OakError, OakStatus,
 };
 use log::error;
 
 /// SDK-specific functionality provided by a receiver.
 pub trait ReceiverExt<T> {
-    /// Close the underlying channel used by the receiver.
+    /// Closes the underlying channel used by the receiver.
     fn close(&self) -> Result<(), OakStatus>;
 
-    /// Attempt to wait for a value on the receiver, blocking if necessary.
+    /// Attempts to wait for a value on the receiver, blocking if necessary.
     fn receive(&self) -> Result<T, OakError>;
 
-    /// Attempt to read a value from the receiver, without blocking.
+    /// Attempts to read a value from the receiver, without blocking.
     fn try_receive(&self) -> Result<T, OakError>;
 
-    /// Wait for a value to be available from the receiver.
+    /// Retrieves the label associated with the underlying channel.
+    fn label(&self) -> Result<Label, OakError>;
+
+    /// Waits for a value to be available from the receiver.
     ///
     /// Returns [`ChannelReadStatus`] of the wrapped handle, or `Err(OakStatus::ErrTerminated)` if
     /// the Oak Runtime is terminating.
@@ -39,18 +42,15 @@ pub trait ReceiverExt<T> {
 }
 
 impl<T: Decodable> ReceiverExt<T> for Receiver<T> {
-    /// Close the underlying channel used by the receiver.
     fn close(&self) -> Result<(), OakStatus> {
         crate::channel_close(self.handle.handle)
     }
 
-    /// Attempt to wait for a value on the receiver, blocking if necessary.
     fn receive(&self) -> Result<T, OakError> {
         self.wait()?;
         self.try_receive()
     }
 
-    /// Attempt to read a value from the receiver, without blocking.
     fn try_receive(&self) -> Result<T, OakError> {
         let mut bytes = Vec::with_capacity(1024);
         let mut handles = Vec::with_capacity(16);
@@ -60,10 +60,11 @@ impl<T: Decodable> ReceiverExt<T> for Receiver<T> {
         T::decode(&message)
     }
 
-    /// Wait for a value to be available from the receiver.
-    ///
-    /// Returns [`ChannelReadStatus`] of the wrapped handle, or `Err(OakStatus::ErrTerminated)` if
-    /// the Oak Runtime is terminating.
+    fn label(&self) -> Result<Label, OakError> {
+        let label = crate::channel_label_read(self.handle.handle)?;
+        Ok(label)
+    }
+
     fn wait(&self) -> Result<ChannelReadStatus, OakStatus> {
         // TODO(#500): Consider creating the handle notification space once and for all in `new`.
         let read_handles = vec![self.handle];

--- a/sdk/rust/oak/src/io/sender.rs
+++ b/sdk/rust/oak/src/io/sender.rs
@@ -16,28 +16,34 @@
 
 use crate::{
     io::{Encodable, Sender},
-    OakError, OakStatus,
+    Label, OakError, OakStatus,
 };
 
 /// Trait for context-dependent functionality on a `Sender`.
 pub trait SenderExt<T> {
-    /// Close the underlying channel used by the sender.
+    /// Closes the underlying channel used by the sender.
     fn close(&self) -> Result<(), OakStatus>;
 
-    /// Attempt to send a value on the sender.
+    /// Attempts to send a value on the sender.
     fn send(&self, t: &T) -> Result<(), OakError>;
+
+    /// Retrieves the label associated with the underlying channel.
+    fn label(&self) -> Result<Label, OakError>;
 }
 
 impl<T: Encodable> SenderExt<T> for Sender<T> {
-    /// Close the underlying channel used by the sender.
     fn close(&self) -> Result<(), OakStatus> {
         crate::channel_close(self.handle.handle)
     }
 
-    /// Attempt to send a value on the sender.
     fn send(&self, t: &T) -> Result<(), OakError> {
         let message = t.encode()?;
         crate::channel_write(self.handle, &message.bytes, &message.handles)?;
         Ok(())
+    }
+
+    fn label(&self) -> Result<Label, OakError> {
+        let label = crate::channel_label_read(self.handle.handle)?;
+        Ok(label)
     }
 }


### PR DESCRIPTION
Deduplicate and canonicalize method documentation.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
