### PR TITLE
Use more descriptive names for options specifying a path

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -470,7 +470,7 @@ running Oak Application:
 ```C++
   // Connect to the Oak Application.
   auto stub = HelloWorld::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert_path), label));
 ```
 <!-- prettier-ignore-end -->
 

--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -60,7 +60,7 @@ hosted at a specific domain name; in this case `aggregator.oakexamples.dev`:
 ```bash
 ./bazel-client-bin/examples/aggregator/client/cpp/client \
   --address=aggregator.oakexamples.dev \
-  --ca_cert=./examples/certs/gcp/ca.pem \
+  --ca_cert_path=./examples/certs/gcp/ca.pem \
   --bucket=test \
   --data=1:10,2:20,3:30
 ```

--- a/examples/aggregator/client/cpp/aggregator.cc
+++ b/examples/aggregator/client/cpp/aggregator.cc
@@ -32,7 +32,7 @@ ABSL_FLAG(std::string, bucket, "", "Bucket under which to aggregate samples");
 ABSL_FLAG(
     std::vector<std::string>, data, std::vector<std::string>{},
     "A comma-separated list of `index:value` entries that represent a single sparse vector sample");
-ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
+ABSL_FLAG(std::string, ca_cert_path, "", "Path to the PEM-encoded CA root certificate");
 
 using ::oak::examples::aggregator::Aggregator;
 using ::oak::examples::aggregator::Sample;
@@ -67,7 +67,8 @@ int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
 
   std::string address = absl::GetFlag(FLAGS_address);
-  std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
+  std::string ca_cert_path =
+      oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert_path));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
   // Label corresponding to the hash of the WebAssembly module that implements the aggregator logic.
@@ -87,7 +88,7 @@ int main(int argc, char** argv) {
       absl::HexStringToBytes("5df07e7163209d363d9c4733910a71947582403627e2916a0daea661052360c6"));
   // Connect to the Oak Application.
   auto stub = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert_path), label));
   if (stub == nullptr) {
     LOG(FATAL) << "Failed to create application stub";
   }

--- a/examples/aggregator/scripts/run_client
+++ b/examples/aggregator/scripts/run_client
@@ -7,4 +7,4 @@ source "${GLOBAL_SCRIPTS_DIR}/common"
 "${GLOBAL_SCRIPTS_DIR}/build_example" -e aggregator
 
 # Run the application client.
-"./bazel-client-bin/examples/aggregator/client/cpp/client" --ca_cert=./examples/certs/gcp/ca.pem "${@}"
+"./bazel-client-bin/examples/aggregator/client/cpp/client" --ca_cert_path=./examples/certs/gcp/ca.pem "${@}"

--- a/examples/hello_world/client/cpp/hello_world.cc
+++ b/examples/hello_world/client/cpp/hello_world.cc
@@ -24,7 +24,7 @@
 #include "oak/common/label.h"
 
 ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
-ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
+ABSL_FLAG(std::string, ca_cert_path, "", "Path to the PEM-encoded CA root certificate");
 
 using ::oak::examples::hello_world::HelloRequest;
 using ::oak::examples::hello_world::HelloResponse;
@@ -64,14 +64,15 @@ int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
 
   std::string address = absl::GetFlag(FLAGS_address);
-  std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
+  std::string ca_cert_path =
+      oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert_path));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
   // TODO(#1066): Use a more restrictive Label.
   oak::label::Label label = oak::PublicUntrustedLabel();
   // Connect to the Oak Application.
   auto stub = HelloWorld::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert_path), label));
   if (stub == nullptr) {
     LOG(FATAL) << "Failed to create application stub";
   }

--- a/examples/http_server/client/rust/src/main.rs
+++ b/examples/http_server/client/rust/src/main.rs
@@ -26,7 +26,7 @@ pub struct Opt {
         help = "Path to the PEM-encoded CA root certificate.",
         default_value = "../../certs/local/ca.pem"
     )]
-    ca_cert: String,
+    ca_cert_path: String,
 }
 
 #[tokio::main]
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
         public_key: key_pair.public_key_der()?,
     };
 
-    let path = &opt.ca_cert;
+    let path = &opt.ca_cert_path;
     let ca_file = fs::File::open(path).unwrap_or_else(|e| panic!("failed to open {}: {}", path, e));
     let mut ca = io::BufReader::new(ca_file);
 

--- a/examples/http_server/example.toml
+++ b/examples/http_server/example.toml
@@ -11,6 +11,6 @@ module = { Cargo = { cargo_manifest = "examples/http_server/module/Cargo.toml" }
 
 [clients]
 rust = { Cargo = { cargo_manifest = "examples/http_server/client/rust/Cargo.toml" }, additional_args = [
-  "--ca-cert=./examples/certs/local/ca.pem"
+  "--ca-cert-path=./examples/certs/local/ca.pem"
 ] }
 shell = { Shell = { script = "examples/http_server/client/client" } }

--- a/examples/injection/client/cpp/injection.cc
+++ b/examples/injection/client/cpp/injection.cc
@@ -24,7 +24,7 @@
 #include "oak/common/label.h"
 
 ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
-ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
+ABSL_FLAG(std::string, ca_cert_path, "", "Path to the PEM-encoded CA root certificate");
 
 using ::oak::examples::injection::BlobResponse;
 using ::oak::examples::injection::BlobStore;
@@ -35,14 +35,15 @@ int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
 
   std::string address = absl::GetFlag(FLAGS_address);
-  std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
+  std::string ca_cert_path =
+      oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert_path));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
   // TODO(#1066): Use a more restrictive Label.
   oak::label::Label label = oak::PublicUntrustedLabel();
   // Connect to the Oak Application.
   auto stub = BlobStore::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert_path), label));
   if (stub == nullptr) {
     LOG(FATAL) << "Failed to create application stub";
   }

--- a/examples/private_set_intersection/client/cpp/private_set_intersection.cc
+++ b/examples/private_set_intersection/client/cpp/private_set_intersection.cc
@@ -25,7 +25,7 @@
 
 ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
 ABSL_FLAG(std::string, set_id, "", "ID of the set intersection");
-ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
+ABSL_FLAG(std::string, ca_cert_path, "", "Path to the PEM-encoded CA root certificate");
 ABSL_FLAG(std::string, public_key, "", "Path to the PEM-encoded public key used as a data label");
 
 using ::oak::examples::private_set_intersection::GetIntersectionRequest;
@@ -68,7 +68,8 @@ int main(int argc, char** argv) {
 
   std::string address = absl::GetFlag(FLAGS_address);
   std::string set_id = absl::GetFlag(FLAGS_set_id);
-  std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
+  std::string ca_cert_path =
+      oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert_path));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
   // TODO(#1066): Use a more restrictive Label, based on a bearer token shared between the two
@@ -77,10 +78,10 @@ int main(int argc, char** argv) {
   oak::label::Label label = oak::WebAssemblyModuleSignatureLabel(public_key);
 
   auto stub_0 = PrivateSetIntersection::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert_path), label));
 
   auto stub_1 = PrivateSetIntersection::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert_path), label));
 
   // Submit sets from different clients.
   std::vector<std::string> set_0{"a", "b", "c"};
@@ -105,7 +106,7 @@ int main(int argc, char** argv) {
   }
   oak::label::Label invalid_label = oak::WebAssemblyModuleSignatureLabel(invalid_public_key);
   auto invalid_stub = PrivateSetIntersection::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), invalid_label));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert_path), invalid_label));
   std::vector<std::string> set_2{"c", "d", "e"};
   auto submit_status_2 = SubmitSet(invalid_stub.get(), set_id, set_2);
   // Error code `3` means `could not process gRPC request`.

--- a/examples/tensorflow/client/cpp/tensorflow.cc
+++ b/examples/tensorflow/client/cpp/tensorflow.cc
@@ -23,7 +23,7 @@
 #include "oak/client/application_client.h"
 
 ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
-ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
+ABSL_FLAG(std::string, ca_cert_path, "", "Path to the PEM-encoded CA root certificate");
 
 using ::oak::examples::tensorflow::InitRequest;
 using ::oak::examples::tensorflow::InitResponse;
@@ -46,14 +46,15 @@ int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
 
   std::string address = absl::GetFlag(FLAGS_address);
-  std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
+  std::string ca_cert_path =
+      oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert_path));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
   // TODO(#1066): Assign a more restrictive label.
   oak::label::Label label = oak::PublicUntrustedLabel();
   // Connect to the Oak Application.
   auto stub = Tensorflow::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert_path), label));
   if (stub == nullptr) {
     LOG(FATAL) << "Failed to create application stub";
   }

--- a/examples/translator/client/go/translator.go
+++ b/examples/translator/client/go/translator.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	address = flag.String("address", "localhost:8080", "Address of the Oak application to connect to")
-	caCert  = flag.String("ca_cert", "", "Path to the PEM-encoded CA root certificate")
+	caCert  = flag.String("ca_cert_path", "", "Path to the PEM-encoded CA root certificate")
 )
 
 // Keep in sync with /oak_runtime/src/node/grpc/server/mod.rs.

--- a/examples/trusted_database/client/cpp/trusted_database.cc
+++ b/examples/trusted_database/client/cpp/trusted_database.cc
@@ -26,7 +26,7 @@
 #include "oak/client/application_client.h"
 
 ABSL_FLAG(std::string, address, "localhost:8080", "Address of the Oak application to connect to");
-ABSL_FLAG(std::string, ca_cert, "", "Path to the PEM-encoded CA root certificate");
+ABSL_FLAG(std::string, ca_cert_path, "", "Path to the PEM-encoded CA root certificate");
 ABSL_FLAG(float, latitude, float{}, "Requested location's latitude in degrees (WGS84)");
 ABSL_FLAG(float, longitude, float{}, "Requested location's longitude in degrees (WGS84)");
 
@@ -59,14 +59,15 @@ int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
 
   std::string address = absl::GetFlag(FLAGS_address);
-  std::string ca_cert = oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert));
+  std::string ca_cert_path =
+      oak::ApplicationClient::LoadRootCert(absl::GetFlag(FLAGS_ca_cert_path));
   LOG(INFO) << "Connecting to Oak Application: " << address;
 
   // TODO(#1066): Use a more restrictive Label.
   oak::label::Label label = oak::PublicUntrustedLabel();
   // Connect to the Oak Application.
   auto stub = TrustedDatabase::NewStub(oak::ApplicationClient::CreateChannel(
-      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
+      address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert_path), label));
   if (stub == nullptr) {
     LOG(FATAL) << "Failed to create application stub";
   }

--- a/oak_runtime/src/node/wasm/mod.rs
+++ b/oak_runtime/src/node/wasm/mod.rs
@@ -1443,7 +1443,7 @@ impl super::Node for WasmNode {
         "wasm"
     }
     fn isolation(&self) -> NodeIsolation {
-        // The Wasm sandbox restricts the external communictions from the Node.
+        // The Wasm sandbox restricts the external communications from the Node.
         NodeIsolation::Sandboxed
     }
 

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -924,7 +924,7 @@ fn run(
                 },
                 "--".to_string(),
                 bazel_target.to_string(),
-                "--ca_cert=../../../../../../../../../examples/certs/local/ca.pem".to_string(),
+                "--ca_cert_path=../../../../../../../../../examples/certs/local/ca.pem".to_string(),
                 ...executable.additional_args.clone(),
                 ...additional_args,
             ],


### PR DESCRIPTION
- Specifies `path` in option names that indicate a path, as suggested in https://github.com/project-oak/oak/pull/1895#discussion_r589695057
- Fixes a few typos
