### PR TITLE
Add defense-in-depth support

### DIFF
--- a/examples/abitest/module_0/rust/tests/integration_test.rs
+++ b/examples/abitest/module_0/rust/tests/integration_test.rs
@@ -47,6 +47,13 @@ async fn setup() -> (
     OakAbiTestServiceClient<tonic::transport::Channel>,
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
+    let permissions = oak_runtime::permissions::PermissionsConfiguration {
+        allow_grpc_server_nodes: true,
+        allow_http_server_nodes: true,
+        allow_log_nodes: true,
+        allow_insecure_http_egress: true,
+        allow_egress_https_authorities: vec!["localhost:7856".to_string()],
+    };
 
     let wasm_modules = build_wasm().expect("failed to build wasm modules");
     let config = oak_tests::runtime_config_wasm(
@@ -54,6 +61,7 @@ async fn setup() -> (
         FRONTEND_MODULE_NAME,
         FRONTEND_ENTRYPOINT_NAME,
         ConfigMap::default(),
+        permissions,
         oak_runtime::SignatureTable::default(),
     );
     let runtime =

--- a/examples/aggregator/gcp/deployment.yaml
+++ b/examples/aggregator/gcp/deployment.yaml
@@ -28,6 +28,7 @@ spec:
               readOnly: true
           args:
             - --application=aggregator.oak
+            - --permissions=permissions.toml
             - --grpc-tls-private-key=/etc/oak-secrets/gcp.key
             - --grpc-tls-certificate=/etc/oak-secrets/gcp.pem
             - --root-tls-certificate=/etc/oak-secrets/ca.pem

--- a/examples/aggregator/scripts/docker_build_and_push
+++ b/examples/aggregator/scripts/docker_build_and_push
@@ -15,6 +15,8 @@ readonly BACKEND_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-aggregator-backend'
 
   # Build the base server.
   docker build --tag=oak_docker --file=./oak_loader/Dockerfile ./oak_loader
+  # Copy the permissions file to `./examples/aggregator/bin`
+  cp ./examples/permissions/* ./examples/aggregator/bin/
   # Build and save the example
   docker build --tag=aggregator --file=./examples/Dockerfile "./examples/aggregator"
   docker tag aggregator "${AGGREGATOR_DOCKER_IMAGE_NAME}":latest

--- a/examples/aggregator/scripts/run_server
+++ b/examples/aggregator/scripts/run_server
@@ -10,6 +10,7 @@ source "${GLOBAL_SCRIPTS_DIR}/common"
 readonly APPLICATION="${PWD}/examples/aggregator/bin/aggregator.oak"
 exec cargo run --release --target=x86_64-unknown-linux-musl --manifest-path=oak_loader/Cargo.toml -- \
   --application="${APPLICATION}" \
+  --permissions="${GLOBAL_SCRIPTS_DIR}/../examples/permissions/permissions.toml" \
   --grpc-tls-private-key="${GLOBAL_SCRIPTS_DIR}/../examples/certs/local/local.key" \
   --grpc-tls-certificate="${GLOBAL_SCRIPTS_DIR}/../examples/certs/local/local.pem" \
   --root-tls-certificate="${GLOBAL_SCRIPTS_DIR}/../examples/certs/local/ca.pem"

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -23,6 +23,7 @@ using the --oidc-client flag:
 ```bash
 cargo run --manifest-path=oak_loader/Cargo.toml -- \
     --application=<APP_CONFIG_PATH> \
+    --permissions=<PERM_CONFIG_PATH_FOR_LOGLESS_SERVERS> \
     --grpc-tls-private-key=<PRIVATE_KEY_PATH> \
     --grpc-tls-certificate=<CERTIFICATE_PATH> \
     --root-tls-certificate=<CERTIFICATE_PATH> \

--- a/examples/chat/module/rust/tests/integration_test.rs
+++ b/examples/chat/module/rust/tests/integration_test.rs
@@ -25,8 +25,13 @@ const MODULE_WASM_FILE_NAME: &str = "chat.wasm";
 #[serial]
 async fn test_chat() {
     let _ = env_logger::builder().is_test(true).try_init();
+    let permissions = oak_runtime::permissions::PermissionsConfiguration {
+        allow_grpc_server_nodes: true,
+        allow_log_nodes: true,
+        ..Default::default()
+    };
 
-    let runtime = oak_tests::run_single_module(MODULE_WASM_FILE_NAME, "main")
+    let runtime = oak_tests::run_single_module(MODULE_WASM_FILE_NAME, "main", permissions)
         .expect("could not configure runtime with test Wasm file");
 
     let room_0_key_pair = oak_sign::KeyPair::generate().expect("could not generate room key pair");

--- a/examples/hello_world/module/rust/tests/integration_test.rs
+++ b/examples/hello_world/module/rust/tests/integration_test.rs
@@ -34,7 +34,11 @@ const TRANSLATOR_MODULE_WASM_FILE_NAME: &str = "translator.wasm";
 #[tokio::test(core_threads = 2)]
 async fn test_say_hello() {
     let _ = env_logger::builder().is_test(true).try_init();
-
+    let permissions = oak_runtime::permissions::PermissionsConfiguration {
+        allow_grpc_server_nodes: true,
+        allow_log_nodes: true,
+        ..Default::default()
+    };
     let runtime_config = oak_tests::runtime_config_wasm(
         hashmap! {
             MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, MAIN_MODULE_WASM_FILE_NAME, oak_tests::Profile::Release).expect("Couldn't compile main module"),
@@ -43,6 +47,7 @@ async fn test_say_hello() {
         MAIN_MODULE_NAME,
         MAIN_ENTRYPOINT_NAME,
         ConfigMap::default(),
+        permissions,
         oak_runtime::SignatureTable::default(),
     );
     let runtime = oak_runtime::configure_and_run(runtime_config)

--- a/examples/permissions/permissions.toml
+++ b/examples/permissions/permissions.toml
@@ -1,0 +1,11 @@
+allow_grpc_server_nodes = true
+allow_http_server_nodes = true
+allow_log_nodes = true
+allow_insecure_http_egress = true
+allow_egress_authorities = [
+  "localhost:7878",
+  "test.invalid:9999",
+  "localhost:8888",
+  "localhost:8080",
+  "localhost:7856",
+]

--- a/examples/private_set_intersection/main_module/rust/tests/integration_test.rs
+++ b/examples/private_set_intersection/main_module/rust/tests/integration_test.rs
@@ -66,11 +66,17 @@ async fn test_set_intersection() {
     let wasm_modules = build_wasm().expect("Couldn't compile Wasm modules");
     let signature =
         sign(&wasm_modules.get(HANDLER_MODULE_NAME).unwrap()).expect("Couldn't sign Wasm module");
+    let permissions = oak_runtime::permissions::PermissionsConfiguration {
+        allow_grpc_server_nodes: true,
+        allow_log_nodes: true,
+        ..Default::default()
+    };
     let config = oak_tests::runtime_config_wasm(
         wasm_modules,
         MAIN_MODULE_NAME,
         ENTRYPOINT_NAME,
         ConfigMap::default(),
+        permissions,
         oak_runtime::SignatureTable {
             values: hashmap! {
                 hex::encode(&signature.hash) => vec![signature.clone()]

--- a/examples/translator/module/rust/tests/integration_test.rs
+++ b/examples/translator/module/rust/tests/integration_test.rs
@@ -23,8 +23,13 @@ const MODULE_WASM_FILE_NAME: &str = "translator.wasm";
 #[tokio::test(core_threads = 2)]
 async fn test_translate() {
     let _ = env_logger::builder().is_test(true).try_init();
+    let permissions = oak_runtime::permissions::PermissionsConfiguration {
+        allow_grpc_server_nodes: true,
+        allow_log_nodes: true,
+        ..Default::default()
+    };
 
-    let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME)
+    let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME, permissions)
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;

--- a/examples/trusted_database/module/rust/tests/integration_test.rs
+++ b/examples/trusted_database/module/rust/tests/integration_test.rs
@@ -121,11 +121,17 @@ async fn test_trusted_database() {
         items: hashmap! {"database".to_string() => XML_DATABASE.as_bytes().to_vec()},
     };
     let wasm_modules = build_wasm().expect("Couldn't build wasm modules");
+    let permissions = oak_runtime::permissions::PermissionsConfiguration {
+        allow_grpc_server_nodes: true,
+        allow_log_nodes: true,
+        ..Default::default()
+    };
     let config = oak_tests::runtime_config_wasm(
         wasm_modules,
         MAIN_MODULE_NAME,
         MAIN_ENTRYPOINT_NAME,
         config_map,
+        permissions,
         oak_runtime::SignatureTable::default(),
     );
     let runtime =

--- a/experimental/benchmark/src/application/oak.rs
+++ b/experimental/benchmark/src/application/oak.rs
@@ -51,11 +51,17 @@ impl OakApplication {
             items: hashmap! {"database".to_string() => database.as_bytes().to_vec()},
         };
         let wasm_modules = build_wasm().expect("Couldn't build wasm modules");
+        let permissions = oak_runtime::permissions::PermissionsConfiguration {
+            allow_grpc_server_nodes: true,
+            allow_log_nodes: true,
+            ..Default::default()
+        };
         let config = oak_tests::runtime_config_wasm(
             wasm_modules,
             MAIN_MODULE_NAME,
             MAIN_ENTRYPOINT_NAME,
             config_map,
+            permissions,
             oak_runtime::SignatureTable::default(),
         );
         let runtime = oak_runtime::configure_and_run(config)

--- a/oak_abi/proto/application.proto
+++ b/oak_abi/proto/application.proto
@@ -156,8 +156,7 @@ message HttpClientConfiguration {
 
 // CryptoConfiguration describes the configuration of a cryptographic
 // pseudo-Node (which is provided by the Oak Runtime).
-message CryptoConfiguration {
-}
+message CryptoConfiguration {}
 
 // Information to identify a particular Roughtime server.
 // Only UDP and Ed25519 public keys are currently supported.

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -1124,6 +1124,7 @@ dependencies = [
  "serde",
  "signal-hook",
  "structopt",
+ "toml",
  "tonic",
 ]
 
@@ -2171,6 +2172,15 @@ dependencies = [
  "log",
  "pin-project-lite 0.1.11",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/oak_loader/Cargo.toml
+++ b/oak_loader/Cargo.toml
@@ -30,6 +30,7 @@ rustls = "*"
 serde = { version = "*", features = ["derive"] }
 signal-hook = "*"
 structopt = "*"
+toml = "*"
 tonic = { version = "*", features = ["tls"] }
 
 [dev-dependencies]

--- a/oak_loader/src/main.rs
+++ b/oak_loader/src/main.rs
@@ -21,6 +21,7 @@
 //! ```shell
 //! cargo run --manifest-path=oak_loader/Cargo.toml -- \
 //!     --application=<APP_CONFIG_PATH> \
+//!     --permissions=<PERM_CONFIG_PATH_FOR_LOGLESS_SERVERS> \
 //!     --grpc-tls-private-key=<PRIVATE_KEY_PATH> \
 //!     --grpc-tls-certificate=<CERTIFICATE_PATH> \
 //!     --root-tls-certificate=<CERTIFICATE_PATH>

--- a/oak_runtime/src/config.rs
+++ b/oak_runtime/src/config.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 pub fn configure_and_run(config: RuntimeConfiguration) -> Result<Arc<Runtime>, OakError> {
     let proxy = RuntimeProxy::create_runtime(
         &config.app_config,
+        &config.permissions_config,
         &config.secure_server_configuration,
         &config.sign_table,
     );

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -28,6 +28,7 @@ use crate::{
     message::Message,
     metrics::Metrics,
     node::{Node, NodeIsolation},
+    permissions::PermissionsConfiguration,
     proto::oak::introspection_events::{
         event::EventDetails, ChannelCreated, Direction, Event, HandleCreated, HandleDestroyed,
         MessageDequeued, MessageEnqueued, NodeCreated, NodeDestroyed,
@@ -75,7 +76,7 @@ mod io;
 mod message;
 mod metrics;
 mod node;
-mod permissions;
+pub mod permissions;
 mod proto;
 mod proxy;
 #[cfg(test)]
@@ -95,6 +96,8 @@ pub struct RuntimeConfiguration {
     pub secure_server_configuration: SecureServerConfiguration,
     /// Application configuration.
     pub app_config: ApplicationConfiguration,
+    /// Permissions configuration.
+    pub permissions_config: PermissionsConfiguration,
     /// Table that contains signatures and public keys corresponding to Oak modules.
     pub sign_table: SignatureTable,
     /// Start-of-day configuration to feed to the running Application.

--- a/oak_runtime/src/node/wasm/tests.rs
+++ b/oak_runtime/src/node/wasm/tests.rs
@@ -15,7 +15,7 @@
 //
 
 use super::*;
-use crate::{RuntimeProxy, SecureServerConfiguration};
+use crate::{permissions::PermissionsConfiguration, RuntimeProxy, SecureServerConfiguration};
 use maplit::hashmap;
 use oak_abi::{
     label::Label,
@@ -50,11 +50,16 @@ fn start_node(
             return Err(OakStatus::ErrInvalidArgs);
         }
     }
+    let permissions = PermissionsConfiguration {
+        allow_grpc_server_nodes: true,
+        ..Default::default()
+    };
     let signature_table = SignatureTable {
         values: hashmap! { module_hash => signatures.to_vec() },
     };
     let proxy = RuntimeProxy::create_runtime(
         &application_configuration,
+        &permissions,
         &SecureServerConfiguration::default(),
         &signature_table,
     );

--- a/oak_runtime/src/permissions.rs
+++ b/oak_runtime/src/permissions.rs
@@ -14,35 +14,91 @@
 // limitations under the License.
 //
 
+use anyhow::{anyhow, Context};
+use oak_abi::proto::oak::application::{
+    node_configuration::ConfigType, GrpcClientConfiguration, HttpClientConfiguration,
+    NodeConfiguration,
+};
+
 /// Provides a declarative description of the features that are permitted
 /// for an Oak application.
 ///
 /// To run an Oak application, one must provide, as input to the `oak_loader`, a TOML
 /// file of permissions, which is parsed into an instance of `PermissionsConfiguration`.
 /// The permissions are applied dynamically at runtime, when creating the Nodes.
-#[allow(dead_code)]
-#[derive(serde::Deserialize, Debug)]
+#[derive(Clone, Default, serde::Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PermissionsConfiguration {
     /// Whether to enable the use of GrpcServerNode.
     #[serde(default)]
-    allow_grpc_server_nodes: bool,
+    pub allow_grpc_server_nodes: bool,
 
     /// Whether to enable the use of HttpServerNode.
     #[serde(default)]
-    allow_http_server_nodes: bool,
+    pub allow_http_server_nodes: bool,
 
     /// Whether to enable the use of LogNode.
     #[serde(default)]
-    allow_log_nodes: bool,
+    pub allow_log_nodes: bool,
 
-    /// Whether to allow introspection. If true, the introspection auxiliary service will be
-    /// started.
+    /// Whether to enable creating an HTTP client for insecure HTTP connection. Such an
+    /// HttpClientNode is configured with an empty authority, and does not use TLS connections.
     #[serde(default)]
-    allow_introspection: bool,
+    pub allow_insecure_http_egress: bool,
 
-    /// List of the allowed URIs that the application can connect to. Only GrpcClientNodes
-    /// that are configured to connect to URIs in this list can be created.
+    /// List of the allowed authorities (of the form `[userinfo@]host[:port]`) that the application
+    /// can connect to via a gRPC or an HTTP client. Only GrpcClientNodes or secure
+    /// HttpClientNodes that are configured to connect to authorities in this list can be
+    /// created. This is in addition to an insecure HttpClientNode that may be allowed via the
+    /// `allow_insecure_http_egress` flag.
     #[serde(default)]
-    allow_grpc_egress_addresses: Vec<String>,
+    pub allow_egress_https_authorities: Vec<String>,
+}
+
+impl PermissionsConfiguration {
+    /// Check if this permissions configuration allows creating a node with the given node
+    /// configuration. This check is disabled when `oak_debug` is enabled. In that case, this
+    /// function returns `true` regardless of the node configuration.
+    pub fn allowed_creation(&self, node_configuration: &NodeConfiguration) -> anyhow::Result<bool> {
+        if cfg!(feature = "oak_debug") {
+            Ok(true)
+        } else {
+            match &node_configuration.config_type {
+                Some(ConfigType::LogConfig(_config)) => Ok(self.allow_log_nodes),
+                Some(ConfigType::GrpcServerConfig(_config)) => Ok(self.allow_grpc_server_nodes),
+                Some(ConfigType::GrpcClientConfig(config)) => self.allow_grpc_client(&config),
+                Some(ConfigType::HttpServerConfig(_config)) => Ok(self.allow_http_server_nodes),
+                Some(ConfigType::HttpClientConfig(config)) => Ok(self.allow_http_client(&config)),
+                _ => Ok(true),
+            }
+        }
+    }
+
+    /// Checks if creating a GrpcClient node with the given configuration is permitted. Returns
+    /// Ok(`true`) if the `authority` part of `config.uri` is in the list of allowed authorities.
+    /// Returns an error if `config.uri` cannot be parsed into a URI object.
+    pub fn allow_grpc_client(&self, config: &GrpcClientConfiguration) -> anyhow::Result<bool> {
+        let uri = config
+            .uri
+            .parse::<http::Uri>()
+            .context(format!("Error parsing URI {}", &config.uri))?;
+
+        Ok(self.allow_egress_https_authorities.contains(
+            &uri.authority()
+                .ok_or_else(|| anyhow!("Empty authority"))?
+                .to_string(),
+        ))
+    }
+
+    /// Checks if creating an HttpClient node with the given configuration is permitted. If
+    /// `config.authority` is empty, returns `true` if insecure HTTP connections are allowed. If
+    /// `config.authority` is not empty, returns `true` if the authority is in the list of allowed
+    /// authorities. Returns `false` otherwise.
+    pub fn allow_http_client(&self, config: &HttpClientConfiguration) -> bool {
+        config.authority.is_empty() && self.allow_insecure_http_egress
+            || !config.authority.is_empty()
+                && self
+                    .allow_egress_https_authorities
+                    .contains(&config.authority)
+    }
 }

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -18,9 +18,9 @@
 //! context of a specific Node or pseudo-Node.
 
 use crate::{
-    construct_debug_id, metrics::Metrics, AuxServer, ChannelHalfDirection, Downgrading,
-    LabelReadStatus, NodeId, NodeMessage, NodePrivilege, NodeReadStatus, Runtime,
-    SecureServerConfiguration, SignatureTable,
+    construct_debug_id, metrics::Metrics, permissions::PermissionsConfiguration, AuxServer,
+    ChannelHalfDirection, Downgrading, LabelReadStatus, NodeId, NodeMessage, NodePrivilege,
+    NodeReadStatus, Runtime, SecureServerConfiguration, SignatureTable,
 };
 use core::sync::atomic::{AtomicBool, AtomicU64};
 use log::debug;
@@ -64,6 +64,7 @@ impl RuntimeProxy {
     /// Creates a [`Runtime`] instance with a single initial Node configured, and no channels.
     pub fn create_runtime(
         application_configuration: &ApplicationConfiguration,
+        permissions_configuration: &PermissionsConfiguration,
         secure_server_configuration: &SecureServerConfiguration,
         signature_table: &SignatureTable,
     ) -> RuntimeProxy {
@@ -77,6 +78,7 @@ impl RuntimeProxy {
             metrics_data: Metrics::new(),
             node_factory: crate::node::ServerNodeFactory {
                 application_configuration: application_configuration.clone(),
+                permissions_configuration: permissions_configuration.clone(),
                 secure_server_configuration: secure_server_configuration.clone(),
                 signature_table: signature_table.clone(),
             },

--- a/oak_runtime/src/tests.rs
+++ b/oak_runtime/src/tests.rs
@@ -43,10 +43,16 @@ fn run_node_body(node_label: &Label, node_privilege: &NodePrivilege, node_body: 
         initial_node_configuration: None,
         module_signatures: vec![],
     };
+    let permissions = crate::permissions::PermissionsConfiguration {
+        allow_grpc_server_nodes: true,
+        allow_log_nodes: true,
+        ..Default::default()
+    };
     let signature_table = SignatureTable::default();
     info!("Create runtime for test");
     let proxy = crate::RuntimeProxy::create_runtime(
         &configuration,
+        &permissions,
         &SecureServerConfiguration {
             grpc_config: Some(GrpcConfiguration {
                 grpc_server_tls_identity: Some(Identity::from_pem(

--- a/oak_runtime/tests/integration_test.rs
+++ b/oak_runtime/tests/integration_test.rs
@@ -60,6 +60,10 @@ mod common {
             }),
             module_signatures: vec![],
         };
+        let permissions = oak_runtime::permissions::PermissionsConfiguration {
+            allow_grpc_server_nodes: true,
+            ..Default::default()
+        };
 
         info!("Starting the runtime with one node.");
         config::configure_and_run(oak_runtime::RuntimeConfiguration {
@@ -67,6 +71,7 @@ mod common {
             introspect_port: None,
             secure_server_configuration: SecureServerConfiguration::default(),
             app_config: application_configuration,
+            permissions_config: permissions,
             sign_table: SignatureTable::default(),
             config_map: ConfigMap::default(),
         })

--- a/oak_services/proto/crypto.proto
+++ b/oak_services/proto/crypto.proto
@@ -51,9 +51,9 @@ service OakCrypto {
 
   // Deterministic AEAD encryption and decryption
   rpc EncryptDeterministically(DeterministicAeadEncryptRequest)
-    returns (DeterministicAeadEncryptResponse) {}
+      returns (DeterministicAeadEncryptResponse) {}
   rpc DecryptDeterministically(DeterministicAeadDecryptRequest)
-    returns (DeterministicAeadDecryptResponse) {}
+      returns (DeterministicAeadDecryptResponse) {}
 
   // Compute and verify MACs
   rpc ComputeMac(ComputeMacRequest) returns (ComputeMacResponse) {}
@@ -71,7 +71,7 @@ service OakCrypto {
 // dependency on all of Tink's protos.
 message KeyTemplate {
   string type_url = 1;  // in format type.googleapis.com/packagename.messagename
-  bytes value = 2;  // contains specific serialized *KeyFormat proto
+  bytes value = 2;      // contains specific serialized *KeyFormat proto
   OutputPrefixType output_prefix_type = 3;
 }
 enum OutputPrefixType {
@@ -170,8 +170,7 @@ message VerifyMacRequest {
   bytes data = 3;
 }
 
-message VerifyMacResponse {
-}
+message VerifyMacResponse {}
 
 message ComputeMacRequest {
   fixed64 keyset_handle = 1;
@@ -207,5 +206,4 @@ message SignatureVerifyRequest {
   bytes data = 3;
 }
 
-message SignatureVerifyResponse {
-}
+message SignatureVerifyResponse {}

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -62,6 +62,12 @@ pub struct RunExamples {
         default_value = "rust"
     )]
     pub application_variant: String,
+    #[structopt(
+        long,
+        help = "Path to permissions file",
+        default_value = "./examples/permissions/permissions.toml"
+    )]
+    pub permissions_file: String,
     // TODO(#396): Clarify the name and type of this, currently it is not very intuitive.
     #[structopt(
         long,

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -414,6 +414,7 @@ fn run_ci() -> Step {
             run_tests_tsan(),
             run_examples(&RunExamples {
                 application_variant: "rust".to_string(),
+                permissions_file: "./examples/permissions/permissions.toml".to_string(),
                 example_name: None,
                 run_server: None,
                 client_additional_args: Vec::new(),
@@ -432,6 +433,7 @@ fn run_ci() -> Step {
             }),
             run_examples(&RunExamples {
                 application_variant: "cpp".to_string(),
+                permissions_file: "./examples/permissions/permissions.toml".to_string(),
                 example_name: None,
                 run_server: None,
                 client_additional_args: Vec::new(),
@@ -451,6 +453,7 @@ fn run_ci() -> Step {
             // Package the Hello World application in a Docker image.
             run_examples(&RunExamples {
                 application_variant: "rust".to_string(),
+                permissions_file: "./examples/permissions/permissions.toml".to_string(),
                 example_name: Some("hello_world".to_string()),
                 run_server: Some(false),
                 client_additional_args: Vec::new(),
@@ -476,6 +479,7 @@ fn run_example_server(
     example_server: &ExampleServer,
     server_additional_args: Vec<String>,
     application_file: &str,
+    permissions_file: &str,
 ) -> Box<dyn Runnable> {
     Cmd::new_with_env(
         "oak_loader/bin/oak_loader",
@@ -486,6 +490,10 @@ fn run_example_server(
             "--http-tls-private-key=./examples/certs/local/local.key".to_string(),
             // TODO(#396): Add `--oidc-client` support.
             format!("--application={}", application_file),
+            match opt.server_variant {
+                ServerVariant::Logless => format!("--permissions={}", permissions_file),
+                _ => "".to_string(),
+            },
             ...match opt.server_variant {
                 ServerVariant::Logless => vec![],
                 _ => vec!["--root-tls-certificate=./examples/certs/local/ca.pem".to_string()],
@@ -573,6 +581,7 @@ fn run_example(opt: &RunExamples, example: &Example) -> Step {
         &example.server,
         opt.server_additional_args.clone(),
         &application.out,
+        &opt.permissions_file,
     );
     let run_clients = Step::Multiple {
         name: "run clients".to_string(),

--- a/sdk/rust/oak_tests/src/lib.rs
+++ b/sdk/rust/oak_tests/src/lib.rs
@@ -103,8 +103,9 @@ const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(800
 /// the default name "oak_main" for its entrypoint.
 pub fn run_single_module_default(
     module_config_name: &str,
+    permissions: oak_runtime::permissions::PermissionsConfiguration,
 ) -> Result<Arc<oak_runtime::Runtime>, oak::OakError> {
-    run_single_module(module_config_name, DEFAULT_ENTRYPOINT_NAME)
+    run_single_module(module_config_name, DEFAULT_ENTRYPOINT_NAME, permissions)
 }
 
 /// Convenience helper to build and run a single-Node application with the given Wasm module file
@@ -112,8 +113,14 @@ pub fn run_single_module_default(
 pub fn run_single_module(
     module_wasm_file_name: &str,
     entrypoint_name: &str,
+    permissions: oak_runtime::permissions::PermissionsConfiguration,
 ) -> Result<Arc<oak_runtime::Runtime>, oak::OakError> {
-    run_single_module_with_config(module_wasm_file_name, entrypoint_name, ConfigMap::default())
+    run_single_module_with_config(
+        module_wasm_file_name,
+        entrypoint_name,
+        ConfigMap::default(),
+        permissions,
+    )
 }
 
 /// Convenience helper to build and run a single-Node application with the given Wasm module file
@@ -122,8 +129,14 @@ pub fn run_single_module_with_config(
     module_wasm_file_name: &str,
     entrypoint_name: &str,
     config_map: ConfigMap,
+    permissions: oak_runtime::permissions::PermissionsConfiguration,
 ) -> Result<Arc<oak_runtime::Runtime>, oak::OakError> {
-    let combined_config = runtime_config(module_wasm_file_name, entrypoint_name, config_map);
+    let combined_config = runtime_config(
+        module_wasm_file_name,
+        entrypoint_name,
+        config_map,
+        permissions,
+    );
     oak_runtime::configure_and_run(combined_config)
 }
 
@@ -134,6 +147,7 @@ pub fn runtime_config(
     module_wasm_file_name: &str,
     entrypoint_name: &str,
     config_map: ConfigMap,
+    permissions: oak_runtime::permissions::PermissionsConfiguration,
 ) -> oak_runtime::RuntimeConfiguration {
     let wasm: HashMap<String, Vec<u8>> = [(
         DEFAULT_MODULE_NAME.to_string(),
@@ -153,6 +167,7 @@ pub fn runtime_config(
         DEFAULT_MODULE_NAME,
         entrypoint_name,
         config_map,
+        permissions,
         oak_runtime::SignatureTable::default(),
     )
 }
@@ -164,6 +179,7 @@ pub fn runtime_config_wasm(
     module_config_name: &str,
     entrypoint_name: &str,
     config_map: ConfigMap,
+    permissions: oak_runtime::permissions::PermissionsConfiguration,
     sign_table: oak_runtime::SignatureTable,
 ) -> oak_runtime::RuntimeConfiguration {
     oak_runtime::RuntimeConfiguration {
@@ -193,6 +209,7 @@ pub fn runtime_config_wasm(
             }),
             module_signatures: vec![],
         },
+        permissions_config: permissions,
         config_map,
         sign_table,
     }


### PR DESCRIPTION
* Updates the runtime to take into account the permissions configuration
  when creating the nodes.
* Adds a new input flag to `oak_loader` for permissions. This is only
  required if `oak_debug` is disabled.
* Updates runner with a path to a permissions `.toml` file
* Updates the documentation with info about permissions file
* Updates gcp scripts accordingly

Fixes #1029

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [x] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [x] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
