### PR TITLE
Update cargo-deny version in Dockerfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,8 @@ jobs:
           - build-server --server-variant=unsafe
           - build-server --server-variant=base
           - build-server --server-variant=experimental
-          - run-tests
+          - run-cargo-tests
+          - run-bazel-tests
           - run-tests-tsan
           - run-examples --application-variant=rust
           - run-examples --application-variant=cpp
@@ -51,12 +52,17 @@ jobs:
         run: |
           docker pull gcr.io/oak-ci/oak:latest
           docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+          df --human-readable
 
       - name: Cargo crev
-        run: ./scripts/docker_run ./scripts/run_cargo_crev
+        run: |
+          ./scripts/docker_run ./scripts/run_cargo_crev
+          df --human-readable
 
       - name: Run command
-        run: ./scripts/docker_run ./scripts/runner ${{ matrix.cmd }}
+        run: |
+          ./scripts/docker_run ./scripts/runner ${{ matrix.cmd }}
+          df --human-readable
 
       - name: Generate root CA certs
         run: ./scripts/docker_run ./scripts/generate_root_ca_certs

--- a/Dockerfile
+++ b/Dockerfile
@@ -238,7 +238,7 @@ RUN chmod +x ${install_dir}/cargo-crev
 
 # Install cargo-deny
 # https://github.com/EmbarkStudios/cargo-deny
-ARG deny_version=0.7.3
+ARG deny_version=0.8.9
 ARG deny_location=https://github.com/EmbarkStudios/cargo-deny/releases/download/${deny_version}/cargo-deny-${deny_version}-x86_64-unknown-linux-musl.tar.gz
 RUN curl --location ${deny_location} | tar --extract --gzip --directory=${install_dir} --strip-components=1
 RUN chmod +x ${install_dir}/cargo-deny

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -46,6 +46,8 @@ pub enum Command {
     Format,
     CheckFormat,
     RunTests,
+    RunCargoTests,
+    RunBazelTests,
     RunTestsTsan,
     RunCargoDeny,
     RunCargoUdeps,

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -86,6 +86,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Command::RunExamples(ref opt) => run_examples(&opt),
             Command::BuildServer(ref opt) => build_server(&opt),
             Command::RunTests => run_tests(),
+            Command::RunCargoTests => run_cargo_tests(),
+            Command::RunBazelTests => run_bazel_tests(),
             Command::RunTestsTsan => run_tests_tsan(),
             Command::Format => format(),
             Command::CheckFormat => check_format(),
@@ -344,14 +346,21 @@ fn build_server(opt: &BuildServer) -> Step {
 fn run_tests() -> Step {
     Step::Multiple {
         name: "tests".to_string(),
-        steps: vec![
-            run_cargo_clippy(),
-            run_cargo_test(),
-            run_cargo_doc(),
-            run_bazel_build(),
-            run_bazel_test(),
-            run_clang_tidy(),
-        ],
+        steps: vec![run_cargo_tests(), run_bazel_tests()],
+    }
+}
+
+fn run_cargo_tests() -> Step {
+    Step::Multiple {
+        name: "cargo tests".to_string(),
+        steps: vec![run_cargo_clippy(), run_cargo_test(), run_cargo_doc()],
+    }
+}
+
+fn run_bazel_tests() -> Step {
+    Step::Multiple {
+        name: "bazel tests".to_string(),
+        steps: vec![run_bazel_build(), run_bazel_test(), run_clang_tidy()],
     }
 }
 


### PR DESCRIPTION
Use latest version of `cargo-deny` to avoid git fetch failure errors: 
```
2021-03-08 18:51:23 [ERROR] failed to fetch advisory database: git operation failed: reference 'refs/heads/master' not found; class=Reference (4); code=NotFound (-3)
```
Ref: https://github.com/EmbarkStudios/cargo-deny/pull/336

Also splits the `run-tests` step in github-ci to `run-cargo-test` and `run-bazel-test` to avoid the `No space left on device` problem.