### PR TITLE
Rewrite hello_world example using async std.

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -618,11 +618,13 @@ dependencies = [
  "assert_matches",
  "either",
  "env_logger",
+ "futures",
  "hello_world_grpc",
  "log",
  "maplit",
  "oak",
  "oak_abi",
+ "oak_async",
  "oak_io",
  "oak_runtime",
  "oak_tests",
@@ -1163,6 +1165,18 @@ dependencies = [
  "prost-build",
  "prost-types",
  "serde",
+]
+
+[[package]]
+name = "oak_async"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "futures-core",
+ "log",
+ "oak",
+ "oak_abi",
+ "prost",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -39,6 +39,7 @@ members = [
 # Oak.
 oak = { path = "../sdk/rust/oak" }
 oak_abi = { path = "../oak_abi" }
+oak_async = { path = "../experimental/oak_async" }
 oak_client = { path = "../oak_client" }
 oak_derive = { path = "../oak_derive" }
 oak_io = { path = "../oak_io" }

--- a/examples/hello_world/module/rust/Cargo.toml
+++ b/examples/hello_world/module/rust/Cargo.toml
@@ -11,9 +11,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 anyhow = "*"
 either = "*"
+futures = "0.3"
 log = "*"
 oak = "=0.1.0"
 oak_abi = "=0.1.0"
+oak_async = "=0.1.0"
 oak_io = "=0.1.0"
 prost = "*"
 translator_common = "=0.1.0"

--- a/examples/hello_world/module/rust/build.rs
+++ b/examples/hello_world/module/rust/build.rs
@@ -15,8 +15,12 @@
 //
 
 fn main() {
-    oak_utils::compile_protos(
+    oak_utils::compile_protos_with_options(
         &["../../proto/hello_world.proto"],
         &["../../proto", "../../../../third_party"],
+        oak_utils::ProtoOptions {
+            experimental_async: true,
+            ..Default::default()
+        },
     );
 }

--- a/examples/hello_world/module/rust/src/lib.rs
+++ b/examples/hello_world/module/rust/src/lib.rs
@@ -19,11 +19,16 @@ pub mod proto {
 }
 
 use either::Either;
+use futures::prelude::*;
 use log::info;
-use oak::grpc;
+use oak::{
+    grpc,
+    io::{Receiver, ReceiverExt},
+};
 use oak_abi::{label::Label, proto::oak::application::ConfigMap};
-use oak_io::Sender;
-use proto::{HelloRequest, HelloResponse, HelloWorld, HelloWorldDispatcher};
+use oak_async::ChannelReadStream;
+use oak_io::{InitWrapper, Sender};
+use proto::{asynchronous::HelloWorld as HelloWorldAsync, HelloRequest, HelloResponse};
 
 #[derive(Default)]
 struct Main;
@@ -39,8 +44,11 @@ impl oak::CommandHandler for Main {
             &Label::public_untrusted(),
             &oak::node_config::wasm("translator", "handler"),
         );
-        let handler_init_sender =
-            oak::io::entrypoint_node_create::<Node>("handler", &Label::public_untrusted(), "app")?;
+        let handler_init_sender = oak::io::node_create::<InitWrapper<Init, grpc::Invocation>>(
+            "handler",
+            &Label::public_untrusted(),
+            &oak::node_config::wasm("app", "async_node"),
+        )?;
         let handler_command_sender = oak::io::send_init(
             handler_init_sender,
             translator_sender_result
@@ -53,99 +61,113 @@ impl oak::CommandHandler for Main {
     }
 }
 
-struct Node {
-    translator: Option<translator_common::TranslatorClient>,
+struct Translator {
+    client: Option<translator_common::TranslatorClient>,
 }
 
-impl oak::WithInit for Node {
-    // Since `Option<T>` is not directly `Encodable` and `Decodable`, we emulate it via a
-    // `Either<(), T>`, which is isomorphic to it.
-    type Init = Either<(), Sender<grpc::Invocation>>;
-
-    fn create(init: Self::Init) -> Self {
-        Node {
-            translator: init.right().map(translator_common::TranslatorClient),
-        }
-    }
-}
-
-oak::entrypoint_command_handler_init!(node => Node);
-oak::impl_dispatcher!(impl Node : HelloWorldDispatcher);
-
-impl Node {
-    fn translate(&self, text: &str, from_lang: &str, to_lang: &str) -> Option<String> {
-        let client = self.translator.as_ref()?;
+impl Translator {
+    pub fn translate(&self, text: &str, from_lang: &str, to_lang: &str) -> Option<String> {
+        let client = self.client.as_ref()?;
         translator_common::translate(client, text, from_lang, to_lang)
     }
 }
 
-impl HelloWorld for Node {
-    fn say_hello(&mut self, req: HelloRequest) -> grpc::Result<HelloResponse> {
-        info!("Say hello to {}", req.greeting);
-        let mut res = HelloResponse::default();
-        res.reply = format!("HELLO {}!", req.greeting);
-        Ok(res)
-    }
+// The Init message received by `async_node`
+// Since `Option<T>` is not directly `Encodable` and `Decodable`, we emulate it via a
+// `Either<(), T>`, which is isomorphic to it.
+type Init = Either<(), Sender<grpc::Invocation>>;
 
-    fn lots_of_replies(&mut self, req: HelloRequest, writer: grpc::ChannelResponseWriter) {
-        info!("Say hello to {}", req.greeting);
-        let mut res1 = HelloResponse::default();
-        res1.reply = format!("HELLO {}!", req.greeting);
-        writer
-            .write(&res1, grpc::WriteMode::KeepOpen)
-            .expect("Failed to write response");
-
-        // Attempt to also generate a translated response.
-        if let Some(salutation) = self.translate(&req.greeting, "en", "fr") {
-            info!("Say bonjour to {}", salutation);
-            let mut res = HelloResponse::default();
-            res.reply = format!("BONJOUR {}!", salutation);
-            writer
-                .write(&res, grpc::WriteMode::KeepOpen)
-                .expect("Failed to write translated response");
-        }
-
-        info!("Say hello again to {}", req.greeting);
-        let mut res2 = HelloResponse::default();
-        res2.reply = format!("HELLO AGAIN {}!", req.greeting);
-        writer
-            .write(&res2, grpc::WriteMode::Close)
-            .expect("Failed to write final response");
-    }
-
-    fn lots_of_greetings(&mut self, reqs: Vec<HelloRequest>) -> grpc::Result<HelloResponse> {
-        info!("Say hello");
-        let mut msg = String::new();
-        msg.push_str("Hello ");
-        msg.push_str(&recipients(&reqs));
-        let mut res = HelloResponse::default();
-        res.reply = msg;
-        Ok(res)
-    }
-
-    fn bidi_hello(&mut self, reqs: Vec<HelloRequest>, writer: grpc::ChannelResponseWriter) {
-        info!("Say hello");
-        let msg = recipients(&reqs);
-        let mut res1 = HelloResponse::default();
-        res1.reply = format!("HELLO {}!", msg);
-        writer
-            .write(&res1, grpc::WriteMode::KeepOpen)
-            .expect("Failed to write response");
-        let mut res2 = HelloResponse::default();
-        res2.reply = format!("BONJOUR {}!", msg);
-        writer
-            .write(&res2, grpc::WriteMode::Close)
-            .expect("Failed to write final response");
-    }
+oak::entrypoint!(async_node <InitWrapper<Init, grpc::Invocation>> => async_node_entrypoint);
+fn async_node_entrypoint(receiver: Receiver<InitWrapper<Init, grpc::Invocation>>) {
+    let InitWrapper {
+        init,
+        command_receiver,
+    } = receiver.receive().expect("Did not receive init message");
+    let translator = Translator {
+        client: init.right().map(translator_common::TranslatorClient),
+    };
+    oak_async::run_command_loop(command_receiver, |invocations| {
+        hello_handler(translator, invocations)
+    });
 }
 
-fn recipients(reqs: &[HelloRequest]) -> String {
-    let mut result = String::new();
-    for (i, req) in reqs.iter().enumerate() {
-        if i > 0 {
-            result.push_str(", ");
-        }
-        result.push_str(&req.greeting);
-    }
-    result
+async fn hello_handler(translator: Translator, invocations: ChannelReadStream<grpc::Invocation>) {
+    let translator = &translator;
+
+    invocations
+        .and_then(HelloWorldAsync::from_invocation)
+        .try_for_each(|command| async {
+            match command {
+                HelloWorldAsync::SayHello(request, response_writer) => {
+                    info!("Say hello to {}", request.greeting);
+                    let mut res = HelloResponse::default();
+                    res.reply = format!("HELLO {}!", request.greeting);
+                    response_writer.send(&res)
+                }
+                HelloWorldAsync::LotsOfReplies(request, response_writer) => {
+                    info!("Say hello to {}", request.greeting);
+                    let mut res1 = HelloResponse::default();
+                    res1.reply = format!("HELLO {}!", request.greeting);
+                    response_writer
+                        .send(&res1)
+                        .expect("Failed to write response");
+
+                    // Attempt to also generate a translated response.
+                    if let Some(salutation) = translator.translate(&request.greeting, "en", "fr") {
+                        info!("Say bonjour to {}", salutation);
+                        let mut res = HelloResponse::default();
+                        res.reply = format!("BONJOUR {}!", salutation);
+                        response_writer
+                            .send(&res)
+                            .expect("Failed to write translated response");
+                    }
+
+                    info!("Say hello again to {}", request.greeting);
+                    let mut res2 = HelloResponse::default();
+                    res2.reply = format!("HELLO AGAIN {}!", request.greeting);
+                    response_writer
+                        .send(&res2)
+                        .expect("Failed to write final response");
+                    // response_writer is automatically closed when it is `Drop`ed
+                    Ok(())
+                }
+                HelloWorldAsync::LotsOfGreetings(requests, response_writer) => {
+                    info!("Say hello");
+                    let mut res = HelloResponse::default();
+                    res.reply = async_recipients(requests).await?;
+                    response_writer.send(&res)
+                }
+                HelloWorldAsync::BidiHello(requests, response_writer) => {
+                    info!("Say hello");
+                    let msg = async_recipients(requests).await?;
+                    let mut res1 = HelloResponse::default();
+                    res1.reply = format!("HELLO {}!", msg);
+                    response_writer
+                        .send(&res1)
+                        .expect("Failed to write response");
+                    let mut res2 = HelloResponse::default();
+                    res2.reply = format!("BONJOUR {}!", msg);
+                    response_writer
+                        .send(&res2)
+                        .expect("Failed to write final response");
+                    Ok(())
+                }
+            }
+        })
+        .await
+        .expect("Error handling request");
+}
+
+async fn async_recipients(
+    mut requests: oak_async::grpc::GrpcRequestStream<HelloRequest>,
+) -> Result<String, oak::OakError> {
+    let first_request = requests.try_next().await?.expect("Nobody to greet");
+    let msg = format!("Hello, {}", &first_request.greeting);
+    requests
+        .try_fold(msg, |mut msg, req| async move {
+            msg.push_str(", ");
+            msg.push_str(&req.greeting);
+            Ok(msg)
+        })
+        .await
 }

--- a/oak_utils/src/lib.rs
+++ b/oak_utils/src/lib.rs
@@ -231,7 +231,7 @@ fn generate_service_enum(enum_name: &Ident, service: &prost_build::Service) -> T
         let input_type = type_ident(&method.input_type);
         let output_type = type_ident(&method.output_type);
         let input_type = if method.client_streaming {
-            quote!(::oak_async::ChannelReadStream<#input_type>)
+            quote!(::oak_async::grpc::GrpcRequestStream<#input_type>)
         } else {
             quote!(#input_type)
         };

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -117,14 +117,14 @@ impl ChannelResponseWriter {
 
     /// Close out the gRPC method invocation with the given final result.
     pub fn close(&self, result: Result<()>) -> std::result::Result<(), OakError> {
-        // Build a final GrpcResponse message wrapper and serialize it into the
-        // channel.
-        let mut grpc_rsp = GrpcResponse::default();
-        grpc_rsp.last = true;
         if let Err(status) = result {
+            // Build a final GrpcResponse message wrapper and serialize it into the
+            // channel.
+            let mut grpc_rsp = GrpcResponse::default();
+            grpc_rsp.last = true;
             grpc_rsp.status = Some(status);
+            self.sender.send(&grpc_rsp)?;
         }
-        self.sender.send(&grpc_rsp)?;
         self.sender.close()?;
         Ok(())
     }


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

Also includes a patch to `ChannelResponseWriter`'s behaviour on `close` and a tiny bugfix to async code generation. I can spin these off into separate PRs if preferred.

If you prefer to keep all examples sync for now, we can also keep this PR around just for testing.