### PR TITLE
Use repo's root as the `proto_path` in calls to `compile_proto` 

### DIFF
--- a/docs/programming-oak.md
+++ b/docs/programming-oak.md
@@ -245,10 +245,7 @@ to autogenerate Rust code from a
 fn main() {
     // Generate the Oak-specific server and client code for the gRPC service,
     // along with the Rust types corresponding to the message definitions.
-    oak_utils::compile_protos(
-        &["../proto/translator.proto"],
-        &["../proto", "../third_party"],
-    );
+    oak_utils::compile_protos(&["examples/translator/proto/translator.proto"], "../../..");
 }
 ```
 <!-- prettier-ignore-end -->

--- a/examples/abitest/grpc/build.rs
+++ b/examples/abitest/grpc/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../proto",
-        &["abitest.proto"],
+        "../../../",
+        &["examples/abitest/proto/abitest.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/abitest/module_0/rust/build.rs
+++ b/examples/abitest/module_0/rust/build.rs
@@ -15,8 +15,5 @@
 //
 
 fn main() {
-    oak_utils::compile_protos(
-        &["../../proto/abitest.proto"],
-        &["../../proto", "../../../../third_party"],
-    );
+    oak_utils::compile_protos(&["../../proto/abitest.proto"], &["../../"]);
 }

--- a/examples/abitest/module_0/rust/build.rs
+++ b/examples/abitest/module_0/rust/build.rs
@@ -15,5 +15,5 @@
 //
 
 fn main() {
-    oak_utils::compile_protos(&["../../proto/abitest.proto"], &["../../"]);
+    oak_utils::compile_protos(&["../../proto/abitest.proto"], "../../");
 }

--- a/examples/aggregator/backend/build.rs
+++ b/examples/aggregator/backend/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../proto",
-        &["aggregator.proto"],
+        "../../../",
+        &["examples/aggregator/proto/aggregator.proto"],
         CodegenOptions {
             build_server: true,
             ..Default::default()

--- a/examples/aggregator/grpc/build.rs
+++ b/examples/aggregator/grpc/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../proto",
-        &["aggregator.proto"],
+        "../../../",
+        &["examples/aggregator/proto/aggregator.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/aggregator/module/rust/build.rs
+++ b/examples/aggregator/module/rust/build.rs
@@ -17,9 +17,9 @@
 fn main() {
     oak_utils::compile_protos(
         &[
-            "../../proto/aggregator.proto",
-            "../../proto/aggregator_init.proto",
+            "examples/aggregator/proto/aggregator.proto",
+            "examples/aggregator/proto/aggregator_init.proto",
         ],
-        &["../../proto", "../../../../"],
+        &["../../../../"],
     );
 }

--- a/examples/aggregator/module/rust/build.rs
+++ b/examples/aggregator/module/rust/build.rs
@@ -20,6 +20,6 @@ fn main() {
             "examples/aggregator/proto/aggregator.proto",
             "examples/aggregator/proto/aggregator_init.proto",
         ],
-        &["../../../../"],
+        "../../../../",
     );
 }

--- a/examples/aggregator/proto/aggregator_init.proto
+++ b/examples/aggregator/proto/aggregator_init.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package oak.examples.aggregator_init;
 
-import "aggregator.proto";
+import "examples/aggregator/proto/aggregator.proto";
 import "oak_services/proto/grpc_invocation.proto";
 import "oak_services/proto/log.proto";
 import "proto/handle.proto";

--- a/examples/authentication/client/build.rs
+++ b/examples/authentication/client/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../../../proto",
-        &["authentication.proto"],
+        "../../../",
+        &["proto/authentication.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/chat/grpc/build.rs
+++ b/examples/chat/grpc/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../proto",
-        &["chat.proto"],
+        "../../../",
+        &["examples/chat/proto/chat.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/chat/module/rust/build.rs
+++ b/examples/chat/module/rust/build.rs
@@ -15,8 +15,5 @@
 //
 
 fn main() {
-    oak_utils::compile_protos(
-        &["../../proto/chat.proto"],
-        &["../../proto", "../../../../"],
-    );
+    oak_utils::compile_protos(&["examples/chat/proto/chat.proto"], &["../../../../"]);
 }

--- a/examples/chat/module/rust/build.rs
+++ b/examples/chat/module/rust/build.rs
@@ -15,5 +15,5 @@
 //
 
 fn main() {
-    oak_utils::compile_protos(&["examples/chat/proto/chat.proto"], &["../../../../"]);
+    oak_utils::compile_protos(&["examples/chat/proto/chat.proto"], "../../../../");
 }

--- a/examples/hello_world/grpc/build.rs
+++ b/examples/hello_world/grpc/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../proto",
-        &["hello_world.proto"],
+        "../../../",
+        &["examples/hello_world/proto/hello_world.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/hello_world/module/rust/build.rs
+++ b/examples/hello_world/module/rust/build.rs
@@ -17,9 +17,9 @@
 fn main() {
     oak_utils::compile_protos(
         &[
-            "../../proto/hello_world.proto",
-            "../../proto/hello_world_internal.proto",
+            "examples/hello_world/proto/hello_world.proto",
+            "examples/hello_world/proto/hello_world_internal.proto",
         ],
-        &["../../proto", "../../../../"],
+        &["../../../../"],
     );
 }

--- a/examples/hello_world/module/rust/build.rs
+++ b/examples/hello_world/module/rust/build.rs
@@ -20,6 +20,6 @@ fn main() {
             "examples/hello_world/proto/hello_world.proto",
             "examples/hello_world/proto/hello_world_internal.proto",
         ],
-        &["../../../../"],
+        "../../../../",
     );
 }

--- a/examples/http_server/module/build.rs
+++ b/examples/http_server/module/build.rs
@@ -16,7 +16,7 @@
 
 fn main() {
     oak_utils::compile_protos(
-        &["../proto/http_server_init.proto"],
-        &["../proto", "../../../"],
+        &["examples/http_server/proto/http_server_init.proto"],
+        &["../../../"],
     );
 }

--- a/examples/http_server/module/build.rs
+++ b/examples/http_server/module/build.rs
@@ -17,6 +17,6 @@
 fn main() {
     oak_utils::compile_protos(
         &["examples/http_server/proto/http_server_init.proto"],
-        &["../../../"],
+        "../../../",
     );
 }

--- a/examples/injection/module/rust/build.rs
+++ b/examples/injection/module/rust/build.rs
@@ -16,7 +16,7 @@
 
 fn main() {
     oak_utils::compile_protos(
-        &["../../proto/injection.proto"],
-        &["../../proto", "../../../.."],
+        &["examples/injection/proto/injection.proto"],
+        &["../../../.."],
     );
 }

--- a/examples/injection/module/rust/build.rs
+++ b/examples/injection/module/rust/build.rs
@@ -15,8 +15,5 @@
 //
 
 fn main() {
-    oak_utils::compile_protos(
-        &["examples/injection/proto/injection.proto"],
-        &["../../../.."],
-    );
+    oak_utils::compile_protos(&["examples/injection/proto/injection.proto"], "../../../..");
 }

--- a/examples/private_set_intersection/client/rust/build.rs
+++ b/examples/private_set_intersection/client/rust/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../../proto",
-        &["private_set_intersection.proto"],
+        "../../../../",
+        &["examples/private_set_intersection/proto/private_set_intersection.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/private_set_intersection/grpc/build.rs
+++ b/examples/private_set_intersection/grpc/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../proto",
-        &["private_set_intersection.proto"],
+        "../../../",
+        &["examples/private_set_intersection/proto/private_set_intersection.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/private_set_intersection/handler_module/rust/build.rs
+++ b/examples/private_set_intersection/handler_module/rust/build.rs
@@ -17,6 +17,6 @@
 fn main() {
     oak_utils::compile_protos(
         &["examples/private_set_intersection/proto/private_set_intersection.proto"],
-        &["../../../.."],
+        "../../../..",
     );
 }

--- a/examples/private_set_intersection/handler_module/rust/build.rs
+++ b/examples/private_set_intersection/handler_module/rust/build.rs
@@ -16,7 +16,7 @@
 
 fn main() {
     oak_utils::compile_protos(
-        &["../../proto/private_set_intersection.proto"],
-        &["../../proto"],
+        &["examples/private_set_intersection/proto/private_set_intersection.proto"],
+        &["../../../.."],
     );
 }

--- a/examples/proxy_attestation/client/rust/build.rs
+++ b/examples/proxy_attestation/client/rust/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../../proto",
-        &["proxy_attestation_example.proto"],
+        "../../../../",
+        &["examples/proxy_attestation/proto/proxy_attestation_example.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/proxy_attestation/module/rust/build.rs
+++ b/examples/proxy_attestation/module/rust/build.rs
@@ -16,7 +16,7 @@
 
 fn main() {
     oak_utils::compile_protos(
-        &["../../proto/proxy_attestation_example.proto"],
-        &["../../proto", "../../../../"],
+        &["examples/proxy_attestation/proto/proxy_attestation_example.proto"],
+        &["../../../../"],
     );
 }

--- a/examples/proxy_attestation/module/rust/build.rs
+++ b/examples/proxy_attestation/module/rust/build.rs
@@ -17,6 +17,6 @@
 fn main() {
     oak_utils::compile_protos(
         &["examples/proxy_attestation/proto/proxy_attestation_example.proto"],
-        &["../../../../"],
+        "../../../../",
     );
 }

--- a/examples/translator/common/build.rs
+++ b/examples/translator/common/build.rs
@@ -18,7 +18,7 @@ fn main() {
     // Generate the Oak-specific server and client code for the gRPC service,
     // along with the Rust types corresponding to the message definitions.
     oak_utils::compile_protos(
-        &["../proto/translator.proto"],
-        &["../proto", "../third_party"],
+        &["examples/translator/proto/translator.proto"],
+        &["../../.."],
     );
 }

--- a/examples/translator/common/build.rs
+++ b/examples/translator/common/build.rs
@@ -17,8 +17,5 @@
 fn main() {
     // Generate the Oak-specific server and client code for the gRPC service,
     // along with the Rust types corresponding to the message definitions.
-    oak_utils::compile_protos(
-        &["examples/translator/proto/translator.proto"],
-        &["../../.."],
-    );
+    oak_utils::compile_protos(&["examples/translator/proto/translator.proto"], "../../..");
 }

--- a/examples/translator/grpc/build.rs
+++ b/examples/translator/grpc/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../proto",
-        &["translator.proto"],
+        "../../../",
+        &["examples/translator/proto/translator.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/trusted_database/client/rust/build.rs
+++ b/examples/trusted_database/client/rust/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../../proto",
-        &["trusted_database.proto"],
+        "../../../..",
+        &["examples/trusted_database/proto/trusted_database.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/examples/trusted_database/module/rust/build.rs
+++ b/examples/trusted_database/module/rust/build.rs
@@ -17,9 +17,9 @@
 fn main() {
     oak_utils::compile_protos(
         &[
-            "../../proto/trusted_database.proto",
-            "../../proto/trusted_database_init.proto",
+            "examples/trusted_database/proto/trusted_database.proto",
+            "examples/trusted_database/proto/trusted_database_init.proto",
         ],
-        &["../../proto", "../../../../"],
+        &["../../../../"],
     );
 }

--- a/examples/trusted_database/module/rust/build.rs
+++ b/examples/trusted_database/module/rust/build.rs
@@ -20,6 +20,6 @@ fn main() {
             "examples/trusted_database/proto/trusted_database.proto",
             "examples/trusted_database/proto/trusted_database_init.proto",
         ],
-        &["../../../../"],
+        "../../../../",
     );
 }

--- a/examples/trusted_database/proto/trusted_database_init.proto
+++ b/examples/trusted_database/proto/trusted_database_init.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package oak.examples.trusted_database_init;
 
-import "trusted_database.proto";
+import "examples/trusted_database/proto/trusted_database.proto";
 import "oak_services/proto/grpc_invocation.proto";
 import "oak_services/proto/log.proto";
 import "proto/handle.proto";

--- a/experimental/benchmark/build.rs
+++ b/experimental/benchmark/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../../examples/trusted_database/proto",
-        &["trusted_database.proto"],
+        "../../",
+        &["examples/trusted_database/proto/trusted_database.proto"],
         CodegenOptions {
             build_client: true,
             build_server: true,

--- a/experimental/gcp_api_gateway/client/build.rs
+++ b/experimental/gcp_api_gateway/client/build.rs
@@ -17,8 +17,8 @@
 use oak_utils::CodegenOptions;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_path = "../../../examples/hello_world/proto";
-    let file_path = "hello_world.proto";
+    let proto_path = "../../../";
+    let file_path = "examples/hello_world/proto/hello_world.proto";
 
     oak_utils::generate_grpc_code(
         proto_path,

--- a/experimental/gcp_api_gateway/server/build.rs
+++ b/experimental/gcp_api_gateway/server/build.rs
@@ -17,8 +17,8 @@
 use oak_utils::CodegenOptions;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_path = "../../../examples/hello_world/proto";
-    let file_path = "hello_world.proto";
+    let proto_path = "../../../";
+    let file_path = "examples/hello_world/proto/hello_world.proto";
 
     oak_utils::generate_grpc_code(
         proto_path,

--- a/experimental/proxy_attestation/build.rs
+++ b/experimental/proxy_attestation/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "proto",
-        &["proxy_attestation.proto"],
+        "../..",
+        &["experimental/proxy_attestation/proto/proxy_attestation.proto"],
         CodegenOptions {
             build_client: true,
             build_server: true,

--- a/experimental/split_grpc/client/build.rs
+++ b/experimental/split_grpc/client/build.rs
@@ -17,8 +17,8 @@
 use oak_utils::CodegenOptions;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_path = "../../../examples/hello_world/proto";
-    let file_path = "hello_world.proto";
+    let proto_path = "../../../";
+    let file_path = "examples/hello_world/proto/hello_world.proto";
 
     oak_utils::generate_grpc_code(
         proto_path,

--- a/experimental/split_grpc/server/build.rs
+++ b/experimental/split_grpc/server/build.rs
@@ -17,8 +17,8 @@
 use oak_utils::CodegenOptions;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_path = "../../../examples/hello_world/proto";
-    let file_path = "hello_world.proto";
+    let proto_path = "../../../";
+    let file_path = "examples/hello_world/proto/hello_world.proto";
 
     oak_utils::generate_grpc_code(
         proto_path,

--- a/oak_abi/build.rs
+++ b/oak_abi/build.rs
@@ -19,10 +19,10 @@
 fn main() {
     oak_utils::compile_protos_with_options(
         &[
-            "../oak_abi/proto/application.proto",
-            "../oak_abi/proto/label.proto",
-            "../oak_abi/proto/identity.proto",
-            "../oak_abi/proto/oak_abi.proto",
+            "oak_abi/proto/application.proto",
+            "oak_abi/proto/label.proto",
+            "oak_abi/proto/identity.proto",
+            "oak_abi/proto/oak_abi.proto",
         ],
         &[".."],
         oak_utils::ProtoOptions {

--- a/oak_abi/build.rs
+++ b/oak_abi/build.rs
@@ -24,7 +24,7 @@ fn main() {
             "oak_abi/proto/identity.proto",
             "oak_abi/proto/oak_abi.proto",
         ],
-        &[".."],
+        "..",
         oak_utils::ProtoOptions {
             // Exclude generation of service code and HandleVisit auto-derive, as it would require a
             // reference to the Oak SDK to compile.

--- a/oak_functions/abi/build.rs
+++ b/oak_functions/abi/build.rs
@@ -18,11 +18,11 @@ extern crate prost_build;
 
 fn main() {
     let file_paths = [
-        "../proto/abi.proto",
-        "../proto/lookup_data.proto",
-        "../proto/invocation.proto",
+        "oak_functions/proto/abi.proto",
+        "oak_functions/proto/lookup_data.proto",
+        "oak_functions/proto/invocation.proto",
     ];
-    prost_build::compile_protos(&file_paths, &["../proto"]).expect("Proto compilation failed");
+    prost_build::compile_protos(&file_paths, &["../.."]).expect("Proto compilation failed");
 
     // Tell cargo to rerun this build script if the proto file has changed.
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath

--- a/oak_functions/examples/fuzzable/module/build.rs
+++ b/oak_functions/examples/fuzzable/module/build.rs
@@ -17,9 +17,8 @@
 extern crate prost_build;
 
 fn main() {
-    let file_paths = ["../../../loader/fuzz/proto/instructions.proto"];
-    prost_build::compile_protos(&file_paths, &["../../../loader/fuzz/proto"])
-        .expect("Proto compilation failed");
+    let file_paths = ["oak_functions/loader/fuzz/proto/instructions.proto"];
+    prost_build::compile_protos(&file_paths, &["../../../.."]).expect("Proto compilation failed");
 
     // Tell cargo to rerun this build script if the proto file has changed.
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath

--- a/oak_functions/loader/fuzz/build.rs
+++ b/oak_functions/loader/fuzz/build.rs
@@ -17,8 +17,8 @@
 extern crate prost_build;
 
 fn main() {
-    let file_paths = ["./proto/instructions.proto"];
-    prost_build::compile_protos(&file_paths, &["./proto"]).expect("Proto compilation failed");
+    let file_paths = ["oak_functions/loader/fuzz/proto/instructions.proto"];
+    prost_build::compile_protos(&file_paths, &["../../../"]).expect("Proto compilation failed");
 
     // Tell cargo to rerun this build script if the proto file has changed.
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath

--- a/oak_io/build.rs
+++ b/oak_io/build.rs
@@ -19,7 +19,7 @@
 fn main() {
     oak_utils::compile_protos_with_options(
         &["proto/handle.proto"],
-        &[".."],
+        "..",
         oak_utils::ProtoOptions {
             // Exclude generation of service code and HandleVisit auto-derive, as it would require a
             // reference to the Oak SDK to compile.

--- a/oak_io/build.rs
+++ b/oak_io/build.rs
@@ -18,7 +18,7 @@
 #[allow(clippy::needless_update)]
 fn main() {
     oak_utils::compile_protos_with_options(
-        &["../proto/handle.proto"],
+        &["proto/handle.proto"],
         &[".."],
         oak_utils::ProtoOptions {
             // Exclude generation of service code and HandleVisit auto-derive, as it would require a

--- a/oak_runtime/build.rs
+++ b/oak_runtime/build.rs
@@ -33,7 +33,7 @@ fn main() {
             "oak_services/proto/http_invocation.proto",
             "proto/introspection_events.proto",
         ],
-        &[".."],
+        "..",
         ProtoOptions {
             ..Default::default()
         },

--- a/oak_runtime/build.rs
+++ b/oak_runtime/build.rs
@@ -29,9 +29,9 @@ fn main() {
 
     compile_protos_with_options(
         &[
-            "../oak_services/proto/grpc_invocation.proto",
-            "../oak_services/proto/http_invocation.proto",
-            "../proto/introspection_events.proto",
+            "oak_services/proto/grpc_invocation.proto",
+            "oak_services/proto/http_invocation.proto",
+            "proto/introspection_events.proto",
         ],
         &[".."],
         ProtoOptions {

--- a/oak_runtime/build.rs
+++ b/oak_runtime/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{compile_protos_with_options, generate_grpc_code, CodegenOptions,
 
 fn main() {
     generate_grpc_code(
-        "../proto",
-        &["authentication.proto"],
+        "../",
+        &["proto/authentication.proto"],
         CodegenOptions {
             build_server: true,
             ..Default::default()

--- a/oak_services/build.rs
+++ b/oak_services/build.rs
@@ -24,7 +24,7 @@ fn main() {
             "third_party/google/rpc/code.proto",
             "third_party/google/rpc/status.proto",
         ],
-        &[".."],
+        "..",
         oak_utils::ProtoOptions {
             // Exclude generation of service code as it would require a reference to the Oak SDK to
             // compile.
@@ -42,7 +42,7 @@ fn main() {
             "oak_services/proto/log.proto",
             "oak_services/proto/roughtime_service.proto",
         ],
-        &[".."],
+        "..",
         oak_utils::ProtoOptions {
             // Exclude generation of service code as it would require a reference to the Oak SDK to
             // compile.

--- a/oak_services/build.rs
+++ b/oak_services/build.rs
@@ -19,10 +19,10 @@
 fn main() {
     oak_utils::compile_protos_with_options(
         &[
-            "../oak_services/proto/grpc_encap.proto",
-            "../oak_services/proto/http_encap.proto",
-            "../third_party/google/rpc/code.proto",
-            "../third_party/google/rpc/status.proto",
+            "oak_services/proto/grpc_encap.proto",
+            "oak_services/proto/http_encap.proto",
+            "third_party/google/rpc/code.proto",
+            "third_party/google/rpc/status.proto",
         ],
         &[".."],
         oak_utils::ProtoOptions {
@@ -38,9 +38,9 @@ fn main() {
     );
     oak_utils::compile_protos_with_options(
         &[
-            "../oak_services/proto/crypto.proto",
-            "../oak_services/proto/log.proto",
-            "../oak_services/proto/roughtime_service.proto",
+            "oak_services/proto/crypto.proto",
+            "oak_services/proto/log.proto",
+            "oak_services/proto/roughtime_service.proto",
         ],
         &[".."],
         oak_utils::ProtoOptions {

--- a/remote_attestation/rust/build.rs
+++ b/remote_attestation/rust/build.rs
@@ -15,7 +15,10 @@
 //
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    prost_build::compile_protos(&["../proto/remote_attestation.proto"], &["../proto"])
-        .expect("Proto compilation failed");
+    prost_build::compile_protos(
+        &["remote_attestation/proto/remote_attestation.proto"],
+        &["../.."],
+    )
+    .expect("Proto compilation failed");
     Ok(())
 }

--- a/sdk/rust/oak/build.rs
+++ b/sdk/rust/oak/build.rs
@@ -23,7 +23,7 @@ fn main() {
             "oak_services/proto/storage_service.proto",
             "oak_services/proto/roughtime_service.proto",
         ],
-        &["../../.."],
+        "../../..",
         oak_utils::ProtoOptions {
             ..Default::default()
         },
@@ -34,7 +34,7 @@ fn main() {
     std::fs::create_dir_all(&handle_tests_out).unwrap();
     oak_utils::compile_protos_with_options(
         &["sdk/rust/oak/tests/handle_extract_inject.proto"],
-        &["../../.."],
+        "../../..",
         oak_utils::ProtoOptions {
             out_dir_override: Some(handle_tests_out),
             ..Default::default()

--- a/sdk/rust/oak/build.rs
+++ b/sdk/rust/oak/build.rs
@@ -17,11 +17,11 @@
 fn main() {
     oak_utils::compile_protos_with_options(
         &[
-            "../../../oak_services/proto/grpc_invocation.proto",
-            "../../../oak_services/proto/http_invocation.proto",
-            "../../../oak_services/proto/crypto.proto",
-            "../../../oak_services/proto/storage_service.proto",
-            "../../../oak_services/proto/roughtime_service.proto",
+            "oak_services/proto/grpc_invocation.proto",
+            "oak_services/proto/http_invocation.proto",
+            "oak_services/proto/crypto.proto",
+            "oak_services/proto/storage_service.proto",
+            "oak_services/proto/roughtime_service.proto",
         ],
         &["../../.."],
         oak_utils::ProtoOptions {
@@ -33,8 +33,8 @@ fn main() {
     handle_tests_out.push("handle_tests");
     std::fs::create_dir_all(&handle_tests_out).unwrap();
     oak_utils::compile_protos_with_options(
-        &["tests/handle_extract_inject.proto"],
-        &["tests/", "../../../proto"],
+        &["sdk/rust/oak/tests/handle_extract_inject.proto"],
+        &["../../.."],
         oak_utils::ProtoOptions {
             out_dir_override: Some(handle_tests_out),
             ..Default::default()

--- a/sdk/rust/oak/tests/handle_extract_inject.proto
+++ b/sdk/rust/oak/tests/handle_extract_inject.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package tests;
 
-import "handle.proto";
+import "proto/handle.proto";
 
 message TestMessage {
   string other_arbitrary_field = 1;


### PR DESCRIPTION
Fixes #2167

The recommended approach for using `protoc` is to use the root of the source tree as the proto path, instead of including multiple paths. All paths must be specified relative to the root of the source tree. This change list updates all invocations of `compile_protos` and `generate_grpc_code` according to this advice. 

I have updated the documentation of `compile_protos` and `generate_grpc_code`, but I don't think there is a way to actually enforce this. 