### PR TITLE
Generate docs for oak_client

### DIFF
--- a/oak_client/Cargo.lock
+++ b/oak_client/Cargo.lock
@@ -653,12 +653,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
-
-[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,7 +1023,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "mio",
- "pin-project-lite 0.1.11",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -1055,7 +1049,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1282,13 +1276,12 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.22"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "log",
- "pin-project-lite 0.2.0",
  "tracing-attributes",
  "tracing-core",
 ]

--- a/scripts/build_gh_pages
+++ b/scripts/build_gh_pages
@@ -35,6 +35,7 @@ readonly TARGET_ABS_PATH="$(realpath "${TARGET_DIR}")"
 # All the dirs that we want to generate docs for.
 declare -ar SOURCE_PATHS=(
   'oak_abi'
+  'oak_client'
   'oak_derive'
   'oak_io'
   'oak_loader'
@@ -47,6 +48,7 @@ declare -ar SOURCE_PATHS=(
 )
 declare -ar TARGET_SUBDIRS=(
   'oak_abi'
+  'oak_client'
   'oak_derive'
   'oak_io'
   'oak_loader'
@@ -61,6 +63,7 @@ declare -ar TARGET_SUBDIRS=(
 # Titles used in the top-level index.html files.
 declare -ar PAGE_TITLES=(
   'ABI'
+  'Client'
   'Derive'
   'IO'
   'Loader'

--- a/scripts/common
+++ b/scripts/common
@@ -22,6 +22,7 @@ declare -ar ALL_CRATES=(
   examples
   experimental
   oak_abi
+  oak_client
   oak_derive
   oak_io
   oak_loader


### PR DESCRIPTION
This change adds `oak_client` to Bash scripts that generate and check Rust docs.