### PR TITLE
Add forward_invocation function

### DIFF
--- a/examples/aggregator/client/android/cpp/client.cc
+++ b/examples/aggregator/client/android/cpp/client.cc
@@ -55,7 +55,7 @@ JNIEXPORT void JNICALL Java_com_google_oak_aggregator_MainActivity_createChannel
   // The particular value corresponds to the hash on the `aggregator.wasm` line in
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("9a3a4781643e20f08d31396b016d97b3b2817782c3362897a75426b18739196f"));
+      absl::HexStringToBytes("643e33dc07c06b4127f28ef81a37002dc4a4852f714cc7295a513245075c7a7a"));
   kChannel = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
   JNI_LOG("gRPC channel has been created");

--- a/examples/aggregator/client/cpp/aggregator.cc
+++ b/examples/aggregator/client/cpp/aggregator.cc
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   // TODO(#1674): Add appropriate TLS endpoint tag to the label as well.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("9a3a4781643e20f08d31396b016d97b3b2817782c3362897a75426b18739196f"));
+      absl::HexStringToBytes("643e33dc07c06b4127f28ef81a37002dc4a4852f714cc7295a513245075c7a7a"));
   // Connect to the Oak Application.
   auto stub = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));

--- a/examples/aggregator/config.toml
+++ b/examples/aggregator/config.toml
@@ -1,3 +1,3 @@
 grpc_server_listen_address = "[::]:8080"
 backend_server_address = "https://localhost:8888"
-aggregator_module_hash = "9a3a4781643e20f08d31396b016d97b3b2817782c3362897a75426b18739196f"
+aggregator_module_hash = "643e33dc07c06b4127f28ef81a37002dc4a4852f714cc7295a513245075c7a7a"

--- a/examples/aggregator/module/rust/src/router.rs
+++ b/examples/aggregator/module/rust/src/router.rs
@@ -15,10 +15,7 @@
 //
 
 use crate::proto::oak::examples::aggregator::RouterInit;
-use anyhow::Context;
-use oak::io::{ReceiverExt, Sender, SenderExt};
-use oak_abi::label::{confidentiality_label, web_assembly_module_tag, Label};
-use oak_services::proto::google::rpc;
+use oak::io::{forward_invocation, Sender};
 
 /// A node that routes each incoming gRPC invocation to a Handler Node that can handle requests with
 /// the label of the incoming request.
@@ -30,42 +27,13 @@ use oak_services::proto::google::rpc;
 pub struct Router {
     /// Invocation sender channel half for Handler Node.
     handler_invocation_sender: Sender<oak::grpc::Invocation>,
-    /// Confidentiality label corresponding to Aggregator WebAssembly module SHA-256 hash.
-    aggregator_hash_label: Label,
 }
 
 impl oak::CommandHandler for Router {
     type Command = oak::grpc::Invocation;
 
-    fn handle_command(&mut self, command: oak::grpc::Invocation) -> anyhow::Result<()> {
-        // The router node has a public confidentiality label, and therefore cannot read the
-        // contents of the request of the invocation (unless it happens to be public as well), but
-        // it can always inspect its label.
-        match (&command.receiver, &command.sender) {
-            (Some(receiver), Some(sender)) => {
-                let label = receiver.label()?;
-                // Check if request label is valid in the context of Aggregator application.
-                if !label.flows_to(&self.aggregator_hash_label) {
-                    let grpc_response_writer =
-                        oak::grpc::ChannelResponseWriter::new(sender.clone());
-                    grpc_response_writer
-                        .close(Err(oak::grpc::build_status(
-                            rpc::Code::InvalidArgument,
-                            "Invalid request label",
-                        )))
-                        .context("Couldn't send error response back")?;
-                    anyhow::bail!("Invalid request label: {:?}", label);
-                }
-
-                // Route gRPC invocations to Handler Node.
-                self.handler_invocation_sender
-                    .send(&command)
-                    .context("Couldn't send invocation to worker node")
-            }
-            _ => {
-                anyhow::bail!("Received malformed gRPC invocation");
-            }
-        }
+    fn handle_command(&mut self, command: Self::Command) -> anyhow::Result<()> {
+        forward_invocation(command, &self.handler_invocation_sender)
     }
 }
 
@@ -79,12 +47,8 @@ impl oak::WithInit for Router {
             .expect("Couldn't receive gRPC invocation sender")
             .sender
             .expect("Empty gRPC invocation sender");
-        let aggregator_hash_label = confidentiality_label(web_assembly_module_tag(
-            &hex::decode(init.aggregator_module_hash).expect("Couldn't decode SHA-256 hex value"),
-        ));
         Self {
             handler_invocation_sender,
-            aggregator_hash_label,
         }
     }
 }

--- a/examples/aggregator/oak_app_manifest.toml
+++ b/examples/aggregator/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "aggregator"
 
 [modules]
-app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/9a3a4781643e20f08d31396b016d97b3b2817782c3362897a75426b18739196f", sha256 = "9a3a4781643e20f08d31396b016d97b3b2817782c3362897a75426b18739196f" } }
+app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/643e33dc07c06b4127f28ef81a37002dc4a4852f714cc7295a513245075c7a7a", sha256 = "643e33dc07c06b4127f28ef81a37002dc4a4852f714cc7295a513245075c7a7a" } }

--- a/examples/private_set_intersection/oak_app_manifest.toml
+++ b/examples/private_set_intersection/oak_app_manifest.toml
@@ -2,4 +2,8 @@ name = "private_set_intersection"
 
 [modules]
 # TODO(865): Use locally built module once reproducibility is fixed.
+<<<<<<< HEAD
 app = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection/89f22e622068a6391f4123780449d2d09fb56f0c6245a7eb641e9fe9af216163", sha256 = "89f22e622068a6391f4123780449d2d09fb56f0c6245a7eb641e9fe9af216163" } }
+=======
+app = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection/be13c78ff2de7c1ce27b6f489c2f05a86206f0bf6205dfab6216b6c183a90d94", sha256 = "be13c78ff2de7c1ce27b6f489c2f05a86206f0bf6205dfab6216b6c183a90d94" } }
+>>>>>>> 4083de3a (Add forward_invocation function)

--- a/examples/private_set_intersection/oak_app_manifest.toml
+++ b/examples/private_set_intersection/oak_app_manifest.toml
@@ -2,8 +2,4 @@ name = "private_set_intersection"
 
 [modules]
 # TODO(865): Use locally built module once reproducibility is fixed.
-<<<<<<< HEAD
-app = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection/89f22e622068a6391f4123780449d2d09fb56f0c6245a7eb641e9fe9af216163", sha256 = "89f22e622068a6391f4123780449d2d09fb56f0c6245a7eb641e9fe9af216163" } }
-=======
-app = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection/be13c78ff2de7c1ce27b6f489c2f05a86206f0bf6205dfab6216b6c183a90d94", sha256 = "be13c78ff2de7c1ce27b6f489c2f05a86206f0bf6205dfab6216b6c183a90d94" } }
->>>>>>> 4083de3a (Add forward_invocation function)
+app = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection/9906d053540910e02d6c9d2de2d438ae8aa22a36e684bedfc01ad03e67318edb", sha256 = "9906d053540910e02d6c9d2de2d438ae8aa22a36e684bedfc01ad03e67318edb" } }

--- a/examples/private_set_intersection/private_set_intersection.sign
+++ b/examples/private_set_intersection/private_set_intersection.sign
@@ -3,19 +3,10 @@ f41SClNtR4i46v2Tuh1fQLbt/ZqRr1lENajCW92jyP4=
 -----END PUBLIC KEY-----
 
 -----BEGIN SIGNATURE-----
-<<<<<<< HEAD
-+aDUsVFZNUlSwDxNEHtojs7O3nqFgBJrLPUO1atkKDaf/zgSJyd2m2GJkSxAkzGZ
-qAfMYIAe0KMiHeR9T48uAg==
+gHUXlmlIy23nWLJtW8fCePVg0gTNjV8smkC4qGEGkbiCq5JbhXE3JsEVhqWl3jdc
+SqUWeStvC649EzBl7ewoAQ==
 -----END SIGNATURE-----
 
 -----BEGIN HASH-----
-ifIuYiBopjkfQSN4BEnS0J+1bwxiRafrZB6f6a8hYWM=
-=======
-98VPvz0/7byzXSSac1NDFUAJb8BXHquRhJPQKwdAU9XCKRq68qvKV6Dl5qEjx10+
-osoRnhQszc9mLsVAt2g0CA==
------END SIGNATURE-----
-
------BEGIN HASH-----
-vhPHj/LefBzie29InC8FqGIG8L9iBd+rYha2wYOpDZQ=
->>>>>>> 4083de3a (Add forward_invocation function)
+mQbQU1QJEOAtbJ0t4tQ4roqiKjbmhL7fwBrQPmcxjts=
 -----END HASH-----

--- a/examples/private_set_intersection/private_set_intersection.sign
+++ b/examples/private_set_intersection/private_set_intersection.sign
@@ -3,10 +3,19 @@ f41SClNtR4i46v2Tuh1fQLbt/ZqRr1lENajCW92jyP4=
 -----END PUBLIC KEY-----
 
 -----BEGIN SIGNATURE-----
+<<<<<<< HEAD
 +aDUsVFZNUlSwDxNEHtojs7O3nqFgBJrLPUO1atkKDaf/zgSJyd2m2GJkSxAkzGZ
 qAfMYIAe0KMiHeR9T48uAg==
 -----END SIGNATURE-----
 
 -----BEGIN HASH-----
 ifIuYiBopjkfQSN4BEnS0J+1bwxiRafrZB6f6a8hYWM=
+=======
+98VPvz0/7byzXSSac1NDFUAJb8BXHquRhJPQKwdAU9XCKRq68qvKV6Dl5qEjx10+
+osoRnhQszc9mLsVAt2g0CA==
+-----END SIGNATURE-----
+
+-----BEGIN HASH-----
+vhPHj/LefBzie29InC8FqGIG8L9iBd+rYha2wYOpDZQ=
+>>>>>>> 4083de3a (Add forward_invocation function)
 -----END HASH-----

--- a/sdk/rust/oak/src/io/mod.rs
+++ b/sdk/rust/oak/src/io/mod.rs
@@ -17,7 +17,9 @@
 //! Wrappers for Oak SDK types to allow their use with [`std::io`].
 
 use crate::OakStatus;
+use anyhow::Context;
 use oak_abi::label::Label;
+use oak_services::proto::google::rpc;
 use std::io;
 
 mod receiver;
@@ -122,6 +124,50 @@ fn send_init<Init: Encodable + Decodable, Command: Encodable + Decodable>(
     };
     sender.send(&init_wrapper)?;
     Ok(command_sender)
+}
+
+/// Sends [`crate::grpc::Invocation`] (containing [`oak_io::Receiver`] and [`oak_io::Sender`])
+/// through invocation sender if [`oak_io::Receiver`] label flows to invocation sender's label.
+/// If failed - sends error back through [`oak_io::Sender`].
+///
+/// Useful for sending invocations from router nodes and checking label correctness without actually
+/// reading the contents of invocation.
+pub fn forward_invocation(
+    invocation: crate::grpc::Invocation,
+    invocation_sender: &Sender<crate::grpc::Invocation>,
+) -> anyhow::Result<()> {
+    match (&invocation.receiver, &invocation.sender) {
+        (Some(request_receiver), Some(response_sender)) => {
+            let request_label = request_receiver
+                .label()
+                .context("Couldn't read request label")?;
+            let sender_label = invocation_sender
+                .label()
+                .context("Couldn't read invocation sender label")?;
+            // Check if request label is valid in the context of invocation sender.
+            if request_label.flows_to(&sender_label) {
+                // Forward invocation through invocation sender.
+                invocation_sender
+                    .send(&invocation)
+                    .context("Couldn't forward invocation")
+            } else {
+                // Return an error through `response_sender`.
+                let grpc_response_writer =
+                    crate::grpc::ChannelResponseWriter::new(response_sender.clone());
+                grpc_response_writer
+                    .close(Err(crate::grpc::build_status(
+                        rpc::Code::InvalidArgument,
+                        "Invalid request label",
+                    )))
+                    .context("Couldn't send error response back")?;
+                Err(anyhow::anyhow!(
+                    "Invalid request label: {:?}",
+                    request_label
+                ))
+            }
+        }
+        _ => Err(anyhow::anyhow!("Received malformed invocation")),
+    }
 }
 
 /// Map a non-OK [`OakStatus`] value to the nearest available [`std::io::Error`].


### PR DESCRIPTION
This change adds `forward_invocation` function that checks invocation receiver label before forwarding it and is used in `Router` Nodes.