### PR TITLE
Add Oak Node builder

### DIFF
--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -42,7 +42,7 @@ use log::{debug, error, info};
 use oak::{
     grpc,
     io::{Receiver, ReceiverExt, SenderExt},
-    node::WasmNode,
+    node::NodeBuilder,
     proto::oak::invocation::{GrpcInvocation, GrpcInvocationReceiver, GrpcInvocationSender},
 };
 use oak_abi::proto::oak::application::ConfigMap;
@@ -210,7 +210,9 @@ oak::entrypoint!(oak_main<ConfigMap> => |receiver: Receiver<ConfigMap>| {
         oak::grpc::server::init(&config.grpc_server_listen_address).expect("Couldn't create gRPC server pseudo-Node");
 
     // Create an Aggregator Node.
-    let init_sender = WasmNode::create("app", "aggregator").expect("Couldn't create Aggregator Node");
+    let init_sender = NodeBuilder::new(&oak::node_config::wasm("app", "aggregator"))
+        .build()
+        .expect("Couldn't create Aggregator Node");
 
     // Create a gRPC client Node with a less restrictive label than the current Node.
     // In particular, the confidentiality component of the current Node label includes the

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -18,7 +18,6 @@ use log::info;
 use oak::{
     grpc,
     io::{Sender, SenderExt},
-    node::WasmNode,
 };
 use oak_abi::proto::oak::application::ConfigMap;
 use proto::{
@@ -56,8 +55,12 @@ struct Room {
 
 impl Room {
     fn new(admin_token: AdminToken) -> Self {
+        let (wh, rh) = oak::channel_create().unwrap();
+        oak::node_create(&oak::node_config::wasm("app", "backend_oak_main"), rh)
+            .expect("could not create node");
+        oak::channel_close(rh.handle).expect("could not close channel");
         Room {
-            sender: WasmNode::create("app", "backend_oak_main").expect("Couldn't create node"),
+            sender: oak::io::Sender::new(wh),
             admin_token,
         }
     }

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -18,6 +18,7 @@ use log::info;
 use oak::{
     grpc,
     io::{Sender, SenderExt},
+    node::WasmNode,
 };
 use oak_abi::proto::oak::application::ConfigMap;
 use proto::{
@@ -55,12 +56,8 @@ struct Room {
 
 impl Room {
     fn new(admin_token: AdminToken) -> Self {
-        let (wh, rh) = oak::channel_create().unwrap();
-        oak::node_create(&oak::node_config::wasm("app", "backend_oak_main"), rh)
-            .expect("could not create node");
-        oak::channel_close(rh.handle).expect("could not close channel");
         Room {
-            sender: oak::io::Sender::new(wh),
+            sender: WasmNode::create("app", "backend_oak_main").expect("Couldn't create node"),
             admin_token,
         }
     }

--- a/examples/trusted_database/module/rust/src/lib.rs
+++ b/examples/trusted_database/module/rust/src/lib.rs
@@ -61,7 +61,7 @@ use log::debug;
 use oak::{
     grpc,
     io::{Receiver, ReceiverExt, SenderExt},
-    node::WasmNode,
+    node::NodeBuilder,
     proto::oak::invocation::GrpcInvocationReceiver,
     CommandHandler,
 };
@@ -78,7 +78,9 @@ impl CommandHandler<grpc::Invocation> for TrustedDatabaseNode {
         // Create a client request handler Node.
         debug!("Creating handler Node");
         // TODO(#1406): Use client assigned label for creating a new handler Node.
-        let sender = WasmNode::create("app", "handler_oak_main").context("Couldn't create handler Node")?;
+        let sender = NodeBuilder::new(&oak::node_config::wasm("app", "handler_oak_main"))
+            .build()
+            .context("Couldn't create handler Node")?;
 
         // Create a gRPC invocation channel for forwarding requests to the
         // `TrustedDatabaseHandlerNode`.

--- a/examples/trusted_database/module/rust/src/lib.rs
+++ b/examples/trusted_database/module/rust/src/lib.rs
@@ -61,6 +61,7 @@ use log::debug;
 use oak::{
     grpc,
     io::{Receiver, ReceiverExt, SenderExt},
+    node::WasmNode,
     proto::oak::invocation::GrpcInvocationReceiver,
     CommandHandler,
 };
@@ -76,15 +77,8 @@ impl CommandHandler<grpc::Invocation> for TrustedDatabaseNode {
     fn handle_command(&mut self, invocation: grpc::Invocation) -> anyhow::Result<()> {
         // Create a client request handler Node.
         debug!("Creating handler Node");
-        let (sender, receiver) = oak::io::channel_create::<TrustedDatabaseCommand>()
-            .context("Couldn't create command channel")?;
         // TODO(#1406): Use client assigned label for creating a new handler Node.
-        oak::node_create(
-            &oak::node_config::wasm("app", "handler_oak_main"),
-            receiver.handle,
-        )
-        .context("Couldn't create handler Node")?;
-        oak::channel_close(receiver.handle.handle).context("Couldn't close receiver channel")?;
+        let sender = WasmNode::create("app", "handler_oak_main").context("Couldn't create handler Node")?;
 
         // Create a gRPC invocation channel for forwarding requests to the
         // `TrustedDatabaseHandlerNode`.

--- a/sdk/rust/oak/src/grpc/client.rs
+++ b/sdk/rust/oak/src/grpc/client.rs
@@ -14,10 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{
-    io::SenderExt,
-    node::NodeBuilder,
-};
+use crate::{io::SenderExt, node::NodeBuilder};
 use log::{info, warn};
 use oak_abi::{label::Label, proto::oak::application::NodeConfiguration};
 

--- a/sdk/rust/oak/src/grpc/server.rs
+++ b/sdk/rust/oak/src/grpc/server.rs
@@ -19,10 +19,10 @@
 use crate::{
     grpc::Invocation,
     io::{Receiver, SenderExt},
+    node::NodeBuilder,
     proto::oak::invocation::GrpcInvocationSender,
     OakStatus,
 };
-use crate::node::NodeBuilder;
 
 /// Initializes a gRPC server pseudo-Node listening on the provided address.
 ///

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -40,6 +40,7 @@ pub mod handle;
 pub mod http;
 pub mod io;
 pub mod logger;
+pub mod node;
 pub mod node_config;
 pub mod rand;
 pub mod roughtime;

--- a/sdk/rust/oak/src/node.rs
+++ b/sdk/rust/oak/src/node.rs
@@ -1,0 +1,84 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::OakStatus;
+use oak_abi::{label::Label, proto::oak::application::NodeConfiguration};
+pub use oak_io::{Decodable, Encodable, Receiver, Sender};
+
+/// Convenience struct for building Nodes.
+pub struct NodeBuilder {
+    config: NodeConfiguration,
+    label: Option<Label>,
+}
+
+// TODO(#1584): Send init messages as a part of building process.
+impl NodeBuilder {
+    pub fn new(config: &NodeConfiguration) -> Self {
+        Self {
+            config: config.clone(),
+            label: None,
+        }
+    }
+
+    /// Set `label` for both newly created Node and a corresponding initial channel to this Node.
+    pub fn label<'a>(&'a mut self, label: &Label) -> &'a mut Self {
+        self.label = Some(label.clone());
+        self
+    }
+
+    /// Build Node using provided [`NodeBuilder::config`] and [`NodeBuilder::label`].
+    /// If [`NodeBuilder::label`] is `None` - uses [`Label::public_untrusted`].
+    /// Returns [`Sender`] for the initial channel to the newly created Node.
+    pub fn build<T: Encodable + Decodable>(&self) -> Result<Sender<T>, OakStatus> {
+        let (sender, receiver) = match &self.label {
+            Some(label) => {
+                let (sender, receiver) = crate::io::channel_create_with_label::<T>(label)?;
+                crate::node_create_with_label(&self.config, label, receiver.handle)?;
+                (sender, receiver)
+            },
+            None => {
+                let (sender, receiver) = crate::io::channel_create::<T>()?;
+                crate::node_create(&self.config, receiver.handle)?;
+                (sender, receiver)
+            }
+        };
+        crate::channel_close(receiver.handle.handle)?;
+        Ok(sender)
+    }
+}
+
+/// Method provider for creating Wasm Nodes.
+pub struct WasmNode<T: Encodable + Decodable> {
+    phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: Encodable + Decodable> WasmNode<T> {
+    /// Creates a Wasm Node with a public label.
+    /// Returns [`Sender`] for the initial channel to the newly created Node.
+    pub fn create(module_name: &str, entrypoint_name: &str) -> Result<Sender<T>, OakStatus> {
+        Self::create_with_label(module_name, entrypoint_name, &Label::public_untrusted())
+    }
+
+    /// Creates a Wasm Node with specific `label`.
+    /// Returns [`Sender`] for the initial channel to the newly created Node.
+    pub fn create_with_label(module_name: &str, entrypoint_name: &str, label: &Label) -> Result<Sender<T>, OakStatus> {
+        let config = &crate::node_config::wasm(module_name, entrypoint_name);
+        let sender = NodeBuilder::new(config)
+            .label(label)
+            .build::<T>()?;
+        Ok(sender)
+    }
+}


### PR DESCRIPTION
This change adds a `NodeBuilder` that creates Oak Nodes and assigns initial channels to them. It also closes corresponding reader channel half.

Fixes https://github.com/project-oak/oak/issues/1583

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to cover any TODOs and/or unfinished work.
