### PR TITLE
Consistently pass the certificate as byte vector in the configurations

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "oak_runtime",
  "prost",
  "rand",
+ "rustls",
  "tonic",
 ]
 

--- a/experimental/Cargo.lock
+++ b/experimental/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "oak_runtime",
  "prost",
  "rand",
+ "rustls",
  "tonic",
 ]
 

--- a/oak_runtime/src/config.rs
+++ b/oak_runtime/src/config.rs
@@ -20,7 +20,6 @@ use crate::{io::SenderExt, Runtime, RuntimeConfiguration, RuntimeProxy};
 use log::{error, info};
 use oak_io::{handle::WriteHandle, OakError};
 use std::sync::Arc;
-use tonic::transport::Certificate;
 
 /// Configures a [`Runtime`] from the given [`RuntimeConfiguration`] and begins execution.
 ///
@@ -48,14 +47,4 @@ pub fn configure_and_run(config: RuntimeConfiguration) -> Result<Arc<Runtime>, O
     // Now that the implicit initial Node has been used to inject the
     // Application's `ConfigMap`, drop all reference to it.
     Ok(proxy.runtime)
-}
-
-/// Load a PEM encoded TLS certificate, performing (minimal) validation.
-pub fn load_certificate(certificate: &str) -> Result<Certificate, ()> {
-    let mut cursor = std::io::Cursor::new(certificate);
-    // `rustls` doesn't specify certificate parsing errors:
-    // https://docs.rs/rustls/0.17.0/rustls/internal/pemfile/fn.certs.html
-    rustls::internal::pemfile::certs(&mut cursor)?;
-
-    Ok(Certificate::from_pem(certificate))
 }

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -32,6 +32,7 @@ use crate::{
         event::EventDetails, ChannelCreated, Direction, Event, HandleCreated, HandleDestroyed,
         MessageDequeued, MessageEnqueued, NodeCreated, NodeDestroyed,
     },
+    tls::Certificate,
 };
 use auth::oidc_utils::ClientInfo;
 use core::sync::atomic::{AtomicBool, AtomicU64, Ordering::SeqCst};
@@ -56,7 +57,7 @@ use std::{
     thread::JoinHandle,
 };
 use tokio::sync::oneshot;
-use tonic::transport::{Certificate, Identity};
+use tonic::transport::Identity;
 
 pub use channel::{ChannelHalf, ChannelHalfDirection};
 pub use config::configure_and_run;
@@ -111,7 +112,7 @@ pub struct GrpcConfiguration {
     /// OpenID Connect Authentication client information.
     pub oidc_client_info: Option<ClientInfo>,
 
-    /// Root TLS certificate to use for all gRPC Client Nodes.
+    /// PEM formatted root TLS certificate to use for all gRPC Client Nodes.
     pub grpc_client_root_tls_certificate: Option<Certificate>,
 }
 
@@ -129,9 +130,8 @@ pub struct SignatureTable {
 pub struct HttpConfiguration {
     /// TLS identity to use for all HTTP Server Nodes.
     pub tls_config: crate::tls::TlsConfig,
-    /// A non-empty vector containing the root TLS certificate, in the PEM format, to use for all
-    /// HTTP Client Nodes.
-    pub http_client_root_tls_certificate: Vec<u8>,
+    /// PEM formatted root TLS certificate to use for all HTTP Client Nodes.
+    pub http_client_root_tls_certificate: Option<Certificate>,
 }
 
 /// Configuration options for secure HTTP and gRPC pseudo-Nodes.

--- a/oak_runtime/src/node/grpc/client.rs
+++ b/oak_runtime/src/node/grpc/client.rs
@@ -75,7 +75,7 @@ impl GrpcClientNode {
     pub fn new(
         node_name: &str,
         config: GrpcClientConfiguration,
-        root_tls_certificate: Certificate,
+        root_tls_certificate_bytes: crate::tls::Certificate,
     ) -> Result<Self, ConfigurationError> {
         let uri = config.uri.parse().map_err(|error| {
             error!("Error parsing URI {}: {:?}", config.uri, error);
@@ -85,6 +85,7 @@ impl GrpcClientNode {
         // We compute the node privilege once and for all at start and just store it, since it does
         // not change throughout the node execution.
         let node_privilege = grpc_client_node_privilege(&uri);
+        let root_tls_certificate = root_tls_certificate_bytes.into();
         Ok(Self {
             node_name: node_name.to_string(),
             uri,

--- a/oak_runtime/src/node/http/tests.rs
+++ b/oak_runtime/src/node/http/tests.rs
@@ -377,10 +377,10 @@ fn create_runtime() -> RuntimeProxy {
         grpc_config: None,
         http_config: Some(crate::HttpConfiguration {
             tls_config,
-            http_client_root_tls_certificate: include_bytes!(
-                "../../../../examples/certs/local/ca.pem"
+            http_client_root_tls_certificate: crate::tls::Certificate::parse(
+                include_bytes!("../../../../examples/certs/local/ca.pem").to_vec(),
             )
-            .to_vec(),
+            .ok(),
         }),
     };
     let signature_table = crate::SignatureTable::default();

--- a/oak_runtime/src/node/mod.rs
+++ b/oak_runtime/src/node/mod.rs
@@ -152,19 +152,17 @@ impl NodeFactory<NodeConfiguration> for ServerNodeFactory {
                 &self.signature_table,
             )?)),
             Some(ConfigType::GrpcClientConfig(config)) => {
-                let grpc_configuration = self
+                let grpc_client_root_tls_certificate = self
                     .secure_server_configuration
                     .clone()
                     .grpc_config
-                    .expect("no gRPC identity provided to Oak Runtime");
+                    .expect("no gRPC identity provided to Oak Runtime")
+                    .grpc_client_root_tls_certificate
+                    .expect("no root TLS certificate provided to Oak Runtime");
                 Ok(Box::new(grpc::client::GrpcClientNode::new(
                     node_name,
                     config.clone(),
-                    grpc_configuration
-                        .grpc_client_root_tls_certificate
-                        .as_ref()
-                        .expect("no gRPC client root TLS certificate provided to Oak Runtime")
-                        .clone(),
+                    grpc_client_root_tls_certificate,
                 )?))
             }
             Some(ConfigType::RoughtimeClientConfig(config)) => Ok(Box::new(
@@ -192,7 +190,8 @@ impl NodeFactory<NodeConfiguration> for ServerNodeFactory {
                     .http_config
                     .clone()
                     .expect("no HTTP configuration provided to Oak Runtime")
-                    .http_client_root_tls_certificate;
+                    .http_client_root_tls_certificate
+                    .expect("no root TLS certificate provided to Oak Runtime");
                 Ok(Box::new(http::client::HttpClientNode::new(
                     node_name,
                     config.clone(),

--- a/oak_runtime/src/tests.rs
+++ b/oak_runtime/src/tests.rs
@@ -52,12 +52,10 @@ fn run_node_body(node_label: &Label, node_privilege: &NodePrivilege, node_body: 
                     include_str!("../../examples/certs/local/local.pem"),
                     include_str!("../../examples/certs/local/local.key"),
                 )),
-                grpc_client_root_tls_certificate: Some(
-                    crate::config::load_certificate(&include_str!(
-                        "../../examples/certs/local/ca.pem"
-                    ))
-                    .unwrap(),
-                ),
+                grpc_client_root_tls_certificate: crate::tls::Certificate::parse(
+                    include_bytes!("../../examples/certs/local/ca.pem").to_vec(),
+                )
+                .ok(),
                 oidc_client_info: None,
             }),
             http_config: None,

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
  "oak_runtime",
  "prost",
  "rand",
+ "rustls",
  "tonic",
 ]
 

--- a/sdk/rust/oak_tests/Cargo.toml
+++ b/sdk/rust/oak_tests/Cargo.toml
@@ -15,4 +15,5 @@ oak_abi = "=0.1.0"
 oak_runtime = "=0.1.0"
 prost = "*"
 rand = { version = "*" }
+rustls = "*"
 tonic = { version = "*", features = ["tls"] }

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -172,10 +172,10 @@ pub fn runtime_config_wasm(
                     include_str!("../certs/local.pem"),
                     include_str!("../certs/local.key"),
                 )),
-                grpc_client_root_tls_certificate: Some(
-                    oak_runtime::config::load_certificate(&include_str!("../certs/ca.pem"))
-                        .unwrap(),
-                ),
+                grpc_client_root_tls_certificate: oak_runtime::tls::Certificate::parse(
+                    include_bytes!("../certs/ca.pem").to_vec(),
+                )
+                .ok(),
                 oidc_client_info: None,
             }),
             http_config: create_http_config(),
@@ -203,7 +203,10 @@ fn create_http_config() -> Option<oak_runtime::HttpConfiguration> {
     )?;
     Some(oak_runtime::HttpConfiguration {
         tls_config,
-        http_client_root_tls_certificate: include_bytes!("../certs/ca.pem").to_vec(),
+        http_client_root_tls_certificate: oak_runtime::tls::Certificate::parse(
+            include_bytes!("../certs/ca.pem").to_vec(),
+        )
+        .ok(),
     })
 }
 


### PR DESCRIPTION
Fixes #1747 