### PR TITLE
Use Either pattern to initialize aggregator node

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -73,6 +73,7 @@ dependencies = [
  "aggregator_common",
  "aggregator_grpc",
  "assert_matches",
+ "either",
  "env_logger",
  "itertools",
  "log",

--- a/examples/aggregator/module/rust/Cargo.toml
+++ b/examples/aggregator/module/rust/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aggregator_common = { path = "../../common" }
+either = "*"
 itertools = "*"
 log = "*"
 oak = "=0.1.0"

--- a/examples/aggregator/proto/aggregator_init.proto
+++ b/examples/aggregator/proto/aggregator_init.proto
@@ -23,9 +23,7 @@ import "oak_services/proto/grpc_invocation.proto";
 
 // Initialization message that should be sent to Aggregator Oak Node.
 message AggregatorInit {
-  // Channel for receiving invocations from gRPC server.
-  oak.invocation.GrpcInvocationReceiver grpc_server_invocation_receiver = 1;
   // Channel for sending invocations to gRPC client that is connected to an external service, which
   // expects aggregated data from Oak.
-  oak.invocation.GrpcInvocationSender grpc_client_invocation_sender = 2;
+  oak.invocation.GrpcInvocationSender grpc_client_invocation_sender = 1;
 }


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
