### PR TITLE
Follow up fixes for #1991

### DIFF
--- a/docs/oak_functions_abi.md
+++ b/docs/oak_functions_abi.md
@@ -48,6 +48,10 @@ being invoked, and the caller is responsible for freeing it if and when
 necessary. The Oak Functions Loader never directly frees any previously
 allocated memory.
 
+A canonical implementation of this function is already
+[provided in the Oak Functions Rust SDK](/oak_functions/sdk/oak_functions/src/lib.rs),
+so if using that, there is no need to implement it manually.
+
 - `param[0]: len: i32`: Number of bytes to allocate.
 
 - `result[0]: i32`: Address of the newly allocated buffer.

--- a/oak_functions/examples/Cargo.lock
+++ b/oak_functions/examples/Cargo.lock
@@ -552,6 +552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "port_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6519412c9e0d4be579b9f0618364d19cb434b324fc6ddb1b27b1e682c7105ed"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +861,7 @@ dependencies = [
  "hyper",
  "log",
  "oak_functions_abi",
+ "port_check",
  "prost",
 ]
 

--- a/oak_functions/loader/Cargo.lock
+++ b/oak_functions/loader/Cargo.lock
@@ -525,6 +525,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "port_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6519412c9e0d4be579b9f0618364d19cb434b324fc6ddb1b27b1e682c7105ed"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +836,7 @@ dependencies = [
  "hyper",
  "log",
  "oak_functions_abi",
+ "port_check",
  "prost",
 ]
 

--- a/oak_functions/sdk/Cargo.lock
+++ b/oak_functions/sdk/Cargo.lock
@@ -353,6 +353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "port_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6519412c9e0d4be579b9f0618364d19cb434b324fc6ddb1b27b1e682c7105ed"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +591,7 @@ dependencies = [
  "hyper",
  "log",
  "oak_functions_abi",
+ "port_check",
  "prost",
 ]
 

--- a/oak_functions/sdk/test_utils/Cargo.toml
+++ b/oak_functions/sdk/test_utils/Cargo.toml
@@ -11,4 +11,5 @@ cargo_metadata = "*"
 log = "*"
 hyper = { version = "*", features = ["client", "http1", "runtime", "server"] }
 oak_functions_abi = { path = "../../abi" }
+port_check = "*"
 prost = "*"


### PR DESCRIPTION
Synchronize tests and allocate ports randomly at runtime to ensure there
are no conflicts even if running in parallel, and properly terminate
and wait for background tasks.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
