### PR TITLE
Check downgrade privilege in gRPC client node

### DIFF
--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -2186,7 +2186,7 @@ impl FrontendNode {
         let ok_rsp = GrpcTestResponse {
             text: "test".to_string(),
         };
-        expect_eq!(grpc_stub.unary_method(ok_req.clone()), Ok(ok_rsp));
+        expect_eq!(grpc_stub.unary_method(ok_req), Ok(ok_rsp));
 
         // Errored unary method invocation of external service via gRPC client pseudo-Node.
         let err_req = GrpcTestRequest {
@@ -2201,26 +2201,13 @@ impl FrontendNode {
             result.unwrap_err().code
         );
 
-        // Attempt to call an external gRPC service using a client with an incorrect confidentiality
-        // label.
+        // Attempt to create a gRPC client pseudo node with an invalid label.
         let invalid_authority_grpc_stub = oak::grpc::client::Client::new(
             "grpc_client",
             &oak::node_config::grpc_client("https://localhost:7878"),
             &confidentiality_label(tls_endpoint_tag("google.com")),
-        )
-        .map(OakAbiTestServiceClient)
-        .ok_or_else(|| {
-            Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "no gRPC client channel available",
-            ))
-        })?;
-        let permission_denied_result = invalid_authority_grpc_stub.unary_method(ok_req);
-        expect_matches!(permission_denied_result, Err(_));
-        expect_eq!(
-            grpc::Code::PermissionDenied as i32,
-            permission_denied_result.unwrap_err().code
         );
+        expect!(invalid_authority_grpc_stub.is_none());
 
         Ok(())
     }

--- a/examples/aggregator/client/cpp/aggregator.cc
+++ b/examples/aggregator/client/cpp/aggregator.cc
@@ -78,6 +78,7 @@ int main(int argc, char** argv) {
   //
   // The particular value corresponds to the hash on the `aggregator.wasm` line in
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
+  // TODO(#1674): Add the appropriate TlsEndpointTag to the label as well once it can be supported.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
       absl::HexStringToBytes("05493131b2041ee7fbbcb41758133b420862c57374d318454646f51014afa838"));
   // Connect to the Oak Application.

--- a/examples/aggregator/module/rust/src/lib.rs
+++ b/examples/aggregator/module/rust/src/lib.rs
@@ -228,7 +228,7 @@ oak::entrypoint!(oak_main<ConfigMap> => |receiver: Receiver<ConfigMap>| {
     // Node creation. This is only allowed if the current Node actually has the
     // appropriate capability (i.e. the correct WebAssembly module hash) as specified by
     // the label component being removed, as set by the client.
-    // TODO(#814): Uncomment and use correct confidentiality labels.
+    // TODO(#1674): Uncomment and use correct confidentiality labels once this can be supported.
     // let label = Label {
     //     confidentiality_tags: vec![Tag {
     //         tag: Some(tag::Tag::TlsEndpointTag(TlsEndpointTag {

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -583,9 +583,9 @@ impl Runtime {
     }
 
     /// Returns the least restrictive (i.e. least confidential, most trusted) label that this Node
-    /// may downgrade `initial_label` to. This takes into account all the [downgrade
-    /// privilege](NodeInfo::privilege) that the node possesses.
-    fn get_node_downgraded_label(&self, node_id: NodeId, initial_label: &Label) -> Label {
+    /// may downgrade `initial_label` to. This takes into account all the downgrade privilege that
+    /// the node possesses.
+    pub fn get_node_downgraded_label(&self, node_id: NodeId, initial_label: &Label) -> Label {
         // Retrieve the set of tags that the node may downgrade.
         let node_privilege = self.get_node_privilege(node_id);
         let node_has_top_privilege = node_privilege

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -390,6 +390,30 @@ impl RuntimeProxy {
         result
     }
 
+    /// See [`Runtime::get_node_label`].
+    pub fn get_node_label(&self) -> Label {
+        debug!("{:?}: get_node_label()", self.node_id);
+        let result = self.runtime.get_node_label(self.node_id);
+        debug!("{:?}: get_node_label() -> {:?}", self.node_id, result);
+        result
+    }
+
+    /// See [`Runtime::get_node_downgraded_label`].
+    pub fn get_node_downgraded_label(&self, initial_label: &Label) -> Label {
+        debug!(
+            "{:?}: get_node_downgraded_label({:?})",
+            self.node_id, initial_label
+        );
+        let result = self
+            .runtime
+            .get_node_downgraded_label(self.node_id, initial_label);
+        debug!(
+            "{:?}: get_node_downgraded_label({:?}) -> {:?}",
+            self.node_id, initial_label, result
+        );
+        result
+    }
+
     /// Return the direction of an ABI handle.
     pub fn channel_direction(
         &self,


### PR DESCRIPTION
To ensure that the gRPC client does not leak information during connection to an external service, it will only try to connect if the gRPC client node has the privilege to declassify to "public".

Fixes #814

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
