### PR TITLE
Add Java client for gRPC Attestation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         timeout-minutes: 30
         run: |
           docker pull gcr.io/oak-ci/oak-android:latest
-          docker build --pull --cache-from=gcr.io/oak-ci/oak-android:latest --tag=gcr.io/oak-ci/oak-android:latest --file=android.Dockerfile .
+          docker build --pull --cache-from=gcr.io/oak-ci/oak-android:latest --tag=gcr.io/oak-ci/oak-android:latest --file=android.Dockerfile --build-arg=USER_UID="$DOCKER_UID" --build-arg=USER_GID="$DOCKER_GID" .
 
       # Build Android Hello-World application.
       - name: Build Android Hello-World

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,6 +56,22 @@ http_archive(
     ],
 )
 
+# Tink crypto library for Java.
+http_archive(
+    name = "tink_java",
+    sha256 = "5856b0207ffb2cf28dd5c421789ffca3cfeea0680055f455e14bec2f335b1765",
+    strip_prefix = "tink-58be99b3c4d09154d12643327f293cc45b2a6a7b/java_src",
+    # Commit from 2021-05-19
+    urls = [
+        "https://github.com/google/tink/archive/58be99b3c4d09154d12643327f293cc45b2a6a7b.tar.gz",
+    ],
+    patches = [
+        # This patch removes Android dependencies from Tink Java libraries.
+        # https://github.com/google/tink/issues/507
+        "//third_party/google/tink:Remove-android-from-java.patch",
+    ],
+)
+
 # BoringSSL
 http_archive(
     name = "boringssl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,16 +59,16 @@ http_archive(
 # Tink crypto library for Java.
 http_archive(
     name = "tink_java",
+    patches = [
+        # This patch removes Android dependencies from Tink Java libraries.
+        # https://github.com/google/tink/issues/507
+        "//third_party/google/tink:Remove-android-from-java.patch",
+    ],
     sha256 = "5856b0207ffb2cf28dd5c421789ffca3cfeea0680055f455e14bec2f335b1765",
     strip_prefix = "tink-58be99b3c4d09154d12643327f293cc45b2a6a7b/java_src",
     # Commit from 2021-05-19
     urls = [
         "https://github.com/google/tink/archive/58be99b3c4d09154d12643327f293cc45b2a6a7b.tar.gz",
-    ],
-    patches = [
-        # This patch removes Android dependencies from Tink Java libraries.
-        # https://github.com/google/tink/issues/507
-        "//third_party/google/tink:Remove-android-from-java.patch",
     ],
 )
 

--- a/android.Dockerfile
+++ b/android.Dockerfile
@@ -90,3 +90,23 @@ RUN mkdir --parents ${ANDROID_NDK_HOME} \
 # Bazel requires HOME variable to be set.
 # https://github.com/bazelbuild/bazel/issues/471
 ENV HOME /workspaces/oak
+
+# We use the `docker` user in order to maintain library paths on different
+# machines and to make Wasm modules reproducible.
+ARG USERNAME=docker
+
+# Placeholder args that are expected to be passed in at image build time.
+# See https://code.visualstudio.com/docs/remote/containers-advanced#_creating-a-nonroot-user
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+# Create the specified user and group.
+#
+# Ignore errors if the user or group already exist (it should only happen if the image is being
+# built as root, which happens on GCB).
+RUN (groupadd --gid=${USER_GID} ${USERNAME} || true) \
+  && (useradd --shell=/bin/bash --uid=${USER_UID} --gid=${USER_GID} --create-home ${USERNAME} || true)
+
+# Set the default user as the newly created one, so that any operations performed from within the
+# Docker container will appear as if performed by the outside user, instead of root.
+USER ${USER_UID}

--- a/experimental/attestation_common/src/crypto.rs
+++ b/experimental/attestation_common/src/crypto.rs
@@ -65,7 +65,7 @@ impl AeadEncryptor {
     }
 
     /// Encrypts `data` using [`AeadEncryptor::key`].
-    /// The resulting encrypted data is prefixed with a [`NONCE`].
+    /// The resulting encrypted data is prefixed with a nonce.
     pub fn encrypt(&mut self, data: &[u8]) -> anyhow::Result<Vec<u8>> {
         // Bind `AeadEncryptor::key` to a `NONCE`.
         let unbound_sealing_key = aead::UnboundKey::new(AEAD_ALGORITHM, &self.key)

--- a/experimental/attestation_common/src/crypto.rs
+++ b/experimental/attestation_common/src/crypto.rs
@@ -37,8 +37,8 @@ static KEY_AGREEMENT_ALGORITHM: &agreement::Algorithm = &agreement::X25519;
 struct OneNonceSequence(Option<aead::Nonce>);
 
 impl OneNonceSequence {
-    fn new() -> Self {
-        let nonce = aead::Nonce::assume_unique_for_key(NONCE);
+    fn new(nonce: [u8; aead::NONCE_LEN]) -> Self {
+        let nonce = aead::Nonce::assume_unique_for_key(nonce);
         Self(Some(nonce))
     }
 }
@@ -52,58 +52,72 @@ impl aead::NonceSequence for OneNonceSequence {
 /// Implementation of Authenticated Encryption with Associated Data (AEAD).
 /// https://datatracker.ietf.org/doc/html/rfc5116
 pub struct AeadEncryptor {
-    // Key used for encrypting data.
-    sealing_key: aead::SealingKey<OneNonceSequence>,
-    // Key used for decrypting data.
-    opening_key: aead::OpeningKey<OneNonceSequence>,
+    /// Key used for encrypting and decrypting data.
+    ///
+    /// AES-GCM algorithm uses the same key for both encryption and decryption.
+    /// https://datatracker.ietf.org/doc/html/rfc5288
+    key: Vec<u8>,
 }
 
 impl AeadEncryptor {
-    pub fn new(key: &[u8]) -> Self {
-        // AES-GCM algorithm uses the same key for both encryption and decryption.
-        // https://datatracker.ietf.org/doc/html/rfc5288
-        let unbound_sealing_key = aead::UnboundKey::new(AEAD_ALGORITHM, &key).unwrap();
-        let sealing_key = ring::aead::SealingKey::new(unbound_sealing_key, OneNonceSequence::new());
-
-        let unbound_opening_key = aead::UnboundKey::new(AEAD_ALGORITHM, &key).unwrap();
-        let opening_key = ring::aead::OpeningKey::new(unbound_opening_key, OneNonceSequence::new());
-
-        Self {
-            sealing_key,
-            opening_key,
-        }
+    pub fn new(key: Vec<u8>) -> Self {
+        Self { key }
     }
 
-    /// Encrypts `data` using [`AeadEncryptor::sealing_key`].
+    /// Encrypts `data` using [`AeadEncryptor::key`].
+    /// The resulting encrypted data is prefixed with a [`NONCE`].
     pub fn encrypt(&mut self, data: &[u8]) -> anyhow::Result<Vec<u8>> {
+        // Bind `AeadEncryptor::key` to a `NONCE`.
+        let unbound_sealing_key = aead::UnboundKey::new(AEAD_ALGORITHM, &self.key)
+            .map_err(|error| anyhow!("Couldn't create sealing key: {:?}", error))?;
+        let mut sealing_key = ring::aead::SealingKey::new(unbound_sealing_key, OneNonceSequence::new(NONCE));
+
         let mut encrypted_data = data.to_vec();
-        self.sealing_key
+        sealing_key
             // Additional authenticated data is not required for the remotely attested channel,
             // since after session key is established client and server exchange messages with a
             // single encrypted field.
             // And the nonce is authenticated by the AEAD algorithm itself.
             // https://datatracker.ietf.org/doc/html/rfc5116#section-2.1
-            .seal_in_place_append_tag(aead::Aad::from(vec![]), &mut encrypted_data)
+            .seal_in_place_append_tag(aead::Aad::empty(), &mut encrypted_data)
             .map_err(|error| anyhow!("Couldn't encrypt data: {:?}", error))?;
-        Ok(encrypted_data)
+        
+        // Add `NONCE` as a prefix to the resulting data.
+        let mut result = NONCE.to_vec();
+        result.extend(encrypted_data.to_vec());
+        
+        Ok(result)
     }
 
-    /// Decrypts and authenticates `data` using [`AeadEncryptor::opening_key`].
+    /// Decrypts and authenticates `data` using [`AeadEncryptor::key`].
+    /// `data` must contain an encrypted message prefixed with a random nonce of [`aead::NONCE_LEN`]
+    /// length.
     pub fn decrypt(&mut self, data: &[u8]) -> anyhow::Result<Vec<u8>> {
-        let mut decrypted_data = data.to_vec();
-        let decrypted_data = self
-            .opening_key
+        // Extract nonce from `data`.
+        let mut nonce: [u8; aead::NONCE_LEN] = Default::default();
+        nonce.copy_from_slice(&data[0..NONCE.len()]);
+
+        // Prepare encrypted message.
+        let mut decrypted_data = data[NONCE.len()..].to_vec();
+
+        // Bind `AeadEncryptor::key` to the extracted `nonce`.
+        let unbound_opening_key = aead::UnboundKey::new(AEAD_ALGORITHM, &self.key).unwrap();
+        let mut opening_key = ring::aead::OpeningKey::new(unbound_opening_key, OneNonceSequence::new(nonce));
+        
+        let decrypted_data = opening_key
             // Additional authenticated data is not required for the remotely attested channel,
             // since after session key is established client and server exchange messages with a
             // single encrypted field.
             // And the nonce is authenticated by the AEAD algorithm itself.
             // https://datatracker.ietf.org/doc/html/rfc5116#section-2.1
-            .open_in_place(aead::Aad::from(vec![]), &mut decrypted_data)
+            .open_in_place(aead::Aad::empty(), &mut decrypted_data)
             .map_err(|error| anyhow!("Couldn't decrypt data: {:?}", error))?;
         Ok(decrypted_data.to_vec())
     }
 }
 
+/// Implementation of the X25519 Elliptic Curve Diffie-Hellman (ECDH) key negotiation.
+/// https://datatracker.ietf.org/doc/html/rfc7748#section-6.1
 pub struct KeyNegotiator {
     private_key: agreement::EphemeralPrivateKey,
 }

--- a/experimental/attestation_common/src/crypto.rs
+++ b/experimental/attestation_common/src/crypto.rs
@@ -70,7 +70,8 @@ impl AeadEncryptor {
         // Bind `AeadEncryptor::key` to a `NONCE`.
         let unbound_sealing_key = aead::UnboundKey::new(AEAD_ALGORITHM, &self.key)
             .map_err(|error| anyhow!("Couldn't create sealing key: {:?}", error))?;
-        let mut sealing_key = ring::aead::SealingKey::new(unbound_sealing_key, OneNonceSequence::new(NONCE));
+        let mut sealing_key =
+            ring::aead::SealingKey::new(unbound_sealing_key, OneNonceSequence::new(NONCE));
 
         let mut encrypted_data = data.to_vec();
         sealing_key
@@ -81,11 +82,11 @@ impl AeadEncryptor {
             // https://datatracker.ietf.org/doc/html/rfc5116#section-2.1
             .seal_in_place_append_tag(aead::Aad::empty(), &mut encrypted_data)
             .map_err(|error| anyhow!("Couldn't encrypt data: {:?}", error))?;
-        
+
         // Add `NONCE` as a prefix to the resulting data.
         let mut result = NONCE.to_vec();
         result.extend(encrypted_data.to_vec());
-        
+
         Ok(result)
     }
 
@@ -102,8 +103,9 @@ impl AeadEncryptor {
 
         // Bind `AeadEncryptor::key` to the extracted `nonce`.
         let unbound_opening_key = aead::UnboundKey::new(AEAD_ALGORITHM, &self.key).unwrap();
-        let mut opening_key = ring::aead::OpeningKey::new(unbound_opening_key, OneNonceSequence::new(nonce));
-        
+        let mut opening_key =
+            ring::aead::OpeningKey::new(unbound_opening_key, OneNonceSequence::new(nonce));
+
         let decrypted_data = opening_key
             // Additional authenticated data is not required for the remotely attested channel,
             // since after session key is established client and server exchange messages with a

--- a/experimental/grpc_attestation/proto/BUILD
+++ b/experimental/grpc_attestation/proto/BUILD
@@ -1,0 +1,41 @@
+#
+# Copyright 2021 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+proto_library(
+    name = "grpc_attestation_proto",
+    srcs = ["grpc_attestation.proto"],
+    deps = ["@com_google_protobuf//:empty_proto"],
+)
+
+java_proto_library(
+    name = "grpc_attestation_java_proto",
+    deps = [":grpc_attestation_proto"],
+)
+
+java_grpc_library(
+    name = "grpc_attestation_java_grpc",
+    srcs = [":grpc_attestation_proto"],
+    deps = [":grpc_attestation_java_proto"],
+)

--- a/experimental/grpc_attestation/proto/grpc_attestation.proto
+++ b/experimental/grpc_attestation/proto/grpc_attestation.proto
@@ -18,6 +18,9 @@ syntax = "proto3";
 
 package oak.examples.grpc_attestation;
 
+option java_multiple_files = true;
+option java_package = "oak.examples.grpc_attestation";
+
 message AttestedInvokeRequest {
   oneof request_type {
     // Client part of session key negotiation.

--- a/experimental/grpc_attestation/src/attestation.rs
+++ b/experimental/grpc_attestation/src/attestation.rs
@@ -148,7 +148,7 @@ impl AttestationServer {
             .derive_session_key(&request.public_key)
             .context("Couldn't derive session key")?;
 
-        let encryptor = AeadEncryptor::new(&session_key);
+        let encryptor = AeadEncryptor::new(session_key);
 
         // Generate attestation info with a TEE report.
         // TEE report contains a hash of the server's public key.
@@ -199,7 +199,7 @@ impl GrpcAttestation for AttestationServer {
 
             let mut handler = RequestHandler::new(encryptor, request_handler);
             while let Some(response) = handler.handle_request(&mut receiver).await.map_err(|error| {
-                let message = format!("Couldn't attest to the client: {:?}", error);
+                let message = format!("Couldn't handle request: {:?}", error);
                 warn!("{}", message);
                 Status::internal(message)
             })? {

--- a/experimental/grpc_attestation/src/main.rs
+++ b/experimental/grpc_attestation/src/main.rs
@@ -68,7 +68,7 @@ pub struct Opt {
     #[structopt(
         long,
         help = "Address to listen on for the gRPC server.",
-        default_value = "[::]:8888"
+        default_value = "[::]:8080"
     )]
     grpc_listen_address: String,
     #[structopt(

--- a/experimental/grpc_attestation_client/java/BUILD
+++ b/experimental/grpc_attestation_client/java/BUILD
@@ -1,0 +1,55 @@
+#
+# Copyright 2021 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_java//java:defs.bzl", "java_binary")
+
+package(
+    licenses = ["notice"],
+)
+
+java_binary(
+    name = "grpc_attestation_client",
+    srcs = [
+        "com/google/oak/grpc_attestation_client/Main.java",
+        "com/google/oak/grpc_attestation_client/AttestationClient.java",
+        "com/google/oak/grpc_attestation_client/KeyNegotiator.java",
+        "com/google/oak/grpc_attestation_client/AeadEncryptor.java",
+    ],
+    main_class = "com.google.oak.grpc_attestation_client.Main",
+    runtime_deps = [
+        "@io_grpc_grpc_java//netty",
+    ],
+    deps = [
+        "//experimental/grpc_attestation/proto:grpc_attestation_java_grpc",
+        "//experimental/grpc_attestation/proto:grpc_attestation_java_proto",
+        "//experimental/grpc_attestation/proto:grpc_attestation_proto",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@io_grpc_grpc_java//api",
+        "@io_grpc_grpc_java//protobuf",
+        "@io_grpc_grpc_java//stub",
+        # "@tink_java//src/main/java/com/google/crypto/tink/subtle:aes_gcm_hkdf_streaming",
+        # "@tink_java//src/main/java/com/google/crypto/tink:aead",
+        # "@tink_java//src/main/java/com/google/crypto/tink/aead:aead_config",
+        "@tink_java//src/main/java/com/google/crypto/tink/subtle:aes_gcm_jce",
+        "@tink_java//src/main/java/com/google/crypto/tink/subtle:x25519",
+    ],
+)
+
+# bazel build //experimental/grpc_attestation_client/java:grpc_attestation_client
+
+# option java_multiple_files = true;
+# option java_package = "oak.examples.grpc_attestation";

--- a/experimental/grpc_attestation_client/java/BUILD
+++ b/experimental/grpc_attestation_client/java/BUILD
@@ -23,10 +23,10 @@ package(
 java_binary(
     name = "grpc_attestation_client",
     srcs = [
-        "com/google/oak/grpc_attestation_client/Main.java",
+        "com/google/oak/grpc_attestation_client/AeadEncryptor.java",
         "com/google/oak/grpc_attestation_client/AttestationClient.java",
         "com/google/oak/grpc_attestation_client/KeyNegotiator.java",
-        "com/google/oak/grpc_attestation_client/AeadEncryptor.java",
+        "com/google/oak/grpc_attestation_client/Main.java",
     ],
     main_class = "com.google.oak.grpc_attestation_client.Main",
     runtime_deps = [

--- a/experimental/grpc_attestation_client/java/BUILD
+++ b/experimental/grpc_attestation_client/java/BUILD
@@ -41,15 +41,7 @@ java_binary(
         "@io_grpc_grpc_java//api",
         "@io_grpc_grpc_java//protobuf",
         "@io_grpc_grpc_java//stub",
-        # "@tink_java//src/main/java/com/google/crypto/tink/subtle:aes_gcm_hkdf_streaming",
-        # "@tink_java//src/main/java/com/google/crypto/tink:aead",
-        # "@tink_java//src/main/java/com/google/crypto/tink/aead:aead_config",
         "@tink_java//src/main/java/com/google/crypto/tink/subtle:aes_gcm_jce",
         "@tink_java//src/main/java/com/google/crypto/tink/subtle:x25519",
     ],
 )
-
-# bazel build //experimental/grpc_attestation_client/java:grpc_attestation_client
-
-# option java_multiple_files = true;
-# option java_package = "oak.examples.grpc_attestation";

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AeadEncryptor.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AeadEncryptor.java
@@ -3,6 +3,10 @@ package com.google.oak.grpc_attestation_client;
 import com.google.crypto.tink.subtle.AesGcmJce;
 import java.security.GeneralSecurityException;
 
+/**
+ * Implementation of Authenticated Encryption with Associated Data (AEAD).
+ * https://datatracker.ietf.org/doc/html/rfc5116
+ */
 public class AeadEncryptor {
     private AesGcmJce encryptor;
 
@@ -10,13 +14,25 @@ public class AeadEncryptor {
         this.encryptor = new AesGcmJce(key);
     }
 
+    /**
+     * Encrypts `data` using `AeadEncryptor::encryptor`.
+     * The resulting encrypted data is prefixed with a random 12 bit nonce.
+     */
     public byte[] encrypt(byte[] data) throws GeneralSecurityException {
-        return this.encryptor.encrypt(data, new byte[0]);
+        // Additional authenticated data is not required for the remotely attested channel,
+        // since after session key is established client and server exchange messages with a
+        // single encrypted field.
+        return this.encryptor.encrypt(data, null);
     }
 
+    /**
+     * Decrypts and authenticates `data` using `AeadEncryptor::encryptor`.
+     * `data` must contain an encrypted message prefixed with a 12 bit nonce.
+     */
     public byte[] decrypt(byte[] data) throws GeneralSecurityException {
-        return this.encryptor.decrypt(data, new byte[0]);
+        // Additional authenticated data is not required for the remotely attested channel,
+        // since after session key is established client and server exchange messages with a
+        // single encrypted field.
+        return this.encryptor.decrypt(data, null);
     }
 }
-
-

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AeadEncryptor.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AeadEncryptor.java
@@ -1,0 +1,22 @@
+package com.google.oak.grpc_attestation_client;
+
+import com.google.crypto.tink.subtle.AesGcmJce;
+import java.security.GeneralSecurityException;
+
+public class AeadEncryptor {
+    private AesGcmJce encryptor;
+
+    public AeadEncryptor(byte[] key) throws GeneralSecurityException {
+        this.encryptor = new AesGcmJce(key);
+    }
+
+    public byte[] encrypt(byte[] data) throws GeneralSecurityException {
+        return this.encryptor.encrypt(data, new byte[0]);
+    }
+
+    public byte[] decrypt(byte[] data) throws GeneralSecurityException {
+        return this.encryptor.decrypt(data, new byte[0]);
+    }
+}
+
+

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AeadEncryptor.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AeadEncryptor.java
@@ -11,6 +11,7 @@ public class AeadEncryptor {
     private AesGcmJce encryptor;
 
     public AeadEncryptor(byte[] key) throws GeneralSecurityException {
+        // TODO(#2120): Use a wrapper AEAD interface and don't use `tink.subtle`.
         this.encryptor = new AesGcmJce(key);
     }
 

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AttestationClient.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AttestationClient.java
@@ -42,8 +42,7 @@ public class AttestationClient {
                 try {
                     messageQueue.put(response);
                 } catch (Exception e) {
-                    logger.log(Level.WARNING, "Couldn't send server response to the message queue");
-                    e.printStackTrace();
+                    logger.log(Level.WARNING, "Couldn't send server response to the message queue: {0}", e);
                 }
             }
 

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AttestationClient.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AttestationClient.java
@@ -6,12 +6,10 @@ import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import java.lang.RuntimeException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import oak.examples.grpc_attestation.AttestedInvokeResponse;
@@ -23,47 +21,28 @@ import oak.examples.grpc_attestation.GrpcAttestationGrpc.GrpcAttestationStub;
 
 public class AttestationClient {
     private static final Logger logger = Logger.getLogger(AttestationClient.class.getName());
-    // String uri;
-    // Bytes expected_tee_measurement;
+    private ManagedChannel channel;
+    private StreamObserver<AttestedInvokeRequest> requestObserver;
+    private BlockingQueue messageQueue;
+    private AeadEncryptor encryptor;
 
-    public AttestationClient(String uri) throws InterruptedException {
-        KeyNegotiator keyNegotiator = null;
-        try {
-            keyNegotiator = new KeyNegotiator();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        // String target = "localhost:8080";
-        ManagedChannel channel = ManagedChannelBuilder
+    public AttestationClient(String uri) throws Exception {
+        // Create gRPC channel.
+        this.channel = ManagedChannelBuilder
             .forTarget(uri)
-            // .forTarget(target)
             .usePlaintext()
             .build();
-
         GrpcAttestationStub stub = GrpcAttestationGrpc.newStub(channel);
-        
-        // String publicKey = "";
-        // ByteString publicKeyBytes = ByteString.copyFromUtf8(publicKey);
-        byte[] publicKey = null;
-        try {
-            publicKey = keyNegotiator.getPublicKey();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        ByteString publicKeyBytes = ByteString.copyFrom(publicKey);
 
-        final CountDownLatch finishLatch = new CountDownLatch(1);
-        BlockingQueue queue = new ArrayBlockingQueue(1000);
-
+        // Create server response handler.
+        this.messageQueue = new ArrayBlockingQueue(1);
         StreamObserver<AttestedInvokeResponse> responseObserver = new StreamObserver<AttestedInvokeResponse>() {
             @Override
             public void onNext(AttestedInvokeResponse response) {
-                // logger.log(Level.INFO, "Client received response: {0}", response);
-                // logger.log(Level.INFO, "Public key: {0}", response.getClientIdentity().getPublicKey());
                 try {
-                    queue.put(response);
+                    messageQueue.put(response);
                 } catch (Exception e) {
+                    logger.log(Level.WARNING, "Couldn't send server response to the message queue");
                     e.printStackTrace();
                 }
             }
@@ -72,68 +51,68 @@ public class AttestationClient {
             public void onError(Throwable t) {
                 Status status = Status.fromThrowable(t);
                 logger.log(Level.WARNING, "Couldn't receive response: {0}", status);
-                finishLatch.countDown();
             }
 
             @Override
-            public void onCompleted() {
-                logger.log(Level.INFO, "Server has finished the stream");
-                finishLatch.countDown();
-            }
+            public void onCompleted() {}
         };
+        this.requestObserver = stub.attestedInvoke(responseObserver);
 
-        StreamObserver<AttestedInvokeRequest> requestObserver = stub.attestedInvoke(responseObserver);
-        try {
-            AttestedInvokeRequest request = AttestedInvokeRequest
-                .newBuilder()
-                .setClientIdentity(
-                    ClientIdentity.newBuilder()
-                        .setPublicKey(publicKeyBytes)
-                        .build()
-                )
-                .build();
+        // Generate client private/public key pair.
+        KeyNegotiator keyNegotiator = new KeyNegotiator();
+        byte[] publicKey = keyNegotiator.getPublicKey();
+        ByteString publicKeyBytes = ByteString.copyFrom(publicKey);
 
-            logger.log(Level.INFO, "Client sends request: {0}", request);
-            requestObserver.onNext(request);
-            AttestedInvokeResponse response = (AttestedInvokeResponse) queue.take();
-            logger.log(Level.INFO, "Client received response: {0}", response);
+        // Send client public key to the server.
+        AttestedInvokeRequest request = AttestedInvokeRequest
+            .newBuilder()
+            .setClientIdentity(
+                ClientIdentity.newBuilder()
+                    .setPublicKey(publicKeyBytes)
+                    .build()
+            )
+            .build();
+        requestObserver.onNext(request);
+        AttestedInvokeResponse response = (AttestedInvokeResponse) this.messageQueue.take();
 
-            byte[] peerPublicKey = response.getServerIdentity().getPublicKey().toByteArray();
-            byte[] sessionKey = keyNegotiator.deriveSessionKey(peerPublicKey);
-            logger.log(Level.INFO, "Session key: {0}", sessionKey);
+        // Generate session key.
+        byte[] peerPublicKey = response.getServerIdentity().getPublicKey().toByteArray();
+        byte[] sessionKey = keyNegotiator.deriveSessionKey(peerPublicKey);
 
-            AeadEncryptor encryptor = new AeadEncryptor(sessionKey);
-            byte[] encrypted_payload = encryptor.encrypt("Example message".getBytes());
-
-            AttestedInvokeRequest data_request = AttestedInvokeRequest
-                .newBuilder()
-                .setEncryptedPayload(ByteString.copyFrom(encrypted_payload))
-                .build();
-
-            logger.log(Level.INFO, "Client sends data request: {0}", request);
-            requestObserver.onNext(data_request);
-            AttestedInvokeResponse data_response = (AttestedInvokeResponse) queue.take();
-            logger.log(Level.INFO, "Client received data response: {0}", response);
-
-
-        // } catch (RuntimeException e) {
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Couldn't send request");
-            requestObserver.onError(e);
-            // throw e;
-            e.printStackTrace();
+        // Verify remote attestation.
+        byte[] attestationInfo = response.getServerIdentity().getAttestationInfo().toByteArray();
+        if (!verifyAttestation(attestationInfo)) {
+            throw new RuntimeException("Couldn't verify attestation info");
         }
-        logger.log(Level.INFO, "Client has finished the stream");
-        requestObserver.onCompleted();
 
-        // AttestedInvokeResponse response = stub.getAttestedData(request);
-
-        finishLatch.await(1, TimeUnit.MINUTES);
-
-        channel.shutdown();
+        // Initialize AEAD encryptor based on the session key.
+        this.encryptor = new AeadEncryptor(sessionKey);
     }
 
-    // public String Send(String message) {
+    private Boolean verifyAttestation(byte[] attestationInfo) {
+        // TODO(#1867): Add remote attestation support.
+        return true;
+    }
 
-    // }
+    protected void finalize() throws Throwable {
+        this.requestObserver.onCompleted();
+        this.channel.shutdown();
+    }
+
+    /**
+     * Encrypts and sends `message` via an attested gRPC channel to the server.
+     */
+    public byte[] Send(byte[] message) throws Exception {
+        byte[] encryptedMessage = encryptor.encrypt(message);
+        AttestedInvokeRequest request = AttestedInvokeRequest
+            .newBuilder()
+            .setEncryptedPayload(ByteString.copyFrom(encryptedMessage))
+            .build();
+
+        this.requestObserver.onNext(request);
+        AttestedInvokeResponse response = (AttestedInvokeResponse) this.messageQueue.take();
+
+        byte[] responsePayload = response.getEncryptedPayload().toByteArray();
+        return encryptor.decrypt(responsePayload);
+    }
 }

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AttestationClient.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/AttestationClient.java
@@ -1,0 +1,139 @@
+package com.google.oak.grpc_attestation_client;
+
+import com.google.oak.grpc_attestation_client.AeadEncryptor;
+import com.google.oak.grpc_attestation_client.KeyNegotiator;
+import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import oak.examples.grpc_attestation.AttestedInvokeResponse;
+import oak.examples.grpc_attestation.AttestedInvokeRequest;
+import oak.examples.grpc_attestation.ClientIdentity;
+import oak.examples.grpc_attestation.ServerIdentity;
+import oak.examples.grpc_attestation.GrpcAttestationGrpc;
+import oak.examples.grpc_attestation.GrpcAttestationGrpc.GrpcAttestationStub;
+
+public class AttestationClient {
+    private static final Logger logger = Logger.getLogger(AttestationClient.class.getName());
+    // String uri;
+    // Bytes expected_tee_measurement;
+
+    public AttestationClient(String uri) throws InterruptedException {
+        KeyNegotiator keyNegotiator = null;
+        try {
+            keyNegotiator = new KeyNegotiator();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // String target = "localhost:8080";
+        ManagedChannel channel = ManagedChannelBuilder
+            .forTarget(uri)
+            // .forTarget(target)
+            .usePlaintext()
+            .build();
+
+        GrpcAttestationStub stub = GrpcAttestationGrpc.newStub(channel);
+        
+        // String publicKey = "";
+        // ByteString publicKeyBytes = ByteString.copyFromUtf8(publicKey);
+        byte[] publicKey = null;
+        try {
+            publicKey = keyNegotiator.getPublicKey();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        ByteString publicKeyBytes = ByteString.copyFrom(publicKey);
+
+        final CountDownLatch finishLatch = new CountDownLatch(1);
+        BlockingQueue queue = new ArrayBlockingQueue(1000);
+
+        StreamObserver<AttestedInvokeResponse> responseObserver = new StreamObserver<AttestedInvokeResponse>() {
+            @Override
+            public void onNext(AttestedInvokeResponse response) {
+                // logger.log(Level.INFO, "Client received response: {0}", response);
+                // logger.log(Level.INFO, "Public key: {0}", response.getClientIdentity().getPublicKey());
+                try {
+                    queue.put(response);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                Status status = Status.fromThrowable(t);
+                logger.log(Level.WARNING, "Couldn't receive response: {0}", status);
+                finishLatch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                logger.log(Level.INFO, "Server has finished the stream");
+                finishLatch.countDown();
+            }
+        };
+
+        StreamObserver<AttestedInvokeRequest> requestObserver = stub.attestedInvoke(responseObserver);
+        try {
+            AttestedInvokeRequest request = AttestedInvokeRequest
+                .newBuilder()
+                .setClientIdentity(
+                    ClientIdentity.newBuilder()
+                        .setPublicKey(publicKeyBytes)
+                        .build()
+                )
+                .build();
+
+            logger.log(Level.INFO, "Client sends request: {0}", request);
+            requestObserver.onNext(request);
+            AttestedInvokeResponse response = (AttestedInvokeResponse) queue.take();
+            logger.log(Level.INFO, "Client received response: {0}", response);
+
+            byte[] peerPublicKey = response.getServerIdentity().getPublicKey().toByteArray();
+            byte[] sessionKey = keyNegotiator.deriveSessionKey(peerPublicKey);
+            logger.log(Level.INFO, "Session key: {0}", sessionKey);
+
+            AeadEncryptor encryptor = new AeadEncryptor(sessionKey);
+            byte[] encrypted_payload = encryptor.encrypt("Example message".getBytes());
+
+            AttestedInvokeRequest data_request = AttestedInvokeRequest
+                .newBuilder()
+                .setEncryptedPayload(ByteString.copyFrom(encrypted_payload))
+                .build();
+
+            logger.log(Level.INFO, "Client sends data request: {0}", request);
+            requestObserver.onNext(data_request);
+            AttestedInvokeResponse data_response = (AttestedInvokeResponse) queue.take();
+            logger.log(Level.INFO, "Client received data response: {0}", response);
+
+
+        // } catch (RuntimeException e) {
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Couldn't send request");
+            requestObserver.onError(e);
+            // throw e;
+            e.printStackTrace();
+        }
+        logger.log(Level.INFO, "Client has finished the stream");
+        requestObserver.onCompleted();
+
+        // AttestedInvokeResponse response = stub.getAttestedData(request);
+
+        finishLatch.await(1, TimeUnit.MINUTES);
+
+        channel.shutdown();
+    }
+
+    // public String Send(String message) {
+
+    // }
+}

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/KeyNegotiator.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/KeyNegotiator.java
@@ -2,40 +2,11 @@ package com.google.oak.grpc_attestation_client;
 
 import com.google.crypto.tink.subtle.X25519;
 import java.security.InvalidKeyException;
-// import java.security.KeyFactory;
-// import java.security.KeyPair;
-// import java.security.KeyPairGenerator;
-// import java.security.NoSuchAlgorithmException;
-// import java.security.PublicKey;
-// import javax.crypto.KeyAgreement;
 
-// public class KeyNegotiator {
-//     private KeyPair keyPair;
-
-//     private static String keyPairGenerationAlgorithm = "X25519"; // "EC";
-//     private static int keySize = 128;
-//     private static String keyAgreementAlgorithm = "X25519"; // "ECDH";
-
-//     public KeyNegotiator() throws NoSuchAlgorithmException, InvalidKeyException {
-//         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(keyPairGenerationAlgorithm);
-//         keyPairGenerator.initialize(keySize);
-//         this.keyPair = keyPairGenerator.generateKeyPair();
-//     }
-
-//     public byte[] getPublicKey() {
-//         return this.keyPair.getPublic().getEncoded();
-//     }
-
-//     public byte[] deriveSessionKey(byte[] peerPublicKeyBytes) throws NoSuchAlgorithmException, InvalidKeyException {
-//         PublicKey peerPublicKey = KeyPairGenerator.getInstance(keyPairGenerationAlgorithm).generatePublic(peerPublicKeyBytes);
-//         KeyAgreement keyAgreement = KeyAgreement.getInstance(keyAgreementAlgorithm);
-//         keyAgreement.init(this.keyPair.getPrivate());
-//         keyAgreement.doPhase(publicKey, true);
-//         byte[] sessionKey = keyAgreement.generateSecret();
-//         return sessionKey;
-//     }
-// }
-
+/**
+ * Implementation of the X25519 Elliptic Curve Diffie-Hellman (ECDH) key negotiation.
+ * https://datatracker.ietf.org/doc/html/rfc7748#section-6.1
+ */
 public class KeyNegotiator {
     private byte[] privateKey;
 
@@ -47,7 +18,10 @@ public class KeyNegotiator {
         return X25519.publicFromPrivate(this.privateKey);
     }
 
+    /** Derives a session key from `peerPublicKey` and `KeyNegotiator::privateKey`. */
     public byte[] deriveSessionKey(byte[] peerPublicKey) throws InvalidKeyException {
+        // TODO(#2100): Derive session key using a KDF.
+        // https://datatracker.ietf.org/doc/html/rfc7748#section-6.1
         return X25519.computeSharedSecret(this.privateKey, peerPublicKey);
     }
 }

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/KeyNegotiator.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/KeyNegotiator.java
@@ -1,0 +1,53 @@
+package com.google.oak.grpc_attestation_client;
+
+import com.google.crypto.tink.subtle.X25519;
+import java.security.InvalidKeyException;
+// import java.security.KeyFactory;
+// import java.security.KeyPair;
+// import java.security.KeyPairGenerator;
+// import java.security.NoSuchAlgorithmException;
+// import java.security.PublicKey;
+// import javax.crypto.KeyAgreement;
+
+// public class KeyNegotiator {
+//     private KeyPair keyPair;
+
+//     private static String keyPairGenerationAlgorithm = "X25519"; // "EC";
+//     private static int keySize = 128;
+//     private static String keyAgreementAlgorithm = "X25519"; // "ECDH";
+
+//     public KeyNegotiator() throws NoSuchAlgorithmException, InvalidKeyException {
+//         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(keyPairGenerationAlgorithm);
+//         keyPairGenerator.initialize(keySize);
+//         this.keyPair = keyPairGenerator.generateKeyPair();
+//     }
+
+//     public byte[] getPublicKey() {
+//         return this.keyPair.getPublic().getEncoded();
+//     }
+
+//     public byte[] deriveSessionKey(byte[] peerPublicKeyBytes) throws NoSuchAlgorithmException, InvalidKeyException {
+//         PublicKey peerPublicKey = KeyPairGenerator.getInstance(keyPairGenerationAlgorithm).generatePublic(peerPublicKeyBytes);
+//         KeyAgreement keyAgreement = KeyAgreement.getInstance(keyAgreementAlgorithm);
+//         keyAgreement.init(this.keyPair.getPrivate());
+//         keyAgreement.doPhase(publicKey, true);
+//         byte[] sessionKey = keyAgreement.generateSecret();
+//         return sessionKey;
+//     }
+// }
+
+public class KeyNegotiator {
+    private byte[] privateKey;
+
+    public KeyNegotiator() {
+        this.privateKey = X25519.generatePrivateKey();
+    }
+
+    public byte[] getPublicKey() throws InvalidKeyException {
+        return X25519.publicFromPrivate(this.privateKey);
+    }
+
+    public byte[] deriveSessionKey(byte[] peerPublicKey) throws InvalidKeyException {
+        return X25519.computeSharedSecret(this.privateKey, peerPublicKey);
+    }
+}

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/KeyNegotiator.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/KeyNegotiator.java
@@ -1,6 +1,8 @@
 package com.google.oak.grpc_attestation_client;
 
+import com.google.oak.grpc_attestation_client.AeadEncryptor;
 import com.google.crypto.tink.subtle.X25519;
+import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 
 /**
@@ -23,5 +25,11 @@ public class KeyNegotiator {
         // TODO(#2100): Derive session key using a KDF.
         // https://datatracker.ietf.org/doc/html/rfc7748#section-6.1
         return X25519.computeSharedSecret(this.privateKey, peerPublicKey);
+    }
+
+    /** Derives a session key and creates an `AeadEncryptor::encryptor` from it */
+    public AeadEncryptor createAeadEncryptor(byte[] peerPublicKey) throws InvalidKeyException, GeneralSecurityException {
+        byte[] sessionKey = this.deriveSessionKey(peerPublicKey);
+        return new AeadEncryptor(sessionKey);
     }
 }

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/Main.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/Main.java
@@ -1,97 +1,20 @@
 package com.google.oak.grpc_attestation_client;
 
 import com.google.oak.grpc_attestation_client.AttestationClient;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class Main {
-// public class GrpcAttestationClient {
     private static final Logger logger = Logger.getLogger(Main.class.getName());
-    // private static final Logger logger = Logger.getLogger(GrpcAttestationClient.class.getName());
 
-    public static void main(String[] args) throws InterruptedException {
+    public static void main(String[] args) throws Exception {
         AttestationClient client = new AttestationClient("localhost:8080");
-        // String target = "localhost:8080";
-        // ManagedChannel channel = ManagedChannelBuilder
-        //     // .forAddress("localhost", 8080)
-        //     .forTarget(target)
-        //     .usePlaintext()
-        //     .build();
 
-        // // GrpcAttestationGrpc.GrpcAttestationBlockingStub stub =
-        // //     GrpcAttestationGrpc.newBlockingStub(channel);
-        // GrpcAttestationStub stub = GrpcAttestationGrpc.newStub(channel);
-        // // GrpcAttestationGrpc.GrpcAttestationStub stub = GrpcAttestationGrpc.newStub(channel);
-        
-        // String publicKey = "";
-        // ByteString publicKeyBytes = ByteString.copyFromUtf8(publicKey);
+        byte[] request = "Example message".getBytes();
+        byte[] response = client.Send(request);
 
-        // // GetAttestedDataRequest request = GetAttestedDataRequest.newBuilder()
-        // //     .setRequestType(
-        // //         AttestationRequest.newBuilder()
-        // //             .setPublicKey(publicKeyBytes)
-        // //             .build()
-        // //     )
-        // //     .build();
-
-        // // StreamObserver<RouteSummary> responseObserver = new StreamObserver<RouteSummary>() {
-        // // StreamObserver<RouteNote> requestObserver = asyncStub.routeChat(new StreamObserver<RouteNote>() {
-
-        // final CountDownLatch finishLatch = new CountDownLatch(1);
-
-        // StreamObserver<GetAttestedDataResponse> responseObserver = new StreamObserver<GetAttestedDataResponse>() {
-        //     @Override
-        //     public void onNext(GetAttestedDataResponse response) {
-        //         logger.log(Level.INFO, "Client received response: {0}", response);
-        //     }
-
-        //     @Override
-        //     public void onError(Throwable t) {
-        //         Status status = Status.fromThrowable(t);
-        //         logger.log(Level.WARNING, "Couldn't receive response: {0}", status);
-        //     }
-
-        //     @Override
-        //     public void onCompleted() {
-        //         logger.log(Level.INFO, "Server has finished the stream");
-        //     }
-        // };
-
-        // StreamObserver<GetAttestedDataRequest> requestObserver = stub.getAttestedData(responseObserver);
-        // try {
-        //     GetAttestedDataRequest[] requests = {
-        //         GetAttestedDataRequest.newBuilder()
-        //             .setAttestationRequest(
-        //                 AttestationRequest.newBuilder()
-        //                     .setPublicKey(publicKeyBytes)
-        //                     .build()
-        //             )
-        //             .build()
-        //     };
-
-        //     for (GetAttestedDataRequest request : requests) {
-        //         logger.log(Level.INFO, "Client sends request: {0}", request);
-        //         requestObserver.onNext(request);
-        //     }
-        // } catch (RuntimeException e) {
-        //     // Cancel RPC
-        //     logger.log(Level.WARNING, "Couldn't send request");
-        //     // logger.log(Level.WARNING, "Couldn't send request: {0}", status);
-        //     requestObserver.onError(e);
-        //     throw e;
-        // }
-        // // Mark the end of requests
-        // logger.log(Level.INFO, "Client has finished the stream");
-        // requestObserver.onCompleted();
-
-        // // GetAttestedDataResponse response = stub.getAttestedData(request);
-
-        // // System.out.println(response);
-
-        // // Receiving happens asynchronously
-        // finishLatch.await(1, TimeUnit.MINUTES);
-
-        // channel.shutdown();
+        String decodedResponse = new String(response, StandardCharsets.UTF_8);
+        System.out.printf("Client received response: %s\n", decodedResponse);
     }
 }
-    

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/Main.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/Main.java
@@ -6,8 +6,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class Main {
-    private static final Logger logger = Logger.getLogger(Main.class.getName());
-
     public static void main(String[] args) throws Exception {
         AttestationClient client = new AttestationClient("localhost:8080");
 

--- a/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/Main.java
+++ b/experimental/grpc_attestation_client/java/com/google/oak/grpc_attestation_client/Main.java
@@ -1,0 +1,97 @@
+package com.google.oak.grpc_attestation_client;
+
+import com.google.oak.grpc_attestation_client.AttestationClient;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Main {
+// public class GrpcAttestationClient {
+    private static final Logger logger = Logger.getLogger(Main.class.getName());
+    // private static final Logger logger = Logger.getLogger(GrpcAttestationClient.class.getName());
+
+    public static void main(String[] args) throws InterruptedException {
+        AttestationClient client = new AttestationClient("localhost:8080");
+        // String target = "localhost:8080";
+        // ManagedChannel channel = ManagedChannelBuilder
+        //     // .forAddress("localhost", 8080)
+        //     .forTarget(target)
+        //     .usePlaintext()
+        //     .build();
+
+        // // GrpcAttestationGrpc.GrpcAttestationBlockingStub stub =
+        // //     GrpcAttestationGrpc.newBlockingStub(channel);
+        // GrpcAttestationStub stub = GrpcAttestationGrpc.newStub(channel);
+        // // GrpcAttestationGrpc.GrpcAttestationStub stub = GrpcAttestationGrpc.newStub(channel);
+        
+        // String publicKey = "";
+        // ByteString publicKeyBytes = ByteString.copyFromUtf8(publicKey);
+
+        // // GetAttestedDataRequest request = GetAttestedDataRequest.newBuilder()
+        // //     .setRequestType(
+        // //         AttestationRequest.newBuilder()
+        // //             .setPublicKey(publicKeyBytes)
+        // //             .build()
+        // //     )
+        // //     .build();
+
+        // // StreamObserver<RouteSummary> responseObserver = new StreamObserver<RouteSummary>() {
+        // // StreamObserver<RouteNote> requestObserver = asyncStub.routeChat(new StreamObserver<RouteNote>() {
+
+        // final CountDownLatch finishLatch = new CountDownLatch(1);
+
+        // StreamObserver<GetAttestedDataResponse> responseObserver = new StreamObserver<GetAttestedDataResponse>() {
+        //     @Override
+        //     public void onNext(GetAttestedDataResponse response) {
+        //         logger.log(Level.INFO, "Client received response: {0}", response);
+        //     }
+
+        //     @Override
+        //     public void onError(Throwable t) {
+        //         Status status = Status.fromThrowable(t);
+        //         logger.log(Level.WARNING, "Couldn't receive response: {0}", status);
+        //     }
+
+        //     @Override
+        //     public void onCompleted() {
+        //         logger.log(Level.INFO, "Server has finished the stream");
+        //     }
+        // };
+
+        // StreamObserver<GetAttestedDataRequest> requestObserver = stub.getAttestedData(responseObserver);
+        // try {
+        //     GetAttestedDataRequest[] requests = {
+        //         GetAttestedDataRequest.newBuilder()
+        //             .setAttestationRequest(
+        //                 AttestationRequest.newBuilder()
+        //                     .setPublicKey(publicKeyBytes)
+        //                     .build()
+        //             )
+        //             .build()
+        //     };
+
+        //     for (GetAttestedDataRequest request : requests) {
+        //         logger.log(Level.INFO, "Client sends request: {0}", request);
+        //         requestObserver.onNext(request);
+        //     }
+        // } catch (RuntimeException e) {
+        //     // Cancel RPC
+        //     logger.log(Level.WARNING, "Couldn't send request");
+        //     // logger.log(Level.WARNING, "Couldn't send request: {0}", status);
+        //     requestObserver.onError(e);
+        //     throw e;
+        // }
+        // // Mark the end of requests
+        // logger.log(Level.INFO, "Client has finished the stream");
+        // requestObserver.onCompleted();
+
+        // // GetAttestedDataResponse response = stub.getAttestedData(request);
+
+        // // System.out.println(response);
+
+        // // Receiving happens asynchronously
+        // finishLatch.await(1, TimeUnit.MINUTES);
+
+        // channel.shutdown();
+    }
+}
+    

--- a/experimental/grpc_attestation_client/rust/src/lib.rs
+++ b/experimental/grpc_attestation_client/rust/src/lib.rs
@@ -140,7 +140,7 @@ impl AttestationClient {
             .derive_session_key(&attestation_response.public_key)
             .context("Couldn't derive session key")?;
 
-        Ok(AeadEncryptor::new(&session_key))
+        Ok(AeadEncryptor::new(session_key))
     }
 
     /// Verifies the validity of the attestation info:

--- a/third_party/google/tink/Remove-android-from-java.patch
+++ b/third_party/google/tink/Remove-android-from-java.patch
@@ -1,0 +1,13 @@
+diff --git src/main/java/com/google/crypto/tink/subtle/BUILD.bazel src/main/java/com/google/crypto/tink/subtle/BUILD.bazel
+index a9fde1379..59d97ef12 100644
+--- src/main/java/com/google/crypto/tink/subtle/BUILD.bazel
++++ src/main/java/com/google/crypto/tink/subtle/BUILD.bazel
+@@ -193,7 +193,7 @@ java_library(
+     srcs = ["Validators.java"],
+     deps = [
+         ":enums",
+-        "//src/main/java/com/google/crypto/tink/config:tink_fips-android",
++        "//src/main/java/com/google/crypto/tink/config:tink_fips",
+     ],
+ )
+


### PR DESCRIPTION
This commit:
- Adds a Java client for gRPC Attestation
- Updates Bazel `WORKSPACE`
- Adds a patch that fixes Tink Java library compilation

Fixes #2113