### PR TITLE
Add label to channels in oak_tests

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -579,7 +579,7 @@ async fn test_say_hello() {
     let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
-    let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+    let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
     let mut client = HelloWorldClient::with_interceptor(channel, interceptor);
 
     let req = HelloRequest {

--- a/examples/abitest/module_0/rust/tests/integration_test.rs
+++ b/examples/abitest/module_0/rust/tests/integration_test.rs
@@ -58,7 +58,7 @@ async fn setup() -> (
     let runtime =
         oak_runtime::configure_and_run(config).expect("unable to configure runtime with test wasm");
 
-    let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+    let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
     let client = OakAbiTestServiceClient::with_interceptor(channel, interceptor);
 
     (runtime, client)

--- a/examples/aggregator/module/rust/tests/integration_test.rs
+++ b/examples/aggregator/module/rust/tests/integration_test.rs
@@ -55,7 +55,7 @@ async fn test_aggregator() {
     )
     .expect("Unable to configure runtime with test wasm!");
 
-    let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+    let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
     let mut client = AggregatorClient::with_interceptor(channel, interceptor);
 
     for i in 0..SAMPLE_THRESHOLD as u32 {

--- a/examples/chat/module/rust/tests/integration_test.rs
+++ b/examples/chat/module/rust/tests/integration_test.rs
@@ -149,7 +149,7 @@ impl<'a> Chatter<'a> {
             user_handle,
             base64::encode(&room_key_pair.pkcs8_public_key())
         );
-        let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+        let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
         // TODO(#1357): Use key pair to authenticate this client and label requests.
         let client = ChatClient::with_interceptor(channel, interceptor);
         Chatter {

--- a/examples/hello_world/module/rust/tests/integration_test.rs
+++ b/examples/hello_world/module/rust/tests/integration_test.rs
@@ -28,7 +28,7 @@ async fn test_say_hello() {
     let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
-    let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+    let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
     let mut client = HelloWorldClient::with_interceptor(channel, interceptor);
 
     let req = HelloRequest {

--- a/examples/private_set_intersection/module/rust/tests/integration_test.rs
+++ b/examples/private_set_intersection/module/rust/tests/integration_test.rs
@@ -31,7 +31,7 @@ async fn test_set_intersection() {
     let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
-    let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+    let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
     let mut client = PrivateSetIntersectionClient::with_interceptor(channel, interceptor);
 
     let req = SubmitSetRequest {

--- a/examples/running_average/module/rust/tests/integration_test.rs
+++ b/examples/running_average/module/rust/tests/integration_test.rs
@@ -34,7 +34,7 @@ async fn test_running_average() {
     let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
         .expect("Unable to configure runtime with test wasm!");
 
-    let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+    let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
     let mut client = RunningAverageClient::with_interceptor(channel, interceptor);
 
     submit_sample(&mut client, 100).await;

--- a/examples/translator/module/rust/tests/integration_test.rs
+++ b/examples/translator/module/rust/tests/integration_test.rs
@@ -27,7 +27,7 @@ async fn test_translate() {
     let runtime = oak_tests::run_single_module(MODULE_WASM_FILE_NAME, "grpc_oak_main")
         .expect("Unable to configure runtime with test wasm!");
 
-    let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+    let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
     let mut client = TranslatorClient::with_interceptor(channel, interceptor);
 
     let req = TranslateRequest {

--- a/examples/trusted_database/module/rust/tests/integration_test.rs
+++ b/examples/trusted_database/module/rust/tests/integration_test.rs
@@ -130,7 +130,7 @@ async fn test_trusted_database() {
     let runtime =
         oak_runtime::configure_and_run(config).expect("Couldn't configure runtime with test wasm");
 
-    let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+    let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
     let mut client = TrustedDatabaseClient::with_interceptor(channel, interceptor);
 
     // Test nearest point of interest.

--- a/experimental/benchmark/src/application/oak.rs
+++ b/experimental/benchmark/src/application/oak.rs
@@ -60,7 +60,7 @@ impl OakApplication {
         let runtime = oak_runtime::configure_and_run(config)
             .expect("Couldn't configure runtime with test wasm");
 
-        let (channel, interceptor) = oak_tests::channel_and_interceptor().await;
+        let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
         let client = TrustedDatabaseClient::with_interceptor(channel, interceptor);
 
         OakApplication { runtime, client }

--- a/oak_abi/proto/label.proto
+++ b/oak_abi/proto/label.proto
@@ -87,7 +87,7 @@ message TlsEndpointTag {
 
 // Policies related to identities, specified using a cryptographic public key.
 message PublicKeyIdentityTag {
-  // Public key counterpart of the private key that is used to sign an authentication challenge. 
+  // Public key counterpart of the private key that is used to sign an authentication challenge.
   // In the current implementation it is represented as a serialized Ed25519 public key.
   // https://ed25519.cr.yp.to
   bytes public_key = 1;


### PR DESCRIPTION
This change adds `Label` to `channel_and_interceptor` since currently we start to check incoming client labels in examples.