### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/build_rust_docs.yaml
+++ b/.github/workflows/build_rust_docs.yaml
@@ -27,7 +27,7 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
-      - name: free disk space
+      - name: Free disk space
         run: |
           df --human-readable
           sudo swapoff --all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,52 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  runner:
+    runs-on: ubuntu-latest
+    # We use the same job template, but parametrize the actual command to be passed to the runner
+    # binary using the matrix strategy, so that we get the commands running in parallel.
+    strategy:
+      fail-fast: false
+      matrix:
+        cmd:
+          - check-format
+          - run-cargo-deny
+          - run-cargo-udeps
+          - build-server --server-variant=base
+          - build-server --server-variant=logless
+          - run-tests
+          - run-tests-tsan
+          - run-examples --application-variant=rust
+          - run-examples --application-variant=cpp
+          - run-examples --application-variant=rust --example-name=hello_world
+            --build-docker
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
+      - name: Free disk space
+        run: |
+          df --human-readable
+          sudo swapoff --all
+          sudo rm --force /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          df --human-readable
+
+      # Build Docker image, caching from the latest version from the remote repository.
+      - name: Docker build
+        timeout-minutes: 30
+        run: |
+          docker pull gcr.io/oak-ci/oak:latest
+          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+
+      - name: Run command
+        run: ./scripts/docker_run ./scripts/runner ${{ matrix.cmd }}

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -47,6 +47,8 @@ pub enum Command {
     CheckFormat,
     RunTests,
     RunTestsTsan,
+    RunCargoDeny,
+    RunCargoUdeps,
     RunCi,
     #[structopt(about = "generate bash completion script to stdout")]
     Completion,

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -91,6 +91,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Command::CheckFormat => check_format(),
             Command::RunCi => run_ci(),
             Command::Completion => panic!("should have been handled above"),
+            Command::RunCargoDeny => run_cargo_deny(),
+            Command::RunCargoUdeps => run_cargo_udeps(),
         };
         // TODO(#396): Add support for running individual commands via command line flags.
         let remaining_steps = steps.len();


### PR DESCRIPTION
This is in addition to the GCP run for the time being, and not blocking
for any submission, but it should give a faster feedback for some of the
  steps since they are run in parallel.