### PR TITLE
Enable colorized output in GitHub actions logs

### DIFF
--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -23,8 +23,8 @@ mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 
 docker_run_flags=(
-  '--interactive'
   '--rm'
+  '--tty'
   '--env=BAZEL_REMOTE_CACHE_ENABLED'
   '--env=BAZEL_GOOGLE_CREDENTIALS'
   "--volume=$PWD/bazel-cache:/.cache/bazel"
@@ -38,9 +38,9 @@ docker_run_flags=(
   "--group-add=$HOST_DOCKER_GID"
 )
 
-# Some CI systems (GitHub actions) do not run with a real TTY attached.
+# Some CI systems (GitHub actions) do not run with an interactive TTY attached.
 if [[ -z "${CI:-}" ]]; then
-  docker_run_flags+=('--tty')
+  docker_run_flags+=('--interactive')
 fi
 
 if [[ "$1" == '--detach' ]]; then


### PR DESCRIPTION
The current logic is not quite right; the thing that is missing from
GitHub action is the interactive STDIN, not the TTY itself. Fixing this
makes most commands detect the TTY correctly, which produces colored
outputs in logs etc.
