### PR TITLE
Update hashes

### DIFF
--- a/examples/aggregator/client/android/cpp/client.cc
+++ b/examples/aggregator/client/android/cpp/client.cc
@@ -55,7 +55,7 @@ JNIEXPORT void JNICALL Java_com_google_oak_aggregator_MainActivity_createChannel
   // The particular value corresponds to the hash on the `aggregator.wasm` line in
   // https://github.com/project-oak/oak/blob/hashes/reproducibility_index.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("4b652112bb9904976fd5a215a4df081956165f1dbc19bf6c77e0eef05c4bc256"));
+      absl::HexStringToBytes("5df07e7163209d363d9c4733910a71947582403627e2916a0daea661052360c6"));
   kChannel = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));
   JNI_LOG("gRPC channel has been created");

--- a/examples/aggregator/client/cpp/aggregator.cc
+++ b/examples/aggregator/client/cpp/aggregator.cc
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
   //
   // TODO(#1674): Add appropriate TLS endpoint tag to the label as well.
   oak::label::Label label = oak::WebAssemblyModuleHashLabel(
-      absl::HexStringToBytes("4b652112bb9904976fd5a215a4df081956165f1dbc19bf6c77e0eef05c4bc256"));
+      absl::HexStringToBytes("5df07e7163209d363d9c4733910a71947582403627e2916a0daea661052360c6"));
   // Connect to the Oak Application.
   auto stub = Aggregator::NewStub(oak::ApplicationClient::CreateChannel(
       address, oak::ApplicationClient::GetTlsChannelCredentials(ca_cert), label));

--- a/examples/aggregator/config.toml
+++ b/examples/aggregator/config.toml
@@ -1,3 +1,3 @@
 grpc_server_listen_address = "[::]:8080"
 backend_server_address = "https://localhost:8888"
-aggregator_module_hash = "4b652112bb9904976fd5a215a4df081956165f1dbc19bf6c77e0eef05c4bc256"
+aggregator_module_hash = "5df07e7163209d363d9c4733910a71947582403627e2916a0daea661052360c6"

--- a/examples/private_set_intersection/private_set_intersection_handler.sign
+++ b/examples/private_set_intersection/private_set_intersection_handler.sign
@@ -3,10 +3,10 @@ MCowBQYDK2VwAyEAf41SClNtR4i46v2Tuh1fQLbt/ZqRr1lENajCW92jyP4=
 -----END PUBLIC KEY-----
 
 -----BEGIN SIGNATURE-----
-7I/aO3rgjTcalCFvvgsUOoByOx+/F7zsuwAojhvvIw6G2voQk5YciKc3F8PYux9S
-xrADMZk8svPPcQf+fg9tAA==
+2no3OmxQVOTaN2JuUjzWiH3C61HhxPWx0SJgqC46+zPMSZVMfUnfcYGpighUyoRt
+ijRNRkj78SVLBMaZ1TBICQ==
 -----END SIGNATURE-----
 
 -----BEGIN HASH-----
-dCHHytUNobqhxd29PSs/46gxfftTs0MemO8s/1t/PGo=
+IU4hEIlGMBMEud5uEKRn1aoEWxcceQP/XDy48DDFCMk=
 -----END HASH-----

--- a/scripts/runner
+++ b/scripts/runner
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+readonly SCRIPTS_DIR="$(dirname "$0")"
+# shellcheck source=scripts/common
+source "$SCRIPTS_DIR/common"
+
 sccache --show-stats
 cargo run --manifest-path=./runner/Cargo.toml -- "$@"
 sccache --show-stats


### PR DESCRIPTION
In #1940 the volume mount point was changed, which results in different
Wasm module hashes.

Also the runner script was not actually failing correctly, which is now
fixed.

Fix #1940

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
