### PR TITLE
Run checks per crate, not workspace.

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2228,7 +2228,6 @@ name = "proxy_attestation_example"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.13.0",
  "hex",
  "log",
  "maplit",

--- a/examples/proxy_attestation/module/rust/Cargo.toml
+++ b/examples/proxy_attestation/module/rust/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "*"
-base64 = "*"
 log = "*"
 oak = "=0.1.0"
 oak_abi = "=0.1.0"

--- a/examples/trusted_database/client/rust/Cargo.toml
+++ b/examples/trusted_database/client/rust/Cargo.toml
@@ -5,6 +5,18 @@ authors = ["Ivan Petrov <ivanpetrov@google.com>"]
 edition = "2018"
 license = "Apache-2.0"
 
+[features]
+binary = [
+  "log",
+  "structopt",
+  "oak_abi",
+  "oak_client",
+  "oak_sign",
+  "anyhow",
+  "env_logger",
+  "tokio"
+]
+
 [lib]
 name = "trusted_database_client"
 path = "src/lib.rs"
@@ -12,19 +24,26 @@ path = "src/lib.rs"
 [[bin]]
 name = "trusted_database_client_bin"
 path = "src/main.rs"
+required-features = ["binary"]
 
 [dependencies]
-anyhow = "*"
-env_logger = "*"
-log = "*"
-oak_abi = "=0.1.0"
-oak_client = "=0.1.0"
-oak_sign = "=0.1.0"
-prost = "*"
-structopt = "*"
-# Pinned to 0.2 because of tonic: https://github.com/hyperium/tonic/blob/master/tonic/Cargo.toml
-tokio = { version = "0.2", features = ["fs", "macros", "sync", "stream"] }
 tonic = { version = "*", features = ["tls"] }
+prost = "*"
+# Dependencies for main, not required to build the library
+log = { version = "*", optional = true }
+structopt = { version = "*", optional = true }
+oak_abi = { version = "=0.1.0", optional = true }
+oak_client = { version = "=0.1.0", optional = true }
+oak_sign = { version = "=0.1.0", optional = true }
+anyhow = { version = "*", optional = true }
+env_logger = { version = "*", optional = true }
+# Pinned to 0.2 because of tonic: https://github.com/hyperium/tonic/blob/master/tonic/Cargo.toml
+tokio = { version = "0.2", features = [
+  "fs",
+  "macros",
+  "sync",
+  "stream"
+], optional = true }
 
 [build-dependencies]
 oak_utils = "*"

--- a/examples/trusted_database/example.toml
+++ b/examples/trusted_database/example.toml
@@ -14,13 +14,16 @@ additional_args = [
   "--config-files=database=third_party/data/cycle-hire-availability/livecyclehireupdates.xml"
 ]
 
-[clients]
-rust = { Cargo = { cargo_manifest = "examples/trusted_database/client/rust/Cargo.toml" }, additional_args = [
+[clients.rust]
+Cargo = { cargo_manifest = "examples/trusted_database/client/rust/Cargo.toml", additional_build_args = [
+  "--features=binary"
+] }
+additional_args = [
   "--root-tls-certificate=examples/certs/local/ca.pem",
   "--latitude=0.0",
-  "--longitude=0.0"
-] }
-cpp = { Bazel = { bazel_target = "//examples/trusted_database/client/cpp:client" }, additional_args = [
-  "--latitude=0.0",
-  "--longitude=0.0"
-] }
+  "--longitude=0.0",
+]
+
+[clients.cpp]
+Bazel = { bazel_target = "//examples/trusted_database/client/cpp:client" }
+additional_args = ["--latitude=0.0", "--longitude=0.0"]

--- a/experimental/Cargo.lock
+++ b/experimental/Cargo.lock
@@ -2897,16 +2897,8 @@ dependencies = [
 name = "trusted_database_client"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "env_logger 0.8.2",
- "log",
- "oak_abi",
- "oak_client",
- "oak_sign",
  "oak_utils",
  "prost",
- "structopt",
- "tokio 0.2.23",
  "tonic",
 ]
 

--- a/experimental/split_grpc/client/Cargo.toml
+++ b/experimental/split_grpc/client/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 env_logger = "*"
 log = "*"
 prost = "*"
-tokio = { version = "*", features = ["fs", "macros"] }
+tokio = { version = "*", features = ["fs", "macros", "rt-multi-thread"] }
 tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -954,11 +954,11 @@ fn source_files() -> impl Iterator<Item = PathBuf> {
         .map(|e| e.into_path())
 }
 
-/// Return an iterator of all known Cargo Manifest files that define workspaces.
-fn workspace_manifest_files() -> impl Iterator<Item = PathBuf> {
+/// Return an iterator of all known Cargo Manifest files that define crates.
+fn crate_manifest_files() -> impl Iterator<Item = PathBuf> {
     source_files()
         .filter(is_cargo_toml_file)
-        .filter(is_cargo_workspace_file)
+        .filter(|p| !is_cargo_workspace_file(p))
 }
 
 /// Return whether the provided path refers to a source file in a programming language.
@@ -1317,7 +1317,7 @@ fn run_check_todo() -> Step {
 fn run_cargo_fmt(mode: FormatMode) -> Step {
     Step::Multiple {
         name: "cargo fmt".to_string(),
-        steps: workspace_manifest_files()
+        steps: crate_manifest_files()
             .map(to_string)
             .map(|entry| Step::Single {
                 name: entry.clone(),
@@ -1347,7 +1347,7 @@ fn run_cargo_fmt(mode: FormatMode) -> Step {
 fn run_cargo_test() -> Step {
     Step::Multiple {
         name: "cargo test".to_string(),
-        steps: workspace_manifest_files()
+        steps: crate_manifest_files()
             .map(to_string)
             .map(|entry| Step::Single {
                 name: entry.clone(),
@@ -1397,7 +1397,7 @@ fn run_cargo_test_tsan() -> Step {
 fn run_cargo_clippy() -> Step {
     Step::Multiple {
         name: "cargo clippy".to_string(),
-        steps: workspace_manifest_files()
+        steps: crate_manifest_files()
             .map(to_string)
             .map(|entry| Step::Single {
                 name: entry.clone(),
@@ -1427,7 +1427,7 @@ fn run_cargo_clippy() -> Step {
 fn run_cargo_deny() -> Step {
     Step::Multiple {
         name: "cargo deny".to_string(),
-        steps: workspace_manifest_files()
+        steps: crate_manifest_files()
             .map(to_string)
             .map(|entry| Step::Single {
                 name: entry.clone(),
@@ -1443,7 +1443,7 @@ fn run_cargo_deny() -> Step {
 fn run_cargo_udeps() -> Step {
     Step::Multiple {
         name: "cargo udeps".to_string(),
-        steps: workspace_manifest_files()
+        steps: crate_manifest_files()
             .map(to_string)
             .map(|entry| Step::Single {
                 name: entry.clone(),


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

When running things like `cargo check` and `cargo clippy` on a workspace instead of a separate crate, Cargo's behaviour is a bit weird, especially regarding crate features. All crates in the workspace will be compiled with the same feature flags, which can result in output different than if the commands were run for the crates individually, e.g.
- This PR add the `rt-multi-thread` feature to the `tokio` dependency of `experimental/split_grpc/client`. Omitting this result in an error when building the crate on its own, but that is hidden from CI because the `proxy` crate depends on `tokio` with the `full` feature enabled, which transitively enables the same feature for the entire workspace.
- With the `linear-handles` feature, we currently have to awkwardly add an explicit `no-linear-handles` feature to cancel out the effects when compiling a workspace where only some crates have it enabled, and others do not support it. See https://github.com/project-oak/oak/blob/main/oak_io/Cargo.toml#L11-L21

We can resolve these issues by always running checks on individual crates, which is what this PR does 😄 