### PR TITLE
Implement planner + router + worker pattern

### DIFF
--- a/examples/chat/module/rust/tests/integration_test.rs
+++ b/examples/chat/module/rust/tests/integration_test.rs
@@ -26,8 +26,8 @@ const MODULE_WASM_FILE_NAME: &str = "chat.wasm";
 async fn test_chat() {
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let runtime = oak_tests::run_single_module(MODULE_WASM_FILE_NAME, "grpc_oak_main")
-        .expect("Unable to configure runtime with test wasm!");
+    let runtime = oak_tests::run_single_module(MODULE_WASM_FILE_NAME, "main")
+        .expect("could not configure runtime with test Wasm file");
 
     let room_0_key_pair = oak_sign::KeyPair::generate().expect("could not generate room key pair");
     let room_1_key_pair = oak_sign::KeyPair::generate().expect("could not generate room key pair");

--- a/examples/chat/oak_app_manifest.toml
+++ b/examples/chat/oak_app_manifest.toml
@@ -5,4 +5,4 @@ app = { path = "examples/chat/bin/chat.wasm" }
 
 [initial_node_configuration]
 wasm_module_name = "app"
-wasm_entrypoint_name = "grpc_oak_main"
+wasm_entrypoint_name = "main"


### PR DESCRIPTION
Introduce macro for setting up a Node with a CommandHandler instance.

Ref #1639

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
