### PR TITLE
Make label compulsory for `oak::channel_create`

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -488,8 +488,8 @@ to the room:
 [embedmd]:# (../examples/chat/module/rust/src/lib.rs Rust /.*self\.rooms\.entry\(/ /\}\);$/)
 ```Rust
                 let channel = self.rooms.entry(label.clone()).or_insert_with(|| {
-                    let (wh, rh) = oak::io::channel_create_with_label(&label)
-                        .expect("could not create channel");
+                    let (wh, rh) =
+                        oak::io::channel_create(&label).expect("could not create channel");
                     oak::node_create_with_label(
                         &oak::node_config::wasm("app", "room"),
                         &label,

--- a/examples/abitest/module_1/rust/src/lib.rs
+++ b/examples/abitest/module_1/rust/src/lib.rs
@@ -16,6 +16,7 @@
 
 use abitest_common::InternalMessage;
 use log::{error, info};
+use oak_abi::label::Label;
 use std::collections::HashSet;
 
 // Backend node for channel testing.  This node listens for read channel handles
@@ -116,7 +117,7 @@ fn inner_main(in_handle: u64) -> Result<(), oak::OakStatus> {
             info!("received frontend request: {:?}", internal_req);
 
             // Create a new channel and write the response into it.
-            let (new_write, new_read) = oak::channel_create()?;
+            let (new_write, new_read) = oak::channel_create(&Label::public_untrusted())?;
             let internal_rsp = InternalMessage {
                 msg: internal_req.msg + "xxx",
             };

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -44,7 +44,7 @@ use oak::{
     io::{Receiver, ReceiverExt, SenderExt},
     proto::oak::invocation::{GrpcInvocation, GrpcInvocationReceiver, GrpcInvocationSender},
 };
-use oak_abi::proto::oak::application::ConfigMap;
+use oak_abi::{label::Label, proto::oak::application::ConfigMap};
 use proto::oak::examples::aggregator::{
     Aggregator, AggregatorClient, AggregatorDispatcher, AggregatorInit, Sample,
 };
@@ -209,7 +209,7 @@ oak::entrypoint!(oak_main<ConfigMap> => |receiver: Receiver<ConfigMap>| {
         oak::grpc::server::init(&config.grpc_server_listen_address).expect("Couldn't create gRPC server pseudo-Node");
 
     // Create an Aggregator Node.
-    let (init_sender, init_receiver) = oak::io::channel_create::<AggregatorInit>()
+    let (init_sender, init_receiver) = oak::io::channel_create::<AggregatorInit>(&Label::public_untrusted())
         .expect("Couldn't create initialization channel");
     oak::node_create(&oak::node_config::wasm("app", "aggregator"), init_receiver.handle)
         .expect("Couldn't create gRPC worker node");
@@ -238,7 +238,7 @@ oak::entrypoint!(oak_main<ConfigMap> => |receiver: Receiver<ConfigMap>| {
     // Send the initialization message to Aggregator Node containing a gRPC server invocation
     // receiver and a gRPC client invocation sender.
     debug!("Sending the initialization message to handler Node");
-    let (invocation_sender, invocation_receiver) = oak::io::channel_create::<grpc::Invocation>()
+    let (invocation_sender, invocation_receiver) = oak::io::channel_create::<grpc::Invocation>(&Label::public_untrusted())
         .expect("Couldn't create gRPC invocation channel");
     let init_message = create_init_message(&invocation_receiver, &grpc_client.invocation_sender);
     init_sender.send(&init_message).expect("Couldn't send the initialization message to Aggregator Node");

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -85,8 +85,8 @@ impl oak::CommandHandler<oak::grpc::Invocation> for Router {
                 // Check if there is a channel to a room with the desired label already, or create
                 // it if not.
                 let channel = self.rooms.entry(label.clone()).or_insert_with(|| {
-                    let (wh, rh) = oak::io::channel_create_with_label(&label)
-                        .expect("could not create channel");
+                    let (wh, rh) =
+                        oak::io::channel_create(&label).expect("could not create channel");
                     oak::node_create_with_label(
                         &oak::node_config::wasm("app", "room"),
                         &label,

--- a/examples/injection/module/rust/src/lib.rs
+++ b/examples/injection/module/rust/src/lib.rs
@@ -69,7 +69,7 @@ use oak::{
     grpc,
     io::{ReceiverExt, SenderExt},
 };
-use oak_abi::proto::oak::application::ConfigMap;
+use oak_abi::{label::Label, proto::oak::application::ConfigMap};
 use oak_io::{Receiver, Sender};
 use proto::{
     blob_request::Request, BlobRequest, BlobResponse, BlobStore, BlobStoreDispatcher,
@@ -79,8 +79,8 @@ use proto::{
 
 oak::entrypoint!(grpc_fe<ConfigMap> => |_receiver| {
     oak::logger::init_default();
-    let (to_provider_write_handle, to_provider_read_handle) = oak::channel_create().unwrap();
-    let (from_provider_write_handle, from_provider_read_handle) = oak::channel_create().unwrap();
+    let (to_provider_write_handle, to_provider_read_handle) = oak::channel_create(&Label::public_untrusted()).unwrap();
+    let (from_provider_write_handle, from_provider_read_handle) = oak::channel_create(&Label::public_untrusted()).unwrap();
 
     oak::node_create(&oak::node_config::wasm("app", "provider"), to_provider_read_handle)
         .expect("Failed to create provider");
@@ -218,9 +218,9 @@ impl oak::CommandHandler<BlobStoreRequest> for BlobStoreProvider {
     fn handle_command(&mut self, _command: BlobStoreRequest) -> anyhow::Result<()> {
         // Create new BlobStore
         let (to_store_write_handle, to_store_read_handle) =
-            oak::channel_create().context("Could not create channel")?;
+            oak::channel_create(&Label::public_untrusted()).context("Could not create channel")?;
         let (from_store_write_handle, from_store_read_handle) =
-            oak::channel_create().context("Could not create channel")?;
+            oak::channel_create(&Label::public_untrusted()).context("Could not create channel")?;
         oak::node_create(
             &oak::node_config::wasm("app", "store"),
             to_store_read_handle,

--- a/sdk/rust/oak/src/grpc/client.rs
+++ b/sdk/rust/oak/src/grpc/client.rs
@@ -40,7 +40,7 @@ impl Client {
     /// The provided [`Label`] specifies the label for the newly created Node and Channel.
     pub fn new_with_label(config: &NodeConfiguration, label: &Label) -> Option<Client> {
         let (invocation_sender, invocation_receiver) =
-            crate::io::channel_create_with_label(label).expect("failed to create channel");
+            crate::io::channel_create(label).expect("failed to create channel");
         let status = crate::node_create_with_label(config, label, invocation_receiver.handle);
         invocation_receiver
             .close()

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     OakError, OakStatus,
 };
 use log::{error, warn};
+use oak_abi::label::Label;
 use oak_services::proto::google::rpc;
 pub use oak_services::proto::{
     google::rpc::*,
@@ -235,7 +236,8 @@ where
 {
     // Create a new channel for request message delivery.
     let (req_sender, req_receiver) =
-        crate::io::channel_create::<GrpcRequest>().expect("failed to create channel");
+        crate::io::channel_create::<GrpcRequest>(&Label::public_untrusted())
+            .expect("failed to create channel");
 
     // Put the request in a GrpcRequest wrapper and send it into the request
     // message channel.
@@ -246,7 +248,8 @@ where
 
     // Create a new channel for responses to arrive on.
     let (rsp_sender, rsp_receiver) =
-        crate::io::channel_create::<GrpcResponse>().expect("failed to create channel");
+        crate::io::channel_create::<GrpcResponse>(&Label::public_untrusted())
+            .expect("failed to create channel");
 
     // Build an Invocation holding the two channels and send it down the
     // specified channel.

--- a/sdk/rust/oak/src/io/mod.rs
+++ b/sdk/rust/oak/src/io/mod.rs
@@ -28,15 +28,10 @@ pub use receiver::ReceiverExt;
 pub use sender::SenderExt;
 
 /// Create a new channel for transmission of `Encodable` and `Decodable` types.
-pub fn channel_create<T: Encodable + Decodable>() -> Result<(Sender<T>, Receiver<T>), OakStatus> {
-    let (wh, rh) = crate::channel_create()?;
-    Ok((Sender::<T>::new(wh), Receiver::<T>::new(rh)))
-}
-
-pub fn channel_create_with_label<T: Encodable + Decodable>(
+pub fn channel_create<T: Encodable + Decodable>(
     label: &Label,
 ) -> Result<(Sender<T>, Receiver<T>), OakStatus> {
-    let (wh, rh) = crate::channel_create_with_label(label)?;
+    let (wh, rh) = crate::channel_create(label)?;
     Ok((Sender::<T>::new(wh), Receiver::<T>::new(rh)))
 }
 

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -224,12 +224,6 @@ pub fn channel_write(half: WriteHandle, buf: &[u8], handles: &[Handle]) -> Resul
     result_from_status(status as i32, ())
 }
 
-/// Similar to [`channel_create_with_label`], but with a fixed label corresponding to "public
-/// untrusted".
-pub fn channel_create() -> Result<(WriteHandle, ReadHandle), OakStatus> {
-    channel_create_with_label(&Label::public_untrusted())
-}
-
 /// Create a new unidirectional channel.
 ///
 /// The provided label must be equal or more restrictive than the label of the calling node, i.e.
@@ -237,7 +231,7 @@ pub fn channel_create() -> Result<(WriteHandle, ReadHandle), OakStatus> {
 ///
 /// On success, returns [`WriteHandle`] and a [`ReadHandle`] values for the
 /// write and read halves (respectively).
-pub fn channel_create_with_label(label: &Label) -> Result<(WriteHandle, ReadHandle), OakStatus> {
+pub fn channel_create(label: &Label) -> Result<(WriteHandle, ReadHandle), OakStatus> {
     let mut write = WriteHandle {
         handle: crate::handle::invalid(),
     };

--- a/sdk/rust/oak/src/logger/mod.rs
+++ b/sdk/rust/oak/src/logger/mod.rs
@@ -23,6 +23,7 @@
 
 use crate::io::SenderExt;
 use log::{Level, Log, Metadata, Record, SetLoggerError};
+use oak_abi::label::Label;
 
 struct OakChannelLogger {
     channel: crate::io::Sender<oak_services::proto::oak::log::LogMessage>,
@@ -83,7 +84,8 @@ pub fn init_default() {
 /// An error is returned if a logger has already been set.
 pub fn init(level: Level) -> Result<(), SetLoggerError> {
     // Create a channel and pass the read half to a fresh logging Node.
-    let (write_handle, read_handle) = crate::channel_create().expect("could not create channel");
+    let (write_handle, read_handle) =
+        crate::channel_create(&Label::public_untrusted()).expect("could not create channel");
     crate::node_create(&crate::node_config::log(), read_handle).expect("could not create node");
     crate::channel_close(read_handle.handle).expect("could not close channel");
 


### PR DESCRIPTION
This is a preparatory change for #1615.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [x] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
