### PR TITLE
Add gitignore pattern for secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ Makefile.conf
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml
 .idea/**/dbnavigator.xml
+
+# Secrets (e.g. tokens, credentials)
+
+*.secret


### PR DESCRIPTION
As part of the Treehouse project we may end up with files that we do not
intend to check in on different branches. This pattern allows calling
them with the same suffix in order to be ignored.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
