### PR TITLE
Remove cargo-deny warnings for wildcard versions

### DIFF
--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -23,6 +23,7 @@ ignore = [
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # TODO(#1270): Remove when no longer needed by tonic, jsonwebtoken and rustls.
 [[bans.skip]]

--- a/experimental/deny.toml
+++ b/experimental/deny.toml
@@ -20,6 +20,7 @@ ignore = [
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_abi/deny.toml
+++ b/oak_abi/deny.toml
@@ -17,6 +17,7 @@ notice = "deny"
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_client/deny.toml
+++ b/oak_client/deny.toml
@@ -21,6 +21,7 @@ ignore = [
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_derive/deny.toml
+++ b/oak_derive/deny.toml
@@ -17,6 +17,7 @@ notice = "deny"
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_io/deny.toml
+++ b/oak_io/deny.toml
@@ -17,6 +17,7 @@ notice = "deny"
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_loader/deny.toml
+++ b/oak_loader/deny.toml
@@ -20,6 +20,7 @@ ignore = [
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # TODO(#1270): Remove when no longer needed by tonic, jsonwebtoken and rustls.
 [[bans.skip]]

--- a/oak_runtime/deny.toml
+++ b/oak_runtime/deny.toml
@@ -20,6 +20,7 @@ ignore = [
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # TODO(#1270): Remove when no longer needed by tonic, jsonwebtoken and rustls.
 [[bans.skip]]

--- a/oak_services/deny.toml
+++ b/oak_services/deny.toml
@@ -17,6 +17,7 @@ notice = "deny"
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_sign/deny.toml
+++ b/oak_sign/deny.toml
@@ -18,6 +18,7 @@ ignore = [
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # List of allowed licenses.
 # For more detailsinformation see http://go/thirdpartylicenses

--- a/oak_utils/deny.toml
+++ b/oak_utils/deny.toml
@@ -14,6 +14,7 @@ notice = "deny"
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # List of allowed licenses.
 # For more detailsinformation see http://go/thirdpartylicenses

--- a/runner/deny.toml
+++ b/runner/deny.toml
@@ -18,6 +18,7 @@ ignore = [
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/sdk/deny.toml
+++ b/sdk/deny.toml
@@ -23,6 +23,7 @@ ignore = [
 # Deny multiple versions unless explicitly skipped.
 [bans]
 multiple-versions = "deny"
+wildcards = "allow"
 
 # TODO(#1270): Remove when no longer needed by tonic and rustls.
 [[bans.skip]]


### PR DESCRIPTION
An updated version of cargo-deny has started warning about wildcard versions for rust crates. This update explicitly allows wildcards to remove these warnings.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
