### PR TITLE
Improve the use of features with server variants in the runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,14 +20,15 @@ jobs:
           - run-cargo-udeps
           - build-server --server-variant=unsafe
           - build-server --server-variant=base
-          - build-server --server-variant=kms
           - build-server --server-variant=experimental
           - run-tests
           - run-tests-tsan
           - run-examples --application-variant=rust
           - run-examples --application-variant=cpp
-          - run-examples --application-variant=rust --example-name=hello_world
+          - run-examples --application-variant=rust --example-name=abitest
             --build-docker
+          - run-examples --server-variant=base --application-variant=rust
+            --example-name=hello_world --build-docker
 
     steps:
       - name: Checkout branch

--- a/examples/abitest/module_0/rust/Cargo.toml
+++ b/examples/abitest/module_0/rust/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 crate-type = ["cdylib", "lib"]
 
 [features]
-default = ["oak_runtime/oak_unsafe"]
+default = ["oak_runtime/oak-unsafe"]
 
 [dependencies]
 abitest_common = { path = "../../abitest_common" }

--- a/examples/abitest/module_0/rust/src/lib.rs
+++ b/examples/abitest/module_0/rust/src/lib.rs
@@ -3155,7 +3155,7 @@ impl FrontendNode {
     }
 
     fn test_logger_pseudo_node_privilege(&mut self) -> TestResult {
-        // Logger pseudo node can be created with a non-public label when the `oak_unsafe` feature
+        // Logger pseudo node can be created with a non-public label when the `oak-unsafe` feature
         // is enabled.
         let label = oak_abi::label::confidentiality_label(oak_abi::label::tls_endpoint_tag(
             GRPC_CLIENT_ADDRESS

--- a/oak_loader/Cargo.toml
+++ b/oak_loader/Cargo.toml
@@ -15,9 +15,9 @@ license = "Apache-2.0"
 # https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
 awskms = ["oak_runtime/awskms"]
 gcpkms = ["oak_runtime/gcpkms"]
-oak_unsafe = ["oak_runtime/oak_unsafe"]
-oak_introspection_client = ["oak_runtime/oak_introspection_client"]
-oak_attestation = ["oak_proxy_attestation", "openssl"]
+oak-unsafe = ["oak_runtime/oak-unsafe"]
+oak-introspection-client = ["oak_runtime/oak-introspection-client"]
+oak-attestation = ["oak_proxy_attestation", "openssl"]
 default = []
 
 [dependencies]

--- a/oak_loader/src/main.rs
+++ b/oak_loader/src/main.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use anyhow::Context;
-#[cfg(feature = "oak_attestation")]
+#[cfg(feature = "oak-attestation")]
 pub mod attestation;
 use log::info;
 mod options;
@@ -45,7 +45,7 @@ mod tests;
 /// Main execution point for the Oak loader.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    if cfg!(feature = "oak_unsafe") {
+    if cfg!(feature = "oak-unsafe") {
         env_logger::init();
     } else {
         eprintln!("No debugging output configured at build time");

--- a/oak_runtime/Cargo.toml
+++ b/oak_runtime/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 license = "Apache-2.0"
 
 [features]
-oak_unsafe = ["regex"]
-oak_introspection_client = []
+oak-unsafe = ["regex"]
+oak-introspection-client = ["oak-unsafe"]
 awskms = ["tink-awskms"]
 gcpkms = ["tink-gcpkms"]
 default = []

--- a/oak_runtime/src/introspect.rs
+++ b/oak_runtime/src/introspect.rs
@@ -25,7 +25,7 @@ use prost::Message;
 use regex::Regex;
 use std::{net::SocketAddr, sync::Arc};
 
-#[cfg(not(feature = "oak_introspection_client"))]
+#[cfg(not(feature = "oak-introspection-client"))]
 mod introspection_client {
     use super::*;
 
@@ -34,7 +34,7 @@ mod introspection_client {
     }
 }
 
-#[cfg(feature = "oak_introspection_client")]
+#[cfg(feature = "oak-introspection-client")]
 mod introspection_client {
     use super::*;
     use hyper::header::CONTENT_ENCODING;

--- a/oak_runtime/src/introspection_events.rs
+++ b/oak_runtime/src/introspection_events.rs
@@ -16,7 +16,7 @@
 
 use crate::{proto::oak::introspection_events::event::EventDetails, Runtime};
 
-#[cfg(feature = "oak_unsafe")]
+#[cfg(feature = "oak-unsafe")]
 fn current_timestamp() -> prost_types::Timestamp {
     let duration_since_unix_epoch = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -32,7 +32,7 @@ fn current_timestamp() -> prost_types::Timestamp {
 impl Runtime {
     /// Generates an introspection event recording a modification to the Runtime's
     /// internal data structures
-    #[cfg(feature = "oak_unsafe")]
+    #[cfg(feature = "oak-unsafe")]
     pub fn introspection_event(&self, event_details: EventDetails) {
         let event = crate::proto::oak::introspection_events::Event {
             timestamp: Some(current_timestamp()),
@@ -46,6 +46,6 @@ impl Runtime {
     }
 
     /// no-op implementation, introspection events are a debugging feature.
-    #[cfg(not(feature = "oak_unsafe"))]
+    #[cfg(not(feature = "oak-unsafe"))]
     pub fn introspection_event(&self, _event_details: EventDetails) {}
 }

--- a/oak_runtime/src/lib.rs
+++ b/oak_runtime/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! # Features
 //!
-//! The `oak_unsafe` feature enables various debugging features, including
+//! The `oak-unsafe` feature enables various debugging features, including
 //! data structure introspection functionality. This feature should only
 //! be enabled in development, as it destroys the privacy guarantees of the
 //! platform by providing easy channels for the exfiltration of private data.
@@ -67,9 +67,9 @@ pub use proxy::RuntimeProxy;
 pub mod auth;
 mod channel;
 pub mod config;
-#[cfg(feature = "oak_unsafe")]
+#[cfg(feature = "oak-unsafe")]
 mod graph;
-#[cfg(feature = "oak_unsafe")]
+#[cfg(feature = "oak-unsafe")]
 mod introspect;
 mod introspection_events;
 mod io;

--- a/oak_runtime/src/node/http/tests.rs
+++ b/oak_runtime/src/node/http/tests.rs
@@ -203,7 +203,7 @@ fn init_logger() {
     let _res = env_logger::builder().is_test(true).try_init();
 }
 
-#[cfg(not(feature = "oak_unsafe"))]
+#[cfg(not(feature = "oak-unsafe"))]
 #[test]
 fn test_cannot_create_server_node_if_not_permitted() {
     init_logger();
@@ -212,7 +212,7 @@ fn test_cannot_create_server_node_if_not_permitted() {
     assert!(result.is_err())
 }
 
-#[cfg(not(feature = "oak_unsafe"))]
+#[cfg(not(feature = "oak-unsafe"))]
 #[test]
 fn test_cannot_create_insecure_http_client_node_if_not_permitted() {
     init_logger();

--- a/oak_runtime/src/node/logger.rs
+++ b/oak_runtime/src/node/logger.rs
@@ -60,7 +60,7 @@ impl super::Node for LogNode {
                 Ok(msg) => {
                     // Log messages that arrive from Oak applications over a logging channel
                     // are controlled by IFC, and so need to be emitted independently of
-                    // whether the Runtime has been built with the `oak_unsafe` feature
+                    // whether the Runtime has been built with the `oak-unsafe` feature
                     // enabled (and thus whether log! is connected up to anything or not).
                     // So send to stderr.
                     let now: chrono::DateTime<chrono::Utc> = chrono::Utc::now();

--- a/oak_runtime/src/node/mod.rs
+++ b/oak_runtime/src/node/mod.rs
@@ -155,11 +155,11 @@ impl NodeFactory<NodeConfiguration> for ServerNodeFactory {
                 instance: Box::new(logger::LogNode::new(node_name)),
 
                 // Allow the logger Node to declassify log messages in debug builds only.
-                #[cfg(feature = "oak_unsafe")]
+                #[cfg(feature = "oak-unsafe")]
                 privilege: NodePrivilege::top_privilege(),
 
                 // The logger must not have any declassification privilege in non-debug builds.
-                #[cfg(not(feature = "oak_unsafe"))]
+                #[cfg(not(feature = "oak-unsafe"))]
                 privilege: NodePrivilege::default(),
             }),
             Some(ConfigType::GrpcServerConfig(config)) => {

--- a/oak_runtime/src/permissions.rs
+++ b/oak_runtime/src/permissions.rs
@@ -57,10 +57,10 @@ pub struct PermissionsConfiguration {
 
 impl PermissionsConfiguration {
     /// Check if this permissions configuration allows creating a node with the given node
-    /// configuration. This check is disabled when `oak_unsafe` is enabled. In that case, this
+    /// configuration. This check is disabled when `oak-unsafe` is enabled. In that case, this
     /// function returns `true` regardless of the node configuration.
     pub fn allowed_creation(&self, node_configuration: &NodeConfiguration) -> anyhow::Result<bool> {
-        if cfg!(feature = "oak_unsafe") {
+        if cfg!(feature = "oak-unsafe") {
             Ok(true)
         } else {
             match &node_configuration.config_type {

--- a/oak_runtime/src/proxy.rs
+++ b/oak_runtime/src/proxy.rs
@@ -123,7 +123,7 @@ impl RuntimeProxy {
             .runtime_health_check
             .set(1);
 
-        #[cfg(feature = "oak_unsafe")]
+        #[cfg(feature = "oak-unsafe")]
         if let Some(port) = runtime_configuration.introspect_port {
             self.runtime
                 .aux_servers

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -110,12 +110,16 @@ pub struct BuildClient {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ServerVariant {
+    /// Production-like server variant, without any of the features enabled
     Base,
-    Coverage,
-    Experimental,
-    Kms,
-    NoIntrospectionClient,
+    /// Debug server with logging and introspection client enabled
     Unsafe,
+    /// Debug server with logging, but no introspection client
+    NoIntrospectionClient,
+    /// Similar to Unsafe, but with additional commands for running coverage
+    Coverage,
+    /// Debug server, with logging, introspection client, and experimental features enabled
+    Experimental,
 }
 
 impl std::str::FromStr for ServerVariant {
@@ -124,7 +128,6 @@ impl std::str::FromStr for ServerVariant {
         match variant {
             "base" => Ok(ServerVariant::Base),
             "coverage" => Ok(ServerVariant::Coverage),
-            "kms" => Ok(ServerVariant::Kms),
             "no-introspection-client" => Ok(ServerVariant::NoIntrospectionClient),
             "experimental" => Ok(ServerVariant::Experimental),
             "unsafe" => Ok(ServerVariant::Unsafe),

--- a/sdk/rust/oak/src/logger/mod.rs
+++ b/sdk/rust/oak/src/logger/mod.rs
@@ -86,7 +86,7 @@ pub fn init(log_sender: Sender<LogMessage>, level: Level) -> Result<(), SetLogge
 
 pub fn create() -> Result<Sender<LogMessage>, OakStatus> {
     // If we get a permission-denied error when creating the logger Node with top secret
-    // confidentiality it means that the Runtime was not built with the `oak_unsafe` feature, so
+    // confidentiality it means that the Runtime was not built with the `oak-unsafe` feature, so
     // we try to create it as a public Node.
     for label in &[confidentiality_label(top()), Label::public_untrusted()] {
         match crate::io::node_create("log", &label, &crate::node_config::log()) {


### PR DESCRIPTION
* `kebab-case` seems to be more conventional for feature names, so the feature names are updated
* Merges `kms` and `experimental` server variants in the runner
* Adds doc comments for server variants
* Adds a new step to `run_ci` and github CI for running the `hello_world` example with the base server and a permissions file. 