### PR TITLE
Use Router and labels in Translator

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -98,7 +98,7 @@ struct Handler;
 impl Translator for Handler {
     fn translate(&mut self, req: TranslateRequest) -> grpc::Result<TranslateResponse> {
         info!(
-            "attempt to translate '{}' from {} to {}",
+            "Attempt to translate '{}' from {} to {}",
             req.text, req.from_lang, req.to_lang
         );
         let mut rsp = TranslateResponse::default();
@@ -108,7 +108,7 @@ impl Translator for Handler {
                     "fr" => "MONDES".to_string(),
                     "it" => "MONDI".to_string(),
                     _ => {
-                        info!("output language {} not found", req.to_lang);
+                        info!("Output language {} not found", req.to_lang);
                         return Err(grpc::build_status(
                             grpc::Code::NotFound,
                             "Output language not found",
@@ -117,7 +117,7 @@ impl Translator for Handler {
                 },
                 _ => {
                     info!(
-                        "input text '{}' in {} not recognized",
+                        "Input text '{}' in {} not recognized",
                         req.text, req.from_lang
                     );
                     return Err(grpc::build_status(
@@ -127,14 +127,14 @@ impl Translator for Handler {
                 }
             },
             _ => {
-                info!("input language '{}' not recognized", req.from_lang);
+                info!("Input language '{}' not recognized", req.from_lang);
                 return Err(grpc::build_status(
                     grpc::Code::NotFound,
                     "Input language unrecognized",
                 ));
             }
         };
-        info!("translation '{}'", rsp.translated_text);
+        info!("Translation '{}'", rsp.translated_text);
         Ok(rsp)
     }
 }
@@ -187,17 +187,17 @@ impl oak::CommandHandler for Main {
 
     fn handle_command(&mut self, _command: ConfigMap) -> anyhow::Result<()> {
         let log_sender = oak::logger::create()?;
-        let handler_sender = oak::io::entrypoint_node_create::<Handler, _, _>(
-            "handler",
+        let router_sender = oak::io::entrypoint_node_create::<Router, _, _>(
+            "router",
             &Label::public_untrusted(),
             "app",
             LogInit {
                 log_sender: Some(log_sender),
             },
         )
-        .context("could not create handler node")?;
-        oak::grpc::server::init_with_sender("[::]:8080", handler_sender)
-            .context("could not create gRPC server pseudo-Node")?;
+        .context("Couldn't create handler node")?;
+        oak::grpc::server::init_with_sender("[::]:8080", router_sender)
+            .context("Couldn't create gRPC server pseudo-Node")?;
         Ok(())
     }
 }

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -195,7 +195,7 @@ impl oak::CommandHandler for Main {
                 log_sender: Some(log_sender),
             },
         )
-        .context("Couldn't create handler node")?;
+        .context("Couldn't create router node")?;
         oak::grpc::server::init_with_sender("[::]:8080", router_sender)
             .context("Couldn't create gRPC server pseudo-Node")?;
         Ok(())

--- a/examples/translator/module/rust/src/lib.rs
+++ b/examples/translator/module/rust/src/lib.rs
@@ -45,7 +45,7 @@ impl oak::CommandHandler for Main {
                 log_sender: Some(log_sender),
             },
         )
-        .context("Couldn't create handler node")?;
+        .context("Couldn't create router node")?;
         oak::grpc::server::init_with_sender("[::]:8080", router_sender)
             .context("Couldn't create gRPC server pseudo-Node")?;
         Ok(())


### PR DESCRIPTION
This change adds Router pattern and client labels to Translator example.
Translator creates individual Handler Nodes for each client request and assigns client labels to them.

Ref https://github.com/project-oak/oak/pull/1745