### PR TITLE
Ignore older duplicate versions in deny.toml

### DIFF
--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -39,11 +39,11 @@ version = "=0.19.0"
 
 [[bans.skip]]
 name = "pin-project"
-version = "=1.0.1"
+version = "=0.4.23"
 
 [[bans.skip]]
 name = "pin-project-internal"
-version = "=1.0.1"
+version = "=0.4.23"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/experimental/deny.toml
+++ b/experimental/deny.toml
@@ -22,11 +22,11 @@ wildcards = "allow"
 
 [[bans.skip]]
 name = "pin-project"
-version = "=1.0.1"
+version = "=0.4.27"
 
 [[bans.skip]]
 name = "pin-project-internal"
-version = "=1.0.1"
+version = "=0.4.27"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_client/deny.toml
+++ b/oak_client/deny.toml
@@ -25,11 +25,11 @@ wildcards = "allow"
 
 [[bans.skip]]
 name = "pin-project"
-version = "=1.0.1"
+version = "=0.4.27"
 
 [[bans.skip]]
 name = "pin-project-internal"
-version = "=1.0.1"
+version = "=0.4.27"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_loader/deny.toml
+++ b/oak_loader/deny.toml
@@ -22,11 +22,11 @@ wildcards = "allow"
 
 [[bans.skip]]
 name = "pin-project"
-version = "=1.0.1"
+version = "=0.4.23"
 
 [[bans.skip]]
 name = "pin-project-internal"
-version = "=1.0.1"
+version = "=0.4.23"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_runtime/deny.toml
+++ b/oak_runtime/deny.toml
@@ -26,11 +26,11 @@ version = "=0.19.0"
 
 [[bans.skip]]
 name = "pin-project"
-version = "=1.0.1"
+version = "=0.4.23"
 
 [[bans.skip]]
 name = "pin-project-internal"
-version = "=1.0.1"
+version = "=0.4.23"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/sdk/deny.toml
+++ b/sdk/deny.toml
@@ -38,11 +38,11 @@ version = "=0.17.0"
 
 [[bans.skip]]
 name = "pin-project"
-version = "=1.0.1"
+version = "=0.4.22"
 
 [[bans.skip]]
 name = "pin-project-internal"
-version = "=1.0.1"
+version = "=0.4.22"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.


### PR DESCRIPTION
Ignoring the older version rather than the newer version should mean that cargo-deny should start warning when the old version is no longer used so that we can then clean it up.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
