### PR TITLE
Delete 'Parsed manifest files'

### DIFF
--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -157,7 +157,6 @@ fn run_examples(opt: &RunExamples) -> Step {
             })
         })
         .collect();
-    eprintln!("parsed examples manifest files: {:?}", examples);
     Step::Multiple {
         name: "examples".to_string(),
         /// TODO(#396): Check that all the example folders are covered by an entry here, or


### PR DESCRIPTION
This change deletes the "Parsed manifest files" output from `runner`.

Fixes https://github.com/project-oak/oak/issues/1956