### PR TITLE
Add channel_read_with_downgrade to SDK

### DIFF
--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -152,10 +152,10 @@ gcloud monitoring dashboards list
 1. Build the example, including the Wasm module
 1. Get module SHA256 hash via
    `sha256sum examples/aggregator/bin/aggregator.wasm`
-1. Push the module to GS via `./scripts/push-example -e aggregator`
+1. Push the module to GS via `./scripts/push_example -e aggregator`
 1. Fix the URL and hash in [`./oak_app_manifest.toml`](./oak_app_manifest.toml)
 1. Fix module hash in the following files:
 
 - `examples/aggregator/config.toml`
 - `examples/aggregator/client/cpp/aggregator.cc`
-- `examples/aggregator/module/android/cpp/client.cc`
+- `examples/aggregator/client/android/cpp/client.cc`

--- a/examples/aggregator/client/android/cpp/client.cc
+++ b/examples/aggregator/client/android/cpp/client.cc
@@ -55,7 +55,7 @@ JNIEXPORT void JNICALL Java_com_google_oak_aggregator_MainActivity_createChannel
   // The particular value corresponds to the hash on the `aggregator.wasm` line in
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("29fbf24bb76ab71b81bee0ce9cc1d995191a5f814ee7e5a1e04e227176779ffe"));
+      absl::HexStringToBytes("3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975"));
   kChannel = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
   JNI_LOG("gRPC channel has been created");

--- a/examples/aggregator/client/cpp/aggregator.cc
+++ b/examples/aggregator/client/cpp/aggregator.cc
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   // TODO(#1674): Add appropriate TLS endpoint tag to the label as well.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("29fbf24bb76ab71b81bee0ce9cc1d995191a5f814ee7e5a1e04e227176779ffe"));
+      absl::HexStringToBytes("3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975"));
   // Connect to the Oak Application.
   auto stub = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));

--- a/examples/aggregator/config.toml
+++ b/examples/aggregator/config.toml
@@ -1,3 +1,3 @@
 grpc_server_listen_address = "[::]:8080"
 backend_server_address = "https://localhost:8888"
-aggregator_module_hash = "29fbf24bb76ab71b81bee0ce9cc1d995191a5f814ee7e5a1e04e227176779ffe"
+aggregator_module_hash = "3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975"

--- a/examples/aggregator/oak_app_manifest.toml
+++ b/examples/aggregator/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "aggregator"
 
 [modules]
-app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/29fbf24bb76ab71b81bee0ce9cc1d995191a5f814ee7e5a1e04e227176779ffe", sha256 = "29fbf24bb76ab71b81bee0ce9cc1d995191a5f814ee7e5a1e04e227176779ffe" } }
+app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975", sha256 = "3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975" } }

--- a/examples/private_set_intersection/oak_app_manifest.toml
+++ b/examples/private_set_intersection/oak_app_manifest.toml
@@ -6,4 +6,4 @@ signature_manifests = [
 [modules]
 app = { path = "examples/private_set_intersection/bin/private_set_intersection.wasm" }
 # TODO(865): Use locally built module once reproducibility is fixed.
-handler = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection_handler/08ac29c2e8fc7de860750457f1e97decc3f0089711e5efd574453085706b0a42", sha256 = "08ac29c2e8fc7de860750457f1e97decc3f0089711e5efd574453085706b0a42" } }
+handler = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection_handler/46ee3f4e2db7ff0789af779e134c8b1848763f0bd5fb830a300ab3fd0efb2bf0", sha256 = "46ee3f4e2db7ff0789af779e134c8b1848763f0bd5fb830a300ab3fd0efb2bf0" } }

--- a/examples/private_set_intersection/private_set_intersection_handler.sign
+++ b/examples/private_set_intersection/private_set_intersection_handler.sign
@@ -3,10 +3,10 @@ f41SClNtR4i46v2Tuh1fQLbt/ZqRr1lENajCW92jyP4=
 -----END PUBLIC KEY-----
 
 -----BEGIN SIGNATURE-----
-OHHEdnjxlKwAQU6dwiI8ZVRfSZ4VOttRWvube1z+/E78ey0NDLwqtfRJ1ZoNc0oY
-ufKZSPJZsUG0spGOYd7qBQ==
+TfYigVCdqcjW7xJReS+S5/XMfkQCpulBf1nrHLkFHRoMpiWw8IbFfdVgVAlwfvmx
+i6JWeP5SnSfO2MyXaqm0AQ==
 -----END SIGNATURE-----
 
 -----BEGIN HASH-----
-CKwpwuj8fehgdQRX8el97MPwCJcR5e/VdEUwhXBrCkI=
+Ru4/Ti23/weJr3eeE0yLGEh2PwvV+4MKMAqz/Q77K/A=
 -----END HASH-----

--- a/experimental/oak_async/tests/fake_runtime.rs
+++ b/experimental/oak_async/tests/fake_runtime.rs
@@ -113,6 +113,20 @@ pub extern "C" fn channel_read(
     })
 }
 
+/// Stub function necessary for Oak ABI.
+#[no_mangle]
+pub extern "C" fn channel_read_with_downgrade(
+    _handle: Handle,
+    _buf: *mut u8,
+    _size: usize,
+    _actual_size: *mut u32,
+    _handle_buf: *mut u8,
+    _handle_count: u32,
+    _actual_handle_count: *mut u32,
+) -> u32 {
+    0
+}
+
 type ReadyChannelData = VecDeque<Result<Vec<u8>, OakStatus>>;
 
 std::thread_local! {

--- a/oak/module/oak_abi.h
+++ b/oak/module/oak_abi.h
@@ -47,6 +47,10 @@ oak_abi::OakStatus channel_read(oak_abi::Handle handle, uint8_t* buff, size_t us
                                 uint32_t* actual_size, oak_abi::Handle* handle_buff,
                                 size_t handle_count, uint32_t* actual_handle_count);
 WASM_IMPORT("oak")
+oak_abi::OakStatus channel_read_with_downgrade(oak_abi::Handle handle, uint8_t* buff, size_t usize,
+                                               uint32_t* actual_size, oak_abi::Handle* handle_buff,
+                                               size_t handle_count, uint32_t* actual_handle_count);
+WASM_IMPORT("oak")
 oak_abi::OakStatus channel_write(oak_abi::Handle handle, uint8_t* buff, size_t usize,
                                  uint8_t* handle_buff, size_t handle_count);
 WASM_IMPORT("oak")

--- a/oak_abi/src/lib.rs
+++ b/oak_abi/src/lib.rs
@@ -132,6 +132,18 @@ extern "C" {
         actual_handle_count: *mut u32,
     ) -> u32;
 
+    /// The same as [`channel_read`](#method.channel_read), but also applies the current Node's
+    /// downgrade privilege when checking IFC restrictions.
+    pub fn channel_read_with_downgrade(
+        handle: u64,
+        buf: *mut u8,
+        size: usize,
+        actual_size: *mut u32,
+        handle_buf: *mut u8,
+        handle_count: u32,
+        actual_handle_count: *mut u32,
+    ) -> u32;
+
     /// Write a message to a channel.
     ///
     /// Write `size` bytes of data from `buf`, together with `handle_count` handles from

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -670,7 +670,7 @@ impl Runtime {
     }
 
     /// Returns the effective label for `initial_label` in the context of the Node, taking into
-    /// acount whether the downgrade privilege should be applied.
+    /// account whether the downgrade privilege should be applied.
     fn get_effective_label(
         &self,
         node_id: NodeId,

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -443,7 +443,7 @@ impl RuntimeProxy {
         result
     }
 
-    /// See [`Runtime::channel_try_read_message`].
+    /// Calls [`Runtime::channel_try_read_message`] without the Node's privilege.
     pub fn channel_try_read_message(
         &self,
         read_handle: oak_abi::Handle,
@@ -466,6 +466,38 @@ impl RuntimeProxy {
         );
         debug!(
             "{:?}: channel_try_read({}, bytes_capacity={}, handles_capacity={}) -> {:?}",
+            self.get_debug_id(),
+            read_handle,
+            bytes_capacity,
+            handles_capacity,
+            result
+        );
+        result
+    }
+
+    /// Calls [`Runtime::channel_try_read_message`] using the Node's privilege.
+    pub fn channel_try_read_message_with_downgrade(
+        &self,
+        read_handle: oak_abi::Handle,
+        bytes_capacity: usize,
+        handles_capacity: usize,
+    ) -> Result<Option<NodeReadStatus>, OakStatus> {
+        debug!(
+            "{:?}: channel_try_read_message_with_downgrade({}, bytes_capacity={}, handles_capacity={})",
+            self.get_debug_id(),
+            read_handle,
+            bytes_capacity,
+            handles_capacity
+        );
+        let result = self.runtime.channel_try_read_message(
+            self.node_id,
+            read_handle,
+            bytes_capacity,
+            handles_capacity,
+            Downgrading::Yes,
+        );
+        debug!(
+            "{:?}: channel_try_read_message_with_downgrade({}, bytes_capacity={}, handles_capacity={}) -> {:?}",
             self.get_debug_id(),
             read_handle,
             bytes_capacity,

--- a/sdk/rust/oak/src/stubs.rs
+++ b/sdk/rust/oak/src/stubs.rs
@@ -49,6 +49,9 @@ pub extern "C" fn wait_on_channels() {
 pub extern "C" fn channel_read() {
     panic!("stub function invoked!");
 }
+pub extern "C" fn channel_read_with_downgrade() {
+    panic!("stub function invoked!");
+}
 #[no_mangle]
 pub extern "C" fn channel_write() {
     panic!("stub function invoked!");


### PR DESCRIPTION
This change adds:
- `channel_read_with_downgrade` to ABI and SDK
- `channel_try_read_message_with_downgrade` to Runtime

Ref https://github.com/project-oak/oak/issues/1736