### PR TITLE
Update runner to remove generated files after running tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           - build-server --server-variant=unsafe
           - build-server --server-variant=base
           - build-server --server-variant=experimental
-          - run-cargo-tests
+          - run-cargo-tests --cleanup
           - run-bazel-tests
           - run-tests-tsan
           - run-examples --application-variant=rust

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -46,7 +46,7 @@ pub enum Command {
     Format,
     CheckFormat,
     RunTests,
-    RunCargoTests,
+    RunCargoTests(CleanupOpt),
     RunBazelTests,
     RunTestsTsan,
     RunCargoDeny,
@@ -156,6 +156,15 @@ pub struct BuildServer {
         help = "rust target to use for the server compilation [e.g. x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, x86_64-apple-darwin]"
     )]
     pub server_rust_target: Option<String>,
+}
+
+#[derive(StructOpt, Clone)]
+pub struct CleanupOpt {
+    #[structopt(
+        long,
+        help = "remove generated files after running tests for each crate"
+    )]
+    pub cleanup: bool,
 }
 
 /// A construct to keep track of the status of the execution. It only cares about the top-level

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Command::RunExamples(ref opt) => run_examples(&opt),
             Command::BuildServer(ref opt) => build_server(&opt),
             Command::RunTests => run_tests(),
-            Command::RunCargoTests => run_cargo_tests(),
+            Command::RunCargoTests(ref opt) => run_cargo_tests(opt.cleanup),
             Command::RunBazelTests => run_bazel_tests(),
             Command::RunTestsTsan => run_tests_tsan(),
             Command::Format => format(),
@@ -351,14 +351,14 @@ fn build_server(opt: &BuildServer) -> Step {
 fn run_tests() -> Step {
     Step::Multiple {
         name: "tests".to_string(),
-        steps: vec![run_cargo_tests(), run_bazel_tests()],
+        steps: vec![run_cargo_tests(false), run_bazel_tests()],
     }
 }
 
-fn run_cargo_tests() -> Step {
+fn run_cargo_tests(cleanup: bool) -> Step {
     Step::Multiple {
         name: "cargo tests".to_string(),
-        steps: vec![run_cargo_clippy(), run_cargo_test(), run_cargo_doc()],
+        steps: vec![run_cargo_clippy(), run_cargo_test(cleanup), run_cargo_doc()],
     }
 }
 
@@ -1379,14 +1379,41 @@ fn run_cargo_fmt(mode: FormatMode) -> Step {
     }
 }
 
-fn run_cargo_test() -> Step {
+fn run_cargo_test(cleanup: bool) -> Step {
     Step::Multiple {
         name: "cargo test".to_string(),
         steps: crate_manifest_files()
             .map(to_string)
-            .map(|entry| Step::Single {
-                name: entry.clone(),
-                command: Cmd::new("cargo", &["test", &format!("--manifest-path={}", &entry)]),
+            .map(|entry| {
+                if cleanup {
+                    Step::Multiple {
+                        name: entry.clone(),
+                        steps: vec![
+                            Step::Single {
+                                name: "run".to_string(),
+                                command: Cmd::new(
+                                    "cargo",
+                                    &["test", &format!("--manifest-path={}", &entry)],
+                                ),
+                            },
+                            Step::Single {
+                                name: "cleanup".to_string(),
+                                command: Cmd::new(
+                                    "rm",
+                                    &["-rf", &entry.replace("Cargo.toml", "target")],
+                                ),
+                            },
+                        ],
+                    }
+                } else {
+                    Step::Single {
+                        name: entry.clone(),
+                        command: Cmd::new(
+                            "cargo",
+                            &["test", &format!("--manifest-path={}", &entry)],
+                        ),
+                    }
+                }
             })
             .collect(),
     }


### PR DESCRIPTION
Update runner to remove generated files after running tests, to avoid the `No space left on device` error in CI builds.