### PR TITLE
Fix Wasm module reproducibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -281,9 +281,12 @@ RUN make depend && make -j"$(nproc)"&& make install_sw install_ssldirs
 ENV PKG_CONFIG_ALLOW_CROSS 1
 ENV OPENSSL_STATIC 1
 
+# We use the `docker` user in order to maintain library paths on different
+# machines and to make Wasm modules reproducible.
+ARG USERNAME=docker
+
 # Placeholder args that are expected to be passed in at image build time.
 # See https://code.visualstudio.com/docs/remote/containers-advanced#_creating-a-nonroot-user
-ARG USERNAME=user-name-goes-here
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 

--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -152,8 +152,6 @@ gcloud monitoring dashboards list
 1. Build the example, including the Wasm module
 1. Get module SHA256 hash via
    `sha256sum examples/aggregator/bin/aggregator.wasm`
-1. Push the module to GS via `./scripts/push_example -e aggregator`
-1. Fix the URL and hash in [`./oak_app_manifest.toml`](./oak_app_manifest.toml)
 1. Fix module hash in the following files:
 
 - `examples/aggregator/config.toml`

--- a/examples/aggregator/client/android/cpp/client.cc
+++ b/examples/aggregator/client/android/cpp/client.cc
@@ -55,7 +55,7 @@ JNIEXPORT void JNICALL Java_com_google_oak_aggregator_MainActivity_createChannel
   // The particular value corresponds to the hash on the `aggregator.wasm` line in
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7"));
+      absl::HexStringToBytes("87dd6f0375b1fcea0e5b8b13adda6cbe6ca9a9eef4ab8557b65f90ac593d9cb7"));
   kChannel = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
   JNI_LOG("gRPC channel has been created");

--- a/examples/aggregator/client/cpp/aggregator.cc
+++ b/examples/aggregator/client/cpp/aggregator.cc
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   // TODO(#1674): Add appropriate TLS endpoint tag to the label as well.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7"));
+      absl::HexStringToBytes("87dd6f0375b1fcea0e5b8b13adda6cbe6ca9a9eef4ab8557b65f90ac593d9cb7"));
   // Connect to the Oak Application.
   auto stub = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));

--- a/examples/aggregator/config.toml
+++ b/examples/aggregator/config.toml
@@ -1,3 +1,3 @@
 grpc_server_listen_address = "[::]:8080"
 backend_server_address = "https://localhost:8888"
-aggregator_module_hash = "2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7"
+aggregator_module_hash = "87dd6f0375b1fcea0e5b8b13adda6cbe6ca9a9eef4ab8557b65f90ac593d9cb7"

--- a/examples/aggregator/oak_app_manifest.toml
+++ b/examples/aggregator/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "aggregator"
 
 [modules]
-app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7", sha256 = "2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7" } }
+app = { path = "examples/aggregator/bin/aggregator.wasm" }

--- a/examples/private_set_intersection/README.md
+++ b/examples/private_set_intersection/README.md
@@ -6,9 +6,6 @@ This example requires a valid signature of the `handler` module. So, whenever
 the code is modified, the wasm module and the signature must be regenerated:
 
 1. Build the example, including the Wasm module
-1. Push the module to GS via
-   `./scripts/push_example -e private_set_intersection`
-1. Fix the URL and hash in [`./oak_app_manifest.toml`](./oak_app_manifest.toml)
 1. Sign the module with the test key that is checked in the repository (only for
    test / debug use):
 

--- a/examples/private_set_intersection/oak_app_manifest.toml
+++ b/examples/private_set_intersection/oak_app_manifest.toml
@@ -5,5 +5,4 @@ signature_manifests = [
 
 [modules]
 app = { path = "examples/private_set_intersection/bin/private_set_intersection.wasm" }
-# TODO(865): Use locally built module once reproducibility is fixed.
-handler = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection_handler/a3e3fce0b23273a5117efd7d94632091990c3637536d80ed1874a2013c8f0f07", sha256 = "a3e3fce0b23273a5117efd7d94632091990c3637536d80ed1874a2013c8f0f07" } }
+handler = { path = "examples/private_set_intersection/bin/private_set_intersection_handler.wasm" }

--- a/examples/private_set_intersection/private_set_intersection_handler.sign
+++ b/examples/private_set_intersection/private_set_intersection_handler.sign
@@ -3,10 +3,10 @@ f41SClNtR4i46v2Tuh1fQLbt/ZqRr1lENajCW92jyP4=
 -----END PUBLIC KEY-----
 
 -----BEGIN SIGNATURE-----
-ITXOClpnflN81KsB2TGBPBkYNnSJu8uhOWH7YDg2UgVXdRFdguAWagQmVFlgt6gb
-qY6f7zg0TfenVKihsYMdCw==
+jQBzS8VmHEM+rUdc35w/sPe9YFF4dFkI65oiXIqUQ6bx+wontkCtHZgk7ph/rFEM
+A3mCko3gxkaXdBRjRphXAQ==
 -----END SIGNATURE-----
 
 -----BEGIN HASH-----
-o+P84LIyc6URfv19lGMgkZkMNjdTbYDtGHSiATyPDwc=
+hzIp2c/Pr7PP4YMXSRXtfFy2F1tv8UsZDKrwCDnpZbQ=
 -----END HASH-----

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -11,12 +11,10 @@ source "$SCRIPTS_DIR/common"
 # https://github.com/googleapis/google-cloud-cpp/blob/a186208b79d900b4ec71c6f9df3acf7638f01dc6/ci/kokoro/docker/build.sh#L147-L152
 readonly DOCKER_UID="${UID:-0}"
 readonly DOCKER_GID="$(id -g)"
-readonly DOCKER_USER="${USER:-root}"
 
 docker build \
   --cache-from="$DOCKER_IMAGE_NAME:latest" \
   --tag="$DOCKER_IMAGE_NAME:latest" \
-  --build-arg=USERNAME="$DOCKER_USER" \
   --build-arg=USER_UID="$DOCKER_UID" \
   --build-arg=USER_GID="$DOCKER_GID" \
   . 1>&2


### PR DESCRIPTION
This change:
- Prevents Docker from depending on the username
- Makes Wasm modules reproducibly buildable inside Docker on different machines (by making rust library paths have the same user)

Fixes https://github.com/project-oak/oak/issues/865