### PR TITLE
Generate simpler gRPC methods

### DIFF
--- a/oak_utils/src/lib.rs
+++ b/oak_utils/src/lib.rs
@@ -70,26 +70,31 @@ impl prost_build::ServiceGenerator for OakServiceGenerator {
         });
 
         let dispatcher_name = format_ident!("{}Dispatcher", service.name);
-        let dispatcher_methods = service.methods.iter().map(|method| {
+        let dispatcher_invocable_methods = service.methods.iter().map(|method| {
             let method_name = format_ident!("{}", method.name);
-            let method_name_string = format!("/{}.{}/{}", service.package, service.proto_name, method.proto_name);
-            // Figure out which generic function applies.
-            let handle_invocation = match (method.client_streaming, method.server_streaming) {
+            let method_name_string = format!(
+                "/{}.{}/{}",
+                service.package, service.proto_name, method.proto_name
+            );
+            // Figure out which `ServerMethod` variant applies.
+            let invocable_method = match (method.client_streaming, method.server_streaming) {
                 (false, false) => quote! {
-                    #oak_package::grpc::handle_req_rsp(|r| (self.0).#method_name(r), req, writer)
+                    Some(Box::new(#oak_package::grpc::ServerMethod::UnaryUnary(T::#method_name)))
                 },
                 (false, true) => quote! {
-                    #oak_package::grpc::handle_req_stream(|r, w| (self.0).#method_name(r, w), req, writer)
+                    // The response type is not actually used in the method signature, so we need to manually specify a placeholder.
+                    Some(Box::new(#oak_package::grpc::ServerMethod::<_, _, ()>::UnaryStream(T::#method_name)))
                 },
                 (true, false) => quote! {
-                    #oak_package::grpc::handle_stream_rsp(|rr| (self.0).#method_name(rr), req, writer)
+                    Some(Box::new(#oak_package::grpc::ServerMethod::StreamUnary(T::#method_name)))
                 },
                 (true, true) => quote! {
-                    #oak_package::grpc::handle_stream_stream(|rr, w| (self.0).#method_name(rr, w), req, writer)
+                    // The response type is not actually used in the method signature, so we need to manually specify a placeholder.
+                    Some(Box::new(#oak_package::grpc::ServerMethod::<_, _, ()>::StreamStream(T::#method_name)))
                 },
             };
             quote! {
-                #method_name_string => #handle_invocation
+                #method_name_string => #invocable_method
             }
         });
 
@@ -129,9 +134,16 @@ impl prost_build::ServiceGenerator for OakServiceGenerator {
             pub struct #dispatcher_name<T: #service_name>(T);
 
             #[allow(dead_code)]
-            impl <T: #service_name> #dispatcher_name<T> {
+            impl <'a, T: #service_name + 'a> #dispatcher_name<T> {
                 pub fn new(node: T) -> #dispatcher_name<T> {
                     #dispatcher_name(node)
+                }
+
+                pub fn server_method(method_name: &str) -> Option<Box<dyn #oak_package::grpc::Invocable<T> + 'a>> {
+                    match method_name {
+                        #(#dispatcher_invocable_methods,)*
+                        _ => None
+                    }
                 }
             }
 
@@ -151,12 +163,10 @@ impl prost_build::ServiceGenerator for OakServiceGenerator {
 
             #[allow(clippy::unit_arg)]
             impl <T: #service_name> #oak_package::grpc::ServerNode for #dispatcher_name<T> {
-                fn invoke(&mut self, method: &str, req: &[u8], writer: #oak_package::grpc::ChannelResponseWriter) {
-                    match method {
-                        #(#dispatcher_methods,)*
-                        _ => {
-                            ::log::error!("unknown method name: {}", method);
-                        }
+                fn invoke(&mut self, method_name: &str, req: &[u8], writer: #oak_package::grpc::ChannelResponseWriter) {
+                    match #dispatcher_name::<T>::server_method(method_name) {
+                        Some(mut server_method) => server_method.invoke(&mut self.0, req, writer),
+                        None => ::log::error!("unknown method name: {}", method_name),
                     }
                 }
             }

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -295,74 +295,71 @@ where
     Ok(rsp)
 }
 
-/// Generic function that handles request deserialization and response
-/// serialization (and sending down a channel) for a function that handles a
-/// request/response pair.
+/// Trait implemented by all server method variants, applied to a server receiver instance having
+/// concrete type `T`.
+pub trait Invocable<T> {
+    /// Generic function that handles request deserialization and response serialization (and
+    /// sending down a channel) for a function that handles a request / response pair (either unary
+    /// or streaming).
+    ///
+    /// Panics if [de-]serialization or channel operations fail.
+    fn invoke(&mut self, target: &mut T, req: &[u8], writer: ChannelResponseWriter);
+}
+
+/// Enum with variants for all combinations of {request, response} × {unary , streaming}, each
+/// containing a pointer to the function of the appropriate type defined on a service
+/// implementation.
 ///
-/// Panics if [de-]serialization or channel operations fail.
-pub fn handle_req_rsp<C, R, Q>(mut node_fn: C, req: &[u8], writer: ChannelResponseWriter)
+/// The functions are "uncurried", i.e. they include an explicit parameter for the receiver type,
+/// which corresponds to `self` in the method definition.
+///
+/// Note that the variants with response stream do not make use of the type parameter `Q`, so this
+/// must be manually specified when creating one of those instances if the compiler cannot infer it
+/// from the context.
+pub enum ServerMethod<T, R, Q> {
+    UnaryUnary(fn(&mut T, R) -> Result<Q>),
+    UnaryStream(fn(&mut T, R, ChannelResponseWriter)),
+    StreamUnary(fn(&mut T, Vec<R>) -> Result<Q>),
+    StreamStream(fn(&mut T, Vec<R>, ChannelResponseWriter)),
+}
+
+impl<T, R, Q> Invocable<T> for ServerMethod<T, R, Q>
 where
-    C: FnMut(R) -> Result<Q>,
     R: prost::Message + Default,
     Q: prost::Message,
 {
-    let r = R::decode(req).expect("Failed to parse request protobuf message");
-    let result = match node_fn(r) {
-        Ok(rsp) => writer.write(&rsp, WriteMode::Close),
-        Err(status) => writer.close(Err(status)),
-    };
-    if let Err(e) = result {
-        panic!("Failed to process response: {:?}", e)
+    fn invoke(&mut self, target: &mut T, req: &[u8], writer: ChannelResponseWriter) {
+        match self {
+            ServerMethod::UnaryUnary(server_method) => {
+                let r = R::decode(req).expect("Failed to parse request protobuf message");
+                let result = match server_method(target, r) {
+                    Ok(rsp) => writer.write(&rsp, WriteMode::Close),
+                    Err(status) => writer.close(Err(status)),
+                };
+                if let Err(e) = result {
+                    panic!("Failed to process response: {:?}", e)
+                }
+            }
+            ServerMethod::UnaryStream(server_method) => {
+                let r = R::decode(req).expect("Failed to parse request protobuf message");
+                server_method(target, r, writer)
+            }
+            ServerMethod::StreamUnary(server_method) => {
+                // TODO(#97): better client-side streaming
+                let rr = vec![R::decode(req).expect("Failed to parse request protobuf message")];
+                let result = match server_method(target, rr) {
+                    Ok(rsp) => writer.write(&rsp, WriteMode::Close),
+                    Err(status) => writer.close(Err(status)),
+                };
+                if let Err(e) = result {
+                    panic!("Failed to process response: {:?}", e)
+                }
+            }
+            ServerMethod::StreamStream(server_method) => {
+                // TODO(#97): better client-side streaming
+                let rr = vec![R::decode(req).expect("Failed to parse request protobuf message")];
+                server_method(target, rr, writer)
+            }
+        }
     }
-}
-
-/// Generic function that handles request deserialization and response
-/// serialization (and sending down a channel) for a function that handles a
-/// request and streams responses.
-///
-/// Panics if [de-]serialization or channel operations fail.
-pub fn handle_req_stream<C, R>(mut node_fn: C, req: &[u8], writer: ChannelResponseWriter)
-where
-    C: FnMut(R, ChannelResponseWriter),
-    R: prost::Message + Default,
-{
-    let r = R::decode(req).expect("Failed to parse request protobuf message");
-    node_fn(r, writer)
-}
-
-/// Generic function that handles request deserialization and response
-/// serialization (and sending down a channel) for a function that handles a
-/// stream of requests to produce a response.
-///
-/// Panics if [de-]serialization or channel operations fail.
-pub fn handle_stream_rsp<C, R, Q>(mut node_fn: C, req: &[u8], writer: ChannelResponseWriter)
-where
-    C: FnMut(Vec<R>) -> Result<Q>,
-    R: prost::Message + Default,
-    Q: prost::Message + Default,
-{
-    // TODO(#97): better client-side streaming
-    let rr = vec![R::decode(req).expect("Failed to parse request protobuf message")];
-    let result = match node_fn(rr) {
-        Ok(rsp) => writer.write(&rsp, WriteMode::Close),
-        Err(status) => writer.close(Err(status)),
-    };
-    if let Err(e) = result {
-        panic!("Failed to process response: {:?}", e)
-    }
-}
-
-/// Generic function that handles request deserialization and response
-/// serialization (and sending down a channel) for a function that handles a
-/// stream of requests to produce a stream of responses.
-///
-/// Panics if [de-]serialization or channel operations fail.
-pub fn handle_stream_stream<C, R>(mut node_fn: C, req: &[u8], writer: ChannelResponseWriter)
-where
-    C: FnMut(Vec<R>, ChannelResponseWriter),
-    R: prost::Message + Default,
-{
-    // TODO(#97): better client-side streaming
-    let rr = vec![R::decode(req).expect("Failed to parse request protobuf message")];
-    node_fn(rr, writer)
 }

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -303,7 +303,7 @@ pub trait Invocable<T> {
     /// or streaming).
     ///
     /// Panics if [de-]serialization or channel operations fail.
-    fn invoke(&mut self, target: &mut T, req: &[u8], writer: ChannelResponseWriter);
+    fn invoke(&self, target: &mut T, req: &[u8], writer: ChannelResponseWriter);
 }
 
 /// Enum with variants for all combinations of {request, response} × {unary , streaming}, each
@@ -328,7 +328,7 @@ where
     R: prost::Message + Default,
     Q: prost::Message,
 {
-    fn invoke(&mut self, target: &mut T, req: &[u8], writer: ChannelResponseWriter) {
+    fn invoke(&self, target: &mut T, req: &[u8], writer: ChannelResponseWriter) {
         match self {
             ServerMethod::UnaryUnary(server_method) => {
                 let r = R::decode(req).expect("Failed to parse request protobuf message");


### PR DESCRIPTION
Instead of going back and forth between the generated code and the code
in `oak::grpc`, this change simplifies the logic of the dispatcher by
returning pointers to the appropriate methods based on method name. This
also allows accessing and manipulating those methods from other code,
enabling also reflection-like operations based on method names.

Ref #1691.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
