### PR TITLE
Use Router in Trusted Database

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -407,13 +407,17 @@ associated type to
 or manually reading from the initial `Receiver`:
 
 <!-- prettier-ignore-start -->
-[embedmd]:# (../examples/trusted_database/module/rust/src/lib.rs Rust /oak::entrypoint/ /.*let config_map =.*/)
+[embedmd]:# (../examples/aggregator/module/rust/src/lib.rs Rust /impl oak::CommandHandler/ /.*context.*/)
 ```Rust
-oak::entrypoint!(oak_main<ConfigMap> => |receiver: Receiver<ConfigMap>| {
-    let log_sender = oak::logger::create().unwrap();
-    oak::logger::init(log_sender, log::Level::Debug).unwrap();
+impl oak::CommandHandler for Main {
+    type Command = ConfigMap;
 
-    let config_map = receiver.receive().expect("Couldn't read config map");
+    fn handle_command(&mut self, command: ConfigMap) -> anyhow::Result<()> {
+        let log_sender = oak::logger::create()?;
+        oak::logger::init(log_sender.clone(), log::Level::Debug)?;
+        let config: Config =
+            toml::from_slice(&command.items.get("config").expect("Couldn't find config"))
+                .context("Couldn't parse TOML config file")?;
 ```
 <!-- prettier-ignore-end -->
 

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -403,8 +403,7 @@ from the implicit incoming channel, usually by implementing the
 trait setting the
 [`Command`](https://project-oak.github.io/oak/sdk/doc/oak/trait.CommandHandler.html#associatedtype.Command)
 associated type to
-[`ConfigMap`](https://project-oak.github.io/oak/sdk/doc/oak/proto/oak/application/struct.ConfigMap.html),
-or manually reading from the initial `Receiver`:
+[`ConfigMap`](https://project-oak.github.io/oak/sdk/doc/oak/proto/oak/application/struct.ConfigMap.html):
 
 <!-- prettier-ignore-start -->
 [embedmd]:# (../examples/aggregator/module/rust/src/lib.rs Rust /impl oak::CommandHandler/ /.*context.*/)

--- a/examples/trusted_database/module/rust/Cargo.toml
+++ b/examples/trusted_database/module/rust/Cargo.toml
@@ -14,6 +14,7 @@ log = "*"
 oak = "=0.1.0"
 oak_abi = "=0.1.0"
 oak_io = "=0.1.0"
+oak_services = "=0.1.0"
 prost = "*"
 serde = "*"
 quick-xml = { version = "*", features = ["serialize"] }

--- a/examples/trusted_database/module/rust/build.rs
+++ b/examples/trusted_database/module/rust/build.rs
@@ -18,7 +18,7 @@ fn main() {
     oak_utils::compile_protos(
         &[
             "../../proto/trusted_database.proto",
-            "../../proto/trusted_database_command.proto",
+            "../../proto/trusted_database_init.proto",
         ],
         &["../../proto", "../../../../"],
     );

--- a/examples/trusted_database/module/rust/src/handler.rs
+++ b/examples/trusted_database/module/rust/src/handler.rs
@@ -27,7 +27,7 @@ const NO_LOCATION_ERROR: &str = "Location is not specified";
 const ID_NOT_FOUND_ERROR: &str = "ID not found";
 const EMPTY_DATABASE_ERROR: &str = "Empty database";
 
-/// Oak Handler Node that contains a copy of the database.
+/// Oak Handler Node that contains a copy of the database and handles client requests.
 #[derive(Default)]
 pub struct Handler {
     points_of_interest: PointOfInterestMap,

--- a/examples/trusted_database/module/rust/src/handler.rs
+++ b/examples/trusted_database/module/rust/src/handler.rs
@@ -17,7 +17,7 @@
 use crate::proto::oak::examples::trusted_database::{
     GetPointOfInterestRequest, GetPointOfInterestResponse, ListPointsOfInterestRequest,
     ListPointsOfInterestResponse, Location, PointOfInterestMap, TrustedDatabase,
-    TrustedDatabaseInit, TrustedDatabaseDispatcher,
+    TrustedDatabaseDispatcher, TrustedDatabaseInit,
 };
 use log::{debug, error, warn};
 use oak::grpc;
@@ -28,6 +28,7 @@ const ID_NOT_FOUND_ERROR: &str = "ID not found";
 const EMPTY_DATABASE_ERROR: &str = "Empty database";
 
 /// Oak Handler Node that contains a copy of the database.
+#[derive(Default)]
 pub struct Handler {
     points_of_interest: PointOfInterestMap,
 }
@@ -37,9 +38,7 @@ impl oak::WithInit for Handler {
 
     fn create(init: Self::Init) -> Self {
         oak::logger::init(init.log_sender.unwrap(), log::Level::Debug).unwrap();
-        let points_of_interest = init
-            .points_of_interest
-            .expect("Couldn't receive database");
+        let points_of_interest = init.points_of_interest.expect("Couldn't receive database");
         Self { points_of_interest }
     }
 }
@@ -72,7 +71,7 @@ impl TrustedDatabase for Handler {
         &mut self,
         request: ListPointsOfInterestRequest,
     ) -> grpc::Result<ListPointsOfInterestResponse> {
-        debug!("Received request: {:?}", request);
+        error!("Received request: {:?}", request);
         let request_location = request.location.ok_or_else(|| {
             let err = grpc::build_status(grpc::Code::InvalidArgument, &NO_LOCATION_ERROR);
             warn!("{:?}", err);

--- a/examples/trusted_database/module/rust/src/handler.rs
+++ b/examples/trusted_database/module/rust/src/handler.rs
@@ -14,39 +14,38 @@
 // limitations under the License.
 //
 
-//! Trusted Database Handler Node.
-//!
-//! In the current implementation clients send their location coordinates (latitude and longitude)
-//! and the Handler Node returns the location of the closest Point Of Interest.
-//!
-//! The Handler Node searches for the closest Point Of Interest in the database received from the
-//! Main Node.
-
 use crate::proto::oak::examples::trusted_database::{
     GetPointOfInterestRequest, GetPointOfInterestResponse, ListPointsOfInterestRequest,
     ListPointsOfInterestResponse, Location, PointOfInterestMap, TrustedDatabase,
-    TrustedDatabaseCommand, TrustedDatabaseDispatcher,
+    TrustedDatabaseInit, TrustedDatabaseDispatcher,
 };
 use log::{debug, error, warn};
-use oak::{
-    grpc,
-    io::{Receiver, ReceiverExt},
-};
+use oak::grpc;
 
 // Error messages.
 const NO_LOCATION_ERROR: &str = "Location is not specified";
 const ID_NOT_FOUND_ERROR: &str = "ID not found";
 const EMPTY_DATABASE_ERROR: &str = "Empty database";
 
-/// Oak Node that contains a copy of the database.
-pub struct TrustedDatabaseHandlerNode {
+/// Oak Handler Node that contains a copy of the database.
+pub struct Handler {
     points_of_interest: PointOfInterestMap,
 }
 
-oak::impl_dispatcher!(impl TrustedDatabaseHandlerNode : TrustedDatabaseDispatcher);
+impl oak::WithInit for Handler {
+    type Init = TrustedDatabaseInit;
+
+    fn create(init: Self::Init) -> Self {
+        oak::logger::init(init.log_sender.unwrap(), log::Level::Debug).unwrap();
+        let points_of_interest = init
+            .points_of_interest
+            .expect("Couldn't receive database");
+        Self { points_of_interest }
+    }
+}
 
 /// A gRPC service implementation for the Private Information Retrieval example.
-impl TrustedDatabase for TrustedDatabaseHandlerNode {
+impl TrustedDatabase for Handler {
     // Find Point Of Interest based on id.
     fn get_point_of_interest(
         &mut self,
@@ -138,18 +137,6 @@ pub fn distance(first: Location, second: Location) -> f32 {
     EARTH_RADIUS * central_angle
 }
 
-oak::entrypoint!(handler_oak_main<TrustedDatabaseCommand> => |command_receiver: Receiver<TrustedDatabaseCommand>| {
-    let log_sender = oak::logger::create().unwrap();
-    oak::logger::init(log_sender, log::Level::Debug).unwrap();
+oak::entrypoint_command_handler_init!(handler => Handler);
 
-    // Receive command.
-    let command: TrustedDatabaseCommand =
-        command_receiver.receive().expect("Couldn't receive command");
-    let receiver = command.invocation_receiver.expect("Couldn't receive gRPC invocation receiver");
-
-    // Run event loop and handle incoming invocations.
-    let node = TrustedDatabaseHandlerNode { points_of_interest: command.points_of_interest.expect("No database entries") };
-    let invocation_receiver = receiver.receiver.expect("Empty gRPC invocation receiver");
-    // The event loop only runs once because the `Main` Node sends a single invocation.
-    oak::run_command_loop(node, invocation_receiver.iter());
-});
+oak::impl_dispatcher!(impl Handler : TrustedDatabaseDispatcher);

--- a/examples/trusted_database/module/rust/src/lib.rs
+++ b/examples/trusted_database/module/rust/src/lib.rs
@@ -57,10 +57,7 @@ mod router;
 #[cfg(test)]
 mod tests;
 
-use crate::{
-    proto::oak::examples::trusted_database::TrustedDatabaseInit,
-    router::Router,
-};
+use crate::{proto::oak::examples::trusted_database::TrustedDatabaseInit, router::Router};
 use anyhow::Context;
 use database::load_database;
 use oak::proto::oak::application::ConfigMap;

--- a/examples/trusted_database/module/rust/src/router.rs
+++ b/examples/trusted_database/module/rust/src/router.rs
@@ -1,0 +1,67 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::{
+    handler::Handler,
+    proto::oak::examples::trusted_database::{PointOfInterestMap, TrustedDatabaseInit},
+};
+use anyhow::Context;
+use oak::{
+    grpc,
+    io::{ReceiverExt, Sender},
+    CommandHandler,
+};
+use oak_services::proto::oak::log::LogMessage;
+
+/// Oak Router Node that contains an in-memory database.
+#[derive(Default)]
+pub struct Router {
+    log_sender: Sender<LogMessage>,
+    points_of_interest: PointOfInterestMap,
+}
+
+impl oak::WithInit for Router {
+    type Init = TrustedDatabaseInit;
+
+    fn create(init: Self::Init) -> Self {
+        let log_sender = init.log_sender.unwrap();
+        oak::logger::init(log_sender.clone(), log::Level::Debug).unwrap();
+        let points_of_interest = init
+            .points_of_interest
+            .expect("Couldn't receive database");
+        Self { log_sender, points_of_interest }
+    }
+}
+
+impl CommandHandler for Router {
+    type Command = grpc::Invocation;
+
+    fn handle_command(&mut self, invocation: Self::Command) -> anyhow::Result<()> {
+        let label = invocation.receiver
+            .context("Couldn't get receiver")?
+            .label()
+            .context("Couldn't get label")?;
+        let init = TrustedDatabaseInit {
+            log_sender: Some(self.log_sender.clone()),
+            points_of_interest: Some(self.points_of_interest.clone()),
+        };
+        oak::io::entrypoint_node_create::<Handler, _, _>("handler", &label, "app", init)
+            .context("Couldn't create handler node")?;
+        Ok(())
+    }
+}
+
+oak::entrypoint_command_handler_init!(router => Router);

--- a/examples/trusted_database/module/rust/src/router.rs
+++ b/examples/trusted_database/module/rust/src/router.rs
@@ -39,10 +39,11 @@ impl oak::WithInit for Router {
     fn create(init: Self::Init) -> Self {
         let log_sender = init.log_sender.unwrap();
         oak::logger::init(log_sender.clone(), log::Level::Debug).unwrap();
-        let points_of_interest = init
-            .points_of_interest
-            .expect("Couldn't receive database");
-        Self { log_sender, points_of_interest }
+        let points_of_interest = init.points_of_interest.expect("Couldn't receive database");
+        Self {
+            log_sender,
+            points_of_interest,
+        }
     }
 }
 
@@ -50,7 +51,8 @@ impl CommandHandler for Router {
     type Command = grpc::Invocation;
 
     fn handle_command(&mut self, invocation: Self::Command) -> anyhow::Result<()> {
-        let label = invocation.receiver
+        let label = invocation
+            .receiver
             .context("Couldn't get receiver")?
             .label()
             .context("Couldn't get label")?;

--- a/examples/trusted_database/proto/trusted_database_init.proto
+++ b/examples/trusted_database/proto/trusted_database_init.proto
@@ -16,12 +16,16 @@
 
 syntax = "proto3";
 
-package oak.examples.trusted_database_command;
+package oak.examples.trusted_database_init;
 
 import "trusted_database.proto";
 import "oak_services/proto/grpc_invocation.proto";
+import "oak_services/proto/log.proto";
+import "proto/handle.proto";
 
-message TrustedDatabaseCommand {
-  oak.invocation.GrpcInvocationReceiver invocation_receiver = 1;
+// Initialization message that should be sent to Router Oak Node and Handler Oak Node.
+message TrustedDatabaseInit {
+  oak.handle.Sender log_sender = 1 [(oak.handle.message_type) = ".oak.log.LogMessage"];
+  // Copy of the database.
   oak.examples.trusted_database.PointOfInterestMap points_of_interest = 2;
 }


### PR DESCRIPTION
This change updates Trusted Database example to use Router pattern.

Ref https://github.com/project-oak/oak/issues/1066