### PR TITLE
Refactor oak sign key pair

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1212,6 +1212,7 @@ name = "oak_sign"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "env_logger",
  "hex",
  "log",

--- a/examples/chat/module/rust/tests/integration_test.rs
+++ b/examples/chat/module/rust/tests/integration_test.rs
@@ -29,10 +29,8 @@ async fn test_chat() {
     let runtime = oak_tests::run_single_module(MODULE_WASM_FILE_NAME, "grpc_oak_main")
         .expect("Unable to configure runtime with test wasm!");
 
-    let room_0_key_pair =
-        oak_sign::KeyBundle::generate().expect("could not generate room key pair");
-    let room_1_key_pair =
-        oak_sign::KeyBundle::generate().expect("could not generate room key pair");
+    let room_0_key_pair = oak_sign::KeyPair::generate().expect("could not generate room key pair");
+    let room_1_key_pair = oak_sign::KeyPair::generate().expect("could not generate room key pair");
 
     let mut alice = Chatter::new(&room_0_key_pair, "Alice").await;
     let mut alice_stream = alice.subscribe().await;
@@ -137,19 +135,19 @@ async fn test_chat() {
 
 struct Chatter<'a> {
     pub client: ChatClient<tonic::transport::Channel>,
-    pub room_key_pair: &'a oak_sign::KeyBundle,
+    pub room_key_pair: &'a oak_sign::KeyPair,
     pub user_handle: String,
 }
 
 impl<'a> Chatter<'a> {
     pub async fn new(
-        room_key_pair: &'a oak_sign::KeyBundle,
+        room_key_pair: &'a oak_sign::KeyPair,
         user_handle: &'static str,
     ) -> Chatter<'a> {
         info!(
             "creating new Chatter({}, {})",
             user_handle,
-            base64::encode(&room_key_pair.public_key())
+            base64::encode(&room_key_pair.pkcs8_public_key())
         );
         let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
         // TODO(#1357): Use key pair to authenticate this client and label requests.

--- a/experimental/Cargo.lock
+++ b/experimental/Cargo.lock
@@ -31,6 +31,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 
 [[package]]
+name = "assert_matches"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
+
+[[package]]
 name = "async-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +896,7 @@ name = "oak_sign"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "env_logger",
  "hex",
  "log",

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -31,6 +31,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
+name = "assert_matches"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
+
+[[package]]
 name = "async-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +806,7 @@ name = "oak_sign"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "env_logger",
  "hex",
  "log",

--- a/oak_runtime/Cargo.lock
+++ b/oak_runtime/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
+name = "assert_matches"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
+
+[[package]]
 name = "async-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +794,7 @@ name = "oak_sign"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "env_logger",
  "hex",
  "log",

--- a/oak_sign/Cargo.lock
+++ b/oak_sign/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
+name = "assert_matches"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,7 @@ name = "oak_sign"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "env_logger",
  "hex",
  "log",

--- a/oak_sign/Cargo.toml
+++ b/oak_sign/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "*"
+assert_matches = "*"
 env_logger = "*"
 hex = "*"
 log = "*"

--- a/oak_sign/src/lib.rs
+++ b/oak_sign/src/lib.rs
@@ -18,7 +18,7 @@ use anyhow::Context;
 use pem::Pem;
 use ring::{
     rand,
-    signature::{self, Ed25519KeyPair, KeyPair},
+    signature::{self, Ed25519KeyPair},
 };
 use std::{
     collections::HashMap,
@@ -31,39 +31,59 @@ pub const PUBLIC_KEY_TAG: &str = "PUBLIC KEY";
 pub const SIGNATURE_TAG: &str = "SIGNATURE";
 pub const HASH_TAG: &str = "HASH";
 
-/// Convenience struct that encapsulates `Ed25519KeyPair`.
-/// Named `KeyBundle` since it uses the `ring::signature::KeyPair` trait.
-pub struct KeyBundle {
-    private_key: Vec<u8>,
+/// Convenience struct that encapsulates `ring::signature::Ed25519KeyPair`.
+#[derive(Debug)]
+pub struct KeyPair {
+    /// PKCS#8 v2 encoded private key and public key.
+    /// https://tools.ietf.org/html/rfc5958
+    ///
+    /// The encoded version is kept because a parsed `key_pair` doesn't contain a method for
+    /// extracting private key bytes.
+    /// https://briansmith.org/rustdoc/ring/signature/struct.Ed25519KeyPair.html
+    pkcs8: Vec<u8>,
+    /// Parsed PKCS#8 v2 key pair representation.
     key_pair: Ed25519KeyPair,
 }
 
-impl KeyBundle {
+impl Clone for KeyPair {
+    fn clone(&self) -> Self {
+        // The `clone` function is implemented as re-parsing, because `Ed25519KeyPair` doesn't
+        // implement `Clone` and all of its fields are private.
+        KeyPair::parse(&self.pkcs8).expect("Couldn't clone key pair")
+    }
+}
+
+impl KeyPair {
     /// Generates a Ed25519 key pair.
-    pub fn generate() -> anyhow::Result<KeyBundle> {
+    pub fn generate() -> anyhow::Result<KeyPair> {
         let rng = rand::SystemRandom::new();
         let private_key = Ed25519KeyPair::generate_pkcs8(&rng)
             .ok()
             .context("Couldn't generate key pair")?;
-        KeyBundle::parse(private_key.as_ref())
+        KeyPair::parse(private_key.as_ref())
     }
 
-    /// Parses a Ed25519 key pair from bytes.
-    pub fn parse(private_key: &[u8]) -> anyhow::Result<KeyBundle> {
-        let key_pair = Ed25519KeyPair::from_pkcs8(private_key)
+    /// Parses a Ed25519 key pair from a PKCS#8 v2 encoded `pkcs8_key_pair`.
+    pub fn parse(pkcs8_key_pair: &[u8]) -> anyhow::Result<KeyPair> {
+        let key_pair = Ed25519KeyPair::from_pkcs8(pkcs8_key_pair)
             .ok()
             .context("Couldn't parse generated key pair")?;
         Ok(Self {
-            private_key: private_key.to_vec(),
+            pkcs8: pkcs8_key_pair.to_vec(),
             key_pair,
         })
     }
 
-    pub fn private_key(&self) -> Vec<u8> {
-        self.private_key.to_vec()
+    /// Returns a PKCS#8 v2 encoded key pair.
+    pub fn pkcs8_key_pair(&self) -> Vec<u8> {
+        self.pkcs8.to_vec()
     }
 
-    pub fn public_key(&self) -> Vec<u8> {
+    /// Returns a PKCS#8 v2 encoded public key.
+    pub fn pkcs8_public_key(&self) -> Vec<u8> {
+        // Trait `ring::signature::KeyPair` that contains `public_key` function is included locally
+        // in this function because it conflicts with [`KeyPair`].
+        use ring::signature::KeyPair;
         self.key_pair.public_key().as_ref().to_vec()
     }
 
@@ -72,7 +92,7 @@ impl KeyBundle {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct SignatureBundle {
     pub public_key: Vec<u8>,
     pub signed_hash: Vec<u8>,
@@ -81,10 +101,10 @@ pub struct SignatureBundle {
 
 impl SignatureBundle {
     /// Signs a SHA-256 hash of the `input` using `private_key`.
-    pub fn create(input: &[u8], key_pair: &KeyBundle) -> anyhow::Result<SignatureBundle> {
+    pub fn create(input: &[u8], key_pair: &KeyPair) -> anyhow::Result<SignatureBundle> {
         let hash = get_sha256(input);
         Ok(SignatureBundle {
-            public_key: key_pair.public_key(),
+            public_key: key_pair.pkcs8_public_key(),
             signed_hash: key_pair.sign(&hash),
             hash,
         })

--- a/oak_sign/src/lib.rs
+++ b/oak_sign/src/lib.rs
@@ -53,6 +53,17 @@ impl Clone for KeyPair {
     }
 }
 
+impl PartialEq for KeyPair {
+    fn eq(&self, other: &Self) -> bool {
+        // Currently only comparing that the encoded version is the same, since `Ed25519KeyPair`
+        // doesn't implement `Eq` and all of its fields are private.
+        // https://github.com/briansmith/ring/blob/8d4e283c16f335166b0e969ccc321acf0de39c0b/src/ec/curve25519/ed25519/signing.rs#L27-L37
+        self.pkcs8 == other.pkcs8
+    }
+}
+
+impl Eq for KeyPair {}
+
 impl KeyPair {
     /// Generates a Ed25519 key pair.
     pub fn generate() -> anyhow::Result<KeyPair> {

--- a/oak_sign/src/tests.rs
+++ b/oak_sign/src/tests.rs
@@ -1,0 +1,49 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use assert_matches::assert_matches;
+use oak_sign::{get_sha256_hex, KeyPair, SignatureBundle};
+
+const TEST_DATA: &str = "Test data";
+const TEST_SHA256: &str = "e27c8214be8b7cf5bccc7c08247e3cb0c1514a48ee1f63197fe4ef3ef51d7e6f";
+
+#[test]
+fn key_pair_test() {
+    let generate_result = KeyPair::generate();
+    assert_matches!(generate_result, Ok(_));
+    let key_pair = generate_result.unwrap();
+
+    let pkcs8_key_pair = key_pair.pkcs8_key_pair();
+    let parse_result = KeyPair::parse(&pkcs8_key_pair);
+    assert_matches!(parse_result, Ok(_));
+}
+
+#[test]
+fn signature_test() {
+    let key_pair = KeyPair::generate().expect("Couldn't create key pair");
+    let create_result = SignatureBundle::create(TEST_DATA.as_bytes(), &key_pair);
+    assert_matches!(create_result, Ok(_));
+    let signature = create_result.unwrap();
+
+    let verify_result = signature.verify();
+    assert_matches!(verify_result, Ok(_));
+}
+
+#[test]
+fn sha256_test() {
+    let hash = get_sha256_hex(TEST_DATA.as_bytes());
+    assert_eq!(hash, TEST_SHA256);
+}

--- a/oak_sign/src/tests.rs
+++ b/oak_sign/src/tests.rs
@@ -31,6 +31,9 @@ fn key_pair_serialization_deserialization_test() {
     let pkcs8_key_pair = key_pair.pkcs8_key_pair();
     let parse_result = KeyPair::parse(&pkcs8_key_pair);
     assert_matches!(parse_result, Ok(_));
+    let parsed_key_pair = parse_result.unwrap();
+
+    assert_eq!(key_pair, parsed_key_pair);
 }
 
 #[test]

--- a/oak_sign/src/tests.rs
+++ b/oak_sign/src/tests.rs
@@ -19,9 +19,11 @@ use oak_sign::{get_sha256_hex, KeyPair, SignatureBundle};
 
 const TEST_DATA: &str = "Test data";
 const TEST_SHA256: &str = "e27c8214be8b7cf5bccc7c08247e3cb0c1514a48ee1f63197fe4ef3ef51d7e6f";
+const INCORRECT_SIGNATURE: &str =
+    "JmtVw8SPMnU/f4fLSBvd+w96C2NAMFn7+rqGVHzWOItsdZ+T+TqBwnEcCNJrJ1wrQWXPwFk+8sRiRFFCOCJVAA==";
 
 #[test]
-fn key_pair_test() {
+fn key_pair_serialization_deserialization_test() {
     let generate_result = KeyPair::generate();
     assert_matches!(generate_result, Ok(_));
     let key_pair = generate_result.unwrap();
@@ -40,6 +42,14 @@ fn signature_test() {
 
     let verify_result = signature.verify();
     assert_matches!(verify_result, Ok(_));
+
+    let incorrect_signature = SignatureBundle {
+        public_key: signature.public_key.to_vec(),
+        signed_hash: INCORRECT_SIGNATURE.as_bytes().to_vec(),
+        hash: signature.signed_hash.to_vec(),
+    };
+    let incorrect_verify_result = incorrect_signature.verify();
+    assert_matches!(incorrect_verify_result, Err(_));
 }
 
 #[test]

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
+name = "assert_matches"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
+
+[[package]]
 name = "async-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +889,7 @@ name = "oak_sign"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "env_logger",
  "hex",
  "log",


### PR DESCRIPTION
This change:
- Refactors `oak_sign::KeyBundle` to `oak_sign::KeyPair`
- Adds more comments
- Implements `Clone` for `oak_sign::KeyPair` (necessary for tests)

Fixes https://github.com/project-oak/oak/issues/1620