### PR TITLE
Replace tokio::fs::read with std::fs::read

### DIFF
--- a/examples/aggregator/backend/src/main.rs
+++ b/examples/aggregator/backend/src/main.rs
@@ -68,12 +68,10 @@ async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let opt = Opt::from_args();
 
-    let private_key = tokio::fs::read(&opt.grpc_tls_private_key)
-        .await
-        .context("Couldn't load private key")?;
-    let certificate = tokio::fs::read(&opt.grpc_tls_certificate)
-        .await
-        .context("Couldn't load certificate")?;
+    let private_key =
+        std::fs::read(&opt.grpc_tls_private_key).context("Couldn't load private key")?;
+    let certificate =
+        std::fs::read(&opt.grpc_tls_certificate).context("Couldn't load certificate")?;
 
     let identity = Identity::from_pem(certificate, private_key);
 

--- a/examples/authentication/client/src/auth_client.rs
+++ b/examples/authentication/client/src/auth_client.rs
@@ -28,7 +28,7 @@ pub async fn build_auth_client(
     ca_cert: &str,
     auth_server: &str,
 ) -> Result<AuthenticationClient<Channel>, Box<dyn std::error::Error>> {
-    let root_cert = tokio::fs::read(ca_cert).await?;
+    let root_cert = std::fs::read(ca_cert)?;
     let root_cert = Certificate::from_pem(root_cert);
     let tls_config = ClientTlsConfig::new().ca_certificate(root_cert);
 

--- a/examples/hello_world/client/rust/src/main.rs
+++ b/examples/hello_world/client/rust/src/main.rs
@@ -49,9 +49,8 @@ async fn main() -> anyhow::Result<()> {
     let opt = Opt::from_args();
 
     let uri = opt.uri.parse().context("Error parsing URI")?;
-    let root_tls_certificate = tokio::fs::read(&opt.root_tls_certificate)
-        .await
-        .context("Could not load certificate file")?;
+    let root_tls_certificate =
+        std::fs::read(&opt.root_tls_certificate).context("Could not load certificate file")?;
 
     info!("Connecting to Oak Application: {:?}", uri);
     let channel = create_tls_channel(&uri, &root_tls_certificate)

--- a/examples/private_set_intersection/client/rust/src/main.rs
+++ b/examples/private_set_intersection/client/rust/src/main.rs
@@ -74,12 +74,10 @@ async fn main() -> anyhow::Result<()> {
     let opt = Opt::from_args();
 
     let uri = opt.uri.parse().context("Error parsing URI")?;
-    let root_tls_certificate = tokio::fs::read(&opt.root_tls_certificate)
-        .await
-        .context("Couldn't load certificate file")?;
-    let public_key_file = tokio::fs::read(&opt.public_key)
-        .await
-        .context("Couldn't load public key file")?;
+    let root_tls_certificate =
+        std::fs::read(&opt.root_tls_certificate).context("Couldn't load certificate file")?;
+    let public_key_file =
+        std::fs::read(&opt.public_key).context("Couldn't load public key file")?;
     let public_key_bytes = pem::parse(public_key_file)
         .context("Empty public key file")?
         .contents;

--- a/examples/trusted_database/client/rust/src/main.rs
+++ b/examples/trusted_database/client/rust/src/main.rs
@@ -52,9 +52,8 @@ async fn main() -> anyhow::Result<()> {
     let opt = Opt::from_args();
 
     let uri = opt.uri.parse().context("Error parsing URI")?;
-    let root_tls_certificate = tokio::fs::read(&opt.root_tls_certificate)
-        .await
-        .context("Couldn't load certificate file")?;
+    let root_tls_certificate =
+        std::fs::read(&opt.root_tls_certificate).context("Couldn't load certificate file")?;
     let latitude = opt.latitude;
     ensure!(
         latitude >= -90.0 && latitude <= 90.0,

--- a/examples/trusted_information_retrieval/backend/src/main.rs
+++ b/examples/trusted_information_retrieval/backend/src/main.rs
@@ -128,12 +128,10 @@ async fn main() -> anyhow::Result<()> {
     let opt = Opt::from_args();
     info!("Running backend database");
 
-    let private_key = tokio::fs::read(&opt.grpc_tls_private_key)
-        .await
-        .context("Couldn't load private key")?;
-    let certificate = tokio::fs::read(&opt.grpc_tls_certificate)
-        .await
-        .context("Couldn't load certificate")?;
+    let private_key =
+        std::fs::read(&opt.grpc_tls_private_key).context("Couldn't load private key")?;
+    let certificate =
+        std::fs::read(&opt.grpc_tls_certificate).context("Couldn't load certificate")?;
     let database_url = Url::parse(&opt.database_url).expect("Couldn't parse database URL");
 
     // Create a mutex-protected database.

--- a/examples/trusted_information_retrieval/client/rust/src/main.rs
+++ b/examples/trusted_information_retrieval/client/rust/src/main.rs
@@ -51,9 +51,8 @@ async fn main() -> anyhow::Result<()> {
     let opt = Opt::from_args();
 
     let uri = opt.uri.parse().context("Error parsing URI")?;
-    let root_tls_certificate = tokio::fs::read(&opt.root_tls_certificate)
-        .await
-        .context("Could not load certificate file")?;
+    let root_tls_certificate =
+        std::fs::read(&opt.root_tls_certificate).context("Could not load certificate file")?;
     let id = opt.id;
 
     info!("Connecting to Oak Application: {:?}", uri);

--- a/experimental/split_grpc/client/src/main.rs
+++ b/experimental/split_grpc/client/src/main.rs
@@ -25,7 +25,7 @@ pub mod proto {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
-    let root_cert = tokio::fs::read("examples/certs/local/ca.pem").await?;
+    let root_cert = std::fs::read("examples/certs/local/ca.pem")?;
     let root_cert = Certificate::from_pem(root_cert);
     let tls_config = ClientTlsConfig::new()
         .ca_certificate(root_cert)

--- a/experimental/split_grpc/server/src/main.rs
+++ b/experimental/split_grpc/server/src/main.rs
@@ -77,8 +77,8 @@ impl HelloWorld for HelloWorldHandler {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cert = tokio::fs::read("examples/certs/local/local.pem").await?;
-    let key = tokio::fs::read("examples/certs/local/local.key").await?;
+    let cert = std::fs::read("examples/certs/local/local.pem")?;
+    let key = std::fs::read("examples/certs/local/local.key")?;
     let identity = Identity::from_pem(cert, key);
     let address = "[::1]:50052".parse()?;
     let handler = HelloWorldHandler::default();


### PR DESCRIPTION
This change replaces `tokio::fs::read` with `std::fs::read`, because `tokio::fs::read` is an unnecessary complication in these particular examples.