### PR TITLE
Fix curl command line in client script

### DIFF
--- a/oak_functions/examples/weather_lookup/client/client
+++ b/oak_functions/examples/weather_lookup/client/client
@@ -9,6 +9,6 @@ curl \
   --request POST \
   --data '{"lat":1,"lon":2}' \
   --silent \
-  --output \
-  --write-out \
+  --output /dev/null \
+  --write-out '%{http_code}\n%{content_type}\n' \
   localhost:8080/invoke


### PR DESCRIPTION
Currently it is generating a file named `--write-out` every time it
runs.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
