### PR TITLE
Pin deadlinks version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -216,7 +216,7 @@ RUN rustup component add \
   rustfmt
 
 # No binary available on Github, have to use cargo install.
-ARG deadlinks_version=0.7.0
+ARG deadlinks_version=0.5.0
 RUN cargo install --version=${deadlinks_version} cargo-deadlinks
 
 # Where to install rust tooling

--- a/Dockerfile
+++ b/Dockerfile
@@ -216,7 +216,8 @@ RUN rustup component add \
   rustfmt
 
 # No binary available on Github, have to use cargo install.
-RUN cargo install cargo-deadlinks
+ARG deadlinks_version=0.7.0
+RUN cargo install --version=${deadlinks_version} cargo-deadlinks
 
 # Where to install rust tooling
 ARG install_dir=${rustup_dir}/bin

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -276,7 +276,7 @@ RUN rustup component add \
   rustfmt
 
 # No binary available on Github, have to use cargo install.
-ARG deadlinks_version=0.7.0
+ARG deadlinks_version=0.5.0
 RUN cargo install --version=${deadlinks_version} cargo-deadlinks
 
 # Where to install rust tooling

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -276,7 +276,8 @@ RUN rustup component add \
   rustfmt
 
 # No binary available on Github, have to use cargo install.
-RUN cargo install cargo-deadlinks
+ARG deadlinks_version=0.7.0
+RUN cargo install --version=${deadlinks_version} cargo-deadlinks
 
 # Where to install rust tooling
 ARG install_dir=${rustup_dir}/bin


### PR DESCRIPTION
This change pins `cargo deadlinks` version to `0.5.0` in the Dockerfile.

Fixes https://github.com/project-oak/oak/issues/1776