### PR TITLE
Make Cargo crev a separate job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,11 +64,6 @@ jobs:
           docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
           df --human-readable
 
-      - name: Cargo crev
-        run: |
-          ./scripts/docker_run ./scripts/run_cargo_crev
-          df --human-readable
-
       - name: Run command
         run: |
           ./scripts/docker_run ./scripts/runner --commands ${{ matrix.cmd }}
@@ -112,3 +107,32 @@ jobs:
         run:
           docker run --volume=$PWD:/workspaces/oak --workdir=/workspaces/oak
           gcr.io/oak-ci/oak-android:latest ./scripts/build_examples_android
+
+  cargo-crev-verify:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
+      # and https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
+      - name: Free disk space
+        run: |
+          df --human-readable
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df --human-readable
+
+      # Build Docker image, caching from the latest version from the remote repository.
+      - name: Docker build
+        timeout-minutes: 30
+        run: |
+          docker pull gcr.io/oak-ci/oak:latest
+          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+          df --human-readable
+
+      - name: Cargo crev verification
+        run: |
+          ./scripts/docker_run ./scripts/run_cargo_crev
+          df --human-readable


### PR DESCRIPTION
Move the Cargo crev verification step to be a separate job in the CI workflow so that it does not run before every runner step.

Fixes #1939 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
