### PR TITLE
Implement type safe wasm entrypoint

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -488,7 +488,7 @@ to the room:
 [embedmd]:# (../examples/chat/module/rust/src/lib.rs Rust /.*self\.rooms\.entry\(/ /\}\);$/)
 ```Rust
                 let channel = self.rooms.entry(label.clone()).or_insert_with(|| {
-                    oak::io::node_create("room", &label, &oak::node_config::wasm("app", "room"))
+                    oak::io::entrypoint_node_create::<ChatDispatcher<Room>>("room", &label, "app")
                         .expect("could not create node")
                 });
 ```

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -35,6 +35,7 @@ oak::entrypoint_command_handler!(main => Main);
 /// Main entrypoint of the chat application.
 ///
 /// This node is in charge of creating the other top-level nodes, but does not process any request.
+#[derive(Default)]
 struct Main;
 
 impl oak::CommandHandler for Main {
@@ -54,7 +55,7 @@ impl oak::CommandHandler for Main {
     }
 }
 
-oak::entrypoint_command_handler!(router => Router::default());
+oak::entrypoint_command_handler!(router => Router);
 
 /// A node that routes each incoming gRPC invocation to a per-room worker node (either pre-existing,
 /// or newly created) that can handle requests with the label of the incoming request.
@@ -113,7 +114,7 @@ impl oak::CommandHandler for Router {
                 // Check if there is a channel to a room with the desired label already, or create
                 // it if not.
                 let channel = self.rooms.entry(label.clone()).or_insert_with(|| {
-                    oak::io::node_create("room", &label, &oak::node_config::wasm("app", "room"))
+                    oak::io::entrypoint_node_create::<ChatDispatcher<Room>>("room", &label, "app")
                         .expect("could not create node")
                 });
                 // Send the invocation to the dedicated worker node.
@@ -127,7 +128,7 @@ impl oak::CommandHandler for Router {
     }
 }
 
-oak::entrypoint_command_handler!(room => ChatDispatcher::new(Room::default()));
+oak::entrypoint_command_handler!(room => ChatDispatcher<Room>);
 
 /// A worker node implementation for an individual label, corresponding to a chat room between the
 /// set of user that share the key to that chat room.

--- a/oak_utils/src/lib.rs
+++ b/oak_utils/src/lib.rs
@@ -135,6 +135,12 @@ impl prost_build::ServiceGenerator for OakServiceGenerator {
                 }
             }
 
+            impl <T: #service_name + Default> Default for #dispatcher_name<T> {
+                fn default() -> Self {
+                    Self::new(T::default())
+                }
+            }
+
             #[allow(clippy::unit_arg)]
             impl <T: #service_name> #oak_package::grpc::ServerNode for #dispatcher_name<T> {
                 fn invoke(&mut self, method: &str, req: &[u8], writer: #oak_package::grpc::ChannelResponseWriter) {

--- a/sdk/rust/oak/src/io/mod.rs
+++ b/sdk/rust/oak/src/io/mod.rs
@@ -49,6 +49,20 @@ pub fn node_create<T: Encodable + Decodable>(
     Ok(sender)
 }
 
+/// Creates a node and corresponding inbound channel of the same type, for nodes that are
+/// instantiated via the [`crate::entrypoint_command_handler`] macro.
+pub fn entrypoint_node_create<T: crate::WasmEntrypoint + crate::CommandHandler>(
+    name: &str,
+    label: &Label,
+    wasm_module_name: &str,
+) -> Result<Sender<T::Command>, OakStatus>
+where
+    T::Command: Encodable + Decodable,
+{
+    let node_config = &crate::node_config::wasm(wasm_module_name, T::ENTRYPOINT_NAME);
+    node_create(name, label, node_config)
+}
+
 /// Map a non-OK [`OakStatus`] value to the nearest available [`std::io::Error`].
 ///
 /// Panics if passed an `OakStatus::Ok` value.


### PR DESCRIPTION
This allows creating Wasm nodes in a type safe way, returning a channel
of the correct type for the particular node instance, as long as that
instance implements the corresponding traits.

Ref #1639

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
