### PR TITLE
Unify wasm compilation flags

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -797,7 +797,7 @@ async fn test_translate() {
         ..Default::default()
     };
 
-    let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME, permissions)
+    let runtime = oak_tests::run_single_module_default(permissions)
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;
@@ -856,8 +856,8 @@ async fn test_say_hello() {
     };
     let runtime_config = oak_tests::runtime_config_wasm(
         hashmap! {
-            MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, MAIN_MODULE_WASM_FILE_NAME, oak_tests::Profile::Release).expect("Couldn't compile main module"),
-            TRANSLATOR_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(TRANSLATOR_MODULE_MANIFEST, TRANSLATOR_MODULE_WASM_FILE_NAME, oak_tests::Profile::Release).expect("Couldn't compile translator module"),
+            MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, oak_tests::Profile::Release).expect("Couldn't compile main module"),
+            TRANSLATOR_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(TRANSLATOR_MODULE_MANIFEST, oak_tests::Profile::Release).expect("Couldn't compile translator module"),
         },
         MAIN_MODULE_NAME,
         MAIN_ENTRYPOINT_NAME,

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -411,6 +411,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
+name = "camino"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "semver-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1781,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
+ "cargo_metadata",
  "lazy_static",
  "log",
  "oak",
@@ -1914,6 +1947,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "petgraph"
@@ -2475,6 +2517,25 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -3346,6 +3407,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/examples/abitest/abitest_common/Cargo.toml
+++ b/examples/abitest/abitest_common/Cargo.toml
@@ -7,5 +7,5 @@ license = "Apache-2.0"
 
 [dependencies]
 serde = { version = "*", features = ["derive"] }
-oak = "=0.1.0"
+oak = { path = "../../../sdk/rust/oak" }
 serde_json = "*"

--- a/examples/abitest/module_0/rust/Cargo.toml
+++ b/examples/abitest/module_0/rust/Cargo.toml
@@ -20,10 +20,10 @@ hex = "*"
 http = "*"
 http_server = { path = "../../../http_server/module" }
 log = "*"
-oak = "=0.1.0"
-oak_abi = "=0.1.0"
-oak_io = "=0.1.0"
-oak_services = "=0.1.0"
+oak = { path = "../../../../sdk/rust/oak" }
+oak_abi = { path = "../../../../oak_abi" }
+oak_io = { path = "../../../../oak_io" }
+oak_services = { path = "../../../../oak_services" }
 prost = "*"
 rand_core = "*"
 rand = "*"
@@ -33,7 +33,7 @@ serde_json = "*"
 tink-proto = "^0.1"
 
 [build-dependencies]
-oak_utils = "*"
+oak_utils = { path = "../../../../oak_utils" }
 
 [dev-dependencies]
 anyhow = "*"
@@ -42,8 +42,8 @@ assert_matches = "*"
 env_logger = "*"
 log = "*"
 maplit = "*"
-oak_runtime = "=0.1.0"
-oak_tests = "=0.1.0"
+oak_runtime = { path = "../../../../oak_runtime" }
+oak_tests = { path = "../../../../sdk/rust/oak_tests" }
 tokio = { version = "*", features = ["macros", "rt-threaded", "stream"] }
 tonic = { version = "*", features = ["tls"] }
 serial_test = "*"

--- a/examples/abitest/module_0/rust/tests/integration_test.rs
+++ b/examples/abitest/module_0/rust/tests/integration_test.rs
@@ -34,15 +34,11 @@ const FRONTEND_MANIFEST: &str = "../../module_0/rust/Cargo.toml";
 const BACKEND_MANIFEST: &str = "../../module_1/rust/Cargo.toml";
 const LINEAR_HANDLES_MANIFEST: &str = "../../module_linear_handles/rust/Cargo.toml";
 
-const FRONTEND_MODULE_WASM_FILE_NAME: &str = "abitest_0_frontend.wasm";
-const BACKEND_MODULE_WASM_FILE_NAME: &str = "abitest_1_backend.wasm";
-const LINEAR_HANDLES_MODULE_WASM_FILE_NAME: &str = "abitest_linear_handles.wasm";
-
 fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
-        FRONTEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, FRONTEND_MODULE_WASM_FILE_NAME, oak_tests::Profile::Debug).context("could not compile frontend module")?,
-        BACKEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(BACKEND_MANIFEST, BACKEND_MODULE_WASM_FILE_NAME, oak_tests::Profile::Debug).context("could not compile backend module")?,
-        LINEAR_HANDLES_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(LINEAR_HANDLES_MANIFEST, LINEAR_HANDLES_MODULE_WASM_FILE_NAME, oak_tests::Profile::Debug).context("could not compile linear_handles module")?,
+        FRONTEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(FRONTEND_MANIFEST, oak_tests::Profile::Debug).context("could not compile frontend module")?,
+        BACKEND_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(BACKEND_MANIFEST, oak_tests::Profile::Debug).context("could not compile backend module")?,
+        LINEAR_HANDLES_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(LINEAR_HANDLES_MANIFEST, oak_tests::Profile::Debug).context("could not compile linear_handles module")?,
     })
 }
 

--- a/examples/abitest/module_1/rust/Cargo.toml
+++ b/examples/abitest/module_1/rust/Cargo.toml
@@ -11,9 +11,9 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 log = "*"
 abitest_common = { path = "../../abitest_common" }
-oak = "=0.1.0"
-oak_abi = "=0.1.0"
-oak_io = "=0.1.0"
+oak = { path = "../../../../sdk/rust/oak" }
+oak_abi = { path = "../../../../oak_abi" }
+oak_io = { path = "../../../../oak_io" }
 prost = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = "*"

--- a/examples/abitest/oak_app_manifest.toml
+++ b/examples/abitest/oak_app_manifest.toml
@@ -1,9 +1,9 @@
 name = "abitest"
 
 [modules]
-frontend_module = { path = "examples/abitest/bin/abitest_0_frontend.wasm" }
-backend_module = { path = "examples/abitest/bin/abitest_1_backend.wasm" }
-linear_handles_module = { path = "examples/abitest/bin/abitest_linear_handles.wasm" }
+frontend_module = { path = "examples/bin/abitest_0_frontend.wasm" }
+backend_module = { path = "examples/bin/abitest_1_backend.wasm" }
+linear_handles_module = { path = "examples/bin/abitest_linear_handles.wasm" }
 
 [initial_node_configuration]
 wasm_module_name = "frontend_module"

--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -150,10 +150,9 @@ gcloud monitoring dashboards list
 ## To update this example
 
 1. Build the example, including the Wasm module
-1. Get module SHA256 hash via
-   `sha256sum examples/aggregator/bin/aggregator.wasm`
+1. Get module SHA256 hash via `sha256sum examples/bin/aggregator.wasm`
 1. Fix module hash in the following files:
 
-- `examples/aggregator/config.toml`
-- `examples/aggregator/client/cpp/aggregator.cc`
-- `examples/aggregator/client/android/cpp/client.cc`
+   - [`/examples/aggregator/config.toml`](/examples/aggregator/config.toml)
+   - [`/examples/aggregator/client/cpp/aggregator.cc`](/examples/aggregator/client/cpp/aggregator.cc)
+   - [`/examples/aggregator/client/android/cpp/client.cc`](/examples/aggregator/client/android/cpp/client.cc)

--- a/examples/aggregator/module/rust/tests/integration_test.rs
+++ b/examples/aggregator/module/rust/tests/integration_test.rs
@@ -29,7 +29,6 @@ use std::{
     convert::{From, TryFrom},
 };
 
-const WASM_MODULE_FILE_NAME: &str = "aggregator.wasm";
 const WASM_MODULE_MANIFEST: &str = "../../module/rust/Cargo.toml";
 const MODULE_NAME: &str = "app";
 const ENTRYPOINT_NAME: &str = "oak_main";
@@ -52,12 +51,9 @@ async fn submit_sample(
 async fn test_aggregator() {
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let wasm_module = oak_tests::compile_rust_wasm(
-        WASM_MODULE_MANIFEST,
-        WASM_MODULE_FILE_NAME,
-        oak_tests::Profile::Release,
-    )
-    .expect("Couldn't compile Wasm module");
+    let wasm_module =
+        oak_tests::compile_rust_wasm(WASM_MODULE_MANIFEST, oak_tests::Profile::Release)
+            .expect("Couldn't compile Wasm module");
     let wasm_module_hash = get_sha256(&wasm_module);
 
     let module_config = format!(

--- a/examples/aggregator/oak_app_manifest.toml
+++ b/examples/aggregator/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "aggregator"
 
 [modules]
-app = { path = "examples/aggregator/bin/aggregator.wasm" }
+app = { path = "examples/bin/aggregator.wasm" }

--- a/examples/chat/module/rust/tests/integration_test.rs
+++ b/examples/chat/module/rust/tests/integration_test.rs
@@ -20,8 +20,6 @@ use log::info;
 use serial_test::serial;
 use std::time::Duration;
 
-const MODULE_WASM_FILE_NAME: &str = "chat.wasm";
-
 #[tokio::test(core_threads = 4)]
 #[serial]
 async fn test_chat() {
@@ -32,7 +30,7 @@ async fn test_chat() {
         ..Default::default()
     };
 
-    let runtime = oak_tests::run_single_module(MODULE_WASM_FILE_NAME, "main", permissions)
+    let runtime = oak_tests::run_single_module("main", permissions)
         .expect("could not configure runtime with test Wasm file");
 
     let room_0_key_pair = oak_sign::KeyPair::generate().expect("could not generate room key pair");

--- a/examples/chat/oak_app_manifest.toml
+++ b/examples/chat/oak_app_manifest.toml
@@ -1,7 +1,7 @@
 name = "chat"
 
 [modules]
-app = { path = "examples/target/wasm32-unknown-unknown/release/chat.wasm" }
+app = { path = "examples/bin/chat.wasm" }
 
 [initial_node_configuration]
 wasm_module_name = "app"

--- a/examples/chat/oak_app_manifest.toml
+++ b/examples/chat/oak_app_manifest.toml
@@ -1,7 +1,7 @@
 name = "chat"
 
 [modules]
-app = { path = "examples/chat/bin/chat.wasm" }
+app = { path = "examples/target/wasm32-unknown-unknown/release/chat.wasm" }
 
 [initial_node_configuration]
 wasm_module_name = "app"

--- a/examples/hello_world/module/rust/tests/integration_test.rs
+++ b/examples/hello_world/module/rust/tests/integration_test.rs
@@ -24,11 +24,9 @@ use tokio::stream::StreamExt;
 const MAIN_MODULE_NAME: &str = "app";
 const MAIN_ENTRYPOINT_NAME: &str = "oak_main";
 const MAIN_MODULE_MANIFEST: &str = "../../module/rust/Cargo.toml";
-const MAIN_MODULE_WASM_FILE_NAME: &str = "hello_world.wasm";
 
 const TRANSLATOR_MODULE_NAME: &str = "translator";
 const TRANSLATOR_MODULE_MANIFEST: &str = "../../../translator/module/rust/Cargo.toml";
-const TRANSLATOR_MODULE_WASM_FILE_NAME: &str = "translator.wasm";
 
 // Test invoking the SayHello Node service method via the Oak runtime.
 #[tokio::test(core_threads = 2)]
@@ -41,8 +39,8 @@ async fn test_say_hello() {
     };
     let runtime_config = oak_tests::runtime_config_wasm(
         hashmap! {
-            MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, MAIN_MODULE_WASM_FILE_NAME, oak_tests::Profile::Release).expect("Couldn't compile main module"),
-            TRANSLATOR_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(TRANSLATOR_MODULE_MANIFEST, TRANSLATOR_MODULE_WASM_FILE_NAME, oak_tests::Profile::Release).expect("Couldn't compile translator module"),
+            MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, oak_tests::Profile::Release).expect("Couldn't compile main module"),
+            TRANSLATOR_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(TRANSLATOR_MODULE_MANIFEST, oak_tests::Profile::Release).expect("Couldn't compile translator module"),
         },
         MAIN_MODULE_NAME,
         MAIN_ENTRYPOINT_NAME,

--- a/examples/hello_world/oak_app_manifest.toml
+++ b/examples/hello_world/oak_app_manifest.toml
@@ -1,5 +1,5 @@
 name = "hello_world"
 
 [modules]
-app = { path = "examples/hello_world/bin/hello_world.wasm" }
-translator = { path = "examples/hello_world/bin/translator.wasm" }
+app = { path = "examples/bin/hello_world.wasm" }
+translator = { path = "examples/bin/translator.wasm" }

--- a/examples/http_server/oak_app_manifest.toml
+++ b/examples/http_server/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "http_server"
 
 [modules]
-app = { path = "examples/http_server/bin/http_server.wasm" }
+app = { path = "examples/bin/http_server.wasm" }

--- a/examples/injection/oak_app_manifest.toml
+++ b/examples/injection/oak_app_manifest.toml
@@ -1,7 +1,7 @@
 name = "injection"
 
 [modules]
-app = { path = "examples/injection/bin/injection.wasm" }
+app = { path = "examples/bin/injection.wasm" }
 
 [initial_node_configuration]
 wasm_module_name = "app"

--- a/examples/private_set_intersection/README.md
+++ b/examples/private_set_intersection/README.md
@@ -12,7 +12,7 @@ the code is modified, the wasm module and the signature must be regenerated:
    ```bash
    ./scripts/oak_sign sign \
      --private-key=./examples/keys/ed25519/test.key \
-     --input-file=./examples/private_set_intersection/bin/private_set_intersection_handler.wasm \
+     --input-file=./examples/bin/private_set_intersection_handler.wasm \
      --signature-file=./examples/private_set_intersection/private_set_intersection_handler.sign
    ```
 

--- a/examples/private_set_intersection/main_module/rust/tests/integration_test.rs
+++ b/examples/private_set_intersection/main_module/rust/tests/integration_test.rs
@@ -34,9 +34,6 @@ use std::{
 // Base64 encoded Ed25519 private key corresponding to Wasm module signature.
 const PRIVATE_KEY_FILE: &str = "../../../keys/ed25519/test.key";
 
-const MAIN_MODULE_FILE_NAME: &str = "private_set_intersection.wasm";
-const HANDLER_MODULE_FILE_NAME: &str = "private_set_intersection_handler.wasm";
-
 const MAIN_MODULE_MANIFEST: &str = "../../main_module/rust/Cargo.toml";
 const HANDLER_MODULE_MANIFEST: &str = "../../handler_module/rust/Cargo.toml";
 
@@ -48,8 +45,8 @@ const TEST_SET_ID: &str = "test";
 
 fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
-        MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, MAIN_MODULE_FILE_NAME, oak_tests::Profile::Release).context("Couldn't compile main module")?,
-        HANDLER_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(HANDLER_MODULE_MANIFEST, HANDLER_MODULE_FILE_NAME, oak_tests::Profile::Release).context("Couldn't compile handler module")?,
+        MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, oak_tests::Profile::Release).context("Couldn't compile main module")?,
+        HANDLER_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(HANDLER_MODULE_MANIFEST, oak_tests::Profile::Release).context("Couldn't compile handler module")?,
     })
 }
 

--- a/examples/private_set_intersection/oak_app_manifest.toml
+++ b/examples/private_set_intersection/oak_app_manifest.toml
@@ -4,5 +4,5 @@ signature_manifests = [
 ]
 
 [modules]
-app = { path = "examples/private_set_intersection/bin/private_set_intersection.wasm" }
-handler = { path = "examples/private_set_intersection/bin/private_set_intersection_handler.wasm" }
+app = { path = "examples/bin/private_set_intersection.wasm" }
+handler = { path = "examples/bin/private_set_intersection_handler.wasm" }

--- a/examples/proxy_attestation/oak_app_manifest.toml
+++ b/examples/proxy_attestation/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "proxy_attestation"
 
 [modules]
-app = { path = "examples/proxy_attestation/bin/proxy_attestation_example.wasm" }
+app = { path = "examples/bin/proxy_attestation_example.wasm" }

--- a/examples/translator/module/rust/tests/integration_test.rs
+++ b/examples/translator/module/rust/tests/integration_test.rs
@@ -18,8 +18,6 @@ use assert_matches::assert_matches;
 use log::info;
 use translator_grpc::proto::{translator_client::TranslatorClient, TranslateRequest};
 
-const MODULE_WASM_FILE_NAME: &str = "translator.wasm";
-
 #[tokio::test(core_threads = 2)]
 async fn test_translate() {
     let _ = env_logger::builder().is_test(true).try_init();
@@ -29,7 +27,7 @@ async fn test_translate() {
         ..Default::default()
     };
 
-    let runtime = oak_tests::run_single_module_default(MODULE_WASM_FILE_NAME, permissions)
+    let runtime = oak_tests::run_single_module_default(permissions)
         .expect("Unable to configure runtime with test wasm!");
 
     let (channel, interceptor) = oak_tests::public_channel_and_interceptor().await;

--- a/examples/translator/oak_app_manifest.toml
+++ b/examples/translator/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "translator"
 
 [modules]
-app = { path = "examples/translator/bin/translator.wasm" }
+app = { path = "examples/bin/translator.wasm" }

--- a/examples/trusted_database/module/rust/tests/integration_test.rs
+++ b/examples/trusted_database/module/rust/tests/integration_test.rs
@@ -27,7 +27,6 @@ use trusted_database_client::proto::{
 const MAIN_MODULE_NAME: &str = "app";
 const MAIN_ENTRYPOINT_NAME: &str = "oak_main";
 const MAIN_MODULE_MANIFEST: &str = "../../module/rust/Cargo.toml";
-const MAIN_MODULE_WASM_FILE_NAME: &str = "trusted_database.wasm";
 
 const XML_DATABASE: &str = r#"<?xml version="1.0" encoding="utf-8"?><stations lastUpdate="1590775020879" version="2.0">
     <station>
@@ -94,7 +93,7 @@ const XML_DATABASE: &str = r#"<?xml version="1.0" encoding="utf-8"?><stations la
 
 fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
-        MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, MAIN_MODULE_WASM_FILE_NAME, oak_tests::Profile::Release).context("Couldn't compile main module")?,
+        MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(MAIN_MODULE_MANIFEST, oak_tests::Profile::Release).context("Couldn't compile main module")?,
     })
 }
 

--- a/examples/trusted_database/oak_app_manifest.toml
+++ b/examples/trusted_database/oak_app_manifest.toml
@@ -1,4 +1,4 @@
 name = "trusted_database"
 
 [modules]
-app = { path = "examples/trusted_database/bin/trusted_database.wasm" }
+app = { path = "examples/bin/trusted_database.wasm" }

--- a/experimental/Cargo.lock
+++ b/experimental/Cargo.lock
@@ -258,6 +258,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
+name = "camino"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "semver-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1519,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
+ "cargo_metadata",
  "lazy_static",
  "log",
  "oak",
@@ -1619,6 +1652,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "petgraph"
@@ -2079,6 +2121,25 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -2917,6 +2978,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/experimental/benchmark/src/application/oak.rs
+++ b/experimental/benchmark/src/application/oak.rs
@@ -27,13 +27,11 @@ use trusted_database_client::proto::{
 const MAIN_MODULE_NAME: &str = "app";
 const MAIN_ENTRYPOINT_NAME: &str = "oak_main";
 const MAIN_MODULE_MANIFEST: &str = "../../examples/trusted_database/module/rust/Cargo.toml";
-const MAIN_MODULE_WASM_FILE_NAME: &str = "trusted_database.wasm";
 
 fn build_wasm() -> anyhow::Result<HashMap<String, Vec<u8>>> {
     Ok(hashmap! {
         MAIN_MODULE_NAME.to_owned() => oak_tests::compile_rust_wasm(
             MAIN_MODULE_MANIFEST,
-            MAIN_MODULE_WASM_FILE_NAME,
             oak_tests::Profile::Release
         ).context("Couldn't compile main module")?,
     })

--- a/oak_functions/loader/Cargo.lock
+++ b/oak_functions/loader/Cargo.lock
@@ -421,7 +421,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "structopt",
- "tempfile",
  "test_utils",
  "tokio",
  "toml",

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -39,5 +39,4 @@ wasmi = "*"
 
 [dev-dependencies]
 hyper = { version = "*", features = ["client"] }
-tempfile = "*"
 test_utils = { path = "../sdk/test_utils" }

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -70,6 +70,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
+name = "camino"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "semver-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +181,12 @@ checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lazy_static"
@@ -263,6 +301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +387,7 @@ version = "0.1.0"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "cargo_metadata",
  "chrono",
  "clap",
  "colored",
@@ -355,12 +403,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -381,6 +454,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -520,6 +604,12 @@ checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 async-recursion = "*"
 async-trait = "*"
+cargo_metadata = "*"
 chrono = "*"
 clap = "*"
 colored = "*"

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -200,6 +200,14 @@ fn build_wasm_module(name: &str, target: &Target, example_name: &str) -> Step {
                         "-Zunstable-options".to_string(),
                         "build".to_string(),
                         "--target=wasm32-unknown-unknown".to_string(),
+                        // Use a fixed `--target-dir`, because it influences the SHA256 hash of the
+                        // Wasm module.
+                        //
+                        // This directory is separate from `examples/target` because it is used by
+                        // `cargo test`, which also executes [`oak_tests::compile_rust_wasm`] and
+                        // thus runs `cargo build` inside it. It may lead to errors, since
+                        // dependencies may be recompiled by `cargo build` and `cargo test` will
+                        // fail to continue.
                         format!("--target-dir={}/wasm", metadata.target_directory),
                         format!("--manifest-path={}", cargo_manifest),
                         format!("--out-dir={}/bin", metadata.workspace_root),

--- a/scripts/build_reproducibility_index
+++ b/scripts/build_reproducibility_index
@@ -12,7 +12,7 @@ source "$SCRIPTS_DIR/common"
 
 # List of artifacts that are expected to be reproducibly built.
 readonly REPRODUCIBLE_ARTIFACTS=(
-  ./examples/*/bin/*.wasm
+  ./examples/bin/*.wasm
   ./oak_loader/bin/oak_loader
   ./oak_functions/loader/bin/oak_functions_loader
 )

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -240,6 +240,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
+name = "camino"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "semver-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1351,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
+ "cargo_metadata",
  "lazy_static",
  "log",
  "oak",
@@ -1448,6 +1481,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "petgraph"
@@ -1921,6 +1963,25 @@ checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -2647,6 +2708,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/sdk/rust/oak/Cargo.toml
+++ b/sdk/rust/oak/Cargo.toml
@@ -13,14 +13,14 @@ anyhow = "*"
 byteorder = "*"
 http = "*"
 log = { version = "*", features = ["std"] }
-oak_abi = "=0.1.0"
+oak_abi = { path = "../../../oak_abi" }
 oak_derive = { path = "../../../oak_derive" }
-oak_io = { version = "=0.1.0" }
-oak_services = "=0.1.0"
+oak_io = { path = "../../../oak_io" }
+oak_services = { path = "../../../oak_services" }
 prost = "*"
 prost-types = "*"
 rand_core = { version = "*", features = ["std"] }
 tink-proto = "^0.1"
 
 [build-dependencies]
-oak_utils = "*"
+oak_utils = { path = "../../../oak_utils" }

--- a/sdk/rust/oak_app_build/src/main.rs
+++ b/sdk/rust/oak_app_build/src/main.rs
@@ -126,7 +126,7 @@ fn get_module_cache_path(manifest_dir: &Path, module_sha256_sum: &str) -> PathBu
 }
 
 /// Get path for the output application file in [`OUTPUT_DIRECTORY`].
-fn get_output_path(manifest_dir: &Path, app_name: &str) -> PathBuf {
+fn get_output_file_path(manifest_dir: &Path, app_name: &str) -> PathBuf {
     manifest_dir
         .join(OUTPUT_DIRECTORY)
         .join(format!("{}.oak", app_name))
@@ -297,10 +297,14 @@ async fn main() -> anyhow::Result<()> {
         module_signatures: signatures,
     };
 
-    let output_file = get_output_path(&manifest_dir, &manifest.name);
+    let output_file_path = get_output_file_path(&manifest_dir, &manifest.name);
+
+    std::fs::create_dir_all(output_file_path.parent().unwrap())
+        .context("Couldn't create output dir")?;
 
     // Serialize application.
-    write_config_to_file(&app_config, &output_file).context("Couldn't write serialized config")?;
+    write_config_to_file(&app_config, &output_file_path)
+        .context("Couldn't write serialized config")?;
 
     Ok(())
 }

--- a/sdk/rust/oak_tests/Cargo.toml
+++ b/sdk/rust/oak_tests/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "*"
 byteorder = "*"
+cargo_metadata = "*"
 lazy_static = "*"
 log = { version = "*", features = ["std"] }
 oak = "=0.1.0"


### PR DESCRIPTION
This removes some of the logic around compiling Wasm modules to a
specific out dir, but I think it makes more sense to keep the default
location and modify the app manifest files to point to it rather than
convincing cargo to put compiled artifacts in non-standard folders, even
if the manifests end up being slightly longer.

- Fix the path of some of the internal dependencies, since some tests
started randomly failing, presumably because of some interference with
externally published crates with the same names (namely `prost`).
