### PR TITLE
Finish NIUtils.v proofs

### DIFF
--- a/experimental/ni_coq/README.md
+++ b/experimental/ni_coq/README.md
@@ -20,7 +20,7 @@ is in vfiles/RuntimeModel.v. Both are evolving.
 
 The following are dependencies of this project:
 
-- coq (8.11.0)
+- coq (8.12.0)
 - coq-record-update (0.2.0)
 
 All of the above may be installed with [opam](https://opam.ocaml.org/), and the

--- a/experimental/ni_coq/vfiles/LowProjPS_Thms.v
+++ b/experimental/ni_coq/vfiles/LowProjPS_Thms.v
@@ -255,11 +255,11 @@ Qed.
 
 Theorem new_secret_chan_unobs: forall ell ell' s h ,
     ~( ell' <<L ell) ->
-    fresh_han s h ->
+    fresh_han_top s h ->
     state_low_eq ell s (state_upd_chan_labeled h 
             {| obj := new_chan; lbl := ell'|} s).
 Proof.
-    cbv [state_low_eq state_low_proj fresh_han new_chan]. intros.
+    cbv [state_low_eq state_low_proj fresh_han_top new_chan]. intros.
     eapply state_low_eq_parts; [cbv [state_upd_chan_labeled]; reflexivity | ].
     eapply chan_state_fe.
     intros. simpl. cbv [low_eq]. destruct s. cbv [State.chans] in *.

--- a/experimental/ni_coq/vfiles/ModelSemUtils.v
+++ b/experimental/ni_coq/vfiles/ModelSemUtils.v
@@ -109,9 +109,15 @@ Definition node_del_rhans (hs: Ensemble handle)(n: node): node :=
 
 Definition new_chan := Some {| ms := [] |}.
 
-Definition fresh_han s h := s.(chans).[?h] = Labeled channel None top.
+Definition fresh_han s h := s.(chans).[?h] = Labeled channel None bot.
 
-Definition fresh_nid s id := s.(nodes).[?id] = Labeled node None top.
+Definition fresh_nid s id := s.(nodes).[?id] = Labeled node None bot.
+
+(* unoccupied handles / IDs are secret for the model + security-def where 
+labels are partially secret *)
+Definition fresh_han_top s h := s.(chans).[?h] = Labeled channel None top.
+
+Definition fresh_nid_top s id := s.(nodes).[?id] = Labeled node None top.
 
 Definition s_set_call s id c :=
     match (s.(nodes).[?id]).(obj) with

--- a/experimental/ni_coq/vfiles/PossibilisticNI.v
+++ b/experimental/ni_coq/vfiles/PossibilisticNI.v
@@ -91,7 +91,7 @@ Proof.
         eapply state_low_eq_trans.
         eapply state_upd_node_unobs; eauto.
         eapply state_chan_append_labeled_unobs; eauto.
-    - (* ReadChannel; *)
+    - (* ReadChannel *)
         assert (~ nlbl0 <<L ell) by congruence.
         assert ( ~ (clbl <<L ell) ) by eauto using ord_trans.
         eapply state_low_eq_trans.
@@ -124,8 +124,6 @@ Proof.
         try eauto; try contradiction. 
     inversion H. unfold not. intros. congruence.
 Qed.
-
-
 
 Theorem step_implies_lowproj_steps_leq: forall ell s1 s1' e1,
     (step_system_ev s1 s1' e1) ->
@@ -296,7 +294,7 @@ Proof.
                   eauto using invert_chans_state_low_proj_flowsto. }
                 { crush; subst_lets; eauto with unwind. }
                 { crush. congruence. }
-            + (* ReadChannle *)
+            + (* ReadChannel *)
                 remember (s_set_call (state_upd_chan han (chan_pop ch)
                    (state_upd_node id (node_get_hans n0 msg0) s)) id c') as s2''.
                 eexists s2'', (lbl _ <--- msg).

--- a/experimental/ni_coq/vfiles/RuntimeModelPS.v
+++ b/experimental/ni_coq/vfiles/RuntimeModelPS.v
@@ -92,7 +92,7 @@ Inductive step_node (id: node_id): call -> state -> state -> Prop :=
     | SCreateChan s n nlbl h clbl:
         (s.(nodes).[?id]) = Labeled node (Some n) nlbl ->
             (* caller is a real node with label nlbl *)
-        fresh_han s h ->
+        fresh_han_top s h ->
             (* the target handle is not in use *)
         nlbl <<L clbl ->
             let s0 := (state_upd_chan_labeled h {|
@@ -104,7 +104,7 @@ Inductive step_node (id: node_id): call -> state -> state -> Prop :=
     | SCreateNode s n nlbl new_id new_lbl h:
         (s.(nodes).[?id]) = Labeled node (Some n) nlbl ->
             (* caller is a real node with label nlbl *)
-        fresh_nid s id ->
+        fresh_nid_top s id ->
             (* target nid is not in use *)
         nlbl <<L new_lbl ->
             (* create new node with read handle *)


### PR DESCRIPTION
The definition of fresh_han and fresh_chan needed to be changed so
that the labels of unused objects is public. For the other definition
where labels are partially secret, I think this would need to stay
"top". Either way, fresh_han and fresh_chan are not really parts of the
implementation; in the implementation I think these objects are just
genuinely newly created objects.

There's also some fixup leftover from the last PR :) 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
