### PR TITLE
Leaks

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -309,7 +309,7 @@ This command generates a signature file `signature.sign` containing a public
 key, a signature of the Wasm module SHA-256 hash (also encoded with PEM) and a
 Wasm module SHA-256 hash itself.
 
-Wasm module signatures are specified as part of the Oak apllication manifest.
+Wasm module signatures are specified as part of the Oak application manifest.
 The application manifest can contain locations of signature manifest files. Each
 signature manifest file contains the locations of signature files for signed Oak
 Wasm modules. Also, since each module can be signed by multiple entities, each

--- a/examples/aggregator/client/android/cpp/client.cc
+++ b/examples/aggregator/client/android/cpp/client.cc
@@ -55,7 +55,7 @@ JNIEXPORT void JNICALL Java_com_google_oak_aggregator_MainActivity_createChannel
   // The particular value corresponds to the hash on the `aggregator.wasm` line in
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975"));
+      absl::HexStringToBytes("6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7"));
   kChannel = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
   JNI_LOG("gRPC channel has been created");

--- a/examples/aggregator/client/cpp/aggregator.cc
+++ b/examples/aggregator/client/cpp/aggregator.cc
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   // TODO(#1674): Add appropriate TLS endpoint tag to the label as well.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975"));
+      absl::HexStringToBytes("6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7"));
   // Connect to the Oak Application.
   auto stub = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));

--- a/examples/aggregator/config.toml
+++ b/examples/aggregator/config.toml
@@ -1,3 +1,3 @@
 grpc_server_listen_address = "[::]:8080"
 backend_server_address = "https://localhost:8888"
-aggregator_module_hash = "3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975"
+aggregator_module_hash = "6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7"

--- a/examples/aggregator/oak_app_manifest.toml
+++ b/examples/aggregator/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "aggregator"
 
 [modules]
-app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975", sha256 = "3fe9708f70d8b63c51ed9c179928f7a48e2d92fcd90e6a4bf87e1572838e2975" } }
+app = { external = { url = "https://storage.googleapis.com/oak-modules/aggregator/6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7", sha256 = "6ec12d5b2631efc2f30b6377a0ad0075e432165752dc360f5354bf9eebc535a7" } }

--- a/examples/chat/module/rust/src/lib.rs
+++ b/examples/chat/module/rust/src/lib.rs
@@ -118,7 +118,7 @@ impl oak::CommandHandler for Router {
         // The router node has a public confidentiality label, and therefore cannot read the
         // contents of the request of the invocation (unless it happens to be public as well), but
         // it can always inspect its label.
-        match (&command.receiver, &command.sender) {
+        let result = match (&command.receiver, &command.sender) {
             (Some(receiver), Some(sender)) => {
                 let label = receiver.label()?;
                 let grpc_response_writer = oak::grpc::ChannelResponseWriter::new(sender.clone());
@@ -150,7 +150,9 @@ impl oak::CommandHandler for Router {
             _ => {
                 anyhow::bail!("received malformed gRPC invocation");
             }
-        }
+        };
+        command.close()?;
+        result
     }
 }
 

--- a/examples/hello_world/module/rust/src/lib.rs
+++ b/examples/hello_world/module/rust/src/lib.rs
@@ -118,8 +118,10 @@ impl CommandHandler for Router {
             },
         )
         .context("Couldn't create handler node")?;
-        handler_invocation_sender
+        let result = handler_invocation_sender
             .send(&invocation)
-            .context("Couldn't send invocation to handler node")
+            .context("Couldn't send invocation to handler node");
+        invocation.close()?;
+        result
     }
 }

--- a/examples/http_server/module/src/lib.rs
+++ b/examples/http_server/module/src/lib.rs
@@ -266,7 +266,8 @@ impl CommandHandler for RedirectHelper {
     type Command = RedirectInvocation;
 
     fn handle_command(&mut self, invocation: RedirectInvocation) -> anyhow::Result<()> {
-        let request = invocation.request_receiver.unwrap().receive()?;
+        let request = invocation.request_receiver.as_ref().unwrap().receive()?;
+        invocation.request_receiver.unwrap().close()?;
         let client_invocation = invocation.http_invocation_source.unwrap();
         let uri = request.uri.parse::<http::Uri>()?;
 

--- a/examples/private_set_intersection/README.md
+++ b/examples/private_set_intersection/README.md
@@ -2,6 +2,9 @@
 
 ## To update this example
 
+This example requires a valid signature of the `handler` module. So, whenever
+the code is modified, the wasm module and the signature must be regenerated:
+
 1. Build the example, including the Wasm module
 1. Push the module to GS via
    `./scripts/push_example -e private_set_intersection`

--- a/examples/private_set_intersection/oak_app_manifest.toml
+++ b/examples/private_set_intersection/oak_app_manifest.toml
@@ -6,4 +6,4 @@ signature_manifests = [
 [modules]
 app = { path = "examples/private_set_intersection/bin/private_set_intersection.wasm" }
 # TODO(865): Use locally built module once reproducibility is fixed.
-handler = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection_handler/ab7e2c01769472c9283d014285343a5e357f0b313372bc4f24b41d0ca5013549", sha256 = "ab7e2c01769472c9283d014285343a5e357f0b313372bc4f24b41d0ca5013549" } }
+handler = { external = { url = "https://storage.googleapis.com/oak-modules/private_set_intersection_handler/f04989bf7db987b00a8a2f4f1ea72b8d415392749b9a44660cb5e1c52135c94e", sha256 = "f04989bf7db987b00a8a2f4f1ea72b8d415392749b9a44660cb5e1c52135c94e" } }

--- a/examples/private_set_intersection/private_set_intersection_handler.sign
+++ b/examples/private_set_intersection/private_set_intersection_handler.sign
@@ -3,10 +3,10 @@ f41SClNtR4i46v2Tuh1fQLbt/ZqRr1lENajCW92jyP4=
 -----END PUBLIC KEY-----
 
 -----BEGIN SIGNATURE-----
-6tIedbmPjPq9Awwgdwktfs0UZA0YYex1luPGuoRxuv/UYVZATPuPlq11hqnRZ+JH
-tMw6TtvrFALN/hKRXJcSBw==
+FYdRH9iIqQSIpcZFFkenfFMtSQGteYGfB4fPlSpcMAugNa+hq7sdMgyzVYef8XJ+
+xsZQiYgeHuqbA2CPYHDTBA==
 -----END SIGNATURE-----
 
 -----BEGIN HASH-----
-q34sAXaUcskoPQFChTQ6XjV/CzEzcrxPJLQdDKUBNUk=
+8EmJv325h7AKii9PHqcrjUFTknSbmkRmDLXhxSE1yU4=
 -----END HASH-----

--- a/examples/translator/module/rust/src/lib.rs
+++ b/examples/translator/module/rust/src/lib.rs
@@ -86,9 +86,11 @@ impl CommandHandler for Router {
             self.init.clone(),
         )
         .context("Couldn't create handler node")?;
-        handler_invocation_sender
+        let ret = handler_invocation_sender
             .send(&invocation)
-            .context("Couldn't send invocation to handler node")
+            .context("Couldn't send invocation to handler node");
+        invocation.close()?;
+        ret
     }
 }
 

--- a/examples/trusted_database/module/rust/src/router.rs
+++ b/examples/trusted_database/module/rust/src/router.rs
@@ -56,9 +56,11 @@ impl CommandHandler for Router {
             self.init.clone(),
         )
         .context("Couldn't create handler node")?;
-        handler_invocation_sender
+        let result = handler_invocation_sender
             .send(&invocation)
-            .context("Couldn't send invocation to handler node")
+            .context("Couldn't send invocation to handler node");
+        invocation.close()?;
+        result
     }
 }
 

--- a/oak_runtime/src/node/http/tests.rs
+++ b/oak_runtime/src/node/http/tests.rs
@@ -794,7 +794,7 @@ impl Node for ClientTesterNode {
             .expect("Couldn't insert HTTP request in the pipe");
 
         // send the invocation to the HTTP client pseudo-node
-        pipe.send_invocation(&runtime, invocation_sender.handle.handle)
+        pipe.send_invocation(&runtime, invocation_sender.handle)
             .expect("Couldn't send the invocation");
 
         // wait for the response to come

--- a/oak_runtime/src/node/http/util.rs
+++ b/oak_runtime/src/node/http/util.rs
@@ -73,16 +73,14 @@ impl Pipe {
     pub fn send_invocation(
         &self,
         runtime: &RuntimeProxy,
-        invocation_channel: oak_abi::Handle,
+        invocation_channel: WriteHandle,
     ) -> anyhow::Result<()> {
         // Create an invocation containing request-specific channels.
         let invocation = HttpInvocation {
             receiver: Some(self.request_receiver.clone()),
             sender: Some(self.response_sender.clone()),
         };
-        let invocation_sender = crate::io::Sender::new(WriteHandle {
-            handle: invocation_channel,
-        });
+        let invocation_sender = crate::io::Sender::new(invocation_channel);
         invocation_sender
             .send_with_downgrade(invocation, runtime)
             .context("Couldn't write the invocation message")

--- a/sdk/rust/oak/src/grpc/mod.rs
+++ b/sdk/rust/oak/src/grpc/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     io::{ReceiverExt, SenderExt},
     OakError, OakStatus,
 };
+use anyhow::Context;
 use log::{error, warn};
 use oak_abi::label::Label;
 use oak_services::proto::google::rpc;
@@ -36,6 +37,19 @@ pub mod server;
 /// [`Status`]: oak_services::proto::google::rpc::Status
 pub type Result<T> = std::result::Result<T, rpc::Status>;
 pub type Invocation = crate::proto::oak::invocation::GrpcInvocation;
+
+impl Invocation {
+    pub fn close(self) -> anyhow::Result<()> {
+        self.receiver
+            .expect("Couldn't get receiver")
+            .close()
+            .context("Couldn't close the receiver")?;
+        self.sender
+            .expect("Couldn't get sender")
+            .close()
+            .context("Couldn't close the sender")
+    }
+}
 
 /// Helper to create a gRPC status object.
 pub fn build_status(code: rpc::Code, msg: &str) -> rpc::Status {

--- a/sdk/rust/oak/src/lib.rs
+++ b/sdk/rust/oak/src/lib.rs
@@ -764,6 +764,7 @@ macro_rules! entrypoint_command_handler_init {
             use ::oak::io::ReceiverExt;
             use ::oak::WithInit;
             let init_wrapper = receiver.receive().expect("could not receive init");
+            receiver.close().expect("could not close the receiver channel");
             let instance = <$handler>::create(init_wrapper.init);
             ::oak::run_command_loop(instance, init_wrapper.command_receiver.iter());
         });


### PR DESCRIPTION
Closes `sender` and `receiver` channels in various places, including in the examples. 

Fixes the problem of orphaned channels reported in #1866, as well as #1718. 
The problem unused/leaked nodes in #1866 will be fixed separately. For that we need a new function similar to `run_command_loop `
https://github.com/project-oak/oak/blob/61ecb0b2a07eac2f39cadee196c4463d4ce694ca/sdk/rust/oak/src/lib.rs#L564
except that it would handle only one command.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [x] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
