### PR TITLE
Make command an associated type of CommandHandler

### DIFF
--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -37,7 +37,9 @@ oak::entrypoint_command_handler!(main => Main);
 /// This node is in charge of creating the other top-level nodes, but does not process any request.
 struct Main;
 
-impl oak::CommandHandler<ConfigMap> for Main {
+impl oak::CommandHandler for Main {
+    type Command = ConfigMap;
+
     fn handle_command(&mut self, _command: ConfigMap) -> anyhow::Result<()> {
         let grpc_channel =
             oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
@@ -88,7 +90,9 @@ fn is_valid_label(_label: &Label) -> bool {
     //     })
 }
 
-impl oak::CommandHandler<oak::grpc::Invocation> for Router {
+impl oak::CommandHandler for Router {
+    type Command = oak::grpc::Invocation;
+
     fn handle_command(&mut self, command: oak::grpc::Invocation) -> anyhow::Result<()> {
         // The router node has a public confidentiality label, and therefore cannot read the
         // contents of the request of the invocation (unless it happens to be public as well), but

--- a/examples/http_server/module/src/lib.rs
+++ b/examples/http_server/module/src/lib.rs
@@ -35,7 +35,8 @@ oak::entrypoint!(oak_main<ConfigMap> => |_receiver| {
 /// should be modified with care!
 pub struct StaticHttpServer;
 
-impl CommandHandler<Invocation> for StaticHttpServer {
+impl CommandHandler for StaticHttpServer {
+    type Command = Invocation;
     fn handle_command(&mut self, invocation: Invocation) -> anyhow::Result<()> {
         let request = invocation.receive()?;
 

--- a/examples/http_server/module/src/lib.rs
+++ b/examples/http_server/module/src/lib.rs
@@ -37,7 +37,7 @@ pub struct StaticHttpServer;
 
 impl CommandHandler for StaticHttpServer {
     type Command = Invocation;
-    
+
     fn handle_command(&mut self, invocation: Invocation) -> anyhow::Result<()> {
         let request = invocation.receive()?;
 

--- a/examples/http_server/module/src/lib.rs
+++ b/examples/http_server/module/src/lib.rs
@@ -37,6 +37,7 @@ pub struct StaticHttpServer;
 
 impl CommandHandler for StaticHttpServer {
     type Command = Invocation;
+    
     fn handle_command(&mut self, invocation: Invocation) -> anyhow::Result<()> {
         let request = invocation.receive()?;
 

--- a/examples/injection/module/rust/src/lib.rs
+++ b/examples/injection/module/rust/src/lib.rs
@@ -214,7 +214,9 @@ impl BlobStoreProvider {
     }
 }
 
-impl oak::CommandHandler<BlobStoreRequest> for BlobStoreProvider {
+impl oak::CommandHandler for BlobStoreProvider {
+    type Command = BlobStoreRequest;
+
     fn handle_command(&mut self, _command: BlobStoreRequest) -> anyhow::Result<()> {
         // Create new BlobStore
         let (to_store_write_handle, to_store_read_handle) =
@@ -296,7 +298,9 @@ fn blob_index(id: u64) -> usize {
     (id - 1) as usize
 }
 
-impl oak::CommandHandler<BlobRequest> for BlobStoreImpl {
+impl oak::CommandHandler for BlobStoreImpl {
+    type Command = BlobRequest;
+
     fn handle_command(&mut self, request: BlobRequest) -> anyhow::Result<()> {
         let response = match request.request {
             Some(Request::Get(req)) => self.get_blob(req),

--- a/examples/trusted_database/module/rust/src/lib.rs
+++ b/examples/trusted_database/module/rust/src/lib.rs
@@ -72,7 +72,9 @@ pub struct TrustedDatabaseNode {
     points_of_interest: PointOfInterestMap,
 }
 
-impl CommandHandler<grpc::Invocation> for TrustedDatabaseNode {
+impl CommandHandler for TrustedDatabaseNode {
+    type Command = grpc::Invocation;
+
     fn handle_command(&mut self, invocation: grpc::Invocation) -> anyhow::Result<()> {
         // Create a client request handler Node.
         debug!("Creating handler Node");

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -148,7 +148,8 @@ pub trait ServerNode {
     fn invoke(&mut self, method: &str, req: &[u8], writer: ChannelResponseWriter);
 }
 
-impl<T: ServerNode> crate::CommandHandler<Invocation> for T {
+impl<T: ServerNode> crate::CommandHandler for T {
+    type Command = Invocation;
     /// Handle incoming gRPC events for a [`ServerNode`].
     ///
     /// Invoking the given `node`'s [`invoke`] method for each incoming request that


### PR DESCRIPTION
This makes sense because there is only at most one implementation of
`CommandHandler` for each underlying type. Also allows cleaning up some
type bounds on a few methods.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
