### PR TITLE
Add abitest example for oak_functions

### DIFF
--- a/oak_functions/Cargo.lock
+++ b/oak_functions/Cargo.lock
@@ -1512,8 +1512,6 @@ dependencies = [
  "oak_functions",
  "oak_functions_abi",
  "oak_functions_abitest_common",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1540,12 +1538,10 @@ name = "oak_functions_abitest_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "assert_matches",
  "env_logger",
  "http",
  "hyper",
  "log",
- "maplit",
  "oak_functions_abi",
  "oak_functions_abitest_common",
  "oak_functions_client",

--- a/oak_functions/Cargo.lock
+++ b/oak_functions/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1504,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_functions_abitest"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "oak_functions",
+ "oak_functions_abi",
+ "oak_functions_abitest_common",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "oak_functions_abitest_backend"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "http",
+ "hyper",
+ "log",
+ "maplit",
+ "oak_functions_abitest_common",
+ "structopt",
+ "test_utils",
+ "tokio",
+]
+
+[[package]]
+name = "oak_functions_abitest_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "env_logger",
+ "http",
+ "hyper",
+ "log",
+ "maplit",
+ "oak_functions_abi",
+ "oak_functions_abitest_common",
+ "oak_functions_client",
+ "prost 0.9.0",
+ "structopt",
+ "tokio",
+]
+
+[[package]]
+name = "oak_functions_abitest_common"
+version = "0.1.0"
+
+[[package]]
 name = "oak_functions_client"
 version = "0.1.0"
 dependencies = [
@@ -2639,7 +2700,9 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]

--- a/oak_functions/Cargo.toml
+++ b/oak_functions/Cargo.toml
@@ -2,6 +2,9 @@
 members = [
   "abi",
   "client/rust/Cargo.toml",
+  "examples/abitest/backend",
+  "examples/abitest/client",
+  "examples/abitest/module",
   "examples/benchmark/module",
   "examples/fuzzable/module",
   "examples/key_value_lookup/module",

--- a/oak_functions/examples/abitest/backend/Cargo.toml
+++ b/oak_functions/examples/abitest/backend/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "oak_functions_abitest_backend"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "*"
+http = "*"
+hyper = { version = "*", features = ["http1", "http2", "runtime", "server"] }
+env_logger = "*"
+futures = "*"
+futures-core = "*"
+futures-util = "*"
+log = "*"
+maplit = "*"
+oak_functions_abitest_common = { path = "../common" }
+structopt = "*"
+test_utils = { path = "../../../sdk/test_utils" }
+tokio = { version = "*", features = [
+  "fs",
+  "macros",
+  "signal",
+  "sync",
+  "rt-multi-thread"
+] }

--- a/oak_functions/examples/abitest/backend/src/main.rs
+++ b/oak_functions/examples/abitest/backend/src/main.rs
@@ -1,0 +1,72 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Oak Functions ABI test backend server.
+
+use anyhow::{anyhow, Context};
+use futures::future::FutureExt;
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use log::info;
+use maplit::hashmap;
+use oak_functions_abitest_common::{TEST_STORAGE_GET, TEST_STORAGE_GET_RESPONSE};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "Oak Functions ABI test backend server")]
+pub struct Opt {
+    #[structopt(
+        long,
+        help = "Address to listen on for the HTTP server.",
+        default_value = "[::]:8081"
+    )]
+    http_listen_address: String,
+}
+
+async fn service(_request: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    info!("Received request");
+    let response = test_utils::serialize_entries(hashmap! {
+        TEST_STORAGE_GET.as_bytes().to_vec() => TEST_STORAGE_GET_RESPONSE.as_bytes().to_vec(),
+    });
+    Ok(Response::new(Body::from(response)))
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let opt = Opt::from_args();
+
+    let address = &opt
+        .http_listen_address
+        .parse()
+        .context("Couldn't parse address")?;
+    let make_service =
+        make_service_fn(|_conn| async { Ok::<_, hyper::Error>(service_fn(service)) });
+
+    let server = Server::bind(&address).serve(make_service);
+    info!(
+        "Oak Functions ABI test backend server is listening on http://{}",
+        &opt.http_listen_address
+    );
+    server
+        .with_graceful_shutdown(tokio::signal::ctrl_c().map(|r| r.unwrap()))
+        .await
+        .map_err(|error| anyhow!("Couldn't run server: {:?}", error))?;
+
+    Ok(())
+}

--- a/oak_functions/examples/abitest/client/Cargo.toml
+++ b/oak_functions/examples/abitest/client/Cargo.toml
@@ -7,12 +7,10 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "*"
-assert_matches = "*"
 env_logger = "*"
 http = "*"
 hyper = { version = "*", features = ["client", "http1", "http2", "runtime"] }
 log = "*"
-maplit = "*"
 oak_functions_abi = { path = "../../../abi" }
 oak_functions_abitest_common = { path = "../common" }
 oak_functions_client = { path = "../../../client/rust" }

--- a/oak_functions/examples/abitest/client/Cargo.toml
+++ b/oak_functions/examples/abitest/client/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "oak_functions_abitest_client"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "*"
+assert_matches = "*"
+env_logger = "*"
+http = "*"
+hyper = { version = "*", features = ["client", "http1", "http2", "runtime"] }
+log = "*"
+maplit = "*"
+oak_functions_abi = { path = "../../../abi" }
+oak_functions_abitest_common = { path = "../common" }
+prost = "*"
+structopt = "*"
+tokio = { version = "*", features = [
+  "fs",
+  "macros",
+  "sync",
+  "rt-multi-thread"
+] }

--- a/oak_functions/examples/abitest/client/Cargo.toml
+++ b/oak_functions/examples/abitest/client/Cargo.toml
@@ -15,6 +15,7 @@ log = "*"
 maplit = "*"
 oak_functions_abi = { path = "../../../abi" }
 oak_functions_abitest_common = { path = "../common" }
+oak_functions_client = { path = "../../../client/rust" }
 prost = "*"
 structopt = "*"
 tokio = { version = "*", features = [

--- a/oak_functions/examples/abitest/client/src/main.rs
+++ b/oak_functions/examples/abitest/client/src/main.rs
@@ -19,8 +19,8 @@
 use anyhow::Context;
 use log::debug;
 use oak_functions_abi::proto::{ConfigurationInfo, Request};
-use oak_functions_client::Client;
 use oak_functions_abitest_common::*;
+use oak_functions_client::Client;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Clone)]
@@ -114,9 +114,9 @@ async fn send_request(uri: &str, body: &str) -> anyhow::Result<String> {
         .await
         .context("Couldn't invoke Oak Functions")?;
 
-    let response_body = std::str::from_utf8(
-        response.body().context("Couldn't get response message")?
-    ).context("Couldn't parse response message to string")?;
+    let response_body =
+        std::str::from_utf8(response.body().context("Couldn't get response message")?)
+            .context("Couldn't parse response message to string")?;
     Ok(response_body.to_string())
 }
 

--- a/oak_functions/examples/abitest/client/src/main.rs
+++ b/oak_functions/examples/abitest/client/src/main.rs
@@ -1,0 +1,136 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Oak Functions ABI test client.
+
+use anyhow::Context;
+use log::info;
+use oak_functions_abi::proto::{Response, StatusCode};
+use oak_functions_abitest_common::*;
+use prost::Message;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "Oak Functions ABI test client.")]
+pub struct Opt {
+    #[structopt(
+        long,
+        help = "URI of the application to connect to",
+        default_value = "http://localhost:8080/invoke"
+    )]
+    uri: String,
+}
+
+struct Test {
+    name: String,
+    expected_response: String,
+}
+
+impl Test {
+    fn new(name: &str, expected_response: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            expected_response: expected_response.to_string(),
+        }
+    }
+}
+
+struct TestManager {
+    uri: String,
+    tests: Vec<Test>,
+}
+
+impl TestManager {
+    fn new(uri: &str) -> Self {
+        let mut tests = vec![];
+        tests.push(Test::new(TEST_READ_WRITE, TEST_READ_WRITE_RESPONSE));
+        tests.push(Test::new(TEST_DOUBLE_READ, TEST_DOUBLE_READ_RESPONSE));
+        tests.push(Test::new(TEST_DOUBLE_WRITE, TEST_DOUBLE_WRITE_RESPONSE));
+        tests.push(Test::new(TEST_WRITE_LOG, TEST_WRITE_LOG_RESPONSE));
+        tests.push(Test::new(TEST_STORAGE_GET, TEST_STORAGE_GET_RESPONSE));
+
+        Self {
+            uri: uri.to_string(),
+            tests,
+        }
+    }
+
+    async fn run_tests(&self) -> anyhow::Result<()> {
+        for test in &self.tests {
+            self.run_test(&test.name, &test.expected_response)
+                .await
+                .context(format!("Couldn't run test: {}", &test.name))?;
+        }
+        Ok(())
+    }
+
+    async fn run_test(&self, test_name: &str, expected_response: &str) -> anyhow::Result<()> {
+        let response = send_request(&self.uri, test_name)
+            .await
+            .context("Couldn't send request")?;
+        assert_eq!(response, expected_response);
+        info!("{} test is successful", test_name);
+        Ok(())
+    }
+}
+
+async fn send_request(uri: &str, body: &str) -> anyhow::Result<String> {
+    let http = hyper::client::HttpConnector::new();
+    let client: hyper::client::Client<_, hyper::Body> = hyper::client::Client::builder()
+        .http2_only(true)
+        .build(http);
+
+    let request = hyper::Request::builder()
+        .method(http::Method::POST)
+        .uri(uri)
+        .body(body.to_string().into())
+        .context("Couldn't create HTTP request")?;
+
+    let response = client
+        .request(request)
+        .await
+        .context("Couldn't send request")?;
+    assert_eq!(response.status(), http::StatusCode::OK);
+
+    let body = hyper::body::to_bytes(response.into_body())
+        .await
+        .context("Couldn't read response body")?;
+    let result = Response::decode(body).context("Couldn't decode response body")?;
+    assert_eq!(StatusCode::Success as i32, result.status);
+
+    let message = String::from_utf8(
+        result
+            .body()
+            .context("Couldn't get response message")?
+            .to_vec(),
+    )
+    .context("Couldn't parse response message to string")?;
+    Ok(message)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let opt = Opt::from_args();
+
+    let test_manager = TestManager::new(&opt.uri);
+    test_manager
+        .run_tests()
+        .await
+        .context("Couldn't run tests")?;
+
+    Ok(())
+}

--- a/oak_functions/examples/abitest/common/Cargo.toml
+++ b/oak_functions/examples/abitest/common/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "oak_functions_abitest_common"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/oak_functions/examples/abitest/common/src/lib.rs
+++ b/oak_functions/examples/abitest/common/src/lib.rs
@@ -1,0 +1,28 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Oak Functions ABI test common constants.
+
+pub const TEST_READ_WRITE: &str = "ReadWrite";
+pub const TEST_READ_WRITE_RESPONSE: &str = "ReadWriteResponse";
+pub const TEST_DOUBLE_READ: &str = "DoubleRead";
+pub const TEST_DOUBLE_READ_RESPONSE: &str = "DoubleReadResponse";
+pub const TEST_DOUBLE_WRITE: &str = "DoubleWrite";
+pub const TEST_DOUBLE_WRITE_RESPONSE: &str = "DoubleWriteResponse";
+pub const TEST_WRITE_LOG: &str = "WriteLog";
+pub const TEST_WRITE_LOG_RESPONSE: &str = "WriteLogResponse";
+pub const TEST_STORAGE_GET: &str = "StorageGet";
+pub const TEST_STORAGE_GET_RESPONSE: &str = "StorageGetResponse";

--- a/oak_functions/examples/abitest/config.toml
+++ b/oak_functions/examples/abitest/config.toml
@@ -1,4 +1,4 @@
-lookup_data_url = "http://localhost:8081"
+lookup_data = { Url = "http://localhost:8081" }
 lookup_data_download_period = "10m"
 worker_threads = 4
 

--- a/oak_functions/examples/abitest/config.toml
+++ b/oak_functions/examples/abitest/config.toml
@@ -1,0 +1,7 @@
+lookup_data_url = "http://localhost:8081"
+lookup_data_download_period = "10m"
+worker_threads = 4
+
+[policy]
+constant_response_size_bytes = 90
+constant_processing_time = "20ms"

--- a/oak_functions/examples/abitest/example.toml
+++ b/oak_functions/examples/abitest/example.toml
@@ -1,0 +1,21 @@
+name = "oak_functions_abitest"
+
+[applications]
+
+[applications.rust]
+type = "Functions"
+wasm_path = "oak_functions/examples/bin/oak_functions_abitest.wasm"
+target = { Cargo = { cargo_manifest = "oak_functions/examples/abitest/module/Cargo.toml" } }
+
+[backends]
+backend = { Cargo = { cargo_manifest = "oak_functions/examples/abitest/backend/Cargo.toml" }, additional_args = [
+  "--http-listen-address=[::]:8081",
+] }
+
+[server]
+additional_args = ["--config-path=./oak_functions/examples/abitest/config.toml"]
+
+[clients]
+rust = { Cargo = { cargo_manifest = "oak_functions/examples/abitest/client/Cargo.toml" }, additional_args = [
+  "--uri=http://localhost:8080/invoke"
+] }

--- a/oak_functions/examples/abitest/example.toml
+++ b/oak_functions/examples/abitest/example.toml
@@ -4,7 +4,7 @@ name = "oak_functions_abitest"
 
 [applications.rust]
 type = "Functions"
-wasm_path = "oak_functions/examples/bin/oak_functions_abitest.wasm"
+wasm_path = "oak_functions/bin/oak_functions_abitest.wasm"
 target = { Cargo = { cargo_manifest = "oak_functions/examples/abitest/module/Cargo.toml" } }
 
 [backends]

--- a/oak_functions/examples/abitest/module/Cargo.toml
+++ b/oak_functions/examples/abitest/module/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "oak_functions_abitest"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+anyhow = "*"
+assert_matches = "*"
+oak_functions = { path = "../../../sdk/oak_functions" }
+oak_functions_abi = { path = "../../../abi" }
+oak_functions_abitest_common = { path = "../common" }
+serde = { version = "*", features = ["derive"] }
+serde_json = "*"

--- a/oak_functions/examples/abitest/module/Cargo.toml
+++ b/oak_functions/examples/abitest/module/Cargo.toml
@@ -14,5 +14,3 @@ assert_matches = "*"
 oak_functions = { path = "../../../sdk/oak_functions" }
 oak_functions_abi = { path = "../../../abi" }
 oak_functions_abitest_common = { path = "../common" }
-serde = { version = "*", features = ["derive"] }
-serde_json = "*"

--- a/oak_functions/examples/abitest/module/src/lib.rs
+++ b/oak_functions/examples/abitest/module/src/lib.rs
@@ -1,0 +1,119 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Oak Functions ABI test.
+
+use anyhow::{anyhow, Context};
+use assert_matches::assert_matches;
+use oak_functions_abitest_common::*;
+use std::collections::HashMap;
+
+type TestFn = fn(&str) -> anyhow::Result<()>;
+
+struct TestManager {
+    tests: HashMap<String, TestFn>,
+}
+
+impl TestManager {
+    fn new() -> Self {
+        let mut tests = HashMap::new();
+        tests.insert(TEST_READ_WRITE.to_string(), Self::test_read_write as TestFn);
+        tests.insert(
+            TEST_DOUBLE_READ.to_string(),
+            Self::test_double_read as TestFn,
+        );
+        tests.insert(
+            TEST_DOUBLE_WRITE.to_string(),
+            Self::test_double_write as TestFn,
+        );
+        tests.insert(TEST_WRITE_LOG.to_string(), Self::test_write_log as TestFn);
+        tests.insert(
+            TEST_STORAGE_GET.to_string(),
+            Self::test_storage_get as TestFn,
+        );
+
+        Self { tests }
+    }
+
+    fn run_test(&self) -> anyhow::Result<()> {
+        let request = oak_functions::read_request()
+            .map_err(|error| anyhow!("Couldn't read request: {:?}", error))?;
+        let test_name = String::from_utf8(request).context("Couldn't parse request")?;
+        let test = self
+            .tests
+            .get(&test_name)
+            .ok_or(anyhow!("Couldn't find test: {}", &test_name))?;
+        test(&test_name).context(format!("Couldn't run test: {}", &test_name))
+    }
+
+    fn test_read_write(_request: &str) -> anyhow::Result<()> {
+        let result = oak_functions::write_response(TEST_READ_WRITE_RESPONSE.as_bytes());
+        assert_matches!(result, Ok(_));
+        Ok(())
+    }
+
+    /// Tests that multiple calls to [`oak_functions_abi::read_request`] function all return the
+    /// same value.
+    fn test_double_read(request: &str) -> anyhow::Result<()> {
+        let result = oak_functions::read_request();
+        assert_matches!(result, Ok(_));
+        let second_request = result.unwrap();
+        assert_eq!(second_request, request.as_bytes());
+
+        let result = oak_functions::write_response(TEST_DOUBLE_READ_RESPONSE.as_bytes());
+        assert_matches!(result, Ok(_));
+        Ok(())
+    }
+
+    /// Tests that multiple calls to [`oak_functions_abi::write_response`] will replace the earlier
+    /// responses. Response value is checked on the client side.
+    fn test_double_write(_request: &str) -> anyhow::Result<()> {
+        // First response is empty.
+        let result = oak_functions::write_response("".as_bytes());
+        assert_matches!(result, Ok(_));
+
+        let result = oak_functions::write_response(TEST_DOUBLE_WRITE_RESPONSE.as_bytes());
+        assert_matches!(result, Ok(_));
+        Ok(())
+    }
+
+    fn test_write_log(request: &str) -> anyhow::Result<()> {
+        let result = oak_functions::write_log_message(request);
+        assert_matches!(result, Ok(_));
+        let result = oak_functions::write_response(TEST_WRITE_LOG_RESPONSE.as_bytes());
+        assert_matches!(result, Ok(_));
+        Ok(())
+    }
+
+    /// Tests the correctness of the data retrieved from the database.
+    /// Response value is checked on the client side.
+    fn test_storage_get(request: &str) -> anyhow::Result<()> {
+        let result = oak_functions::storage_get_item(request.as_bytes());
+        assert_matches!(result, Ok(_));
+        let data = result.unwrap();
+        assert_matches!(data, Some(_));
+
+        let result = oak_functions::write_response(&data.unwrap());
+        assert_matches!(result, Ok(_));
+        Ok(())
+    }
+}
+
+#[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn main() {
+    let test_manager = TestManager::new();
+    test_manager.run_test().expect("Couldn't run test");
+}

--- a/oak_functions/examples/abitest/module/src/lib.rs
+++ b/oak_functions/examples/abitest/module/src/lib.rs
@@ -65,13 +65,12 @@ impl TestManager {
         Ok(())
     }
 
-    /// Tests that multiple calls to [`oak_functions_abi::read_request`] function all return the
-    /// same value.
+    /// Tests that a second call to [`oak_functions_abi::read_request`] returns the same value.
     fn test_double_read(request: &str) -> anyhow::Result<()> {
         let result = oak_functions::read_request();
         assert_matches!(result, Ok(_));
-        let second_request = result.unwrap();
-        assert_eq!(second_request, request.as_bytes());
+        let second_read_result = result.unwrap();
+        assert_eq!(second_read_result, request.as_bytes());
 
         let result = oak_functions::write_response(TEST_DOUBLE_READ_RESPONSE.as_bytes());
         assert_matches!(result, Ok(_));

--- a/remote_attestation/rust/Cargo.lock
+++ b/remote_attestation/rust/Cargo.lock
@@ -816,7 +816,6 @@ dependencies = [
  "memchr",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]
@@ -1138,15 +1137,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/remote_attestation/rust/Cargo.lock
+++ b/remote_attestation/rust/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "memchr",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]
@@ -1137,6 +1138,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"


### PR DESCRIPTION
This commit adds an `abitest` example to Oak Functions.

Ref https://github.com/project-oak/oak/issues/1963