### PR TITLE
Add linear-handles feature to oak_io

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -69,6 +69,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "abitest_linear_handles"
+version = "0.1.0"
+dependencies = [
+ "oak_abi",
+ "oak_io",
+]
+
+[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "abitest/grpc",
   "abitest/module_0/rust",
   "abitest/module_1/rust",
+  "abitest/module_linear_handles/rust",
   "aggregator/backend",
   "aggregator/grpc",
   "aggregator/common",

--- a/examples/abitest/example.toml
+++ b/examples/abitest/example.toml
@@ -9,6 +9,7 @@ out = "examples/abitest/bin/abitest.oak"
 [applications.rust.modules]
 module_0 = { Cargo = { cargo_manifest = "examples/abitest/module_0/rust/Cargo.toml" } }
 module_1 = { Cargo = { cargo_manifest = "examples/abitest/module_1/rust/Cargo.toml" } }
+module_linear_handles = { Cargo = { cargo_manifest = "examples/abitest/module_linear_handles/rust/Cargo.toml" } }
 
 [clients]
 cpp = { Bazel = { bazel_target = "//examples/abitest/client/cpp:client" }, additional_args = [

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -888,7 +888,7 @@ impl FrontendNode {
         oak::channel_write(init_wh, &[], &[result_wh.handle])
             .expect("Failed to write result handle");
 
-        // the linear_handles module should return a single result message (without handles), its
+        // The linear_handles module should return a single result message (without handles), its
         // body a string containing the test result.
         let mut buf = Vec::new();
         let mut handles = Vec::new();

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -50,6 +50,7 @@ const FRONTEND_MODULE_NAME: &str = "frontend_module";
 const BACKEND_MODULE_NAME: &str = "backend_module";
 const BACKEND_ENTRYPOINT_NAME: &str = "backend_oak_main";
 const STORAGE_NAME_PREFIX: &str = "abitest";
+const LINEAR_HANDLES_MODULE_NAME: &str = "linear_handles_module";
 
 // Distinct listening addresses to avoid port-in-use errors
 const HTTP_ADDR: &str = "[::]:8383";
@@ -233,6 +234,10 @@ impl OakAbiTestService for FrontendNode {
         tests.insert(
             "HandleCloneRaw",
             (Self::test_handle_clone_raw, Count::Unchanged),
+        );
+        tests.insert(
+            "LinearHandles",
+            (Self::test_linear_handles, Count::Unchanged),
         );
         tests.insert(
             "ChannelReadRaw",
@@ -859,6 +864,45 @@ impl FrontendNode {
         }
         expect_eq!(Ok(()), oak::channel_close(w));
         expect_eq!(Ok(()), oak::channel_close(r));
+        Ok(())
+    }
+
+    fn test_linear_handles(&mut self) -> TestResult {
+        let (init_wh, init_rh) =
+            oak::channel_create("linear_handle_init", &Label::public_untrusted()).unwrap();
+        // The actual tests run in a separate node, as that code must be compiled with oak_io
+        // feature linear-handles enabled
+        oak::node_create(
+            "linear_handles",
+            &oak::node_config::wasm(LINEAR_HANDLES_MODULE_NAME, "linear_handles_oak_main"),
+            &Label::public_untrusted(),
+            init_rh,
+        )
+        .expect("failed to create linear_handles Node");
+
+        let (result_wh, result_rh) =
+            oak::channel_create("linear_handle_result", &Label::public_untrusted()).unwrap();
+
+        // The linear_handles module expects to read a single init message with exactly one handle:
+        // a write handle to return the result message in.
+        oak::channel_write(init_wh, &[], &[result_wh.handle])
+            .expect("Failed to write result handle");
+
+        // the linear_handles module should return a single result message (without handles), its
+        // body a string containing the test result.
+        let mut buf = Vec::new();
+        let mut handles = Vec::new();
+        oak::wait_on_channels(&[result_rh]).expect("Channel did not become readable");
+        oak::channel_read(result_rh, &mut buf, &mut handles).expect("Failed to read response");
+        let msg = String::from_utf8(buf).expect("Response message is not valid UTF8");
+        // "OK" if all tests passed, the error message otherwise.
+        expect_eq!(msg, "OK");
+
+        expect_eq!(Ok(()), oak::channel_close(init_wh.handle));
+        expect_eq!(Ok(()), oak::channel_close(init_rh.handle));
+        expect_eq!(Ok(()), oak::channel_close(result_wh.handle));
+        expect_eq!(Ok(()), oak::channel_close(result_rh.handle));
+
         Ok(())
     }
 

--- a/examples/abitest/module_0/rust/tests/integration_test.rs
+++ b/examples/abitest/module_0/rust/tests/integration_test.rs
@@ -27,18 +27,22 @@ use std::{collections::HashMap, sync::Arc};
 // config held in ../../../config.
 const FRONTEND_MODULE_NAME: &str = "frontend_module";
 const BACKEND_MODULE_NAME: &str = "backend_module";
+const LINEAR_HANDLES_MODULE_NAME: &str = "linear_handles_module";
 const FRONTEND_ENTRYPOINT_NAME: &str = "frontend_oak_main";
 
 const FRONTEND_MANIFEST: &str = "../../module_0/rust/Cargo.toml";
 const BACKEND_MANIFEST: &str = "../../module_1/rust/Cargo.toml";
+const LINEAR_HANDLES_MANIFEST: &str = "../../module_linear_handles/rust/Cargo.toml";
 
 const FRONTEND_MODULE_WASM_FILE_NAME: &str = "abitest_0_frontend.wasm";
 const BACKEND_MODULE_WASM_FILE_NAME: &str = "abitest_1_backend.wasm";
+const LINEAR_HANDLES_MODULE_WASM_FILE_NAME: &str = "abitest_linear_handles.wasm";
 
 fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
         FRONTEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, FRONTEND_MODULE_WASM_FILE_NAME, oak_tests::Profile::Debug).context("could not compile frontend module")?,
         BACKEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(BACKEND_MANIFEST, BACKEND_MODULE_WASM_FILE_NAME, oak_tests::Profile::Debug).context("could not compile backend module")?,
+        LINEAR_HANDLES_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(LINEAR_HANDLES_MANIFEST, LINEAR_HANDLES_MODULE_WASM_FILE_NAME, oak_tests::Profile::Debug).context("could not compile linear_handles module")?,
     })
 }
 

--- a/examples/abitest/module_linear_handles/rust/Cargo.toml
+++ b/examples/abitest/module_linear_handles/rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "abitest_linear_handles"
+version = "0.1.0"
+authors = ["Daan de Graaf <daagra@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+oak_abi = "=0.1.0"
+oak_io = { version = "=0.1.0", features = ["linear-handles"] }

--- a/examples/abitest/module_linear_handles/rust/src/lib.rs
+++ b/examples/abitest/module_linear_handles/rust/src/lib.rs
@@ -1,0 +1,198 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// Tests the linear-handles feature in `oak_io`.
+// Note: This environment is very bare. the Oak SDK does not support linear handles, so we can
+// only use the ABI and `oak_io`
+use oak_abi::proto::oak::label::Label;
+use oak_io::{
+    handle::{ReadHandle, WriteHandle},
+    OakStatus,
+};
+
+fn run_tests() {
+    test_cloned_handles_are_valid_and_distinct();
+
+    test_original_and_clone_are_connected();
+
+    test_drop_closes_handle();
+}
+
+fn test_cloned_handles_are_valid_and_distinct() {
+    let (w, r) = channel_create().expect("Failed to create channel");
+    let w2 = w.clone();
+    let r2 = r.clone();
+
+    // Check that the handles are not invalid
+    assert!(w2.handle != oak_abi::INVALID_HANDLE);
+    assert!(r2.handle != oak_abi::INVALID_HANDLE);
+    // Check that the handles are distinct from the original ones
+    assert!(w.handle != w2.handle);
+    assert!(r.handle != r2.handle);
+}
+
+// Writes from the cloned handle should be readable from the original, and vice versa
+fn test_original_and_clone_are_connected() {
+    let (w, r) = channel_create().expect("Failed to create channel");
+    let w2 = w.clone();
+    let r2 = r.clone();
+
+    // Write from original, read from clone
+    channel_write(&w, "msg1").expect("Failed to write to w");
+    let msg1 = channel_read(&r2).expect("Failed to read from r2");
+    assert_eq!(msg1, "msg1");
+
+    // Write from clone, read from original
+    channel_write(&w2, "msg2").expect("Failed to write to w2");
+    let msg2 = channel_read(&r).expect("Failed to read from r");
+    assert_eq!(msg2, "msg2");
+}
+
+fn test_drop_closes_handle() {
+    let (w, r) = channel_create().expect("Failed to create channel");
+    assert_eq!(channel_read(&r), Err(OakStatus::ErrChannelEmpty));
+
+    // Explicitly drop the handle
+    core::mem::drop(w);
+
+    // Channel is now orphaned
+    assert_eq!(channel_read(&r), Err(OakStatus::ErrChannelClosed));
+}
+
+#[no_mangle]
+pub extern "C" fn linear_handles_oak_main(init_handle: u64) {
+    let _ = std::panic::catch_unwind(|| {
+        // Set up a panic handler that reports errors to the parent node
+        std::panic::set_hook(Box::new(move |panic_info| {
+            let message = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+                s.to_owned()
+            } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+                s
+            } else {
+                "<no message available>"
+            };
+            let location = if let Some(location) = panic_info.location() {
+                format!("{}:{}", location.file(), location.line())
+            } else {
+                "<location unavailable>".to_string()
+            };
+            write_result(
+                init_handle,
+                &format!(
+                    "panic in linear handles module at ({}), message: {}",
+                    location, message
+                ),
+            );
+        }));
+        run_tests();
+
+        write_result(init_handle, "OK");
+    });
+}
+
+fn write_result(init_handle: u64, msg: &str) {
+    let buf = msg.as_bytes();
+    let mut _actual_size = 0u32;
+    let mut _actual_handle_count = 0u32;
+    let mut result_handle = 0u64;
+
+    unsafe {
+        oak_abi::channel_read(
+            init_handle,
+            0 as *mut u8,
+            0,
+            &mut _actual_size as *mut u32,
+            &mut result_handle as *mut u64 as *mut u8,
+            1,
+            &mut _actual_handle_count as *mut u32,
+        );
+
+        oak_abi::channel_write(
+            result_handle,
+            buf.as_ptr() as *const u8,
+            buf.len(),
+            0 as *const u8,
+            0,
+        );
+    }
+}
+
+fn channel_read(r: &ReadHandle) -> Result<String, OakStatus> {
+    const BUF_LEN: usize = 256;
+    let mut buf = [0u8; BUF_LEN];
+    let mut actual_size = 0u32;
+    let mut _actual_handle_count = 0u32;
+
+    let result = unsafe {
+        oak_abi::channel_read(
+            r.handle,
+            &mut buf[0] as *mut u8,
+            BUF_LEN,
+            &mut actual_size as *mut u32,
+            0 as *mut u8,
+            0,
+            &mut _actual_handle_count as *mut u32,
+        )
+    };
+    let result = OakStatus::from_i32(result as i32).unwrap();
+    match result {
+        OakStatus::Ok => Ok(String::from_utf8_lossy(&buf[..(actual_size as usize)]).into_owned()),
+        e => Err(e),
+    }
+}
+
+fn channel_write(w: &WriteHandle, msg: &str) -> Result<(), OakStatus> {
+    let result = unsafe {
+        oak_abi::channel_write(
+            w.handle,
+            msg.as_ptr() as *const u8,
+            msg.len(),
+            0 as *const u8,
+            0,
+        )
+    };
+    let result = OakStatus::from_i32(result as i32).unwrap();
+    match result {
+        OakStatus::Ok => Ok(()),
+        e => Err(e),
+    }
+}
+
+fn channel_create() -> Result<(WriteHandle, ReadHandle), OakStatus> {
+    let mut w = WriteHandle {
+        handle: oak_abi::INVALID_HANDLE,
+    };
+    let mut r = ReadHandle {
+        handle: oak_abi::INVALID_HANDLE,
+    };
+    let name_bytes = "test_channel".as_bytes();
+    let label_bytes = Label::public_untrusted().serialize();
+    let result = unsafe {
+        oak_abi::channel_create(
+            &mut w.handle as *mut u64,
+            &mut r.handle as *mut u64,
+            name_bytes.as_ptr(),
+            name_bytes.len(),
+            label_bytes.as_ptr(),
+            label_bytes.len(),
+        )
+    };
+    let result = OakStatus::from_i32(result as i32).unwrap();
+    match result {
+        OakStatus::Ok => Ok((w, r)),
+        e => Err(e),
+    }
+}

--- a/examples/abitest/oak_app_manifest.toml
+++ b/examples/abitest/oak_app_manifest.toml
@@ -3,6 +3,7 @@ name = "abitest"
 [modules]
 frontend_module = { path = "examples/abitest/bin/abitest_0_frontend.wasm" }
 backend_module = { path = "examples/abitest/bin/abitest_1_backend.wasm" }
+linear_handles_module = { path = "examples/abitest/bin/abitest_linear_handles.wasm" }
 
 [initial_node_configuration]
 wasm_module_name = "frontend_module"

--- a/oak_io/Cargo.toml
+++ b/oak_io/Cargo.toml
@@ -7,11 +7,18 @@ authors = ["Conrad Grobler <grobler@google.com>"]
 edition = "2018"
 license = "Apache-2.0"
 
+[features]
 # Make handles linear.
 # At the expense of making them non-copy, this causes handles to be
 # automaticaly dropped, so that channels cannot accidentally linger on.
-[features]
 linear-handles = []
+# For crates that explicitly do NOT support linear-handles yet (e.g. Oak SDK)
+# If this crate is compiled with both features, linear-handles suppport is
+# disabled.
+# When compiling individual crates this would not be needed, but compiling an
+# entire workspace with just one crate enabling 'linear-handles' will also
+# enable it for all crates in that workspace, due to a quirk in Cargo.
+no-linear-handles = []
 
 [dependencies]
 hex = "*"

--- a/oak_io/Cargo.toml
+++ b/oak_io/Cargo.toml
@@ -7,6 +7,12 @@ authors = ["Conrad Grobler <grobler@google.com>"]
 edition = "2018"
 license = "Apache-2.0"
 
+# Make handles linear.
+# At the expense of making them non-copy, this causes handles to be
+# automaticaly dropped, so that channels cannot accidentally linger on.
+[features]
+linear-handles = []
+
 [dependencies]
 hex = "*"
 oak_abi = { path = "../oak_abi" }

--- a/oak_io/src/handle.rs
+++ b/oak_io/src/handle.rs
@@ -22,7 +22,8 @@ use oak_abi::Handle;
 /// Wrapper for a handle to the read half of a channel.
 ///
 /// For use when the underlying [`Handle`] is known to be for a receive half.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(not(feature = "linear-handles"), derive(Copy, Clone))]
 pub struct ReadHandle {
     pub handle: Handle,
 }
@@ -42,7 +43,8 @@ impl From<Handle> for ReadHandle {
 /// Wrapper for a handle to the send half of a channel.
 ///
 /// For use when the underlying [`Handle`] is known to be for a send half.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(not(feature = "linear-handles"), derive(Copy, Clone))]
 pub struct WriteHandle {
     pub handle: Handle,
 }
@@ -56,6 +58,67 @@ impl std::fmt::Debug for WriteHandle {
 impl From<Handle> for WriteHandle {
     fn from(handle: Handle) -> Self {
         WriteHandle { handle }
+    }
+}
+
+/// Provides implementations of `Clone` and `Drop` for handle types, based on the `handle_clone` and
+/// `channel_close` ABI syscalls, respectively.
+#[cfg(feature = "linear-handles")]
+mod linear_handles {
+    use super::*;
+    use crate::OakStatus;
+    use log::trace;
+
+    /// Creates a new distinct handle using `oak_abi::clone_handle`
+    impl Clone for ReadHandle {
+        fn clone(&self) -> Self {
+            Self {
+                handle: clone_handle(self.handle),
+            }
+        }
+    }
+
+    /// Creates a new distinct handle using `oak_abi::clone_handle`
+    impl Clone for WriteHandle {
+        fn clone(&self) -> Self {
+            Self {
+                handle: clone_handle(self.handle),
+            }
+        }
+    }
+
+    /// Closes the handle using `oak_abi::channel_close`
+    impl Drop for ReadHandle {
+        fn drop(&mut self) {
+            drop_handle(self.handle);
+        }
+    }
+
+    /// Closes the handle using `oak_abi::channel_close`
+    impl Drop for WriteHandle {
+        fn drop(&mut self) {
+            drop_handle(self.handle);
+        }
+    }
+
+    fn clone_handle(handle: Handle) -> Handle {
+        let mut cloned_handle = 0;
+        let result = OakStatus::from_i32(unsafe {
+            oak_abi::handle_clone(handle, &mut cloned_handle as *mut Handle) as i32
+        })
+        .expect("handle_clone returned invalid oak status");
+        if result != OakStatus::Ok {
+            panic!("Failed to clone handle: {:?}", result);
+        }
+        cloned_handle
+    }
+
+    fn drop_handle(handle: Handle) {
+        // The channel may have already been closed, or it may be invalid due to extracting it for
+        // serialization, so we only log errors here (and at the lowest priority).
+        trace!("Drop handle {}: {}", handle, unsafe {
+            oak_abi::channel_close(handle)
+        });
     }
 }
 

--- a/oak_io/src/receiver.rs
+++ b/oak_io/src/receiver.rs
@@ -26,7 +26,8 @@ use prost::{
 /// For use when the underlying [`Handle`] is known to be for a receive half.
 ///
 /// [`Handle`]: crate::Handle
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
+#[cfg_attr(not(feature = "linear-handles"), derive(Copy))]
 pub struct Receiver<T: Decodable> {
     pub handle: ReadHandle,
     phantom: std::marker::PhantomData<T>,

--- a/oak_io/src/sender.rs
+++ b/oak_io/src/sender.rs
@@ -26,7 +26,8 @@ use prost::{
 /// For use when the underlying [`Handle`] is known to be for a send half.
 ///
 /// [`Handle`]: crate::Handle
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(not(feature = "linear-handles"), derive(Copy))]
 pub struct Sender<T: Encodable> {
     pub handle: WriteHandle,
     phantom: std::marker::PhantomData<T>,

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -1516,7 +1516,7 @@ dependencies = [
  "serde",
  "signal-hook",
  "structopt",
- "tokio",
+ "tokio 0.2.23",
  "toml",
  "tonic",
 ]
@@ -1536,7 +1536,7 @@ dependencies = [
  "openssl",
  "prost",
  "structopt",
- "tokio",
+ "tokio 0.2.23",
  "tonic",
 ]
 

--- a/sdk/rust/oak/Cargo.toml
+++ b/sdk/rust/oak/Cargo.toml
@@ -12,7 +12,7 @@ http = "*"
 log = { version = "*", features = ["std"] }
 oak_abi = "=0.1.0"
 oak_derive = { path = "../../../oak_derive" }
-oak_io = "=0.1.0"
+oak_io = { version = "=0.1.0", features = ["no-linear-handles"] }
 oak_services = "=0.1.0"
 prost = "*"
 prost-types = "*"


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [x] Pull request includes prototype/experimental work that is under
      construction.

The feature enables what I hope will eventually be the default behaviour for handles. Roughly speaking, this does 3 things:
- Make handles non-`Copy`
- Add a `Clone` impl that calls `oak_abi::handle_clone`
- Add a `Drop` impl that calls `oak_abi::channel_close`

This builds on #1782.
Related issue: #1686. It is step (3) in https://github.com/project-oak/oak/issues/1686#issuecomment-765351586.