### PR TITLE
Implement Iterator for Receiver

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -64,7 +64,7 @@ oak::entrypoint!(grpc_oak_main<ConfigMap> => |_receiver| {
     };
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_command_loop(node, grpc_channel);
+    oak::run_command_loop(node, grpc_channel.iter());
 });
 ```
 <!-- prettier-ignore-end -->
@@ -112,7 +112,7 @@ oak::entrypoint!(grpc_oak_main<ConfigMap> => |_receiver| {
     let dispatcher = TranslatorDispatcher::new(Node);
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_command_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel.iter());
 }
 ```
 <!-- prettier-ignore-end -->
@@ -144,7 +144,7 @@ pub extern "C" fn frontend_oak_main(_in_handle: u64) {
         let dispatcher = OakAbiTestServiceDispatcher::new(node);
         let grpc_channel =
             oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-        oak::run_command_loop(dispatcher, grpc_channel);
+        oak::run_command_loop(dispatcher, grpc_channel.iter());
     });
 }
 ```

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -25,7 +25,7 @@ use log::{debug, error, info, trace, warn};
 use oak::{
     grpc,
     handle::is_valid,
-    io::{ReceiverExt, SenderExt},
+    io::{Receiver, ReceiverExt, SenderExt},
     ChannelReadStatus, OakError, OakStatus,
 };
 use oak_abi::{
@@ -162,7 +162,7 @@ pub extern "C" fn frontend_oak_main(_in_handle: u64) {
         let dispatcher = OakAbiTestServiceDispatcher::new(node);
         let grpc_channel =
             oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-        oak::run_command_loop(dispatcher, grpc_channel);
+        oak::run_command_loop(dispatcher, grpc_channel.iter());
     });
 }
 
@@ -2411,12 +2411,13 @@ pub extern "C" fn channel_loser(_handle: u64) {
 #[no_mangle]
 pub extern "C" fn http_oak_main(http_channel: u64) {
     oak::logger::init_default();
-    let node = http_server::StaticHttpServer {};
+    let node = http_server::StaticHttpServer;
     oak::run_command_loop(
         node,
-        oak_io::handle::ReadHandle {
+        Receiver::new(oak_io::handle::ReadHandle {
             handle: http_channel,
-        },
+        })
+        .iter(),
     );
 }
 

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -174,7 +174,7 @@ oak::entrypoint!(aggregator<AggregatorInit> => |init_receiver: Receiver<Aggregat
         }
     );
     let dispatcher = AggregatorDispatcher::new(node);
-    oak::run_command_loop(dispatcher, grpc_server_invocation_receiver);
+    oak::run_command_loop(dispatcher, grpc_server_invocation_receiver.iter());
 });
 
 #[derive(Debug, serde::Deserialize)]

--- a/examples/hello_world/module/rust/src/lib.rs
+++ b/examples/hello_world/module/rust/src/lib.rs
@@ -19,7 +19,7 @@ pub mod proto {
 }
 
 use log::info;
-use oak::grpc;
+use oak::{grpc, io::ReceiverExt};
 use oak_abi::proto::oak::application::ConfigMap;
 use proto::{HelloRequest, HelloResponse, HelloWorld, HelloWorldDispatcher};
 
@@ -32,7 +32,7 @@ oak::entrypoint!(oak_main<ConfigMap> => |_receiver| {
     let dispatcher = HelloWorldDispatcher::new(node);
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_command_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel.iter());
 });
 
 struct Node {

--- a/examples/http_server/module/src/lib.rs
+++ b/examples/http_server/module/src/lib.rs
@@ -17,7 +17,7 @@
 //! Simple example starting an Oak Application serving a static page over HTTP.
 
 use log::{info, warn};
-use oak::{http::Invocation, CommandHandler, OakError, OakStatus};
+use oak::{http::Invocation, io::ReceiverExt, CommandHandler, OakError, OakStatus};
 use oak_abi::proto::oak::application::ConfigMap;
 
 oak::entrypoint!(oak_main<ConfigMap> => |_receiver| {
@@ -27,7 +27,7 @@ oak::entrypoint!(oak_main<ConfigMap> => |_receiver| {
     let http_channel =
         oak::http::init("[::]:8080").expect("Could not create HTTP server pseudo-Node!");
 
-    oak::run_command_loop(node, http_channel);
+    oak::run_command_loop(node, http_channel.iter());
 });
 
 /// A simple HTTP server that responds with `OK` (200) to every request sent to `/`, and with

--- a/examples/injection/module/rust/src/lib.rs
+++ b/examples/injection/module/rust/src/lib.rs
@@ -98,7 +98,7 @@ oak::entrypoint!(grpc_fe<ConfigMap> => |_receiver| {
     let grpc_channel = oak::grpc::server::init("[::]:8080")
         .expect("could not create gRPC server pseudo-Node");
 
-    oak::run_command_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel.iter());
 });
 
 oak::entrypoint!(provider<BlobStoreRequest> => |receiver: Receiver<BlobStoreRequest>| {
@@ -112,7 +112,7 @@ oak::entrypoint!(provider<BlobStoreRequest> => |receiver: Receiver<BlobStoreRequ
             .expect("Did not receive a decodable message")
             .sender
             .expect("No sender in received message");
-    oak::run_command_loop(BlobStoreProvider::new(frontend_sender), receiver);
+    oak::run_command_loop(BlobStoreProvider::new(frontend_sender), receiver.iter());
 });
 
 oak::entrypoint!(store<BlobRequest> => |receiver: Receiver<BlobRequest>| {
@@ -126,7 +126,7 @@ oak::entrypoint!(store<BlobRequest> => |receiver: Receiver<BlobRequest>| {
             .expect("Did not receive a write handle")
             .sender
             .expect("No write handle in received message");
-    oak::run_command_loop(BlobStoreImpl::new(sender), receiver);
+    oak::run_command_loop(BlobStoreImpl::new(sender), receiver.iter());
 });
 
 enum BlobStoreAccess {

--- a/examples/private_set_intersection/module/rust/src/lib.rs
+++ b/examples/private_set_intersection/module/rust/src/lib.rs
@@ -38,7 +38,7 @@ pub mod proto {
     ));
 }
 
-use oak::grpc;
+use oak::{grpc, io::ReceiverExt};
 use oak_abi::proto::oak::application::ConfigMap;
 use proto::{
     GetIntersectionRequest, GetIntersectionResponse, PrivateSetIntersection,
@@ -50,7 +50,7 @@ oak::entrypoint!(oak_main<ConfigMap> => |_receiver| {
     let dispatcher = PrivateSetIntersectionDispatcher::new(Node::default());
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_command_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel.iter());
 });
 
 /// Maximum number of contributed private sets.

--- a/examples/running_average/module/rust/src/lib.rs
+++ b/examples/running_average/module/rust/src/lib.rs
@@ -26,7 +26,7 @@ pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/oak.examples.running_average.rs"));
 }
 
-use oak::grpc;
+use oak::{grpc, io::ReceiverExt};
 use oak_abi::proto::oak::application::ConfigMap;
 use proto::{GetAverageResponse, RunningAverage, RunningAverageDispatcher, SubmitSampleRequest};
 
@@ -34,7 +34,7 @@ oak::entrypoint!(oak_main<ConfigMap> => |_receiver| {
     let dispatcher = RunningAverageDispatcher::new(Node::default());
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-    oak::run_command_loop(dispatcher, grpc_channel);
+    oak::run_command_loop(dispatcher, grpc_channel.iter());
 });
 
 #[derive(Default)]

--- a/examples/trusted_database/module/rust/src/handler.rs
+++ b/examples/trusted_database/module/rust/src/handler.rs
@@ -149,5 +149,5 @@ oak::entrypoint!(handler_oak_main<TrustedDatabaseCommand> => |command_receiver: 
     let dispatcher = TrustedDatabaseDispatcher::new(node);
     let invocation_receiver = receiver.receiver.expect("Empty gRPC invocation receiver");
     // The event loop only runs once because the `Main` Node sends a single invocation.
-    oak::run_command_loop(dispatcher, invocation_receiver);
+    oak::run_command_loop(dispatcher, invocation_receiver.iter());
 });

--- a/examples/trusted_database/module/rust/src/lib.rs
+++ b/examples/trusted_database/module/rust/src/lib.rs
@@ -127,5 +127,5 @@ oak::entrypoint!(oak_main<ConfigMap> => |receiver: Receiver<ConfigMap>| {
     let points_of_interest = load_database(config_map).expect("Couldn't load database");
     let grpc_channel =
         oak::grpc::server::init("[::]:8080").expect("Couldn't create gRPC server pseudo-Node");
-    oak::run_command_loop(TrustedDatabaseNode { points_of_interest }, grpc_channel);
+    oak::run_command_loop(TrustedDatabaseNode { points_of_interest }, grpc_channel.iter());
 });


### PR DESCRIPTION
The logic is mostly refactored from the `run_command_loop` function,
which is now much simpler and allows passing in arbitrary iterator over
messages. This in turn will allow processing the incoming stream of
messages in a functional way, e.g. when combined with #1637.

Fixes #1593

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
