### PR TITLE
Add handle_clone to ABI and runtime.

### DIFF
--- a/docs/abi.md
+++ b/docs/abi.md
@@ -227,6 +227,14 @@ Closes the channel identified by `param[0]`.
 - `param[0]: u64`: Handle to channel
 - `result[0]: u32`: Status of operation
 
+### `handle_clone`
+
+Creates a new distinct handle to the same channel as `param[0]`.
+
+- `param[0]: u64`: Handle to channel
+- `param[1]: usize`: Address of an 8-byte location that will receive the cloned
+  handle (as a little-endian u64).
+
 ### `node_create`
 
 Creates a new Node running the Node configuration identified by `param[0]` and

--- a/oak/module/oak_abi.h
+++ b/oak/module/oak_abi.h
@@ -66,6 +66,8 @@ WASM_IMPORT("oak")
 oak_abi::OakStatus channel_label_read(oak_abi::Handle handle, uint8_t* label_buf, size_t label_size,
                                       uint32_t* actual_size);
 WASM_IMPORT("oak")
+oak_abi::OakStatus handle_clone(oak_abi::Handle handle, oak_abi::Handle* cloned_handle);
+WASM_IMPORT("oak")
 oak_abi::OakStatus node_label_read(uint8_t* label_buf, size_t label_size, uint32_t* actual_size);
 WASM_IMPORT("oak")
 oak_abi::OakStatus node_privilege_read(uint8_t* label_buf, size_t label_size,

--- a/oak_abi/src/lib.rs
+++ b/oak_abi/src/lib.rs
@@ -192,6 +192,13 @@ extern "C" {
         label_len: usize,
     ) -> u32;
 
+    /// Create a new distinct handle to the same channel as `handle`.
+    ///
+    /// The new handle value is written to `cloned_handle_out`.
+    ///
+    /// Returns the status of the operation, as an [`OakStatus`] value.
+    pub fn handle_clone(handle: u64, cloned_handle_out: *mut u64) -> u32;
+
     /// Closes the channel identified by `handle`.
     ///
     /// Returns the status of the operation, as an [`OakStatus`] value.

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -906,6 +906,20 @@ impl Runtime {
         Ok((write_handle, read_handle))
     }
 
+    /// Creates a new distinct handle to the same channel as `handle`.
+    fn handle_clone(
+        self: &Arc<Self>,
+        node_id: NodeId,
+        handle: oak_abi::Handle,
+    ) -> Result<oak_abi::Handle, OakStatus> {
+        if self.is_terminating() {
+            return Err(OakStatus::ErrTerminated);
+        }
+
+        let cloned_half = self.abi_to_half(node_id, handle)?;
+        Ok(self.new_abi_handle(node_id, cloned_half))
+    }
+
     /// Reads the readable statuses for a slice of `ChannelHalf`s.
     fn readers_statuses(
         &self,

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -313,6 +313,17 @@ impl RuntimeProxy {
         result
     }
 
+    /// Calls [`Runtime::handle_clone`].
+    pub fn handle_clone(&self, handle: oak_abi::Handle) -> Result<oak_abi::Handle, OakStatus> {
+        debug!("{:?}: handle_clone({:?}", self.node_id, handle,);
+        let result = self.runtime.handle_clone(self.node_id, handle);
+        debug!(
+            "{:?}: handle_clone({:?}) -> {:?}",
+            self.node_id, handle, result
+        );
+        result
+    }
+
     /// See [`Runtime::channel_close`].
     pub fn channel_close(&self, handle: oak_abi::Handle) -> Result<(), OakStatus> {
         debug!("{:?}: channel_close({})", self.get_debug_id(), handle);

--- a/sdk/rust/oak/src/stubs.rs
+++ b/sdk/rust/oak/src/stubs.rs
@@ -70,6 +70,10 @@ pub extern "C" fn channel_close() {
     panic!("stub function invoked!");
 }
 #[no_mangle]
+pub extern "C" fn handle_clone() {
+    panic!("stub function invoked!");
+}
+#[no_mangle]
 pub extern "C" fn node_create() {
     panic!("stub function invoked!");
 }


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.

This adds a new ABI call `handle_clone` and implements it in the Oak runtime. This function can be used to create distinct read handles. Following PRs will change the SDK implementations of handles to correctly implement `Clone` and `Drop` based on `handle_clone` and `channel_close`, so that the runtime can keep track of the number of live channel handles.

Background: https://github.com/project-oak/oak/issues/1686#issuecomment-731309914