### PR TITLE
Add Envoy Proxy Experiment

### DIFF
--- a/experimental/envoy_proxy/README.md
+++ b/experimental/envoy_proxy/README.md
@@ -1,0 +1,78 @@
+# Envoy Proxy Experiment
+
+This experiment shows how to create a persistent connection to a Docker container in Cloud Run.
+It is done by using [TCP tunneling over HTTP](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/upgrades#tunneling-tcp-over-http)
+in Envoy proxy.
+
+The experiment consists of 2 Envoy proxies: _client side_ and _server side_.
+
+- Client side proxy accepts TCP streams and tunnels them over HTTP streams.
+- Server side proxy listens for HTTP streams and unwraps TCP streams from them.
+
+Proxy experiment is organized as follows:
+
+- `curl`
+  - Sends an HTTP GET request on `localhost:8000`
+- `client_listener`
+  - Tunnels TCP stream over HTTP/2 stream
+- `client_cluster`
+  - Sends HTTP/2 stream on `APP_URL:443` using TLS
+  - Checks Google public certificate
+- Cloud Run Frontend
+  - Terminates TLS connection
+  - Redirects HTTP/2 stream to the Docker container on port `8080`
+- `server_listener`
+  - Unwraps a TCP stream from an HTTP/2 stream
+- `server_cluster`
+  - Forwards TCP stream to the server on port `8081`
+- `python` server
+  - Responds to an HTTP GET request
+
+## Running experiment
+
+Build Docker images:
+
+```bash
+./experimental/envoy_proxy/scripts/build.sh
+```
+
+### Running on localhost
+
+Run the server:
+
+```bash
+docker run -it --network='host' 'gcr.io/oak-ci/envoy-proxy-example-server'
+```
+
+Run the client:
+
+```bash
+docker run -it --network='host' 'gcr.io/oak-ci/envoy-proxy-example-client' localhost
+```
+
+### Running in Cloud Run
+
+Export environment variables (the corresponding JSON key can be created in [GCP console](https://pantheon.corp.google.com/iam-admin/serviceaccounts/details/107443053308787082748/keys?project=oak-ci)):
+
+```bash
+export GCP_PROJECT_ID=oak-ci
+export GCP_ACCOUNT_FILE=${JSON_KEY_PATH}
+```
+
+Deploy the server:
+
+```bash
+./experimental/envoy_proxy/scripts/deploy.sh
+```
+
+Run the client:
+
+```bash
+docker run -it --network='host' 'gcr.io/oak-ci/envoy-proxy-example-client'
+```
+
+Delete the server (_optional_):
+
+```bash
+./experimental/envoy_proxy/scripts/delete.sh
+```

--- a/experimental/envoy_proxy/README.md
+++ b/experimental/envoy_proxy/README.md
@@ -1,7 +1,8 @@
 # Envoy Proxy Experiment
 
-This experiment shows how to create a persistent connection to a Docker container in Cloud Run.
-It is done by using [TCP tunneling over HTTP](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/upgrades#tunneling-tcp-over-http)
+This experiment shows how to create a persistent connection to a Docker
+container in Cloud Run. It is done by using
+[TCP tunneling over HTTP](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/upgrades#tunneling-tcp-over-http)
 in Envoy proxy.
 
 The experiment consists of 2 Envoy proxies: _client side_ and _server side_.
@@ -52,7 +53,8 @@ docker run -it --network='host' 'gcr.io/oak-ci/envoy-proxy-example-client' local
 
 ### Running in Cloud Run
 
-Export environment variables (the corresponding JSON key can be created in [GCP console](https://pantheon.corp.google.com/iam-admin/serviceaccounts/details/107443053308787082748/keys?project=oak-ci)):
+Export environment variables (the corresponding JSON key can be created in
+[GCP console](https://pantheon.corp.google.com/iam-admin/serviceaccounts/details/107443053308787082748/keys?project=oak-ci)):
 
 ```bash
 export GCP_PROJECT_ID=oak-ci

--- a/experimental/envoy_proxy/client/client.Dockerfile
+++ b/experimental/envoy_proxy/client/client.Dockerfile
@@ -4,7 +4,10 @@ FROM envoyproxy/envoy-dev:22825906e35c1d61b495f7b5f2517249cc56f77d
 RUN apt-get --yes update \
   && apt-get install --no-install-recommends --yes \
   curl \
-  netcat-openbsd
+  netcat-openbsd \
+  # Cleanup
+  && apt-get clean \
+  && rm --recursive --force /var/lib/apt/lists/*
 
 COPY client/client.yaml /etc/envoy/client.yaml
 COPY client/client_localhost.yaml /etc/envoy/client_localhost.yaml

--- a/experimental/envoy_proxy/client/client.Dockerfile
+++ b/experimental/envoy_proxy/client/client.Dockerfile
@@ -1,0 +1,13 @@
+# Use Envoy Proxy 1.19.0-dev.
+FROM envoyproxy/envoy-dev:22825906e35c1d61b495f7b5f2517249cc56f77d
+
+RUN apt-get --yes update \
+  && apt-get install --no-install-recommends --yes \
+  curl \
+  netcat-openbsd
+
+COPY client/client.yaml /etc/envoy/client.yaml
+COPY client/client_localhost.yaml /etc/envoy/client_localhost.yaml
+COPY scripts/run_client.sh /etc/envoy/run_client.sh
+
+ENTRYPOINT ["/etc/envoy/run_client.sh"]

--- a/experimental/envoy_proxy/client/client.yaml
+++ b/experimental/envoy_proxy/client/client.yaml
@@ -1,0 +1,47 @@
+static_resources:
+  listeners:
+    # Accepts TCP streams and tunnels them over HTTP streams.
+    # https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/upgrades#tunneling-tcp-over-http
+    - name: client_listener
+      address:
+        # Client proxy address to listen on.
+        socket_address:
+          protocol: TCP
+          address: 0.0.0.0
+          port_value: 8000
+      filter_chains:
+        - filters:
+            - name: tcp
+              typed_config:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                stat_prefix: tcp_stats
+                cluster: client_cluster
+                tunneling_config:
+                  hostname: envoy-proxy-example-62sa4xcfia-nw.a.run.app
+                  # Send TCP segments in POST HTTP requests.
+                  use_post: true
+
+  clusters:
+    # Connects to the remote server proxy via Cloud Run, which terminated the TLS connection.
+    - name: client_cluster
+      connect_timeout: 5s
+      type: LOGICAL_DNS
+      http2_protocol_options: {}
+      load_assignment:
+        cluster_name: client_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    # Remote server proxy address to connect to.
+                    socket_address:
+                      address: envoy-proxy-example-62sa4xcfia-nw.a.run.app
+                      port_value: 443
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          common_tls_context:
+            validation_context:
+              trusted_ca: { 'filename': '/etc/ssl/certs/ca-certificates.crt' }
+          sni: envoy-proxy-example-62sa4xcfia-nw.a.run.app

--- a/experimental/envoy_proxy/client/client_localhost.yaml
+++ b/experimental/envoy_proxy/client/client_localhost.yaml
@@ -1,0 +1,39 @@
+static_resources:
+  listeners:
+    # Accepts TCP streams and tunnels them over HTTP streams.
+    # https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/upgrades#tunneling-tcp-over-http
+    - name: listener
+      address:
+        # Client proxy address to listen on.
+        socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 8000
+      filter_chains:
+        - filters:
+            - name: tcp
+              typed_config:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                stat_prefix: tcp_stats
+                cluster: cluster
+                tunneling_config:
+                  hostname: localhost
+                  # Send TCP segments in POST HTTP requests.
+                  use_post: true
+
+  clusters:
+    # Connects to the local server proxy.
+    - name: cluster
+      connect_timeout: 5s
+      type: LOGICAL_DNS
+      http2_protocol_options: {}
+      load_assignment:
+        cluster_name: cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    # Local server proxy address to connect to.
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8080

--- a/experimental/envoy_proxy/scripts/build.sh
+++ b/experimental/envoy_proxy/scripts/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+readonly EXPERIMENAL_SCRIPTS_DIR="$(dirname "$0")"
+source "$EXPERIMENAL_SCRIPTS_DIR/common.sh"
+
+docker build \
+  --file="./experimental/envoy_proxy/client/client.Dockerfile" \
+  --tag="${ENVOY_CLIENT_IMAGE_NAME}:latest" \
+  ./experimental/envoy_proxy
+
+docker build \
+  --file="./experimental/envoy_proxy/server/server.Dockerfile" \
+  --tag="${ENVOY_SERVER_IMAGE_NAME}:latest" \
+  ./experimental/envoy_proxy

--- a/experimental/envoy_proxy/scripts/build.sh
+++ b/experimental/envoy_proxy/scripts/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 readonly EXPERIMENAL_SCRIPTS_DIR="$(dirname "$0")"
+# shellcheck source=experimental/envoy_proxy/scripts/common.sh
 source "$EXPERIMENAL_SCRIPTS_DIR/common.sh"
 
 docker build \

--- a/experimental/envoy_proxy/scripts/common.sh
+++ b/experimental/envoy_proxy/scripts/common.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034  # Unused variables OK as this script is `source`d.
+
+readonly SCRIPTS_DIR="$(dirname "$0")/../../../scripts/"
+# shellcheck source=scripts/common
+source "$SCRIPTS_DIR/common"
+
+readonly ENVOY_CLIENT_IMAGE_NAME='gcr.io/oak-ci/envoy-proxy-example-client'
+readonly ENVOY_SERVER_IMAGE_NAME='gcr.io/oak-ci/envoy-proxy-example-server'
+readonly ENVOY_SERVER_INSTANCE_NAME='envoy-proxy-example'

--- a/experimental/envoy_proxy/scripts/delete.sh
+++ b/experimental/envoy_proxy/scripts/delete.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+readonly EXPERIMENAL_SCRIPTS_DIR="$(dirname "$0")"
+source "$EXPERIMENAL_SCRIPTS_DIR/common.sh"
+
+# shellcheck source=scripts/gcp_common
+source "$SCRIPTS_DIR/gcp_common"
+
+# Authenticate as the service account
+gcloud auth activate-service-account \
+  --project="${GCP_PROJECT_ID}" \
+  --key-file="${GCP_ACCOUNT_FILE}"
+
+# Delete the application from Cloud Run.
+gcloud beta run services "${ENVOY_SERVER_INSTANCE_NAME}" \
+  --region=europe-west2 \
+  --platform=managed

--- a/experimental/envoy_proxy/scripts/delete.sh
+++ b/experimental/envoy_proxy/scripts/delete.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 readonly EXPERIMENAL_SCRIPTS_DIR="$(dirname "$0")"
+# shellcheck source=experimental/envoy_proxy/scripts/common.sh
 source "$EXPERIMENAL_SCRIPTS_DIR/common.sh"
 
 # shellcheck source=scripts/gcp_common

--- a/experimental/envoy_proxy/scripts/deploy.sh
+++ b/experimental/envoy_proxy/scripts/deploy.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 readonly EXPERIMENAL_SCRIPTS_DIR="$(dirname "$0")"
+# shellcheck source=experimental/envoy_proxy/scripts/common.sh
 source "$EXPERIMENAL_SCRIPTS_DIR/common.sh"
 
 # shellcheck source=scripts/gcp_common

--- a/experimental/envoy_proxy/scripts/deploy.sh
+++ b/experimental/envoy_proxy/scripts/deploy.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+readonly EXPERIMENAL_SCRIPTS_DIR="$(dirname "$0")"
+source "$EXPERIMENAL_SCRIPTS_DIR/common.sh"
+
+# shellcheck source=scripts/gcp_common
+source "$SCRIPTS_DIR/gcp_common"
+
+docker push "${ENVOY_SERVER_IMAGE_NAME}:latest"
+
+# Authenticate as the service account
+gcloud auth activate-service-account \
+  --project="${GCP_PROJECT_ID}" \
+  --key-file="${GCP_ACCOUNT_FILE}"
+
+# Deploy the application on Cloud Run.
+gcloud beta run deploy "${ENVOY_SERVER_INSTANCE_NAME}" \
+  --region=europe-west2 \
+  --image="${ENVOY_SERVER_IMAGE_NAME}:latest" \
+  --allow-unauthenticated \
+  --concurrency=20 \
+  --min-instances=1 \
+  --max-instances=10 \
+  --use-http2 \
+  --platform=managed

--- a/experimental/envoy_proxy/scripts/run_client.sh
+++ b/experimental/envoy_proxy/scripts/run_client.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o xtrace
+set -o pipefail
+
+echo Running client proxy
+if [[ "${1:-}" == localhost ]]; then
+    # Dedicated `--base-id` is needed to run multiple Envoy proxies on the same machine:
+    # https://github.com/envoyproxy/envoy/issues/88
+    /usr/local/bin/envoy --config-path /etc/envoy/client_localhost.yaml --base-id 1 -- --alsologtostderr &
+else
+    /usr/local/bin/envoy --config-path /etc/envoy/client.yaml -- --alsologtostderr &
+fi
+# Give slack time for Envoy proxy to start in the background.
+sleep 1
+
+echo Running HTTP client
+curl --location --verbose localhost:8000

--- a/experimental/envoy_proxy/scripts/run_server.sh
+++ b/experimental/envoy_proxy/scripts/run_server.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o xtrace
+set -o pipefail
+
+echo Running server proxy
+/usr/local/bin/envoy -c /etc/envoy/server.yaml -- --alsologtostderr &
+# Give slack time for Envoy proxy to start in the background.
+sleep 1
+
+echo Running HTTP server
+python3 -m http.server 8081
+echo HTTP server exited with $?

--- a/experimental/envoy_proxy/server/server.Dockerfile
+++ b/experimental/envoy_proxy/server/server.Dockerfile
@@ -4,7 +4,10 @@ FROM envoyproxy/envoy-dev:22825906e35c1d61b495f7b5f2517249cc56f77d
 RUN apt-get --yes update \
   && apt-get install --no-install-recommends --yes \
   python3 \
-  netcat-openbsd
+  netcat-openbsd \
+  # Cleanup
+  && apt-get clean \
+  && rm --recursive --force /var/lib/apt/lists/*
 
 COPY server/server.yaml /etc/envoy/server.yaml
 COPY scripts/run_server.sh /etc/envoy/run_server.sh

--- a/experimental/envoy_proxy/server/server.Dockerfile
+++ b/experimental/envoy_proxy/server/server.Dockerfile
@@ -1,0 +1,12 @@
+# Use Envoy Proxy 1.19.0-dev.
+FROM envoyproxy/envoy-dev:22825906e35c1d61b495f7b5f2517249cc56f77d
+
+RUN apt-get --yes update \
+  && apt-get install --no-install-recommends --yes \
+  python3 \
+  netcat-openbsd
+
+COPY server/server.yaml /etc/envoy/server.yaml
+COPY scripts/run_server.sh /etc/envoy/run_server.sh
+
+ENTRYPOINT ["/etc/envoy/run_server.sh"]

--- a/experimental/envoy_proxy/server/server.yaml
+++ b/experimental/envoy_proxy/server/server.yaml
@@ -1,0 +1,54 @@
+static_resources:
+  listeners:
+    # Listens for HTTP streams and unwraps TCP streams from them.
+    - name: server_listener
+      address:
+        # Server proxy address to listen on.
+        socket_address:
+          protocol: TCP
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - '*'
+                      routes:
+                        - match:
+                            prefix: '/'
+                            headers:
+                              - name: ':method'
+                                exact_match: 'POST'
+                          route:
+                            cluster: server_cluster
+                            upgrade_configs:
+                              - upgrade_type: CONNECT
+                                connect_config:
+                                  allow_post: true
+                http_filters:
+                  - name: envoy.filters.http.router
+                http2_protocol_options:
+                  allow_connect: true
+
+  clusters:
+    # Forward TCP stream to the server application.
+    - name: server_cluster
+      connect_timeout: 2s
+      http2_protocol_options: {}
+      load_assignment:
+        cluster_name: server_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    # Server application address.
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8081


### PR DESCRIPTION
This commit adds an Envoy Proxy experiment that shows how Envoy proxy can create a consistent connection to a Cloud Run backend by encapsulating TCP streams in HTTP/2 streams.