### PR TITLE
Remove unused tools to free up CI disk space

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,6 @@ jobs:
       - name: Free disk space
         run: |
           df --human-readable
-          sudo swapoff --all
-          sudo rm --force /swapfile
           sudo apt clean
           docker rmi $(docker image ls --all --quiet)
           rm --recursive --force "$AGENT_TOOLSDIRECTORY"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v2
 
       # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
+      # and https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
       - name: Free disk space
         run: |
           df --human-readable
@@ -39,6 +40,7 @@ jobs:
           sudo rm --force /swapfile
           sudo apt clean
           docker rmi $(docker image ls --all --quiet)
+          rm -rf "$AGENT_TOOLSDIRECTORY"
           df --human-readable
 
       # Build Docker image, caching from the latest version from the remote repository.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
           sudo rm --force /swapfile
           sudo apt clean
           docker rmi $(docker image ls --all --quiet)
-          rm -rf "$AGENT_TOOLSDIRECTORY"
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
           df --human-readable
 
       # Build Docker image, caching from the latest version from the remote repository.


### PR DESCRIPTION
Currently it seems our CI workflow is running out of space. 
Some PRs where this is happening:

https://github.com/project-oak/oak/pull/1843
https://github.com/project-oak/oak/pull/1846
https://github.com/project-oak/oak/pull/1857

This tries to patch it by removing some prebuilt tools included by GitHub to free up more space. 
An approach recommend here: https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
And used by big repos such as https://github.com/facebook/proxygen

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
