### PR TITLE
Add loop to oak_main in oak_runtime integration test

### DIFF
--- a/oak_runtime/tests/integration_test.rs
+++ b/oak_runtime/tests/integration_test.rs
@@ -37,10 +37,24 @@ mod common {
     use wat::parse_str;
 
     pub fn start_runtime() -> Result<Arc<Runtime>, OakError> {
+        // Loop 100 000 times in the main function to make sure the Wasm node is alive for a while
+        // before exiting.
         let wat = r#"
         (module
             (type (;0;) (func (param i64)))
-            (func $oak_main (type 0))
+            (func $oak_main (type 0)
+                (local i64)
+                i64.const 100000
+                local.set 1
+                (block
+                    (loop
+                        local.get 1
+                        i64.const -1
+                        i64.add
+                        local.tee 1
+                        i64.eqz
+                        br_if 1
+                        br 0)))
             (memory (;0;) 18)
             (export "memory" (memory 0))
             (export "oak_main" (func $oak_main)))

--- a/oak_runtime/tests/integration_test.rs
+++ b/oak_runtime/tests/integration_test.rs
@@ -38,7 +38,11 @@ mod common {
 
     pub fn start_runtime() -> Result<Arc<Runtime>, OakError> {
         // Loop 100 000 times in the main function to make sure the Wasm node is alive for a while
-        // before exiting.
+        // before exiting. This is needed to avoid a race condition causing
+        // `test_metrics_gives_the_correct_number_of_nodes` to sometimes fail. If the Wasm node has
+        // finished execution before the metrics count is requested the reported node count will be
+        // incorrect.
+        //
         // TODO(#2026): Change to infinite loop once the runtime can interrupt the Wasm node's
         // execution.
         let wat = r#"

--- a/oak_runtime/tests/integration_test.rs
+++ b/oak_runtime/tests/integration_test.rs
@@ -39,6 +39,8 @@ mod common {
     pub fn start_runtime() -> Result<Arc<Runtime>, OakError> {
         // Loop 100 000 times in the main function to make sure the Wasm node is alive for a while
         // before exiting.
+        // TODO(#2026): Change to infinite loop once the runtime can interrupt the Wasm node's
+        // execution.
         let wat = r#"
         (module
             (type (;0;) (func (param i64)))

--- a/oak_runtime/tests/integration_test.rs
+++ b/oak_runtime/tests/integration_test.rs
@@ -43,18 +43,18 @@ mod common {
         (module
             (type (;0;) (func (param i64)))
             (func $oak_main (type 0)
-                (local i64)
+                (local i64)             ;; Declare local variable.
                 i64.const 100000
-                local.set 1
-                (block
-                    (loop
-                        local.get 1
+                local.set 1             ;; Set local variable to 100 000.
+                (block                  ;; Outer block.
+                    (loop               ;; Inner block for loop.
+                        local.get 1     ;; Load local variable.
                         i64.const -1
-                        i64.add
-                        local.tee 1
+                        i64.add         ;; Add -1.
+                        local.tee 1     ;; Store local variable, but keep value for comaprison.
                         i64.eqz
-                        br_if 1
-                        br 0)))
+                        br_if 1         ;; Jump back to outer block if local variable is 0.
+                        br 0)))         ;; Jump back to start of loop inner block.
             (memory (;0;) 18)
             (export "memory" (memory 0))
             (export "oak_main" (func $oak_main)))


### PR DESCRIPTION
To address CI flakiness (see #2008). `test_metrics_gives_the_correct_number_of_nodes` sometimes fails because the Wasm node has already exited when getting the metrics. This makes sure that it is around for a short while by looping 100 000 times in the exported main function.

The 100 000 iteration count is a guess, but it seems sufficient to remove the flakiness (at least locally based on running the test 50 times) without slowing down the test too much.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [x] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
