### PR TITLE
Fix condition for running functions examples

### DIFF
--- a/runner/src/examples.rs
+++ b/runner/src/examples.rs
@@ -380,7 +380,7 @@ pub fn run_functions_examples(opt: &RunFunctionsExamples) -> Step {
                 panic!("could not parse example manifest file {:?}: {}", path, err)
             })
         })
-        .filter(|example: &Example| !example.has_classic_app())
+        .filter(|example: &Example| example.has_functions_app() && !example.has_classic_app())
         .collect();
 
     Step::Multiple {


### PR DESCRIPTION
Currently `run-functions-examples` also runs `https_attestation` and `tls_attestation` which are not `Oak Functions` examples. 
