### PR TITLE
Cancel pending workflow runs

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,20 @@
+# Cancel any previous workflow runs that are not completed.
+#
+# See https://github.com/styfle/cancel-workflow-action#advanced-pull-requests-from-forks.
+
+name: Cancel
+on:
+  workflow_run:
+    workflows:
+      - Build Reproducibility Index
+      - Build Rust docs
+      - Continous Integration
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
This should save us a few GitHub actions instances when pushing to a PR
that has already some runs in progress.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
