### PR TITLE
Allow creating node entrypoint with init data

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -600,6 +600,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "either",
  "env_logger",
  "hello_world_grpc",
  "log",

--- a/examples/hello_world/module/rust/Cargo.toml
+++ b/examples/hello_world/module/rust/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "*"
+either = "*"
 log = "*"
 oak = "=0.1.0"
 oak_abi = "=0.1.0"

--- a/oak_io/src/lib.rs
+++ b/oak_io/src/lib.rs
@@ -89,8 +89,8 @@ impl<L: Decodable, R: Decodable> Decodable for Either<L, R> {
 /// different channel, to be processed in an event-loop pattern.
 #[derive(Clone, Debug, PartialEq)]
 pub struct InitWrapper<Init, Command: Decodable> {
-    init: Init,
-    command_receiver: Receiver<Command>,
+    pub init: Init,
+    pub command_receiver: Receiver<Command>,
 }
 
 /// Implementation of [`Encodable`] for [`InitWrapper`] that encodes the handle of the command

--- a/oak_utils/src/lib.rs
+++ b/oak_utils/src/lib.rs
@@ -141,6 +141,14 @@ impl prost_build::ServiceGenerator for OakServiceGenerator {
                 }
             }
 
+            impl <T: #service_name + #oak_package::WithInit> #oak_package::WithInit for #dispatcher_name<T> {
+                type Init = T::Init;
+
+                fn create(init: Self::Init) -> Self {
+                    Self::new(T::create(init))
+                }
+            }
+
             #[allow(clippy::unit_arg)]
             impl <T: #service_name> #oak_package::grpc::ServerNode for #dispatcher_name<T> {
                 fn invoke(&mut self, method: &str, req: &[u8], writer: #oak_package::grpc::ChannelResponseWriter) {


### PR DESCRIPTION
Introduce a `WithInit` trait implemented by structs that correspond to
nodes that require receiving initialization data over their inbound
channel, before accepting command from the wrapped channel.

Currently there are two entrypoint-related macros, one for structs that
impl `Default` and do not require init data, and the new one for structs
that impl `WithInit`, which expect an `InitWrapper` message. It may be
possible to unify them in the future with some more macro magic, or we
may just decide to make everything impl `WithInit`, using `()` as init
in case the node does not require init data, but for now I think the
separation makes sense.

Ref #1639

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
