### PR TITLE
Add explicit write permissions to actions

### DIFF
--- a/.github/workflows/build_rust_docs.yaml
+++ b/.github/workflows/build_rust_docs.yaml
@@ -10,6 +10,9 @@ jobs:
   build_rust_docs:
     runs-on: ubuntu-20.04
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2

--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -10,6 +10,9 @@ jobs:
   build_reproducibility_index:
     runs-on: ubuntu-20.04
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2


### PR DESCRIPTION
This is required before we can change the default `GITHUB_TOKEN` permissions to read-only.

See #2003 and https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
