### PR TITLE
Add wait_on_channels_with_downgrade to SDK

### DIFF
--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -1159,6 +1159,8 @@ impl FrontendNode {
         expect_eq!(Ok(()), oak::channel_close(private_out_channel.handle));
         expect_eq!(Ok(()), oak::channel_close(private_in_channel.handle));
 
+        // TODO(#1819): Check the case where results are different from the `channel_read` once the
+        // ABI tests can support wasm hash labels.
         Ok(())
     }
 
@@ -1704,6 +1706,8 @@ impl FrontendNode {
         expect_eq!(Ok(()), oak::channel_close(private_out_channel.handle));
         expect_eq!(Ok(()), oak::channel_close(private_in_channel.handle));
 
+        // TODO(#1819): Check the case where results are different from the `wait_on_channels` once
+        // the ABI tests can support wasm hash labels.
         Ok(())
     }
 

--- a/examples/aggregator/client/android/cpp/client.cc
+++ b/examples/aggregator/client/android/cpp/client.cc
@@ -55,7 +55,7 @@ JNIEXPORT void JNICALL Java_com_google_oak_aggregator_MainActivity_createChannel
   // The particular value corresponds to the hash on the `aggregator.wasm` line in
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7"));
+      absl::HexStringToBytes("2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7"));
   kChannel = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
   JNI_LOG("gRPC channel has been created");

--- a/examples/aggregator/client/cpp/aggregator.cc
+++ b/examples/aggregator/client/cpp/aggregator.cc
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   // TODO(#1674): Add appropriate TLS endpoint tag to the label as well.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7"));
+      absl::HexStringToBytes("2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7"));
   // Connect to the Oak Application.
   auto stub = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));

--- a/examples/aggregator/config.toml
+++ b/examples/aggregator/config.toml
@@ -1,3 +1,3 @@
 grpc_server_listen_address = "[::]:8080"
 backend_server_address = "https://localhost:8888"
-aggregator_module_hash = "6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7"
+aggregator_module_hash = "2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7"

--- a/examples/aggregator/oak_app_manifest.toml
+++ b/examples/aggregator/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "aggregator"
 
 [modules]
-app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7", sha256 = "6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7" } }
+app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7", sha256 = "2d33ea304486337108d2fc23ee583947bd8f91f0c526637bd330db39251b9ec7" } }

--- a/examples/private_set_intersection/oak_app_manifest.toml
+++ b/examples/private_set_intersection/oak_app_manifest.toml
@@ -6,4 +6,4 @@ signature_manifests = [
 [modules]
 app = { path = "examples/private_set_intersection/bin/private_set_intersection.wasm" }
 # TODO(865): Use locally built module once reproducibility is fixed.
-handler = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection_handler/f04989bf7db987b00a8a2f4f1ea72b8d415392749b9a44660cb5e1c52135c94e", sha256 = "f04989bf7db987b00a8a2f4f1ea72b8d415392749b9a44660cb5e1c52135c94e" } }
+handler = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection_handler/a3e3fce0b23273a5117efd7d94632091990c3637536d80ed1874a2013c8f0f07", sha256 = "a3e3fce0b23273a5117efd7d94632091990c3637536d80ed1874a2013c8f0f07" } }

--- a/examples/private_set_intersection/private_set_intersection_handler.sign
+++ b/examples/private_set_intersection/private_set_intersection_handler.sign
@@ -3,10 +3,10 @@ f41SClNtR4i46v2Tuh1fQLbt/ZqRr1lENajCW92jyP4=
 -----END PUBLIC KEY-----
 
 -----BEGIN SIGNATURE-----
-FYdRH9iIqQSIpcZFFkenfFMtSQGteYGfB4fPlSpcMAugNa+hq7sdMgyzVYef8XJ+
-xsZQiYgeHuqbA2CPYHDTBA==
+ITXOClpnflN81KsB2TGBPBkYNnSJu8uhOWH7YDg2UgVXdRFdguAWagQmVFlgt6gb
+qY6f7zg0TfenVKihsYMdCw==
 -----END SIGNATURE-----
 
 -----BEGIN HASH-----
-8EmJv325h7AKii9PHqcrjUFTknSbmkRmDLXhxSE1yU4=
+o+P84LIyc6URfv19lGMgkZkMNjdTbYDtGHSiATyPDwc=
 -----END HASH-----

--- a/experimental/oak_async/tests/fake_runtime.rs
+++ b/experimental/oak_async/tests/fake_runtime.rs
@@ -67,6 +67,12 @@ pub extern "C" fn wait_on_channels(buf: *mut u8, count: u32) -> u32 {
     }) as i32 as u32
 }
 
+/// Stub function necessary for Oak ABI.
+#[no_mangle]
+pub extern "C" fn wait_on_channels_with_downgrade(_buf: *mut u8, _count: u32) -> u32 {
+    0
+}
+
 type WaitOnChannelsHandler = Box<dyn FnMut(&mut [HandleWithStatus]) -> OakStatus>;
 std::thread_local! {
     static WAIT_ON_CHANNELS_HANDLER: RefCell<Option<WaitOnChannelsHandler>> = RefCell::new(None);

--- a/oak/module/oak_abi.h
+++ b/oak/module/oak_abi.h
@@ -42,6 +42,7 @@ enum OakStatus : uint32_t {
 
 // Function declarations for the host functions available on the Oak ABI.
 WASM_IMPORT("oak") oak_abi::OakStatus wait_on_channels(uint8_t* buff, int32_t count);
+WASM_IMPORT("oak") oak_abi::OakStatus wait_on_channels_with_downgrade(uint8_t* buff, int32_t count);
 WASM_IMPORT("oak")
 oak_abi::OakStatus channel_read(oak_abi::Handle handle, uint8_t* buff, size_t usize,
                                 uint32_t* actual_size, oak_abi::Handle* handle_buff,

--- a/oak_abi/src/lib.rs
+++ b/oak_abi/src/lib.rs
@@ -100,6 +100,10 @@ extern "C" {
     /// [`OakStatus`]: crate::OakStatus
     pub fn wait_on_channels(buf: *mut u8, count: u32) -> u32;
 
+    /// The same as [`wait_on_channels`](#method.wait_on_channels), but also applies the current
+    /// Node's downgrade privilege when checking IFC restrictions.
+    pub fn wait_on_channels_with_downgrade(buf: *mut u8, count: u32) -> u32;
+
     /// Read a message from a channel.
     ///
     /// Reads from the channel identified by `handle`, storing data into `buf`

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -341,7 +341,7 @@ impl RuntimeProxy {
         result
     }
 
-    /// See [`Runtime::wait_on_channels`].
+    /// Calls [`Runtime::wait_on_channels`] without using the Node's privilege.
     pub fn wait_on_channels(
         &self,
         read_handles: &[oak_abi::Handle],
@@ -356,6 +356,28 @@ impl RuntimeProxy {
             .wait_on_channels(self.node_id, read_handles, Downgrading::No);
         debug!(
             "{:?}: wait_on_channels(count={}) -> {:?}",
+            self.get_debug_id(),
+            read_handles.len(),
+            result
+        );
+        result
+    }
+
+    /// Calls [`Runtime::wait_on_channels`] using the Node's privilege.
+    pub fn wait_on_channels_with_downgrade(
+        &self,
+        read_handles: &[oak_abi::Handle],
+    ) -> Result<Vec<ChannelReadStatus>, OakStatus> {
+        debug!(
+            "{:?}: wait_on_channels_with_downgrade(count={})",
+            self.get_debug_id(),
+            read_handles.len()
+        );
+        let result = self
+            .runtime
+            .wait_on_channels(self.node_id, read_handles, Downgrading::Yes);
+        debug!(
+            "{:?}: wait_on_channels_with_downgrade(count={}) -> {:?}",
             self.get_debug_id(),
             read_handles.len(),
             result

--- a/sdk/rust/oak/src/io/receiver.rs
+++ b/sdk/rust/oak/src/io/receiver.rs
@@ -227,7 +227,7 @@ impl<T: Decodable> ReceiverExt<T> for Receiver<T> {
 
     fn wait_with_downgrade(&self) -> Result<ChannelReadStatus, OakStatus> {
         // TODO(#500): Consider creating the handle notification space once and for all in `new`.
-        let read_handles = vec![self.handle];
+        let read_handles = vec![&self.handle];
         let mut space = crate::new_handle_space(&read_handles);
         crate::prep_handle_space(&mut space);
         let status = unsafe {

--- a/sdk/rust/oak/src/stubs.rs
+++ b/sdk/rust/oak/src/stubs.rs
@@ -46,9 +46,14 @@ pub extern "C" fn wait_on_channels() {
     panic!("stub function invoked!");
 }
 #[no_mangle]
+pub extern "C" fn wait_on_channels_with_downgrade() {
+    panic!("stub function invoked!");
+}
+#[no_mangle]
 pub extern "C" fn channel_read() {
     panic!("stub function invoked!");
 }
+#[no_mangle]
 pub extern "C" fn channel_read_with_downgrade() {
     panic!("stub function invoked!");
 }


### PR DESCRIPTION
This change adds:
- `wait_on_channels_with_downgrade` to ABI, SDK andRuntime

Fixes https://github.com/project-oak/oak/issues/1736