### PR TITLE
Add remote attestation via gRPC

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -962,6 +962,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "grpc_attestation_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "base64 0.13.0",
+ "env_logger",
+ "http",
+ "log",
+ "oak_abi",
+ "oak_attestation_common",
+ "oak_client",
+ "oak_grpc_attestation",
+ "oak_grpc_attestation_client",
+ "oak_sign",
+ "pem",
+ "prost",
+ "ring",
+ "structopt",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1591,7 @@ dependencies = [
  "anyhow",
  "log",
  "openssl",
+ "ring",
  "rustls",
  "serde",
  "serde_json",
@@ -1601,6 +1627,64 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "oak_grpc_attestation"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "env_logger",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "log",
+ "oak_attestation_common",
+ "oak_utils",
+ "openssl",
+ "prost",
+ "ring",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "structopt",
+ "tokio",
+ "tokio-rustls",
+ "tonic",
+]
+
+[[package]]
+name = "oak_grpc_attestation_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "env_logger",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "log",
+ "oak_attestation_common",
+ "oak_grpc_attestation",
+ "openssl",
+ "prost",
+ "ring",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "structopt",
+ "tokio",
+ "tokio-rustls",
+ "tonic",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "authentication/client",
   "chat/module/rust",
   "chat/grpc",
+  "grpc_attestation/client",
   "hello_world/grpc",
   "hello_world/client/rust",
   "hello_world/module/rust",
@@ -47,6 +48,8 @@ oak_abi = { path = "../oak_abi" }
 oak_attestation_common = { path = "../experimental/attestation_common" }
 oak_client = { path = "../oak_client" }
 oak_derive = { path = "../oak_derive" }
+oak_grpc_attestation = { path = "../experimental/grpc_attestation" }
+oak_grpc_attestation_client = { path = "../experimental/grpc_attestation_client/rust" }
 oak_io = { path = "../oak_io" }
 oak_proxy_attestation = { path = "../experimental/proxy_attestation" }
 oak_runtime = { path = "../oak_runtime" }

--- a/examples/grpc_attestation/client/Cargo.toml
+++ b/examples/grpc_attestation/client/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "grpc_attestation_client"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "*"
+async-stream = "*"
+base64 = "*"
+env_logger = "*"
+http = "*"
+log = "*"
+oak_abi = "=0.1.0"
+oak_attestation_common = "*"
+oak_client = { version = "=0.1.0", features = ["oak-attestation"] }
+oak_grpc_attestation = "*"
+oak_grpc_attestation_client = "*"
+oak_sign = "=0.1.0"
+pem = "*"
+prost = "*"
+ring = "*"
+structopt = "*"
+tokio = { version = "*", features = [
+  "fs",
+  "macros",
+  "sync",
+  "rt-multi-thread"
+] }
+tokio-stream = "*"
+tonic = { version = "*", features = ["tls", "transport"] }

--- a/examples/grpc_attestation/client/src/main.rs
+++ b/examples/grpc_attestation/client/src/main.rs
@@ -1,0 +1,63 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::{anyhow, Context};
+use log::info;
+use oak_grpc_attestation_client::AttestationClient;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "Proxy Attestation Client")]
+pub struct Opt {
+    #[structopt(
+        long,
+        help = "URI of the gRPC Attestation Service",
+        default_value = "http://localhost:8080"
+    )]
+    uri: String,
+}
+
+// TODO(#1867): Add remote attestation support.
+const TEST_TEE_MEASUREMENT: &str = "Test TEE measurement";
+const INVALID_TEST_TEE_MEASUREMENT: &str = "Invalid test TEE measurement";
+// Example message expected from the Oak application.
+const EXAMPLE_MESSAGE: &str = "Example message";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let opt = Opt::from_args();
+
+    if AttestationClient::create(&opt.uri, INVALID_TEST_TEE_MEASUREMENT.as_bytes()).await.is_ok() {
+        return Err(anyhow!("Invalid TEE measurement accepted"));
+    }
+
+    info!("Creating client");
+    let mut client = AttestationClient::create(&opt.uri, TEST_TEE_MEASUREMENT.as_bytes())
+        .await
+        .context("Couldn't create client")?;
+
+    info!("Sending request");
+    let response = client
+        .send(EXAMPLE_MESSAGE.as_bytes())
+        .await
+        .context("Couldn't send message")?
+        .context("No message received")?;
+    let data = String::from_utf8(response).context("Couldn't parse response")?;
+    info!("Client received data: {:?}", data);
+
+    Ok(())
+}

--- a/examples/grpc_attestation/client/src/main.rs
+++ b/examples/grpc_attestation/client/src/main.rs
@@ -41,7 +41,10 @@ async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let opt = Opt::from_args();
 
-    if AttestationClient::create(&opt.uri, INVALID_TEST_TEE_MEASUREMENT.as_bytes()).await.is_ok() {
+    if AttestationClient::create(&opt.uri, INVALID_TEST_TEE_MEASUREMENT.as_bytes())
+        .await
+        .is_ok()
+    {
         return Err(anyhow!("Invalid TEE measurement accepted"));
     }
 

--- a/examples/grpc_attestation/example.toml
+++ b/examples/grpc_attestation/example.toml
@@ -1,5 +1,7 @@
 name = "grpc_attestation"
 
+# Currently backend sends responses to the client, so there is no need for Oak application.
+# TODO(#1932): Use gRPC Attestation for Weather Example in Oak Functions.
 [applications]
 
 [backends]

--- a/examples/grpc_attestation/example.toml
+++ b/examples/grpc_attestation/example.toml
@@ -1,0 +1,14 @@
+name = "grpc_attestation"
+
+[applications]
+
+[backends]
+backend = { Cargo = { cargo_manifest = "experimental/grpc_attestation/Cargo.toml" }, additional_args = [
+  "--grpc-listen-address=[::]:8080",
+  "--tee-certificate=./examples/certs/local/ca.pem",
+] }
+
+[clients]
+rust = { Cargo = { cargo_manifest = "examples/grpc_attestation/client/Cargo.toml" }, additional_args = [
+  "--uri=https://localhost:8080"
+] }

--- a/experimental/Cargo.lock
+++ b/experimental/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "assert_matches",
  "log",
  "openssl",
+ "ring",
  "rustls",
  "serde",
  "serde_json",
@@ -1290,6 +1291,64 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "oak_grpc_attestation"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "env_logger",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "log",
+ "oak_attestation_common",
+ "oak_utils",
+ "openssl",
+ "prost",
+ "ring",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "structopt",
+ "tokio",
+ "tokio-rustls",
+ "tonic",
+]
+
+[[package]]
+name = "oak_grpc_attestation_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "env_logger",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "log",
+ "oak_attestation_common",
+ "oak_grpc_attestation",
+ "openssl",
+ "prost",
+ "ring",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "structopt",
+ "tokio",
+ "tokio-rustls",
+ "tonic",
 ]
 
 [[package]]

--- a/experimental/Cargo.toml
+++ b/experimental/Cargo.toml
@@ -9,6 +9,8 @@ members = [
   "proxy_attestation",
   "tls_attestation",
   "https_attestation",
+  "grpc_attestation",
+  "grpc_attestation_client/rust",
 ]
 
 [patch.crates-io]

--- a/experimental/attestation_common/Cargo.toml
+++ b/experimental/attestation_common/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 anyhow = "*"
 log = "*"
 openssl = "*"
+ring = "*"
 rustls = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = "*"

--- a/experimental/attestation_common/src/crypto.rs
+++ b/experimental/attestation_common/src/crypto.rs
@@ -1,0 +1,155 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::anyhow;
+use ring::{
+    aead::{self, BoundKey},
+    agreement, rand,
+};
+
+// `ring::aead` uses 96-bit (12-byte) nonces.
+// https://briansmith.org/rustdoc/ring/aead/constant.NONCE_LEN.html
+//
+// TODO(#2087): Use a unique nonce for each message.
+const NONCE: [u8; aead::NONCE_LEN] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+// Algorithm used for encrypting/decrypting messages.
+// https://datatracker.ietf.org/doc/html/rfc5288
+static AEAD_ALGORITHM: &aead::Algorithm = &aead::AES_256_GCM;
+// Algorithm used for negotiating a session key.
+// https://datatracker.ietf.org/doc/html/rfc7748
+static KEY_AGREEMENT_ALGORITHM: &agreement::Algorithm = &agreement::X25519;
+
+/// Nonce implementation used by [`AeadInterface`].
+/// It returns a single nonce once and then only returns errors.
+struct OneNonceSequence(Option<aead::Nonce>);
+
+impl OneNonceSequence {
+    fn new() -> Self {
+        let nonce = aead::Nonce::assume_unique_for_key(NONCE);
+        Self(Some(nonce))
+    }
+}
+
+impl aead::NonceSequence for OneNonceSequence {
+    fn advance(&mut self) -> Result<aead::Nonce, ring::error::Unspecified> {
+        self.0.take().ok_or(ring::error::Unspecified)
+    }
+}
+
+/// Implementation of Authenticated Encryption with Associated Data (AEAD).
+/// https://datatracker.ietf.org/doc/html/rfc5116
+pub struct AeadEncryptor {
+    // Key used for encrypting data.
+    sealing_key: aead::SealingKey<OneNonceSequence>,
+    // Key used for decrypting data.
+    opening_key: aead::OpeningKey<OneNonceSequence>,
+}
+
+impl AeadEncryptor {
+    pub fn new(key: &[u8]) -> Self {
+        // AES-GCM algorithm uses the same key is used for both encryption and decryption.
+        // https://datatracker.ietf.org/doc/html/rfc5288
+        let unbound_sealing_key = aead::UnboundKey::new(AEAD_ALGORITHM, &key).unwrap();
+        let sealing_key = ring::aead::SealingKey::new(unbound_sealing_key, OneNonceSequence::new());
+
+        let unbound_opening_key = aead::UnboundKey::new(AEAD_ALGORITHM, &key).unwrap();
+        let opening_key = ring::aead::OpeningKey::new(unbound_opening_key, OneNonceSequence::new());
+
+        Self {
+            sealing_key,
+            opening_key,
+        }
+    }
+
+    /// Encrypts `data` using [`AeadEncryptor::sealing_key`].
+    ///
+    /// Additional authenticated data is not required for the remotely attested channel,
+    /// since after session key is established client and server exchange messages with a
+    /// single encrypted field.
+    /// And the nonce is authenticated by the AEAD algorithm itself.
+    /// https://datatracker.ietf.org/doc/html/rfc5116#section-2.1
+    pub fn encrypt(&mut self, data: &[u8]) -> anyhow::Result<Vec<u8>> {
+        let mut encrypted_data = data.to_vec();
+        self.sealing_key
+            .seal_in_place_append_tag(
+                aead::Aad::from(vec![]),
+                &mut encrypted_data,
+            )
+            .map_err(|error| anyhow!("Couldn't encrypt data: {:?}", error))?;
+        Ok(encrypted_data)
+    }
+
+    /// Decrypts and authenticates `data` using [`AeadEncryptor::opening_key`].
+    ///
+    /// Additional authenticated data is not required for the remotely attested channel,
+    /// since after session key is established client and server exchange messages with a
+    /// single encrypted field.
+    /// And the nonce is authenticated by the AEAD algorithm itself.
+    /// https://datatracker.ietf.org/doc/html/rfc5116#section-2.1
+    pub fn decrypt(&mut self, data: &[u8]) -> anyhow::Result<Vec<u8>> {
+        let mut decrypted_data = data.to_vec();
+        let decrypted_data = self
+            .opening_key
+            .open_in_place(
+                aead::Aad::from(vec![]),
+                &mut decrypted_data,
+            )
+            .map_err(|error| anyhow!("Couldn't decrypt data: {:?}", error))?;
+        Ok(decrypted_data.to_vec())
+    }
+}
+
+pub struct KeyNegotiator {
+    private_key: agreement::EphemeralPrivateKey,
+}
+
+impl KeyNegotiator {
+    pub fn create() -> anyhow::Result<Self> {
+        let rng = rand::SystemRandom::new();
+        let private_key = agreement::EphemeralPrivateKey::generate(KEY_AGREEMENT_ALGORITHM, &rng)
+            .map_err(|error| anyhow!("Couldn't generate private key: {:?}", error))?;
+        Ok(Self { private_key })
+    }
+
+    pub fn public_key(&self) -> anyhow::Result<Vec<u8>> {
+        let public_key = self
+            .private_key
+            .compute_public_key()
+            .map_err(|error| anyhow!("Couldn't get public key: {:?}", error))?;
+        Ok(public_key.as_ref().to_vec())
+    }
+
+    pub fn derive_session_key(self, peer_public_key: &[u8]) -> anyhow::Result<Vec<u8>> {
+        let peer_public_key =
+            agreement::UnparsedPublicKey::new(KEY_AGREEMENT_ALGORITHM, peer_public_key);
+        let session_key = agreement::agree_ephemeral(
+            self.private_key,
+            &peer_public_key,
+            ring::error::Unspecified,
+            Self::kdf,
+        )
+        .map_err(|error| anyhow!("Couldn't derive session key: {:?}", error))?;
+        Ok(session_key)
+    }
+
+    /// Derives a session key from `key_material`.
+    fn kdf(key_material: &[u8]) -> Result<Vec<u8>, ring::error::Unspecified> {
+        // TODO(#2100): Derive a session key not just from `key_material` but also from server's and
+        // client's public keys.
+        // https://datatracker.ietf.org/doc/html/rfc7748#section-6.1
+        Ok(key_material.to_vec())
+    }
+}

--- a/experimental/attestation_common/src/crypto.rs
+++ b/experimental/attestation_common/src/crypto.rs
@@ -32,7 +32,7 @@ static AEAD_ALGORITHM: &aead::Algorithm = &aead::AES_256_GCM;
 // https://datatracker.ietf.org/doc/html/rfc7748
 static KEY_AGREEMENT_ALGORITHM: &agreement::Algorithm = &agreement::X25519;
 
-/// Nonce implementation used by [`AeadInterface`].
+/// Nonce implementation used by [`AeadEncryptor`].
 /// It returns a single nonce once and then only returns errors.
 struct OneNonceSequence(Option<aead::Nonce>);
 
@@ -84,10 +84,7 @@ impl AeadEncryptor {
     pub fn encrypt(&mut self, data: &[u8]) -> anyhow::Result<Vec<u8>> {
         let mut encrypted_data = data.to_vec();
         self.sealing_key
-            .seal_in_place_append_tag(
-                aead::Aad::from(vec![]),
-                &mut encrypted_data,
-            )
+            .seal_in_place_append_tag(aead::Aad::from(vec![]), &mut encrypted_data)
             .map_err(|error| anyhow!("Couldn't encrypt data: {:?}", error))?;
         Ok(encrypted_data)
     }
@@ -103,10 +100,7 @@ impl AeadEncryptor {
         let mut decrypted_data = data.to_vec();
         let decrypted_data = self
             .opening_key
-            .open_in_place(
-                aead::Aad::from(vec![]),
-                &mut decrypted_data,
-            )
+            .open_in_place(aead::Aad::from(vec![]), &mut decrypted_data)
             .map_err(|error| anyhow!("Couldn't decrypt data: {:?}", error))?;
         Ok(decrypted_data.to_vec())
     }

--- a/experimental/grpc_attestation/Cargo.toml
+++ b/experimental/grpc_attestation/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "oak_grpc_attestation"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+name = "oak_grpc_attestation"
+path = "src/lib.rs"
+
+[[bin]]
+name = "oak_grpc_attestation_bin"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "*"
+async-stream = "*"
+env_logger = "*"
+futures = "*"
+futures-core = "*"
+futures-util = "*"
+hex = "*"
+http = "*"
+hyper = { version = "*", features = [
+  "client",
+  "http1",
+  "http2",
+  "runtime",
+  "server"
+] }
+log = "*"
+oak_attestation_common = { version = "*", path = "../attestation_common" }
+openssl = "*"
+prost = "*"
+ring = "*"
+rustls = "*"
+serde = "*"
+serde_json = "*"
+sha2 = "*"
+structopt = "*"
+tokio = { version = "*", features = [
+  "fs",
+  "macros",
+  "net",
+  "signal",
+  "sync",
+  "rt-multi-thread"
+] }
+tokio-rustls = "*"
+tonic = { version = "*", features = ["tls"] }
+
+[build-dependencies]
+oak_utils = { path = "../../oak_utils" }

--- a/experimental/grpc_attestation/build.rs
+++ b/experimental/grpc_attestation/build.rs
@@ -14,18 +14,17 @@
 // limitations under the License.
 //
 
-pub mod certificate;
-pub mod crypto;
-pub mod keying_material;
-pub mod report;
-#[cfg(test)]
-mod tests;
+use oak_utils::{generate_grpc_code, CodegenOptions};
 
-use sha2::{digest::Digest, Sha256};
-
-/// Computes a SHA-256 digest of `input` and returns it in a form of raw bytes.
-pub fn get_sha256(input: &[u8]) -> Vec<u8> {
-    let mut hasher = Sha256::new();
-    hasher.update(&input);
-    hasher.finalize().to_vec()
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    generate_grpc_code(
+        "proto",
+        &["grpc_attestation.proto"],
+        CodegenOptions {
+            build_client: true,
+            build_server: true,
+            extern_paths: vec![],
+        },
+    )?;
+    Ok(())
 }

--- a/experimental/grpc_attestation/proto/grpc_attestation.proto
+++ b/experimental/grpc_attestation/proto/grpc_attestation.proto
@@ -1,0 +1,63 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.examples.grpc_attestation;
+
+message AttestedInvokeRequest {
+  oneof request_type {
+    // Client part of session key negotiation.
+    ClientIdentity client_identity = 1;
+    // Payload encrypted using the session key.
+    bytes encrypted_payload = 2;
+  }
+}
+
+// TODO(#2105): Implement challenge-response in gRPC Attestation.
+message ClientIdentity {
+  // Client public key needed to establish a session key between client and server.
+  bytes public_key = 1;
+}
+
+message AttestedInvokeResponse {
+  oneof response_type {
+    // Server part of session key negotiation.
+    ServerIdentity server_identity = 1;
+    // Payload encrypted using the session key.
+    bytes encrypted_payload = 2;
+  }
+}
+
+// TODO(#2106): Support various claims in gRPC Attestation.
+message ServerIdentity {
+  // Server public key needed to establish a session key between client and server.
+  bytes public_key = 1;
+  // Information used for remote attestation such as a TEE report and a TEE provider's certificate.
+  // TEE report should contain a hash of the server's public key.
+  bytes attestation_info = 2;
+}
+
+service GrpcAttestation {
+  // Creates a message stream for session key negotiation and encrypted payload exchange.
+  //
+  // The created message stream looks as follows:
+  // - Client->Server: `AttestedInvokeRequest` with `ClientIdentity`.
+  // - Client->Server: `AttestedInvokeResponse` with `ServerIdentity`.
+  // - Client->Server: `AttestedInvokeRequest` with `encrypted_payload`.
+  // - Server->Client: `AttestedInvokeResponse` with `encrypted_payload`.
+  rpc AttestedInvoke(stream AttestedInvokeRequest) returns (stream AttestedInvokeResponse);
+}

--- a/experimental/grpc_attestation/src/attestation.rs
+++ b/experimental/grpc_attestation/src/attestation.rs
@@ -1,0 +1,202 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::{anyhow, Context};
+use futures::{Stream, StreamExt};
+use log::info;
+use oak_attestation_common::{
+    crypto::{AeadEncryptor, KeyNegotiator},
+    get_sha256,
+    report::{AttestationInfo, Report},
+};
+use oak_grpc_attestation::proto::{
+    attested_invoke_request::RequestType, attested_invoke_response::ResponseType,
+    grpc_attestation_server::GrpcAttestation, AttestedInvokeRequest, AttestedInvokeResponse,
+    ServerIdentity,
+};
+use std::pin::Pin;
+use tonic::{Request, Response, Status, Streaming};
+
+/// Utility structure that receives messages from gRPC streams.
+struct Receiver {
+    request_stream: Streaming<AttestedInvokeRequest>,
+}
+
+impl Receiver {
+    /// Receives requests from [`Receiver::request_stream`].
+    /// Returns `Ok(None)` to indicate that the corresponding gRPC stream has ended.
+    async fn receive(&mut self) -> anyhow::Result<Option<AttestedInvokeRequest>> {
+        let request = if let Some(request) = self.request_stream.next().await {
+            Some(request.context("Couldn't receive request")?)
+        } else {
+            None
+        };
+        Ok(request)
+    }
+}
+
+struct RequestHandler {
+    /// Utility object for decrypting and encrypting messages using a Diffie-Hellman session key.
+    encryptor: AeadEncryptor,
+    /// Handler function that processes data from client requests and creates responses.
+    handler: fn(&[u8]) -> Vec<u8>,
+}
+
+impl RequestHandler {
+    pub fn new(encryptor: AeadEncryptor, handler: fn(&[u8]) -> Vec<u8>) -> Self {
+        Self { encryptor, handler }
+    }
+
+    /// Decrypts a client request, runs [`RequestHandler::handler`] on them and returns an encrypted
+    /// response.
+    pub async fn handle_request(
+        &mut self,
+        receiver: &mut Receiver,
+    ) -> anyhow::Result<Option<AttestedInvokeResponse>> {
+        if let Some(request) = receiver.receive().await.context("Couldn't receive request")? {
+            let request_type = request.request_type.context("Couldn't read request type")?;
+            let encrypted_payload = if let RequestType::EncryptedPayload(encrypted_payload) = request_type {
+                Ok(encrypted_payload)
+            } else {
+                Err(anyhow!("Received incorrect message type"))
+            }?;
+            let payload = self
+                .encryptor
+                .decrypt(&encrypted_payload)
+                .context("Couldn't decrypt data")?;
+
+            let data = (self.handler)(&payload);
+            let encrypted_data = self
+                .encryptor
+                .encrypt(&data)
+                .context("Couldn't encrypt data")?;
+            let response = AttestedInvokeResponse {
+                response_type: Some(ResponseType::EncryptedPayload(data)),
+            };
+
+            Ok(Some(response))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// gRPC Attestation Service implementation.
+pub struct AttestationServer {
+    /// PEM encoded X.509 certificate that signs TEE firmware key.
+    tee_certificate: Vec<u8>,
+    /// Processes data from client requests and creates responses.
+    request_handler: fn(&[u8]) -> Vec<u8>,
+}
+
+impl AttestationServer {
+    pub fn create(
+        tee_certificate: Vec<u8>,
+        request_handler: fn(&[u8]) -> Vec<u8>,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            tee_certificate,
+            request_handler,
+        })
+    }
+
+    /// Attest a single gRPC streaming request. Client messages are provided via `receiver`.
+    async fn attest(
+        receiver: &mut Receiver,
+        tee_certificate: Vec<u8>,
+    ) -> anyhow::Result<(AttestedInvokeResponse, AeadEncryptor)> {
+        let request = receiver
+            .receive()
+            .await
+            .context("Couldn't receive attestation request")?
+            .context("Stream stopped preemptively")?;
+
+        // Receive client's attestation request containing a public key.
+        // TODO(#2103): Refactor gRPC Attestation protocol state machine.
+        let request_type = request.request_type.context("Couldn't read request type")?;
+        let request =
+            if let RequestType::ClientIdentity(request) = request_type {
+                Ok(request)
+            } else {
+                Err(anyhow!("Received incorrect message type"))
+            }?;
+        info!("Server received attestation request: {:?}", request);
+
+        // Generate session key.
+        let key_negotiator = KeyNegotiator::create().context("Couldn't create key negotiator")?;
+        let public_key = key_negotiator
+            .public_key()
+            .context("Couldn't get public key")?;
+        let session_key = key_negotiator
+            .derive_session_key(&request.public_key)
+            .context("Couldn't derive session key")?;
+
+        let encryptor = AeadEncryptor::new(&session_key);
+
+        // Generate attestation info with a TEE report.
+        // TEE report contains a hash of the server's public key.
+        let public_key_hash = get_sha256(&public_key);
+        let tee_report = Report::new(&public_key_hash);
+        let attestation_info = AttestationInfo {
+            report: tee_report,
+            certificate: tee_certificate,
+        };
+        let serialized_attestation_info = attestation_info
+            .to_string()
+            .context("Couldn't serialize attestation info")?;
+
+        let attestation_response = AttestedInvokeResponse {
+            response_type: Some(ResponseType::ServerIdentity(ServerIdentity {
+                public_key,
+                attestation_info: serialized_attestation_info.as_bytes().to_vec(),
+            })),
+        };
+
+        Ok((attestation_response, encryptor))
+    }
+}
+
+#[tonic::async_trait]
+impl GrpcAttestation for AttestationServer {
+    type AttestedInvokeStream = Pin<
+        Box<dyn Stream<Item = Result<AttestedInvokeResponse, Status>> + Send + Sync + 'static>,
+    >;
+
+    async fn attested_invoke(
+        &self,
+        request_stream: Request<tonic::Streaming<AttestedInvokeRequest>>,
+    ) -> Result<Response<Self::AttestedInvokeStream>, Status> {
+        let tee_certificate = self.tee_certificate.clone();
+        let request_handler = self.request_handler;
+        info!("Server received request stream");
+
+        let request_stream = request_stream.into_inner();
+        let response_stream = async_stream::try_stream! {
+            let mut receiver = Receiver { request_stream };
+            let (attestation_response, encryptor) = Self::attest(&mut receiver, tee_certificate)
+                .await
+                .map_err(Status::internal("Couldn't attest to the client"))?;
+            yield attestation_response;
+
+            let mut handler = RequestHandler::new(encryptor, request_handler);
+            while let Some(response) = handler.handle_request(&mut receiver).await.map_err(Status::internal("Couldn't process stream"))? {
+                yield response
+            }
+        };
+
+        Ok(Response::new(Box::pin(response_stream)))
+    }
+}

--- a/experimental/grpc_attestation/src/lib.rs
+++ b/experimental/grpc_attestation/src/lib.rs
@@ -14,18 +14,6 @@
 // limitations under the License.
 //
 
-pub mod certificate;
-pub mod crypto;
-pub mod keying_material;
-pub mod report;
-#[cfg(test)]
-mod tests;
-
-use sha2::{digest::Digest, Sha256};
-
-/// Computes a SHA-256 digest of `input` and returns it in a form of raw bytes.
-pub fn get_sha256(input: &[u8]) -> Vec<u8> {
-    let mut hasher = Sha256::new();
-    hasher.update(&input);
-    hasher.finalize().to_vec()
+pub mod proto {
+    tonic::include_proto!("oak.examples.grpc_attestation");
 }

--- a/experimental/grpc_attestation/src/main.rs
+++ b/experimental/grpc_attestation/src/main.rs
@@ -47,7 +47,7 @@
 //!
 //! It's important to note that for each new gRPC stream both Client and Server generate new pairs
 //! of private/public key pairs and negotiate new session keys.
-//! 
+//!
 //! Key negotiation is done using [`ring::agreement`](https://briansmith.org/rustdoc/ring/agreement/index.html).
 //!
 //! Note: Current version of the gRPC Attestation Service doesn't have remote attestation.

--- a/experimental/grpc_attestation/src/main.rs
+++ b/experimental/grpc_attestation/src/main.rs
@@ -1,0 +1,120 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! gRPC Attestation Service implementation.
+//!
+//! gRPC Attestation Service performs remote attestation for each incoming streaming gRPC request.
+//!
+//! It is assumed that prior to the attestation workflow Service remotely attests its TEE platform
+//! key with the TEE firmware Provider. Provider sends back a signature rooted in some well-known
+//! root key (e.g. AMD root key), thus confirming the authenticity of the TEE platform key.
+//!
+//! Remote attestation is done as follows:
+//! - Client generates an ephemeral (single-use) private/public key pair
+//! - Client sends a streaming gRPC request with its public key to the Server
+//! - Server generates an ephemeral (single-use) private/public key pair
+//! - Server uses its and Client's public keys to generate a symmetric session key, which is shared
+//!   between client and server
+//! - Server puts the hash of its public key into the TEE report request
+//!   - It means that when a TEE report is signed, the public key will also be signed
+//! - Server requests a TEE report from the TEE firmware
+//! - Server sends its public key, a TEE report and Provider's certificate to the Client
+//! - Client checks the validity of the TEE report
+//!   - It checks that the TEE report is signed by TEE Provider’s root key
+//!   - It checks that the public key hash from the TEE report is equal to the hash of the public
+//!     key presented in the server response
+//!   - It also extracts the TEE measurement from the TEE report and compares it to the expected one
+//!   - If the TEE report is not valid, then the Client closes the connection and aborts the
+//!     protocol
+//! - Client uses its and Server's public keys to generate a symmetric session key, which is shared
+//!   between client and server
+//! - Client uses the session key to encrypt further requests to the Server
+//! - Server uses the session key to decrypt further requests from the Client and encrypt
+//!   corresponding responses
+//!
+//! It's important to note that for each new gRPC stream both Client and Server generate new pairs
+//! of private/public key pairs and negotiate new session keys.
+//! 
+//! Key negotiation is done using [`ring::agreement`](https://briansmith.org/rustdoc/ring/agreement/index.html).
+//!
+//! Note: Current version of the gRPC Attestation Service doesn't have remote attestation.
+
+mod attestation;
+
+use crate::attestation::AttestationServer;
+use anyhow::Context;
+use futures::FutureExt;
+use log::info;
+use oak_grpc_attestation::proto::grpc_attestation_server::GrpcAttestationServer;
+use structopt::StructOpt;
+use tonic::transport::Server;
+
+#[derive(StructOpt, Clone)]
+#[structopt(about = "gRPC Attestation")]
+pub struct Opt {
+    #[structopt(
+        long,
+        help = "Address to listen on for the gRPC server.",
+        default_value = "[::]:8888"
+    )]
+    grpc_listen_address: String,
+    #[structopt(
+        long,
+        help = "PEM encoded X.509 certificate that signs TEE firmware key.",
+        default_value = "./examples/certs/local/ca.pem"
+    )]
+    tee_certificate: String,
+}
+
+// Example message sent to the client.
+const EXAMPLE_MESSAGE: &str = "Example message";
+
+fn request_handler(request: &[u8]) -> Vec<u8> {
+    let parsed_request = String::from_utf8(request.to_vec()).expect("Couldn't parse request");
+    info!("Server received data: {:?}", parsed_request);
+    EXAMPLE_MESSAGE.as_bytes().to_vec()
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let opt = Opt::from_args();
+
+    let grpc_listen_address = opt
+        .grpc_listen_address
+        .parse()
+        .context("Couldn't parse address")?;
+    let tee_certificate =
+        std::fs::read(&opt.tee_certificate).context("Couldn't load certificate")?;
+
+    info!(
+        "Starting proxy attestation server at {:?}",
+        grpc_listen_address
+    );
+    Server::builder()
+        .add_service(GrpcAttestationServer::new(
+            AttestationServer::create(tee_certificate, request_handler)
+                .context("Couldn't create proxy")?,
+        ))
+        .serve_with_shutdown(
+            grpc_listen_address,
+            tokio::signal::ctrl_c().map(|r| r.unwrap()),
+        )
+        .await
+        .context("Couldn't start server")?;
+
+    Ok(())
+}

--- a/experimental/grpc_attestation_client/rust/Cargo.toml
+++ b/experimental/grpc_attestation_client/rust/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "oak_grpc_attestation_client"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "*"
+async-stream = "*"
+env_logger = "*"
+futures = "*"
+futures-core = "*"
+futures-util = "*"
+hex = "*"
+http = "*"
+hyper = { version = "*", features = [
+  "client",
+  "http1",
+  "http2",
+  "runtime",
+  "server"
+] }
+log = "*"
+oak_attestation_common = { version = "*", path = "../../attestation_common" }
+oak_grpc_attestation = { version = "*", path = "../../grpc_attestation" }
+openssl = "*"
+prost = "*"
+ring = "*"
+rustls = "*"
+serde = "*"
+serde_json = "*"
+sha2 = "*"
+structopt = "*"
+tokio = { version = "*", features = [
+  "fs",
+  "macros",
+  "net",
+  "signal",
+  "sync",
+  "rt-multi-thread"
+] }
+tokio-rustls = "*"
+tonic = { version = "*", features = ["tls"] }

--- a/experimental/grpc_attestation_client/rust/src/lib.rs
+++ b/experimental/grpc_attestation_client/rust/src/lib.rs
@@ -109,9 +109,7 @@ impl AttestationClient {
 
         // Create attestation request with client's public key.
         let request = AttestedInvokeRequest {
-            request_type: Some(RequestType::ClientIdentity(ClientIdentity {
-                public_key,
-            })),
+            request_type: Some(RequestType::ClientIdentity(ClientIdentity { public_key })),
         };
         let response = client
             .send(request)
@@ -175,7 +173,7 @@ impl AttestationClient {
 
     /// Sends data encrypted by the [`AttestationClient::encryptor`] to the server and returns
     /// server responses.
-    /// `Ok(None)` output means that the corresponding gRPC stream has ended.
+    /// Returns `Ok(None)` to indicate that the corresponding gRPC stream has ended.
     pub async fn send(&mut self, data: &[u8]) -> anyhow::Result<Option<Vec<u8>>> {
         let encrypted_data = self
             .encryptor

--- a/experimental/grpc_attestation_client/rust/src/lib.rs
+++ b/experimental/grpc_attestation_client/rust/src/lib.rs
@@ -1,0 +1,213 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::{anyhow, Context};
+use oak_attestation_common::{
+    crypto::{AeadEncryptor, KeyNegotiator},
+    report::AttestationInfo,
+};
+use oak_grpc_attestation::proto::{
+    attested_invoke_request::RequestType, attested_invoke_response::ResponseType,
+    grpc_attestation_client::GrpcAttestationClient, AttestedInvokeRequest, AttestedInvokeResponse,
+    ClientIdentity,
+};
+use tokio::sync::mpsc::Sender;
+use tonic::{transport::Channel, Request, Streaming};
+
+const MESSAGE_BUFFER_SIZE: usize = 1;
+
+/// Convenience structure for sending requests and receiving responses from the server.
+struct Client {
+    sender: Sender<AttestedInvokeRequest>,
+    response_stream: Streaming<AttestedInvokeResponse>,
+}
+
+impl Client {
+    async fn create(uri: &str) -> anyhow::Result<Self> {
+        let channel = Channel::from_shared(uri.to_string())
+            .context("Couldn't create gRPC channel")?
+            .connect()
+            .await
+            .context("Couldn't connect via gRPC channel")?;
+        let mut client = GrpcAttestationClient::new(channel);
+
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(MESSAGE_BUFFER_SIZE);
+
+        let request_stream = async_stream::stream! {
+            while let Some(message) = receiver.recv().await {
+                yield message;
+            }
+        };
+
+        let response = client
+            .attested_invoke(Request::new(request_stream))
+            .await
+            .context("Couldn't send request")?;
+        let response_stream = response.into_inner();
+
+        Ok(Self {
+            sender,
+            response_stream,
+        })
+    }
+
+    async fn send(
+        &mut self,
+        request: AttestedInvokeRequest,
+    ) -> anyhow::Result<Option<AttestedInvokeResponse>> {
+        self.sender
+            .send(request)
+            .await
+            .context("Couldn't send request")?;
+        self.response_stream
+            .message()
+            .await
+            .context("Couldn't receive response")
+    }
+}
+
+/// gRPC Attestation Service client implementation.
+pub struct AttestationClient {
+    client: Client,
+    encryptor: AeadEncryptor,
+}
+
+impl AttestationClient {
+    pub async fn create(uri: &str, expected_tee_measurement: &[u8]) -> anyhow::Result<Self> {
+        let mut client = Client::create(uri)
+            .await
+            .context("Couldn't create gRPC client")?;
+        let encryptor = AttestationClient::attest(&mut client, expected_tee_measurement)
+            .await
+            .context("Couldn't attest server")?;
+
+        Ok(Self { client, encryptor })
+    }
+
+    /// Attests server for a single gRPC streaming request.
+    async fn attest(
+        client: &mut Client,
+        expected_tee_measurement: &[u8],
+    ) -> anyhow::Result<AeadEncryptor> {
+        let key_negotiator = KeyNegotiator::create().expect("Couldn't create key negotiator");
+        let public_key = key_negotiator
+            .public_key()
+            .expect("Couldn't get public key");
+
+        // Create attestation request with client's public key.
+        let request = AttestedInvokeRequest {
+            request_type: Some(RequestType::ClientIdentity(ClientIdentity {
+                public_key,
+            })),
+        };
+        let response = client
+            .send(request)
+            .await
+            .context("Couldn't send attestation request")?
+            .context("Stream stopped preemptively")?;
+
+        // Receive server's attestation containing public key.
+        let response_type = response
+            .response_type
+            .context("Couldn't read response type")?;
+        let attestation_response =
+            if let ResponseType::ServerIdentity(attestation_response) = response_type {
+                Ok(attestation_response)
+            } else {
+                Err(anyhow!("Received incorrect message type"))
+            }?;
+
+        // Verify server's attestation info.
+        AttestationClient::verify_attestation(
+            attestation_response.attestation_info,
+            expected_tee_measurement,
+        )
+        .context("Couldn't verify server attestation")?;
+
+        // Create attestation key based on client's and server's public keys.
+        let session_key = key_negotiator
+            .derive_session_key(&attestation_response.public_key)
+            .context("Couldn't derive session key")?;
+
+        Ok(AeadEncryptor::new(&session_key))
+    }
+
+    /// Verifies the validity of the attestation info:
+    /// - Checks that the TEE report is signed by TEE Provider’s root key.
+    /// - Checks that the public key hash from the TEE report is equal to the hash of the public key
+    ///   presented in the server response.
+    /// - Extracts the TEE measurement from the TEE report and compares it to the
+    ///   `expected_tee_measurement`.
+    fn verify_attestation(
+        attestation_info: Vec<u8>,
+        expected_tee_measurement: &[u8],
+    ) -> anyhow::Result<()> {
+        let serialized_attestation_info =
+            String::from_utf8(attestation_info).context("Couldn't get attestation info string")?;
+        let deserialized_attestation_info =
+            AttestationInfo::from_string(&serialized_attestation_info)
+                .context("Couldn't deserialize attestation info")?;
+
+        // TODO(#1867): Add remote attestation support, use real TEE reports and check that
+        // `AttestationInfo::certificate` is signed by one of the root certificates.
+        deserialized_attestation_info
+            .verify()
+            .context("Couldn't verify attestation info")?;
+        if expected_tee_measurement == deserialized_attestation_info.report.measurement {
+            Ok(())
+        } else {
+            Err(anyhow!("Incorrect TEE measurement"))
+        }
+    }
+
+    /// Sends data encrypted by the [`AttestationClient::encryptor`] to the server and returns
+    /// server responses.
+    /// `Ok(None)` output means that the corresponding gRPC stream has ended.
+    pub async fn send(&mut self, data: &[u8]) -> anyhow::Result<Option<Vec<u8>>> {
+        let encrypted_data = self
+            .encryptor
+            .encrypt(data)
+            .context("Couldn't encrypt data")?;
+        let data_request = AttestedInvokeRequest {
+            request_type: Some(RequestType::EncryptedPayload(encrypted_data)),
+        };
+
+        let response = self
+            .client
+            .send(data_request)
+            .await
+            .context("Couldn't send data request")?;
+        let data = if let Some(response) = response {
+            let response_type = response
+                .response_type
+                .context("Couldn't read response type")?;
+            let encrypted_payload = if let ResponseType::EncryptedPayload(data) = response_type {
+                Ok(data)
+            } else {
+                Err(anyhow!("Received incorrect message type"))
+            }?;
+            let payload = self
+                .encryptor
+                .decrypt(&encrypted_payload)
+                .context("Couldn't decrypt data")?;
+            Some(payload)
+        } else {
+            None
+        };
+
+        Ok(data)
+    }
+}

--- a/oak_client/Cargo.lock
+++ b/oak_client/Cargo.lock
@@ -693,6 +693,7 @@ dependencies = [
  "anyhow",
  "log",
  "openssl",
+ "ring",
  "rustls",
  "serde",
  "serde_json",

--- a/oak_loader/Cargo.lock
+++ b/oak_loader/Cargo.lock
@@ -1336,6 +1336,7 @@ dependencies = [
  "anyhow",
  "log",
  "openssl",
+ "ring",
  "rustls",
  "serde",
  "serde_json",


### PR DESCRIPTION
This change adds an experimental version of gRPC remote attestation scheme.
This attestation scheme uses:
- [`ring::agreement`](https://briansmith.org/rustdoc/ring/agreement/index.html) to exchange X25519 Diffie-Hellman keys
- [`ring::aead`](https://briansmith.org/rustdoc/ring/aead/index.html) to encrypt and authenticate messages with AES-GCM