### PR TITLE
Create labeled channel in gRPC client

### DIFF
--- a/sdk/rust/oak/src/grpc/client.rs
+++ b/sdk/rust/oak/src/grpc/client.rs
@@ -40,7 +40,7 @@ impl Client {
     /// The provided [`Label`] specifies the label for the newly created Node and Channel.
     pub fn new_with_label(config: &NodeConfiguration, label: &Label) -> Option<Client> {
         let (invocation_sender, invocation_receiver) =
-            crate::io::channel_create().expect("failed to create channel");
+            crate::io::channel_create_with_label(label).expect("failed to create channel");
         let status = crate::node_create_with_label(config, label, invocation_receiver.handle);
         invocation_receiver
             .close()


### PR DESCRIPTION
This change fixes channel label in gRPC client.
Previously, when gRPC client node was created with a specific label, the corresponding channel didn't have one (only had a public label).