### PR TITLE
Stop ignoring RUSTSEC advisories

### DIFF
--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -13,12 +13,6 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = [
-  # TODO(#1267): Remove when mio no longer depends on net2.
-  "RUSTSEC-2020-0016",
-  # TODO(#1874): Remove when tonic and hyper versions are updated.
-  "RUSTSEC-2021-0020",
-]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]

--- a/experimental/deny.toml
+++ b/experimental/deny.toml
@@ -10,12 +10,6 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = [
-  # TODO(#1267): Remove when mio no longer depends on net2.
-  "RUSTSEC-2020-0016",
-  # TODO(#1874): Remove when tonic and hyper versions are updated.
-  "RUSTSEC-2021-0020",
-]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]

--- a/oak_client/deny.toml
+++ b/oak_client/deny.toml
@@ -13,12 +13,6 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = [
-  # TODO(#1267): Remove when mio no longer depends on net2.
-  "RUSTSEC-2020-0016",
-  # TODO(#1874): Remove when tonic and hyper versions are updated.
-  "RUSTSEC-2021-0020",
-]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]

--- a/oak_loader/deny.toml
+++ b/oak_loader/deny.toml
@@ -10,12 +10,6 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = [
-  # TODO(#1267): Remove when mio no longer depends on net2.
-  "RUSTSEC-2020-0016",
-  # TODO(#1874): Remove when tonic and hyper versions are updated.
-  "RUSTSEC-2021-0020",
-]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]

--- a/oak_runtime/deny.toml
+++ b/oak_runtime/deny.toml
@@ -10,12 +10,6 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = [
-  # TODO(#1267): Remove when mio no longer depends on net2.
-  "RUSTSEC-2020-0016",
-  # TODO(#1874): Remove when tonic and hyper versions are updated.
-  "RUSTSEC-2021-0020",
-]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]

--- a/oak_runtime/src/node/http/server.rs
+++ b/oak_runtime/src/node/http/server.rs
@@ -60,9 +60,6 @@ use oak_abi::proto::oak::identity::SignedChallenge;
 use prost::Message;
 use tokio_rustls::TlsAcceptor;
 
-// Workaround for https://rust-lang.github.io/rust-clippy/master/index.html#borrow_interior_mutable_const.
-static TRANSFER_ENCODING: http::header::HeaderName = http::header::TRANSFER_ENCODING;
-
 /// Checks that port is not reserved (i.e., is greater than 1023).
 fn check_port(address: &SocketAddr) -> Result<(), ConfigurationError> {
     if address.port() > 1023 {
@@ -309,7 +306,6 @@ struct HttpRequestHandler {
 
 impl HttpRequestHandler {
     async fn handle(&self, req: Request<Body>) -> anyhow::Result<Response<Body>> {
-        let req = validate_request(req)?;
         let request = to_oak_http_request(req).await?;
         match get_oak_label(&request) {
             Ok(oak_label) => {
@@ -371,23 +367,6 @@ impl HttpRequestHandler {
             runtime: self.runtime.clone(),
             response_receiver,
         })
-    }
-}
-
-/// Check if the request contains a `TRANSFER_ENCODING` header, and reject the request in that case
-/// by returning an error.
-// TODO(#1874): Remove when tonic and hyper versions are updated.
-fn validate_request(req: Request<Body>) -> anyhow::Result<Request<Body>> {
-    if req
-        .headers()
-        .get(&TRANSFER_ENCODING.as_str().to_string())
-        .is_some()
-    {
-        Err(anyhow!(
-            "Requests containing TRANSFER_ENCODING headers are not allowed."
-        ))
-    } else {
-        Ok(req)
     }
 }
 

--- a/sdk/deny.toml
+++ b/sdk/deny.toml
@@ -13,12 +13,6 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = [
-  # TODO(#1267): Remove when mio no longer depends on net2.
-  "RUSTSEC-2020-0016",
-  # TODO(#1874): Remove when tonic and hyper versions are updated.
-  "RUSTSEC-2021-0020",
-]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]


### PR DESCRIPTION
This change also removes code to defend against `RUSTSEC-2021-0020`, which is no longer applicable.

Fixes #1267
Fixes #1874

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
