### PR TITLE
Use type safe methods in http_server example

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -598,6 +598,7 @@ dependencies = [
 name = "hello_world"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "env_logger",
  "hello_world_grpc",

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -2541,9 +2541,9 @@ pub extern "C" fn channel_loser(_handle: u64) {
 #[no_mangle]
 pub extern "C" fn http_oak_main(http_channel: u64) {
     oak::logger::init_default();
-    let node = http_server::StaticHttpServer;
+    let handler = http_server::StaticHttpHandler;
     oak::run_command_loop(
-        node,
+        handler,
         Receiver::new(oak_io::handle::ReadHandle {
             handle: http_channel,
         })

--- a/examples/hello_world/module/rust/Cargo.toml
+++ b/examples/hello_world/module/rust/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+anyhow = "*"
 log = "*"
 oak = "=0.1.0"
 oak_abi = "=0.1.0"

--- a/examples/http_server/README.md
+++ b/examples/http_server/README.md
@@ -5,9 +5,9 @@ with "Hello from HTTP server!\n" to all requests.
 
 This Oak Application has an
 [HTTP server pseudo-node](/docs/concepts.md#pseudo-nodes) that connects to a
-`StaticHttpServer` that implements
+`StaticHttpHandler` that implements
 [Node](https://project-oak.github.io/oak/sdk/doc/oak/trait.Node.html).
-`StaticHttpServer` is the node serving HTTP requests.
+`StaticHttpHandler` is the main logic of the node serving HTTP requests.
 
 To run the example interactively:
 

--- a/examples/http_server/module/src/lib.rs
+++ b/examples/http_server/module/src/lib.rs
@@ -30,7 +30,7 @@ impl oak::CommandHandler for Main {
 
     fn handle_command(&mut self, _command: ConfigMap) -> anyhow::Result<()> {
         let http_handler_sender = oak::io::entrypoint_node_create::<StaticHttpHandler>(
-            "router",
+            "handler",
             &Label::public_untrusted(),
             "app",
         )


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
