### PR TITLE
Add SDK support for HTTP client pseudo-node

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -453,6 +453,18 @@ The available pseudo-Nodes are:
   - A handle for the read half of a channel holding the outbound request.
   - A handle for the write half of a channel that the corresponding response
     message(s) should be written to.
+- **HTTP client pseudo-Node**: Provides a mechanism for Oak Nodes to make use of
+  an external (non-Oak) HTTP or HTTPS services. Similar to the `gRPC client`,
+  invocations to an `HTTP client` must have two attached handles (in the
+  following order):
+
+  - A handle for the read half of a channel holding the outbound request.
+  - A handle for the write half of a channel that the corresponding response
+    message(s) should be written to.
+
+  This logic is currently encapsulated in the SDK in
+  `oak::http::client::HttpClient`.
+
 - **Storage pseudo-Node**: Provides a proxy mechanism for access to a persistent
   storage mechanism. Nodes that require storage functionality write storage
   requests to a channel that reaches the storage pseudo-Node, then read the

--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -656,6 +656,11 @@ TODO: describe use of storage
 TODO: describe use of gRPC client pseudo-Node to connect to external gRPC
 services.
 
+## Using External HTTP Services
+
+TODO: describe use of HTTP client pseudo-Node to connect to external HTTP
+services.
+
 ## Testing
 
 > "Beware of bugs in the above code; I have only proved it correct, not tried

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -103,12 +103,13 @@ method for each request.
 
 The [`oak::http`](https://project-oak.github.io/oak/sdk/doc/oak/http/index.html)
 module holds functionality that is helpful for interacting with the outside
-world over HTTP, via an explicitly created
-[HTTP server pseudo-Node](concepts.md#pseudo-nodes).
+world over HTTP/HTTPS, via an explicitly created
+[HTTP server pseudo-Node](concepts.md#pseudo-nodes), or via an explicitly
+created HTTP client pseudo-Node.
 
 An Oak Node that acts as an HTTP server is used with the
 [`oak::run_command_loop()`](https://project-oak.github.io/oak/sdk/doc/oak/fn.run_command_loop.html)
-function to services HTTP requests in a loop, calling the
+function to serve HTTP requests in a loop, calling the
 [`CommandHandler::handle_command()`](https://project-oak.github.io/oak/sdk/doc/oak/trait.CommandHandler.html#tymethod.handle_command)
 method for each request.
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -753,6 +753,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.0",
  "env_logger",
+ "http",
  "hyper",
  "hyper-rustls",
  "log",

--- a/examples/http_server/client/rust/Cargo.toml
+++ b/examples/http_server/client/rust/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 anyhow = "*"
 base64 = "*"
 env_logger = "*"
+http = "*"
 hyper = "*"
 hyper-rustls = { version = "*", default-features = false, features = [
   "webpki-tokio"

--- a/sdk/rust/oak/src/http/client.rs
+++ b/sdk/rust/oak/src/http/client.rs
@@ -1,0 +1,84 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::{
+    http::{util::Pipe, Invocation},
+    OakError,
+};
+use http::{Request, Response};
+use oak_abi::label::{confidentiality_label, tls_endpoint_tag, Label};
+use oak_io::Sender;
+use oak_services::proto::oak::encap::HttpRequest;
+use std::convert::TryInto;
+
+/// Initializes an HTTP client pseudo-Node serving requests that have the given authority in their
+/// URIs. If the authority is empty, the node is public and can handle any incoming request.
+/// Otherwise, the node is created with the `authority` as its confidentially tag. In this case, the
+/// client can only serve HTTPS requests to the services indicated by the `authority`.
+///
+/// Returns an [`HttpClient`].
+pub fn init(authority: &str) -> Result<HttpClient, OakError> {
+    let config = crate::node_config::http_client(authority);
+    let label = if authority.is_empty() {
+        Label::public_untrusted()
+    } else {
+        confidentiality_label(tls_endpoint_tag(authority))
+    };
+    let sender = crate::io::node_create::<Invocation>("http_client", &label, &config)?;
+    Ok(HttpClient {
+        sender,
+        authority: authority.to_string(),
+    })
+}
+
+pub struct HttpClient {
+    sender: Sender<Invocation>,
+    authority: String,
+}
+
+impl HttpClient {
+    /// Sends the given request via the HTTP client pseudo-node. The `response_label` should match
+    /// the label of the Oak Node.
+    pub fn send_request(
+        &self,
+        request: Request<Vec<u8>>,
+        response_label: &Label,
+    ) -> Result<Response<Vec<u8>>, OakError> {
+        // Use the authority of the client node as the label of the request channel.
+        let request_label = if self.authority.is_empty() {
+            Label::public_untrusted()
+        } else {
+            confidentiality_label(tls_endpoint_tag(&self.authority))
+        };
+        // create a pipe with a request and a response channel
+        let pipe = Pipe::new(&request_label, response_label)?;
+
+        // insert the request into the request channel
+        pipe.insert_message(HttpRequest::from(request))?;
+
+        // wrap the request and response channels in an invocation, and send it to the HTTP client
+        // pseudo-node
+        pipe.send_invocation(&self.sender)?;
+
+        // wait for the response to be received
+        let rsp = pipe.get_response()?;
+
+        // close all the channels in the pipe
+        pipe.close();
+
+        rsp.try_into().map_err(OakError::OakStatus)
+    }
+}

--- a/sdk/rust/oak/src/http/mod.rs
+++ b/sdk/rust/oak/src/http/mod.rs
@@ -14,20 +14,22 @@
 // limitations under the License.
 //
 
-//! Functionality to help Oak Nodes create HTTP server pseudo-Nodes.
+//! Functionality to help Oak Nodes create HTTP server and HTTP client pseudo-Nodes.
 
 use crate::{
-    io::{Receiver, ReceiverExt, Sender, SenderExt},
-    proto::oak::invocation::HttpInvocationSender,
+    io::{ReceiverExt, SenderExt},
     OakError, OakStatus,
 };
 use http::{Request, Response};
 use log::warn;
-use oak_abi::label::Label;
 pub use oak_services::proto::oak::encap::{HeaderMap, HttpRequest, HttpResponse};
 use std::convert::TryInto;
 
 pub type Invocation = crate::proto::oak::invocation::HttpInvocation;
+
+pub mod client;
+pub mod server;
+mod util;
 
 /// This implementation provides an interface for sending requests and receiving responses, using
 /// the idiomatic http types. Internally, these types are converted into protobuf encoded requests
@@ -69,62 +71,4 @@ impl Invocation {
             None => warn!("No receive present on invocation."),
         };
     }
-}
-
-/// Initializes an HTTP server pseudo-Node listening on the provided address.
-///
-/// Returns a [`Receiver`] to read HTTP [`Invocation`]s from.
-pub fn init(address: &str) -> Result<Receiver<Invocation>, OakStatus> {
-    // Create a separate channel for receiving invocations and pass it to a newly created HTTP
-    // pseudo-Node.
-    let (invocation_sender, invocation_receiver) =
-        crate::io::channel_create::<Invocation>("HTTP invocation", &Label::public_untrusted())
-            .expect("Couldn't create HTTP invocation channel");
-    match init_with_sender(address, invocation_sender) {
-        Ok(_) => {}
-        Err(e) => {
-            let _ = invocation_receiver.close();
-            return Err(e);
-        }
-    };
-    Ok(invocation_receiver)
-}
-
-/// Initializes an HTTP server pseudo-Node listening on the provided address.
-///
-/// Accepts a [`Sender`] of [`Invocation`] messages on which to send incoming HTTP invocations.
-pub fn init_with_sender(
-    address: &str,
-    invocation_sender: Sender<Invocation>,
-) -> Result<(), OakStatus> {
-    let config = crate::node_config::http_server(address);
-    // TODO(#1631): When we have a separate top for each sub-lattice, this should be changed to
-    // the top of the identity sub-lattice.
-    let top_label = oak_abi::label::confidentiality_label(oak_abi::label::top());
-    // Create a channel and pass the read half to a new HTTP server pseudo-Node.
-    let init_sender =
-        match crate::io::node_create::<HttpInvocationSender>("http_server", &top_label, &config) {
-            Ok(s) => s,
-            Err(e) => {
-                let _ = invocation_sender.close();
-                return Err(e);
-            }
-        };
-
-    let http_server_init = HttpInvocationSender {
-        sender: Some(invocation_sender),
-    };
-    init_sender
-        .send(&http_server_init)
-        .expect("Could not send init message to HTTP server pseudo-node");
-    init_sender
-        .close()
-        .expect("Couldn't close init message channel to HTTP server pseudo-node");
-    http_server_init
-        .sender
-        .unwrap()
-        .close()
-        .expect("Couldn't close local copy of invocation sender channel");
-
-    Ok(())
 }

--- a/sdk/rust/oak/src/http/server.rs
+++ b/sdk/rust/oak/src/http/server.rs
@@ -1,0 +1,83 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::{
+    io::{Receiver, ReceiverExt, Sender, SenderExt},
+    proto::oak::invocation::HttpInvocationSender,
+    OakStatus,
+};
+use oak_abi::label::Label;
+pub use oak_services::proto::oak::encap::{HeaderMap, HttpRequest, HttpResponse};
+
+pub type Invocation = crate::proto::oak::invocation::HttpInvocation;
+
+/// Initializes an HTTP server pseudo-Node listening on the provided address.
+///
+/// Returns a [`Receiver`] to read HTTP [`Invocation`]s from.
+pub fn init(address: &str) -> Result<Receiver<Invocation>, OakStatus> {
+    // Create a separate channel for receiving invocations and pass it to a newly created HTTP
+    // pseudo-Node.
+    let (invocation_sender, invocation_receiver) =
+        crate::io::channel_create::<Invocation>("HTTP invocation", &Label::public_untrusted())
+            .expect("Couldn't create HTTP invocation channel");
+    match init_with_sender(address, invocation_sender) {
+        Ok(_) => {}
+        Err(e) => {
+            let _ = invocation_receiver.close();
+            return Err(e);
+        }
+    };
+    Ok(invocation_receiver)
+}
+
+/// Initializes an HTTP server pseudo-Node listening on the provided address.
+///
+/// Accepts a [`Sender`] of [`Invocation`] messages on which to send incoming HTTP invocations.
+pub fn init_with_sender(
+    address: &str,
+    invocation_sender: Sender<Invocation>,
+) -> Result<(), OakStatus> {
+    let config = crate::node_config::http_server(address);
+    // TODO(#1631): When we have a separate top for each sub-lattice, this should be changed to
+    // the top of the identity sub-lattice.
+    let top_label = oak_abi::label::confidentiality_label(oak_abi::label::top());
+    // Create a channel and pass the read half to a new HTTP server pseudo-Node.
+    let init_sender =
+        match crate::io::node_create::<HttpInvocationSender>("http_server", &top_label, &config) {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = invocation_sender.close();
+                return Err(e);
+            }
+        };
+
+    let http_server_init = HttpInvocationSender {
+        sender: Some(invocation_sender),
+    };
+    init_sender
+        .send(&http_server_init)
+        .expect("Could not send init message to HTTP server pseudo-node");
+    init_sender
+        .close()
+        .expect("Couldn't close init message channel to HTTP server pseudo-node");
+    http_server_init
+        .sender
+        .unwrap()
+        .close()
+        .expect("Couldn't close local copy of invocation sender channel");
+
+    Ok(())
+}

--- a/sdk/rust/oak/src/http/util.rs
+++ b/sdk/rust/oak/src/http/util.rs
@@ -1,0 +1,115 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::{
+    io::{Receiver, ReceiverExt, Sender, SenderExt},
+    proto::oak::invocation::HttpInvocation,
+    OakError,
+};
+use log::error;
+use oak_abi::label::Label;
+use oak_services::proto::oak::encap::{HttpRequest, HttpResponse};
+
+/// A pair of temporary channels to pass the HTTP request to the HTTP Client and receive the
+/// response.
+pub struct Pipe {
+    http_invocation: HttpInvocation,
+    pub request_writer: Sender<HttpRequest>,
+    pub response_reader: Receiver<HttpResponse>,
+}
+
+impl Pipe {
+    pub fn new(request_label: &Label, response_label: &Label) -> Result<Self, OakError> {
+        // Create a channel for passing HTTP requests to the HTTP Client node.
+        let (request_writer, request_reader) =
+            crate::io::channel_create("HTTP request", request_label)?;
+
+        let (response_writer, response_reader) =
+            crate::io::channel_create("HTTP response", response_label)?;
+
+        let http_invocation = HttpInvocation {
+            receiver: Some(request_reader),
+            sender: Some(response_writer),
+        };
+
+        Ok(Pipe {
+            http_invocation,
+            request_writer,
+            response_reader,
+        })
+    }
+
+    /// Inserts the incoming HTTP request in the `request channel` part of the `HttpInvocation`.
+    pub fn insert_message(&self, request: HttpRequest) -> Result<(), OakError> {
+        // Put the HTTP request message inside the per-invocation request channel.
+        self.request_writer.send(&request)
+    }
+
+    /// Sends the `HttpInvocation` with request and response channels on the invocation_channel.
+    pub fn send_invocation(
+        &self,
+        invocation_channel: &oak_io::Sender<HttpInvocation>,
+    ) -> Result<(), OakError> {
+        // Send the invocation containing request-specific channels.
+        invocation_channel.send(&self.http_invocation)
+    }
+
+    pub fn get_response(&self) -> Result<HttpResponse, OakError> {
+        self.response_reader.receive()
+    }
+
+    /// Close all local handles except for the one that allows reading responses.
+    pub fn close(self) {
+        if let Err(err) = self.request_writer.close() {
+            error!(
+                "Failed to close request writer channel for invocation: {:?}",
+                err
+            );
+        }
+        if let Err(err) = self.response_reader.close() {
+            error!(
+                "Failed to close response reader channel for invocation: {:?}",
+                err
+            );
+        }
+        self.http_invocation.close();
+    }
+}
+
+impl HttpInvocation {
+    fn close(self) {
+        if let Err(err) = self
+            .receiver
+            .ok_or(oak_abi::OakStatus::ErrBadHandle)
+            .and_then(|receiver| receiver.close())
+        {
+            error!(
+                "Failed to close request reader channel for invocation: {:?}",
+                err
+            );
+        }
+        if let Err(err) = self
+            .sender
+            .ok_or(oak_abi::OakStatus::ErrBadHandle)
+            .and_then(|sender| sender.close())
+        {
+            error!(
+                "Failed to close response writer channel for invocation: {:?}",
+                err
+            );
+        }
+    }
+}

--- a/sdk/rust/oak/src/node_config.rs
+++ b/sdk/rust/oak/src/node_config.rs
@@ -18,7 +18,8 @@
 
 use oak_abi::proto::oak::application::{
     node_configuration::ConfigType, GrpcClientConfiguration, GrpcServerConfiguration,
-    HttpServerConfiguration, LogConfiguration, NodeConfiguration, WebAssemblyConfiguration,
+    HttpClientConfiguration, HttpServerConfiguration, LogConfiguration, NodeConfiguration,
+    WebAssemblyConfiguration,
 };
 
 pub fn grpc_client(address: &str) -> NodeConfiguration {
@@ -33,6 +34,14 @@ pub fn grpc_server(address: &str) -> NodeConfiguration {
     NodeConfiguration {
         config_type: Some(ConfigType::GrpcServerConfig(GrpcServerConfiguration {
             address: address.to_string(),
+        })),
+    }
+}
+
+pub fn http_client(authority: &str) -> NodeConfiguration {
+    NodeConfiguration {
+        config_type: Some(ConfigType::HttpClientConfig(HttpClientConfiguration {
+            authority: authority.to_string(),
         })),
     }
 }


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [x] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
