### PR TITLE
Add typed channel_create in Oak Runtime

### DIFF
--- a/oak_runtime/src/io.rs
+++ b/oak_runtime/src/io.rs
@@ -113,3 +113,24 @@ impl<T: Encodable> SenderExt<T> for Sender<T> {
             .map_err(|err| err.into())
     }
 }
+
+/// Creates a new channel for transmission of [`Encodable`] and [`Decodable`] types.
+pub fn channel_create<T: Encodable + Decodable>(
+    runtime: &RuntimeProxy,
+    name: &str,
+    label: &Label,
+) -> Result<(Sender<T>, Receiver<T>), OakStatus> {
+    let (wh, rh) = runtime.channel_create(name, label)?;
+    Ok((Sender::<T>::new(wh.into()), Receiver::<T>::new(rh.into())))
+}
+
+/// Uses the current node's label-downgrading privilege to create a new channel for transmission of
+/// [`Encodable`] and [`Decodable`] types.
+pub fn channel_create_with_downgrade<T: Encodable + Decodable>(
+    runtime: &RuntimeProxy,
+    name: &str,
+    label: &Label,
+) -> Result<(Sender<T>, Receiver<T>), OakStatus> {
+    let (wh, rh) = runtime.channel_create_with_downgrade(name, label)?;
+    Ok((Sender::<T>::new(wh.into()), Receiver::<T>::new(rh.into())))
+}

--- a/oak_runtime/src/io.rs
+++ b/oak_runtime/src/io.rs
@@ -115,6 +115,7 @@ impl<T: Encodable> SenderExt<T> for Sender<T> {
 }
 
 /// Creates a new channel for transmission of [`Encodable`] and [`Decodable`] types.
+#[allow(dead_code)]
 pub fn channel_create<T: Encodable + Decodable>(
     runtime: &RuntimeProxy,
     name: &str,

--- a/oak_runtime/src/node/http/tests.rs
+++ b/oak_runtime/src/node/http/tests.rs
@@ -759,10 +759,7 @@ impl Node for ClientTesterNode {
             .expect("Could not send the invocation");
 
         // wait for the response to come
-        let response_receiver = crate::io::Receiver::<HttpResponse>::new(ReadHandle {
-            handle: pipe.response_reader,
-        });
-        let response = response_receiver.receive(&runtime);
+        let response = pipe.response_receiver.receive(&runtime);
 
         pipe.close(&runtime);
 


### PR DESCRIPTION
This change:
- Adds typed `channel_create` and `channel_create_with_downgrade` to `oak_runtime`
- Updates gRPC server and HTTP tests with new functions

Fixes https://github.com/project-oak/oak/issues/1496