### PR TITLE
Encapsulate Wasm state for Oak Functions loader

### DIFF
--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -32,6 +32,49 @@ pub(crate) struct WasmHandler {
     module: Arc<wasmi::Module>,
 }
 
+/// Encapsulates the state of a Wasm invocation for a single user request.
+struct WasmState {
+    instance: wasmi::ModuleRef,
+    #[allow(dead_code)]
+    memory: wasmi::MemoryRef,
+    #[allow(dead_code)]
+    request_bytes: Vec<u8>,
+    response_bytes: Vec<u8>,
+}
+
+impl WasmState {
+    fn new(module: &wasmi::Module, request_bytes: Vec<u8>) -> anyhow::Result<WasmState> {
+        // TODO(#1919): Make request body available to the Wasm module via ABI functions.
+        // TODO(#1919): Get the actual response from the Wasm module via ABI functions.
+        let instance = wasmi::ModuleInstance::new(module, &wasmi::ImportsBuilder::default())
+            .context("failed to instantiate Wasm module")?
+            .assert_no_start();
+        let memory = instance
+            .export_by_name("memory")
+            .context("could not find Wasm `memory` export")?
+            .as_memory()
+            .cloned()
+            .context("could not interpret Wasm `memory` export as memory")?;
+        Ok(WasmState {
+            instance,
+            memory,
+            request_bytes,
+            response_bytes: "Welcome to Oak Functions\n".as_bytes().to_vec(),
+        })
+    }
+
+    fn invoke(&mut self) {
+        let result = self
+            .instance
+            .invoke_export(MAIN_FUNCTION_NAME, &[], &mut wasmi::NopExternals);
+        info!(
+            "{:?}: Running Wasm module completed with result: {:?}",
+            std::thread::current().id(),
+            result
+        );
+    }
+}
+
 impl WasmHandler {
     pub(crate) fn create(wasm_module_bytes: &[u8]) -> anyhow::Result<Self> {
         let module = wasmi::Module::from_buffer(&wasm_module_bytes)?;
@@ -40,10 +83,13 @@ impl WasmHandler {
         })
     }
 
-    pub(crate) fn handle_request(&self, req: &Request<Body>) -> anyhow::Result<Response<Body>> {
+    pub(crate) async fn handle_request(
+        &self,
+        req: Request<Body>,
+    ) -> anyhow::Result<Response<Body>> {
         info!("The request is: {:?}", req);
         match (req.method(), req.uri().path()) {
-            (&hyper::Method::POST, "/invoke") => self.handle_invoke(req),
+            (&hyper::Method::POST, "/invoke") => self.handle_invoke(req).await,
             (method, path) => http::response::Builder::new()
                 .status(StatusCode::BAD_REQUEST)
                 .body(format!("Invalid request: {} {}\n", method, path).into())
@@ -51,24 +97,13 @@ impl WasmHandler {
         }
     }
 
-    fn handle_invoke(&self, _req: &Request<Body>) -> anyhow::Result<Response<Body>> {
-        // TODO(#1919): Make request body available to the Wasm module via ABI functions.
-        let instance = wasmi::ModuleInstance::new(&self.module, &wasmi::ImportsBuilder::default())
-            .context("failed to instantiate Wasm module")?
-            .assert_no_start();
-
-        let result = instance.invoke_export(MAIN_FUNCTION_NAME, &[], &mut wasmi::NopExternals);
-
-        info!(
-            "{:?}: Running Wasm module completed with result: {:?}",
-            std::thread::current().id(),
-            result
-        );
-
-        // TODO(#1919): Get the actual response from the Wasm module via ABI functions.
+    async fn handle_invoke(&self, req: Request<Body>) -> anyhow::Result<Response<Body>> {
+        let request_bytes = hyper::body::to_bytes(req.into_body()).await.unwrap();
+        let mut wasm_state = WasmState::new(&self.module, request_bytes.to_vec())?;
+        wasm_state.invoke();
         http::response::Builder::new()
-            .status(StatusCode::BAD_REQUEST)
-            .body(Body::from("Welcome to Oak Functions!\n"))
+            .status(StatusCode::OK)
+            .body(Body::from(wasm_state.response_bytes))
             .context("Couldn't create response")
     }
 }
@@ -88,7 +123,7 @@ pub async fn create_and_start_server(
         async move {
             Ok::<_, hyper::Error>(service_fn(move |req| {
                 let wasm_handler = wasm_handler.clone();
-                async move { async { wasm_handler.handle_request(&req) }.await }
+                async move { wasm_handler.handle_request(req).await }
             }))
         }
     });


### PR DESCRIPTION
Make functions more async-friendly.

Make tests actually check responses.

Ensure benchmarks actually exercise the Wasm invocation. Note that now
the time is around 400ms, which seems more realistic than the previous
50ms, I suspect some (or all) of the Wasm execution was being optimized
away earlier.

Ref #1935

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
