### PR TITLE
runtime: include label in channel half info

### DIFF
--- a/oak_runtime/src/channel.rs
+++ b/oak_runtime/src/channel.rs
@@ -199,9 +199,10 @@ impl std::fmt::Debug for ChannelHalf {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Channel {} ('{}') {}",
+            "Channel {} ('{}', label={:?}) {}",
             self.channel.id,
             self.channel.name,
+            self.channel.label,
             match self.direction {
                 ChannelHalfDirection::Write => "WRITE",
                 ChannelHalfDirection::Read => "READ",


### PR DESCRIPTION
This makes the label information for channels visible in the
introspection graph.

# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
