### PR TITLE
Add `init_with_sender` method for HTTP and gRPC 

### DIFF
--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -41,15 +41,14 @@ impl oak::CommandHandler for Main {
     type Command = ConfigMap;
 
     fn handle_command(&mut self, _command: ConfigMap) -> anyhow::Result<()> {
-        let grpc_channel =
-            oak::grpc::server::init("[::]:8080").expect("could not create gRPC server pseudo-Node");
-        oak::node_create(
+        let router_sender = oak::io::node_create::<oak::grpc::Invocation>(
             "router",
-            &oak::node_config::wasm("app", "router"),
             &Label::public_untrusted(),
-            grpc_channel.handle,
+            &oak::node_config::wasm("app", "router"),
         )
         .expect("could not create router node");
+        oak::grpc::server::init_with_sender("[::]:8080", router_sender)
+            .expect("could not create gRPC server pseudo-Node");
         Ok(())
     }
 }


### PR DESCRIPTION
This allows creating a gRPC server node passing an existing channel to a
node that will receive invocations.

I expect that as we move towards a model in which the main node sets up
other nodes, but does not directly process requests, this new method
will be preferred instead of the existing one that also creates a local
channel from which to read invocations, since the main node would not
have any use for it.

Ref #1639
