### PR TITLE
Remove unused `bans.skip` entries from the SDK's `deny.toml`

### DIFF
--- a/sdk/deny.toml
+++ b/sdk/deny.toml
@@ -23,19 +23,6 @@ ignore = [
 multiple-versions = "deny"
 wildcards = "allow"
 
-# TODO(#1270): Remove when no longer needed by tonic and rustls.
-[[bans.skip]]
-name = "base64"
-version = "=0.11.0"
-
-[[bans.skip]]
-name = "tokio-rustls"
-version = "=0.13.1"
-
-[[bans.skip]]
-name = "rustls"
-version = "=0.17.0"
-
 [[bans.skip]]
 name = "pin-project"
 version = "=0.4.22"


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
