### PR TITLE
Run multiple backends

### DIFF
--- a/examples/aggregator/backend/src/main.rs
+++ b/examples/aggregator/backend/src/main.rs
@@ -39,6 +39,12 @@ use tonic::{
 #[derive(StructOpt, Clone)]
 #[structopt(about = "Aggregator Backend")]
 pub struct Opt {
+    #[structopt(
+        long,
+        help = "Address to listen on for the gRPC server.",
+        default_value = "[::]:8888"
+    )]
+    grpc_listen_address: String,
     #[structopt(long, help = "Private RSA key file used by gRPC server.")]
     grpc_tls_private_key: String,
     #[structopt(
@@ -75,7 +81,10 @@ async fn main() -> anyhow::Result<()> {
 
     let identity = Identity::from_pem(certificate, private_key);
 
-    let address = "[::]:8888".parse().context("Couldn't parse address")?;
+    let address = opt
+        .grpc_listen_address
+        .parse()
+        .context("Couldn't parse address")?;
     let handler = AggregatorBackend::default();
 
     info!("Starting the backend server at {:?}", address);

--- a/examples/aggregator/example.toml
+++ b/examples/aggregator/example.toml
@@ -1,5 +1,8 @@
 name = "aggregator"
+
+[backends]
 backend = { Cargo = { cargo_manifest = "examples/aggregator/backend/Cargo.toml" }, additional_args = [
+  "--grpc-listen-address=[::]:8888",
   "--grpc-tls-private-key=./examples/certs/local/local.key",
   "--grpc-tls-certificate=./examples/certs/local/local.pem",
 ] }

--- a/examples/proxy_attestation/example.toml
+++ b/examples/proxy_attestation/example.toml
@@ -1,5 +1,8 @@
 name = "proxy_attestation"
+
+[backends]
 backend = { Cargo = { cargo_manifest = "experimental/proxy_attestation/Cargo.toml" }, additional_args = [
+  "--grpc-listen-address=[::]:8888",
   "--grpc-tls-private-key=./examples/certs/local/local.key",
   "--grpc-tls-certificate=./examples/certs/local/local.pem",
 ] }

--- a/experimental/proxy_attestation/src/main.rs
+++ b/experimental/proxy_attestation/src/main.rs
@@ -63,6 +63,12 @@ use tonic::{
 #[derive(StructOpt, Clone)]
 #[structopt(about = "Proxy Attestation")]
 pub struct Opt {
+    #[structopt(
+        long,
+        help = "Address to listen on for the gRPC server.",
+        default_value = "[::]:8888"
+    )]
+    grpc_listen_address: String,
     #[structopt(long, help = "Private RSA key PEM encoded file used by gRPC server.")]
     grpc_tls_private_key: String,
     #[structopt(
@@ -166,7 +172,10 @@ async fn main() -> anyhow::Result<()> {
         std::fs::read(&opt.grpc_tls_certificate).context("Couldn't load certificate")?;
 
     let identity = Identity::from_pem(certificate, private_key);
-    let address = "[::]:8888".parse().context("Couldn't parse address")?;
+    let address = opt
+        .grpc_listen_address
+        .parse()
+        .context("Couldn't parse address")?;
 
     // Create proxy attestation gRPC server.
     info!("Starting proxy attestation server at {:?}", address);


### PR DESCRIPTION
This change:
- Adds the ability to run multiple backend servers in Oak examples
- Makes running `applications` not mandatory (for examples that do not involve Oak modules)