### PR TITLE
Refactoring

### DIFF
--- a/experimental/ni_coq/_CoqProject
+++ b/experimental/ni_coq/_CoqProject
@@ -9,6 +9,7 @@ vfiles/RuntimeModel.v
 vfiles/Events.v
 vfiles/EvAugSemantics.v
 vfiles/LowEquivalences.v
+vfiles/TraceLowEq.v
 vfiles/Tactics.v
 vfiles/TraceTheorems.v
 vfiles/NIUtilTheorems.v

--- a/experimental/ni_coq/_CoqProject
+++ b/experimental/ni_coq/_CoqProject
@@ -2,6 +2,9 @@
 vfiles/Lattice.v 
 vfiles/Parameters.v 
 vfiles/GenericMap.v
+vfiles/State.v
+vfiles/ModelSemUtils.v
+vfiles/ModelTypes.v
 vfiles/RuntimeModel.v
 vfiles/Events.v
 vfiles/EvAugSemantics.v
@@ -10,4 +13,5 @@ vfiles/Tactics.v
 vfiles/TraceTheorems.v
 vfiles/NIUtilTheorems.v
 vfiles/Unwind.v
+vfiles/PossibilisticNI_def.v
 vfiles/PossibilisticNI.v

--- a/experimental/ni_coq/_CoqProject
+++ b/experimental/ni_coq/_CoqProject
@@ -12,6 +12,7 @@ vfiles/LowEquivalences.v
 vfiles/TraceLowEq.v
 vfiles/Tactics.v
 vfiles/TraceTheorems.v
+vfiles/Unfold.v
 vfiles/NIUtilTheorems.v
 vfiles/Unwind.v
 vfiles/PossibilisticNI_def.v

--- a/experimental/ni_coq/vfiles/EvAugSemantics.v
+++ b/experimental/ni_coq/vfiles/EvAugSemantics.v
@@ -4,7 +4,9 @@ From OakIFC Require Import
     Lattice
     Parameters
     GenericMap
+    ModelSemUtils
     RuntimeModel
+    State
     Events.
 Import ListNotations.
 
@@ -16,6 +18,7 @@ From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
 
 Local Open Scope map_scope.
+Local Open Scope ev_notation.
 (*
 The top-level security condition compares traces involving both states (as
 in "state" in RuntimeModel.v) and events. This file augments the semantics 
@@ -48,14 +51,8 @@ so the call is a piece of state that probably does not matter at the moment)
 
 Definition trace := list (state * event_l).
 
-Declare Scope aug_scope.
-Local Open Scope aug_scope.
-Notation "ell '--->' msg":= (Labeled event (Some (OutEv msg)) ell) (at level 10) : aug_scope.
-Notation "ell '<---' msg":= (Labeled event (Some (InEv msg)) ell) (at level 10) : aug_scope.
-Notation "ell '---'":= (Labeled event None ell) (at level 10) : aug_scope.
-Notation "'--' ell '--'" := (Labeled event (Some NCreateEv) ell) (at level 10) : aug_scope.
-
-
+(* This is used for state/event pairs in EvAug. 
+* The type is slightly awkward now post refactor *)
 Definition head_st (t: trace) :=
     match t with 
         | nil => None

--- a/experimental/ni_coq/vfiles/Events.v
+++ b/experimental/ni_coq/vfiles/Events.v
@@ -1,11 +1,10 @@
 From OakIFC Require Import
     Lattice
     Parameters
-    RuntimeModel.
+    State.
 Require Import Coq.Lists.List.
 Import ListNotations.
 
-(* This file contains  *)
 
 Inductive event: Type :=
     | InEv (m: message): event
@@ -13,5 +12,12 @@ Inductive event: Type :=
     | NCreateEv: event.
 (* note that messages include the bytes and handles sent via channels *)
 (* eventually, downgrades will also be represented by events *)
+
+Declare Scope ev_notation.
+Local Open Scope ev_notation.
+Notation "ell '--->' msg":= (Labeled event (Some (OutEv msg)) ell) (at level 10) : ev_notation.
+Notation "ell '<---' msg":= (Labeled event (Some (InEv msg)) ell) (at level 10): ev_notation.
+Notation "ell '---'":= (Labeled event None ell) (at level 10) : ev_notation.
+Notation "'--' ell '--'" := (Labeled event (Some NCreateEv) ell) (at level 10) : ev_notation.
 
 Definition event_l := @labeled event.

--- a/experimental/ni_coq/vfiles/LowEquivalences.v
+++ b/experimental/ni_coq/vfiles/LowEquivalences.v
@@ -6,9 +6,9 @@ From OakIFC Require Import
     Parameters
     GenericMap
     Lattice
+    State
     Events
-    RuntimeModel
-    EvAugSemantics.
+    ModelTypes.
 
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
@@ -139,7 +139,7 @@ Definition state_low_eq := fun ell s1 s2 =>
     and discussion in PossibilisticNI.v
 *)
 
-Inductive trace_low_eq: level -> trace -> trace -> Prop :=
+Inductive trace_low_eq: @trace_low_eqT (state * (@labeled event)) :=
     | NilEQ ell: trace_low_eq ell [] []
     | AddBoth ell xs xe ys ye t1 t2:
         trace_low_eq ell t1 t2 ->

--- a/experimental/ni_coq/vfiles/ModelSemUtils.v
+++ b/experimental/ni_coq/vfiles/ModelSemUtils.v
@@ -1,0 +1,120 @@
+Require Import List.
+Import ListNotations.
+Require Import Coq.Sets.Ensembles.
+From OakIFC Require Import
+    Lattice
+    Parameters
+    GenericMap
+    State.
+
+(* 
+These are small functions of states or state elements that might be common
+accross different model semantics
+*)
+
+(* RecordUpdate is a conveninece feature that provides functional updates for
+* records with notation: https://github.com/tchajed/coq-record-update *)
+(* To work with record updates from this library in proofs "unfold set" quickly
+* changes goals back to normal Coq built-in record updates *)
+From RecordUpdate Require Import RecordSet.
+Import RecordSetNotations.
+Local Open Scope map_scope.
+
+(* Ensembles don't have implicit type params and these lines fix that *)
+Arguments Ensembles.In {U}.
+Arguments Ensembles.Add {U}.
+Arguments Ensembles.Subtract {U}.
+Arguments Ensembles.Singleton {U}.
+Arguments Ensembles.Union {U}.
+Arguments Ensembles.Setminus{U}.
+Arguments Ensembles.Included{U}.
+
+(*============================================================================
+* Utils
+============================================================================*)
+
+Definition chan_append (c: channel)(m: message): channel :=
+    c <|ms := c.(ms) ++ [m]|>.
+
+(* this is used in channel read where there is a premise
+* that checks that the channel is not empty *)
+Definition chan_pop (c: channel): channel :=
+    c <| ms := match c.(ms) with
+            | nil => nil
+            | m :: ms' => ms'
+        end |>.
+
+Definition msg_is_head (ch: channel)(m: message): Prop :=
+    match ch.(ms) with
+        | [] => False
+        | m' :: ms' => m' = m
+    end. 
+
+Definition node_get_hans (n: node)(m: message): node :=
+    n <| read_handles := (Union n.(read_handles) m.(rhs)) |>
+      <| write_handles := (Union n.(write_handles) m.(whs)) |>.
+
+Definition state_upd_node (nid: node_id)(n: node)(s: state): state :=
+    (* n_l is a (labeled node) with the same label as the old one,
+    but the contents updated to n *)
+    let n_l := s.(nodes).[? nid] <| obj  := Some n |> in
+    s <| nodes := s.(nodes) .[ nid <- n_l ] |>.
+
+Definition state_upd_node_labeled (nid: node_id )(n_l: node_l)(s: state): state :=
+    s<| nodes := s.(nodes).[nid <- n_l] |>.
+
+Definition state_upd_chan (h: handle)(ch: channel)(s: state): state :=
+    let ch_l := s.(chans).[? h] <| obj := Some ch |> in
+    s <| chans := s.(chans) .[ h <- ch_l ] |>.
+
+Definition state_upd_chan_labeled (h: handle)(ch_l: channel_l)(s: state): state :=
+    s <| chans := s.(chans) .[ h <- ch_l ] |>.
+
+(* 
+    A node is allowed to write to a handle with a higher label than the node.
+    As a result, the node may not be allowed to tell whether the handle
+    maps to a real channel or not. To hide the state of the channel,
+    a message is appended when the handle maps to a real channel, but if
+    there is no channel with the given handle, the update does nothing.
+*)
+Definition chan_append_labeled (h: handle)(m: message)(s: state)  :=
+    let old_chl := s.(chans).[? h] in
+    match old_chl.(obj) with
+        |  None => old_chl
+        |  Some ch => old_chl <| obj := Some (chan_append ch m) |>
+    end.
+
+(* I suspect it may be easier to do proofs of things like the unwinding
+theorem about this function from states to states rather than
+trying to reason about chan_append_labeled (which is state-dependent)
+separately from the place where the state update happens
+
+If it does not turn out to be easier, perhaps this improves
+readability anyway.
+*)
+Definition state_chan_append_labeled (h: handle)(m: message)(s: state) :=
+    state_upd_chan_labeled h (chan_append_labeled h m s) s.
+
+Definition node_add_rhan (h: handle)(n: node): node:=
+    n <| read_handles := Ensembles.Add n.(read_handles) h |>.
+
+Definition node_add_whan (h: handle)(n: node): node :=
+    n <| write_handles := Ensembles.Add n.(write_handles) h |>.
+
+Definition node_del_rhan (h: handle)(n: node): node :=
+    n <| read_handles := Ensembles.Subtract n.(read_handles) h |>.
+
+Definition node_del_rhans (hs: Ensemble handle)(n: node): node :=
+    n <| read_handles := Ensembles.Setminus n.(read_handles) hs |>.
+
+Definition new_chan := Some {| ms := [] |}.
+
+Definition fresh_han s h := s.(chans).[?h] = Labeled channel None top.
+
+Definition fresh_nid s id := s.(nodes).[?id] = Labeled node None top.
+
+Definition s_set_call s id c :=
+    match (s.(nodes).[?id]).(obj) with
+        | None => s
+        | Some n => state_upd_node id (n <|ncall := c|>) s
+    end.

--- a/experimental/ni_coq/vfiles/ModelSemUtils.v
+++ b/experimental/ni_coq/vfiles/ModelSemUtils.v
@@ -118,3 +118,4 @@ Definition s_set_call s id c :=
         | None => s
         | Some n => state_upd_node id (n <|ncall := c|>) s
     end.
+

--- a/experimental/ni_coq/vfiles/ModelTypes.v
+++ b/experimental/ni_coq/vfiles/ModelTypes.v
@@ -1,0 +1,8 @@
+From OakIFC Require Import State.
+
+Definition trace {TraceEltT} := list @TraceEltT.
+Definition trace_semanticsT {TraceEltT: Type} :=
+    trace -> trace -> Prop.
+
+Definition trace_low_eqT {TraceEltT: Type} :=
+    level -> trace -> trace -> Prop.

--- a/experimental/ni_coq/vfiles/ModelTypes.v
+++ b/experimental/ni_coq/vfiles/ModelTypes.v
@@ -9,3 +9,7 @@ Definition trace_semanticsT {TraceEltT: Type} :=
 
 Definition trace_low_eqT {TraceEltT: Type} :=
     level -> (@trace TraceEltT) -> (@trace TraceEltT) -> Prop.
+
+Definition low_proj_t {A: Type}: Type := level -> A -> A.
+
+Definition low_eq_t {A: Type}: Type := level -> A -> A -> Prop.

--- a/experimental/ni_coq/vfiles/ModelTypes.v
+++ b/experimental/ni_coq/vfiles/ModelTypes.v
@@ -1,8 +1,11 @@
-From OakIFC Require Import State.
+Require Import List.
+From OakIFC Require Import
+    Parameters
+    Lattice.
 
-Definition trace {TraceEltT} := list @TraceEltT.
+Definition trace {TraceEltT: Type} := @list TraceEltT.
 Definition trace_semanticsT {TraceEltT: Type} :=
-    trace -> trace -> Prop.
+    (@trace TraceEltT) -> (@trace TraceEltT) -> Prop.
 
 Definition trace_low_eqT {TraceEltT: Type} :=
-    level -> trace -> trace -> Prop.
+    level -> (@trace TraceEltT) -> (@trace TraceEltT) -> Prop.

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -46,21 +46,7 @@ Admitted.
 
 Hint Resolve multi_system_ev_refl multi_system_ev_tran : multi.
 
-(* Hints for [eauto with unwind] *)
-Hint Resolve state_upd_chan_unwind chan_append_unwind chan_low_proj_loweq
-    chan_low_proj_idempotent state_upd_node_unwind set_call_unwind
-    state_upd_chan_unwind state_low_proj_loweq
-    state_upd_chan_labeled_unwind
-    state_chan_append_labeled_unwind: unwind.
-Hint Extern 4 (node_low_eq _ _ _) => reflexivity : unwind.
-Hint Extern 4 (chan_low_eq _ _ _) => reflexivity : unwind.
-(* meant to be case where we have (cleq ch (proj ch) ) and want to swap order *)
-Hint Extern 4 (chan_low_eq _ _ (chan_low_proj _ _)) => symmetry : unwind.
-Hint Extern 4 (state_low_eq _ _ (state_low_proj _ _)) => symmetry : unwind.
-Hint Extern 2 (chan_low_proj _ _ = chan_low_proj _ _)
-=> simple eapply chan_low_proj_loweq : unwind.
-
-(* hits for eauto in event part of the unobservable step proof *)
+(* hints for eauto in event part of the unobservable step proof *)
 Hint Extern 4 (low_proj _ _  = _ ) => erewrite nflows_labeled_proj : unobs_ev.
 Hint Extern 4 (_  = low_proj _ _ ) => erewrite nflows_labeled_proj : unobs_ev.
 Hint Extern 4 (event_low_eq _ _ _) => unfold event_low_eq : unobs_ev.

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -183,6 +183,7 @@ Definition conjecture_possibilistic_ni := forall ell t1_init t2_init t1n,
         (step_system_ev_multi t2_init t2n) /\
         (trace_low_eq ell t1n t2n)).
 
+(* TODO move this and next 2 theorems to NIUtilTheorems *)
 Theorem state_low_eq_parts: forall ell s1 s2,
     node_state_low_eq ell s1.(nodes) s2.(nodes) -> 
     chan_state_low_eq ell s1.(chans) s2.(chans) ->

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -511,11 +511,11 @@ Proof.
 Qed.
 
 Theorem possibilistic_ni_unwind_t: forall ell t1 t2 t1',
-(trace_low_eq ell t1 t2) ->
+(trace_low_eq_pni ell t1 t2) ->
 (step_system_ev_t t1 t1') ->
 (exists t2',
     (step_system_ev_t t2 t2') /\
-    (trace_low_eq ell t1' t2')).
+    (trace_low_eq_pni ell t1' t2')).
 Proof.
     intros. 
     inversion H; crush.

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -5,132 +5,24 @@ From OakIFC Require Import
     Parameters
     GenericMap
     RuntimeModel
+    ModelSemUtils
     EvAugSemantics
+    State
     Events
     LowEquivalences
     TraceTheorems
     NIUtilTheorems
     Unwind
+    PossibilisticNI_def
     Tactics.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
 Local Open Scope map_scope.
-Local Open Scope aug_scope.
+Local Open Scope ev_notation.
 
 (*
-This is the top-level candidate security condition. This is a
-"possibilistic security condition". A possibilistic security condition
-says that two executions look the same from the perspective of an observer
-if all _possible behaviors_ look the same if they begin from initial states
-that look the same to the observer.
-In other words there is some way to reach an execution trace
-that looks the same beginning from the other state.
-
-Trapeze uses a possibilistic definition of security:
-https://pdfs.semanticscholar.org/809b/f2702a765b9e7dba4624a1dbc53af11579db.pdf
-See also:
-https://www.cs.cornell.edu/andru/papers/csfw03.pdf
-
+This is a proof that step_system_ev enforces Possibilistic Noninterference
 *)
-
-(* An alternative way of specifying security for
-   concurrent systems is observational determinism, which says
-   that for any two executions that begin from low-equivalent
-   initial states, all actual observed behaviors 
-   (by contrast to the possibly observed behaviors)
-   _always_ look the same.
-
-    This looks like:
-    forall s1 s2 t1 t2,
-        (s1 =L s2) /\
-        (step_multi s1) => t1 /\
-        (step_multi s2) => t2 ->
-            t1 =L t2.
-
-    An advantage of observational determinism over possibilistic
-    noninterference is that O.D. is preserved by refinement. This does
-    not matter in this context since we are not doing a refinement proof.
-    
-    O.D. also has requirements about data race freedom that are not
-    needed to prove a possibilistic security definition. (It may be
-    worth looking into whether or not the runtime actually satisfies
-    these data race freedom requirements later, though it does not
-    seem high priority).
-
-    ***
-    These two definitions also crucially require different
-    definitions of trace low-equivalence as discussed in Events.v
-    ***
-*)
-
-(* TODO: maybe move to Tactics.v *)
-Local Ltac logical_simplify :=
-  repeat match goal with
-         | H : _ /\ _ |- _ => destruct H
-         | H : exists _, _ |- _ => destruct H
-         | H1 : ?P, H2 : ?P -> _ |- _ =>
-           (* only proceed if P is a Prop; if H1 is a nat, for instance, P
-              would be a Type, and we don't want to specialize foralls. *)
-           match type of P with Prop => idtac end;
-           specialize (H2 H1)
-         | H : ?x = ?x |- _ => clear H
-         end.
-
-Local Ltac step_econstruct :=
-    repeat match goal with
-        | H: _ = ncall _ |- _ => progress rewrite <- H
-    end;
-    lazymatch goal with
-        | |- step_system_ev _ _ _ => econstructor; eauto
-        | |- step_node_ev _ _ _ _ _  => econstructor; eauto
-        | |- step_system _ _ => econstructor; eauto
-        | |- step_node _ _ _ _ => econstructor; eauto
-    end.
-
-(* Single step of [crush] *)
-Local Ltac crush_step :=
-  repeat match goal with
-         | _ => progress intros
-         | _ => progress subst
-         | _ => progress logical_simplify
-         | _ => progress step_econstruct
-         | H : Some _ = Some _ |- _ => invert_clean H
-         | H1 : ?x = Some _, H2 : ?x = Some _ |- _ =>
-           rewrite H2 in H1; invert_clean H1
-         | _ => reflexivity
-         end.
-(* General-purpose tactic that simplifies and solves simple goals for
-   possibilistic NI. *)
-Local Ltac crush := repeat crush_step.
-
-Local Ltac subst_lets :=
-  repeat match goal with x := _ |- _ => subst x end.
-
-Local Ltac split_ands :=
-  repeat match goal with |- _ /\ _ => split end.
-
-Local Ltac apply_all_constructors :=
-  lazymatch goal with
-  | |- step_system_ev _ _ _ =>
-    eapply SystemEvStepNode; apply_all_constructors
-  | |- step_node_ev _ _ _ _ _ =>
-    econstructor; apply_all_constructors
-  | |- step_node _ _ _ _ =>
-    econstructor; apply_all_constructors
-  | _ => idtac (* ignore goals that don't match one of the previous patterns *)
-  end.
-
-Lemma separate_lableled {A} (o : option A) (l : level) (x : labeled) :
-  obj x = o -> lbl x = l -> x = Labeled _ o l.
-Proof. destruct x; cbn; congruence. Qed.
-
-Ltac separate_hyp T :=
-  repeat match goal with
-         | H : ?s = Labeled T ?o ?l |- _ =>
-           assert (obj s = o /\ lbl s = l) by (rewrite H; tauto);
-           clear H; logical_simplify
-         end.
-Ltac separate_goal := apply separate_lableled.
 
 Lemma invert_chans_state_low_proj_flowsto ell lvl s han :
   lvl <<L ell ->
@@ -140,12 +32,16 @@ Proof.
   destruct s.
   repeat match goal with
          | _ => progress cbn [state_low_proj
-                               RuntimeModel.chans RuntimeModel.lbl ]
+                               State.chans State.lbl ]
          | _ => progress cbv [low_proj chan_state_low_proj fnd]
          | _ => destruct_match
          | _ => tauto
          end.
     intros.
+    (*
+    Note: I think this is not true with the low-projection def
+    where labels are partially secret
+    *)
 Admitted.
 
 Hint Resolve multi_system_ev_refl multi_system_ev_tran : multi.
@@ -170,59 +66,28 @@ Hint Extern 4 (_  = low_proj _ _ ) => erewrite nflows_labeled_proj : unobs_ev.
 Hint Extern 4 (event_low_eq _ _ _) => unfold event_low_eq : unobs_ev.
 Hint Extern 4 (low_eq _ _ _) => unfold low_eq : unobs_ev.
 
-Definition is_init(t: trace) := length t = 1.
-
 Definition empty_event (ell: level) := Labeled event None ell.
 
-Definition conjecture_possibilistic_ni := forall ell t1_init t2_init t1n,
-    (trace_low_eq ell t1_init t2_init) /\
-    (is_init t1_init) /\
-    (is_init t2_init) /\
-    (step_system_ev_multi t1_init t1n) ->
-    (exists t2n,
-        (step_system_ev_multi t2_init t2n) /\
-        (trace_low_eq ell t1n t2n)).
-
-(* TODO move this and next 2 theorems to NIUtilTheorems *)
-Theorem state_low_eq_parts: forall ell s1 s2,
-    node_state_low_eq ell s1.(nodes) s2.(nodes) -> 
-    chan_state_low_eq ell s1.(chans) s2.(chans) ->
-    state_low_eq ell s1 s2.
+Theorem trace_leq_imples_head_st_leq: forall ell t1 t2 s1 s2,
+    (head_st t1 = Some s1) ->
+    (head_st t2 = Some s2) ->
+    (trace_low_eq ell t1 t2) ->
+    (state_low_eq ell s1 s2).
 Proof.
-    cbv [node_state_low_eq chan_state_low_eq state_low_eq].
-    intros. eauto.
-Qed.
+    inversion 3. 
+    - 
+        exfalso. rewrite <- H3 in H. inversion H.
+    - 
+        assert (xs = s1). {
+            assert (head_st ((xs, xe) :: t0 ) = Some xs) by reflexivity.
+            congruence.
+        }
 
-Theorem chan_state_fe: forall ell chs1 chs2,
-    (forall h, low_eq ell chs1.[?h] chs2.[?h]) ->
-    chan_state_low_eq ell chs1 chs2.
-Proof.
-    (* shouldn't be needed after change to state loweq defs *)
-Admitted.
-
-Theorem new_secret_chan_unobs: forall ell ell' s h ,
-    ~( ell' <<L ell) ->
-    fresh_han s h ->
-    state_low_eq ell s (state_upd_chan_labeled h 
-            {| obj := new_chan; lbl := ell'|} s).
-Proof.
-    cbv [state_low_eq state_low_proj fresh_han new_chan]. intros.
-    eapply state_low_eq_parts; [cbv [state_upd_chan_labeled]; reflexivity | ].
-    eapply chan_state_fe.
-    intros. simpl. cbv [low_eq]. destruct s. cbv [RuntimeModel.chans] in *.
-    unfold low_proj.
-    destruct (dec_eq_h h h0). 
-    - rewrite <- e. rewrite H0.
-    replace 
-        ((chans .[ h <- {| obj := Some {| ms := [] |}; lbl := ell' |}]).[? h])
-        with
-        ({| obj := Some {| ms := [] |}; lbl := ell' |}) by (symmetry; eapply upd_eq).
-    destruct (top <<? ell); destruct (ell' <<? ell); (contradiction || reflexivity).
-    -  replace 
-        ( (chans .[ h <- {| obj := Some {| ms := [] |}; lbl := ell' |}]).[? h0])
-        with
-        (chans.[? h0]).
-        reflexivity. symmetry. apply upd_neq; auto. 
+        assert (ys = s2). {
+            assert (head_st ((ys, ye) :: t3 ) = Some ys) by reflexivity.
+            congruence.
+        }
+    congruence.
 Qed.
 
 Theorem unobservable_node_step: forall ell s s' e id nl n,
@@ -309,7 +174,7 @@ Theorem low_eq_to_unobs {A: Type}: forall ell (x1 x2: @labeled A),
     ~(x1.(lbl) <<L ell) ->
     ~(x2.(lbl) <<L ell).
 Proof.
-    destruct x1, x2. cbv [low_eq low_proj RuntimeModel.lbl].
+    destruct x1, x2. cbv [low_eq low_proj State.lbl].
     intros. destruct (lbl <<? ell); destruct (lbl0 <<? ell);
         try eauto; try contradiction. 
     inversion H. unfold not. intros.
@@ -559,37 +424,6 @@ Proof.
             + (* e1 ={ell} *) assumption.
 Admitted.
 
-Lemma state_low_eq_implies_node_lookup_eq ell s1 s2 :
-  state_low_eq ell s1 s2 ->
-  forall id,
-    (nodes (state_low_proj ell s2)).[? id]
-    = (nodes (state_low_proj ell s1)).[? id].
-Proof.
-  cbv [state_low_proj state_low_eq node_state_low_proj fnd].
-  cbn [nodes chans]. intros; logical_simplify.
-  congruence.
-Qed.
-
-Lemma state_low_eq_implies_chan_lookup_eq ell s1 s2 :
-  state_low_eq ell s1 s2 ->
-  forall han,
-    (chans (state_low_proj ell s2)).[? han]
-    = (chans (state_low_proj ell s1)).[? han].
-Proof.
-  cbv [state_low_proj state_low_eq chan_state_low_proj fnd].
-  cbn [nodes chans]. intros; logical_simplify.
-  congruence.
-Qed.
-
-Lemma state_low_eq_projection ell s1 s2 :
-  state_low_eq ell s1 s2 ->
-  state_low_eq ell (state_low_proj ell s1) (state_low_proj ell s2).
-Proof.
-  cbv [state_low_proj state_low_eq node_state_low_proj chan_state_low_proj fnd].
-  cbn [nodes chans]. intros; logical_simplify.
-  split; intros; congruence.
-Qed.
-
 Lemma step_node_projection ell s1 s2 s3 id c :
   state_low_eq ell s1 s2 ->
   step_node id c (state_low_proj ell s2) s3 ->
@@ -696,7 +530,7 @@ Proof.
         econstructor; crush; eauto.
 Qed.
 
-Theorem possibilistic_ni: conjecture_possibilistic_ni.
+Theorem possibilistic_ni: (conjecture_possibilistic_ni step_system_ev_multi).
 Proof.
   unfold conjecture_possibilistic_ni. crush.
   let H := match goal with H : step_system_ev_multi _ _ |- _ => H end in

--- a/experimental/ni_coq/vfiles/PossibilisticNI_def.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI_def.v
@@ -1,0 +1,76 @@
+Require Import Coq.Lists.List.
+Import ListNotations.
+From OakIFC Require Import
+    Lattice
+    Parameters
+    ModelTypes
+    State
+    Events
+    LowEquivalences
+    ModelTypes
+    TraceLowEq
+    Tactics.
+(*
+This is the top-level candidate security condition. This is a
+"possibilistic security condition". A possibilistic security condition
+says that two executions look the same from the perspective of an observer
+if all _possible behaviors_ look the same if they begin from initial states
+that look the same to the observer.
+In other words there is some way to reach an execution trace
+that looks the same beginning from the other state.
+
+Trapeze uses a possibilistic definition of security:
+https://pdfs.semanticscholar.org/809b/f2702a765b9e7dba4624a1dbc53af11579db.pdf
+See also:
+https://www.cs.cornell.edu/andru/papers/csfw03.pdf
+
+*)
+
+(* An alternative way of specifying security for
+   concurrent systems is observational determinism, which says
+   that for any two executions that begin from low-equivalent
+   initial states, all actual observed behaviors 
+   (by contrast to the possibly observed behaviors)
+   _always_ look the same.
+
+    This looks like:
+    forall s1 s2 t1 t2,
+        (s1 =L s2) /\
+        (step_multi s1) => t1 /\
+        (step_multi s2) => t2 ->
+            t1 =L t2.
+
+    An advantage of observational determinism over possibilistic
+    noninterference is that O.D. is preserved by refinement. This does
+    not matter in this context since we are not doing a refinement proof.
+    
+    O.D. also has requirements about data race freedom that are not
+    needed to prove a possibilistic security definition. (It may be
+    worth looking into whether or not the runtime actually satisfies
+    these data race freedom requirements later, though it does not
+    seem high priority).
+
+    ***
+    These two definitions also crucially require different
+    definitions of trace low-equivalence as discussed in Events.v
+    ***
+*)
+
+(* PNI is tied to a specific def of traces and of trace low-equivalence *)
+
+Definition pni_t := @trace (state * event_l).
+Definition is_init(t: pni_t) := length t = 1.
+
+Definition trace_low_eq_pni := 
+    @trace_low_eq (state_low_eq)(@low_eq event).
+
+Definition conjecture_possibilistic_ni 
+    (sem: @trace_semanticsT (state * event_l))
+        := forall ell t1_init t2_init t1n,
+    (trace_low_eq_pni ell t1_init t2_init) /\
+    (is_init t1_init) /\
+    (is_init t2_init) /\
+    (sem t1_init t1n) ->
+    (exists t2n,
+        (sem t2_init t2n) /\
+        (trace_low_eq_pni ell t1n t2n)).

--- a/experimental/ni_coq/vfiles/State.v
+++ b/experimental/ni_coq/vfiles/State.v
@@ -1,0 +1,98 @@
+Require Import Coq.Sets.Ensembles.
+From OakIFC Require Import
+    Lattice
+    Parameters
+    GenericMap.
+
+(* RecordUpdate is a conveninece feature that provides functional updates for
+* records with notation: https://github.com/tchajed/coq-record-update *)
+(* To work with record updates from this library in proofs "unfold set" quickly
+* changes goals back to normal Coq built-in record updates *)
+From RecordUpdate Require Import RecordSet.
+Import RecordSetNotations.
+Local Open Scope map_scope.
+
+(*============================================================================
+ Commands, State, Etc.
+============================================================================*)
+(* These are messages sent over channels *)
+Record message := Message {
+    bytes : data;            (* the data part of the message *)
+    rhs : Ensemble handle;   (* a set of read handles being sent *)
+    whs : Ensemble handle;   (* a set of write handles being sent *)
+}.
+(* etamessage just enumerates the fields of the record, as provided
+* by https://github.com/tchajed/coq-record-update *)
+(* When a new field is added to a record, be sure to add it here as well *)
+Instance etamessage : Settable _ := settable! Message<bytes; rhs; whs>.
+
+(* 
+messages model the messages in the oak impl. found in
+oak/oak_io/src/lib.rs. Note that unlike in the implementation,
+this model separates read and write handles into two different types
+*)
+
+Record channel := Chan {
+    ms: list message;    (* list of pending messages in channel *)
+}.
+Instance etachannel : Settable _ := settable! Chan<ms>.
+
+
+(* ABI Calls *)
+Inductive call: Type :=
+    | WriteChannel (h: handle)(m: message): call
+        (* write a message m,
+        * a set of read handles rhs, and 
+        * a set of write handles whs
+        * into the channel pointed to by h unless this would
+        * cause an IFC violation *)
+    | ReadChannel (h: handle): call
+        (* read the top message and all the handles from the
+        * channel into the caller, unless this would cause an IFC violation *)
+    | CreateChannel (lbl: level): call
+        (* create a new channel with label lbl, unless IFC violation *)
+    | CreateNode (lbl: level)(h: handle): call
+        (* create a new node with label lbl, unless IFC violation *)
+    | Internal: call. (* this is any action done by the node other than some
+                         ABI call, it is "internal" to the node because it does
+                         not affect the rest of the system*)
+(* TODO wait_on_channels, channel_close *)
+
+Record node := Node {
+    read_handles: Ensemble handle;
+    write_handles: Ensemble handle;
+    ncall: call
+}.
+Instance etanode: Settable _ :=
+    settable! Node<read_handles; write_handles; ncall>.
+
+Instance Knid: KeyT := {
+    t := node_id; 
+    eq_dec := dec_eq_nid;
+}.
+Instance Khandle: KeyT := {
+    t := handle;
+    eq_dec := dec_eq_h;
+}.
+
+Record labeled {A: Type} := Labeled {
+    obj: option A;
+    lbl: level;
+}.
+
+Definition node_l := @labeled node.
+Definition channel_l := @labeled channel.
+
+Instance etalabeled_chan : Settable _ := settable! (Labeled channel)<obj; lbl >.
+Instance etalabeled_node : Settable _ := settable! (Labeled node)<obj ; lbl >.
+
+Definition node_state := tg_map Knid (@labeled node).
+Definition chan_state := tg_map Khandle (@labeled channel).
+Record state := State {
+    nodes: node_state;
+    chans: chan_state;
+}.
+
+Instance etastate: Settable _ :=
+    settable! State<nodes; chans>.
+

--- a/experimental/ni_coq/vfiles/TraceLowEq.v
+++ b/experimental/ni_coq/vfiles/TraceLowEq.v
@@ -1,0 +1,116 @@
+Require Import Coq.Lists.List.
+Require Import Coq.Sets.Ensembles.
+Import ListNotations.
+From OakIFC Require Import
+    Lattice
+    Parameters
+    GenericMap
+    Lattice
+    State
+    Events
+    ModelTypes
+    LowEquivalences.
+
+From RecordUpdate Require Import RecordSet.
+Import RecordSetNotations.
+
+(* Ensembles don't have implicit type params and this line fixes that *)
+Arguments Ensembles.Empty_set{U}.
+
+(*============================================================================
+* Trace Low Equivalences
+*===========================================================================*)
+
+(* We might need two different definitions of trace low-equivalence
+* depending on the top-level security condition *)
+
+(* This is a straightforward definition of trace low-equivalence
+    Roughly, it says that 
+    t1 =L t2 <-> forall i, t1[i] =L t2[i].
+
+    This definition would be useful for a 
+    "possibilistic security condition". A possibilistic security condition
+    says that two executions look the same from the perspective of an observer
+    if all _possible behaviors_ look the same if they begin from initial states
+    that look the same to the observer.
+
+    Possibilistic security conditions say that
+    forall s1 s2 t1, 
+        (s1 =L s2 -> <c, s1> => t1),
+        exists t2, <c, s2> => t2 /\ t1 =L t2.
+
+    In other words there is some way to reach an execution trace
+    that looks the same beginning from the other state.
+    
+    Trapeze uses a possibilistic definition of security:
+    https://pdfs.semanticscholar.org/809b/f2702a765b9e7dba4624a1dbc53af11579db.pdf
+    See also:
+    https://www.cs.cornell.edu/andru/papers/csfw03.pdf
+
+    and discussion in PossibilisticNI.v
+*)
+
+Inductive trace_low_eq {s_leq: @low_eq_t state}{e_leq: @low_eq_t event_l}:
+        @trace_low_eqT (state * (@labeled event)) :=
+    | NilEQ ell: trace_low_eq ell [] []
+    | AddBoth ell xs xe ys ye t1 t2:
+        trace_low_eq ell t1 t2 ->
+        e_leq ell xe ye ->
+        s_leq ell xs ys ->
+        trace_low_eq ell ((xs, xe)::t1) ((ys, ye)::t2).
+
+
+(* An alternative way of specifying security for
+   concurrent systems is observational determinism, which says
+   that for any two executions that begin from low-equivalent
+   initial states, the actual observed behaviors 
+   (by contrast to possibly observed behaviors)
+   _always_ look the same.
+
+    This looks like:
+    forall s1 s2 t1 t2,
+        (s1 =L s2) /\
+        (step_multi s1) => t1 /\
+        (step_multi s2) => t2 ->
+            t1 =L t2.
+
+    If we write this top-level theorem using the straightforward
+    definition of trace low-equivalence from above, the security condition
+    would rule out *some* timing channels that we know our system does not
+    prevent (so the security condition would not work). 
+
+    The straightforward security condition would rule out the case where:
+    - The observer is L
+    - There is label L' s.t. not (L' flowsTo L)
+    - A node called Other with Label L' takes more state transitions in one execution to
+    perform some computation than in the other.
+
+    While the "Other" node is executing, it can only affect parts of the system
+    labeled L' (or higher), so for this part of a single execution, it will
+    look like a sequence where ... si =L si+1 =L si+2 ... . In other words, the
+    sub-sequence is low-equivalent. If the observer really can't measure time,
+    two sequences that differ just in the number of transitions by "Other"
+    really do look the same.
+
+    This definition of trace low-equivalence rules this out by collapsing
+    adjacent low-equivalent states (called "high stutter") in the traces.
+*)
+
+Inductive stut_trace_low_eq {s_leq: @low_eq_t state}{e_leq: @low_eq_t event_l}:
+        @trace_low_eqT (state * (@labeled event)) :=
+    | SNilEQ ell: stut_trace_low_eq ell [] []
+    | SAddBoth ell xs xe ys ye t1 t2:
+        stut_trace_low_eq ell t1 t2 ->
+        event_low_eq ell xe ye ->
+        state_low_eq ell xs ys ->
+        stut_trace_low_eq ell ((xs, xe)::t1) ((ys, ye)::t2)
+    | SAddEqR ell xs xe ys ye t1 t2:
+        stut_trace_low_eq ell t1 ((ys, ye)::t2) ->
+        event_low_eq ell xe ye ->
+        state_low_eq ell xs ys ->
+        stut_trace_low_eq ell t1 ((xs, xe)::(ys, ye)::t2)
+    | SAddEqL ell xs xe ys ye t1 t2:
+        stut_trace_low_eq ell ((ys, ye)::t1) t2 ->
+        event_low_eq ell xe ye ->
+        state_low_eq ell xs ys ->
+        stut_trace_low_eq ell ((xs, xe)::t1) ((ys, ye)::t2).

--- a/experimental/ni_coq/vfiles/Unfold.v
+++ b/experimental/ni_coq/vfiles/Unfold.v
@@ -1,0 +1,24 @@
+From OakIFC Require Import
+    Lattice
+    Parameters
+    GenericMap
+    State
+    Events
+    ModelSemUtils
+    RuntimeModel
+    LowEquivalences.
+
+(* so far the proofs haven't wanted to unfold state elements deeper than this*)
+Hint Unfold obj lbl fnd: structs.
+
+Hint Unfold state_low_eq chan_state_low_eq node_state_low_eq event_low_eq
+    chan_low_eq node_low_eq low_eq state_low_proj chan_state_low_proj
+    node_state_low_proj event_low_proj chan_low_proj node_low_proj
+    low_proj: loweq.
+
+Hint Unfold chan_append chan_pop msg_is_head node_get_hans state_upd_node
+    state_upd_node_labeled state_upd_chan state_upd_chan_labeled
+    chan_append_labeled state_chan_append_labeled node_add_rhan
+    node_add_whan node_del_rhan node_del_rhans new_chan fresh_han fresh_nid
+    s_set_call: semutils.
+

--- a/experimental/ni_coq/vfiles/Unwind.v
+++ b/experimental/ni_coq/vfiles/Unwind.v
@@ -4,12 +4,12 @@ From OakIFC Require Import
     Lattice
     Parameters
     GenericMap
-    RuntimeModel
-    EvAugSemantics
+    State
     Events
+    ModelSemUtils
     LowEquivalences
-    Tactics
-    NIUtilTheorems.
+    NIUtilTheorems
+    Tactics.
 From RecordUpdate Require Import RecordSet.
 Import RecordSetNotations.
 Local Open Scope map_scope.
@@ -39,11 +39,11 @@ Proof.
     destruct s1, s2; intros *.
     inversion 1; subst.
     cbv [state_upd_node state_low_eq state_low_proj set] in *.
-    cbn [RuntimeModel.nodes RuntimeModel.chans] in *.
+    cbn [State.nodes State.chans] in *.
     split; try congruence; intros.
     destruct (dec_eq_nid id nid).
     - rewrite e in *. specialize (H0 nid).
-    cbv [node_state_low_proj low_proj fnd RuntimeModel.lbl RuntimeModel.obj] in *.
+    cbv [node_state_low_proj low_proj fnd State.lbl State.obj] in *.
     simpl in *. erewrite upd_eq. erewrite upd_eq.
     destruct (nodes nid), (nodes0 nid).
     pose proof (top_is_top ell).
@@ -55,8 +55,8 @@ Proof.
     pose proof (ord_anti ell top ltac:(eauto) ltac:(eauto));
     congruence.
     - specialize (H0 nid).
-    cbv [node_state_low_proj low_proj fnd RuntimeModel.lbl 
-        RuntimeModel.obj] in *.
+    cbv [node_state_low_proj low_proj fnd State.lbl 
+        State.obj] in *.
     simpl in *. erewrite upd_neq; auto. erewrite upd_neq; auto.
 Qed.
 

--- a/experimental/ni_coq/vfiles/Unwind.v
+++ b/experimental/ni_coq/vfiles/Unwind.v
@@ -107,6 +107,19 @@ Proof.
     destruct (s1.(nodes).[? id]) eqn:E1; destruct (s2.(nodes).[? id]) eqn:E2.
 Admitted.
 
+Hint Resolve state_upd_chan_unwind chan_append_unwind chan_low_proj_loweq
+    chan_low_proj_idempotent state_upd_node_unwind set_call_unwind
+    state_upd_chan_unwind state_low_proj_loweq state_upd_chan_labeled_unwind
+    state_upd_node_labeled_unwind state_chan_append_labeled_unwind
+    labeled_low_proj_loweq: unwind.
+Hint Extern 4 (node_low_eq _ _ _) => reflexivity : unwind.
+Hint Extern 4 (chan_low_eq _ _ _) => reflexivity : unwind.
+(* meant to be case where we have (cleq ch (proj ch) ) and want to swap order *)
+Hint Extern 4 (chan_low_eq _ _ (chan_low_proj _ _)) => symmetry : unwind.
+Hint Extern 4 (state_low_eq _ _ (state_low_proj _ _)) => symmetry : unwind.
+Hint Extern 2 (chan_low_proj _ _ = chan_low_proj _ _)
+=> simple eapply chan_low_proj_loweq : unwind.
+
 Hint Resolve state_upd_chan_unwind chan_append_unwind
                 set_call_unwind state_upd_node_unwind
                 state_upd_chan_labeled_unwind


### PR DESCRIPTION
The goal of this refactor is to support:
- keeping around more than one definition of low-equivalence / low-projection and some of the lower-level theorems about those
        (though they might not really be hot-swappable in the top-level proofs since some properties will be available with one 
        set of definitions but not in the other)
- having multiple runtime models that can benefit from some common definitions
- having multiple security properties and disconnecting the property definitions from the models that have them.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
