### PR TITLE
Add explicit codecov permissions

### DIFF
--- a/.github/workflows/upload_coverage.yaml
+++ b/.github/workflows/upload_coverage.yaml
@@ -10,6 +10,9 @@ jobs:
   upload_coverage:
     runs-on: ubuntu-20.04
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2


### PR DESCRIPTION
This is to make sure that the codecov.io upload script only has read permissions, even if the default permissions for the repo allow writing.

See #2003 and https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
