### PR TITLE
Move gRPC Attestation proto to remote_attestation

### DIFF
--- a/experimental/grpc_attestation/build.rs
+++ b/experimental/grpc_attestation/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "proto",
-        &["grpc_attestation.proto"],
+        "../../remote_attestation/proto",
+        &["remote_attestation.proto"],
         CodegenOptions {
             build_client: true,
             build_server: true,

--- a/experimental/grpc_attestation/src/attestation.rs
+++ b/experimental/grpc_attestation/src/attestation.rs
@@ -24,7 +24,7 @@ use oak_attestation_common::{
 };
 use oak_grpc_attestation::proto::{
     attested_invoke_request::RequestType, attested_invoke_response::ResponseType,
-    grpc_attestation_server::GrpcAttestation, AttestedInvokeRequest, AttestedInvokeResponse,
+    remote_attestation_server::RemoteAttestation, AttestedInvokeRequest, AttestedInvokeResponse,
     ServerIdentity,
 };
 use std::pin::Pin;
@@ -174,7 +174,7 @@ impl AttestationServer {
 }
 
 #[tonic::async_trait]
-impl GrpcAttestation for AttestationServer {
+impl RemoteAttestation for AttestationServer {
     type AttestedInvokeStream =
         Pin<Box<dyn Stream<Item = Result<AttestedInvokeResponse, Status>> + Send + Sync + 'static>>;
 

--- a/experimental/grpc_attestation/src/lib.rs
+++ b/experimental/grpc_attestation/src/lib.rs
@@ -15,5 +15,5 @@
 //
 
 pub mod proto {
-    tonic::include_proto!("oak.examples.grpc_attestation");
+    tonic::include_proto!("oak.remote_attestation");
 }

--- a/experimental/grpc_attestation/src/main.rs
+++ b/experimental/grpc_attestation/src/main.rs
@@ -58,7 +58,7 @@ use crate::attestation::AttestationServer;
 use anyhow::Context;
 use futures::FutureExt;
 use log::info;
-use oak_grpc_attestation::proto::grpc_attestation_server::GrpcAttestationServer;
+use oak_grpc_attestation::proto::remote_attestation_server::RemoteAttestationServer;
 use structopt::StructOpt;
 use tonic::transport::Server;
 
@@ -105,7 +105,7 @@ async fn main() -> anyhow::Result<()> {
         grpc_listen_address
     );
     Server::builder()
-        .add_service(GrpcAttestationServer::new(
+        .add_service(RemoteAttestationServer::new(
             AttestationServer::create(tee_certificate, request_handler)
                 .context("Couldn't create proxy")?,
         ))

--- a/experimental/grpc_attestation_client/rust/src/lib.rs
+++ b/experimental/grpc_attestation_client/rust/src/lib.rs
@@ -21,8 +21,8 @@ use oak_attestation_common::{
 };
 use oak_grpc_attestation::proto::{
     attested_invoke_request::RequestType, attested_invoke_response::ResponseType,
-    remote_attestation_client::RemoteAttestationClient, AttestedInvokeRequest, AttestedInvokeResponse,
-    ClientIdentity,
+    remote_attestation_client::RemoteAttestationClient, AttestedInvokeRequest,
+    AttestedInvokeResponse, ClientIdentity,
 };
 use tokio::sync::mpsc::Sender;
 use tonic::{transport::Channel, Request, Streaming};

--- a/experimental/grpc_attestation_client/rust/src/lib.rs
+++ b/experimental/grpc_attestation_client/rust/src/lib.rs
@@ -21,7 +21,7 @@ use oak_attestation_common::{
 };
 use oak_grpc_attestation::proto::{
     attested_invoke_request::RequestType, attested_invoke_response::ResponseType,
-    grpc_attestation_client::GrpcAttestationClient, AttestedInvokeRequest, AttestedInvokeResponse,
+    remote_attestation_client::RemoteAttestationClient, AttestedInvokeRequest, AttestedInvokeResponse,
     ClientIdentity,
 };
 use tokio::sync::mpsc::Sender;
@@ -42,7 +42,7 @@ impl Client {
             .connect()
             .await
             .context("Couldn't connect via gRPC channel")?;
-        let mut client = GrpcAttestationClient::new(channel);
+        let mut client = RemoteAttestationClient::new(channel);
 
         let (sender, mut receiver) = tokio::sync::mpsc::channel(MESSAGE_BUFFER_SIZE);
 

--- a/oak_functions/client/java/BUILD
+++ b/oak_functions/client/java/BUILD
@@ -32,9 +32,9 @@ java_library(
         "@io_grpc_grpc_java//netty",
     ],
     deps = [
-        "//experimental/grpc_attestation/proto:grpc_attestation_java_grpc",
-        "//experimental/grpc_attestation/proto:grpc_attestation_java_proto",
-        "//experimental/grpc_attestation/proto:grpc_attestation_proto",
+        "//remote_attestation/proto:remote_attestation_java_grpc",
+        "//remote_attestation/proto:remote_attestation_java_proto",
+        "//remote_attestation/proto:remote_attestation_proto",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@io_grpc_grpc_java//api",

--- a/oak_functions/client/java/src/AttestationClient.java
+++ b/oak_functions/client/java/src/AttestationClient.java
@@ -12,12 +12,12 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import oak.examples.grpc_attestation.AttestedInvokeResponse;
-import oak.examples.grpc_attestation.AttestedInvokeRequest;
-import oak.examples.grpc_attestation.ClientIdentity;
-import oak.examples.grpc_attestation.ServerIdentity;
-import oak.examples.grpc_attestation.GrpcAttestationGrpc;
-import oak.examples.grpc_attestation.GrpcAttestationGrpc.GrpcAttestationStub;
+import oak.remote_attestation.AttestedInvokeResponse;
+import oak.remote_attestation.AttestedInvokeRequest;
+import oak.remote_attestation.ClientIdentity;
+import oak.remote_attestation.ServerIdentity;
+import oak.remote_attestation.RemoteAttestationGrpc;
+import oak.remote_attestation.RemoteAttestationGrpc.RemoteAttestationStub;
 
 // TODO(#2121): Implement a protocol independent state machine.
 public class AttestationClient {
@@ -33,7 +33,7 @@ public class AttestationClient {
             .forTarget(uri)
             .usePlaintext()
             .build();
-        GrpcAttestationStub stub = GrpcAttestationGrpc.newStub(channel);
+        RemoteAttestationStub stub = RemoteAttestationGrpc.newStub(channel);
 
         // Create server response handler.
         this.messageQueue = new ArrayBlockingQueue(1);

--- a/remote_attestation/proto/BUILD
+++ b/remote_attestation/proto/BUILD
@@ -24,18 +24,18 @@ package(
 )
 
 proto_library(
-    name = "grpc_attestation_proto",
-    srcs = ["grpc_attestation.proto"],
+    name = "remote_attestation_proto",
+    srcs = ["remote_attestation.proto"],
     deps = ["@com_google_protobuf//:empty_proto"],
 )
 
 java_proto_library(
-    name = "grpc_attestation_java_proto",
-    deps = [":grpc_attestation_proto"],
+    name = "remote_attestation_java_proto",
+    deps = [":remote_attestation_proto"],
 )
 
 java_grpc_library(
-    name = "grpc_attestation_java_grpc",
-    srcs = [":grpc_attestation_proto"],
-    deps = [":grpc_attestation_java_proto"],
+    name = "remote_attestation_java_grpc",
+    srcs = [":remote_attestation_proto"],
+    deps = [":remote_attestation_java_proto"],
 )

--- a/remote_attestation/proto/remote_attestation.proto
+++ b/remote_attestation/proto/remote_attestation.proto
@@ -16,10 +16,10 @@
 
 syntax = "proto3";
 
-package oak.examples.grpc_attestation;
+package oak.remote_attestation;
 
 option java_multiple_files = true;
-option java_package = "oak.examples.grpc_attestation";
+option java_package = "oak.remote_attestation";
 
 message AttestedInvokeRequest {
   oneof request_type {
@@ -30,7 +30,7 @@ message AttestedInvokeRequest {
   }
 }
 
-// TODO(#2105): Implement challenge-response in gRPC Attestation.
+// TODO(#2105): Implement challenge-response in remote attestation.
 message ClientIdentity {
   // Client public key needed to establish a session key between client and server.
   bytes public_key = 1;
@@ -45,7 +45,7 @@ message AttestedInvokeResponse {
   }
 }
 
-// TODO(#2106): Support various claims in gRPC Attestation.
+// TODO(#2106): Support various claims in remote attestation.
 message ServerIdentity {
   // Server public key needed to establish a session key between client and server.
   bytes public_key = 1;
@@ -54,7 +54,7 @@ message ServerIdentity {
   bytes attestation_info = 2;
 }
 
-service GrpcAttestation {
+service RemoteAttestation {
   // Creates a message stream for session key negotiation and encrypted payload exchange.
   //
   // The created message stream looks as follows:


### PR DESCRIPTION
This change moves gRPC Attestation proto from `experimental/grpc_attestation/proto` to `remote_attestation`.