### PR TITLE
Implement Decodable and Encodable for Either type

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1143,6 +1143,7 @@ dependencies = [
 name = "oak_io"
 version = "0.1.0"
 dependencies = [
+ "either",
  "oak_abi",
  "oak_derive",
  "oak_utils",

--- a/experimental/Cargo.lock
+++ b/experimental/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
 name = "oak_io"
 version = "0.1.0"
 dependencies = [
+ "either",
  "oak_abi",
  "oak_derive",
  "oak_utils",

--- a/oak_derive/Cargo.lock
+++ b/oak_derive/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
 name = "oak_io"
 version = "0.1.0"
 dependencies = [
+ "either",
  "oak_abi",
  "oak_derive",
  "oak_utils",

--- a/oak_io/Cargo.lock
+++ b/oak_io/Cargo.lock
@@ -7,6 +7,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
+name = "assert_matches"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
+
+[[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +135,8 @@ dependencies = [
 name = "oak_io"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
+ "either",
  "oak_abi",
  "oak_derive",
  "oak_utils",

--- a/oak_io/Cargo.toml
+++ b/oak_io/Cargo.toml
@@ -12,6 +12,10 @@ oak_abi = { path = "../oak_abi" }
 oak_derive = { path = "../oak_derive" }
 prost = "*"
 prost-types = "*"
+either = "*"
+
+[dev-dependencies]
+assert_matches = "*"
 
 [build-dependencies]
 oak_utils = { path = "../oak_utils" }

--- a/oak_io/src/lib.rs
+++ b/oak_io/src/lib.rs
@@ -24,10 +24,11 @@ mod receiver;
 mod sender;
 
 pub use decodable::Decodable;
+use either::Either;
 pub use encodable::Encodable;
 pub use error::OakError;
 use handle::{ReadHandle, WriteHandle};
-pub use oak_abi::Handle;
+pub use oak_abi::{Handle, OakStatus};
 pub use receiver::Receiver;
 pub use sender::Sender;
 
@@ -36,4 +37,117 @@ pub use sender::Sender;
 pub struct Message {
     pub bytes: Vec<u8>,
     pub handles: Vec<Handle>,
+}
+
+/// Implementation of [`Encodable`] for [`Either`] that encodes the variant (0 or 1) in the first
+/// byte of the resulting [`Message`].
+impl<L: Encodable, R: Encodable> Encodable for Either<L, R> {
+    fn encode(&self) -> Result<Message, OakError> {
+        let (variant, mut inner) = match self {
+            // Left variant == 0.
+            Either::Left(m) => (0, m.encode()?),
+            // Right variant == 1.
+            Either::Right(m) => (1, m.encode()?),
+        };
+        // Insert the variant byte as the beginning of the message bytes, and leave handles as they
+        // are.
+        inner.bytes.insert(0, variant);
+        Ok(inner)
+    }
+}
+
+/// Implementation of [`Decodable`] for [`Either`] that decodes the variant (0 or 1) from the first
+/// byte of the provided [`Message`].
+impl<L: Decodable, R: Decodable> Decodable for Either<L, R> {
+    fn decode(message: &Message) -> Result<Self, OakError> {
+        match message.bytes.get(0) {
+            // Left variant == 0.
+            Some(0) => {
+                let inner_message = Message {
+                    bytes: message.bytes[1..].to_vec(),
+                    handles: message.handles.clone(),
+                };
+                Ok(Either::Left(L::decode(&inner_message)?))
+            }
+            // Right variant == 1.
+            Some(1) => {
+                let inner_message = Message {
+                    bytes: message.bytes[1..].to_vec(),
+                    handles: message.handles.clone(),
+                };
+                Ok(Either::Right(R::decode(&inner_message)?))
+            }
+            // Invalid variant, or not enough bytes.
+            _ => Err(OakStatus::ErrInvalidArgs.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn either_round_trip() {
+        type T = Either<u32, u32>;
+
+        {
+            // This test case is just a baseline reference for the ones below, to spell out the
+            // protobuf encoding of the inner object.
+            let original = 1988;
+            let encoded = original.encode().unwrap();
+            assert_eq!(
+                Message {
+                    bytes: vec![8, 196, 15],
+                    handles: vec![]
+                },
+                encoded
+            );
+            let decoded = u32::decode(&encoded).unwrap();
+            assert_eq!(original, decoded);
+        }
+
+        {
+            let original = T::Left(1988);
+            let encoded = original.encode().unwrap();
+            // Note the first byte corresponds to the variant == 0.
+            assert_eq!(
+                Message {
+                    bytes: vec![0, 8, 196, 15],
+                    handles: vec![]
+                },
+                encoded
+            );
+            let decoded = T::decode(&encoded).unwrap();
+            assert_eq!(original, decoded);
+        }
+
+        {
+            let original = T::Right(1988);
+            let encoded = original.encode().unwrap();
+            // Note the first byte corresponds to the variant == 1.
+            assert_eq!(
+                Message {
+                    bytes: vec![1, 8, 196, 15],
+                    handles: vec![]
+                },
+                encoded
+            );
+            let decoded = T::decode(&encoded).unwrap();
+            assert_eq!(original, decoded);
+        }
+
+        {
+            let invalid_variant = 42;
+            let encoded_invalid = Message {
+                bytes: vec![invalid_variant, 8, 196, 15],
+                handles: vec![],
+            };
+            assert_matches!(
+                T::decode(&encoded_invalid),
+                Err(OakError::OakStatus(OakStatus::ErrInvalidArgs))
+            );
+        }
+    }
 }

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -710,6 +710,7 @@ dependencies = [
 name = "oak_io"
 version = "0.1.0"
 dependencies = [
+ "either",
  "oak_abi",
  "oak_derive",
  "oak_utils",

--- a/oak_runtime/Cargo.lock
+++ b/oak_runtime/Cargo.lock
@@ -716,6 +716,7 @@ dependencies = [
 name = "oak_io"
 version = "0.1.0"
 dependencies = [
+ "either",
  "oak_abi",
  "oak_derive",
  "oak_utils",

--- a/oak_services/Cargo.lock
+++ b/oak_services/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
 name = "oak_io"
 version = "0.1.0"
 dependencies = [
+ "either",
  "oak_abi",
  "oak_derive",
  "oak_utils",

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
 name = "oak_io"
 version = "0.1.0"
 dependencies = [
+ "either",
  "oak_abi",
  "oak_derive",
  "oak_utils",


### PR DESCRIPTION
The `Either` type comes from the https://docs.rs/either/1.6.1/either/
crate instead of being re-implemented from scratch, as that has useful
methods already defined on it, and it is pretty lightweight.

This may be used as foundation for more interesting patterns related to
multiplexing several message types on the same channel, e.g. init and
command messages.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
