### PR TITLE
Add Proxy Attestation example

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
           - build-server --server-variant=base
           - build-server --server-variant=logless
           - build-server --server-variant=kms
+          - build-server --server-variant=experimental
           - run-tests
           - run-tests-tsan
           - run-examples --application-variant=rust

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -735,6 +735,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,7 +1102,7 @@ dependencies = [
  "oak_abi",
  "oak_sign",
  "prost",
- "rustls 0.18.1",
+ "rustls",
  "serde_json",
  "structopt",
  "tokio 0.2.23",
@@ -1134,7 +1149,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "log",
- "rustls 0.18.1",
+ "rustls",
  "tokio 0.2.23",
  "tokio-rustls",
  "webpki",
@@ -1512,6 +1527,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_proxy_attestation"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "http",
+ "log",
+ "oak_utils",
+ "openssl",
+ "prost",
+ "structopt",
+ "tokio 0.2.23",
+ "tonic",
+]
+
+[[package]]
 name = "oak_runtime"
 version = "0.1.0"
 dependencies = [
@@ -1544,7 +1578,7 @@ dependencies = [
  "regex",
  "reqwest",
  "roughenough",
- "rustls 0.18.1",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -1605,7 +1639,7 @@ dependencies = [
  "oak_runtime",
  "prost",
  "rand",
- "rustls 0.19.0",
+ "rustls",
  "tonic",
 ]
 
@@ -1640,6 +1674,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1802,6 +1863,12 @@ checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
 dependencies = [
  "der",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "pmac"
@@ -2013,6 +2080,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxy_attestation_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.13.0",
+ "env_logger",
+ "http",
+ "log",
+ "oak_abi",
+ "oak_client",
+ "oak_proxy_attestation",
+ "oak_sign",
+ "oak_utils",
+ "pem",
+ "prost",
+ "structopt",
+ "tokio 0.2.23",
+ "tonic",
+]
+
+[[package]]
+name = "proxy_attestation_example"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.13.0",
+ "hex",
+ "log",
+ "maplit",
+ "oak",
+ "oak_abi",
+ "oak_io",
+ "oak_services",
+ "oak_utils",
+ "prost",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,7 +2249,7 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "pin-project-lite 0.2.0",
- "rustls 0.18.1",
+ "rustls",
  "serde",
  "serde_urlencoded",
  "tokio 0.2.23",
@@ -2190,19 +2295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
  "base64 0.12.3",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
-dependencies = [
- "base64 0.13.0",
  "log",
  "ring",
  "sct",
@@ -2710,7 +2802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
- "rustls 0.18.1",
+ "rustls",
  "tokio 0.2.23",
  "webpki",
 ]
@@ -3167,6 +3259,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,6 +23,8 @@ members = [
   "private_set_intersection/client/rust",
   "private_set_intersection/main_module/rust",
   "private_set_intersection/handler_module/rust",
+  "proxy_attestation/client/rust",
+  "proxy_attestation/module/rust",
   "translator/grpc",
   "translator/common",
   "translator/module/rust",
@@ -40,6 +42,7 @@ oak_abi = { path = "../oak_abi" }
 oak_client = { path = "../oak_client" }
 oak_derive = { path = "../oak_derive" }
 oak_io = { path = "../oak_io" }
+oak_proxy_attestation = { path = "../experimental/proxy_attestation" }
 oak_runtime = { path = "../oak_runtime" }
 oak_services = { path = "../oak_services" }
 oak_sign = { path = "../oak_sign" }

--- a/examples/proxy_attestation/client/rust/Cargo.toml
+++ b/examples/proxy_attestation/client/rust/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "proxy_attestation_client"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+name = "proxy_attestation_client"
+path = "src/lib.rs"
+
+[[bin]]
+name = "proxy_attestation_client_bin"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "*"
+base64 = "*"
+env_logger = "*"
+http = "*"
+log = "*"
+oak_abi = "=0.1.0"
+oak_client = "=0.1.0"
+oak_proxy_attestation = "*"
+oak_sign = "=0.1.0"
+pem = "*"
+prost = "*"
+structopt = "*"
+# Pinned to 0.2 because of tonic: https://github.com/hyperium/tonic/blob/master/tonic/Cargo.toml
+tokio = { version = "0.2", features = ["fs", "macros", "sync", "stream"] }
+tonic = { version = "*", features = ["tls"] }
+
+[build-dependencies]
+oak_utils = "*"

--- a/examples/proxy_attestation/client/rust/build.rs
+++ b/examples/proxy_attestation/client/rust/build.rs
@@ -1,0 +1,29 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    generate_grpc_code(
+        "../../proto",
+        &["proxy_attestation_example.proto"],
+        CodegenOptions {
+            build_client: true,
+            ..Default::default()
+        },
+    )?;
+    Ok(())
+}

--- a/examples/proxy_attestation/client/rust/src/lib.rs
+++ b/examples/proxy_attestation/client/rust/src/lib.rs
@@ -1,0 +1,19 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub mod proto {
+    tonic::include_proto!("oak.examples.proxy_attestation_example");
+}

--- a/examples/proxy_attestation/client/rust/src/main.rs
+++ b/examples/proxy_attestation/client/rust/src/main.rs
@@ -1,0 +1,139 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Client for the Proxy Attestation example.
+//!
+//! Client first connects to the Proxy Attestation Service and downloads its root certificate.
+//! Then client uses this certificate in order to connect to the example Oak application, assuming
+//! that the example application received a signed certificate from the Proxy Attestation Service.
+
+use anyhow::Context;
+use http::uri::Uri;
+use log::info;
+use oak_abi::label::Label;
+use oak_client::{create_tls_channel, interceptors::label::LabelInterceptor};
+use oak_proxy_attestation::proto::{
+    proxy_attestation_client::ProxyAttestationClient, GetRootCertificateRequest,
+};
+use proxy_attestation_client::proto::{
+    example_application_client::ExampleApplicationClient, GetExampleMessageRequest,
+};
+use structopt::StructOpt;
+use tonic::{transport::Channel, Request};
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "Private Set Intersection Client")]
+pub struct Opt {
+    #[structopt(
+        long,
+        help = "URI of the Oak application",
+        default_value = "https://localhost:8080"
+    )]
+    app_uri: String,
+    #[structopt(
+        long,
+        help = "URI of the Proxy Attestation Service",
+        default_value = "https://localhost:8888"
+    )]
+    proxy_uri: String,
+    #[structopt(
+        long,
+        help = "PEM encoded X.509 TLS root certificate file of Proxy Attestation Service"
+    )]
+    proxy_root_tls_certificate: String,
+}
+
+/// Create gRPC client for Proxy Attestation Service.
+async fn create_proxy_client(
+    uri: &Uri,
+    root_tls_certificate: &[u8],
+) -> anyhow::Result<ProxyAttestationClient<Channel>> {
+    info!("Connecting to Proxy Attestation Service: {:?}", uri);
+    let channel = create_tls_channel(uri, root_tls_certificate)
+        .await
+        .context("Couldn't create TLS channel")?;
+    Ok(ProxyAttestationClient::new(channel))
+}
+
+/// Create gRPC client for Oak application.
+async fn create_application_client(
+    uri: &Uri,
+    root_tls_certificate: &[u8],
+) -> anyhow::Result<ExampleApplicationClient<Channel>> {
+    info!("Connecting to Oak application: {:?}", uri);
+    let channel = create_tls_channel(uri, root_tls_certificate)
+        .await
+        .context("Couldn't create TLS channel")?;
+    let label = Label::public_untrusted();
+    let interceptor =
+        LabelInterceptor::create(&label).context("Couldn't create gRPC interceptor")?;
+    Ok(ExampleApplicationClient::with_interceptor(
+        channel,
+        interceptor,
+    ))
+}
+
+/// Request root TLS certificate from Proxy Attestation Service.
+async fn get_root_tls_certificate(
+    proxy_uri: &Uri,
+    proxy_root_tls_certificate: &[u8],
+) -> anyhow::Result<Vec<u8>> {
+    let mut client = create_proxy_client(&proxy_uri, &proxy_root_tls_certificate)
+        .await
+        .context("Couldn't create gRPC client")?;
+    let request = Request::new(GetRootCertificateRequest {});
+    let response = client
+        .get_root_certificate(request)
+        .await
+        .context("Couldn't get public key")?;
+    Ok(response.get_ref().root_certificate.to_vec())
+}
+
+/// Connect to Oak application using root TLS certificate received from Proxy Attestation Service.
+/// TODO(#1861): Check TEE quotes in server certificates.
+async fn create_application_connection(
+    uri: &Uri,
+    root_tls_certificate: &[u8],
+) -> anyhow::Result<()> {
+    let mut client = create_application_client(&uri, &root_tls_certificate)
+        .await
+        .context("Couldn't create gRPC client")?;
+    let request = Request::new(GetExampleMessageRequest {});
+    client
+        .get_example_message(request)
+        .await
+        .context("Couldn't connect to backend")?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let opt = Opt::from_args();
+
+    let app_uri = opt.app_uri.parse().context("Error parsing URI")?;
+    let proxy_uri = opt.proxy_uri.parse().context("Error parsing URI")?;
+    let proxy_root_tls_certificate =
+        std::fs::read(&opt.proxy_root_tls_certificate).context("Couldn't load certificate file")?;
+
+    let root_tls_certificate =
+        get_root_tls_certificate(&proxy_uri, &proxy_root_tls_certificate).await?;
+    info!("Received root certificate from Proxy Attestation Service");
+    create_application_connection(&app_uri, &root_tls_certificate).await?;
+    info!("Successfully connected to Oak application");
+
+    Ok(())
+}

--- a/examples/proxy_attestation/example.toml
+++ b/examples/proxy_attestation/example.toml
@@ -1,0 +1,27 @@
+name = "proxy_attestation"
+backend = { Cargo = { cargo_manifest = "experimental/proxy_attestation/Cargo.toml" }, additional_args = [
+  "--grpc-tls-private-key=./examples/certs/local/local.key",
+  "--grpc-tls-certificate=./examples/certs/local/local.pem",
+] }
+
+[applications]
+
+[applications.rust]
+manifest = "examples/proxy_attestation/oak_app_manifest.toml"
+out = "examples/proxy_attestation/bin/proxy_attestation.oak"
+
+[applications.rust.modules]
+module = { Cargo = { cargo_manifest = "examples/proxy_attestation/module/rust/Cargo.toml" } }
+
+[server]
+additional_args = [
+  "--proxy-uri=https://localhost:8888",
+  "--proxy-root-tls-certificate=examples/certs/local/ca.pem",
+]
+
+[clients]
+rust = { Cargo = { cargo_manifest = "examples/proxy_attestation/client/rust/Cargo.toml" }, additional_args = [
+  "--app-uri=https://localhost:8080",
+  "--proxy-uri=https://localhost:8888",
+  "--proxy-root-tls-certificate=examples/certs/local/ca.pem",
+] }

--- a/examples/proxy_attestation/module/rust/Cargo.toml
+++ b/examples/proxy_attestation/module/rust/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "proxy_attestation_example"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+anyhow = "*"
+base64 = "*"
+log = "*"
+oak = "=0.1.0"
+oak_abi = "=0.1.0"
+oak_io = "=0.1.0"
+oak_services = "=0.1.0"
+prost = "*"
+
+[dev-dependencies]
+anyhow = "*"
+hex = "*"
+log = "*"
+maplit = "*"
+
+[build-dependencies]
+oak_utils = "*"

--- a/examples/proxy_attestation/module/rust/build.rs
+++ b/examples/proxy_attestation/module/rust/build.rs
@@ -1,0 +1,22 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+fn main() {
+    oak_utils::compile_protos(
+        &["../../proto/proxy_attestation_example.proto"],
+        &["../../proto", "../../../../"],
+    );
+}

--- a/examples/proxy_attestation/module/rust/src/lib.rs
+++ b/examples/proxy_attestation/module/rust/src/lib.rs
@@ -1,0 +1,95 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub mod proto {
+    pub mod oak {
+        pub use oak::proto::oak::invocation;
+        pub use oak_services::proto::oak::log;
+        pub mod examples {
+            pub mod proxy_attestation {
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/oak.examples.proxy_attestation_example.rs"
+                ));
+            }
+        }
+    }
+}
+
+use crate::proto::oak::examples::proxy_attestation::{
+    ExampleApplication, ExampleApplicationDispatcher, GetExampleMessageRequest,
+    GetExampleMessageResponse,
+};
+use anyhow::Context;
+use log::info;
+use oak::{grpc, Label};
+use oak_abi::proto::oak::application::ConfigMap;
+use oak_services::proto::oak::log::LogInit;
+
+oak::entrypoint_command_handler!(oak_main => Main);
+
+#[derive(Default)]
+struct Main;
+
+impl oak::CommandHandler for Main {
+    type Command = ConfigMap;
+
+    fn handle_command(&mut self, _command: ConfigMap) -> anyhow::Result<()> {
+        let log_sender = oak::logger::create()?;
+        oak::logger::init(log_sender.clone(), log::Level::Debug)?;
+
+        let handler_command_sender = oak::io::entrypoint_node_create::<Handler, _, _>(
+            "handler",
+            &Label::public_untrusted(),
+            "app",
+            LogInit {
+                log_sender: Some(log_sender),
+            },
+        )
+        .context("Couldn't create handler node")?;
+
+        oak::grpc::server::init_with_sender("[::]:8080", handler_command_sender)
+            .context("Couldn't create gRPC server pseudo-Node")?;
+        Ok(())
+    }
+}
+
+oak::impl_dispatcher!(impl Handler : ExampleApplicationDispatcher);
+oak::entrypoint_command_handler_init!(handler => Handler);
+
+#[derive(Default)]
+pub struct Handler;
+
+impl oak::WithInit for Handler {
+    type Init = LogInit;
+
+    fn create(init: Self::Init) -> Self {
+        oak::logger::init(init.log_sender.unwrap(), log::Level::Debug).unwrap();
+        Self::default()
+    }
+}
+
+impl ExampleApplication for Handler {
+    fn get_example_message(
+        &mut self,
+        _req: GetExampleMessageRequest,
+    ) -> grpc::Result<GetExampleMessageResponse> {
+        info!("Received request");
+        Ok(GetExampleMessageResponse {
+            message: "Example message".to_string(),
+        })
+    }
+}

--- a/examples/proxy_attestation/oak_app_manifest.toml
+++ b/examples/proxy_attestation/oak_app_manifest.toml
@@ -1,0 +1,4 @@
+name = "proxy_attestation"
+
+[modules]
+app = { path = "examples/proxy_attestation/bin/proxy_attestation_example.wasm" }

--- a/examples/proxy_attestation/proto/proxy_attestation_example.proto
+++ b/examples/proxy_attestation/proto/proxy_attestation_example.proto
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.examples.proxy_attestation_example;
+
+import "google/protobuf/empty.proto";
+
+message GetExampleMessageRequest {}
+
+message GetExampleMessageResponse {
+  string message = 1;
+}
+
+service ExampleApplication {
+  rpc GetExampleMessage(GetExampleMessageRequest) returns (GetExampleMessageResponse);
+}

--- a/experimental/Cargo.lock
+++ b/experimental/Cargo.lock
@@ -546,6 +546,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,7 +881,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "log",
- "rustls 0.18.1",
+ "rustls",
  "tokio 0.2.23",
  "tokio-rustls",
  "webpki",
@@ -1075,6 +1090,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-uds"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio 0.6.22",
+]
+
+[[package]]
 name = "miow"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1281,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_proxy_attestation"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger 0.8.2",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "http",
+ "log",
+ "oak_utils",
+ "openssl",
+ "prost",
+ "structopt",
+ "tokio 0.2.23",
+ "tonic",
+]
+
+[[package]]
 name = "oak_runtime"
 version = "0.1.0"
 dependencies = [
@@ -1287,7 +1332,7 @@ dependencies = [
  "regex",
  "reqwest",
  "roughenough",
- "rustls 0.18.1",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -1348,7 +1393,7 @@ dependencies = [
  "oak_runtime",
  "prost",
  "rand",
- "rustls 0.19.0",
+ "rustls",
  "tonic",
 ]
 
@@ -1375,6 +1420,33 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "p256"
@@ -1512,6 +1584,12 @@ checksum = "9911ed9965aeee333588f226ad2baeabda478bf5ec151550735ed1760df759ba"
 dependencies = [
  "const-oid",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "pmac"
@@ -1790,7 +1868,7 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "pin-project-lite 0.2.0",
- "rustls 0.18.1",
+ "rustls",
  "serde",
  "serde_urlencoded",
  "tokio 0.2.23",
@@ -1836,19 +1914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
  "base64 0.12.3",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
-dependencies = [
- "base64 0.13.0",
  "log",
  "ring",
  "sct",
@@ -2313,12 +2378,16 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
+ "libc",
  "memchr",
  "mio 0.6.22",
+ "mio-uds",
  "num_cpus",
  "pin-project-lite 0.1.11",
+ "signal-hook-registry",
  "slab",
  "tokio-macros 0.2.6",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2372,7 +2441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
- "rustls 0.18.1",
+ "rustls",
  "tokio 0.2.23",
  "webpki",
 ]
@@ -2784,6 +2853,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"

--- a/experimental/Cargo.toml
+++ b/experimental/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "split_grpc/proxy",
   "split_grpc/server",
   "benchmark",
+  "proxy_attestation",
 ]
 
 [patch.crates-io]

--- a/experimental/proxy_attestation/Cargo.toml
+++ b/experimental/proxy_attestation/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "oak_proxy_attestation"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+name = "oak_proxy_attestation"
+path = "src/lib.rs"
+
+[[bin]]
+name = "oak_proxy_attestation_bin"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "*"
+env_logger = "*"
+futures = "*"
+futures-core = "*"
+futures-util = "*"
+http = "*"
+log = "*"
+openssl = "*"
+prost = "*"
+structopt = "*"
+# Pinned to 0.2 because of tonic: https://github.com/hyperium/tonic/blob/master/tonic/Cargo.toml
+tokio = { version = "0.2", features = [
+  "fs",
+  "macros",
+  "signal",
+  "sync",
+  "stream"
+] }
+tonic = { version = "*", features = ["tls"] }
+
+[build-dependencies]
+oak_utils = { path = "../../oak_utils" }

--- a/experimental/proxy_attestation/build.rs
+++ b/experimental/proxy_attestation/build.rs
@@ -1,0 +1,29 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use oak_utils::{generate_grpc_code, CodegenOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    generate_grpc_code(
+        "proto",
+        &["proxy_attestation.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: true,
+        },
+    )?;
+    Ok(())
+}

--- a/experimental/proxy_attestation/proto/proxy_attestation.proto
+++ b/experimental/proxy_attestation/proto/proxy_attestation.proto
@@ -1,0 +1,49 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.examples.proxy_attestation;
+
+import "google/protobuf/empty.proto";
+
+message GetSignedCertificateRequest {
+  bytes certificate_request = 1;
+}
+
+message GetSignedCertificateResponse {
+  bytes certificate = 1;
+}
+
+message GetRootCertificateRequest {}
+
+message GetRootCertificateResponse {
+  bytes root_certificate = 1;
+}
+
+// Service for signing X.509 certificates.
+// https://tools.ietf.org/html/rfc5280
+service ProxyAttestation {
+  // Get signed X.509 certificate based on the provided certificate signing request.
+  rpc GetSignedCertificate(GetSignedCertificateRequest) returns (GetSignedCertificateResponse);
+  // Get root X.509 certificate used by the Proxy Attestation Service to sign certificates.
+  // This certificate is generated insode the TEE and is not the same certificate that is used to
+  // connect to the proxy itself.
+  //
+  // Note: Current implementation doesn't support sealing, so the proxy generates a new certificate
+  // on startup.
+  rpc GetRootCertificate(GetRootCertificateRequest) returns (GetRootCertificateResponse);
+}

--- a/experimental/proxy_attestation/src/certificate.rs
+++ b/experimental/proxy_attestation/src/certificate.rs
@@ -1,0 +1,182 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use log::info;
+use openssl::{
+    asn1::Asn1Time,
+    bn::{BigNum, MsbOption},
+    error::ErrorStack,
+    hash::MessageDigest,
+    nid::Nid,
+    pkey::{PKey, Private},
+    rsa::Rsa,
+    x509::{
+        extension::{AuthorityKeyIdentifier, BasicConstraints, KeyUsage, SubjectKeyIdentifier},
+        X509Extension, X509NameBuilder, X509Req, X509,
+    },
+};
+
+// X.509 certificate parameters.
+// https://tools.ietf.org/html/rfc5280
+const RSA_KEY_SIZE: u32 = 2048;
+// Version is zero-indexed, so the value of `2` corresponds to the version `3`.
+const CERTIFICATE_VERSION: i32 = 2;
+// Length of the randomly generated X.509 certificate serial number (which is 20 bytes) excluding
+// the most significant bit.
+const SERIAL_NUMBER_SIZE: i32 = 159;
+const CERTIFICATE_EXPIRATION_INTERVAL_IN_DAYS: u32 = 1;
+
+/// Custom X.509 extension with a TEE application quote that was remotely attested by the Proxy
+/// Attestation Service.
+pub struct Quote {
+    value: String,
+}
+
+impl Quote {
+    pub fn new(value: &str) -> Self {
+        Self {
+            value: format!("Quote:{}", value.to_string()),
+        }
+    }
+
+    /// Return the [`Quote`] extension as an [`X509Extension`].
+    pub fn build(&self) -> Result<X509Extension, ErrorStack> {
+        // Using [`Nid::NETSCAPE_COMMENT`] identifier since `rust-openssl` doesn't support custom
+        // extensions yet:
+        // https://github.com/sfackler/rust-openssl/issues/1411
+        X509Extension::new_nid(None, None, Nid::NETSCAPE_COMMENT, &self.value)
+    }
+}
+
+/// Convenience structure for creating X.509 certificates.
+/// https://tools.ietf.org/html/rfc5280
+pub struct CertificateAuthority {
+    pub key_pair: PKey<Private>,
+    pub root_certificate: X509,
+}
+
+impl CertificateAuthority {
+    pub fn new() -> Self {
+        let (key_pair, root_certificate) =
+            Self::generate_root_certificate().expect("Couldn't generate root TLS certificate");
+        Self {
+            key_pair,
+            root_certificate,
+        }
+    }
+
+    /// Creates a root X.509 certificate and a corresponding private/public key pair.
+    pub fn generate_root_certificate() -> anyhow::Result<(PKey<Private>, X509)> {
+        info!("Generating root certificate");
+
+        let rsa = Rsa::generate(RSA_KEY_SIZE)?;
+        let key_pair = PKey::from_rsa(rsa)?;
+
+        let mut name = X509NameBuilder::new()?;
+        name.append_entry_by_text("O", "Oak")?;
+        name.append_entry_by_text("CN", "Proxy Attestation Service")?;
+        let name = name.build();
+
+        let mut builder = X509::builder()?;
+        builder.set_version(CERTIFICATE_VERSION)?;
+        let serial_number = {
+            let mut serial = BigNum::new()?;
+            serial.rand(SERIAL_NUMBER_SIZE, MsbOption::MAYBE_ZERO, false)?;
+            serial.to_asn1_integer()?
+        };
+        builder.set_serial_number(&serial_number)?;
+        builder.set_subject_name(&name)?;
+        builder.set_issuer_name(&name)?;
+        builder.set_pubkey(&key_pair)?;
+        let not_before = Asn1Time::days_from_now(0)?;
+        builder.set_not_before(&not_before)?;
+        let not_after = Asn1Time::days_from_now(CERTIFICATE_EXPIRATION_INTERVAL_IN_DAYS)?;
+        builder.set_not_after(&not_after)?;
+
+        builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
+        builder.append_extension(
+            KeyUsage::new()
+                .critical()
+                .key_cert_sign()
+                .crl_sign()
+                .build()?,
+        )?;
+
+        let subject_key_identifier =
+            SubjectKeyIdentifier::new().build(&builder.x509v3_context(None, None))?;
+        builder.append_extension(subject_key_identifier)?;
+
+        builder.sign(&key_pair, MessageDigest::sha256())?;
+        let certificate = builder.build();
+
+        Ok((key_pair, certificate))
+    }
+
+    /// Create an X509 certificate based on the certificate signing `request`.
+    pub fn sign_certificate(&self, request: X509Req, tee_quote: &str) -> anyhow::Result<X509> {
+        info!("Signing certificate");
+
+        let mut builder = X509::builder()?;
+        builder.set_version(2)?;
+        let serial_number = {
+            let mut serial = BigNum::new()?;
+            serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+            serial.to_asn1_integer()?
+        };
+        builder.set_serial_number(&serial_number)?;
+        builder.set_subject_name(request.subject_name())?;
+        builder.set_issuer_name(self.root_certificate.subject_name())?;
+        builder.set_pubkey(&request.public_key()?.as_ref())?;
+        let not_before = Asn1Time::days_from_now(0)?;
+        builder.set_not_before(&not_before)?;
+        let not_after = Asn1Time::days_from_now(365)?;
+        builder.set_not_after(&not_after)?;
+
+        builder.append_extension(BasicConstraints::new().build()?)?;
+
+        builder.append_extension(
+            KeyUsage::new()
+                .critical()
+                .non_repudiation()
+                .digital_signature()
+                .key_encipherment()
+                .build()?,
+        )?;
+
+        let subject_key_identifier = SubjectKeyIdentifier::new()
+            .build(&builder.x509v3_context(Some(&self.root_certificate), None))?;
+        builder.append_extension(subject_key_identifier)?;
+
+        let auth_key_identifier = AuthorityKeyIdentifier::new()
+            .keyid(false)
+            .issuer(false)
+            .build(&builder.x509v3_context(Some(&self.root_certificate), None))?;
+        builder.append_extension(auth_key_identifier)?;
+
+        // Add X.509 extensions from the certificate signing request.
+        for extension in request.extensions()?.iter() {
+            builder.append_extension2(extension)?;
+        }
+
+        let tee_quote_extension = Quote::new(tee_quote).build()?;
+        builder.append_extension(tee_quote_extension)?;
+
+        builder.sign(&self.key_pair, MessageDigest::sha256())?;
+        let certificate = builder.build();
+
+        Ok(certificate)
+    }
+}

--- a/experimental/proxy_attestation/src/lib.rs
+++ b/experimental/proxy_attestation/src/lib.rs
@@ -1,0 +1,19 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub mod proto {
+    tonic::include_proto!("oak.examples.proxy_attestation");
+}

--- a/experimental/proxy_attestation/src/main.rs
+++ b/experimental/proxy_attestation/src/main.rs
@@ -1,0 +1,181 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Proxy Attestation Service implementation.
+//!
+//! Proxy Attestation Service works as a Certificate Authority for TEE applications. It attests
+//! applications and creates signed certificates for TEE applications, which they use to create TLS
+//! connections with clients.
+//!
+//! The work cycle of the proxy is represented in 2 stages.
+//! First stage corresponds to the backend server attestation:
+//! - TEE application connects to the proxy
+//! - Proxy attests the application using a corresponding remote attestation protocol
+//! - Application sends the proxy a certificate signing request
+//! - Proxy creates a signed certificate and sends it back to the application
+//!     - The certificate contains application's TEE measurements
+//!
+//! Second stage corresponds to the client connection:
+//! - Client remotely attests the proxy using a corresponding attestation protocol
+//! - Proxy sends the client its root certificate
+//!     - Client trusts that this is a correct certificate, since it was sent via a secure channel
+//!       created during the attestation process
+//! - Client connects to the application using TLS, and the application uses a TLS certificate
+//!   previously signed by the proxy
+//! - Client checks that the certificate was signed by the root certificate and also checks TEE
+//!   measurements
+//! - If all checks were successful, client establishes a secure connection
+//!
+//! Note: Current version of Remote Attestation Service doesn't have remote attestation.
+
+mod certificate;
+
+use crate::certificate::CertificateAuthority;
+use anyhow::Context;
+use futures::future::FutureExt;
+use log::{error, info};
+use oak_proxy_attestation::proto::{
+    proxy_attestation_server::{ProxyAttestation, ProxyAttestationServer},
+    GetRootCertificateRequest, GetRootCertificateResponse, GetSignedCertificateRequest,
+    GetSignedCertificateResponse,
+};
+use openssl::x509::X509Req;
+use structopt::StructOpt;
+use tonic::{
+    transport::{Identity, Server, ServerTlsConfig},
+    Request, Response, Status,
+};
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "Proxy Attestation")]
+pub struct Opt {
+    #[structopt(long, help = "Private RSA key PEM encoded file used by gRPC server.")]
+    grpc_tls_private_key: String,
+    #[structopt(
+        long,
+        help = "PEM encoded X.509 TLS certificate file used by gRPC server."
+    )]
+    grpc_tls_certificate: String,
+}
+
+const TEST_TEE_QUOTE: &str = "Test TEE quote";
+
+/// Placeholder function for collecting quotes of remotely attested TEEs.
+fn get_tee_quote(_req: &Request<GetSignedCertificateRequest>) -> String {
+    // TODO(#1867): Add remote attestation support.
+    TEST_TEE_QUOTE.to_string()
+}
+
+pub struct Proxy {
+    certificate_authority: CertificateAuthority,
+}
+
+impl Proxy {
+    fn new() -> Self {
+        Self {
+            certificate_authority: CertificateAuthority::new(),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl ProxyAttestation for Proxy {
+    /// Creates a signed X.509 certificate based on the certificate signing request.
+    async fn get_signed_certificate(
+        &self,
+        req: Request<GetSignedCertificateRequest>,
+    ) -> Result<Response<GetSignedCertificateResponse>, Status> {
+        info!("Received certificate sign request");
+        let tee_quote = get_tee_quote(&req);
+        let certificate_request = X509Req::from_pem(&req.into_inner().certificate_request)
+            .map_err(|error| {
+                let msg = "Certificate deserialize certificate request";
+                error!("{}: {}", msg, error);
+                Status::invalid_argument(msg)
+            })?;
+        match self
+            .certificate_authority
+            .sign_certificate(certificate_request, &tee_quote)
+        {
+            Ok(certificate) => match certificate.to_pem() {
+                Ok(serialized_certificate) => {
+                    info!("Sending signed certificate");
+                    let mut res = GetSignedCertificateResponse::default();
+                    res.certificate = serialized_certificate;
+                    Ok(Response::new(res))
+                }
+                Err(error) => {
+                    let msg = "Certificate serialization error";
+                    error!("{}: {}", msg, error);
+                    Err(Status::internal(msg))
+                }
+            },
+            Err(error) => {
+                let msg = "Certificate signing error";
+                error!("{}: {}", msg, error);
+                Err(Status::internal(msg))
+            }
+        }
+    }
+
+    /// Sends back root X.509 certificate in PEM format.
+    /// https://tools.ietf.org/html/rfc7468
+    async fn get_root_certificate(
+        &self,
+        _req: Request<GetRootCertificateRequest>,
+    ) -> Result<Response<GetRootCertificateResponse>, Status> {
+        info!("Received root certificate request");
+        match self.certificate_authority.root_certificate.to_pem() {
+            Ok(serialized_certificate) => {
+                info!("Sending root certificate");
+                let mut res = GetRootCertificateResponse::default();
+                res.root_certificate = serialized_certificate;
+                Ok(Response::new(res))
+            }
+            Err(error) => {
+                let msg = "Certificate serialization error";
+                error!("{}: {}", msg, error);
+                Err(Status::internal(msg))
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let opt = Opt::from_args();
+
+    let private_key =
+        std::fs::read(&opt.grpc_tls_private_key).context("Couldn't load private key")?;
+    let certificate =
+        std::fs::read(&opt.grpc_tls_certificate).context("Couldn't load certificate")?;
+
+    let identity = Identity::from_pem(certificate, private_key);
+    let address = "[::]:8888".parse().context("Couldn't parse address")?;
+
+    // Create proxy attestation gRPC server.
+    info!("Starting proxy attestation server at {:?}", address);
+    Server::builder()
+        .tls_config(ServerTlsConfig::new().identity(identity))
+        .context("Couldn't create TLS configuration")?
+        .add_service(ProxyAttestationServer::new(Proxy::new()))
+        .serve_with_shutdown(address, tokio::signal::ctrl_c().map(|r| r.unwrap()))
+        .await
+        .context("Couldn't start server")?;
+
+    Ok(())
+}

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -1395,17 +1395,40 @@ dependencies = [
  "anyhow",
  "env_logger",
  "hex",
+ "http",
  "log",
  "maplit",
  "oak_abi",
+ "oak_proxy_attestation",
  "oak_runtime",
  "oak_sign",
+ "openssl",
  "prost",
  "rustls",
  "serde",
  "signal-hook",
  "structopt",
+ "tokio",
  "toml",
+ "tonic",
+]
+
+[[package]]
+name = "oak_proxy_attestation"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "http",
+ "log",
+ "oak_utils",
+ "openssl",
+ "prost",
+ "structopt",
+ "tokio",
  "tonic",
 ]
 
@@ -1536,6 +1559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.13.0+1.1.1i"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045e4dc48af57aad93d665885789b43222ae26f4886494da12d1ed58d309dcb6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1576,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/oak_loader/Cargo.toml
+++ b/oak_loader/Cargo.toml
@@ -16,22 +16,29 @@ license = "Apache-2.0"
 awskms = ["oak_runtime/awskms"]
 oak_debug = ["oak_runtime/oak_debug"]
 oak_introspection_client = ["oak_runtime/oak_introspection_client"]
+oak_attestation = ["oak_proxy_attestation", "openssl"]
 default = ["oak_debug"]
 
 [dependencies]
 anyhow = "*"
 env_logger = "*"
 hex = "*"
+http = "*"
 log = "*"
 oak_abi = { path = "../oak_abi" }
 oak_runtime = { path = "../oak_runtime", default-features = false }
+oak_proxy_attestation = { path = "../experimental/proxy_attestation", optional = true }
 oak_sign = { path = "../oak_sign" }
+# `vendored` is necessary to build `openssl` for MUSL.
+# https://github.com/sfackler/rust-openssl/issues/1376
+openssl = { version = "*", features = ["vendored"], optional = true }
 prost = { path = "../third_party/prost" }
 rustls = "*"
 serde = { version = "*", features = ["derive"] }
 signal-hook = "*"
 structopt = "*"
 toml = "*"
+tokio = { version = "0.2", features = ["fs", "macros", "sync", "stream"] }
 tonic = { version = "*", features = ["tls"] }
 
 [dev-dependencies]

--- a/oak_loader/src/attestation.rs
+++ b/oak_loader/src/attestation.rs
@@ -1,0 +1,115 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::Context;
+use http::uri::Uri;
+use log::info;
+use oak_proxy_attestation::proto::{
+    proxy_attestation_client::ProxyAttestationClient, GetSignedCertificateRequest,
+};
+use openssl::{
+    hash::MessageDigest,
+    pkey::{PKey, Private},
+    rsa::Rsa,
+    x509::{X509NameBuilder, X509ReqBuilder},
+};
+use tonic::{
+    transport::{Certificate, Channel, ClientTlsConfig, Identity},
+    Request,
+};
+
+const RSA_KEY_SIZE: u32 = 2048;
+
+/// Creates an X.509 certificate signing request and sends it to the Proxy Attestation Service.
+/// After receiving back a signed certificate, creates TLS [`Identity`].
+pub async fn get_tls_identity_from_proxy(
+    uri: &Uri,
+    root_tls_certificate: &[u8],
+) -> anyhow::Result<Identity> {
+    // Create certificate signing request and a corresponding private/public key pair.
+    let rsa_key_pair = Rsa::generate(RSA_KEY_SIZE)?;
+    let private_key = rsa_key_pair.private_key_to_pem()?.to_vec();
+    let key_pair = PKey::from_rsa(rsa_key_pair)?;
+    let certificate_request = create_certificate_request(&key_pair)?;
+
+    // Request a signed certificate from the Proxy Attestation Service.
+    info!(
+        "Sending certificate signing request to Proxy Attestation Service: {:?}",
+        uri
+    );
+    let mut client = create_proxy_client(&uri, &root_tls_certificate)
+        .await
+        .context("Couldn't create gRPC client")?;
+    let request = Request::new(GetSignedCertificateRequest {
+        certificate_request,
+    });
+    let response = client
+        .get_signed_certificate(request)
+        .await
+        .context("Couldn't get signed certificate")?;
+    let certificate = response.get_ref().certificate.to_vec();
+    info!("Received signed certificate from Proxy Attestation Service");
+
+    Ok(Identity::from_pem(&certificate, &private_key))
+}
+
+/// Creates an X.509 certificate signing request.
+/// https://tools.ietf.org/html/rfc5280
+///
+/// TODO(#1869): Load certificate signing request from a PEM file.
+fn create_certificate_request(key_pair: &PKey<Private>) -> anyhow::Result<Vec<u8>> {
+    let mut builder = X509ReqBuilder::new()?;
+    builder.set_pubkey(&key_pair)?;
+
+    let mut name = X509NameBuilder::new()?;
+    name.append_entry_by_text("O", "Oak")?;
+    name.append_entry_by_text("CN", "Example Application")?;
+    let name = name.build();
+    builder.set_subject_name(&name)?;
+
+    use openssl::{stack::Stack, x509::extension::SubjectAlternativeName};
+    let mut extensions = Stack::new()?;
+    let subject_alt_name = SubjectAlternativeName::new()
+        .dns("project-oak.local")
+        .dns("localhost")
+        .ip("127.0.0.1")
+        .ip("::1")
+        .build(&builder.x509v3_context(None))?;
+    extensions.push(subject_alt_name)?;
+    builder.add_extensions(&extensions)?;
+
+    builder.sign(&key_pair, MessageDigest::sha256())?;
+    let request = builder.build();
+    request
+        .to_pem()
+        .context("Couldn't create PEM encoded certificate request")
+}
+
+/// Creates TLS client for connecting to the Proxy Attestation Service.
+async fn create_proxy_client(
+    uri: &Uri,
+    root_tls_certificate: &[u8],
+) -> anyhow::Result<ProxyAttestationClient<Channel>> {
+    let tls_config =
+        ClientTlsConfig::new().ca_certificate(Certificate::from_pem(root_tls_certificate.to_vec()));
+    let channel = Channel::builder(uri.clone())
+        .tls_config(tls_config)
+        .context("Couldn't create TLS configuration")?
+        .connect()
+        .await
+        .context("Couldn't connect to Oak Application")?;
+    Ok(ProxyAttestationClient::new(channel))
+}

--- a/oak_loader/src/main.rs
+++ b/oak_loader/src/main.rs
@@ -28,6 +28,8 @@
 //! ```
 
 use anyhow::Context;
+#[cfg(feature = "oak_attestation")]
+pub mod attestation;
 use log::info;
 mod options;
 use oak_runtime::config::configure_and_run;
@@ -41,7 +43,8 @@ use std::sync::{
 mod tests;
 
 /// Main execution point for the Oak loader.
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     if cfg!(feature = "oak_debug") {
         env_logger::init();
     } else {
@@ -49,7 +52,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Create Runtime config.
-    let runtime_configuration = create_runtime_config()?;
+    let runtime_configuration = create_runtime_config().await?;
 
     // Start the Runtime from the given config.
     info!("starting Runtime");

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -113,8 +113,9 @@ pub enum ServerVariant {
     Base,
     Coverage,
     Logless,
-    NoIntrospectionClient,
     Kms,
+    NoIntrospectionClient,
+    Experimental,
 }
 
 impl std::str::FromStr for ServerVariant {
@@ -126,6 +127,7 @@ impl std::str::FromStr for ServerVariant {
             "logless" => Ok(ServerVariant::Logless),
             "kms" => Ok(ServerVariant::Kms),
             "no-introspection-client" => Ok(ServerVariant::NoIntrospectionClient),
+            "experimental" => Ok(ServerVariant::Experimental),
             _ => Err(format!("Failed to parse server variant {}", variant)),
         }
     }
@@ -135,8 +137,8 @@ impl std::str::FromStr for ServerVariant {
 pub struct BuildServer {
     #[structopt(
         long,
-        help = "server variant: [base, coverage, logless, no-introspection-client]",
-        default_value = "base"
+        help = "server variant: [base, coverage, logless, no-introspection-client, experimental]",
+        default_value = "experimental"
     )]
     pub server_variant: ServerVariant,
     #[structopt(

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -271,7 +271,7 @@ fn build_server(opt: &BuildServer) -> Step {
                 ),
             }],
             match opt.server_variant {
-                ServerVariant::Base | ServerVariant::Coverage | ServerVariant::Kms => vec![Step::Single {
+                ServerVariant::Base | ServerVariant::Coverage | ServerVariant::Kms | ServerVariant::Experimental => vec![Step::Single {
                     name: "build introspection browser client".to_string(),
                     command: Cmd::new("npm",
                                       vec![

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -317,9 +317,13 @@ fn build_server(opt: &BuildServer) -> Step {
                                 format!("--target={}", opt.server_rust_target.as_deref().unwrap_or(DEFAULT_SERVER_RUST_TARGET)),
                                 "--release".to_string(),
                             ],
-                        // If building in coverage mode, use the default target from the host, and build
-                        // in debug mode.
+                            // If building in coverage mode, use the default target from the host, and build
+                            // in debug mode.
                             ServerVariant::Coverage => vec!["--features=oak_introspection_client".to_string()],
+                            ServerVariant::Experimental => vec!["--features=oak_attestation,oak_introspection_client".to_string(),
+                                format!("--target={}", opt.server_rust_target.as_deref().unwrap_or(DEFAULT_SERVER_RUST_TARGET)),
+                                "--release".to_string(),
+                            ],
                         },
                     ],
                     &if opt.server_variant == ServerVariant::Coverage {
@@ -419,6 +423,11 @@ fn run_ci() -> Step {
                 server_rust_toolchain: None,
                 server_rust_target: None,
             }),
+            build_server(&BuildServer {
+                server_variant: ServerVariant::Experimental,
+                server_rust_toolchain: None,
+                server_rust_target: None,
+            }),
             run_tests(),
             run_tests_tsan(),
             run_examples(&RunExamples {
@@ -435,7 +444,7 @@ fn run_ci() -> Step {
                     client_rust_target: None,
                 },
                 build_server: BuildServer {
-                    server_variant: ServerVariant::Base,
+                    server_variant: ServerVariant::Experimental,
                     server_rust_toolchain: None,
                     server_rust_target: None,
                 },


### PR DESCRIPTION
This change adds Proxy Attestation example.
It consists of:
- `experimental/proxy_attestation`: CA that can create signed certificates based on certificate signing requests
- `examples/proxy_attestation/client`: Client that can request the CA root certificate and use it to connect to an Oak application
- `examples/proxy_attestation/module`: Simple example Oak application

Certificate signing requests are created by `oak_loader`.

Fixes https://github.com/project-oak/oak/issues/1860
Ref https://github.com/project-oak/oak/issues/1374