### PR TITLE
Use config file instead of command line flags

### DIFF
--- a/oak_functions/Dockerfile
+++ b/oak_functions/Dockerfile
@@ -10,6 +10,12 @@ COPY ./loader/target/x86_64-unknown-linux-musl/release/oak_functions_loader ${oa
 # Normally we would use the $PORT env variable here, but since we do not have a shell available in
 # the Docker image, we hardcode its default value (8080) here.
 # https://cloud.google.com/run/docs/reference/container-contract#port
-ENTRYPOINT ["/oak_functions_loader", "--http-listen-port=8080", "--wasm-path=/module.wasm"]
+ENTRYPOINT [ \
+    "/oak_functions_loader", \
+    "--http-listen-port=8080", \
+    "--wasm-path=/module.wasm", \
+    "--config-path=/config.toml" \
+]
 
-# Individual applications must copy their own Wasm module to /module.wasm.
+# Individual applications must copy their own Wasm module to /module.wasm and their config file to
+# /config.toml .

--- a/oak_functions/Dockerfile
+++ b/oak_functions/Dockerfile
@@ -17,5 +17,5 @@ ENTRYPOINT [ \
     "--config-path=/config.toml" \
 ]
 
-# Individual applications must copy their own Wasm module to /module.wasm and their config file to
-# /config.toml .
+# Individual applications must copy their own Wasm module to `/module.wasm` and their config file to
+# `/config.toml`.

--- a/oak_functions/examples/Cargo.lock
+++ b/oak_functions/examples/Cargo.lock
@@ -447,8 +447,11 @@ dependencies = [
  "oak_functions_abi",
  "prost",
  "prost-build",
+ "serde",
+ "serde_derive",
  "structopt",
  "tokio",
+ "toml",
  "wasmi",
 ]
 
@@ -673,6 +676,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +806,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/oak_functions/examples/hello_world/README.md
+++ b/oak_functions/examples/hello_world/README.md
@@ -12,8 +12,8 @@ To build and run this example manually follow these steps:
    ```shell
    cargo -Zunstable-options build --release \
        --target=wasm32-unknown-unknown \
-       --manifest-path=oak_functions/examples/hello_world/module/Cargo.toml \
-       --out-dir=oak_functions/examples/hello_world/bin
+       --manifest-path=./oak_functions/examples/hello_world/module/Cargo.toml \
+       --out-dir=./oak_functions/examples/hello_world/bin
    ```
 
 1. Build the `loader` with debugging enabled if needed:
@@ -28,12 +28,12 @@ To build and run this example manually follow these steps:
 
    ```shell
    ./oak_functions/loader/target/release/oak_functions_loader \
-       --wasm-path=oak_functions/examples/hello_world/bin/hello_world.wasm \
-       --lookup-data-path=""
+       --wasm-path=./oak_functions/examples/hello_world/bin/hello_world.wasm \
+       --config-path=./oak_functions/examples/hello_world/config.toml
    ```
 
 1. Invoke with:
 
    ```shell
-   curl --include --fail-early --request POST --data 'request-body' localhost:8080/invoke
+   curl --include --fail-early --request POST --data 'world' localhost:8080/invoke
    ```

--- a/oak_functions/loader/Cargo.lock
+++ b/oak_functions/loader/Cargo.lock
@@ -419,9 +419,12 @@ dependencies = [
  "oak_functions_abi",
  "prost",
  "prost-build",
+ "serde",
+ "serde_derive",
  "structopt",
  "tempfile",
  "tokio",
+ "toml",
  "wasmi",
 ]
 
@@ -648,6 +651,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +773,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -20,8 +20,10 @@ env_logger = "*"
 http = "*"
 hyper = { version = "*", features = ["client", "http1", "runtime", "server"] }
 log = "*"
+oak_functions_abi = { path = "../abi" }
 prost = "*"
-oak_functions_abi = { version = "0.1.0", path = "../abi" }
+serde = "*"
+serde_derive = "*"
 structopt = "*"
 tokio = { version = "*", features = [
   "fs",
@@ -29,6 +31,7 @@ tokio = { version = "*", features = [
   "sync",
   "rt-multi-thread"
 ] }
+toml = "*"
 wasmi = "*"
 
 [dev-dependencies]

--- a/oak_functions/loader/src/main.rs
+++ b/oak_functions/loader/src/main.rs
@@ -181,6 +181,7 @@ async fn main() -> anyhow::Result<()> {
         .with_context(|| format!("Couldn't read config file {}", &opt.config_path))?;
     let config: Config =
         toml::from_slice(&config_file_bytes).context("Couldn't parse config file")?;
+    // Print the parsed config to STDERR regardless of whether the logger is initialized.
     eprintln!("parsed config file:\n{:#?}", config);
 
     // For now the server runs in the same thread, so `notify_sender` is not really needed.

--- a/oak_functions/loader/testdata/.dockerignore
+++ b/oak_functions/loader/testdata/.dockerignore
@@ -1,2 +1,3 @@
 /*
 !/non-oak-minimal.wasm
+!/config.toml

--- a/oak_functions/loader/testdata/Dockerfile
+++ b/oak_functions/loader/testdata/Dockerfile
@@ -1,3 +1,6 @@
-FROM gcr.io/oak-ci/oak-functions@sha256:2acd77d705f74c612de2d61ed16835c446988e0a9dbe82b7f18d8de461c9d678
+# Allow deploying the latest version for development.
+# hadolint ignore=DL3007
+FROM gcr.io/oak-ci/oak-functions:latest
 
-COPY ./non-oak-minimal.wasm ./module.wasm
+COPY ./non-oak-minimal.wasm /module.wasm
+COPY ./config.toml /config.toml

--- a/oak_functions/loader/testdata/config.toml
+++ b/oak_functions/loader/testdata/config.toml
@@ -1,0 +1,1 @@
+lookup_data_path = "/dev/null"

--- a/oak_functions/loader/testdata/config.toml
+++ b/oak_functions/loader/testdata/config.toml
@@ -1,1 +1,0 @@
-lookup_data_path = "/dev/null"

--- a/scripts/deploy_oak_functions_loader
+++ b/scripts/deploy_oak_functions_loader
@@ -57,7 +57,8 @@ gcloud run deploy "${FUNCTIONS_INSTANCE_NAME}" \
 
 curl \
   --include \
+  --fail \
   --fail-early \
   --request POST \
   --data 'test-request-body' \
-  "https://${FUNCTIONS_INSTANCE_NAME}-62sa4xcfia-nw.a.run.app/invoke?n=[0-63]"
+  "https://${FUNCTIONS_INSTANCE_NAME}-62sa4xcfia-nw.a.run.app/invoke?n=[0-15]"


### PR DESCRIPTION
Reduce the number of test requests when deploying.

Make curl fail if the server does not return an OK HTTP status.

Fix #1961

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
