### PR TITLE
Remove unnecessary types for gRPC client

### DIFF
--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -2164,18 +2164,14 @@ impl FrontendNode {
         Ok(())
     }
     fn test_grpc_client_unary_method(&mut self) -> TestResult {
-        let grpc_stub = oak::grpc::client::Client::new(
-            "grpc_client",
-            &oak::node_config::grpc_client("https://localhost:7878"),
-            &Label::public_untrusted(),
-        )
-        .map(OakAbiTestServiceClient)
-        .ok_or_else(|| {
-            Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "no gRPC client channel available",
-            ))
-        })?;
+        let grpc_stub = oak::grpc::client::init("https://localhost:7878")
+            .map(OakAbiTestServiceClient)
+            .map_err(|_err| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "no gRPC client channel available",
+                ))
+            })?;
 
         // Successful unary method invocation of external service via gRPC client pseudo-Node.
         let ok_req = GrpcTestRequest {
@@ -2204,18 +2200,14 @@ impl FrontendNode {
         Ok(())
     }
     fn test_grpc_client_server_streaming_method(&mut self) -> TestResult {
-        let grpc_stub = oak::grpc::client::Client::new(
-            "grpc_client",
-            &oak::node_config::grpc_client("https://localhost:7878"),
-            &Label::public_untrusted(),
-        )
-        .map(OakAbiTestServiceClient)
-        .ok_or_else(|| {
-            Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "no gRPC client channel available",
-            ))
-        })?;
+        let grpc_stub = oak::grpc::client::init("https://localhost:7878")
+            .map(OakAbiTestServiceClient)
+            .map_err(|_err| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "no gRPC client channel available",
+                ))
+            })?;
         // Successful server-streaming method invocation of external service via
         // gRPC client pseudo-Node.
         let ok_req = GrpcTestRequest {
@@ -2284,18 +2276,14 @@ impl FrontendNode {
     fn test_absent_grpc_client_unary_method(&mut self) -> TestResult {
         // Expect to have a channel to a gRPC client pseudo-Node, but the remote
         // gRPC service is unavailable.
-        let grpc_stub = oak::grpc::client::Client::new(
-            "grpc_client",
-            &oak::node_config::grpc_client("https://test.invalid:9999"),
-            &Label::public_untrusted(),
-        )
-        .map(OakAbiTestServiceClient)
-        .ok_or_else(|| {
-            Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "no gRPC client channel available",
-            ))
-        })?;
+        let grpc_stub = oak::grpc::client::init("https://test.invalid:9999")
+            .map(OakAbiTestServiceClient)
+            .map_err(|_err| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "no gRPC client channel available",
+                ))
+            })?;
         let req = GrpcTestRequest {
             method_result: Some(proto::grpc_test_request::MethodResult::OkText(
                 "test".to_string(),
@@ -2312,18 +2300,14 @@ impl FrontendNode {
     fn test_absent_grpc_client_server_streaming_method(&mut self) -> TestResult {
         // Expect to have a channel to a gRPC client pseudo-Node, but the remote
         // gRPC service is unavailable.
-        let grpc_stub = oak::grpc::client::Client::new(
-            "grpc_client",
-            &oak::node_config::grpc_client("https://test.invalid:9999"),
-            &Label::public_untrusted(),
-        )
-        .map(OakAbiTestServiceClient)
-        .ok_or_else(|| {
-            Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "no gRPC client channel available",
-            ))
-        })?;
+        let grpc_stub = oak::grpc::client::init("https://test.invalid:9999")
+            .map(OakAbiTestServiceClient)
+            .map_err(|_err| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "no gRPC client channel available",
+                ))
+            })?;
         let req = GrpcTestRequest {
             method_result: Some(proto::grpc_test_request::MethodResult::OkText(
                 "test".to_string(),

--- a/examples/hello_world/module/rust/src/lib.rs
+++ b/examples/hello_world/module/rust/src/lib.rs
@@ -67,10 +67,7 @@ impl oak::WithInit for Node {
 
     fn create(init: Self::Init) -> Self {
         Node {
-            translator: init
-                .right()
-                .map(|invocation_sender| grpc::client::Client { invocation_sender })
-                .map(translator_common::TranslatorClient),
+            translator: init.right().map(translator_common::TranslatorClient),
         }
     }
 }

--- a/oak_utils/src/lib.rs
+++ b/oak_utils/src/lib.rs
@@ -105,7 +105,7 @@ impl prost_build::ServiceGenerator for OakServiceGenerator {
                 false =>
                     quote! {
                         pub fn #method_name(&self, req: #input_type) -> #oak_package::grpc::Result<#output_type> {
-                            #oak_package::grpc::invoke_grpc_method(#method_name_string, &req, &self.0.invocation_sender)
+                            #oak_package::grpc::invoke_grpc_method(#method_name_string, &req, &self.0)
                         }
                     },
                 true =>
@@ -115,7 +115,7 @@ impl prost_build::ServiceGenerator for OakServiceGenerator {
                     // the underlying handle.
                     quote! {
                         pub fn #method_name(&self, req: #input_type) -> #oak_package::grpc::Result<#oak_package::io::Receiver<#oak_package::grpc::GrpcResponse>> {
-                            #oak_package::grpc::invoke_grpc_method_stream(#method_name_string, &req, &self.0.invocation_sender)
+                            #oak_package::grpc::invoke_grpc_method_stream(#method_name_string, &req, &self.0)
                         }
                     },
             }
@@ -162,7 +162,7 @@ impl prost_build::ServiceGenerator for OakServiceGenerator {
             }
 
             #[allow(dead_code)]
-            pub struct #client_name(pub #oak_package::grpc::client::Client);
+            pub struct #client_name(pub #oak_package::io::Sender<#oak_package::grpc::Invocation>);
 
             #[allow(dead_code)]
             impl #client_name {

--- a/sdk/rust/oak/src/roughtime/mod.rs
+++ b/sdk/rust/oak/src/roughtime/mod.rs
@@ -38,11 +38,11 @@ impl Roughtime {
         let config = NodeConfiguration {
             config_type: Some(ConfigType::RoughtimeClientConfig(config.clone())),
         };
-        crate::grpc::client::Client::new("roughtime", &config, &Label::public_untrusted()).map(
-            |client| Roughtime {
-                client: RoughtimeServiceClient(client),
-            },
-        )
+        crate::io::node_create("roughtime", &Label::public_untrusted(), &config)
+            .map(|invocation_sender| Roughtime {
+                client: RoughtimeServiceClient(invocation_sender),
+            })
+            .ok()
     }
 
     /// Get the current Roughtime value as a Duration since UNIX epoch.

--- a/sdk/rust/oak/src/storage/mod.rs
+++ b/sdk/rust/oak/src/storage/mod.rs
@@ -38,16 +38,17 @@ pub struct Storage {
 impl Storage {
     /// Creates a [`Storage`] instance using the given configuration.
     pub fn new(config: &StorageProxyConfiguration) -> Option<Storage> {
-        crate::grpc::client::Client::new(
+        crate::io::node_create(
             "storage",
+            &Label::public_untrusted(),
             &NodeConfiguration {
                 config_type: Some(ConfigType::StorageConfig(config.clone())),
             },
-            &Label::public_untrusted(),
         )
-        .map(|client| Storage {
-            client: StorageServiceClient(client),
+        .map(|invocation_sender| Storage {
+            client: StorageServiceClient(invocation_sender),
         })
+        .ok()
     }
 
     /// Read the value associated with the given `name` from the storage


### PR DESCRIPTION
Most of them are not particularly useful now that we use `Sender` and
`Receiver` more extensively elsewhere in the SDK API.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
