### PR TITLE
Give write permissions on pull requests rather than issues for Reproducibility Index workflow

### DIFF
--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -14,7 +14,7 @@ jobs:
       # Allow the job to update the repo with the latest index.
       contents: write
       # Allow the job to add a comment to the PR.
-      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout branch

--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -13,6 +13,12 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
+ignore = [
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0061",
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0060",
+]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]

--- a/experimental/deny.toml
+++ b/experimental/deny.toml
@@ -10,6 +10,12 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
+ignore = [
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0061",
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0060",
+]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]

--- a/oak_loader/deny.toml
+++ b/oak_loader/deny.toml
@@ -10,6 +10,12 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
+ignore = [
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0061",
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0060",
+]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]

--- a/oak_runtime/deny.toml
+++ b/oak_runtime/deny.toml
@@ -10,6 +10,12 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
+ignore = [
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0061",
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0060",
+]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]

--- a/sdk/deny.toml
+++ b/sdk/deny.toml
@@ -13,6 +13,12 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
+ignore = [
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0061",
+  # TODO(#2055): Remove once tink-aead dependencies are updated.
+  "RUSTSEC-2021-0060",
+]
 
 # Deny multiple versions unless explicitly skipped.
 [bans]


### PR DESCRIPTION
See https://github.com/project-oak/oak/pull/2049#issuecomment-830242473

This change also resolves new cargo-deny errors related to new RUSTSEC advisories about unmaintained crates. These errors are currently blocking CI runs.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
