### PR TITLE
Download lookup data from URL instead of file

### DIFF
--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -18,7 +18,7 @@ bytes = "*"
 byteorder = { version = "*", default-features = false }
 env_logger = "*"
 http = "*"
-hyper = { version = "*", features = ["http1", "server", "runtime"] }
+hyper = { version = "*", features = ["client", "http1", "runtime", "server"] }
 log = "*"
 prost = "*"
 oak_functions_abi = { version = "0.1.0", path = "../abi" }

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -275,7 +275,7 @@ pub async fn create_and_start_server(
         }
     });
 
-    let server = Server::bind(&address).serve(service);
+    let server = Server::bind(address).serve(service);
 
     let graceful_server = server.with_graceful_shutdown(async {
         // Treat notification failure the same as a notification.


### PR DESCRIPTION
Use a mock server in test to simulate serving such a file over HTTP.

Ref #1930

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
