### PR TITLE
Move `name` out of node configuration proto

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -237,11 +237,13 @@ If creating the specified Node would violate
 [information flow control](/docs/concepts.md#labels), returns
 `ERR_PERMISSION_DENIED`.
 
-- `param[0]: usize`: Source buffer holding serialized `NodeConfiguration`
-- `param[1]: usize`: Serialized NodeConfiguration size in bytes
-- `param[2]: usize`: Source buffer holding serialized `Label`
-- `param[3]: usize`: Label size in bytes
-- `param[4]: usize`: Handle to channel
+- `param[0]: usize`: Source buffer holding the UTF-8 encoded name
+- `param[1]: usize`: Name size in bytes
+- `param[2]: usize`: Source buffer holding serialized `NodeConfiguration`
+- `param[3]: usize`: Serialized NodeConfiguration size in bytes
+- `param[4]: usize`: Source buffer holding serialized `Label`
+- `param[5]: usize`: Label size in bytes
+- `param[6]: usize`: Handle to channel
 - `result[0]: u32`: Status of operation
 
 ### `node_label_read`

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -490,8 +490,13 @@ to the room:
                 let channel = self.rooms.entry(label.clone()).or_insert_with(|| {
                     let (wh, rh) = oak::io::channel_create("Room init", &label)
                         .expect("could not create channel");
-                    oak::node_create(&oak::node_config::wasm("app", "room"), &label, rh.handle)
-                        .expect("could not create node");
+                    oak::node_create(
+                        "room",
+                        &oak::node_config::wasm("app", "room"),
+                        &label,
+                        rh.handle,
+                    )
+                    .expect("could not create node");
                     rh.close().expect("could not close channel");
                     wh
                 });

--- a/examples/aggregator/client/cpp/aggregator.cc
+++ b/examples/aggregator/client/cpp/aggregator.cc
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
   // The particular value corresponds to the hash on the `aggregator.wasm` line in
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("9a75540f69287bc579f896416030de0e06ba915aa93279384859fa25c7a384ce"));
+      absl::HexStringToBytes("05493131b2041ee7fbbcb41758133b420862c57374d318454646f51014afa838"));
   // Connect to the Oak Application.
   auto stub = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -214,6 +214,7 @@ oak::entrypoint!(oak_main<ConfigMap> => |receiver: Receiver<ConfigMap>| {
     )
     .expect("Couldn't create channel to aggregator node");
     oak::node_create(
+        "aggregator",
         &oak::node_config::wasm("app", "aggregator"),
         &Label::public_untrusted(),
         aggregator_receiver.handle,
@@ -236,9 +237,12 @@ oak::entrypoint!(oak_main<ConfigMap> => |receiver: Receiver<ConfigMap>| {
     //     }],
     //     integrity_tags: vec![],
     // };
-    let grpc_client =
-        oak::grpc::client::Client::new(&oak::node_config::grpc_client("https://localhost:8888"))
-            .expect("Couldn't create gRPC client");
+    let grpc_client = oak::grpc::client::Client::new(
+        "grpc_client",
+        &oak::node_config::grpc_client("https://localhost:8888"),
+        &Label::public_untrusted(),
+    )
+    .expect("Couldn't create gRPC client");
 
     // Send the initialization message to Aggregator Node containing a gRPC server invocation
     // receiver and a gRPC client invocation sender.

--- a/examples/aggregator/oak_app_manifest.toml
+++ b/examples/aggregator/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "aggregator"
 
 [modules]
-app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/9a75540f69287bc579f896416030de0e06ba915aa93279384859fa25c7a384ce", sha256 = "9a75540f69287bc579f896416030de0e06ba915aa93279384859fa25c7a384ce" } }
+app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/05493131b2041ee7fbbcb41758133b420862c57374d318454646f51014afa838", sha256 = "05493131b2041ee7fbbcb41758133b420862c57374d318454646f51014afa838" } }

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -87,8 +87,13 @@ impl oak::CommandHandler<oak::grpc::Invocation> for Router {
                 let channel = self.rooms.entry(label.clone()).or_insert_with(|| {
                     let (wh, rh) = oak::io::channel_create("Room init", &label)
                         .expect("could not create channel");
-                    oak::node_create(&oak::node_config::wasm("app", "room"), &label, rh.handle)
-                        .expect("could not create node");
+                    oak::node_create(
+                        "room",
+                        &oak::node_config::wasm("app", "room"),
+                        &label,
+                        rh.handle,
+                    )
+                    .expect("could not create node");
                     rh.close().expect("could not close channel");
                     wh
                 });

--- a/examples/hello_world/module/rust/src/lib.rs
+++ b/examples/hello_world/module/rust/src/lib.rs
@@ -20,14 +20,18 @@ pub mod proto {
 
 use log::info;
 use oak::{grpc, io::ReceiverExt};
-use oak_abi::proto::oak::application::ConfigMap;
+use oak_abi::{label::Label, proto::oak::application::ConfigMap};
 use proto::{HelloRequest, HelloResponse, HelloWorld, HelloWorldDispatcher};
 
 oak::entrypoint!(oak_main<ConfigMap> => |_receiver| {
     oak::logger::init_default();
     let node = Node {
-        translator: grpc::client::Client::new(&oak::node_config::wasm("translator", "oak_main"))
-            .map(translator_common::TranslatorClient),
+        translator: grpc::client::Client::new(
+            "translator",
+            &oak::node_config::wasm("translator", "oak_main"),
+            &Label::public_untrusted()
+        )
+        .map(translator_common::TranslatorClient),
     };
     let dispatcher = HelloWorldDispatcher::new(node);
     let grpc_channel =

--- a/examples/injection/module/rust/src/lib.rs
+++ b/examples/injection/module/rust/src/lib.rs
@@ -82,7 +82,7 @@ oak::entrypoint!(grpc_fe<ConfigMap> => |_receiver| {
     let (to_provider_write_handle, to_provider_read_handle) = oak::channel_create("To-provider", &Label::public_untrusted()).unwrap();
     let (from_provider_write_handle, from_provider_read_handle) = oak::channel_create("From-provider", &Label::public_untrusted()).unwrap();
 
-    oak::node_create(&oak::node_config::wasm("app", "provider"), &Label::public_untrusted(), to_provider_read_handle)
+    oak::node_create("provider", &oak::node_config::wasm("app", "provider"), &Label::public_untrusted(), to_provider_read_handle)
         .expect("Failed to create provider");
     oak::channel_close(to_provider_read_handle.handle).expect("Failed to close channel");
 
@@ -224,6 +224,7 @@ impl oak::CommandHandler<BlobStoreRequest> for BlobStoreProvider {
             oak::channel_create("From-store", &Label::public_untrusted())
                 .context("Could not create channel")?;
         oak::node_create(
+            "store",
             &oak::node_config::wasm("app", "store"),
             &Label::public_untrusted(),
             to_store_read_handle,

--- a/examples/private_set_intersection/oak_app_manifest.toml
+++ b/examples/private_set_intersection/oak_app_manifest.toml
@@ -2,4 +2,4 @@ name = "private_set_intersection"
 
 [modules]
 # TODO(865): Use locally built module once reproducibility is fixed.
-app = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection/21963350a129dd79db7952b2e5ea9b1ef31e855becac22d6a980efede61da06f", sha256 = "21963350a129dd79db7952b2e5ea9b1ef31e855becac22d6a980efede61da06f" } }
+app = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection/46b9c8e07fbe70fb42dfc74ad304526efb3cdf1cb2f526ae77a865ebecc41e1d", sha256 = "46b9c8e07fbe70fb42dfc74ad304526efb3cdf1cb2f526ae77a865ebecc41e1d" } }

--- a/examples/private_set_intersection/private_set_intersection.sign
+++ b/examples/private_set_intersection/private_set_intersection.sign
@@ -3,10 +3,10 @@ f41SClNtR4i46v2Tuh1fQLbt/ZqRr1lENajCW92jyP4=
 -----END PUBLIC KEY-----
 
 -----BEGIN SIGNATURE-----
-6pSC4WodR+brN9OkhSX/mudNriLNzPvzftAP4MO0rybe9YxPDRC/vbBSB2ewAIjo
-+UR86oYG657laC3bGX0tCw==
+BeHuxNezvy4x0MUJ1quk01EJghz6K2wMwS4DGW1V08wyQZ4hYYhHTqSP2Ea+JD1H
+yD7AGkfUM9MMexAEist5Aw==
 -----END SIGNATURE-----
 
 -----BEGIN HASH-----
-IZYzUKEp3XnbeVKy5eqbHvMehVvsrCLWqYDv7eYdoG8=
+RrnI4H++cPtC38dK0wRSbvs83xyy9Saud6hl6+zEHh0=
 -----END HASH-----

--- a/examples/trusted_database/module/rust/src/lib.rs
+++ b/examples/trusted_database/module/rust/src/lib.rs
@@ -83,6 +83,7 @@ impl CommandHandler<grpc::Invocation> for TrustedDatabaseNode {
         .context("Couldn't create command channel")?;
         // TODO(#1406): Use client assigned label for creating a new handler Node.
         oak::node_create(
+            "handler",
             &oak::node_config::wasm("app", "handler_oak_main"),
             &Label::public_untrusted(),
             receiver.handle,

--- a/experimental/web/index.html
+++ b/experimental/web/index.html
@@ -166,6 +166,8 @@
                     return status;
                   },
                   node_create: (
+                    nameBuf,
+                    nameSize,
                     configBuf,
                     configLen,
                     labelBuf,
@@ -173,6 +175,9 @@
                     handle
                   ) => {
                     const status = OakStatus.values.OK;
+                    const name = new TextDecoder().decode(
+                      this.readMemory(nameBuf, nameSize)
+                    );
                     const config = NodeConfiguration.decode(
                       this.readMemory(configBuf, configLen)
                     );
@@ -180,12 +185,15 @@
                       this.readMemory(labelBuf, labelSize)
                     );
                     const entry = `${new Date().toISOString()}: node_create(${[
+                      nameBuf,
+                      nameSize,
                       configBuf,
                       configLen,
                       labelBuf,
                       labelSize,
                       handle,
                     ].join(', ')}) -> ${status}
+      name: ${JSON.stringify(name)}
       config: ${JSON.stringify(config)}
       label: ${JSON.stringify(label)}`;
                     this.trace.push(entry);

--- a/oak/module/oak_abi.h
+++ b/oak/module/oak_abi.h
@@ -63,8 +63,9 @@ WASM_IMPORT("oak")
 oak_abi::OakStatus node_privilege_read(uint8_t* label_buf, size_t label_size,
                                        uint32_t* actual_size);
 WASM_IMPORT("oak")
-oak_abi::OakStatus node_create(uint8_t* config_buf, size_t config_size, uint8_t* label_buf,
-                               size_t label_size, oak_abi::Handle handle);
+oak_abi::OakStatus node_create(uint8_t* name_buf, size_t name_size, uint8_t* config_buf,
+                               size_t config_size, uint8_t* label_buf, size_t label_size,
+                               oak_abi::Handle handle);
 WASM_IMPORT("oak")
 oak_abi::OakStatus random_get(uint8_t* buf, size_t buf_size);
 

--- a/oak/module/oak_main.h
+++ b/oak/module/oak_main.h
@@ -45,18 +45,15 @@ WASM_EXPORT void oak_main(oak_abi::Handle _handle) {
 
   // Create a gRPC server pseudo-Node
   // Manually create an encapsulated NodeConfiguration protobuf and send it back.
-  //    0a                     b00001.010 = tag 1 (NodeConfiguration.name), length-delimited field
-  //    0b                     length=11
-  //      677270635f736572     "grpc_server"
-  //    2a                     b00101.010 = tag 5 (NodeConfiguration.grpc_server_config)
+  //    22                     b00100.010 = tag 4 (NodeConfiguration.grpc_server_config)
   //    0b                     length=11
   //      0a                   b00001.010 = tag 1 (GrpcServerConfiguration.address)
   //      09                   length=9
   //        5b3a3a5d3a38303830 "[::]:8080"
-  char node_config[] =
-      "\x0a\x0b\x67\x72\x70\x63\x5f\x73\x65\x72\x76\x65\x72\x2a\x0b\x0a\x09\x5b\x3a\x3a\x5d\x3a\x38"
-      "\x30\x38\x30";
-  result = node_create((uint8_t*)node_config, sizeof(node_config) - 1, nullptr, 0, read_handle);
+  char node_name[] = "grpc_server";
+  char node_config[] = "\x22\x0b\x0a\x09\x5b\x3a\x3a\x5d\x3a\x38\x30\x38\x30";
+  result = node_create((uint8_t*)node_name, sizeof(node_name) - 1, (uint8_t*)node_config,
+                       sizeof(node_config) - 1, nullptr, 0, read_handle);
   if (result != oak_abi::OakStatus::OK) {
     return;
   }

--- a/oak_abi/proto/application.proto
+++ b/oak_abi/proto/application.proto
@@ -52,19 +52,14 @@ message ApplicationConfiguration {
 
 // NodeConfiguration indicates the configuration of a created Node.
 message NodeConfiguration {
-  // Display name of the newly created node instance, for debugging purposes.
-  //
-  // Does not need to be unique.
-  string name = 1;
-
   oneof config_type {
-    WebAssemblyConfiguration wasm_config = 2;
-    LogConfiguration log_config = 3;
-    StorageProxyConfiguration storage_config = 4;
-    GrpcServerConfiguration grpc_server_config = 5;
-    GrpcClientConfiguration grpc_client_config = 6;
-    RoughtimeClientConfiguration roughtime_client_config = 7;
-    HttpServerConfiguration http_server_config = 8;
+    WebAssemblyConfiguration wasm_config = 1;
+    LogConfiguration log_config = 2;
+    StorageProxyConfiguration storage_config = 3;
+    GrpcServerConfiguration grpc_server_config = 4;
+    GrpcClientConfiguration grpc_client_config = 5;
+    RoughtimeClientConfiguration roughtime_client_config = 6;
+    HttpServerConfiguration http_server_config = 7;
   }
 }
 

--- a/oak_abi/src/lib.rs
+++ b/oak_abi/src/lib.rs
@@ -213,6 +213,10 @@ extern "C" {
 
     /// Creates a new Node instance running code identified by a serialized [`NodeConfiguration`].
     ///
+    /// The name of the new node is provided in the memory area given by `name_buf` and `name_len`.
+    /// The name does not have to be unique and can be empty. It is used in logs to help identify
+    /// nodes for debugging purposes.
+    ///
     /// The serialized configuration object is provided in the memory area given by `config_buf` and
     /// `config_len`.
     ///
@@ -224,6 +228,8 @@ extern "C" {
     /// [`OakStatus`]: crate::OakStatus
     /// [`NodeConfiguration`]: crate::proto::oak::application::NodeConfiguration
     pub fn node_create(
+        name_buf: *const u8,
+        name_len: usize,
         config_buf: *const u8,
         config_len: usize,
         label_buf: *const u8,

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -1176,9 +1176,9 @@ impl Runtime {
         node_info.node_stopper = Some(node_stopper);
     }
 
-    /// Create a Node within the [`Runtime`] corresponding to a given module name and
-    /// entrypoint. The channel identified by `initial_handle` is installed in the new
-    /// Node's handle table and the new handle value is passed to the newly created Node.
+    /// Create a Node within the [`Runtime`] with the specified name and based on the provided
+    /// configuration. The channel identified by `initial_handle` is installed in the new Node's
+    /// handle table and the new handle value is passed to the newly created Node.
     ///
     /// The caller also specifies a [`Label`], which is assigned to the newly created Node. See
     /// <https://github.com/project-oak/oak/blob/main/docs/concepts.md#labels> for more
@@ -1190,18 +1190,19 @@ impl Runtime {
     fn node_create_and_register(
         self: Arc<Self>,
         node_id: NodeId,
+        name: &str,
         config: &NodeConfiguration,
         label: &Label,
         initial_handle: oak_abi::Handle,
     ) -> Result<(), OakStatus> {
         // This only creates a Node instance, but does not start it.
-        let instance = self.node_factory.create_node(config).map_err(|err| {
+        let instance = self.node_factory.create_node(name, config).map_err(|err| {
             warn!("could not create node: {:?}", err);
             OakStatus::ErrInvalidArgs
         })?;
 
         // Register the instance within the `Runtime`.
-        self.node_register(node_id, instance, &config.name, label, initial_handle)
+        self.node_register(node_id, instance, name, label, initial_handle)
     }
 
     /// Registers the given [`Node`] instance within the [`Runtime`]. The registration fails if the

--- a/oak_runtime/src/node/http/tests.rs
+++ b/oak_runtime/src/node/http/tests.rs
@@ -190,14 +190,18 @@ fn create_runtime() -> RuntimeProxy {
 fn create_server_node(runtime: &RuntimeProxy, port: u32) -> oak_abi::Handle {
     let (init_receiver, invocation_receiver) = create_communication_channel(runtime);
     let server_config = NodeConfiguration {
-        name: "test_server".to_string(),
         config_type: Some(ConfigType::HttpServerConfig(HttpServerConfiguration {
             address: format!("[::]:{}", port),
         })),
     };
 
     runtime
-        .node_create(&server_config, &Label::public_untrusted(), init_receiver)
+        .node_create(
+            "test_server",
+            &server_config,
+            &Label::public_untrusted(),
+            init_receiver,
+        )
         .expect("Could not create HTTP server node!");
 
     invocation_receiver

--- a/oak_runtime/src/node/mod.rs
+++ b/oak_runtime/src/node/mod.rs
@@ -102,9 +102,9 @@ pub struct ServerNodeFactory {
 impl NodeFactory<NodeConfiguration> for ServerNodeFactory {
     fn create_node(
         &self,
+        node_name: &str,
         node_configuration: &NodeConfiguration,
     ) -> Result<Box<dyn Node>, ConfigurationError> {
-        let node_name = &node_configuration.name;
         match &node_configuration.config_type {
             Some(ConfigType::LogConfig(LogConfiguration {})) => {
                 Ok(Box::new(logger::LogNode::new(node_name)))
@@ -175,6 +175,11 @@ impl NodeFactory<NodeConfiguration> for ServerNodeFactory {
 /// A trait implemented by a concrete factory of nodes that creates nodes based on a Node
 /// configuration of type `T`.
 pub trait NodeFactory<T> {
-    /// Creates a new [`Node`] instance based on the provided Node configuration information.
-    fn create_node(&self, node_configuration: &T) -> Result<Box<dyn Node>, ConfigurationError>;
+    /// Creates a new [`Node`] instance with the specified name and based on the provided Node
+    /// configuration information.
+    fn create_node(
+        &self,
+        node_name: &str,
+        node_configuration: &T,
+    ) -> Result<Box<dyn Node>, ConfigurationError>;
 }

--- a/oak_runtime/src/node/wasm/tests.rs
+++ b/oak_runtime/src/node/wasm/tests.rs
@@ -60,8 +60,8 @@ fn start_node(
     let (_write_handle, read_handle) = proxy.channel_create("", &Label::public_untrusted())?;
 
     let result = proxy.node_create(
+        "test",
         &NodeConfiguration {
-            name: "test".to_string(),
             config_type: Some(ConfigType::WasmConfig(WebAssemblyConfiguration {
                 wasm_module_name: module_name.to_string(),
                 wasm_entrypoint_name: entrypoint_name.to_string(),

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -149,6 +149,7 @@ impl RuntimeProxy {
         );
 
         self.node_create(
+            "Initial",
             &node_configuration,
             // When first starting, we assign the least privileged label to the entry point Node.
             &Label::public_untrusted(),
@@ -168,20 +169,25 @@ impl RuntimeProxy {
     /// See [`Runtime::node_create_and_register`].
     pub fn node_create(
         &self,
+        name: &str,
         config: &NodeConfiguration,
         label: &Label,
         initial_handle: oak_abi::Handle,
     ) -> Result<(), OakStatus> {
-        debug!("{:?}: node_create({:?}, {:?})", self.node_id, config, label);
+        debug!(
+            "{:?}: node_create({:?}, {:?}, {:?})",
+            self.node_id, name, config, label
+        );
         let result = self.runtime.clone().node_create_and_register(
             self.node_id,
+            name,
             config,
             label,
             initial_handle,
         );
         debug!(
-            "{:?}: node_create({:?}, {:?}) -> {:?}",
-            self.node_id, config, label, result
+            "{:?}: node_create({:?}, {:?}, {:?}) -> {:?}",
+            self.node_id, name, config, label, result
         );
         result
     }

--- a/oak_runtime/src/tests.rs
+++ b/oak_runtime/src/tests.rs
@@ -398,10 +398,10 @@ fn create_node_same_label_ok() {
         Box::new(move |runtime| {
             let (_write_handle, read_handle) = runtime.channel_create("", &label_clone)?;
             let node_configuration = NodeConfiguration {
-                name: "test".to_string(),
                 config_type: Some(ConfigType::LogConfig(LogConfiguration {})),
             };
-            let result = runtime.node_create(&node_configuration, &label_clone, read_handle);
+            let result =
+                runtime.node_create("test", &node_configuration, &label_clone, read_handle);
             assert_eq!(Ok(()), result);
             Ok(())
         }),
@@ -419,11 +419,9 @@ fn create_node_invalid_configuration_err() {
         Box::new(move |runtime| {
             let (_write_handle, read_handle) = runtime.channel_create("", &label_clone)?;
             // Node configuration without config type.
-            let node_configuration = NodeConfiguration {
-                name: "test".to_string(),
-                config_type: None,
-            };
-            let result = runtime.node_create(&node_configuration, &label_clone, read_handle);
+            let node_configuration = NodeConfiguration { config_type: None };
+            let result =
+                runtime.node_create("test", &node_configuration, &label_clone, read_handle);
             assert_eq!(Err(OakStatus::ErrInvalidArgs), result);
             Ok(())
         }),
@@ -453,11 +451,14 @@ fn create_node_less_confidential_label_err() {
         Box::new(move |runtime| {
             let (_write_handle, read_handle) = runtime.channel_create("", &initial_label_clone)?;
             let node_configuration = NodeConfiguration {
-                name: "test".to_string(),
                 config_type: Some(ConfigType::LogConfig(LogConfiguration {})),
             };
-            let result =
-                runtime.node_create(&node_configuration, &less_confidential_label, read_handle);
+            let result = runtime.node_create(
+                "test",
+                &node_configuration,
+                &less_confidential_label,
+                read_handle,
+            );
             assert_eq!(Err(OakStatus::ErrPermissionDenied), result);
             Ok(())
         }),
@@ -484,11 +485,14 @@ fn create_node_more_confidential_label_ok() {
         Box::new(move |runtime| {
             let (_write_handle, read_handle) = runtime.channel_create("", &initial_label_clone)?;
             let node_configuration = NodeConfiguration {
-                name: "test".to_string(),
                 config_type: Some(ConfigType::LogConfig(LogConfiguration {})),
             };
-            let result =
-                runtime.node_create(&node_configuration, &more_confidential_label, read_handle);
+            let result = runtime.node_create(
+                "test",
+                &node_configuration,
+                &more_confidential_label,
+                read_handle,
+            );
             assert_eq!(Ok(()), result);
             Ok(())
         }),

--- a/oak_runtime/tests/integration_test.rs
+++ b/oak_runtime/tests/integration_test.rs
@@ -53,7 +53,6 @@ mod common {
                 "module".to_string() => binary,
             },
             initial_node_configuration: Some(NodeConfiguration {
-                name: "test".to_string(),
                 config_type: Some(ConfigType::WasmConfig(WebAssemblyConfiguration {
                     wasm_module_name: "module".to_string(),
                     wasm_entrypoint_name: "oak_main".to_string(),

--- a/sdk/rust/oak/src/grpc/client.rs
+++ b/sdk/rust/oak/src/grpc/client.rs
@@ -24,24 +24,17 @@ pub struct Client {
 }
 
 impl Client {
-    /// Similar to [`Client::new_with_label`] but with a fixed label corresponding to "public
-    /// untrusted".
-    pub fn new(config: &NodeConfiguration) -> Option<Client> {
-        Client::new_with_label(config, &Label::public_untrusted())
-    }
-
     /// Creates a new Node that implements a gRPC service, and if successful return a Client.
     ///
-    /// The config name specifies the Node configuration that provides the service; the
-    /// entrypoint name is required if this specifies another WebAssembly Oak Node, but is
-    /// ignored if the Node configuration is for a gRPC client pseudo-Node (which acts as a
-    /// proxy for a remote non-Oak gRPC service).
+    /// The `node_name` is used for the newly create node.
+    ///
+    /// The `config` specifies the Node configuration that is used for creating the target node.
     ///
     /// The provided [`Label`] specifies the label for the newly created Node and Channel.
-    pub fn new_with_label(config: &NodeConfiguration, label: &Label) -> Option<Client> {
+    pub fn new(node_name: &str, config: &NodeConfiguration, label: &Label) -> Option<Client> {
         let (invocation_sender, invocation_receiver) =
             crate::io::channel_create("gRPC invocation", label).expect("failed to create channel");
-        let status = crate::node_create(config, label, invocation_receiver.handle);
+        let status = crate::node_create(node_name, config, label, invocation_receiver.handle);
         invocation_receiver
             .close()
             .expect("failed to close channel");

--- a/sdk/rust/oak/src/grpc/server.rs
+++ b/sdk/rust/oak/src/grpc/server.rs
@@ -35,7 +35,12 @@ pub fn init(address: &str) -> Result<Receiver<Invocation>, OakStatus> {
         crate::io::channel_create::<GrpcInvocationSender>("gRPC init", &Label::public_untrusted())
             .expect("Couldn't create init channel to gRPC server pseudo-node");
     let config = crate::node_config::grpc_server(address);
-    crate::node_create(&config, &Label::public_untrusted(), init_receiver.handle)?;
+    crate::node_create(
+        "grpc_server",
+        &config,
+        &Label::public_untrusted(),
+        init_receiver.handle,
+    )?;
     init_receiver
         .close()
         .expect("Couldn't close init channel to gRPC server pseudo-node");

--- a/sdk/rust/oak/src/http/mod.rs
+++ b/sdk/rust/oak/src/http/mod.rs
@@ -83,7 +83,12 @@ pub fn init(address: &str) -> Result<Receiver<Invocation>, OakStatus> {
     let (init_sender, init_receiver) =
         crate::io::channel_create::<HttpInvocationSender>("HTTP init", &Label::public_untrusted())
             .expect("Couldn't create init channel to HTTP server pseudo-node");
-    crate::node_create(&config, &Label::public_untrusted(), init_receiver.handle)?;
+    crate::node_create(
+        "http_server",
+        &config,
+        &Label::public_untrusted(),
+        init_receiver.handle,
+    )?;
     init_receiver
         .close()
         .expect("Couldn't close init channel to HTTP server pseudo-node");

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -267,10 +267,12 @@ pub fn channel_close(handle: Handle) -> Result<(), OakStatus> {
 ///
 /// See https://github.com/project-oak/oak/blob/main/docs/concepts.md#labels
 pub fn node_create(
+    name: &str,
     config: &NodeConfiguration,
     label: &Label,
     half: ReadHandle,
 ) -> Result<(), OakStatus> {
+    let name_bytes = name.as_bytes();
     let label_bytes = label.serialize();
     let mut config_bytes = Vec::new();
     config.encode(&mut config_bytes).map_err(|err| {
@@ -279,6 +281,8 @@ pub fn node_create(
     })?;
     let status = unsafe {
         oak_abi::node_create(
+            name_bytes.as_ptr(),
+            name_bytes.len(),
             config_bytes.as_ptr(),
             config_bytes.len(),
             label_bytes.as_ptr(),

--- a/sdk/rust/oak/src/logger/mod.rs
+++ b/sdk/rust/oak/src/logger/mod.rs
@@ -87,6 +87,7 @@ pub fn init(level: Level) -> Result<(), SetLoggerError> {
     let (write_handle, read_handle) = crate::channel_create("Logger", &Label::public_untrusted())
         .expect("could not create channel");
     crate::node_create(
+        "log",
         &crate::node_config::log(),
         &Label::public_untrusted(),
         read_handle,

--- a/sdk/rust/oak/src/node_config.rs
+++ b/sdk/rust/oak/src/node_config.rs
@@ -23,7 +23,6 @@ use oak_abi::proto::oak::application::{
 
 pub fn grpc_client(address: &str) -> NodeConfiguration {
     NodeConfiguration {
-        name: "grpc_client".to_string(),
         config_type: Some(ConfigType::GrpcClientConfig(GrpcClientConfiguration {
             uri: address.to_string(),
         })),
@@ -32,7 +31,6 @@ pub fn grpc_client(address: &str) -> NodeConfiguration {
 
 pub fn grpc_server(address: &str) -> NodeConfiguration {
     NodeConfiguration {
-        name: "grpc_server".to_string(),
         config_type: Some(ConfigType::GrpcServerConfig(GrpcServerConfiguration {
             address: address.to_string(),
         })),
@@ -41,7 +39,6 @@ pub fn grpc_server(address: &str) -> NodeConfiguration {
 
 pub fn http_server(address: &str) -> NodeConfiguration {
     NodeConfiguration {
-        name: "http_server".to_string(),
         config_type: Some(ConfigType::HttpServerConfig(HttpServerConfiguration {
             address: address.to_string(),
         })),
@@ -50,7 +47,6 @@ pub fn http_server(address: &str) -> NodeConfiguration {
 
 pub fn wasm(module_name: &str, entrypoint_name: &str) -> NodeConfiguration {
     NodeConfiguration {
-        name: format!("wasm.{}.{}", module_name, entrypoint_name),
         config_type: Some(ConfigType::WasmConfig(WebAssemblyConfiguration {
             wasm_module_name: module_name.to_string(),
             wasm_entrypoint_name: entrypoint_name.to_string(),
@@ -60,7 +56,6 @@ pub fn wasm(module_name: &str, entrypoint_name: &str) -> NodeConfiguration {
 
 pub fn log() -> NodeConfiguration {
     NodeConfiguration {
-        name: "log".to_string(),
         config_type: Some(ConfigType::LogConfig(LogConfiguration {})),
     }
 }

--- a/sdk/rust/oak/src/roughtime/mod.rs
+++ b/sdk/rust/oak/src/roughtime/mod.rs
@@ -20,8 +20,11 @@ use crate::{
     grpc,
     proto::oak::roughtime::{GetRoughtimeRequest, RoughtimeServiceClient},
 };
-use oak_abi::proto::oak::application::{
-    node_configuration::ConfigType, NodeConfiguration, RoughtimeClientConfiguration,
+use oak_abi::{
+    label::Label,
+    proto::oak::application::{
+        node_configuration::ConfigType, NodeConfiguration, RoughtimeClientConfiguration,
+    },
 };
 
 /// Local representation of the connection to an external Roughtime service.
@@ -33,12 +36,13 @@ impl Roughtime {
     /// Creates a [`Roughtime`] instance using the given configuration.
     pub fn new(config: &RoughtimeClientConfiguration) -> Option<Roughtime> {
         let config = NodeConfiguration {
-            name: "roughtime".to_string(),
             config_type: Some(ConfigType::RoughtimeClientConfig(config.clone())),
         };
-        crate::grpc::client::Client::new(&config).map(|client| Roughtime {
-            client: RoughtimeServiceClient(client),
-        })
+        crate::grpc::client::Client::new("roughtime", &config, &Label::public_untrusted()).map(
+            |client| Roughtime {
+                client: RoughtimeServiceClient(client),
+            },
+        )
     }
 
     /// Get the current Roughtime value as a Duration since UNIX epoch.

--- a/sdk/rust/oak/src/storage/mod.rs
+++ b/sdk/rust/oak/src/storage/mod.rs
@@ -23,8 +23,11 @@ use crate::{
         StorageItem, StorageServiceClient,
     },
 };
-use oak_abi::proto::oak::application::{
-    node_configuration::ConfigType, NodeConfiguration, StorageProxyConfiguration,
+use oak_abi::{
+    label::Label,
+    proto::oak::application::{
+        node_configuration::ConfigType, NodeConfiguration, StorageProxyConfiguration,
+    },
 };
 
 /// Local representation of the connection to an external storage service.
@@ -35,10 +38,13 @@ pub struct Storage {
 impl Storage {
     /// Creates a [`Storage`] instance using the given configuration.
     pub fn new(config: &StorageProxyConfiguration) -> Option<Storage> {
-        crate::grpc::client::Client::new(&NodeConfiguration {
-            name: "storage".to_string(),
-            config_type: Some(ConfigType::StorageConfig(config.clone())),
-        })
+        crate::grpc::client::Client::new(
+            "storage",
+            &NodeConfiguration {
+                config_type: Some(ConfigType::StorageConfig(config.clone())),
+            },
+            &Label::public_untrusted(),
+        )
         .map(|client| Storage {
             client: StorageServiceClient(client),
         })

--- a/sdk/rust/oak/src/stubs.rs
+++ b/sdk/rust/oak/src/stubs.rs
@@ -79,7 +79,15 @@ pub extern "C" fn channel_close(_handle: u64) -> u32 {
     panic!("stub function invoked!");
 }
 #[no_mangle]
-pub extern "C" fn node_create(_config_buf: *const u8, _config_len: usize, _handle: u64) -> u32 {
+pub extern "C" fn node_create(
+    _name_buf: *const u8,
+    _name_len: usize,
+    _config_buf: *const u8,
+    _config_len: usize,
+    _label_buf: *const u8,
+    _label_len: usize,
+    _handle: u64,
+) -> u32 {
     panic!("stub function invoked!");
 }
 #[no_mangle]

--- a/sdk/rust/oak_app_build/src/main.rs
+++ b/sdk/rust/oak_app_build/src/main.rs
@@ -230,7 +230,6 @@ async fn main() -> anyhow::Result<()> {
     let app_config = ApplicationConfiguration {
         wasm_modules: modules,
         initial_node_configuration: Some(NodeConfiguration {
-            name: manifest.name.clone(),
             config_type: Some(ConfigType::WasmConfig(WebAssemblyConfiguration {
                 wasm_module_name: manifest.initial_node_configuration.wasm_module_name,
                 wasm_entrypoint_name: manifest.initial_node_configuration.wasm_entrypoint_name,

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -176,7 +176,6 @@ pub fn runtime_config_wasm(
         app_config: ApplicationConfiguration {
             wasm_modules,
             initial_node_configuration: Some(NodeConfiguration {
-                name: "test".to_string(),
                 config_type: Some(ConfigType::WasmConfig(WebAssemblyConfiguration {
                     wasm_module_name: module_config_name.to_string(),
                     wasm_entrypoint_name: entrypoint_name.to_string(),


### PR DESCRIPTION
This change moves the name field out of `NodeConfiguration` and adds it as an explicit parameter to `node_create` for consistency with `channel_create`. This is a follow-up to #1632 and another step towards #1615.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [x] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
