### PR TITLE
Enable dependabot for oak Functions loader

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: '70...100'
 
 parsers:
   gcov:
@@ -17,8 +17,8 @@ parsers:
 comment: false
 
 ignore:
-  - "examples/"    # Just track Rust->host compiled code
-  - "third_party/" # Ignore local forks
-  - "**/build.rs"  # Ignore build scripts
-  - "**/tests/"
-  - "**/tests.rs"
+  - 'examples/' # Just track Rust->host compiled code
+  - 'third_party/' # Ignore local forks
+  - '**/build.rs' # Ignore build scripts
+  - '**/tests/'
+  - '**/tests.rs'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/oak_loader"
+  - package-ecosystem: 'cargo'
+    directory: '/oak_loader'
     schedule:
-      interval: "daily"
+      interval: 'daily'
+  - package-ecosystem: 'cargo'
+    directory: '/oak_functions/loader'
+    schedule:
+      interval: 'daily'

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -291,7 +291,7 @@ fn build_server(opt: &BuildServer) -> Step {
                 _ => vec![]
             },
             vec![
-                build_rust_binary("oak_loader", opt, 
+                build_rust_binary("oak_loader", opt,
                 &if opt.server_variant == ServerVariant::Coverage {
                     hashmap! {
                         // Build the Runtime server in coverage mode, as per https://github.com/mozilla/grcov
@@ -1058,7 +1058,7 @@ fn is_toml_file(path: &PathBuf) -> bool {
 
 fn is_yaml_file(path: &PathBuf) -> bool {
     let filename = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
-    filename.ends_with(".yaml")
+    filename.ends_with(".yaml") || filename.ends_with(".yml")
 }
 
 fn is_html_file(path: &PathBuf) -> bool {


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
