### PR TITLE
Make label mandatory on `oak::node_create`

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -490,12 +490,8 @@ to the room:
                 let channel = self.rooms.entry(label.clone()).or_insert_with(|| {
                     let (wh, rh) =
                         oak::io::channel_create(&label).expect("could not create channel");
-                    oak::node_create_with_label(
-                        &oak::node_config::wasm("app", "room"),
-                        &label,
-                        rh.handle,
-                    )
-                    .expect("could not create node");
+                    oak::node_create(&oak::node_config::wasm("app", "room"), &label, rh.handle)
+                        .expect("could not create node");
                     rh.close().expect("could not close channel");
                     wh
                 });

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -211,7 +211,7 @@ oak::entrypoint!(oak_main<ConfigMap> => |receiver: Receiver<ConfigMap>| {
     // Create an Aggregator Node.
     let (init_sender, init_receiver) = oak::io::channel_create::<AggregatorInit>(&Label::public_untrusted())
         .expect("Couldn't create initialization channel");
-    oak::node_create(&oak::node_config::wasm("app", "aggregator"), init_receiver.handle)
+    oak::node_create(&oak::node_config::wasm("app", "aggregator"), &Label::public_untrusted(), init_receiver.handle)
         .expect("Couldn't create gRPC worker node");
     oak::channel_close(init_receiver.handle.handle).expect("Couldn't close receiver channel");
 

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -87,12 +87,8 @@ impl oak::CommandHandler<oak::grpc::Invocation> for Router {
                 let channel = self.rooms.entry(label.clone()).or_insert_with(|| {
                     let (wh, rh) =
                         oak::io::channel_create(&label).expect("could not create channel");
-                    oak::node_create_with_label(
-                        &oak::node_config::wasm("app", "room"),
-                        &label,
-                        rh.handle,
-                    )
-                    .expect("could not create node");
+                    oak::node_create(&oak::node_config::wasm("app", "room"), &label, rh.handle)
+                        .expect("could not create node");
                     rh.close().expect("could not close channel");
                     wh
                 });

--- a/examples/injection/module/rust/src/lib.rs
+++ b/examples/injection/module/rust/src/lib.rs
@@ -82,7 +82,7 @@ oak::entrypoint!(grpc_fe<ConfigMap> => |_receiver| {
     let (to_provider_write_handle, to_provider_read_handle) = oak::channel_create(&Label::public_untrusted()).unwrap();
     let (from_provider_write_handle, from_provider_read_handle) = oak::channel_create(&Label::public_untrusted()).unwrap();
 
-    oak::node_create(&oak::node_config::wasm("app", "provider"), to_provider_read_handle)
+    oak::node_create(&oak::node_config::wasm("app", "provider"), &Label::public_untrusted(), to_provider_read_handle)
         .expect("Failed to create provider");
     oak::channel_close(to_provider_read_handle.handle).expect("Failed to close channel");
 
@@ -223,6 +223,7 @@ impl oak::CommandHandler<BlobStoreRequest> for BlobStoreProvider {
             oak::channel_create(&Label::public_untrusted()).context("Could not create channel")?;
         oak::node_create(
             &oak::node_config::wasm("app", "store"),
+            &Label::public_untrusted(),
             to_store_read_handle,
         )?;
         oak::channel_close(to_store_read_handle.handle).context("Could not close channel")?;

--- a/examples/trusted_database/module/rust/src/lib.rs
+++ b/examples/trusted_database/module/rust/src/lib.rs
@@ -82,6 +82,7 @@ impl CommandHandler<grpc::Invocation> for TrustedDatabaseNode {
         // TODO(#1406): Use client assigned label for creating a new handler Node.
         oak::node_create(
             &oak::node_config::wasm("app", "handler_oak_main"),
+            &Label::public_untrusted(),
             receiver.handle,
         )
         .context("Couldn't create handler Node")?;

--- a/sdk/rust/oak/src/grpc/client.rs
+++ b/sdk/rust/oak/src/grpc/client.rs
@@ -41,7 +41,7 @@ impl Client {
     pub fn new_with_label(config: &NodeConfiguration, label: &Label) -> Option<Client> {
         let (invocation_sender, invocation_receiver) =
             crate::io::channel_create(label).expect("failed to create channel");
-        let status = crate::node_create_with_label(config, label, invocation_receiver.handle);
+        let status = crate::node_create(config, label, invocation_receiver.handle);
         invocation_receiver
             .close()
             .expect("failed to close channel");

--- a/sdk/rust/oak/src/grpc/server.rs
+++ b/sdk/rust/oak/src/grpc/server.rs
@@ -35,7 +35,7 @@ pub fn init(address: &str) -> Result<Receiver<Invocation>, OakStatus> {
         crate::io::channel_create::<GrpcInvocationSender>(&Label::public_untrusted())
             .expect("Couldn't create init channel to gRPC server pseudo-node");
     let config = crate::node_config::grpc_server(address);
-    crate::node_create(&config, init_receiver.handle)?;
+    crate::node_create(&config, &Label::public_untrusted(), init_receiver.handle)?;
     init_receiver
         .close()
         .expect("Couldn't close init channel to gRPC server pseudo-node");

--- a/sdk/rust/oak/src/http/mod.rs
+++ b/sdk/rust/oak/src/http/mod.rs
@@ -83,7 +83,7 @@ pub fn init(address: &str) -> Result<Receiver<Invocation>, OakStatus> {
     let (init_sender, init_receiver) =
         crate::io::channel_create::<HttpInvocationSender>(&Label::public_untrusted())
             .expect("Couldn't create init channel to HTTP server pseudo-node");
-    crate::node_create(&config, init_receiver.handle)?;
+    crate::node_create(&config, &Label::public_untrusted(), init_receiver.handle)?;
     init_receiver
         .close()
         .expect("Couldn't close init channel to HTTP server pseudo-node");

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -256,12 +256,6 @@ pub fn channel_close(handle: Handle) -> Result<(), OakStatus> {
     result_from_status(status as i32, ())
 }
 
-/// Similar to [`node_create_with_label`], but with a fixed label corresponding to "public
-/// untrusted".
-pub fn node_create(config: &NodeConfiguration, half: ReadHandle) -> Result<(), OakStatus> {
-    node_create_with_label(config, &Label::public_untrusted(), half)
-}
-
 /// Creates a new Node running the configuration identified by `config_name`, running the entrypoint
 /// identified by `entrypoint_name` (for a Web Assembly Node; this parameter is ignored when
 /// creating a pseudo-Node), with the provided `label`, and passing it the given handle.
@@ -270,7 +264,7 @@ pub fn node_create(config: &NodeConfiguration, half: ReadHandle) -> Result<(), O
 /// the label of the calling node must "flow to" the provided label.
 ///
 /// See https://github.com/project-oak/oak/blob/main/docs/concepts.md#labels
-pub fn node_create_with_label(
+pub fn node_create(
     config: &NodeConfiguration,
     label: &Label,
     half: ReadHandle,

--- a/sdk/rust/oak/src/logger/mod.rs
+++ b/sdk/rust/oak/src/logger/mod.rs
@@ -86,7 +86,12 @@ pub fn init(level: Level) -> Result<(), SetLoggerError> {
     // Create a channel and pass the read half to a fresh logging Node.
     let (write_handle, read_handle) =
         crate::channel_create(&Label::public_untrusted()).expect("could not create channel");
-    crate::node_create(&crate::node_config::log(), read_handle).expect("could not create node");
+    crate::node_create(
+        &crate::node_config::log(),
+        &Label::public_untrusted(),
+        read_handle,
+    )
+    .expect("could not create node");
     crate::channel_close(read_handle.handle).expect("could not close channel");
 
     log::set_boxed_logger(Box::new(OakChannelLogger {


### PR DESCRIPTION
This is a preparatory change for #1615.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [x] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
