### PR TITLE
Prove step_implies_lowproj_steps_leq

### DIFF
--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -16,6 +16,29 @@ Require Import Coq.Classes.RelationClasses.
 
 Local Open Scope map_scope.
 
+Section misc.
+Theorem can_split_node_index: forall s id n ell,
+    (nodes s).[? id] = {| obj := Some n; lbl := ell |} ->
+    (obj (nodes s).[? id] = Some n) /\
+    (lbl (nodes s).[? id] = ell).
+Proof.
+    intros. split; destruct ((nodes s).[? id]).
+    - unfold RuntimeModel.obj. inversion H. reflexivity.
+    - unfold RuntimeModel.lbl. inversion H. reflexivity.
+Qed.
+
+Theorem can_split_chan_index: forall s han ch ell,
+    (chans s).[? han] = {| obj := Some ch; lbl := ell|} ->
+    (obj (chans s).[? han] = Some ch) /\
+    (lbl (chans s).[? han] = ell).
+Proof.
+    intros. split; destruct ((chans s).[? han]).
+    - unfold RuntimeModel.obj. inversion H. reflexivity.
+    - unfold RuntimeModel.lbl. inversion H. reflexivity.
+Qed.
+
+End misc.
+
 Section low_projection.
 
 Theorem flows_labeled_proj {A: Type}: forall ell (x: @labeled A),
@@ -33,16 +56,6 @@ Proof.
     intros. destruct x. unfold low_proj. simpl in H.
     destruct (lbl <<? ell); eauto; try contradiction.
 Qed.
-
-Theorem proj_pres_handle_fresh: forall ell s,
-    handle_fresh (state_low_proj ell s) = handle_fresh s.
-Proof.
-Admitted.
-
-Theorem proj_pres_nid_fresh: forall ell s,
-    nid_fresh (state_low_proj ell s) = nid_fresh s.
-Proof.
-Admitted.
 
 Definition idempotent {A: Type} (f: A -> A) := forall a, f (f a) = f a.
 

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -141,6 +141,11 @@ Theorem state_nidx_to_proj_state_idx: forall ell s id n,
 Proof.
 Admitted.
 
+Theorem state_hidx_to_proj_state_hidx': forall ell s h,
+    (chans (state_low_proj ell s)).[? h] = (low_proj ell (chans s).[?h ]).
+Proof.
+Admitted.
+
 Theorem state_hidx_to_proj_state_hidx: forall ell s h ch,
     ((chans s).[? h] = ch) ->
     ((chans (state_low_proj ell s)).[? h] = (low_proj ell ch)).

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -277,6 +277,9 @@ Proof.
                 pose proof (can_split_node_index _ _ _ _ Hn_idx_s1proj);
                 logical_simplify.
                 apply_all_constructors; eauto. congruence.
+                erewrite state_hidx_to_proj_state_hidx'.
+                erewrite low_projection_preserves_lbl.
+                eauto.
                 (* low-equiv *)
                 subst_lets. eauto 7 with unwind.
             + (* ReadChannel *)

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -124,8 +124,10 @@ Hint Resolve multi_system_ev_refl multi_system_ev_tran : multi.
 
 (* Hints for [eauto with unwind] *)
 Hint Resolve state_upd_chan_unwind chan_append_unwind chan_low_proj_loweq
-    chan_low_proj_idempotent state_upd_node_unwind set_call_unwind 
-    state_low_proj_loweq : unwind.
+    chan_low_proj_idempotent state_upd_node_eq_unwind set_call_unwind 
+    state_upd_chan_eq_unwind state_low_proj_loweq 
+    state_upd_chan_labeled_unwind
+    state_chan_append_labeled_unwind: unwind.
 Hint Extern 4 (node_low_eq _ _ _) => reflexivity : unwind.
 Hint Extern 4 (chan_low_eq _ _ _) => reflexivity : unwind.
 (* meant to be case where we have (cleq ch (proj ch) ) and want to swap order *)
@@ -229,6 +231,8 @@ Admitted.
 Qed.
 *)
 
+
+
 Theorem step_implies_lowproj_steps_leq: forall ell s1 s1' e1,
     (step_system_ev s1 s1' e1) ->
     (exists s2' e2,
@@ -249,45 +253,70 @@ Proof.
                 pose proof (state_nidx_to_proj_state_idx ell _ _ nl
                     ltac:(eauto)) as Hn_idx_s1proj;
                 (erewrite flows_labeled_proj in Hn_idx_s1proj; eauto);
-                inversion H3; crush.
+                inversion H3; crush; subst_lets.
+                all: try replace n0 with n in * by
+                (pose proof (can_split_node_index _ _ _ _ ltac:(eauto));
+                    logical_simplify; congruence). 
+            (*
+                I can't quite get this to work. Coq complains
+                about s1 not being found in environment
+                all: try rename s1' into s1. 
+                    attempt to try SInternal from erroring
+                    in following tactic:
+                all: try lazymatch goal with
+                    | H: (nodes s1).[? id] = _ |- _ =>
+                        rewrite H in Hn_idx_s1proj;
+                        pose proof (can_split_node_index _ _ _ _ Hn_idx_s1proj);
+                        logical_simplify
+                end.
+            *)
             + (* WriteChannel *)
-                do 2 eexists; split_ands; [ | | reflexivity ]; admit.
-                (*
-                1:apply_all_constructors;
-                  solve [eauto using state_hidx_to_proj_state_hidx with flowsto].
-                subst_lets. eauto 7 with unwind.
-                *)
-            + (* ReadChannel *)
-                admit.
-                (*
-                pose proof (state_hidx_to_proj_state_hidx ell _ _ _
-                    ltac:(eauto)) as Hch_hidx_s1proj.
-                rewrite flows_chan_proj in *; eauto using ord_trans.
                 do 2 eexists; split_ands; [ | | reflexivity ].
-                1:apply_all_constructors; solve [eauto].
-                subst_lets. eauto with unwind.
-                *)
-            + (* CreateChannel *)
-                do 2 eexists; split_ands; [ | | reflexivity ]; admit.
-                (*
-                1:apply_all_constructors;
-                  solve [eauto; rewrite ?proj_pres_handle_fresh; eauto].
+                (* step *)
+                rewrite H5 in Hn_idx_s1proj;
+                pose proof (can_split_node_index _ _ _ _ Hn_idx_s1proj);
+                logical_simplify.
+                apply_all_constructors; eauto. congruence.
+                (* low-equiv *)
+                subst_lets. eauto 7 with unwind.
+            + (* ReadChannel *)
+                do 2 eexists; split_ands; [ | | reflexivity ].
+                (* step *)
+                rewrite H5 in Hn_idx_s1proj;
+                pose proof (can_split_node_index _ _ _ _ Hn_idx_s1proj);
+                logical_simplify.
+                apply_all_constructors; eauto. congruence.
+                pose proof (state_hidx_to_proj_state_hidx ell _ _ _ ltac:(eauto)).
+                assert (nlbl <<L ell) by congruence.  (* the last eauto needs this *)
+                rewrite flows_labeled_proj in H12; eauto.
+                simpl. eauto using ord_trans.
+                (* state low_eq *)
                 subst_lets. eauto 6 with unwind.
-                *)
+            + (* CreateChannel *)
+                do 2 eexists; split_ands; [ | | reflexivity ]. 
+                (* step *)
+                rewrite H4 in Hn_idx_s1proj;
+                pose proof (can_split_node_index _ _ _ _ Hn_idx_s1proj);
+                logical_simplify.
+                apply_all_constructors; eauto. congruence.
+                (* state loweq *)
+                subst_lets. eauto 7 with unwind.
             + (* CreateNode *)
-                do 2 eexists; split_ands; [ | | reflexivity ]; admit.
-                (*
-                1:apply_all_constructors;
-                  solve [eauto; rewrite ?proj_pres_nid_fresh; eauto].
-                subst_lets. eauto with unwind.
-                *)
+                do 2 eexists; split_ands; [ | | reflexivity ].
+                rewrite H5 in Hn_idx_s1proj;
+                pose proof (can_split_node_index _ _ _ _ Hn_idx_s1proj);
+                logical_simplify.
+                apply_all_constructors; eauto. congruence.
+                eauto with unwind.
             +  (* Internal *)
-                do 2 eexists; split_ands; [ | | reflexivity ]; admit.
-                (*
-                1:apply_all_constructors;
-                  solve [eauto; rewrite ?proj_pres_nid_fresh; eauto].
-                subst_lets. eauto with unwind.
-                *)
+                do 2 eexists; split_ands; [ | | reflexivity ].
+                eapply SystemEvStepNode; eauto.
+                rewrite Hn_idx_s1proj. eauto.
+                rewrite <- H1.
+                eapply SInternalEv.
+                congruence.
+                econstructor.
+                eauto with unwind.
         * (* not flowsTo case *)
             rename n0 into Hflows.
             pose proof (unobservable_node_step _ _ _ _ _ nl _ ltac:(eauto)
@@ -307,7 +336,7 @@ Proof.
             pose proof (state_low_proj_loweq ell s1); congruence.
             (* events leq *)
             congruence.
-Admitted.
+Qed.
 
 Theorem low_proj_steps_implies_leq_step: forall ell s s1' e1,
     (step_system_ev (state_low_proj ell s) s1' e1) ->

--- a/experimental/ni_coq/vfiles/RuntimeModel.v
+++ b/experimental/ni_coq/vfiles/RuntimeModel.v
@@ -208,6 +208,10 @@ Inductive step_node (id: node_id): call -> state -> state -> Prop :=
     | SWriteChan s n nlbl han clbl msg:
         (s.(nodes).[?id]) = Labeled node (Some n) nlbl ->
             (* caller is a real node with label nlbl *)
+        (s.(chans).[? han]).(lbl) = clbl ->
+            (* the handle has label clbl, though the call does not
+            check whether or not a channel is allocated to the handle
+            to avoid leaks (it can be Some or None) *)
         In n.(write_handles) han ->     (* caller has write handle *)
         nlbl <<L clbl ->     (* label of caller flowsTo label of ch*)
         Included msg.(rhs) n.(read_handles) ->

--- a/experimental/ni_coq/vfiles/Unwind.v
+++ b/experimental/ni_coq/vfiles/Unwind.v
@@ -32,6 +32,12 @@ Definition state_unwind (f: state -> state):
 but we have to fix the way the definitions are curried.
 *)
 
+Theorem state_upd_node_eq_unwind: forall ell id n s1 s2,
+    state_low_eq ell s1 s2 ->
+    state_low_eq ell (state_upd_node id n s1) (state_upd_node id n s2).
+Proof.
+Admitted.
+
 Theorem state_upd_node_unwind: forall ell id n1 n2 n1obj n2obj s1 s2,
     node_low_eq ell n1 n2 ->
     n1.(obj) = Some n1obj ->
@@ -51,6 +57,12 @@ Theorem chan_append_unwind: forall ell ch1 ch2 ch1obj ch2obj msg,
 Proof.
 Admitted. (* WIP // TODO *)
 
+Theorem state_upd_chan_eq_unwind: forall ell han ch s1 s2,
+    state_low_eq ell s1 s2 ->
+    state_low_eq ell (state_upd_chan han ch s1) (state_upd_chan han ch s2).
+Proof.
+Admitted.
+
 Theorem state_upd_chan_unwind: forall ell han ch1 ch2 ch1obj ch2obj s1 s2,
     chan_low_eq ell ch1 ch2 ->
     ch1.(obj) = Some ch1obj ->
@@ -67,10 +79,18 @@ Theorem state_upd_node_labeled_unwind: forall ell id n1 n2 s1 s2,
 Proof.
 Admitted.
 
-Theorem state_upd_chan_labeled_unwind: forall ell id ch1 ch2 s1 s2,
+Theorem state_upd_chan_labeled_unwind: forall ell h ch1 ch2 s1 s2,
     chan_low_eq ell ch1 ch2 ->
     state_low_eq ell s1 s2 ->
-    state_low_eq ell (state_upd_chan_labeled id ch1 s1) (state_upd_chan_labeled id ch2 s2).
+    state_low_eq ell (state_upd_chan_labeled h ch1 s1) (state_upd_chan_labeled h ch2 s2).
+Proof.
+Admitted.
+
+Theorem state_chan_append_labeled_unwind: forall ell han msg s1 s2,
+    state_low_eq ell s1 s2 ->
+    state_low_eq ell 
+        (state_chan_append_labeled han msg s1)
+        (state_chan_append_labeled han msg s2).
 Proof.
 Admitted.
 


### PR DESCRIPTION
Notably, the way channel append works when writing to a channel needed
to be changed in order to make this provable. Because it is possible for
a public node to send a message to a secret channel, and because a
public observer cannot distinguish between a handle that points to a
secret channel and a handle that points to nothing (becuase the channel
was deleted for example), the write call cannot check whether or not the
handle is allocated because this would cause a leak. This potential leak made
step_implies_lowproj unprovable without changing the semantics.

The change is in chan_append_labeled and the semantics of the write call.
If the write call is to a handle that points to nothing, the write has no
effect and no error is thrown. See chan_append_labeled.

For similar reasons, the checks for "fresh" node ids and handles had to
be removed, though I think these don't correspond to anything in the
real implementation anyway.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
