### PR TITLE
Allow multiple versions of the same crate in cargo-deny

### DIFF
--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -20,50 +20,8 @@ ignore = [
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
-
-# TODO(#1270): Remove when rusty-machine no longer depends on old version.
-[[bans.skip]]
-name = "rand"
-version = "=0.3.23"
-
-# TODO(#1270): Remove when rusty-machine no longer depends on old version.
-[[bans.skip]]
-name = "rand"
-version = "=0.4.6"
-
-[[bans.skip]]
-name = "webpki-roots"
-version = "=0.19.0"
-
-[[bans.skip]]
-name = "pin-project"
-version = "=0.4.23"
-
-[[bans.skip]]
-name = "pin-project-internal"
-version = "=0.4.23"
-
-[[bans.skip]]
-name = "cfg-if"
-version = "=0.1.10"
-
-[[bans.skip]]
-name = "lock_api"
-version = "=0.3.4"
-
-[[bans.skip]]
-name = "parking_lot"
-version = "=0.10.2"
-
-[[bans.skip]]
-name = "parking_lot_core"
-version = "=0.7.2"
-
-[[bans.skip]]
-name = "webpki-roots"
-version = "=0.19.0"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/experimental/deny.toml
+++ b/experimental/deny.toml
@@ -17,24 +17,8 @@ ignore = [
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
-
-[[bans.skip]]
-name = "pin-project"
-version = "=0.4.27"
-
-[[bans.skip]]
-name = "pin-project-internal"
-version = "=0.4.27"
-
-[[bans.skip]]
-name = "cfg-if"
-version = "=0.1.10"
-
-[[bans.skip]]
-name = "webpki-roots"
-version = "=0.19.0"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_abi/deny.toml
+++ b/oak_abi/deny.toml
@@ -16,7 +16,7 @@ notice = "deny"
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
 
 # List of allowed licenses.

--- a/oak_client/deny.toml
+++ b/oak_client/deny.toml
@@ -20,16 +20,8 @@ ignore = [
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
-
-[[bans.skip]]
-name = "pin-project"
-version = "=0.4.27"
-
-[[bans.skip]]
-name = "pin-project-internal"
-version = "=0.4.27"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_derive/deny.toml
+++ b/oak_derive/deny.toml
@@ -16,7 +16,7 @@ notice = "deny"
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
 
 # List of allowed licenses.

--- a/oak_io/deny.toml
+++ b/oak_io/deny.toml
@@ -16,7 +16,7 @@ notice = "deny"
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
 
 # List of allowed licenses.

--- a/oak_loader/deny.toml
+++ b/oak_loader/deny.toml
@@ -17,24 +17,8 @@ ignore = [
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
-
-[[bans.skip]]
-name = "pin-project"
-version = "=0.4.23"
-
-[[bans.skip]]
-name = "pin-project-internal"
-version = "=0.4.23"
-
-[[bans.skip]]
-name = "cfg-if"
-version = "=0.1.10"
-
-[[bans.skip]]
-name = "webpki-roots"
-version = "=0.19.0"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_runtime/deny.toml
+++ b/oak_runtime/deny.toml
@@ -17,28 +17,8 @@ ignore = [
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
-
-[[bans.skip]]
-name = "webpki-roots"
-version = "=0.19.0"
-
-[[bans.skip]]
-name = "pin-project"
-version = "=0.4.23"
-
-[[bans.skip]]
-name = "pin-project-internal"
-version = "=0.4.23"
-
-[[bans.skip]]
-name = "cfg-if"
-version = "=0.1.10"
-
-[[bans.skip]]
-name = "webpki-roots"
-version = "=0.19.0"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.

--- a/oak_services/deny.toml
+++ b/oak_services/deny.toml
@@ -16,7 +16,7 @@ notice = "deny"
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
 
 # List of allowed licenses.

--- a/oak_sign/deny.toml
+++ b/oak_sign/deny.toml
@@ -13,7 +13,7 @@ notice = "deny"
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
 
 # List of allowed licenses.

--- a/oak_utils/deny.toml
+++ b/oak_utils/deny.toml
@@ -13,7 +13,7 @@ notice = "deny"
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
 
 # List of allowed licenses.

--- a/runner/deny.toml
+++ b/runner/deny.toml
@@ -17,7 +17,7 @@ ignore = [
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
 
 # List of allowed licenses.

--- a/sdk/deny.toml
+++ b/sdk/deny.toml
@@ -20,24 +20,8 @@ ignore = [
 
 # Deny multiple versions unless explicitly skipped.
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards = "allow"
-
-[[bans.skip]]
-name = "pin-project"
-version = "=0.4.22"
-
-[[bans.skip]]
-name = "pin-project-internal"
-version = "=0.4.22"
-
-[[bans.skip]]
-name = "cfg-if"
-version = "=0.1.10"
-
-[[bans.skip]]
-name = "webpki-roots"
-version = "=0.19.0"
 
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.


### PR DESCRIPTION
We currently allow multiple versions anyway by just adding exceptions and then removing it later when no longer needed. This change means that we don't have to keep doing this maintenance for now while the versions are not very stable. We can add the checks in later for specific crates if exact versions become important.

Closes #1270 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
