### PR TITLE
Change deploy script for Oak Functions to run outside docker

### DIFF
--- a/experimental/oak_functions_with_envoy/scripts/build.sh
+++ b/experimental/oak_functions_with_envoy/scripts/build.sh
@@ -4,14 +4,11 @@ readonly EXPERIMENTAL_SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=experimental/oak_functions_with_envoy/scripts/common.sh
 source "$EXPERIMENTAL_SCRIPTS_DIR/common.sh"
 
-# Build Oak Functions server binary
-./scripts/docker_run ./scripts/runner build-functions-server --server-variant=base
-
-# Build the `weather_lookup` example application built on Oak Functions.
-cargo -Zunstable-options build --release \
-  --target=wasm32-unknown-unknown \
-  --manifest-path=./oak_functions/examples/weather_lookup/module/Cargo.toml \
-  --out-dir=./oak_functions/examples/weather_lookup/bin
+# Build Oak Functions server binary, and the `weather_lookup` example application built on Oak Functions.
+./scripts/docker_run ./scripts/runner run-functions-examples \
+  --example-name=weather_lookup \
+  --run-server=false \
+  --client-variant=none
 
 # Copy binaries to `experimental` directory, because global `.dockerignore` ignores all the files.
 readonly EXPERIMENTAL_BIN=./experimental/oak_functions_with_envoy/bin

--- a/experimental/oak_functions_with_envoy/scripts/build.sh
+++ b/experimental/oak_functions_with_envoy/scripts/build.sh
@@ -4,7 +4,6 @@ readonly EXPERIMENTAL_SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=experimental/oak_functions_with_envoy/scripts/common.sh
 source "$EXPERIMENTAL_SCRIPTS_DIR/common.sh"
 
-# TODO(#1943): Remove when #1943 is submitted.
 cargo build --target=x86_64-unknown-linux-musl \
   --manifest-path=./oak_functions/loader/Cargo.toml \
   --release

--- a/experimental/oak_functions_with_envoy/scripts/build.sh
+++ b/experimental/oak_functions_with_envoy/scripts/build.sh
@@ -4,9 +4,8 @@ readonly EXPERIMENTAL_SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=experimental/oak_functions_with_envoy/scripts/common.sh
 source "$EXPERIMENTAL_SCRIPTS_DIR/common.sh"
 
-cargo build --target=x86_64-unknown-linux-musl \
-  --manifest-path=./oak_functions/loader/Cargo.toml \
-  --release
+# Build Oak Functions server binary
+./scripts/docker_run ./scripts/runner build-functions-server --server-variant=base
 
 # Build the `weather_lookup` example application built on Oak Functions.
 cargo -Zunstable-options build --release \

--- a/oak_functions/examples/weather_lookup/README.md
+++ b/oak_functions/examples/weather_lookup/README.md
@@ -37,12 +37,13 @@ To build and run this example manually follow these steps:
 1. Invoke with:
 
    ```shell
-   curl \
-     --include \
-     --fail-early \
-     --http2 \
-     --http2-prior-knowledge \
-     --request POST \
-     --data '{"lat":51,"lon":0}' \
-     http://localhost:8080/invoke
+   cargo run --manifest-path=./oak_functions/client/Cargo.toml \
+       --uri=http://localhost:8080,
+       --request={\"lat\":52,\"lon\":0}
    ```
+
+Alternatively, the `runner` could be used to run this example:
+
+```shell
+./scripts/runner run-functions-examples --example-name=weather_lookup
+```

--- a/scripts/deploy_oak_functions_loader
+++ b/scripts/deploy_oak_functions_loader
@@ -7,8 +7,7 @@ source "$SCRIPTS_DIR/common"
 # shellcheck source=scripts/gcp_common
 source "$SCRIPTS_DIR/gcp_common"
 
-# TODO(#1943): Remove when #1943 is submitted.
-cargo build --target=x86_64-unknown-linux-musl --manifest-path=./oak_functions/loader/Cargo.toml --release
+./scripts/docker_run cargo build --target=x86_64-unknown-linux-musl --manifest-path=./oak_functions/loader/Cargo.toml --release
 
 # Build and push base Oak Functions Loader image.
 
@@ -22,7 +21,7 @@ docker push "${FUNCTIONS_DOCKER_IMAGE_NAME}:latest"
 
 # Build and push the `weather_lookup` example application built on Oak Functions.
 
-cargo -Zunstable-options build --release \
+./scripts/docker_run cargo -Zunstable-options build --release \
   --target=wasm32-unknown-unknown \
   --manifest-path=./oak_functions/examples/weather_lookup/module/Cargo.toml \
   --out-dir=./oak_functions/examples/weather_lookup/bin
@@ -62,7 +61,7 @@ gcloud beta run deploy "${FUNCTIONS_INSTANCE_NAME}" \
 readonly HOST_NAME="$(gcloud api-gateway gateways describe "${GATEWAY_ID}" --location="${GCP_REGION}" --format='value(defaultHostname)')"
 
 #Build the client to test the connection.
-cargo build --manifest-path=./oak_functions/client/Cargo.toml
+./scripts/docker_run cargo build --manifest-path=./oak_functions/client/Cargo.toml
 
 # Attempt to communicate with the newly deployed application.
 ./oak_functions/client/target/debug/oak_functions_client \

--- a/scripts/deploy_oak_functions_loader
+++ b/scripts/deploy_oak_functions_loader
@@ -7,8 +7,11 @@ source "$SCRIPTS_DIR/common"
 # shellcheck source=scripts/gcp_common
 source "$SCRIPTS_DIR/gcp_common"
 
-# Build Oak Functions server binary
-./scripts/docker_run ./scripts/runner build-functions-server --server-variant=base
+# Build Oak Functions server binary and the `weather_lookup` example application, and the client to test the connection.
+./scripts/docker_run ./scripts/runner run-functions-examples \
+  --example-name=weather_lookup \
+  --run-server=false \
+  --client-variant=none
 
 # Build and push base Oak Functions Loader image.
 
@@ -21,11 +24,6 @@ docker build \
 docker push "${FUNCTIONS_DOCKER_IMAGE_NAME}:latest"
 
 # Build and push the `weather_lookup` example application built on Oak Functions.
-
-./scripts/docker_run cargo -Zunstable-options build --release \
-  --target=wasm32-unknown-unknown \
-  --manifest-path=./oak_functions/examples/weather_lookup/module/Cargo.toml \
-  --out-dir=./oak_functions/examples/weather_lookup/bin
 
 readonly FUNCTIONS_EXAMPLE_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-functions-weather-lookup'
 
@@ -60,9 +58,6 @@ gcloud beta run deploy "${FUNCTIONS_INSTANCE_NAME}" \
 
 # Find the gateway URL.
 readonly HOST_NAME="$(gcloud api-gateway gateways describe "${GATEWAY_ID}" --location="${GCP_REGION}" --format='value(defaultHostname)')"
-
-#Build the client to test the connection.
-./scripts/docker_run cargo build --manifest-path=./oak_functions/client/Cargo.toml
 
 # Attempt to communicate with the newly deployed application.
 ./oak_functions/client/target/debug/oak_functions_client \

--- a/scripts/deploy_oak_functions_loader
+++ b/scripts/deploy_oak_functions_loader
@@ -7,7 +7,8 @@ source "$SCRIPTS_DIR/common"
 # shellcheck source=scripts/gcp_common
 source "$SCRIPTS_DIR/gcp_common"
 
-./scripts/docker_run cargo build --target=x86_64-unknown-linux-musl --manifest-path=./oak_functions/loader/Cargo.toml --release
+# Build Oak Functions server binary
+./scripts/docker_run ./scripts/runner build-functions-server --server-variant=base
 
 # Build and push base Oak Functions Loader image.
 


### PR DESCRIPTION
I could not run this script without docker, because of missing Rust crates, and GCP commands don't work when running inside docker.

This change list also removes (no longer applicable) mentions of #1943, which was merged a long time ago. But we still need to build the loader binary in the script.
