### PR TITLE
Allow passing borrowed handles to SDK functions.

### DIFF
--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -1516,7 +1516,7 @@ dependencies = [
  "serde",
  "signal-hook",
  "structopt",
- "tokio",
+ "tokio 0.2.23",
  "toml",
  "tonic",
 ]
@@ -1536,7 +1536,7 @@ dependencies = [
  "openssl",
  "prost",
  "structopt",
- "tokio",
+ "tokio 0.2.23",
  "tonic",
 ]
 

--- a/sdk/rust/oak/src/io/receiver.rs
+++ b/sdk/rust/oak/src/io/receiver.rs
@@ -169,7 +169,7 @@ impl<T: Decodable> ReceiverExt<T> for Receiver<T> {
     fn try_receive(&self) -> Result<T, OakError> {
         let mut bytes = Vec::with_capacity(1024);
         let mut handles = Vec::with_capacity(16);
-        crate::channel_read(self.handle, &mut bytes, &mut handles)?;
+        crate::channel_read(&self.handle, &mut bytes, &mut handles)?;
         // `bytes` and `handles` are moved into `Message`, so there is no extra copy happening here.
         let message = crate::io::Message { bytes, handles };
         T::decode(&message)
@@ -191,7 +191,7 @@ impl<T: Decodable> ReceiverExt<T> for Receiver<T> {
 
     fn wait(&self) -> Result<ChannelReadStatus, OakStatus> {
         // TODO(#500): Consider creating the handle notification space once and for all in `new`.
-        let read_handles = vec![self.handle];
+        let read_handles = vec![&self.handle];
         let mut space = crate::new_handle_space(&read_handles);
         crate::prep_handle_space(&mut space);
         let status =

--- a/sdk/rust/oak/src/io/sender.rs
+++ b/sdk/rust/oak/src/io/sender.rs
@@ -42,13 +42,13 @@ impl<T: Encodable> SenderExt<T> for Sender<T> {
 
     fn send(&self, t: &T) -> Result<(), OakError> {
         let message = t.encode()?;
-        crate::channel_write(self.handle, &message.bytes, &message.handles)?;
+        crate::channel_write(&self.handle, &message.bytes, &message.handles)?;
         Ok(())
     }
 
     fn send_with_downgrade(&self, t: &T) -> Result<(), OakError> {
         let message = t.encode()?;
-        crate::channel_write_with_downgrade(self.handle, &message.bytes, &message.handles)?;
+        crate::channel_write_with_downgrade(&self.handle, &message.bytes, &message.handles)?;
         Ok(())
     }
 


### PR DESCRIPTION
This is currently not needed because handles implement `Copy`, but once
they are made linear, using borrowed handles will be the only way to use
these functions without giving up ownership of the handle.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

Related issue: #1686