### PR TITLE
Run examples with no clients

### DIFF
--- a/examples/proxy_attestation/example.toml
+++ b/examples/proxy_attestation/example.toml
@@ -7,14 +7,14 @@ backend = { Cargo = { cargo_manifest = "experimental/proxy_attestation/Cargo.tom
   "--grpc-tls-certificate=./examples/certs/local/local.pem",
 ] }
 
-[applications]
+# [applications]
 
-[applications.rust]
-manifest = "examples/proxy_attestation/oak_app_manifest.toml"
-out = "examples/proxy_attestation/bin/proxy_attestation.oak"
+# [applications.rust]
+# manifest = "examples/proxy_attestation/oak_app_manifest.toml"
+# out = "examples/proxy_attestation/bin/proxy_attestation.oak"
 
-[applications.rust.modules]
-module = { Cargo = { cargo_manifest = "examples/proxy_attestation/module/rust/Cargo.toml" } }
+# [applications.rust.modules]
+# module = { Cargo = { cargo_manifest = "examples/proxy_attestation/module/rust/Cargo.toml" } }
 
 [server]
 additional_args = [

--- a/examples/proxy_attestation/example.toml
+++ b/examples/proxy_attestation/example.toml
@@ -7,14 +7,14 @@ backend = { Cargo = { cargo_manifest = "experimental/proxy_attestation/Cargo.tom
   "--grpc-tls-certificate=./examples/certs/local/local.pem",
 ] }
 
-# [applications]
+[applications]
 
-# [applications.rust]
-# manifest = "examples/proxy_attestation/oak_app_manifest.toml"
-# out = "examples/proxy_attestation/bin/proxy_attestation.oak"
+[applications.rust]
+manifest = "examples/proxy_attestation/oak_app_manifest.toml"
+out = "examples/proxy_attestation/bin/proxy_attestation.oak"
 
-# [applications.rust.modules]
-# module = { Cargo = { cargo_manifest = "examples/proxy_attestation/module/rust/Cargo.toml" } }
+[applications.rust.modules]
+module = { Cargo = { cargo_manifest = "examples/proxy_attestation/module/rust/Cargo.toml" } }
 
 [server]
 additional_args = [

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -658,14 +658,7 @@ fn run_example(opt: &RunExamples, example: &Example) -> Step {
     #[allow(clippy::collapsible_if)]
     let run_backend_server_clients: Step = if opt.run_server.unwrap_or(true) {
         let run_server_clients = if example.applications.is_empty() {
-            if opt.build_client.client_variant == NO_CLIENTS {
-                Step::Multiple {
-                    name: "run clients (empty)".to_string(),
-                    steps: vec![],
-                }
-            } else {
-                run_clients
-            }
+            run_clients
         } else {
             let application = example
                 .applications
@@ -710,14 +703,7 @@ fn run_example(opt: &RunExamples, example: &Example) -> Step {
                 }
             })
     } else {
-        if opt.build_client.client_variant == NO_CLIENTS {
-            Step::Multiple {
-                name: "run clients (empty)".to_string(),
-                steps: vec![],
-            }
-        } else {
-            run_clients
-        }
+        run_clients
     };
 
     Step::Multiple {

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -659,10 +659,10 @@ fn run_example(opt: &RunExamples, example: &Example) -> Step {
     let run_backend_server_clients: Step = if opt.run_server.unwrap_or(true) {
         let run_server_clients = if example.applications.is_empty() {
             if opt.build_client.client_variant == NO_CLIENTS {
-                panic!(
-                    "`{}` client variant is not supported when no applications are provided",
-                    NO_CLIENTS
-                );
+                Step::Multiple {
+                    name: "run clients (empty)".to_string(),
+                    steps: vec![],
+                }
             } else {
                 run_clients
             }
@@ -710,13 +710,13 @@ fn run_example(opt: &RunExamples, example: &Example) -> Step {
                 }
             })
     } else {
-        if opt.build_client.client_variant != NO_CLIENTS {
-            run_clients
-        } else {
+        if opt.build_client.client_variant == NO_CLIENTS {
             Step::Multiple {
                 name: "run clients (empty)".to_string(),
                 steps: vec![],
             }
+        } else {
+            run_clients
         }
     };
 
@@ -724,11 +724,7 @@ fn run_example(opt: &RunExamples, example: &Example) -> Step {
         name: example.name.to_string(),
         steps: vec![
             if example.applications.is_empty() {
-                if opt.build_client.client_variant == NO_CLIENTS {
-                    panic!("`{}` client variant is not supported when no applications are provided", NO_CLIENTS);
-                } else {
-                    vec![]
-                }
+                vec![]
             } else {
                 let application = example
                     .applications


### PR DESCRIPTION
This change restores the ability to run examples with no clients.
Required for `reproducibility` builds.