### PR TITLE
Migrate Abitest to linear handles

### DIFF
--- a/examples/abitest/module_0/rust/Cargo.toml
+++ b/examples/abitest/module_0/rust/Cargo.toml
@@ -42,7 +42,7 @@ assert_matches = "*"
 env_logger = "*"
 log = "*"
 maplit = "*"
-oak_runtime = "=0.1.0"
+oak_runtime = { version = "=0.1.0", features = ["linear-handles"] }
 oak_tests = "=0.1.0"
 tokio = { version = "*", features = ["macros", "rt-threaded", "stream"] }
 tonic = { version = "*", features = ["tls"] }

--- a/examples/abitest/module_0/rust/Cargo.toml
+++ b/examples/abitest/module_0/rust/Cargo.toml
@@ -20,7 +20,7 @@ hex = "*"
 http = "*"
 http_server = { path = "../../../http_server/module" }
 log = "*"
-oak = "=0.1.0"
+oak = { version = "=0.1.0", features = ["linear-handles"] }
 oak_abi = "=0.1.0"
 oak_io = "=0.1.0"
 oak_services = "=0.1.0"

--- a/examples/abitest/module_1/rust/Cargo.toml
+++ b/examples/abitest/module_1/rust/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 log = "*"
 abitest_common = { path = "../../abitest_common" }
-oak = "=0.1.0"
+oak = { version = "=0.1.0", features = ["linear-handles"] }
 oak_abi = "=0.1.0"
 oak_io = "=0.1.0"
 prost = "*"


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

This is a minimal set of changes to get abitest passing with `linear-handles` turned on. We should clean up unnecessary channel close calls and merge the `linear-handles` module into module 0 in a follow-up PR.