### PR TITLE
Use challenge response for authentication

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -707,11 +707,13 @@ name = "https_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "env_logger",
  "hyper",
  "hyper-rustls",
  "log",
  "oak_abi",
+ "oak_sign",
  "prost",
  "rustls",
  "serde_json",

--- a/examples/abitest/client/cpp/BUILD
+++ b/examples/abitest/client/cpp/BUILD
@@ -66,6 +66,7 @@ cc_library(
     hdrs = ["httptest.h"],
     deps = [
         ":httplib_config",
+        "//oak/common:identity",
         "//oak/common:label",
         "@com_github_google_glog//:glog",
     ],

--- a/examples/abitest/client/cpp/httptest.h
+++ b/examples/abitest/client/cpp/httptest.h
@@ -25,7 +25,7 @@ typedef bool (*HttpTestFn)();
 extern const std::map<std::string, HttpTestFn> http_tests;
 
 bool test_https_with_json_label_ok();
-bool test_https_with_protobuf_label_ok();
+bool test_https_with_protobuf_label_and_identity_ok();
 bool test_https_without_label_err_bad_request();
 bool test_unsecure_http_err();
 

--- a/examples/http_server/client/rust/Cargo.toml
+++ b/examples/http_server/client/rust/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "*"
+base64 = "*"
 env_logger = "*"
 hyper = "*"
 hyper-rustls = { version = "*", default-features = false, features = [
@@ -14,6 +15,7 @@ hyper-rustls = { version = "*", default-features = false, features = [
 ] }
 log = "*"
 oak_abi = "=0.1.0"
+oak_sign = "*"
 prost = "*"
 rustls = "*"
 serde_json = "*"

--- a/oak/common/BUILD
+++ b/oak/common/BUILD
@@ -54,6 +54,16 @@ cc_library(
 )
 
 cc_library(
+    name = "identity",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//oak_abi/proto:identity_cc_proto",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
     name = "nonce_generator",
     srcs = [],
     hdrs = ["nonce_generator.h"],

--- a/oak_abi/build.rs
+++ b/oak_abi/build.rs
@@ -21,6 +21,7 @@ fn main() {
         &[
             "../oak_abi/proto/application.proto",
             "../oak_abi/proto/label.proto",
+            "../oak_abi/proto/identity.proto",
             "../oak_abi/proto/oak_abi.proto",
         ],
         &[".."],

--- a/oak_abi/proto/BUILD
+++ b/oak_abi/proto/BUILD
@@ -70,3 +70,17 @@ cc_grpc_library(
     well_known_protos = True,
     deps = [":application_cc_proto"],
 )
+
+proto_library(
+    name = "identity_proto",
+    srcs = ["identity.proto"],
+    deps = [
+        "@com_google_protobuf//:descriptor_proto",
+        "@com_google_protobuf//:empty_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "identity_cc_proto",
+    deps = [":identity_proto"],
+)

--- a/oak_abi/proto/identity.proto
+++ b/oak_abi/proto/identity.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 The Project Oak Authors
+// Copyright 2020 The Project Oak Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,18 +14,16 @@
 // limitations under the License.
 //
 
-pub mod oak {
-    include!(concat!(env!("OUT_DIR"), "/oak_abi.rs"));
+syntax = "proto3";
 
-    pub mod application {
-        include!(concat!(env!("OUT_DIR"), "/oak.application.rs"));
-    }
+package oak.identity;
 
-    pub mod label {
-        include!(concat!(env!("OUT_DIR"), "/oak.label.rs"));
-    }
+import "google/protobuf/empty.proto";
 
-    pub mod identity {
-        include!(concat!(env!("OUT_DIR"), "/oak.identity.rs"));
-    }
+// Response from the client to a signing challenge. The client uses its private key to sign the hash
+// of the challenge obtained from the server. The response contains the signed hash along with the
+// public key corresponding to the private key used for signing.
+message SignedChallenge {
+  bytes signed_hash = 1;
+  bytes public_key = 2;
 }

--- a/oak_abi/proto/label.proto
+++ b/oak_abi/proto/label.proto
@@ -43,7 +43,8 @@ message Tag {
     WebAssemblyModuleTag web_assembly_module_tag = 2;
     WebAssemblyModuleSignatureTag web_assembly_module_signature_tag = 3;
     TlsEndpointTag tls_endpoint_tag = 4;
-    Top top_tag = 5;
+    PublicKeyIdentityTag public_key_identity_tag = 5;
+    Top top_tag = 6;
   }
 }
 
@@ -82,6 +83,14 @@ message TlsEndpointTag {
   // The TLS authority (host:port) of the remote endpoint, which is validated by the Oak Runtime
   // using the set of Certificate Authorities (CA) that are available to it.
   string authority = 1;
+}
+
+// Policies related to identities, specified using a cryptographic public key.
+message PublicKeyIdentityTag {
+  // Public key counterpart of the private key that is used to sign an authentication challenge. 
+  // In the current implementation it is represented as a serialized Ed25519 public key.
+  // https://ed25519.cr.yp.to
+  bytes public_key = 1;
 }
 
 // Message representing top element of the principal lattice. It can be used as a confidentiality

--- a/oak_abi/src/label/mod.rs
+++ b/oak_abi/src/label/mod.rs
@@ -134,8 +134,19 @@ pub fn tls_endpoint_tag(authority: &str) -> Tag {
     }
 }
 
+/// Creates a [`Tag`] having as principal the provided identification Ed25519 public key.
+///
+/// See https://github.com/project-oak/oak/blob/main/oak_abi/proto/label.proto
+pub fn public_key_identity_tag(public_key: Vec<u8>) -> Tag {
+    Tag {
+        tag: Some(tag::Tag::PublicKeyIdentityTag(PublicKeyIdentityTag {
+            public_key,
+        })),
+    }
+}
+
 /// Convenience function for creating the top tag.
 pub fn top() -> Tag {
-    let tag = Some(crate::proto::oak::label::tag::Tag::TopTag(Top {}));
+    let tag = Some(tag::Tag::TopTag(Top {}));
     Tag { tag }
 }

--- a/oak_abi/src/lib.rs
+++ b/oak_abi/src/lib.rs
@@ -44,6 +44,15 @@ pub const OAK_LABEL_HTTP_JSON_KEY: &str = "oak-label";
 /// The header key used for protobuf encoded Labels in HTTP requests.
 pub const OAK_LABEL_HTTP_PROTOBUF_KEY: &str = "oak-label-bin";
 
+/// The header key used for JSON formatted signed authentication challenge.
+pub const OAK_SIGNED_CHALLENGE_JSON_KEY: &str = "oak-signed-auth-challenge";
+
+/// The header key used for protobuf formatted signed authentication challenge.
+pub const OAK_SIGNED_CHALLENGE_PROTOBUF_KEY: &str = "oak-signed-auth-challenge-bin";
+
+// TODO(#1357): Remove, or move to tests, when we have a per-connection challenge string.
+pub const OAK_CHALLENGE: &str = "oak-challenge";
+
 /// Handle used to identify read or write channel halves.
 ///
 /// These handles are used for all host function calls.

--- a/oak_runtime/src/node/http/mod.rs
+++ b/oak_runtime/src/node/http/mod.rs
@@ -20,7 +20,7 @@
 //! asynchronously.
 
 use crate::{
-    io::{ReceiverExt, SenderExt},
+    io::{ReceiverExt, Sender, SenderExt},
     node::{ConfigurationError, Node, NodePrivilege},
     proto::oak::invocation::{HttpInvocation, HttpInvocationSender},
     RuntimeProxy,
@@ -33,10 +33,14 @@ use hyper::{
     Body, Server, StatusCode,
 };
 use log::{debug, error, info, warn};
-use oak_abi::{label::Label, proto::oak::application::HttpServerConfiguration, OakStatus};
+use oak_abi::{
+    label::{confidentiality_label, public_key_identity_tag, Label},
+    proto::oak::application::HttpServerConfiguration,
+    OakStatus,
+};
 use oak_io::{
     handle::{ReadHandle, WriteHandle},
-    OakError, Receiver, Sender,
+    OakError, Receiver,
 };
 use oak_services::proto::oak::encap::{HeaderMap, HttpRequest, HttpResponse};
 use std::{io, net::SocketAddr, pin::Pin};
@@ -50,11 +54,22 @@ use futures_util::{
     future::TryFutureExt,
     stream::{StreamExt, TryStreamExt},
 };
+use oak_abi::proto::oak::identity::SignedChallenge;
 use prost::Message;
 use tokio_rustls::TlsAcceptor;
 
 #[cfg(test)]
 pub mod tests;
+
+// TODO(#1693): Use anyhow instead of HttpError.
+#[derive(Debug)]
+enum HttpError {
+    ChannelOperation(String),
+    HttpRequest(String),
+    HttpResponse(String),
+    IdentityVerification(String),
+    RequestLabel(String),
+}
 
 /// Checks that port is not reserved (i.e., is greater than 1023).
 fn check_port(address: &SocketAddr) -> Result<(), ConfigurationError> {
@@ -297,6 +312,17 @@ struct HttpRequestHandler {
 
 impl HttpRequestHandler {
     async fn handle(&self, req: Request<Body>) -> Result<Response<Body>, OakStatus> {
+        // Hyper requires an error type that implements [`std::error::Error`]. [`HttpError`] does
+        // not currently implement this trait. So, this wrapper is added to log and convert the
+        // error.
+        // TODO(#1693): Use anyhow instead of HttpError.
+        self.handle_request(req).await.map_err(|err| {
+            warn!("Error when handling the request: {:?}", err);
+            OakStatus::ErrInternal
+        })
+    }
+
+    async fn handle_request(&self, req: Request<Body>) -> Result<Response<Body>, HttpError> {
         let request = to_oak_http_request(req).await?;
         match get_oak_label(&request) {
             Ok(oak_label) => {
@@ -308,42 +334,65 @@ impl HttpRequestHandler {
 
                 debug!("Injecting the request into the Oak Node");
                 let response = self
-                    .inject_http_request(request, &oak_label)
+                    .inject_http_request(request, oak_label)
                     .map_err(|err| {
-                        warn!(
+                        HttpError::ChannelOperation(format!(
                             "Error when injecting the request into the Oak Node: {:?}",
                             err
-                        );
-                        OakStatus::ErrInternal
+                        ))
                     })?;
 
                 response.try_into_hyper_response()
             }
-            Err(OakStatus::ErrInvalidArgs) => http::response::Builder::new()
-                .status(StatusCode::BAD_REQUEST)
-                .body(Body::from("Invalid or missing Oak label."))
-                .map_err(|e| {
-                    warn!("Could not create response: {}", e);
-                    OakStatus::ErrInternal
-                }),
-            Err(_oak_status) => http::response::Builder::new()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::from("Internal server error."))
-                .map_err(|e| {
-                    warn!("Could not create response: {}", e);
-                    OakStatus::ErrInternal
-                }),
+            Err(HttpError::RequestLabel(msg)) => {
+                warn!("Invalid or missing Oak label: {}", msg);
+                http::response::Builder::new()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Body::from("Invalid or missing Oak label."))
+                    .map_err(|e| {
+                        HttpError::HttpResponse(format!("Could not create response: {}", e))
+                    })
+            }
+            Err(HttpError::IdentityVerification(msg)) => {
+                warn!("Could not verify user's identity: {}", msg);
+                http::response::Builder::new()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Body::from("Could not verify user's identity."))
+                    .map_err(|e| {
+                        HttpError::HttpResponse(format!("Could not create response: {}", e))
+                    })
+            }
+            Err(http_err) => {
+                warn!("Internal server error: {:?}", http_err);
+                http::response::Builder::new()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Body::from("Internal server error."))
+                    .map_err(|e| {
+                        HttpError::HttpResponse(format!("Could not create response: {}", e))
+                    })
+            }
         }
     }
 
+    /// Creates a pair of channels for interaction with the Oak node, and sends the request to the
+    /// Oak node. If the request is successfully handled, this function returns an
+    /// [`HttpResponseReceiver`] with a handle to the channel containing the response.
     fn inject_http_request(
         &self,
         request: HttpRequest,
-        label: &Label,
-    ) -> Result<HttpResponseIterator, ()> {
-        // Create a pair of temporary channels to pass the HTTP request and to receive the
-        // response.
-        let pipe = Pipe::new(&self.runtime.clone(), label)?;
+        request_label: Label,
+    ) -> Result<HttpResponseReceiver, HttpError> {
+        let user_identity = get_user_identity(&request)?;
+        let user_identity_label = if user_identity.is_empty() {
+            // If no identity is provided, return public-untrusted
+            Label::public_untrusted()
+        } else {
+            confidentiality_label(public_key_identity_tag(user_identity))
+        };
+
+        // Create a pair of temporary channels to pass the HTTP request to the Oak Node, and
+        // receive the response.
+        let pipe = Pipe::new(&self.runtime.clone(), &request_label, &user_identity_label)?;
 
         // Put the HTTP request message inside the per-invocation request channel.
         pipe.insert_message(&self.runtime, request)?;
@@ -354,14 +403,14 @@ impl HttpRequestHandler {
         // Close all local handles except for the one that allows reading responses.
         pipe.close(&self.runtime);
 
-        Ok(HttpResponseIterator {
+        Ok(HttpResponseReceiver {
             runtime: self.runtime.clone(),
             response_reader: pipe.response_reader,
         })
     }
 }
 
-/// A pair of temporary channels to pass the HTTP request and to receive the response.
+/// A pair of temporary channels to pass the HTTP request to the Oak Node and receive the response.
 struct Pipe {
     request_writer: oak_abi::Handle,
     request_reader: oak_abi::Handle,
@@ -370,19 +419,31 @@ struct Pipe {
 }
 
 impl Pipe {
-    fn new(runtime: &RuntimeProxy, label: &Label) -> Result<Self, ()> {
+    fn new(
+        runtime: &RuntimeProxy,
+        request_label: &Label,
+        user_identity_label: &Label,
+    ) -> Result<Self, HttpError> {
         // Create a channel for passing HTTP requests to the Oak node. This channel is created with
-        // the label specified by the caller. This will fail if the label has a non-empty
+        // the label specified by the caller. Without a `public_fully_trusted` label or a privilege
+        // that allows removing integrity tags, this will fail if the label has a non-empty
         // integrity component.
         let (request_writer, request_reader) = runtime
-            .channel_create("HTTP request", &label)
+            .channel_create("HTTP request", request_label)
             .map_err(|err| {
-                warn!("could not create HTTP request channel: {:?}", err);
+                HttpError::ChannelOperation(format!(
+                    "could not create HTTP request channel: {:?}",
+                    err
+                ))
             })?;
+
         let (response_writer, response_reader) = runtime
-            .channel_create("HTTP response", &Label::public_untrusted())
+            .channel_create("HTTP response", user_identity_label)
             .map_err(|err| {
-                warn!("could not create HTTP response channel: {:?}", err);
+                HttpError::ChannelOperation(format!(
+                    "could not create HTTP response channel: {:?}",
+                    err
+                ))
             })?;
 
         Ok(Pipe {
@@ -393,24 +454,30 @@ impl Pipe {
         })
     }
 
-    fn insert_message(&self, runtime: &RuntimeProxy, request: HttpRequest) -> Result<(), ()> {
+    /// Inserts the incoming HTTP request in the `request channel` part of the `HttpInvocation`.
+    fn insert_message(
+        &self,
+        runtime: &RuntimeProxy,
+        request: HttpRequest,
+    ) -> Result<(), HttpError> {
         // Put the HTTP request message inside the per-invocation request channel.
         let sender = crate::io::Sender::new(WriteHandle {
             handle: self.request_writer,
         });
         sender.send(request, runtime).map_err(|err| {
-            error!(
+            HttpError::ChannelOperation(format!(
                 "Couldn't write the request to the HTTP request channel: {:?}",
                 err
-            )
+            ))
         })
     }
 
+    /// Sends the `HttpInvocation` with request and response channels to the Oak Node.
     fn send_invocation(
         &self,
         runtime: &RuntimeProxy,
         invocation_channel: oak_abi::Handle,
-    ) -> Result<(), ()> {
+    ) -> Result<(), HttpError> {
         // Create an invocation containing request-specific channels.
         let invocation = HttpInvocation {
             receiver: Some(Receiver::new(ReadHandle {
@@ -426,11 +493,14 @@ impl Pipe {
         invocation_sender
             .send(invocation, runtime)
             .map_err(|error| {
-                error!("Couldn't write the invocation message: {:?}", error);
+                HttpError::ChannelOperation(format!(
+                    "Couldn't write the invocation message: {:?}",
+                    error
+                ))
             })
     }
 
-    // Close all local handles except for the one that allows reading responses.
+    /// Close all local handles except for the one that allows reading responses.
     fn close(&self, runtime: &RuntimeProxy) {
         if let Err(err) = runtime.channel_close(self.request_writer) {
             error!(
@@ -456,7 +526,7 @@ impl Pipe {
 /// HTTP requests can either provide JSON formatted labels or protobuf encoded labels. But exactly
 /// one of these should be provided. This method checks that exactly one label is provided in a
 /// header in the request and extracts it for use for further handling of the request.
-fn get_oak_label(req: &HttpRequest) -> Result<Label, OakStatus> {
+fn get_oak_label(req: &HttpRequest) -> Result<Label, HttpError> {
     let headers = (
         req.headers.as_ref().and_then(|map| {
             map.headers
@@ -473,48 +543,140 @@ fn get_oak_label(req: &HttpRequest) -> Result<Label, OakStatus> {
     match headers {
         (Some([json_label]), None) => parse_json_label(json_label),
         (None, Some([protobuf_label])) => parse_protobuf_label(protobuf_label),
-        _ => {
-            warn!(
-                "Exactly one header must be provided as an {} or {} header.",
-                oak_abi::OAK_LABEL_HTTP_JSON_KEY,
-                oak_abi::OAK_LABEL_HTTP_PROTOBUF_KEY
-            );
-            Err(OakStatus::ErrInvalidArgs)
-        }
+        _ => Err(HttpError::RequestLabel(format!(
+            "Exactly one request label must be provided via an {} or an {} header.",
+            oak_abi::OAK_LABEL_HTTP_JSON_KEY,
+            oak_abi::OAK_LABEL_HTTP_PROTOBUF_KEY
+        ))),
     }
 }
 
-fn parse_json_label(label_str: &[u8]) -> Result<Label, OakStatus> {
+/// Similar to the request label headers, signed challenge headers can either be JSON formatted or
+/// protobuf encoded. At most one of these formats should be provided. This method:
+///
+/// 1. parses the signed challenge, if one is provided
+/// 2. verifies that the signature is valid
+/// 3. if the signature is valid, returns the public key in the signed challenge as the user's
+/// identity.
+///
+/// Providing the user's identity in the HTTP request is optional, so if a challenge response is
+/// not provided, an empty vector is returned.
+fn get_user_identity(req: &HttpRequest) -> Result<Vec<u8>, HttpError> {
+    let headers = (
+        req.headers.as_ref().and_then(|map| {
+            map.headers
+                .get(oak_abi::OAK_SIGNED_CHALLENGE_JSON_KEY)
+                .map(|m| m.values.as_slice())
+        }),
+        req.headers.as_ref().and_then(|map| {
+            map.headers
+                .get(oak_abi::OAK_SIGNED_CHALLENGE_PROTOBUF_KEY)
+                .map(|m| m.values.as_slice())
+        }),
+    );
+
+    match headers {
+        (Some([json_signature]), None) => verify_json_challenge(json_signature),
+        (None, Some([protobuf_signature])) => verify_protobuf_challenge(protobuf_signature),
+        (None, None) => Ok(vec![]),
+        _ => Err(HttpError::IdentityVerification(format!(
+            "At most one signed-challenge must be provided via an {} or an {} header.",
+            oak_abi::OAK_SIGNED_CHALLENGE_JSON_KEY,
+            oak_abi::OAK_SIGNED_CHALLENGE_PROTOBUF_KEY
+        ))),
+    }
+}
+
+fn parse_json_label(label_str: &[u8]) -> Result<Label, HttpError> {
     let label_str = String::from_utf8(label_str.to_vec()).map_err(|err| {
-        warn!(
+        HttpError::RequestLabel(format!(
             "The label must be a valid UTF-8 JSON-formatted string: {}",
             err
-        );
-        OakStatus::ErrInvalidArgs
+        ))
     })?;
-    serde_json::from_str(&label_str).map_err(|err| {
-        warn!("Could not parse HTTP label: {}", err);
-        OakStatus::ErrInvalidArgs
-    })
+    serde_json::from_str(&label_str)
+        .map_err(|err| HttpError::RequestLabel(format!("Could not parse HTTP label: {}", err)))
 }
 
-fn parse_protobuf_label(base64_protobuf_label: &[u8]) -> Result<Label, OakStatus> {
+fn parse_protobuf_label(base64_protobuf_label: &[u8]) -> Result<Label, HttpError> {
     let protobuf_label = base64::decode(base64_protobuf_label).map_err(|err| {
-        warn!("Could not decode Base64 HTTP label: {}", err);
-        OakStatus::ErrInvalidArgs
+        HttpError::RequestLabel(format!("Could not decode Base64 HTTP label: {}", err))
     })?;
-    Label::decode(&protobuf_label[..]).map_err(|err| {
-        warn!("Could not parse HTTP label: {}", err);
-        OakStatus::ErrInvalidArgs
+    Label::decode(&protobuf_label[..])
+        .map_err(|err| HttpError::RequestLabel(format!("Could not parse HTTP label: {}", err)))
+}
+
+/// Checks that the input signature (containing the signed challenge and the corresponding public
+/// key) is valid. If the signature is valid, this function returns the public key, otherwise
+/// returns an [`HttpError`].
+fn verify_json_challenge(signature: &[u8]) -> Result<Vec<u8>, HttpError> {
+    let signature = parse_json_signed_challenge(signature.to_vec()).map_err(|err| {
+        HttpError::IdentityVerification(format!(
+            "Could not parse json formatted signed challenge: {:?}",
+            err
+        ))
+    })?;
+    verify_signed_challenge(signature)
+}
+
+/// Tries to parse the signed challenge retrieved from the HTTP request into an instance of
+/// [`SignedChallenge`]. If not successful, returns an [`HttpError`].
+fn parse_json_signed_challenge(bytes: Vec<u8>) -> Result<SignedChallenge, HttpError> {
+    let signature_str = String::from_utf8(bytes).map_err(|err| {
+        HttpError::IdentityVerification(format!("Could not parse signed challenge: {:?}", err))
+    })?;
+    serde_json::from_str(&signature_str).map_err(|err| {
+        HttpError::IdentityVerification(format!("Malformed signed challenge: {:?}", err))
     })
 }
 
-struct HttpResponseIterator {
+/// Checks that the input signature (containing the signed challenge and the corresponding public
+/// key) is valid. If the signature is valid, this function returns the public key, otherwise it
+/// returns an [`HttpError`].
+fn verify_protobuf_challenge(base64_signature: &[u8]) -> Result<Vec<u8>, HttpError> {
+    let signature_bytes = base64::decode(base64_signature).map_err(|err| {
+        HttpError::IdentityVerification(format!(
+            "Could not decode Base64 signed challenge: {}",
+            err
+        ))
+    })?;
+    let signature = SignedChallenge::decode(&signature_bytes[..]).map_err(|err| {
+        HttpError::IdentityVerification(format!(
+            "Could not parse protobuf encoded signed challenge: {}",
+            err
+        ))
+    })?;
+    verify_signed_challenge(signature)
+}
+
+/// Verifies the signed challenge retrieved from the HTTP request, and returns the public key if the
+/// signature is valid.
+fn verify_signed_challenge(
+    signature: oak_abi::proto::oak::identity::SignedChallenge,
+) -> Result<Vec<u8>, HttpError> {
+    let hash = oak_sign::get_sha256(oak_abi::OAK_CHALLENGE.as_bytes());
+
+    let sig_bundle = oak_sign::SignatureBundle {
+        public_key: signature.public_key.clone(),
+        signed_hash: signature.signed_hash,
+        hash,
+    };
+
+    match sig_bundle.verify() {
+        Ok(()) => Ok(signature.public_key),
+        Err(err) => Err(HttpError::IdentityVerification(format!(
+            "Could not verify the signature: {}.",
+            err
+        ))),
+    }
+}
+
+struct HttpResponseReceiver {
     runtime: RuntimeProxy,
     response_reader: oak_abi::Handle,
 }
 
-impl HttpResponseIterator {
+impl HttpResponseReceiver {
     fn read_response(&self) -> Result<HttpResponse, OakError> {
         let response_receiver = crate::io::Receiver::<HttpResponse>::new(ReadHandle {
             handle: self.response_reader,
@@ -522,7 +684,7 @@ impl HttpResponseIterator {
         response_receiver.receive(&self.runtime)
     }
 
-    fn try_into_hyper_response(&self) -> Result<Response<Body>, OakStatus> {
+    fn try_into_hyper_response(&self) -> Result<Response<Body>, HttpError> {
         info!(
             "Generating response for runtime {} and reader {:?}.",
             self.runtime.node_id.0, self.response_reader
@@ -535,8 +697,7 @@ impl HttpResponseIterator {
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(Body::empty())
                     .map_err(|err| {
-                        warn!("Could not build response: {}", err);
-                        OakStatus::ErrInternal
+                        HttpError::HttpResponse(format!("Could not create response: {}", err))
                     })
             }
         }
@@ -544,18 +705,17 @@ impl HttpResponseIterator {
 }
 
 /// Create an instance of Oak HttpRequest from the given hyper Request.
-async fn to_oak_http_request(req: Request<Body>) -> Result<HttpRequest, OakStatus> {
+async fn to_oak_http_request(req: Request<Body>) -> Result<HttpRequest, HttpError> {
     let uri = req.uri().to_string();
     let method = req.method().as_str().to_string();
     let headers = Some(HeaderMap::from(req.headers().to_owned()));
     let body = hyper::body::to_bytes(req.into_body())
         .await
         .map_err(|err| {
-            warn!(
+            HttpError::HttpRequest(format!(
                 "Error when reading request body from the connection: {}",
                 err
-            );
-            OakStatus::ErrInternal
+            ))
         })?
         .to_vec();
 
@@ -568,7 +728,7 @@ async fn to_oak_http_request(req: Request<Body>) -> Result<HttpRequest, OakStatu
 }
 
 /// Convert an instance of Oak HttpResponse to hyper Response.
-fn to_hyper_response(http_response: HttpResponse) -> Result<Response<Body>, OakStatus> {
+fn to_hyper_response(http_response: HttpResponse) -> Result<Response<Body>, HttpError> {
     let mut builder = http::response::Builder::new();
     if let Some(headers) = http_response.headers {
         let headers = headers.into_iter();
@@ -580,8 +740,5 @@ fn to_hyper_response(http_response: HttpResponse) -> Result<Response<Body>, OakS
     builder
         .status(http_response.status as u16)
         .body(Body::from(http_response.body))
-        .map_err(|err| {
-            warn!("Could not build response: {}", err);
-            OakStatus::ErrInternal
-        })
+        .map_err(|err| HttpError::HttpResponse(format!("Could not build response: {}", err)))
 }

--- a/oak_utils/src/lib.rs
+++ b/oak_utils/src/lib.rs
@@ -356,6 +356,13 @@ where
         prost_config.out_dir(out_dir);
     }
     prost_config
+        // We require identity-related types to be serializable and deserializable to and from JSON.
+        .type_attribute(
+            ".oak.identity",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(".oak.identity", "#[serde(rename_all = \"camelCase\")]");
+    prost_config
         // We require label-related types to be comparable and hashable so that they can be used in
         // hash-based collections.
         .type_attribute(".oak.label", "#[derive(Eq, Hash)]")


### PR DESCRIPTION
Similar to #1586, but instead of using an intermediate `UserNode` it relies on the `top` privilege of the `HttpServerNode` to set the user's identity in the response channel. Moreover, it omits setting the user's identity in the integrity component of the request label. 

Ref #1357, #1428