### PR TITLE
Add Clang for ARM

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -23,6 +23,17 @@ package(
     licenses = ["notice"],
 )
 
+# Build configurations for different platforms.
+config_setting(
+    name = "arm_build",
+    values = {"cpu": "arm"},
+)
+
+config_setting(
+    name = "x86_build",
+    values = {"cpu": "x86"},
+)
+
 # Export LICENSE file for projects that reference Oak in Bazel as an external dependency.
 exports_files(["LICENSE"])
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -355,6 +355,14 @@ http_archive(
     url = "http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
 )
 
+http_archive(
+    name = "clang_arm",
+    build_file = "//toolchain:all_files.BUILD",
+    sha256 = "0f5c314f375ebd5c35b8c1d5e5b161d9efaeff0523bac287f8b4e5b751272f51",
+    strip_prefix = "clang+llvm-8.0.0-armv7a-linux-gnueabihf",
+    url = "http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz",
+)
+
 # Gcc compiler for Arm
 # We need the compiler in order to get the sysroot for aarch64_linux to crosscompile + all the
 # needed libraries to link agaisnt.

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -58,18 +58,6 @@ cc_toolchain_suite(
     },
 )
 
-config_setting(
-    name = "arm_build",
-    values = {"cpu": "arm"},
-)
-
-config_setting(
-    name = "x86_build",
-    values = {
-        "cpu": "x86",
-    },
-)
-
 # Include all the files that we install for clang plus the scrips to call into it.
 filegroup(
     name = "clang_files",
@@ -77,8 +65,8 @@ filegroup(
         "ar.sh",
         "clang.sh",
     ] + select({
-        ":arm_build": ["@clang_arm//:all_files"],
-        ":x86_build": ["@clang//:all_files"],
+        "//:arm_build": ["@clang_arm//:all_files"],
+        "//:x86_build": ["@clang//:all_files"],
         "//conditions:default": ["@clang//:all_files"],
     }),
 )
@@ -92,8 +80,8 @@ filegroup(
         "clang.sh",
         "@gcc_arm//:all_files",
     ] + select({
-        ":arm_build": ["@clang_arm//:all_files"],
-        ":x86_build": ["@clang//:all_files"],
+        "//:arm_build": ["@clang_arm//:all_files"],
+        "//:x86_build": ["@clang//:all_files"],
         "//conditions:default": ["@clang//:all_files"],
     }),
 )

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -58,14 +58,29 @@ cc_toolchain_suite(
     },
 )
 
+config_setting(
+    name = "arm_build",
+    values = {"cpu": "arm"},
+)
+
+config_setting(
+    name = "x86_build",
+    values = {
+        "cpu": "x86",
+    },
+)
+
 # Include all the files that we install for clang plus the scrips to call into it.
 filegroup(
     name = "clang_files",
     srcs = [
         "ar.sh",
         "clang.sh",
-        "@clang//:all_files",
-    ],
+    ] + select({
+        ":arm_build": ["@clang_arm//:all_files"],
+        ":x86_build": ["@clang//:all_files"],
+        "//conditions:default": ["@clang//:all_files"],
+    }),
 )
 
 # Include all clang files plus the gcc_arm sysroot and libraries.
@@ -75,9 +90,12 @@ filegroup(
     srcs = [
         "ar.sh",
         "clang.sh",
-        "@clang//:all_files",
         "@gcc_arm//:all_files",
-    ],
+    ] + select({
+        ":arm_build": ["@clang_arm//:all_files"],
+        ":x86_build": ["@clang//:all_files"],
+        "//conditions:default": ["@clang//:all_files"],
+    }),
 )
 
 # Include all the files that we install for emscripten.

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -68,14 +68,19 @@ def _impl(ctx):
     # TODO: Bazel has a limitation as these paths can be only relative to the toolchain folder.
     # The hack around this is to have a script file that just redirects to the correct binary.
     # We need to fix this once Bazel does this properly.
+    if ctx.attr.cpu == "armv8":
+        clang = "clang_arm.sh"
+    else:
+        clang = "clang.sh"
+
     tool_paths = [
         tool_path(
             name = "gcc",
-            path = "clang.sh",
+            path = clang,
         ),
         tool_path(
             name = "ld",
-            path = "clang.sh",
+            path = clang,
         ),
         tool_path(
             name = "ar",

--- a/toolchain/clang_arm.sh
+++ b/toolchain/clang_arm.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -o errexit
+
+external/clang_arm/bin/clang "$@"


### PR DESCRIPTION
This change makes Bazel select between ARM and x86 versions of `clang`.