### PR TITLE
Run cargo-deny at the workspace level

### DIFF
--- a/oak_functions/abi/deny.toml
+++ b/oak_functions/abi/deny.toml
@@ -19,5 +19,5 @@ wildcards = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = ["Apache-2.0", "MPL-2.0", "MIT"]
+allow = ["Apache-2.0", "MIT"]
 copyleft = "deny"

--- a/oak_functions/sdk/deny.toml
+++ b/oak_functions/sdk/deny.toml
@@ -19,5 +19,5 @@ wildcards = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = ["Apache-2.0", "MPL-2.0", "MIT"]
+allow = ["Apache-2.0", "MIT"]
 copyleft = "deny"


### PR DESCRIPTION
This changes the runner to run cargo-deny at the workspace level where the deny.toml files are defined to resolve warnings about unencountered licenses.

Fixes #2009 

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
