### PR TITLE
Low projection makes labels themselves partially secret

### DIFF
--- a/experimental/ni_coq/vfiles/LowEquivalences.v
+++ b/experimental/ni_coq/vfiles/LowEquivalences.v
@@ -41,11 +41,34 @@ Definition low_proj {A: Type} ell ( labeled_thing: @labeled A) :=
         | Labeled _ o ell' => if( ell' <<? ell ) 
             then labeled_thing
             else Labeled A None top
-                (* Importantly, the label of the secret thing is NOT ell'
-                but instead the top of the information flow lattice 
-                (secret, untrusted) which means the specifc label is 
-                *)
     end.
+    (* 
+    Importantly, the label of the secret thing is NOT ell'
+    but instead the top of the information flow lattice 
+    (secret, untrusted) which means that in this formulation,
+    labels are not completely public. Instead, an observer at level
+    ell can see:
+        - whether the label of an object flows to ell, for any object.
+        - the precise label of the object if its label does flow to ell.
+    Putting it another way, the label ell' of a secret object is not observable,
+    but whether or not (ell' <<L ell) is observable.
+
+    This defintion is necessary in order to make the theorem provable while
+    still supporting dynamic creation of nodes and channels. 
+    Noninterference proofs often rely on theorems that roughly say "when a
+    secret step is taken, no public state is updated". (In this code, these
+    theorems often have "unobs" in their names. In the literature these are
+    sometimes called clearance). To create a node
+    or channel, a new labeled object appears, which is effectively a "label
+    change". If labels are public, we can't prove the "unobs" theorems because
+    because the node/channel creation calls DO create new labels and therefore
+    do update public state. 
+    
+    By revealing only partial information about labels to an arbitrary
+    observer, we can show that since secret nodes can only create secret
+    objects, these label changes in the secret part of the lattice are actually
+    hidden.
+    *)
 
 Definition node_low_proj := @low_proj node.
 Definition chan_low_proj := @low_proj channel.

--- a/experimental/ni_coq/vfiles/LowEquivalences.v
+++ b/experimental/ni_coq/vfiles/LowEquivalences.v
@@ -40,7 +40,11 @@ Definition low_proj {A: Type} ell ( labeled_thing: @labeled A) :=
     match labeled_thing with
         | Labeled _ o ell' => if( ell' <<? ell ) 
             then labeled_thing
-            else Labeled A None ell'
+            else Labeled A None top
+                (* Importantly, the label of the secret thing is NOT ell'
+                but instead the top of the information flow lattice 
+                (secret, untrusted) which means the specifc label is 
+                *)
     end.
 
 Definition node_low_proj := @low_proj node.

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -5,7 +5,8 @@ From OakIFC Require Import
         RuntimeModel
         EvAugSemantics
         Events
-        LowEquivalences.
+        LowEquivalences
+        Tactics.
 Require Import Coq.Lists.List.
 Import ListNotations.
 From RecordUpdate Require Import RecordSet.
@@ -96,7 +97,20 @@ Section low_projection.
       @low_proj_loweq state state_low_proj state_low_eq.
   Proof.
   Admitted.
- 
+
+  Theorem proj_labels_increase {A: Type }: forall ell ell' (x: @labeled A),
+    ell' <<L x.(lbl) -> ell' <<L (low_proj ell x).(lbl).
+    destruct x. cbv [RuntimeModel.lbl]. unfold low_proj. destruct_match.
+    intros. eauto. intros. eapply top_is_top.
+  Qed.
+  
+  Theorem low_projection_preserves_observability {A: Type}: forall ell (x: @labeled A),
+    x.(lbl) <<L ell -> (low_proj ell x).(lbl) <<L ell.
+  Proof.
+      destruct x. cbv [RuntimeModel.lbl].
+      unfold low_proj. destruct_match.  eauto. contradiction.
+  Qed.
+    
   (*
   Theorem low_projection_preserves_lbl {A: Type}: forall ell (x: @labeled A),
       (low_proj ell x).(lbl) = x.(lbl).
@@ -170,6 +184,20 @@ Section low_projection.
       (state_low_proj ell s).(nodes).[? id] = n' ->
       ~(n.(lbl) <<L ell) ->
       ~(n'.(lbl) <<L ell).
+  Proof.
+  Admitted.
+
+  Theorem proj_preserves_fresh_han: forall ell s h,
+      fresh_han s h ->
+      fresh_han (state_low_proj ell s) h.
+  Proof.
+      (* depends on concurrent change to def of states, but
+      should be true *)
+  Admitted.
+
+  Theorem proj_preserves_fresh_nid: forall ell s id,
+      fresh_nid s id ->
+      fresh_nid (state_low_proj ell s) id.
   Proof.
   Admitted.
 

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -41,227 +41,218 @@ End misc.
 
 Section low_projection.
 
-Theorem flows_labeled_proj {A: Type}: forall ell (x: @labeled A),
-    (lbl x <<L ell) ->
-    (low_proj ell x) = x.
-Proof.
-    intros. destruct x. unfold low_proj. simpl in H.
-    destruct (lbl <<? ell); eauto; try contradiction.
-Qed.
-
-Theorem nflows_labeled_proj {A: Type}: forall ell (x: @labeled A),
-    ~(lbl x <<L ell) ->
-    (low_proj ell x) = Labeled A None (lbl x).
-Proof.
-    intros. destruct x. unfold low_proj. simpl in H.
-    destruct (lbl <<? ell); eauto; try contradiction.
-Qed.
-
-Definition idempotent {A: Type} (f: A -> A) := forall a, f (f a) = f a.
-
-Theorem labeled_low_proj_idempotent {A: Type}:
-    forall ell, idempotent (@low_proj A ell).
-Proof.
-    intros. unfold idempotent. intros x.
-    destruct x. unfold low_proj. destruct (lbl <<? ell)  eqn:Hflows;
-    rewrite Hflows; eauto.
-Qed.
-
-Definition node_low_proj_idempotent := @labeled_low_proj_idempotent node.
-Definition chan_low_proj_idempotent := @labeled_low_proj_idempotent channel.
-Definition event_low_proj_idempotent := @labeled_low_proj_idempotent event.
-
-Theorem state_low_proj_idempotent: forall ell, idempotent (state_low_proj ell).
-Proof.
-Admitted.
-
-Definition low_proj_loweq {A: Type}{a_low_proj: @low_proj_t A}
-    {a_low_eq: @low_eq_t A} := forall ell x,
-    (a_low_eq ell (a_low_proj ell x) x).
-
-Theorem labeled_low_proj_loweq {A: Type}:
-    @low_proj_loweq (@labeled A) low_proj low_eq.
-Proof.
-    unfold low_proj_loweq. unfold low_eq. unfold low_proj. intros.
-    destruct x. destruct (lbl <<? ell) eqn:Hflows;
-    rewrite Hflows; reflexivity.
-Qed.
-
-Definition node_low_proj_loweq := @labeled_low_proj_loweq node.
-Definition chan_low_proj_loweq := @labeled_low_proj_loweq channel.
-Definition event_low_proj_loweq := @labeled_low_proj_loweq event.
-
-Theorem state_low_proj_loweq: 
-    @low_proj_loweq state state_low_proj state_low_eq.
-Proof.
-Admitted.
-
-Theorem low_projection_preserves_lbl {A: Type}: forall ell (x: @labeled A),
-    (low_proj ell x).(lbl) = x.(lbl).
-Proof.
-    intros. destruct x. simpl. destruct (lbl <<? ell); auto.
-Qed.
-
-Definition node_projection_preserves_lbl :=
-    @low_projection_preserves_lbl node.
-Definition chan_projection_preserves_lbl := 
-    @low_projection_preserves_lbl channel.
-
-Theorem uncons_proj_chan_s: forall ell s han ch,
-    (chans (state_low_proj ell s)).[? han] = ch ->
-    exists ch',
-        (chans s).[? han] = ch' /\
-        low_proj ell ch' = ch.
-Proof.
-Admitted.
-
-Theorem uncons_proj_node_s': forall ell s id,
-    (nodes (state_low_proj ell s)).[? id] = 
-    (low_proj ell (nodes s).[? id]).
-Proof.
-    unfold state_low_proj. unfold fnd. unfold node_state_low_proj. simpl. intros.
-    destruct (lbl (nodes s id) <<? ell); try reflexivity.
-Qed.
-
-Theorem uncons_proj_node_s: forall ell s id n,
-    (nodes (state_low_proj ell s)).[? id] = n ->
-    exists n',
-        ((nodes s).[? id] = n') /\
-        (low_proj ell n') = n.
-Proof.
-    intros. rewrite uncons_proj_node_s' in H.
-    unfold fnd in *. unfold state_low_proj in *. simpl in *.
-    exists (nodes s id); split; eauto.
-Qed.
-
-Theorem state_nidx_to_proj_state_idx: forall ell s id n,
-    ((nodes s).[? id] = n) ->
-    ((nodes (state_low_proj ell s)).[? id] = (low_proj ell n)).
-Proof.
-Admitted.
-
-Theorem state_hidx_to_proj_state_hidx': forall ell s h,
-    (chans (state_low_proj ell s)).[? h] = (low_proj ell (chans s).[?h ]).
-Proof.
-Admitted.
-
-Theorem state_hidx_to_proj_state_hidx: forall ell s h ch,
-    ((chans s).[? h] = ch) ->
-    ((chans (state_low_proj ell s)).[? h] = (low_proj ell ch)).
-Proof.
-Admitted.
-
-(* TODO give better name *)
-Theorem proj_node_state_to_proj_n: forall ell s id nl n,
-    ((nodes (state_low_proj ell s)).[? id] = nl) ->
-    nl.(obj) = Some n ->
-    exists nl' n',
-        (nodes s).[? id] = nl' /\
-        (low_proj ell nl') = nl /\
-        nl'.(obj) = Some n'.
-Proof.
-Admitted.
-
-Theorem node_projection_preserves_flowsto: forall ell s id n n',
-    s.(nodes).[? id] = n ->
-    (state_low_proj ell s).(nodes).[? id] = n' ->
-    ~(n.(lbl) <<L ell) ->
-    ~(n'.(lbl) <<L ell).
-Proof.
-Admitted.
+  Theorem flows_labeled_proj {A: Type}: forall ell (x: @labeled A),
+      (lbl x <<L ell) ->
+      (low_proj ell x) = x.
+  Proof.
+      intros. destruct x. unfold low_proj. simpl in H.
+      destruct (lbl <<? ell); eauto; try contradiction.
+  Qed.
+  
+  Theorem nflows_labeled_proj {A: Type}: forall ell (x: @labeled A),
+      ~(lbl x <<L ell) ->
+      (low_proj ell x) = Labeled A None top.
+  Proof.
+      intros. destruct x. unfold low_proj. simpl in H.
+      destruct (lbl <<? ell); eauto; try contradiction.
+  Qed.
+  
+  Definition idempotent {A: Type} (f: A -> A) := forall a, f (f a) = f a.
+  
+  Theorem labeled_low_proj_idempotent {A: Type}:
+      forall ell, idempotent (@low_proj A ell).
+  Proof.
+      intros. unfold idempotent. intros x.
+      destruct x. unfold low_proj. destruct (lbl <<? ell)  eqn:Hflows.
+      rewrite Hflows; eauto. destruct (top <<? ell); reflexivity.
+  Qed.
+  
+  Definition node_low_proj_idempotent := @labeled_low_proj_idempotent node.
+  Definition chan_low_proj_idempotent := @labeled_low_proj_idempotent channel.
+  Definition event_low_proj_idempotent := @labeled_low_proj_idempotent event.
+  
+  Theorem state_low_proj_idempotent: forall ell, idempotent (state_low_proj ell).
+  Proof.
+  Admitted.
+  
+  Definition low_proj_loweq {A: Type}{a_low_proj: @low_proj_t A}
+      {a_low_eq: @low_eq_t A} := forall ell x,
+      (a_low_eq ell (a_low_proj ell x) x).
+  
+  Theorem labeled_low_proj_loweq {A: Type}:
+      @low_proj_loweq (@labeled A) low_proj low_eq.
+  Proof.
+      unfold low_proj_loweq. unfold low_eq. unfold low_proj. intros.
+      destruct x. destruct (lbl <<? ell) eqn:Hflows.
+      rewrite Hflows. reflexivity.
+      destruct (top <<? ell); reflexivity.
+  Qed.
+  
+  Definition node_low_proj_loweq := @labeled_low_proj_loweq node.
+  Definition chan_low_proj_loweq := @labeled_low_proj_loweq channel.
+  Definition event_low_proj_loweq := @labeled_low_proj_loweq event.
+  
+  Theorem state_low_proj_loweq: 
+      @low_proj_loweq state state_low_proj state_low_eq.
+  Proof.
+  Admitted.
+ 
+  (*
+  Theorem low_projection_preserves_lbl {A: Type}: forall ell (x: @labeled A),
+      (low_proj ell x).(lbl) = x.(lbl).
+  Proof.
+      intros. destruct x. simpl. destruct (lbl <<? ell); auto.
+  Qed.
+  
+  Definition node_projection_preserves_lbl :=
+      @low_projection_preserves_lbl node.
+  Definition chan_projection_preserves_lbl := 
+      @low_projection_preserves_lbl channel.
+  *)
+  
+  Theorem uncons_proj_chan_s: forall ell s han ch,
+      (chans (state_low_proj ell s)).[? han] = ch ->
+      exists ch',
+          (chans s).[? han] = ch' /\
+          low_proj ell ch' = ch.
+  Proof.
+  Admitted.
+  
+  Theorem uncons_proj_node_s': forall ell s id,
+      (nodes (state_low_proj ell s)).[? id] = 
+      (low_proj ell (nodes s).[? id]).
+  Proof.
+      unfold state_low_proj. unfold fnd. unfold node_state_low_proj. simpl. intros.
+      destruct (lbl (nodes s id) <<? ell); try reflexivity.
+  Qed.
+  
+  Theorem uncons_proj_node_s: forall ell s id n,
+      (nodes (state_low_proj ell s)).[? id] = n ->
+      exists n',
+          ((nodes s).[? id] = n') /\
+          (low_proj ell n') = n.
+  Proof.
+      intros. rewrite uncons_proj_node_s' in H.
+      unfold fnd in *. unfold state_low_proj in *. simpl in *.
+      exists (nodes s id); split; eauto.
+  Qed.
+  
+  Theorem state_nidx_to_proj_state_idx: forall ell s id n,
+      ((nodes s).[? id] = n) ->
+      ((nodes (state_low_proj ell s)).[? id] = (low_proj ell n)).
+  Proof.
+  Admitted.
+  
+  Theorem state_hidx_to_proj_state_hidx': forall ell s h,
+      (chans (state_low_proj ell s)).[? h] = (low_proj ell (chans s).[?h ]).
+  Proof.
+  Admitted.
+  
+  Theorem state_hidx_to_proj_state_hidx: forall ell s h ch,
+      ((chans s).[? h] = ch) ->
+      ((chans (state_low_proj ell s)).[? h] = (low_proj ell ch)).
+  Proof.
+  Admitted.
+  
+  (* TODO give better name *)
+  Theorem proj_node_state_to_proj_n: forall ell s id nl n,
+      ((nodes (state_low_proj ell s)).[? id] = nl) ->
+      nl.(obj) = Some n ->
+      exists nl' n',
+          (nodes s).[? id] = nl' /\
+          (low_proj ell nl') = nl /\
+          nl'.(obj) = Some n'.
+  Proof.
+  Admitted.
+  
+  Theorem node_projection_preserves_flowsto: forall ell s id n n',
+      s.(nodes).[? id] = n ->
+      (state_low_proj ell s).(nodes).[? id] = n' ->
+      ~(n.(lbl) <<L ell) ->
+      ~(n'.(lbl) <<L ell).
+  Proof.
+  Admitted.
 
 End low_projection.
 
 Section low_equivalence.
 
-
-Global Instance node_state_low_eq_refl: forall ell, Reflexive (node_state_low_eq ell) | 10.
-Proof. congruence. Qed.
-
-Global Instance node_state_low_eq_trans: forall ell, Transitive (node_state_low_eq ell) | 10.
-Proof. congruence. Qed.
-
-Global Instance node_state_low_eq_sym: forall ell, Symmetric (node_state_low_eq ell) | 10.
-Proof. congruence. Qed.
-
-Global Instance chan_state_low_eq_refl: forall ell, Reflexive (chan_state_low_eq ell) | 10.
-Proof. congruence. Qed.
-
-Global Instance chan_state_low_eq_trans: forall ell, Transitive (chan_state_low_eq ell) | 10.
-Proof. congruence. Qed.
-
-Global Instance chan_state_low_eq_sym: forall ell, Symmetric (chan_state_low_eq ell) | 10.
-Proof. congruence. Qed.
-
-Global Instance state_low_eq_refl: forall ell, Reflexive (state_low_eq ell) | 10.
-Proof. unfold state_low_eq. unfold Reflexive. eauto.  Qed.
-
-Global Instance state_low_eq_trans: forall ell, Transitive (state_low_eq ell) | 10.
-Proof. cbv [Transitive state_low_eq]. intros. destruct H, H0. split; congruence. Qed.
-
-Global Instance state_low_eq_sym: forall ell, Symmetric (state_low_eq ell) | 10.
-Proof. intros. unfold Symmetric. unfold state_low_eq. intros. destruct H. split; eauto.
-Qed.
-
-Global Instance event_low_eq_refl: forall ell, Reflexive (event_low_eq ell) | 10.
-Proof. congruence. Qed.
-
-Global Instance event_low_eq_trans: forall ell, Transitive (event_low_eq ell) | 10.
-Proof. congruence. Qed.
-
-Global Instance event_low_eq_sym: forall ell, Symmetric (event_low_eq ell) | 10.
-Proof. congruence. Qed.
-
-Theorem state_loweq_from_substates: forall ell s1 s2,
-    node_state_low_eq ell (nodes s1) (nodes s2) ->
-    chan_state_low_eq ell (chans s1) (chans s2) ->
-    state_low_eq ell s1 s2.
-Proof.
-  intros. unfold state_low_eq. unfold low_eq. unfold state_low_proj. eauto.
-Qed.
-
-Theorem state_loweq_to_deref_node: forall ell s1 s2 id n1,
-    (nodes s1).[? id] = n1 ->
-    (state_low_eq ell s1 s2) ->
-    exists n2,
-        (nodes s2).[? id] = n2 /\
-        (node_low_eq ell n1 n2).
-Proof.
-    intros. inversion H0. unfold node_state_low_proj in *. 
-Admitted. 
-
-Theorem node_low_eq_to_lbl_eq: forall ell n1 n2,
-    (node_low_eq ell n1 n2) ->
-    (n1.(lbl) = n2.(lbl)).
-Proof.
-    intros. inversion H.
-    assert ( lbl (low_proj ell n1) = lbl (low_proj ell n2)).
-    rewrite H1. reflexivity.
-    rewrite !node_projection_preserves_lbl in H0.
-    assumption.
-Qed.
-
-Theorem trace_leq_imples_head_st_leq: forall ell t1 t2 s1 s2,
-    (head_st t1 = Some s1) ->
-    (head_st t2 = Some s2) ->
-    (trace_low_eq ell t1 t2) ->
-    (state_low_eq ell s1 s2).
-Proof.
-    inversion 3. 
-    - 
-        exfalso. rewrite <- H3 in H. inversion H.
-    - 
-        assert (xs = s1). {
-            assert (head_st ((xs, xe) :: t0 ) = Some xs) by reflexivity.
-            congruence.
-        }
-
-        assert (ys = s2). {
-            assert (head_st ((ys, ye) :: t3 ) = Some ys) by reflexivity.
-            congruence.
-        }
-    congruence.
-Qed.
+  Global Instance node_state_low_eq_refl: forall ell, Reflexive (node_state_low_eq ell) | 10.
+  Proof. congruence. Qed.
+  
+  Global Instance node_state_low_eq_trans: forall ell, Transitive (node_state_low_eq ell) | 10.
+  Proof. congruence. Qed.
+  
+  Global Instance node_state_low_eq_sym: forall ell, Symmetric (node_state_low_eq ell) | 10.
+  Proof. congruence. Qed.
+  
+  Global Instance chan_state_low_eq_refl: forall ell, Reflexive (chan_state_low_eq ell) | 10.
+  Proof. congruence. Qed.
+  
+  Global Instance chan_state_low_eq_trans: forall ell, Transitive (chan_state_low_eq ell) | 10.
+  Proof. congruence. Qed.
+  
+  Global Instance chan_state_low_eq_sym: forall ell, Symmetric (chan_state_low_eq ell) | 10.
+  Proof. congruence. Qed.
+  
+  Global Instance state_low_eq_refl: forall ell, Reflexive (state_low_eq ell) | 10.
+  Proof. unfold state_low_eq. unfold Reflexive. eauto.  Qed.
+  
+  Global Instance state_low_eq_trans: forall ell, Transitive (state_low_eq ell) | 10.
+  Proof. cbv [Transitive state_low_eq]. intros. destruct H, H0. split; congruence. Qed.
+  
+  Global Instance state_low_eq_sym: forall ell, Symmetric (state_low_eq ell) | 10.
+  Proof. intros. unfold Symmetric. unfold state_low_eq. intros. destruct H. split; eauto.
+  Qed.
+  
+  Global Instance event_low_eq_refl: forall ell, Reflexive (event_low_eq ell) | 10.
+  Proof. congruence. Qed.
+  
+  Global Instance event_low_eq_trans: forall ell, Transitive (event_low_eq ell) | 10.
+  Proof. congruence. Qed.
+  
+  Global Instance event_low_eq_sym: forall ell, Symmetric (event_low_eq ell) | 10.
+  Proof. congruence. Qed.
+  
+  Theorem state_loweq_from_substates: forall ell s1 s2,
+      node_state_low_eq ell (nodes s1) (nodes s2) ->
+      chan_state_low_eq ell (chans s1) (chans s2) ->
+      state_low_eq ell s1 s2.
+  Proof.
+    intros. unfold state_low_eq. unfold low_eq. unfold state_low_proj. eauto.
+  Qed.
+  
+  Theorem state_loweq_to_deref_node: forall ell s1 s2 id n1,
+      (nodes s1).[? id] = n1 ->
+      (state_low_eq ell s1 s2) ->
+      exists n2,
+          (nodes s2).[? id] = n2 /\
+          (node_low_eq ell n1 n2).
+  Proof.
+      intros. inversion H0. unfold node_state_low_proj in *. 
+  Admitted. 
+  
+  Theorem trace_leq_imples_head_st_leq: forall ell t1 t2 s1 s2,
+      (head_st t1 = Some s1) ->
+      (head_st t2 = Some s2) ->
+      (trace_low_eq ell t1 t2) ->
+      (state_low_eq ell s1 s2).
+  Proof.
+      inversion 3. 
+      - 
+          exfalso. rewrite <- H3 in H. inversion H.
+      - 
+          assert (xs = s1). {
+              assert (head_st ((xs, xe) :: t0 ) = Some xs) by reflexivity.
+              congruence.
+          }
+  
+          assert (ys = s2). {
+              assert (head_st ((ys, ye) :: t3 ) = Some ys) by reflexivity.
+              congruence.
+          }
+      congruence.
+  Qed.
 
 End low_equivalence.
 

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -271,24 +271,27 @@ Section unobservable.
     not visible to ell the old and new state are ell-equivalent
 *)
 
-Theorem set_call_unobs: forall ell s id n c,
-    (nodes s).[? id] = n ->
-    ~(lbl n <<L ell) ->
+Theorem set_call_unobs: forall ell s id c,
+    ~(lbl (nodes s).[? id] <<L ell) ->
     (state_low_eq ell s (s_set_call s id c)).
 Proof.
 Admitted.
 
-Theorem state_upd_chan_unobs: forall ell s han ch ch',
-    (chans s).[? han] = ch ->
-    ~(lbl ch <<L ell) ->
-    (state_low_eq ell s (state_upd_chan han ch' s)).
+Theorem state_upd_chan_unobs: forall ell s han ch,
+    ~(lbl (chans s).[? han] <<L ell) ->
+    (state_low_eq ell s (state_upd_chan han ch s)).
 Proof.
 Admitted.
 
-Theorem state_upd_node_unobs: forall ell s id n n',
-    (nodes s).[? id] = n ->
-    ~(lbl n <<L ell) ->
-    (state_low_eq ell s (state_upd_node id n' s)).
+Theorem state_chan_append_labeled_unobs: forall ell s han msg,
+    ~(lbl (chans s).[? han] <<L ell) ->
+    (state_low_eq ell s (state_chan_append_labeled han msg s)).
+Proof.
+Admitted.
+
+Theorem state_upd_node_unobs: forall ell s id n,
+    ~(lbl (nodes s).[? id] <<L ell) ->
+    (state_low_eq ell s (state_upd_node id n s)).
 Proof.
 Admitted.
 

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -104,26 +104,19 @@ Section low_projection.
     intros. eauto. intros. eapply top_is_top.
   Qed.
   
-  Theorem low_projection_preserves_observability {A: Type}: forall ell (x: @labeled A),
-    x.(lbl) <<L ell -> (low_proj ell x).(lbl) <<L ell.
+  Theorem low_proj_preserves_obs {A: Type}: forall ell (x: @labeled A),
+    x.(lbl) <<L ell <-> (low_proj ell x).(lbl) <<L ell.
   Proof.
       destruct x. cbv [RuntimeModel.lbl].
-      unfold low_proj. destruct_match.  eauto. contradiction.
+      unfold low_proj. split; destruct_match. 
+      (* -> *)
+      eauto. contradiction.
+      (* <- *)
+      eauto. intros. pose proof (top_is_top ell).
+      replace ell with top by (apply ord_anti; auto).
+      apply top_is_top. 
   Qed.
     
-  (*
-  Theorem low_projection_preserves_lbl {A: Type}: forall ell (x: @labeled A),
-      (low_proj ell x).(lbl) = x.(lbl).
-  Proof.
-      intros. destruct x. simpl. destruct (lbl <<? ell); auto.
-  Qed.
-  
-  Definition node_projection_preserves_lbl :=
-      @low_projection_preserves_lbl node.
-  Definition chan_projection_preserves_lbl := 
-      @low_projection_preserves_lbl channel.
-  *)
-  
   Theorem uncons_proj_chan_s: forall ell s han ch,
       (chans (state_low_proj ell s)).[? han] = ch ->
       exists ch',
@@ -179,14 +172,6 @@ Section low_projection.
   Proof.
   Admitted.
   
-  Theorem node_projection_preserves_flowsto: forall ell s id n n',
-      s.(nodes).[? id] = n ->
-      (state_low_proj ell s).(nodes).[? id] = n' ->
-      ~(n.(lbl) <<L ell) ->
-      ~(n'.(lbl) <<L ell).
-  Proof.
-  Admitted.
-
   Theorem proj_preserves_fresh_han: forall ell s h,
       fresh_han s h ->
       fresh_han (state_low_proj ell s) h.

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -18,285 +18,285 @@ Require Import Coq.Classes.RelationClasses.
 Local Open Scope map_scope.
 
 Section misc.
-  Theorem can_split_node_index: forall s id n ell,
-      (nodes s).[? id] = {| obj := Some n; lbl := ell |} ->
-      (obj (nodes s).[? id] = Some n) /\
-      (lbl (nodes s).[? id] = ell).
-  Proof.
-      intros. split; destruct ((nodes s).[? id]).
-      - unfold RuntimeModel.obj. inversion H. reflexivity.
-      - unfold RuntimeModel.lbl. inversion H. reflexivity.
-  Qed.
-
-  Theorem can_split_chan_index: forall s han ch ell,
-      (chans s).[? han] = {| obj := Some ch; lbl := ell|} ->
-      (obj (chans s).[? han] = Some ch) /\
-      (lbl (chans s).[? han] = ell).
-  Proof.
-    intros. split; destruct ((chans s).[? han]).
+Theorem can_split_node_index: forall s id n ell,
+    (nodes s).[? id] = {| obj := Some n; lbl := ell |} ->
+    (obj (nodes s).[? id] = Some n) /\
+    (lbl (nodes s).[? id] = ell).
+Proof.
+    intros. split; destruct ((nodes s).[? id]).
     - unfold RuntimeModel.obj. inversion H. reflexivity.
     - unfold RuntimeModel.lbl. inversion H. reflexivity.
-  Qed.
+Qed.
+
+Theorem can_split_chan_index: forall s han ch ell,
+    (chans s).[? han] = {| obj := Some ch; lbl := ell|} ->
+    (obj (chans s).[? han] = Some ch) /\
+    (lbl (chans s).[? han] = ell).
+Proof.
+  intros. split; destruct ((chans s).[? han]).
+  - unfold RuntimeModel.obj. inversion H. reflexivity.
+  - unfold RuntimeModel.lbl. inversion H. reflexivity.
+Qed.
 
 End misc.
 
 Section low_projection.
 
-  Theorem flows_labeled_proj {A: Type}: forall ell (x: @labeled A),
-      (lbl x <<L ell) ->
-      (low_proj ell x) = x.
-  Proof.
-      intros. destruct x. unfold low_proj. simpl in H.
-      destruct (lbl <<? ell); eauto; try contradiction.
-  Qed.
-  
-  Theorem nflows_labeled_proj {A: Type}: forall ell (x: @labeled A),
-      ~(lbl x <<L ell) ->
-      (low_proj ell x) = Labeled A None top.
-  Proof.
-      intros. destruct x. unfold low_proj. simpl in H.
-      destruct (lbl <<? ell); eauto; try contradiction.
-  Qed.
-  
-  Definition idempotent {A: Type} (f: A -> A) := forall a, f (f a) = f a.
-  
-  Theorem labeled_low_proj_idempotent {A: Type}:
-      forall ell, idempotent (@low_proj A ell).
-  Proof.
-      intros. unfold idempotent. intros x.
-      destruct x. unfold low_proj. destruct (lbl <<? ell)  eqn:Hflows.
-      rewrite Hflows; eauto. destruct (top <<? ell); reflexivity.
-  Qed.
-  
-  Definition node_low_proj_idempotent := @labeled_low_proj_idempotent node.
-  Definition chan_low_proj_idempotent := @labeled_low_proj_idempotent channel.
-  Definition event_low_proj_idempotent := @labeled_low_proj_idempotent event.
-  
-  Theorem state_low_proj_idempotent: forall ell, idempotent (state_low_proj ell).
-  Proof.
-  Admitted.
-  
-  Definition low_proj_loweq {A: Type}{a_low_proj: @low_proj_t A}
-      {a_low_eq: @low_eq_t A} := forall ell x,
-      (a_low_eq ell (a_low_proj ell x) x).
-  
-  Theorem labeled_low_proj_loweq {A: Type}:
-      @low_proj_loweq (@labeled A) low_proj low_eq.
-  Proof.
-      unfold low_proj_loweq. unfold low_eq. unfold low_proj. intros.
-      destruct x. destruct (lbl <<? ell) eqn:Hflows.
-      rewrite Hflows. reflexivity.
-      destruct (top <<? ell); reflexivity.
-  Qed.
-  
-  Definition node_low_proj_loweq := @labeled_low_proj_loweq node.
-  Definition chan_low_proj_loweq := @labeled_low_proj_loweq channel.
-  Definition event_low_proj_loweq := @labeled_low_proj_loweq event.
-  
-  Theorem state_low_proj_loweq: 
-      @low_proj_loweq state state_low_proj state_low_eq.
-  Proof.
-  Admitted.
+Theorem flows_labeled_proj {A: Type}: forall ell (x: @labeled A),
+    (lbl x <<L ell) ->
+    (low_proj ell x) = x.
+Proof.
+    intros. destruct x. unfold low_proj. simpl in H.
+    destruct (lbl <<? ell); eauto; try contradiction.
+Qed.
 
-  Theorem proj_labels_increase {A: Type }: forall ell ell' (x: @labeled A),
-    ell' <<L x.(lbl) -> ell' <<L (low_proj ell x).(lbl).
-    destruct x. cbv [RuntimeModel.lbl]. unfold low_proj. destruct_match.
-    intros. eauto. intros. eapply top_is_top.
-  Qed.
+Theorem nflows_labeled_proj {A: Type}: forall ell (x: @labeled A),
+    ~(lbl x <<L ell) ->
+    (low_proj ell x) = Labeled A None top.
+Proof.
+    intros. destruct x. unfold low_proj. simpl in H.
+    destruct (lbl <<? ell); eauto; try contradiction.
+Qed.
+
+Definition idempotent {A: Type} (f: A -> A) := forall a, f (f a) = f a.
+
+Theorem labeled_low_proj_idempotent {A: Type}:
+    forall ell, idempotent (@low_proj A ell).
+Proof.
+    intros. unfold idempotent. intros x.
+    destruct x. unfold low_proj. destruct (lbl <<? ell)  eqn:Hflows.
+    rewrite Hflows; eauto. destruct (top <<? ell); reflexivity.
+Qed.
   
-  Theorem low_proj_preserves_obs {A: Type}: forall ell (x: @labeled A),
-    x.(lbl) <<L ell <-> (low_proj ell x).(lbl) <<L ell.
-  Proof.
-      destruct x. cbv [RuntimeModel.lbl].
-      unfold low_proj. split; destruct_match. 
-      (* -> *)
-      eauto. contradiction.
-      (* <- *)
-      eauto. intros. pose proof (top_is_top ell).
-      replace ell with top by (apply ord_anti; auto).
-      apply top_is_top. 
-  Qed.
+Definition node_low_proj_idempotent := @labeled_low_proj_idempotent node.
+Definition chan_low_proj_idempotent := @labeled_low_proj_idempotent channel.
+Definition event_low_proj_idempotent := @labeled_low_proj_idempotent event.
+
+Theorem state_low_proj_idempotent: forall ell, idempotent (state_low_proj ell).
+Proof.
+Admitted.
+
+Definition low_proj_loweq {A: Type}{a_low_proj: @low_proj_t A}
+    {a_low_eq: @low_eq_t A} := forall ell x,
+    (a_low_eq ell (a_low_proj ell x) x).
+
+Theorem labeled_low_proj_loweq {A: Type}:
+    @low_proj_loweq (@labeled A) low_proj low_eq.
+Proof.
+    unfold low_proj_loweq. unfold low_eq. unfold low_proj. intros.
+    destruct x. destruct (lbl <<? ell) eqn:Hflows.
+    rewrite Hflows. reflexivity.
+    destruct (top <<? ell); reflexivity.
+Qed.
+
+Definition node_low_proj_loweq := @labeled_low_proj_loweq node.
+Definition chan_low_proj_loweq := @labeled_low_proj_loweq channel.
+Definition event_low_proj_loweq := @labeled_low_proj_loweq event.
+
+Theorem state_low_proj_loweq: 
+    @low_proj_loweq state state_low_proj state_low_eq.
+Proof.
+Admitted.
+
+Theorem proj_labels_increase {A: Type }: forall ell ell' (x: @labeled A),
+  ell' <<L x.(lbl) -> ell' <<L (low_proj ell x).(lbl).
+  destruct x. cbv [RuntimeModel.lbl]. unfold low_proj. destruct_match.
+  intros. eauto. intros. eapply top_is_top.
+Qed.
+
+Theorem low_proj_preserves_obs {A: Type}: forall ell (x: @labeled A),
+  x.(lbl) <<L ell <-> (low_proj ell x).(lbl) <<L ell.
+Proof.
+    destruct x. cbv [RuntimeModel.lbl].
+    unfold low_proj. split; destruct_match. 
+    (* -> *)
+    eauto. contradiction.
+    (* <- *)
+    eauto. intros. pose proof (top_is_top ell).
+    replace ell with top by (apply ord_anti; auto).
+    apply top_is_top. 
+Qed.
     
-  Theorem uncons_proj_chan_s: forall ell s han ch,
-      (chans (state_low_proj ell s)).[? han] = ch ->
-      exists ch',
-          (chans s).[? han] = ch' /\
-          low_proj ell ch' = ch.
-  Proof.
-  Admitted.
-  
-  Theorem uncons_proj_node_s': forall ell s id,
-      (nodes (state_low_proj ell s)).[? id] = 
-      (low_proj ell (nodes s).[? id]).
-  Proof.
-      unfold state_low_proj. unfold fnd. unfold node_state_low_proj. simpl. intros.
-      destruct (lbl (nodes s id) <<? ell); try reflexivity.
-  Qed.
-  
-  Theorem uncons_proj_node_s: forall ell s id n,
-      (nodes (state_low_proj ell s)).[? id] = n ->
-      exists n',
-          ((nodes s).[? id] = n') /\
-          (low_proj ell n') = n.
-  Proof.
-      intros. rewrite uncons_proj_node_s' in H.
-      unfold fnd in *. unfold state_low_proj in *. simpl in *.
-      exists (nodes s id); split; eauto.
-  Qed.
-  
-  Theorem state_nidx_to_proj_state_idx: forall ell s id n,
-      ((nodes s).[? id] = n) ->
-      ((nodes (state_low_proj ell s)).[? id] = (low_proj ell n)).
-  Proof.
-  Admitted.
-  
-  Theorem state_hidx_to_proj_state_hidx': forall ell s h,
-      (chans (state_low_proj ell s)).[? h] = (low_proj ell (chans s).[?h ]).
-  Proof.
-  Admitted.
-  
-  Theorem state_hidx_to_proj_state_hidx: forall ell s h ch,
-      ((chans s).[? h] = ch) ->
-      ((chans (state_low_proj ell s)).[? h] = (low_proj ell ch)).
-  Proof.
-  Admitted.
-  
-  (* TODO give better name *)
-  Theorem proj_node_state_to_proj_n: forall ell s id nl n,
-      ((nodes (state_low_proj ell s)).[? id] = nl) ->
-      nl.(obj) = Some n ->
-      exists nl' n',
-          (nodes s).[? id] = nl' /\
-          (low_proj ell nl') = nl /\
-          nl'.(obj) = Some n'.
-  Proof.
-  Admitted.
-  
-  Theorem proj_preserves_fresh_han: forall ell s h,
-      fresh_han s h ->
-      fresh_han (state_low_proj ell s) h.
-  Proof.
-      (* depends on concurrent change to def of states, but
-      should be true *)
-  Admitted.
+Theorem uncons_proj_chan_s: forall ell s han ch,
+    (chans (state_low_proj ell s)).[? han] = ch ->
+    exists ch',
+        (chans s).[? han] = ch' /\
+        low_proj ell ch' = ch.
+Proof.
+Admitted.
 
-  Theorem proj_preserves_fresh_nid: forall ell s id,
-      fresh_nid s id ->
-      fresh_nid (state_low_proj ell s) id.
-  Proof.
-  Admitted.
+Theorem uncons_proj_node_s': forall ell s id,
+    (nodes (state_low_proj ell s)).[? id] = 
+    (low_proj ell (nodes s).[? id]).
+Proof.
+    unfold state_low_proj. unfold fnd. unfold node_state_low_proj. simpl. intros.
+    destruct (lbl (nodes s id) <<? ell); try reflexivity.
+Qed.
+
+Theorem uncons_proj_node_s: forall ell s id n,
+    (nodes (state_low_proj ell s)).[? id] = n ->
+    exists n',
+        ((nodes s).[? id] = n') /\
+        (low_proj ell n') = n.
+Proof.
+    intros. rewrite uncons_proj_node_s' in H.
+    unfold fnd in *. unfold state_low_proj in *. simpl in *.
+    exists (nodes s id); split; eauto.
+Qed.
+
+Theorem state_nidx_to_proj_state_idx: forall ell s id n,
+    ((nodes s).[? id] = n) ->
+    ((nodes (state_low_proj ell s)).[? id] = (low_proj ell n)).
+Proof.
+Admitted.
+
+Theorem state_hidx_to_proj_state_hidx': forall ell s h,
+    (chans (state_low_proj ell s)).[? h] = (low_proj ell (chans s).[?h ]).
+Proof.
+Admitted.
+
+Theorem state_hidx_to_proj_state_hidx: forall ell s h ch,
+    ((chans s).[? h] = ch) ->
+    ((chans (state_low_proj ell s)).[? h] = (low_proj ell ch)).
+Proof.
+Admitted.
+
+(* TODO give better name *)
+Theorem proj_node_state_to_proj_n: forall ell s id nl n,
+    ((nodes (state_low_proj ell s)).[? id] = nl) ->
+    nl.(obj) = Some n ->
+    exists nl' n',
+        (nodes s).[? id] = nl' /\
+        (low_proj ell nl') = nl /\
+        nl'.(obj) = Some n'.
+Proof.
+Admitted.
+
+Theorem proj_preserves_fresh_han: forall ell s h,
+    fresh_han s h ->
+    fresh_han (state_low_proj ell s) h.
+Proof.
+    (* depends on concurrent change to def of states, but
+    should be true *)
+Admitted.
+
+Theorem proj_preserves_fresh_nid: forall ell s id,
+    fresh_nid s id ->
+    fresh_nid (state_low_proj ell s) id.
+Proof.
+Admitted.
 
 End low_projection.
 
 Section low_equivalence.
 
-  Global Instance node_state_low_eq_refl: forall ell, Reflexive (node_state_low_eq ell) | 10.
-  Proof. congruence. Qed.
-  
-  Global Instance node_state_low_eq_trans: forall ell, Transitive (node_state_low_eq ell) | 10.
-  Proof. congruence. Qed.
-  
-  Global Instance node_state_low_eq_sym: forall ell, Symmetric (node_state_low_eq ell) | 10.
-  Proof. congruence. Qed.
-  
-  Global Instance chan_state_low_eq_refl: forall ell, Reflexive (chan_state_low_eq ell) | 10.
-  Proof. congruence. Qed.
-  
-  Global Instance chan_state_low_eq_trans: forall ell, Transitive (chan_state_low_eq ell) | 10.
-  Proof. congruence. Qed.
-  
-  Global Instance chan_state_low_eq_sym: forall ell, Symmetric (chan_state_low_eq ell) | 10.
-  Proof. congruence. Qed.
-  
-  Global Instance state_low_eq_refl: forall ell, Reflexive (state_low_eq ell) | 10.
-  Proof. unfold state_low_eq. unfold Reflexive. eauto.  Qed.
-  
-  Global Instance state_low_eq_trans: forall ell, Transitive (state_low_eq ell) | 10.
-  Proof. cbv [Transitive state_low_eq]. intros. destruct H, H0. split; congruence. Qed.
-  
-  Global Instance state_low_eq_sym: forall ell, Symmetric (state_low_eq ell) | 10.
-  Proof. intros. unfold Symmetric. unfold state_low_eq. intros. destruct H. split; eauto.
-  Qed.
-  
-  Global Instance event_low_eq_refl: forall ell, Reflexive (event_low_eq ell) | 10.
-  Proof. congruence. Qed.
-  
-  Global Instance event_low_eq_trans: forall ell, Transitive (event_low_eq ell) | 10.
-  Proof. congruence. Qed.
-  
-  Global Instance event_low_eq_sym: forall ell, Symmetric (event_low_eq ell) | 10.
-  Proof. congruence. Qed.
-  
-  Theorem state_loweq_from_substates: forall ell s1 s2,
-      node_state_low_eq ell (nodes s1) (nodes s2) ->
-      chan_state_low_eq ell (chans s1) (chans s2) ->
-      state_low_eq ell s1 s2.
-  Proof.
-    intros. unfold state_low_eq. unfold low_eq. unfold state_low_proj. eauto.
-  Qed.
-  
-  Theorem state_loweq_to_deref_node: forall ell s1 s2 id n1,
-      (nodes s1).[? id] = n1 ->
-      (state_low_eq ell s1 s2) ->
-      exists n2,
-          (nodes s2).[? id] = n2 /\
-          (node_low_eq ell n1 n2).
-  Proof.
-      intros. inversion H0. unfold node_state_low_proj in *. 
-  Admitted. 
-  
-  Theorem trace_leq_imples_head_st_leq: forall ell t1 t2 s1 s2,
-      (head_st t1 = Some s1) ->
-      (head_st t2 = Some s2) ->
-      (trace_low_eq ell t1 t2) ->
-      (state_low_eq ell s1 s2).
-  Proof.
-      inversion 3. 
-      - 
-          exfalso. rewrite <- H3 in H. inversion H.
-      - 
-          assert (xs = s1). {
-              assert (head_st ((xs, xe) :: t0 ) = Some xs) by reflexivity.
-              congruence.
-          }
-  
-          assert (ys = s2). {
-              assert (head_st ((ys, ye) :: t3 ) = Some ys) by reflexivity.
-              congruence.
-          }
-      congruence.
-  Qed.
+Global Instance node_state_low_eq_refl: forall ell, Reflexive (node_state_low_eq ell) | 10.
+Proof. congruence. Qed.
+
+Global Instance node_state_low_eq_trans: forall ell, Transitive (node_state_low_eq ell) | 10.
+Proof. congruence. Qed.
+
+Global Instance node_state_low_eq_sym: forall ell, Symmetric (node_state_low_eq ell) | 10.
+Proof. congruence. Qed.
+
+Global Instance chan_state_low_eq_refl: forall ell, Reflexive (chan_state_low_eq ell) | 10.
+Proof. congruence. Qed.
+
+Global Instance chan_state_low_eq_trans: forall ell, Transitive (chan_state_low_eq ell) | 10.
+Proof. congruence. Qed.
+
+Global Instance chan_state_low_eq_sym: forall ell, Symmetric (chan_state_low_eq ell) | 10.
+Proof. congruence. Qed.
+
+Global Instance state_low_eq_refl: forall ell, Reflexive (state_low_eq ell) | 10.
+Proof. unfold state_low_eq. unfold Reflexive. eauto.  Qed.
+
+Global Instance state_low_eq_trans: forall ell, Transitive (state_low_eq ell) | 10.
+Proof. cbv [Transitive state_low_eq]. intros. destruct H, H0. split; congruence. Qed.
+
+Global Instance state_low_eq_sym: forall ell, Symmetric (state_low_eq ell) | 10.
+Proof. intros. unfold Symmetric. unfold state_low_eq. intros. destruct H. split; eauto.
+Qed.
+
+Global Instance event_low_eq_refl: forall ell, Reflexive (event_low_eq ell) | 10.
+Proof. congruence. Qed.
+
+Global Instance event_low_eq_trans: forall ell, Transitive (event_low_eq ell) | 10.
+Proof. congruence. Qed.
+
+Global Instance event_low_eq_sym: forall ell, Symmetric (event_low_eq ell) | 10.
+Proof. congruence. Qed.
+
+Theorem state_loweq_from_substates: forall ell s1 s2,
+    node_state_low_eq ell (nodes s1) (nodes s2) ->
+    chan_state_low_eq ell (chans s1) (chans s2) ->
+    state_low_eq ell s1 s2.
+Proof.
+  intros. unfold state_low_eq. unfold low_eq. unfold state_low_proj. eauto.
+Qed.
+
+Theorem state_loweq_to_deref_node: forall ell s1 s2 id n1,
+    (nodes s1).[? id] = n1 ->
+    (state_low_eq ell s1 s2) ->
+    exists n2,
+        (nodes s2).[? id] = n2 /\
+        (node_low_eq ell n1 n2).
+Proof.
+    intros. inversion H0. unfold node_state_low_proj in *. 
+Admitted. 
+
+Theorem trace_leq_imples_head_st_leq: forall ell t1 t2 s1 s2,
+    (head_st t1 = Some s1) ->
+    (head_st t2 = Some s2) ->
+    (trace_low_eq ell t1 t2) ->
+    (state_low_eq ell s1 s2).
+Proof.
+    inversion 3. 
+    - 
+        exfalso. rewrite <- H3 in H. inversion H.
+    - 
+        assert (xs = s1). {
+            assert (head_st ((xs, xe) :: t0 ) = Some xs) by reflexivity.
+            congruence.
+        }
+
+        assert (ys = s2). {
+            assert (head_st ((ys, ye) :: t3 ) = Some ys) by reflexivity.
+            congruence.
+        }
+    congruence.
+Qed.
 
 End low_equivalence.
 
 Section unobservable.
 
-  (* These are theorems that say that when you change a part of a state that is
-      not visible to ell the old and new state are ell-equivalent
-  *)
-  
-  Theorem set_call_unobs: forall ell s id c,
-      ~(lbl (nodes s).[? id] <<L ell) ->
-      (state_low_eq ell s (s_set_call s id c)).
-  Proof.
-  Admitted.
-  
-  Theorem state_upd_chan_unobs: forall ell s han ch,
-      ~(lbl (chans s).[? han] <<L ell) ->
-      (state_low_eq ell s (state_upd_chan han ch s)).
-  Proof.
-  Admitted.
-  
-  Theorem state_chan_append_labeled_unobs: forall ell s han msg,
-      ~(lbl (chans s).[? han] <<L ell) ->
-      (state_low_eq ell s (state_chan_append_labeled han msg s)).
-  Proof.
-  Admitted.
-  
-  Theorem state_upd_node_unobs: forall ell s id n,
-      ~(lbl (nodes s).[? id] <<L ell) ->
-      (state_low_eq ell s (state_upd_node id n s)).
-  Proof.
-  Admitted.
+(* These are theorems that say that when you change a part of a state that is
+    not visible to ell the old and new state are ell-equivalent
+*)
+
+Theorem set_call_unobs: forall ell s id c,
+    ~(lbl (nodes s).[? id] <<L ell) ->
+    (state_low_eq ell s (s_set_call s id c)).
+Proof.
+Admitted.
+
+Theorem state_upd_chan_unobs: forall ell s han ch,
+    ~(lbl (chans s).[? han] <<L ell) ->
+    (state_low_eq ell s (state_upd_chan han ch s)).
+Proof.
+Admitted.
+
+Theorem state_chan_append_labeled_unobs: forall ell s han msg,
+    ~(lbl (chans s).[? han] <<L ell) ->
+    (state_low_eq ell s (state_chan_append_labeled han msg s)).
+Proof.
+Admitted.
+
+Theorem state_upd_node_unobs: forall ell s id n,
+    ~(lbl (nodes s).[? id] <<L ell) ->
+    (state_low_eq ell s (state_upd_node id n s)).
+Proof.
+Admitted.
   
 End unobservable.

--- a/experimental/ni_coq/vfiles/NIUtilTheorems.v
+++ b/experimental/ni_coq/vfiles/NIUtilTheorems.v
@@ -17,25 +17,25 @@ Require Import Coq.Classes.RelationClasses.
 Local Open Scope map_scope.
 
 Section misc.
-Theorem can_split_node_index: forall s id n ell,
-    (nodes s).[? id] = {| obj := Some n; lbl := ell |} ->
-    (obj (nodes s).[? id] = Some n) /\
-    (lbl (nodes s).[? id] = ell).
-Proof.
-    intros. split; destruct ((nodes s).[? id]).
-    - unfold RuntimeModel.obj. inversion H. reflexivity.
-    - unfold RuntimeModel.lbl. inversion H. reflexivity.
-Qed.
+  Theorem can_split_node_index: forall s id n ell,
+      (nodes s).[? id] = {| obj := Some n; lbl := ell |} ->
+      (obj (nodes s).[? id] = Some n) /\
+      (lbl (nodes s).[? id] = ell).
+  Proof.
+      intros. split; destruct ((nodes s).[? id]).
+      - unfold RuntimeModel.obj. inversion H. reflexivity.
+      - unfold RuntimeModel.lbl. inversion H. reflexivity.
+  Qed.
 
-Theorem can_split_chan_index: forall s han ch ell,
-    (chans s).[? han] = {| obj := Some ch; lbl := ell|} ->
-    (obj (chans s).[? han] = Some ch) /\
-    (lbl (chans s).[? han] = ell).
-Proof.
+  Theorem can_split_chan_index: forall s han ch ell,
+      (chans s).[? han] = {| obj := Some ch; lbl := ell|} ->
+      (obj (chans s).[? han] = Some ch) /\
+      (lbl (chans s).[? han] = ell).
+  Proof.
     intros. split; destruct ((chans s).[? han]).
     - unfold RuntimeModel.obj. inversion H. reflexivity.
     - unfold RuntimeModel.lbl. inversion H. reflexivity.
-Qed.
+  Qed.
 
 End misc.
 
@@ -267,32 +267,32 @@ End low_equivalence.
 
 Section unobservable.
 
-(* These are theorems that say that when you change a part of a state that is
-    not visible to ell the old and new state are ell-equivalent
-*)
-
-Theorem set_call_unobs: forall ell s id c,
-    ~(lbl (nodes s).[? id] <<L ell) ->
-    (state_low_eq ell s (s_set_call s id c)).
-Proof.
-Admitted.
-
-Theorem state_upd_chan_unobs: forall ell s han ch,
-    ~(lbl (chans s).[? han] <<L ell) ->
-    (state_low_eq ell s (state_upd_chan han ch s)).
-Proof.
-Admitted.
-
-Theorem state_chan_append_labeled_unobs: forall ell s han msg,
-    ~(lbl (chans s).[? han] <<L ell) ->
-    (state_low_eq ell s (state_chan_append_labeled han msg s)).
-Proof.
-Admitted.
-
-Theorem state_upd_node_unobs: forall ell s id n,
-    ~(lbl (nodes s).[? id] <<L ell) ->
-    (state_low_eq ell s (state_upd_node id n s)).
-Proof.
-Admitted.
-
+  (* These are theorems that say that when you change a part of a state that is
+      not visible to ell the old and new state are ell-equivalent
+  *)
+  
+  Theorem set_call_unobs: forall ell s id c,
+      ~(lbl (nodes s).[? id] <<L ell) ->
+      (state_low_eq ell s (s_set_call s id c)).
+  Proof.
+  Admitted.
+  
+  Theorem state_upd_chan_unobs: forall ell s han ch,
+      ~(lbl (chans s).[? han] <<L ell) ->
+      (state_low_eq ell s (state_upd_chan han ch s)).
+  Proof.
+  Admitted.
+  
+  Theorem state_chan_append_labeled_unobs: forall ell s han msg,
+      ~(lbl (chans s).[? han] <<L ell) ->
+      (state_low_eq ell s (state_chan_append_labeled han msg s)).
+  Proof.
+  Admitted.
+  
+  Theorem state_upd_node_unobs: forall ell s id n,
+      ~(lbl (nodes s).[? id] <<L ell) ->
+      (state_low_eq ell s (state_upd_node id n s)).
+  Proof.
+  Admitted.
+  
 End unobservable.

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -168,7 +168,13 @@ Proof.
         eapply state_upd_node_unobs; eauto.
         eapply state_chan_append_labeled_unobs; eauto.
     - (* WriteChannel; events loweq*)
-        
+        simpl. Check nflows_labeled_proj.
+        unfold event_low_eq. unfold low_eq.
+        erewrite nflows_labeled_proj.
+        erewrite nflows_labeled_proj.
+        all: eauto.
+    - (* ReadChannel; states loweq *)
+
 Admitted.
 (*
     - (* WriteChannel; states loweq *) 
@@ -239,8 +245,6 @@ Admitted.
     erewrite event_low_proj_idempotent. reflexivity.
 Qed.
 *)
-
-
 
 Theorem step_implies_lowproj_steps_leq: forall ell s1 s1' e1,
     (step_system_ev s1 s1' e1) ->
@@ -351,6 +355,14 @@ Proof.
             (* events leq *)
             congruence.
 Qed.
+(*
+=======
+            admit. (* depends on soon-to-change def of state low-eqs *)
+            pose proof (state_low_proj_loweq ell s1).
+            all: congruence.
+Admitted.
+>>>>>>> 4b5dd548 (Fixup from old PR.)
+*)
 
 Lemma separate_lableled {A} (o : option A) (l : level) (x : labeled) :
   obj x = o -> lbl x = l -> x = Labeled _ o l.

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -160,6 +160,15 @@ Theorem unobservable_node_step: forall ell s s' e id nl n,
     (state_low_eq ell s s') /\ (event_low_eq ell e (empty_event e.(lbl))).
 Proof.
     intros. inversion H1; (split; [ inversion H5 | ] ); subst_lets; crush.
+    - (* WriteChannel; states loweq *)
+        assert ((nodes s).[? id].(lbl) = nlbl0) by (rewrite H11; reflexivity).
+        assert (~ nlbl0 <<L ell) by congruence.
+        assert ( ~ (lbl (chans s).[? han] <<L ell) ) by eauto using ord_trans.
+        eapply state_low_eq_trans.
+        eapply state_upd_node_unobs; eauto.
+        eapply state_chan_append_labeled_unobs; eauto.
+    - (* WriteChannel; events loweq*)
+        
 Admitted.
 (*
     - (* WriteChannel; states loweq *) 
@@ -489,7 +498,9 @@ Proof.
                 eapply set_call_unobs. eauto.
                 replace (lbl ns1') with (lbl n')
                     by (eapply node_low_eq_to_lbl_eq; eassumption).
-                admit.
+                replace (lbl n') with (lbl nl). eauto.
+                rewrite <- Hproj_n'.
+                eapply low_projection_preserves_lbl.
             + (* e1 ={ell} *) assumption.
 Admitted.
 

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -335,13 +335,13 @@ Proof.
         destruct (nl.(lbl) <<? ell).
         * (* flowsto case *)
             inversion H_step_s1_s1'; crush; remember ((nodes s1).[?id]) as nl;
-                pose proof (state_nidx_to_proj_state_idx ell _ _ nl
-                    ltac:(eauto)) as Hn_idx_s1proj;
-                (erewrite flows_labeled_proj in Hn_idx_s1proj; eauto);
-                inversion H3; crush; subst_lets.
-                all: try replace n0 with n in * by
-                (pose proof (can_split_node_index _ _ _ _ ltac:(eauto));
-                    logical_simplify; congruence). 
+            pose proof (state_nidx_to_proj_state_idx ell _ _ nl
+                ltac:(eauto)) as Hn_idx_s1proj;
+            (erewrite flows_labeled_proj in Hn_idx_s1proj; eauto);
+            inversion H3; crush; subst_lets.
+            all: try replace n0 with n in * by
+            (pose proof (can_split_node_index _ _ _ _ ltac:(eauto));
+                logical_simplify; congruence). 
             (*
                 I can't quite get this to work. Coq complains
                 about s1 not being found in environment
@@ -447,31 +447,30 @@ Proof.
         pose proof (uncons_proj_node_s _ _ _ nl ltac:(eauto))
             as [n' [Hidx_n' Hproj_n']].
         destruct (nl.(lbl) <<? ell).
-        * admit.
-          (* flowsto case*)
-          (*
-            inversion H_step_projs_s1'; inversion H3;
-              (rewrite @flows_labeled_proj in *; eauto); crush;
-                lazymatch goal with
-                | |- _ <<L _ => erewrite <-low_projection_preserves_lbl; rewrite Hproj_n';
-                                solve [eauto]
+        * (* flowsto case*)
+            inversion H_step_projs_s1'; inversion H3.
+            all: rewrite @flows_labeled_proj in *; eauto; crush.
+            all: erewrite uncons_proj_node_s' in *.
+            all: lazymatch goal with
+                | H: lbl (low_proj _ _ ) <<L _ |- _ <<L _ =>
+                    rewrite <- low_proj_preserves_obs in H; eauto
                 | _ => idtac
-                end.
-            *)
-        (* WriteChannel *)
-          (*
-          remember (s_set_call (state_chan_append_labeled han msg
-                                                          (state_upd_node id n'0 s)) id c') as s2''.
-          separate_hyp node.
-          eexists s2'', (lbl _ ---> msg). split.
-          { crush; try congruence;
-              [ separate_goal; eauto; congruence | ].
-            rewrite <-Hproj_n' in *.
-            eauto using invert_chans_state_low_proj_flowsto. }
-          split.
-          { crush; subst_lets; eauto with unwind. }
-          { crush. congruence. }
-          *)
+            end.
+            all: separate_hyp node; separate_hyp channel.
+            + (* WriteChannel *)
+                remember (s_set_call (state_chan_append_labeled han msg
+                                        (state_upd_node id n'0 s)) id c') as s2''.
+                eexists s2'', (lbl _ ---> msg); split; [ | split].
+                { crush; try congruence. 
+                    separate_goal; eauto; congruence.
+                  rewrite <-Hproj_n' in *.
+                  eauto using invert_chans_state_low_proj_flowsto. }
+                { crush; subst_lets; eauto with unwind. }
+                { crush. congruence. }
+            + (* ReadChannel *) admit.
+            + (* CreateChannel *) admit.
+            + (* CreateNode *) admit. 
+            + (* Internal *) admit.
           (*
            + (* WriteChannel *)
                 pose proof (uncons_proj_chan_s _ _ _ _ ltac:(eauto))

--- a/experimental/ni_coq/vfiles/RuntimeModel.v
+++ b/experimental/ni_coq/vfiles/RuntimeModel.v
@@ -188,6 +188,10 @@ Definition node_del_rhans (hs: Ensemble handle)(n: node): node :=
 
 Definition new_chan := Some {| ms := [] |}.
 
+Definition fresh_han s h := s.(chans).[?h] = Labeled channel None top.
+
+Definition fresh_nid s id := s.(nodes).[?id] = Labeled node None top.
+
 Definition s_set_call s id c :=
     match (s.(nodes).[?id]).(obj) with
         | None => s
@@ -256,6 +260,8 @@ Inductive step_node (id: node_id): call -> state -> state -> Prop :=
     | SCreateChan s n nlbl h clbl:
         (s.(nodes).[?id]) = Labeled node (Some n) nlbl ->
             (* caller is a real node with label nlbl *)
+        fresh_han s h ->
+            (* the target handle is not in use *)
         nlbl <<L clbl ->
             let s0 := (state_upd_chan_labeled h {|
                 obj := new_chan; lbl := clbl;
@@ -266,6 +272,8 @@ Inductive step_node (id: node_id): call -> state -> state -> Prop :=
     | SCreateNode s n nlbl new_id new_lbl h:
         (s.(nodes).[?id]) = Labeled node (Some n) nlbl ->
             (* caller is a real node with label nlbl *)
+        fresh_nid s id ->
+            (* target nid is not in use *)
         nlbl <<L new_lbl ->
             (* create new node with read handle *)
         let s0 := (state_upd_node_labeled new_id {|

--- a/experimental/ni_coq/vfiles/Unwind.v
+++ b/experimental/ni_coq/vfiles/Unwind.v
@@ -40,14 +40,6 @@ Proof.
   inversion 1; subst.
   cbv [state_upd_node state_low_eq state_low_proj set].
   cbn [RuntimeModel.nodes RuntimeModel.chans].
-  (* this is not provable as stated; because the node-maps are functions, the
-     fact that they return the same result for every input doesn't mean they
-     obey Leibniz equality. The [low_eq] definition should probably say,
-     instead of [low_proj ell x = low_proj ell y], something like:
-
-     (forall id, nodes (low_proj_ell x) id = nodes (low_proj ell y) id)
-     /\ (forall han, chans (low_proj_ell x) han = chans (low_proj ell y) han)
-   *)
 Admitted. (* WIP // TODO *)
 
 Theorem chan_append_unwind: forall ell ch1 ch2 ch1obj ch2obj msg,


### PR DESCRIPTION
The commit messages are worth reading as a guide for the most significant changes,

particularly the commit message for "[WIP]Working on unobs; need significant def change"

The proof state is roughly where it was before despite the low-level definitional change.

I fixed and then unfixed the spacing in NIUtils to make the PR readable temporarily :) 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
