### PR TITLE
Centralize node privilege assignment

### DIFF
--- a/oak_runtime/src/node/crypto/mod.rs
+++ b/oak_runtime/src/node/crypto/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     io::{Receiver, ReceiverExt},
     node::invocation::InvocationExt,
     proto::oak::invocation::GrpcInvocation as Invocation,
-    NodePrivilege, RuntimeProxy,
+    RuntimeProxy,
 };
 use log::{debug, error, info};
 use oak_abi::OakStatus;
@@ -174,13 +174,6 @@ impl CryptoNode {
 impl super::Node for CryptoNode {
     fn node_type(&self) -> &'static str {
         "crypto"
-    }
-
-    fn get_privilege(&self) -> NodePrivilege {
-        NodePrivilege::default()
-        // TODO(#1842): sort out IFC interactions so that the crypto pseudo-Node can receive
-        // labelled plaintext data and emit unlabelled encrypted data (which would probably
-        // mean top_privilege() goes here).
     }
 
     /// Main execution loop for the crypto pseudo-Node.

--- a/oak_runtime/src/node/grpc/server/mod.rs
+++ b/oak_runtime/src/node/grpc/server/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     metrics::Metrics,
     node::{
         grpc::{codec::VecCodec, to_tonic_status},
-        ConfigurationError, Node, NodePrivilege,
+        ConfigurationError, Node,
     },
     proto::oak::invocation::{GrpcInvocation, GrpcInvocationSender},
     RuntimeProxy,
@@ -128,14 +128,6 @@ impl GrpcServerNode {
 impl Node for GrpcServerNode {
     fn node_type(&self) -> &'static str {
         "grpc-server"
-    }
-
-    fn get_privilege(&self) -> NodePrivilege {
-        // This node needs to have `top` privilege to be able to declassify data tagged with any
-        // arbitrary user identities.
-        // TODO(#1631): When we have a separate top for each sub-lattice, this should be changed to
-        // the top of the identity sub-lattice.
-        NodePrivilege::top_privilege()
     }
 
     fn run(

--- a/oak_runtime/src/node/http/server.rs
+++ b/oak_runtime/src/node/http/server.rs
@@ -21,7 +21,7 @@
 
 use crate::{
     io::ReceiverExt,
-    node::{http::util::Pipe, ConfigurationError, Node, NodePrivilege},
+    node::{http::util::Pipe, ConfigurationError, Node},
     proto::oak::invocation::HttpInvocationSender,
     RuntimeProxy,
 };
@@ -210,14 +210,6 @@ impl HttpServerNode {
 impl Node for HttpServerNode {
     fn node_type(&self) -> &'static str {
         "http-server"
-    }
-
-    fn get_privilege(&self) -> NodePrivilege {
-        // This node needs to have `top` privilege to be able to declassify data tagged with any
-        // arbitrary user identities.
-        // TODO(#1631): When we have a separate top for each sub-lattice, this should be changed to
-        // the top of the `identity` sub-lattice.
-        NodePrivilege::top_privilege()
     }
 
     fn run(

--- a/oak_runtime/src/node/logger.rs
+++ b/oak_runtime/src/node/logger.rs
@@ -18,7 +18,7 @@
 
 use crate::{
     io::{Receiver, ReceiverExt},
-    NodePrivilege, RuntimeProxy,
+    RuntimeProxy,
 };
 use log::{error, info, warn};
 use oak_abi::OakStatus;
@@ -44,18 +44,6 @@ impl LogNode {
 impl super::Node for LogNode {
     fn node_type(&self) -> &'static str {
         "logger"
-    }
-
-    #[cfg(feature = "oak_unsafe")]
-    fn get_privilege(&self) -> NodePrivilege {
-        // Allow the logger Node to declassify log messages in debug builds only.
-        NodePrivilege::top_privilege()
-    }
-
-    #[cfg(not(feature = "oak_unsafe"))]
-    fn get_privilege(&self) -> NodePrivilege {
-        // The logger must not have any declassification privilege in non-debug builds.
-        NodePrivilege::default()
     }
 
     /// Main execution loop for the logging pseudo-Node just waits for incoming


### PR DESCRIPTION
Note to reviewers: please double check I am not mixing up privileges for
the various node types, thanks!

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
