### PR TITLE
ABI for lookups

### DIFF
--- a/docs/oak_functions_abi.md
+++ b/docs/oak_functions_abi.md
@@ -36,25 +36,65 @@ functions** as
 
 ### `read_request`
 
-Reads the user request. The low-level operation involves writing the request
-into the provided space on the WebAssembly module's memory. If the provided
-space for data (`param[0]` and `param[1]`) is not large enough for the read
-operation, then no data is written to the destination buffer, and the function
-returns `BUFFER_TOO_SMALL`. In this case, the required size is written in the
-space provided by `param[2]`, so that the operation can be repeated with a
-larger buffer.
+Reads the request sent by the client.
+
+The low-level operation involves writing the request into the provided space on
+the WebAssembly module's memory.
+
+If the provided space for data (`param[0]` and `param[1]`) is not large enough
+for the read operation, then no data is written to the destination buffer, and
+the function returns `ERR_BUFFER_TOO_SMALL`. In this case, the required size is
+written in the space provided by `param[2]`, so that the operation can be
+repeated with a larger buffer.
+
+Multiple calls all result in the same values in the destination buffer, and
+return the same status.
 
 - `param[0]: usize`: Destination buffer address
 - `param[1]: usize`: Destination buffer size in bytes
 - `param[2]: usize`: Address of a 4-byte location that will receive the number
   of bytes in the request (as a little-endian u32).
-- `result[0]: u32`: Status of operation
+- `result[0]: u32`: Status of operation as
+  [`OakStatus`](https://github.com/project-oak/oak/blob/main/oak_functions/proto/abi.proto)
 
 ### `write_response`
 
-Writes the response that should be sent to the user. The low-level operation
-involves reading the response from the WebAssembly module's memory.
+Writes the response to be sent back to the client.
+
+The low-level operation involves reading the response from the WebAssembly
+module's memory.
+
+Multiple calls overwrite the response bytes, and only the last invocation is
+considered for the actual response sent to the client.
+
+If this function is never invoked, then an empty response is returned to the
+client.
 
 - `param[0]: usize`: Source buffer address holding message
 - `param[1]: usize`: Source buffer size in bytes
-- `result[0]: u32`: Status of operation
+- `result[0]: u32`: Status of operation as
+  [`OakStatus`](https://github.com/project-oak/oak/blob/main/oak_functions/proto/abi.proto)
+
+### `storage_get_item`
+
+Retrieves a single item by key from the lookup data in-memory store.
+
+If no item with the provided key is present, returns
+`ERR_STORAGE_ITEM_NOT_FOUND`.
+
+The in-memory store may be periodically refreshed, so multiple calls to this
+function, even with identical arguments, may result in different outcomes,
+including flipping from success to error or vice versa. In particular, retrying
+calling this method after re-allocating the destination buffer based on the
+`value_actual_size` reported size may still fail, for instance if the entry was
+changed to have a larger value in the meanwhile; in fact, the entry may even
+have been deleted entirely between calls.
+
+- `param[0]: usize`: Source buffer address holding key
+- `param[1]: usize`: Source buffer size in bytes
+- `param[2]: usize`: Destination buffer address
+- `param[3]: usize`: Destination buffer size in bytes
+- `param[4]: usize`: Address of a 4-byte location that will receive the number
+  of bytes of the value (as a little-endian u32).
+- `result[0]: u32`: Status of operation as
+  [`OakStatus`](https://github.com/project-oak/oak/blob/main/oak_functions/proto/abi.proto)

--- a/docs/oak_functions_abi.md
+++ b/docs/oak_functions_abi.md
@@ -86,9 +86,9 @@ The in-memory store may be periodically refreshed, so multiple calls to this
 function, even with identical arguments, may result in different outcomes,
 including flipping from success to error or vice versa. In particular, retrying
 calling this method after re-allocating the destination buffer based on the
-`value_actual_size` reported size may still fail, for instance if the entry was
-changed to have a larger value in the meanwhile; in fact, the entry may even
-have been deleted entirely between calls.
+`param[4]` reported size may still fail, for instance if the entry was changed
+to have a larger value in the meanwhile; in fact, the entry may even have been
+deleted entirely between calls.
 
 - `param[0]: usize`: Source buffer address holding key
 - `param[1]: usize`: Source buffer size in bytes

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -30,33 +30,18 @@ pub mod proto {
 // See https://rustwasm.github.io/book/reference/js-ffi.html
 #[link(wasm_import_module = "oak_functions")]
 extern "C" {
-    /// Reads the user request.
-    ///
-    /// Stores the user request into `buf`. The size of the request data is stored into
-    /// `actual_size`.
-    ///
-    /// If the provided space for data (`buf` plus `size`) is not large enough for the read
-    /// operation, then no data will be written into `buf` and [`ErrBufferTooSmall`] will be
-    /// returned. In this case, the size of the required space will be returned in the space
-    /// provided by `actual_size`.
-    ///
-    /// Returns the status of the operation, as an [`OakStatus`] value.
-    ///
-    /// Multiple calls all result in the same values in the `buf`, and return the same status.
-    ///
-    /// [`ErrBufferTooSmall`]: crate::OakStatus::ErrBufferTooSmall
-    /// [`OakStatus`]: crate::OakStatus
+    /// See [`read_request`](https://github.com/project-oak/oak/blob/main/docs/oak_functions_abi.md#read_request).
     pub fn read_request(buf: *mut u8, size: usize, actual_size: *mut u32) -> u32;
 
-    /// Writes the response.
-    ///
-    /// Stores `size` bytes of data from `buf` into the WebAssembly interface. This can then be
-    /// returned to the user as the response.
-    ///
-    /// Returns the status of the operation, as an [`OakStatus`] value.
-    ///
-    /// Multiple calls overwrite the response bytes in the Wasm memory.
-    ///
-    /// [`OakStatus`]: crate::OakStatus
+    /// See [`write_response`](https://github.com/project-oak/oak/blob/main/docs/oak_functions_abi.md#write_response).
     pub fn write_response(buf: *const u8, size: usize) -> u32;
+
+    /// See [`storage_get_item`](https://github.com/project-oak/oak/blob/main/docs/oak_functions_abi.md#storage_get_item).
+    pub fn storage_get_item(
+        key_buf: *const u8,
+        key_size: usize,
+        value_buf: *mut u8,
+        value_size: usize,
+        value_actual_size: *mut u32,
+    ) -> u32;
 }

--- a/oak_functions/examples/Cargo.lock
+++ b/oak_functions/examples/Cargo.lock
@@ -187,6 +187,7 @@ version = "0.1.0"
 dependencies = [
  "http",
  "hyper",
+ "maplit",
  "oak_functions",
  "oak_functions_loader",
  "test_utils",
@@ -320,6 +321,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memory_units"
@@ -767,7 +774,10 @@ name = "test_utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "hyper",
  "log",
+ "oak_functions_abi",
+ "prost",
 ]
 
 [[package]]

--- a/oak_functions/examples/hello_world/module/Cargo.toml
+++ b/oak_functions/examples/hello_world/module/Cargo.toml
@@ -15,6 +15,7 @@ oak_functions = { path = "../../../sdk/oak_functions" }
 oak_functions_loader = { path = "../../../loader" }
 http = "*"
 hyper = { version = "*", features = ["client"] }
+maplit = "*"
 test_utils = { path = "../../../sdk/test_utils" }
 tokio = { version = "*", features = [
   "fs",

--- a/oak_functions/examples/hello_world/module/src/lib.rs
+++ b/oak_functions/examples/hello_world/module/src/lib.rs
@@ -24,10 +24,20 @@ pub extern "C" fn main() {
     // Read the request
     let request_body = oak_functions::read_request().expect("Couldn't read request body.");
 
+    // Try to look up the name in the storage data, and if found use the result as surname in the
+    // response message.
+    let surname = oak_functions::storage_get_item(&request_body).expect("Couldn't look up surname");
+
     // Create response body
     let response_body = format!(
-        "Hello {}!\n",
-        std::str::from_utf8(&request_body).expect("Couldn't convert bytes to string")
+        "Hello {}{}!\n",
+        std::str::from_utf8(&request_body).expect("Couldn't convert bytes to string"),
+        surname
+            .map(|v| std::str::from_utf8(&v)
+                .expect("Couldn't convert bytes to string")
+                .to_string())
+            .map(|v| format!(" {}", v))
+            .unwrap_or_default()
     );
 
     // Write the response body

--- a/oak_functions/examples/hello_world/module/src/tests.rs
+++ b/oak_functions/examples/hello_world/module/src/tests.rs
@@ -64,7 +64,7 @@ async fn test_server() {
             &wasm_module_bytes,
             lookup_data,
             notify_receiver,
-            Logger::default(),
+            logger,
         )
         .await
     });

--- a/oak_functions/examples/hello_world/module/src/tests.rs
+++ b/oak_functions/examples/hello_world/module/src/tests.rs
@@ -14,12 +14,16 @@
 // limitations under the License.
 
 use hyper::client::Client;
-use oak_functions_loader::{logger::Logger, server::create_and_start_server};
-use std::net::{Ipv6Addr, SocketAddr};
+use maplit::hashmap;
+use oak_functions_loader::{logger::Logger, lookup::LookupData, server::create_and_start_server};
+use std::{
+    net::{Ipv6Addr, SocketAddr},
+    sync::Arc,
+};
 
 const WASM_MODULE_NAME: &str = "hello_world.wasm";
-const EXPECTED_RESPONSE: &str = "Hello World!\n";
 const OAK_FUNCTIONS_SERVER_PORT: u16 = 9001;
+const STATIC_SERVER_PORT: u16 = 9002;
 
 #[tokio::test]
 async fn test_server() {
@@ -35,24 +39,67 @@ async fn test_server() {
     )
     .expect("Couldn't read Wasm module");
 
-    let server_fut = create_and_start_server(
-        &address,
-        &wasm_module_bytes,
-        notify_receiver,
-        Logger::default(),
-    );
-    let client_fut = start_client(OAK_FUNCTIONS_SERVER_PORT, notify_sender);
+    let mock_static_server = Arc::new(test_utils::MockStaticServer::default());
 
-    let (res, _) = tokio::join!(server_fut, client_fut);
+    let mock_static_server_clone = mock_static_server.clone();
+    tokio::spawn(async move { mock_static_server_clone.serve(STATIC_SERVER_PORT).await });
+
+    mock_static_server.set_response_body(test_utils::serialize_entries(hashmap! {
+        b"Harry".to_vec() => b"Potter".to_vec(),
+        b"Sirius".to_vec() => b"Black".to_vec(),
+        b"Ron".to_vec() => b"Weasley".to_vec(),
+    }));
+
+    let logger = Logger::for_test();
+
+    let lookup_data = Arc::new(LookupData::new_empty(
+        &format!("http://localhost:{}", STATIC_SERVER_PORT),
+        logger.clone(),
+    ));
+    lookup_data.refresh().await.unwrap();
+
+    let server_join_handle = tokio::spawn(async move {
+        create_and_start_server(
+            &address,
+            &wasm_module_bytes,
+            lookup_data,
+            notify_receiver,
+            Logger::default(),
+        )
+        .await
+    });
+
+    {
+        // No lookup match.
+        let response_fut = make_request(OAK_FUNCTIONS_SERVER_PORT, b"World").await;
+        assert_eq!(
+            "Hello World!\n",
+            std::str::from_utf8(response_fut.as_slice()).unwrap()
+        );
+    }
+    {
+        // Lookup match.
+        let response_fut = make_request(OAK_FUNCTIONS_SERVER_PORT, b"Harry").await;
+        assert_eq!(
+            "Hello Harry Potter!\n",
+            std::str::from_utf8(response_fut.as_slice()).unwrap()
+        );
+    }
+
+    notify_sender
+        .send(())
+        .expect("Couldn't send completion signal.");
+
+    let res = server_join_handle.await.unwrap();
     assert!(res.is_ok());
 }
 
-async fn start_client(port: u16, notify_sender: tokio::sync::oneshot::Sender<()>) {
+async fn make_request(port: u16, request_body: &[u8]) -> Vec<u8> {
     let client = Client::new();
     let request = hyper::Request::builder()
         .method(http::Method::POST)
         .uri(format!("http://localhost:{}/invoke", port))
-        .body(hyper::Body::from("World"))
+        .body(hyper::Body::from(request_body.to_vec()))
         .unwrap();
     let resp = client
         .request(request)
@@ -60,12 +107,8 @@ async fn start_client(port: u16, notify_sender: tokio::sync::oneshot::Sender<()>
         .expect("Error while awaiting response");
 
     assert_eq!(resp.status(), hyper::StatusCode::OK);
-    assert_eq!(
-        hyper::body::to_bytes(resp.into_body()).await.unwrap(),
-        EXPECTED_RESPONSE
-    );
-
-    notify_sender
-        .send(())
-        .expect("Couldn't send completion signal.");
+    hyper::body::to_bytes(resp.into_body())
+        .await
+        .unwrap()
+        .to_vec()
 }

--- a/oak_functions/loader/Cargo.lock
+++ b/oak_functions/loader/Cargo.lock
@@ -742,7 +742,10 @@ name = "test_utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "hyper",
  "log",
+ "oak_functions_abi",
+ "prost",
 ]
 
 [[package]]

--- a/oak_functions/loader/src/lib.rs
+++ b/oak_functions/loader/src/lib.rs
@@ -15,4 +15,5 @@
 //
 
 pub mod logger;
+pub mod lookup;
 pub mod server;

--- a/oak_functions/loader/src/lookup.rs
+++ b/oak_functions/loader/src/lookup.rs
@@ -1,0 +1,153 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::logger::Logger;
+use anyhow::Context;
+use log::Level;
+use prost::Message;
+use std::{collections::HashMap, sync::RwLock, time::Instant};
+
+/// An in-memory lookup store instance that can refresh its internal entries from the provided data
+/// file URL.
+///
+/// Entries in the data file path must be consecutive binary encoded and length delimited
+/// protobuf messages according to the definition in `/oak_functions/proto/lookup_data.proto`.
+pub struct LookupData {
+    lookup_data_url: String,
+    entries: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
+    logger: Logger,
+}
+
+impl LookupData {
+    /// Creates a new empty [`LookupData`] instance that can refresh its internal entries from the
+    /// provided data file URL.
+    ///
+    /// The returned instance is empty, and must be populated by calling the [`LookupData::refresh`]
+    /// method at least once.
+    pub fn new_empty(lookup_data_url: &str, logger: Logger) -> LookupData {
+        LookupData {
+            lookup_data_url: lookup_data_url.to_string(),
+            entries: RwLock::new(HashMap::new()),
+            logger,
+        }
+    }
+
+    /// Refreshes the internal entries of this struct from the data file URL provided at
+    /// construction time.
+    ///
+    /// If successful, entries are completely replaced (i.e. not merged).
+    ///
+    /// If there is any error while reading or parsing the data, an error is returned by this
+    /// method, and existing entries are left untouched. The caller may retry the refresh operation
+    /// at a future time.
+    pub async fn refresh(&self) -> anyhow::Result<()> {
+        // TODO(#1930): Avoid loading the entire file in memory for parsing.
+        let client = hyper::Client::new();
+        let res = client
+            .get(
+                self.lookup_data_url
+                    .parse()
+                    .context("could not parse lookup data URL")?,
+            )
+            .await
+            .context("could not fetch lookup data")?;
+
+        let start = Instant::now();
+        let lookup_data_buf = hyper::body::to_bytes(res.into_body())
+            .await
+            .context("could not read lookup data response body")?;
+        self.logger.log_public(
+            Level::Info,
+            &format!(
+                "downloaded {} bytes of lookup data in {:.0?}",
+                lookup_data_buf.len(),
+                start.elapsed()
+            ),
+        );
+
+        let start = Instant::now();
+        let entries = parse_lookup_entries(&mut lookup_data_buf.as_ref())
+            .context("could not parse lookup data")?;
+
+        self.logger.log_public(
+            Level::Info,
+            &format!(
+                "parsed {} entries of lookup data in {:.0?}",
+                entries.len(),
+                start.elapsed()
+            ),
+        );
+
+        // This block is here to emphasize and ensure that the write lock is only held for a very
+        // short time.
+        let start = Instant::now();
+        {
+            *self
+                .entries
+                .write()
+                .expect("could not lock entries for write") = entries;
+        }
+        self.logger.log_public(
+            Level::Debug,
+            &format!(
+                "lookup data write lock acquisition time: {:.0?}",
+                start.elapsed()
+            ),
+        );
+
+        Ok(())
+    }
+
+    /// Convenience getter for an individual entry that reduces lock contention by cloning the
+    /// resulting value as quickly as possible and returning it instead of a reference.
+    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.entries
+            .read()
+            .expect("could not lock entries for read")
+            .get(key)
+            .cloned()
+    }
+
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.entries
+            .read()
+            .expect("could not lock entries for read")
+            .len()
+    }
+
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.entries
+            .read()
+            .expect("Could not lock entries for read")
+            .is_empty()
+    }
+}
+
+pub fn parse_lookup_entries<B: prost::bytes::Buf>(
+    lookup_data_buffer: B,
+) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
+    let mut lookup_data_buffer = lookup_data_buffer;
+    let mut entries = HashMap::new();
+    while lookup_data_buffer.has_remaining() {
+        let entry =
+            oak_functions_abi::proto::Entry::decode_length_delimited(&mut lookup_data_buffer)
+                .context("could not decode entry")?;
+        entries.insert(entry.key, entry.value);
+    }
+    Ok(entries)
+}

--- a/oak_functions/loader/src/main.rs
+++ b/oak_functions/loader/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
 
     let (notify_sender, notify_receiver) = tokio::sync::oneshot::channel::<()>();
 
-    let _lookup_data = load_lookup_data(&config, logger.clone()).await?;
+    let lookup_data = load_lookup_data(&config, logger.clone()).await?;
 
     // TODO(#1930): Pass lookup data to the server instance.
 
@@ -158,7 +158,10 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn load_lookup_data(config: &Config, logger: Logger) -> anyhow::Result<Arc<LookupData>> {
-    let lookup_data = Arc::new(LookupData::new_empty(&config.lookup_data_url, logger));
+    let lookup_data = Arc::new(LookupData::new_empty(
+        &config.lookup_data_url,
+        logger.clone(),
+    ));
     if !config.lookup_data_url.is_empty() {
         // First load the lookup data upfront in a blocking fashion.
         // TODO(#1930): Retry the initial lookup a few times if it fails.

--- a/oak_functions/loader/src/main.rs
+++ b/oak_functions/loader/src/main.rs
@@ -19,22 +19,21 @@
 
 use anyhow::Context;
 use log::Level;
-use prost::Message;
 use serde_derive::Deserialize;
 use std::{
-    collections::HashMap,
     fs,
     net::{Ipv6Addr, SocketAddr},
-    sync::{Arc, RwLock},
-    time::{Duration, Instant},
+    sync::Arc,
+    time::Duration,
 };
 use structopt::StructOpt;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
 mod logger;
+mod lookup;
 mod server;
-use crate::{logger::Logger, server::create_and_start_server};
+use crate::{logger::Logger, lookup::LookupData, server::create_and_start_server};
 
 #[cfg(test)]
 mod tests;
@@ -76,130 +75,11 @@ pub struct Opt {
     config_path: String,
 }
 
-struct LookupData {
-    lookup_data_url: String,
-    entries: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
-    logger: Logger,
-}
-
-impl LookupData {
-    /// Creates a new [`LookupData`] instance that can refresh its internal entries from the
-    /// provided data file URL.
-    ///
-    /// Entries in the data file path must be consecutive binary encoded and length delimited
-    /// protobuf messages according to the definition in `/oak_functions/proto/lookup_data.proto`.
-    ///
-    /// The returned instance is empty, and must be populated by calling the [`LookupData::refresh`]
-    /// method at least once.
-    fn new_empty(lookup_data_url: &str, logger: Logger) -> LookupData {
-        LookupData {
-            lookup_data_url: lookup_data_url.to_string(),
-            entries: RwLock::new(HashMap::new()),
-            logger,
-        }
-    }
-
-    /// Refreshes the internal entries of this struct from the data file URL provided at
-    /// construction time.
-    ///
-    /// If successful, entries are completely replaced (i.e. not merged).
-    ///
-    /// If there is any error while reading or parsing the data, an error is returned by this
-    /// method, and existing entries are left untouched. The caller may retry the refresh operation
-    /// at a future time.
-    async fn refresh(&self) -> anyhow::Result<()> {
-        // TODO(#1930): Avoid loading the entire file in memory for parsing.
-        let client = hyper::Client::new();
-        let res = client
-            .get(
-                self.lookup_data_url
-                    .parse()
-                    .context("could not parse lookup data URL")?,
-            )
-            .await
-            .context("could not fetch lookup data")?;
-
-        let start = Instant::now();
-        let lookup_data_buf = hyper::body::to_bytes(res.into_body())
-            .await
-            .context("could not read lookup data response body")?;
-        self.logger.log_public(
-            Level::Info,
-            &format!(
-                "downloaded {} bytes of lookup data in {:.0?}",
-                lookup_data_buf.len(),
-                start.elapsed()
-            ),
-        );
-
-        let start = Instant::now();
-        let entries = parse_lookup_entries(&mut lookup_data_buf.as_ref())
-            .context("could not parse lookup data")?;
-
-        self.logger.log_public(
-            Level::Info,
-            &format!(
-                "parsed {} entries of lookup data in {:.0?}",
-                entries.len(),
-                start.elapsed()
-            ),
-        );
-
-        // This block is here to emphasize and ensure that the write lock is only held for a very
-        // short time.
-        let start = Instant::now();
-        {
-            *self
-                .entries
-                .write()
-                .expect("could not lock entries for write") = entries;
-        }
-        self.logger.log_public(
-            Level::Debug,
-            &format!(
-                "lookup data write lock acquisition time: {:.0?}",
-                start.elapsed()
-            ),
-        );
-
-        Ok(())
-    }
-
-    /// Convenience getter for an individual entry that reduces lock contention by cloning the
-    /// resulting value as quickly as possible and returning it instead of a reference.
-    #[allow(dead_code)]
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.entries
-            .read()
-            .expect("could not lock entries for read")
-            .get(key)
-            .cloned()
-    }
-
-    #[allow(dead_code)]
-    fn len(&self) -> usize {
-        self.entries
-            .read()
-            .expect("could not lock entries for read")
-            .len()
-    }
-}
-
-fn parse_lookup_entries<B: bytes::Buf>(
-    lookup_data_buffer: B,
-) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
-    let mut lookup_data_buffer = lookup_data_buffer;
-    let mut entries = HashMap::new();
-    while lookup_data_buffer.has_remaining() {
-        let entry =
-            oak_functions_abi::proto::Entry::decode_length_delimited(&mut lookup_data_buffer)
-                .context("could not decode entry")?;
-        entries.insert(entry.key, entry.value);
-    }
-    Ok(entries)
-}
-
-async fn background_refresh_lookup_data(lookup_data: &LookupData, period: Duration) {
+async fn background_refresh_lookup_data(
+    lookup_data: &LookupData,
+    period: Duration,
+    logger: &Logger,
+) {
     // Create an interval that starts after `period`, since the data was already refreshed
     // initially.
     let mut interval = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
@@ -207,7 +87,7 @@ async fn background_refresh_lookup_data(lookup_data: &LookupData, period: Durati
         interval.tick().await;
         // If there is an error, we skip the current refresh and wait for the next tick.
         if let Err(err) = lookup_data.refresh().await {
-            lookup_data.logger.log_public(
+            logger.log_public(
                 Level::Error,
                 &format!("error refreshing lookup data: {}", err),
             );
@@ -242,9 +122,15 @@ async fn main() -> anyhow::Result<()> {
 
     let address = SocketAddr::from((Ipv6Addr::UNSPECIFIED, opt.http_listen_port));
     let server_handle = tokio::spawn(async move {
-        create_and_start_server(&address, &wasm_module_bytes, notify_receiver, logger)
-            .await
-            .context("error while waiting for the server to terminate")
+        create_and_start_server(
+            &address,
+            &wasm_module_bytes,
+            lookup_data,
+            notify_receiver,
+            logger,
+        )
+        .await
+        .context("error while waiting for the server to terminate")
     });
 
     // Wait for the termination signal.
@@ -283,8 +169,10 @@ async fn load_lookup_data(config: &Config, logger: Logger) -> anyhow::Result<Arc
         if let Some(lookup_data_download_period) = config.lookup_data_download_period {
             // Create background task to periodically refresh the lookup data.
             let lookup_data = lookup_data.clone();
+            let logger = logger.clone();
             tokio::spawn(async move {
-                background_refresh_lookup_data(&lookup_data, lookup_data_download_period).await
+                background_refresh_lookup_data(&lookup_data, lookup_data_download_period, &logger)
+                    .await
             });
         };
     }

--- a/oak_functions/proto/abi.proto
+++ b/oak_functions/proto/abi.proto
@@ -29,4 +29,6 @@ enum OakStatus {
   ERR_BUFFER_TOO_SMALL = 3;
   // Internal error.
   ERR_INTERNAL = 4;
+  // Lookup storage item not found.
+  ERR_STORAGE_ITEM_NOT_FOUND = 5;
 }

--- a/oak_functions/sdk/Cargo.lock
+++ b/oak_functions/sdk/Cargo.lock
@@ -43,6 +43,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+
+[[package]]
+name = "futures-task"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+
+[[package]]
+name = "futures-util"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +108,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "hyper"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +184,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,10 +211,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "oak_functions"
@@ -133,6 +272,38 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "pin-project"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -268,6 +439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,8 +478,55 @@ name = "test_utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "hyper",
  "log",
+ "oak_functions_abi",
+ "prost",
 ]
+
+[[package]]
+name = "tokio"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+dependencies = [
+ "autocfg",
+ "libc",
+ "mio",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-segmentation"
@@ -311,6 +539,16 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"

--- a/oak_functions/sdk/Cargo.lock
+++ b/oak_functions/sdk/Cargo.lock
@@ -26,6 +26,12 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -87,7 +93,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -207,7 +213,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -465,7 +471,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand",
  "redox_syscall",
@@ -504,12 +510,11 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
- "cfg-if",
- "pin-project-lite",
+ "cfg-if 0.1.10",
  "tracing-core",
 ]
 

--- a/oak_functions/sdk/oak_functions/src/lib.rs
+++ b/oak_functions/sdk/oak_functions/src/lib.rs
@@ -23,6 +23,8 @@ use oak_functions_abi::proto::OakStatus;
 /// Reads and returns the user request.
 ///
 /// This function is idempotent. Multiple call to this function all return the same value.
+///
+/// See [`read_request`](https://github.com/project-oak/oak/blob/main/docs/oak_functions_abi.md#read_request).
 pub fn read_request() -> Result<Vec<u8>, OakStatus> {
     let mut buf = Vec::with_capacity(1024);
     read_request_util(&mut buf)?;
@@ -87,6 +89,8 @@ fn read_request_util(buf: &mut Vec<u8>) -> Result<(), OakStatus> {
 ///
 /// Multiple calls to this function will replace the earlier responses. Only the last response that
 /// is written will be kept and returned to the user.
+///
+/// See [`write_response`](https://github.com/project-oak/oak/blob/main/docs/oak_functions_abi.md#write_response).
 pub fn write_response(buf: &[u8]) -> Result<(), OakStatus> {
     let status = unsafe { oak_functions_abi::write_response(buf.as_ptr(), buf.len()) };
     result_from_status(status as i32, ())
@@ -103,6 +107,7 @@ pub fn storage_get_item(key: &[u8]) -> Result<Option<Vec<u8>>, OakStatus> {
 
     // It is possible that the item for a given key changes or gets deleted entirely between the two
     // iterations below if the lookup data is refreshed in between, which may cause weird errors.
+    // TODO(#754): Consider a different allocation strategy to avoid this problem.
 
     let mut buf = Vec::with_capacity(1024);
 

--- a/oak_functions/sdk/test_utils/Cargo.toml
+++ b/oak_functions/sdk/test_utils/Cargo.toml
@@ -8,3 +8,6 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "*"
 log = "*"
+hyper = { version = "*", features = ["client", "http1", "runtime", "server"] }
+oak_functions_abi = { path = "../../abi" }
+prost = "*"

--- a/oak_functions/sdk/test_utils/src/lib.rs
+++ b/oak_functions/sdk/test_utils/src/lib.rs
@@ -122,6 +122,8 @@ impl MockStaticServer {
     }
 }
 
+/// Serializes the provided map as a contiguous buffer of length-delimited protobuf messages of type
+/// [`Entry`](https://github.com/project-oak/oak/blob/main/oak_functions/proto/lookup_data.proto).
 pub fn serialize_entries(entries: HashMap<Vec<u8>, Vec<u8>>) -> Vec<u8> {
     let mut buf = Vec::new();
     for (key, value) in entries.into_iter() {

--- a/oak_functions/sdk/test_utils/src/lib.rs
+++ b/oak_functions/sdk/test_utils/src/lib.rs
@@ -17,9 +17,20 @@
 //! Test utilities to help with unit testing of Oak-Functions SDK code.
 
 use anyhow::Context;
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Body, Response,
+};
 use log::info;
-
-use std::{path::PathBuf, process::Command};
+use prost::Message;
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    net::{Ipv6Addr, SocketAddr},
+    path::PathBuf,
+    process::Command,
+    sync::{Arc, Mutex},
+};
 
 // TODO(#1965): Move this and the similar function in `oak/sdk` to a common crate.
 /// Uses cargo to compile a Rust manifest to Wasm bytes.
@@ -70,4 +81,54 @@ pub fn compile_rust_wasm(
     info!("Compiled Wasm module path: {:?}", module_path);
 
     std::fs::read(module_path).context("Couldn't read compiled module")
+}
+
+/// A mock implementation of a static server that always returns the same configurable response for
+/// any incoming HTTP request.
+#[derive(Default)]
+pub struct MockStaticServer {
+    response_body: Arc<Mutex<Vec<u8>>>,
+}
+
+impl MockStaticServer {
+    /// Sets the content of the response body to return for any request.
+    pub fn set_response_body(&self, response_body: Vec<u8>) {
+        *self
+            .response_body
+            .lock()
+            .expect("could not lock response body mutex") = response_body;
+    }
+
+    /// Starts serving, listening on the provided port.
+    pub async fn serve(&self, port: u16) {
+        let address = SocketAddr::from((Ipv6Addr::UNSPECIFIED, port));
+        let response_body = self.response_body.clone();
+        let server = hyper::Server::bind(&address).serve(make_service_fn(|_conn| {
+            let response_body = response_body.clone();
+            async {
+                Ok::<_, Infallible>(service_fn(move |_req| {
+                    let response_body = response_body.clone();
+                    async move {
+                        let response_body: Vec<u8> = response_body
+                            .lock()
+                            .expect("could not lock response body mutex")
+                            .clone();
+                        Ok::<_, Infallible>(Response::new(Body::from(response_body)))
+                    }
+                }))
+            }
+        }));
+        server.await.unwrap();
+    }
+}
+
+pub fn serialize_entries(entries: HashMap<Vec<u8>, Vec<u8>>) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for (key, value) in entries.into_iter() {
+        let entry_proto = oak_functions_abi::proto::Entry { key, value };
+        entry_proto
+            .encode_length_delimited(&mut buf)
+            .expect("could not encode entry as length delimited");
+    }
+    buf
 }


### PR DESCRIPTION
- move lookup functionality to its own mod
- pass LookupData instance to server
- add ABI method for looking up individual items
- add OakStatus value to indicate the absence of a lookup item
- add SDK wrapper
- refactor various Wasm memory-related functions
- move ABI documentation to the Readme file, and reference that from the
Rust code, instead of maintaining different slightly different versions
- modify hello world example to make use of the lookup functionality

Ref: #1930

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
