### PR TITLE
Add `write` permission on issues to reproducibility index workflow

### DIFF
--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -12,6 +12,7 @@ jobs:
 
     permissions:
       contents: write
+      issues: write
 
     steps:
       - name: Checkout branch

--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     permissions:
+      # Allow the job to update the repo with the latest index.
       contents: write
+      # Allow the job to add a comment to the PR.
       issues: write
 
     steps:


### PR DESCRIPTION
This is to allow the workflow to add a comment to the current PR discussion.

See https://github.com/project-oak/oak/pull/2004#discussion_r623840132

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
