### PR TITLE
Add Rust Proxy Attestation client

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -259,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "assert_matches"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,7 +361,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
 dependencies = [
  "funty",
- "radium",
+ "radium 0.4.1",
+ "wyz",
+]
+
+[[package]]
+name = "bitvec"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+dependencies = [
+ "funty",
+ "radium 0.5.3",
+ "tap",
  "wyz",
 ]
 
@@ -605,6 +623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
 name = "dbl"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +644,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
 dependencies = [
  "const-oid",
+]
+
+[[package]]
+name = "der-oid-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd17d13ecf875e704369fdbde242483ac769fc18f6af21e43d5a692a079732fc"
+dependencies = [
+ "nom",
+ "num-bigint 0.3.1",
+ "num-traits",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "der-parser"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4b1e27396f46037881c39d821660f2ff48797aaa7152a45ded7a93b368a819"
+dependencies = [
+ "der-oid-macro",
+ "nom",
+ "num-bigint 0.3.1",
+ "num-traits",
+ "proc-macro-hack",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -683,7 +733,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "592b1c857559479c056b73a3053c717108a70e4dce320ad28c79c63f5c2e62ba"
 dependencies = [
- "bitvec",
+ "bitvec 0.18.4",
  "digest",
  "ff",
  "generic-array",
@@ -726,7 +776,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
- "bitvec",
+ "bitvec 0.18.4",
  "rand_core",
  "subtle",
 ]
@@ -1279,6 +1329,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,10 +1480,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec 0.19.4",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1498,6 +1585,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_attestation_common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "openssl",
+ "serde",
+ "serde_json",
+ "sha2",
+ "x509-parser",
+]
+
+[[package]]
 name = "oak_client"
 version = "0.1.0"
 dependencies = [
@@ -1506,9 +1605,14 @@ dependencies = [
  "hyper",
  "log",
  "oak_abi",
+ "oak_attestation_common",
  "oak_sign",
  "prost",
+ "regex",
+ "tokio-rustls",
  "tonic",
+ "webpki",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1546,6 +1650,7 @@ dependencies = [
  "futures-util",
  "http",
  "log",
+ "oak_attestation_common",
  "oak_utils",
  "openssl",
  "prost",
@@ -1662,6 +1767,15 @@ dependencies = [
  "quote",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2508c8f170e55be68508b1113956a760a82684f42022f8834fb16ca198621211"
+dependencies = [
+ "der-parser",
 ]
 
 [[package]]
@@ -2152,6 +2266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
 
 [[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustls"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,6 +2438,12 @@ dependencies = [
  "sct",
  "webpki",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
 name = "ryu"
@@ -2455,7 +2590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
 dependencies = [
  "chrono",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-traits",
 ]
 
@@ -2488,6 +2623,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2547,6 +2688,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3530,6 +3677,26 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "x509-parser"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7999ae290e75ec1d4dc8e9ff9870e48e3542a8f2e9c1e2e07d7ca02b459e10"
+dependencies = [
+ "base64 0.13.0",
+ "chrono",
+ "data-encoding",
+ "der-oid-macro",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "num-bigint 0.3.1",
+ "oid-registry",
+ "rusticata-macros",
+ "rustversion",
+ "thiserror",
+]
 
 [[package]]
 name = "zeroize"

--- a/examples/proxy_attestation/client/rust/Cargo.toml
+++ b/examples/proxy_attestation/client/rust/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "*"
 http = "*"
 log = "*"
 oak_abi = "=0.1.0"
-oak_client = "=0.1.0"
+oak_client = { version = "=0.1.0", features = ["oak-attestation"] }
 oak_proxy_attestation = "*"
 oak_sign = "=0.1.0"
 pem = "*"

--- a/examples/proxy_attestation/module/rust/src/lib.rs
+++ b/examples/proxy_attestation/module/rust/src/lib.rs
@@ -39,6 +39,9 @@ use oak::{grpc, Label};
 use oak_abi::proto::oak::application::ConfigMap;
 use oak_services::proto::oak::log::LogInit;
 
+// Example message to send to the client.
+const EXAMPLE_MESSAGE: &str = "Example message";
+
 oak::entrypoint_command_handler!(oak_main => Main);
 
 #[derive(Default)]
@@ -89,7 +92,7 @@ impl ExampleApplication for Handler {
     ) -> grpc::Result<GetExampleMessageResponse> {
         info!("Received request");
         Ok(GetExampleMessageResponse {
-            message: "Example message".to_string(),
+            message: EXAMPLE_MESSAGE.to_string(),
         })
     }
 }

--- a/experimental/Cargo.lock
+++ b/experimental/Cargo.lock
@@ -123,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "assert_matches"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,7 +208,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
 dependencies = [
  "funty",
- "radium",
+ "radium 0.4.1",
+ "wyz",
+]
+
+[[package]]
+name = "bitvec"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+dependencies = [
+ "funty",
+ "radium 0.5.3",
+ "tap",
  "wyz",
 ]
 
@@ -407,12 +425,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
 name = "dbl"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2735145c3b9ba15f2d7a3ae8cdafcbc8c98a7bef7f62afe9d08bd99fbf7130de"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "der-oid-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd17d13ecf875e704369fdbde242483ac769fc18f6af21e43d5a692a079732fc"
+dependencies = [
+ "nom",
+ "num-bigint 0.3.1",
+ "num-traits",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "der-parser"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4b1e27396f46037881c39d821660f2ff48797aaa7152a45ded7a93b368a819"
+dependencies = [
+ "der-oid-macro",
+ "nom",
+ "num-bigint 0.3.1",
+ "num-traits",
+ "proc-macro-hack",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -476,7 +526,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b76528f382c916bbb94470b4e7ad107a3d01619503f7ffba86c93aea04e215"
 dependencies = [
- "bitvec",
+ "bitvec 0.18.4",
  "digest",
  "ff",
  "generic-array",
@@ -528,7 +578,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
- "bitvec",
+ "bitvec 0.18.4",
  "rand_core",
  "subtle",
 ]
@@ -988,6 +1038,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1203,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d521ee2250f619dd5e06515ba405858d249edc8fae9ddee2dba0695e57db01b"
+dependencies = [
+ "bitvec 0.19.4",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1228,17 @@ name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1243,6 +1329,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_attestation_common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "openssl",
+ "serde",
+ "serde_json",
+ "sha2",
+ "x509-parser",
+]
+
+[[package]]
 name = "oak_client"
 version = "0.1.0"
 dependencies = [
@@ -1291,6 +1390,7 @@ dependencies = [
  "futures-util",
  "http",
  "log",
+ "oak_attestation_common",
  "oak_utils",
  "openssl",
  "prost",
@@ -1406,6 +1506,15 @@ dependencies = [
  "quote",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2508c8f170e55be68508b1113956a760a82684f42022f8834fb16ca198621211"
+dependencies = [
+ "der-parser",
 ]
 
 [[package]]
@@ -1761,6 +1870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
 
 [[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +2022,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustls"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +2042,12 @@ dependencies = [
  "sct",
  "webpki",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
 name = "ryu"
@@ -2042,7 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
 dependencies = [
  "chrono",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-traits",
 ]
 
@@ -2111,6 +2241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2304,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3114,6 +3256,26 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "x509-parser"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7999ae290e75ec1d4dc8e9ff9870e48e3542a8f2e9c1e2e07d7ca02b459e10"
+dependencies = [
+ "base64 0.13.0",
+ "chrono",
+ "data-encoding",
+ "der-oid-macro",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "num-bigint 0.3.1",
+ "oid-registry",
+ "rusticata-macros",
+ "rustversion",
+ "thiserror",
+]
 
 [[package]]
 name = "zeroize"

--- a/experimental/Cargo.toml
+++ b/experimental/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "split_grpc/proxy",
   "split_grpc/server",
   "benchmark",
+  "attestation_common",
   "proxy_attestation",
 ]
 

--- a/experimental/attestation_common/Cargo.toml
+++ b/experimental/attestation_common/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "oak_attestation_common"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+name = "oak_attestation_common"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "*"
+openssl = "*"
+serde = { version = "*", features = ["derive"] }
+serde_json = "*"
+sha2 = "*"
+x509-parser = "*"
+
+[dev-dependencies]
+assert_matches = "*"

--- a/experimental/attestation_common/src/lib.rs
+++ b/experimental/attestation_common/src/lib.rs
@@ -29,7 +29,7 @@ pub const TEE_EXTENSION_OID: Oid<'static> = der_parser::oid!(2.16.840.1.113730.1
 
 /// Placeholder implementation of TEE report for remote attestation.
 /// https://www.amd.com/system/files/TechDocs/56860.pdf#page=39
-/// 
+///
 /// TODO(#1867): Add remote attestation support and use real TEE report.
 #[derive(Deserialize, Serialize, Debug, Default, PartialEq)]
 pub struct Report {

--- a/experimental/attestation_common/src/lib.rs
+++ b/experimental/attestation_common/src/lib.rs
@@ -1,0 +1,72 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#[cfg(test)]
+mod tests;
+
+use anyhow::Context;
+use openssl::{nid::Nid, x509::X509Extension};
+use serde::{Deserialize, Serialize};
+use x509_parser::der_parser::{self, oid::Oid};
+
+// Using `NETSCAPE_COMMENT` extension since `rust-openssl` doesn't support custom
+// extensions yet.
+// https://github.com/sfackler/rust-openssl/issues/1411
+// https://www.alvestrand.no/objectid/2.16.840.1.113730.1.13.html
+pub const TEE_EXTENSION_OID: Oid<'static> = der_parser::oid!(2.16.840.1.113730.1.13);
+
+/// Placeholder implementation of TEE report for remote attestation.
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct Report {
+    /// TEE measurement, i.e. VM hash.
+    pub measurement: Vec<u8>,
+    /// Arbitrary data to put into the TEE report.
+    pub data: Vec<u8>,
+}
+
+impl Report {
+    pub fn new(measurement: &[u8], data: &[u8]) -> Self {
+        Self {
+            measurement: measurement.to_vec(),
+            data: data.to_vec(),
+        }
+    }
+
+    pub fn from_string(input: &str) -> anyhow::Result<Self> {
+        serde_json::from_str(input).context("Couldn't deserialize TEE report")
+    }
+
+    pub fn to_string(&self) -> anyhow::Result<String> {
+        serde_json::to_string(&self).context("Couldn't serialize TEE report")
+    }
+
+    /// Return the TEE [`Report`] as a custom [`X509Extension`].
+    pub fn to_extension(&self) -> anyhow::Result<X509Extension> {
+        let report_string = self.to_string()?;
+        // [`Nid::NETSCAPE_COMMENT`] is a numerical identifier for an OpenSSL object that
+        // corresponds to an X.509 extension implementation.
+        X509Extension::new_nid(None, None, Nid::NETSCAPE_COMMENT, &report_string)
+            .context("Couldn't create X.509 extension")
+    }
+}
+
+/// Computes a SHA-256 digest of `input` and returns it in a form of raw bytes.
+pub fn get_sha256(input: &[u8]) -> Vec<u8> {
+    use sha2::digest::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(&input);
+    hasher.finalize().to_vec()
+}

--- a/experimental/attestation_common/src/lib.rs
+++ b/experimental/attestation_common/src/lib.rs
@@ -22,26 +22,37 @@ use openssl::{nid::Nid, x509::X509Extension};
 use serde::{Deserialize, Serialize};
 use x509_parser::der_parser::{self, oid::Oid};
 
-// Using `NETSCAPE_COMMENT` extension since `rust-openssl` doesn't support custom
-// extensions yet.
+// Using `NETSCAPE_COMMENT` extension since `rust-openssl` doesn't support custom extensions yet.
 // https://github.com/sfackler/rust-openssl/issues/1411
 // https://www.alvestrand.no/objectid/2.16.840.1.113730.1.13.html
 pub const TEE_EXTENSION_OID: Oid<'static> = der_parser::oid!(2.16.840.1.113730.1.13);
 
 /// Placeholder implementation of TEE report for remote attestation.
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+/// https://www.amd.com/system/files/TechDocs/56860.pdf#page=39
+/// 
+/// TODO(#1867): Add remote attestation support and use real TEE report.
+#[derive(Deserialize, Serialize, Debug, Default, PartialEq)]
 pub struct Report {
+    /// Version number of this attestation report.
+    pub version: u8,
+    /// Security version number of SNP firmware.
+    pub svn: u8,
+    /// The install version of firmware.
+    pub platform_version: u8,
+    /// Arbitrary data to put into the TEE report.
+    pub report_data: Vec<u8>,
     /// TEE measurement, i.e. VM hash.
     pub measurement: Vec<u8>,
-    /// Arbitrary data to put into the TEE report.
-    pub data: Vec<u8>,
+    /// Signature of this report.
+    pub signature: Vec<u8>,
 }
 
 impl Report {
     pub fn new(measurement: &[u8], data: &[u8]) -> Self {
         Self {
             measurement: measurement.to_vec(),
-            data: data.to_vec(),
+            report_data: data.to_vec(),
+            ..Default::default()
         }
     }
 

--- a/experimental/attestation_common/src/tests.rs
+++ b/experimental/attestation_common/src/tests.rs
@@ -19,6 +19,7 @@ use assert_matches::assert_matches;
 
 const TEST_TEE_MEASUREMENT: &str = "Test TEE measurement";
 const TEST_TEE_DATA: &str = "Test TEE data";
+const TEST_REPORT: &str = r#"{"measurement":[84,101,115,116,32,84,69,69,32,109,101,97,115,117,114,101,109,101,110,116],"data":[84,101,115,116,32,84,69,69,32,100,97,116,97]}"#;
 
 #[test]
 fn test_report_serialization() {
@@ -27,10 +28,10 @@ fn test_report_serialization() {
     let serialized_report_result = report.to_string();
     assert_matches!(serialized_report_result, Ok(_));
     let serialized_report = serialized_report_result.unwrap();
+    assert_eq!(serialized_report, TEST_REPORT);
 
-    let deserialized_report_result = Report::from_string(&serialized_report);
+    let deserialized_report_result = Report::from_string(TEST_REPORT);
     assert_matches!(deserialized_report_result, Ok(_));
     let deserialized_report = deserialized_report_result.unwrap();
-
-    assert_eq!(report, deserialized_report);
+    assert_eq!(deserialized_report, report);
 }

--- a/experimental/attestation_common/src/tests.rs
+++ b/experimental/attestation_common/src/tests.rs
@@ -1,0 +1,36 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::Report;
+use assert_matches::assert_matches;
+
+const TEST_TEE_MEASUREMENT: &str = "Test TEE measurement";
+const TEST_TEE_DATA: &str = "Test TEE data";
+
+#[test]
+fn test_report_serialization() {
+    let report = Report::new(TEST_TEE_MEASUREMENT.as_bytes(), TEST_TEE_DATA.as_bytes());
+
+    let serialized_report_result = report.to_string();
+    assert_matches!(serialized_report_result, Ok(_));
+    let serialized_report = serialized_report_result.unwrap();
+
+    let deserialized_report_result = Report::from_string(&serialized_report);
+    assert_matches!(deserialized_report_result, Ok(_));
+    let deserialized_report = deserialized_report_result.unwrap();
+
+    assert_eq!(report, deserialized_report);
+}

--- a/experimental/attestation_common/src/tests.rs
+++ b/experimental/attestation_common/src/tests.rs
@@ -17,9 +17,9 @@
 use crate::Report;
 use assert_matches::assert_matches;
 
-const TEST_TEE_MEASUREMENT: &str = "Test TEE measurement";
-const TEST_TEE_DATA: &str = "Test TEE data";
-const TEST_REPORT: &str = r#"{"measurement":[84,101,115,116,32,84,69,69,32,109,101,97,115,117,114,101,109,101,110,116],"data":[84,101,115,116,32,84,69,69,32,100,97,116,97]}"#;
+const TEST_TEE_MEASUREMENT: &str = "Measurement";
+const TEST_TEE_DATA: &str = "Data";
+const TEST_REPORT: &str = r#"{"version":0,"svn":0,"platform_version":0,"report_data":[68,97,116,97],"measurement":[77,101,97,115,117,114,101,109,101,110,116],"signature":[]}"#;
 
 #[test]
 fn test_report_serialization() {

--- a/experimental/proxy_attestation/Cargo.toml
+++ b/experimental/proxy_attestation/Cargo.toml
@@ -21,6 +21,7 @@ futures-core = "*"
 futures-util = "*"
 http = "*"
 log = "*"
+oak_attestation_common = { version = "*", path = "../attestation_common" }
 openssl = "*"
 prost = "*"
 structopt = "*"

--- a/experimental/proxy_attestation/src/certificate.rs
+++ b/experimental/proxy_attestation/src/certificate.rs
@@ -15,7 +15,7 @@
 //
 
 use log::info;
-use oak_attestation_common::{get_sha256, Report};
+use oak_attestation_common::Report;
 use openssl::{
     asn1::Asn1Time,
     bn::{BigNum, MsbOption},
@@ -106,7 +106,7 @@ impl CertificateAuthority {
     pub fn sign_certificate(
         &self,
         request: X509Req,
-        tee_measurement: &[u8],
+        tee_report: &Report,
     ) -> anyhow::Result<X509> {
         info!("Signing certificate");
 
@@ -152,8 +152,7 @@ impl CertificateAuthority {
             builder.append_extension2(extension)?;
         }
 
-        let public_key_hash = get_sha256(&request.public_key()?.public_key_to_pem()?);
-        let tee_report_extension = Report::new(tee_measurement, &public_key_hash).to_extension()?;
+        let tee_report_extension = tee_report.to_extension()?;
         builder.append_extension(tee_report_extension)?;
 
         builder.sign(&self.key_pair, MessageDigest::sha256())?;

--- a/experimental/proxy_attestation/src/certificate.rs
+++ b/experimental/proxy_attestation/src/certificate.rs
@@ -103,11 +103,7 @@ impl CertificateAuthority {
     }
 
     /// Create an X509 certificate based on the certificate signing `request`.
-    pub fn sign_certificate(
-        &self,
-        request: X509Req,
-        tee_report: &Report,
-    ) -> anyhow::Result<X509> {
+    pub fn sign_certificate(&self, request: X509Req, tee_report: &Report) -> anyhow::Result<X509> {
         info!("Signing certificate");
 
         let mut builder = X509::builder()?;

--- a/experimental/proxy_attestation/src/certificate.rs
+++ b/experimental/proxy_attestation/src/certificate.rs
@@ -15,17 +15,16 @@
 //
 
 use log::info;
+use oak_attestation_common::{get_sha256, Report};
 use openssl::{
     asn1::Asn1Time,
     bn::{BigNum, MsbOption},
-    error::ErrorStack,
     hash::MessageDigest,
-    nid::Nid,
     pkey::{PKey, Private},
     rsa::Rsa,
     x509::{
         extension::{AuthorityKeyIdentifier, BasicConstraints, KeyUsage, SubjectKeyIdentifier},
-        X509Extension, X509NameBuilder, X509Req, X509,
+        X509NameBuilder, X509Req, X509,
     },
 };
 
@@ -38,28 +37,6 @@ const CERTIFICATE_VERSION: i32 = 2;
 // the most significant bit.
 const SERIAL_NUMBER_SIZE: i32 = 159;
 const CERTIFICATE_EXPIRATION_INTERVAL_IN_DAYS: u32 = 1;
-
-/// Custom X.509 extension with a TEE application quote that was remotely attested by the Proxy
-/// Attestation Service.
-pub struct Quote {
-    value: String,
-}
-
-impl Quote {
-    pub fn new(value: &str) -> Self {
-        Self {
-            value: format!("Quote:{}", value.to_string()),
-        }
-    }
-
-    /// Return the [`Quote`] extension as an [`X509Extension`].
-    pub fn build(&self) -> Result<X509Extension, ErrorStack> {
-        // Using [`Nid::NETSCAPE_COMMENT`] identifier since `rust-openssl` doesn't support custom
-        // extensions yet:
-        // https://github.com/sfackler/rust-openssl/issues/1411
-        X509Extension::new_nid(None, None, Nid::NETSCAPE_COMMENT, &self.value)
-    }
-}
 
 /// Convenience structure for creating X.509 certificates.
 /// https://tools.ietf.org/html/rfc5280
@@ -126,7 +103,11 @@ impl CertificateAuthority {
     }
 
     /// Create an X509 certificate based on the certificate signing `request`.
-    pub fn sign_certificate(&self, request: X509Req, tee_quote: &str) -> anyhow::Result<X509> {
+    pub fn sign_certificate(
+        &self,
+        request: X509Req,
+        tee_measurement: &[u8],
+    ) -> anyhow::Result<X509> {
         info!("Signing certificate");
 
         let mut builder = X509::builder()?;
@@ -171,8 +152,9 @@ impl CertificateAuthority {
             builder.append_extension2(extension)?;
         }
 
-        let tee_quote_extension = Quote::new(tee_quote).build()?;
-        builder.append_extension(tee_quote_extension)?;
+        let public_key_hash = get_sha256(&request.public_key()?.public_key_to_pem()?);
+        let tee_report_extension = Report::new(tee_measurement, &public_key_hash).to_extension()?;
+        builder.append_extension(tee_report_extension)?;
 
         builder.sign(&self.key_pair, MessageDigest::sha256())?;
         let certificate = builder.build();

--- a/experimental/proxy_attestation/src/main.rs
+++ b/experimental/proxy_attestation/src/main.rs
@@ -77,7 +77,7 @@ const TEST_TEE_MEASUREMENT: &str = "Test TEE measurement";
 
 /// Placeholder function for collecting TEE measurement of remotely attested TEEs.
 fn get_example_tee_report() -> Report {
-    Report::new(TEST_TEE_MEASUREMENT.to_string().as_bytes(), &vec![])
+    Report::new(TEST_TEE_MEASUREMENT.to_string().as_bytes(), &[])
 }
 
 pub struct Proxy {

--- a/oak_client/Cargo.lock
+++ b/oak_client/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "assert_matches"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +104,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +155,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +184,38 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "der-oid-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd17d13ecf875e704369fdbde242483ac769fc18f6af21e43d5a692a079732fc"
+dependencies = [
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "der-parser"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4b1e27396f46037881c39d821660f2ff48797aaa7152a45ded7a93b368a819"
+dependencies = [
+ "der-oid-macro",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "proc-macro-hack",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "digest"
@@ -198,6 +258,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +287,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures-channel"
@@ -446,6 +527,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +609,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "oak_abi"
 version = "0.1.0"
 dependencies = [
@@ -526,6 +663,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_attestation_common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "openssl",
+ "serde",
+ "serde_json",
+ "sha2",
+ "x509-parser",
+]
+
+[[package]]
 name = "oak_client"
 version = "0.1.0"
 dependencies = [
@@ -534,9 +683,14 @@ dependencies = [
  "hyper",
  "log",
  "oak_abi",
+ "oak_attestation_common",
  "oak_sign",
  "prost",
+ "regex",
+ "tokio-rustls",
  "tonic",
+ "webpki",
+ "x509-parser",
 ]
 
 [[package]]
@@ -568,6 +722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2508c8f170e55be68508b1113956a760a82684f42022f8834fb16ca198621211"
+dependencies = [
+ "der-parser",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +741,33 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "pem"
@@ -659,6 +849,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +883,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -748,6 +950,12 @@ checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -849,6 +1057,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustls"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +1077,18 @@ dependencies = [
  "sct",
  "webpki",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "sct"
@@ -889,6 +1118,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -927,6 +1167,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -970,6 +1216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1251,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1353,6 +1625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,4 +1792,30 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "x509-parser"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7999ae290e75ec1d4dc8e9ff9870e48e3542a8f2e9c1e2e07d7ca02b459e10"
+dependencies = [
+ "base64 0.13.0",
+ "chrono",
+ "data-encoding",
+ "der-oid-macro",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "num-bigint",
+ "oid-registry",
+ "rusticata-macros",
+ "rustversion",
+ "thiserror",
 ]

--- a/oak_client/Cargo.toml
+++ b/oak_client/Cargo.toml
@@ -7,15 +7,31 @@ authors = ["Ivan Petrov <ivanpetrov@google.com>"]
 edition = "2018"
 license = "Apache-2.0"
 
+[features]
+oak-attestation = [
+  "oak_attestation_common",
+  "regex",
+  "tokio-rustls",
+  "x509-parser",
+  "webpki"
+]
+
 [dependencies]
 anyhow = "*"
 http = "*"
 hyper = "*"
 log = "*"
 oak_abi = { path = "../oak_abi" }
+oak_attestation_common = { path = "../experimental/attestation_common", optional = true }
 oak_sign = { path = "../oak_sign" }
 prost = "*"
+regex = { version = "*", optional = true }
+tokio-rustls = { version = "*", features = [
+  "dangerous_configuration"
+], optional = true }
 tonic = { version = "*", features = ["tls"] }
+x509-parser = { version = "*", optional = true }
+webpki = { version = "*", optional = true }
 
 # Patch dependencies on oak crates so that they refer to the versions within this same repository.
 #

--- a/oak_client/src/attestation.rs
+++ b/oak_client/src/attestation.rs
@@ -36,7 +36,6 @@ pub async fn create_attested_tls_channel(
         .await
         .context("Couldn't connect to Oak Application")
 }
-
 /// Create client TLS configuration with a custom X.509 certificate verifier.
 /// [`root_tls_certificate`] should contain only a single PEM encoded certificate.
 /// https://tools.ietf.org/html/rfc1421

--- a/oak_client/src/attestation.rs
+++ b/oak_client/src/attestation.rs
@@ -1,0 +1,158 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::{anyhow, Context};
+use http::uri::Uri;
+use oak_attestation_common::{Report, TEE_EXTENSION_OID};
+use tokio_rustls::rustls;
+use tonic::transport::{Channel, ClientTlsConfig};
+use x509_parser::{der_parser::der::parse_der, parse_x509_certificate};
+
+/// Creates a remotely attested TLS channel for connecting to Oak.
+pub async fn create_attested_tls_channel(
+    uri: &Uri,
+    root_tls_certificate: &[u8],
+    tee_measurement: &[u8],
+) -> anyhow::Result<Channel> {
+    let tls_config = create_tls_attestation_config(root_tls_certificate, tee_measurement)
+        .context("Couldn't create TLS config")?;
+    Channel::builder(uri.clone())
+        .tls_config(tls_config)
+        .context("Couldn't create TLS configuration")?
+        .connect()
+        .await
+        .context("Couldn't connect to Oak Application")
+}
+
+/// Create client TLS configuration with a custom X.509 certificate verifier.
+/// [`root_tls_certificate`] should contain only a single PEM encoded certificate.
+/// https://tools.ietf.org/html/rfc1421
+pub fn create_tls_attestation_config(
+    root_tls_certificate: &[u8],
+    tee_measurement: &[u8],
+) -> anyhow::Result<ClientTlsConfig> {
+    let mut config = rustls::ClientConfig::new();
+
+    // Configure ALPN to accept HTTP/2.
+    // https://tools.ietf.org/html/rfc7639
+    config.set_protocols(&[b"h2".to_vec()]);
+
+    // Add root TLS certificate.
+    let mut cc_reader = std::io::BufReader::new(&root_tls_certificate[..]);
+    let certs = rustls::internal::pemfile::certs(&mut cc_reader)
+        .map_err(|error| anyhow!("Couldn't parse TLS certificate: {:?}", error))?;
+    // Only the Proxy Attestation root certificate is required.
+    if certs.len() != 1 {
+        return Err(anyhow!(
+            "Only a single PEM certificate must be provided, provided {}",
+            certs.len()
+        ));
+    }
+    config
+        .root_store
+        .add(&certs[0])
+        .context("Couldn't add root certificate")?;
+
+    // Set custom X.509 certificate verifier.
+    config
+        .dangerous()
+        // [`rustls::DangerousClientConfig::set_certificate_verifier`] completely overwrites the
+        // default verifier.
+        // https://docs.rs/rustls/0.19.0/rustls/struct.DangerousClientConfig.html#impl
+        .set_certificate_verifier(std::sync::Arc::new(RemoteAttestationVerifier::new(
+            tee_measurement,
+        )));
+
+    Ok(ClientTlsConfig::new().rustls_client_config(config))
+}
+
+/// Custom X.509 certificate verifier that checks TEE reports in the X.509 TEE extension.
+struct RemoteAttestationVerifier {
+    tee_measurement: Vec<u8>,
+}
+
+impl RemoteAttestationVerifier {
+    fn new(tee_measurement: &[u8]) -> Self {
+        Self {
+            tee_measurement: tee_measurement.to_vec(),
+        }
+    }
+
+    fn check_tee_report(&self, extension: &str) -> anyhow::Result<()> {
+        let tee_report = Report::from_string(extension).context("Couldn't parse TEE report")?;
+        if self.tee_measurement == tee_report.measurement {
+            Ok(())
+        } else {
+            Err(anyhow!("Incorrect TEE report"))
+        }
+    }
+}
+
+impl rustls::ServerCertVerifier for RemoteAttestationVerifier {
+    fn verify_server_cert(
+        &self,
+        roots: &rustls::RootCertStore,
+        certs: &[rustls::Certificate],
+        hostname: webpki::DNSNameRef,
+        ocsp: &[u8],
+    ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
+        // Only a certificate created by the Attestation Proxy is required.
+        if certs.len() != 1 {
+            return Err(rustls::TLSError::General(format!(
+                "Only a single certificate must be provided, provided {}",
+                certs.len()
+            )));
+        }
+        let certificate = &certs[0].0;
+
+        // Parse X.509 certificate encoded using DER format.
+        // https://tools.ietf.org/html/rfc7468
+        let (_, parsed_certificate) = parse_x509_certificate(&certificate).map_err(|error| {
+            rustls::TLSError::General(format!("Couldn't parse certificate: {}", error))
+        })?;
+
+        // Extract X.509 TEE extension.
+        let extensions = parsed_certificate.extensions();
+        let tee_extension = extensions.get(&TEE_EXTENSION_OID).ok_or_else(|| {
+            rustls::TLSError::General("Couldn't find X.509 TEE extension".to_string())
+        })?;
+        let tee_extension_value = parse_der(tee_extension.value)
+            .map_err(|error| {
+                rustls::TLSError::General(format!(
+                    "Couldn't parse X.509 TEE extension: {:?}",
+                    error
+                ))
+            })?
+            .1
+            .as_str()
+            .map_err(|error| {
+                rustls::TLSError::General(format!("Couldn't parse TEE report value: {:?}", error))
+            })?;
+
+        // Check that X.509 TEE extension contains a correct TEE report.
+        self.check_tee_report(tee_extension_value)
+            .map_err(|error| {
+                rustls::TLSError::General(format!("Incorrect TEE report: {:?}", error))
+            })?;
+
+        // Use [`rustls::WebPKIVerifier`] to check certificate correctness.
+        // This check is required since [`rustls::DangerousClientConfig::set_certificate_verifier`]
+        // completely overwrites the default verifier.
+        // https://docs.rs/rustls/0.19.0/rustls/struct.DangerousClientConfig.html#impl
+        let verifier = rustls::WebPKIVerifier::new();
+        verifier.verify_server_cert(roots, certs, hostname, ocsp)
+    }
+}

--- a/oak_client/src/attestation.rs
+++ b/oak_client/src/attestation.rs
@@ -36,6 +36,7 @@ pub async fn create_attested_tls_channel(
         .await
         .context("Couldn't connect to Oak Application")
 }
+
 /// Create client TLS configuration with a custom X.509 certificate verifier.
 /// [`root_tls_certificate`] should contain only a single PEM encoded certificate.
 /// https://tools.ietf.org/html/rfc1421

--- a/oak_client/src/lib.rs
+++ b/oak_client/src/lib.rs
@@ -20,6 +20,8 @@ use anyhow::Context;
 use http::uri::Uri;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 
+#[cfg(feature = "oak-attestation")]
+pub mod attestation;
 pub mod interceptors;
 
 /// Creates a TLS channel for connecting to Oak.

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -220,7 +220,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
 dependencies = [
  "funty",
- "radium",
+ "radium 0.4.1",
+ "wyz",
+]
+
+[[package]]
+name = "bitvec"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+dependencies = [
+ "funty",
+ "radium 0.5.3",
+ "tap",
  "wyz",
 ]
 
@@ -273,12 +285,6 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "bytes"
@@ -544,12 +550,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
 name = "dbl"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2735145c3b9ba15f2d7a3ae8cdafcbc8c98a7bef7f62afe9d08bd99fbf7130de"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "der-oid-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd17d13ecf875e704369fdbde242483ac769fc18f6af21e43d5a692a079732fc"
+dependencies = [
+ "nom",
+ "num-bigint 0.3.1",
+ "num-traits",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "der-parser"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4b1e27396f46037881c39d821660f2ff48797aaa7152a45ded7a93b368a819"
+dependencies = [
+ "der-oid-macro",
+ "nom",
+ "num-bigint 0.3.1",
+ "num-traits",
+ "proc-macro-hack",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -640,7 +678,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b76528f382c916bbb94470b4e7ad107a3d01619503f7ffba86c93aea04e215"
 dependencies = [
- "bitvec",
+ "bitvec 0.18.4",
  "digest",
  "ff",
  "generic-array",
@@ -679,7 +717,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
- "bitvec",
+ "bitvec 0.18.4",
  "rand_core",
  "subtle",
 ]
@@ -1224,6 +1262,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1463,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d521ee2250f619dd5e06515ba405858d249edc8fae9ddee2dba0695e57db01b"
+dependencies = [
+ "bitvec 0.19.4",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1488,17 @@ name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1473,6 +1547,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_attestation_common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "openssl",
+ "serde",
+ "serde_json",
+ "sha2",
+ "x509-parser",
+]
+
+[[package]]
 name = "oak_derive"
 version = "0.1.0"
 dependencies = [
@@ -1512,7 +1598,7 @@ dependencies = [
  "oak_sign",
  "openssl",
  "prost",
- "rustls 0.18.1",
+ "rustls 0.19.0",
  "serde",
  "signal-hook",
  "structopt",
@@ -1532,6 +1618,7 @@ dependencies = [
  "futures-util",
  "http",
  "log",
+ "oak_attestation_common",
  "oak_utils",
  "openssl",
  "prost",
@@ -1547,7 +1634,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.0",
  "byteorder",
- "bytes 0.6.0",
+ "bytes 1.0.1",
  "chrono",
  "futures-core",
  "futures-util",
@@ -1633,6 +1720,15 @@ dependencies = [
  "quote",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2508c8f170e55be68508b1113956a760a82684f42022f8834fb16ca198621211"
+dependencies = [
+ "der-parser",
 ]
 
 [[package]]
@@ -1988,6 +2084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
 
 [[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,6 +2364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustls"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2409,12 @@ dependencies = [
  "schannel",
  "security-framework",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
 name = "ryu"
@@ -2498,7 +2615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
 dependencies = [
  "chrono",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-traits",
 ]
 
@@ -2540,6 +2657,12 @@ checksum = "c66a8cff4fa24853fdf6b51f75c6d7f8206d7c75cab4e467bcd7f25c2b1febe0"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdweb"
@@ -2648,6 +2771,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3658,6 +3787,26 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "x509-parser"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7999ae290e75ec1d4dc8e9ff9870e48e3542a8f2e9c1e2e07d7ca02b459e10"
+dependencies = [
+ "base64 0.13.0",
+ "chrono",
+ "data-encoding",
+ "der-oid-macro",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "num-bigint 0.3.1",
+ "oid-registry",
+ "rusticata-macros",
+ "rustversion",
+ "thiserror",
+]
 
 [[package]]
 name = "xml-rs"


### PR DESCRIPTION
This commit adds a Proxy Attestation client with a custom TLS certificate verifier, that checks TEE quotes in X.509 TEE extensions.

Fixes https://github.com/project-oak/oak/issues/1861