### PR TITLE
Add separate Android targets to Oak Functions

### DIFF
--- a/oak_functions/client/android/BUILD
+++ b/oak_functions/client/android/BUILD
@@ -27,7 +27,7 @@ android_library(
     manifest = "AndroidManifest.xml",
     resource_files = glob(["com/google/oak/functions/android/client/res/**"]),
     deps = [
-        "//oak_functions/client/java:client",
+        "//oak_functions/client/java:client_android",
         "//oak_functions/proto:invocation_java_proto",
         "@com_google_guava_guava",
         "@com_google_protobuf//:protobuf_java",

--- a/oak_functions/client/java/BUILD
+++ b/oak_functions/client/java/BUILD
@@ -51,9 +51,6 @@ android_library(
     srcs = [
         "src/com/google/oak/functions/client/AttestationClient.java",
     ],
-    runtime_deps = [
-        "@io_grpc_grpc_java//netty",
-    ],
     deps = [
         "//oak_functions/proto:invocation_java_proto",
         "//oak_functions/proto:server_java_grpc",

--- a/oak_functions/client/java/BUILD
+++ b/oak_functions/client/java/BUILD
@@ -27,9 +27,6 @@ java_library(
     srcs = [
         "src/com/google/oak/functions/client/AttestationClient.java",
     ],
-    runtime_deps = [
-        "@io_grpc_grpc_java//netty",
-    ],
     deps = [
         "//oak_functions/proto:invocation_java_proto",
         "//oak_functions/proto:server_java_grpc",
@@ -40,6 +37,7 @@ java_library(
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@io_grpc_grpc_java//api",
+        "@io_grpc_grpc_java//netty",
         "@io_grpc_grpc_java//protobuf",
         "@io_grpc_grpc_java//stub",
     ],

--- a/oak_functions/client/java/BUILD
+++ b/oak_functions/client/java/BUILD
@@ -61,6 +61,7 @@ android_library(
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@io_grpc_grpc_java//api",
+        "@io_grpc_grpc_java//netty",
         "@io_grpc_grpc_java//protobuf",
         "@io_grpc_grpc_java//stub",
     ],

--- a/oak_functions/client/java/BUILD
+++ b/oak_functions/client/java/BUILD
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+load("@rules_android//android:rules.bzl", "android_library")
 load("@rules_java//java:defs.bzl", "java_library")
 
 package(
@@ -31,11 +32,33 @@ java_library(
     ],
     deps = [
         "//oak_functions/proto:invocation_java_proto",
-        "//oak_functions/proto:invocation_proto",
         "//oak_functions/proto:server_java_grpc",
         "//oak_functions/proto:server_java_proto",
-        "//oak_functions/proto:server_proto",
         "//remote_attestation/java:remote_attestation",
+        "//remote_attestation/proto:remote_attestation_java_proto",
+        "@com_google_guava_guava",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@io_grpc_grpc_java//api",
+        "@io_grpc_grpc_java//protobuf",
+        "@io_grpc_grpc_java//stub",
+    ],
+)
+
+# Dedicated Android target is necessary for using Tink internally.
+android_library(
+    name = "client_android",
+    srcs = [
+        "src/com/google/oak/functions/client/AttestationClient.java",
+    ],
+    runtime_deps = [
+        "@io_grpc_grpc_java//netty",
+    ],
+    deps = [
+        "//oak_functions/proto:invocation_java_proto",
+        "//oak_functions/proto:server_java_grpc",
+        "//oak_functions/proto:server_java_proto",
+        "//remote_attestation/java:remote_attestation_android",
         "//remote_attestation/proto:remote_attestation_java_proto",
         "@com_google_guava_guava",
         "@com_google_protobuf//:protobuf_java",

--- a/remote_attestation/java/BUILD
+++ b/remote_attestation/java/BUILD
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+load("@rules_android//android:rules.bzl", "android_library")
 load("@rules_java//java:defs.bzl", "java_library")
 
 package(
@@ -29,9 +30,25 @@ java_library(
         "src/com/google/oak/remote_attestation/KeyNegotiator.java",
     ],
     deps = [
-        "//remote_attestation/proto:remote_attestation_java_grpc",
         "//remote_attestation/proto:remote_attestation_java_proto",
-        "//remote_attestation/proto:remote_attestation_proto",
+        "@com_google_guava_guava",
+        "@com_google_protobuf//:protobuf_java",
+        "@tink_java//src/main/java/com/google/crypto/tink/subtle:aes_gcm_jce",
+        "@tink_java//src/main/java/com/google/crypto/tink/subtle:hkdf",
+        "@tink_java//src/main/java/com/google/crypto/tink/subtle:x25519",
+    ],
+)
+
+# Dedicated Android target is necessary for using Tink internally.
+android_library(
+    name = "remote_attestation_android",
+    srcs = [
+        "src/com/google/oak/remote_attestation/AeadEncryptor.java",
+        "src/com/google/oak/remote_attestation/AttestationStateMachine.java",
+        "src/com/google/oak/remote_attestation/KeyNegotiator.java",
+    ],
+    deps = [
+        "//remote_attestation/proto:remote_attestation_java_proto",
         "@com_google_guava_guava",
         "@com_google_protobuf//:protobuf_java",
         "@tink_java//src/main/java/com/google/crypto/tink/subtle:aes_gcm_jce",

--- a/remote_attestation/java/BUILD
+++ b/remote_attestation/java/BUILD
@@ -44,7 +44,7 @@ android_library(
     name = "remote_attestation_android",
     srcs = [
         "src/com/google/oak/remote_attestation/AeadEncryptor.java",
-        "src/com/google/oak/remote_attestation/AttestationStateMachine.java",
+        "src/com/google/oak/remote_attestation/AttestationEngine.java",
         "src/com/google/oak/remote_attestation/KeyNegotiator.java",
     ],
     deps = [

--- a/scripts/build_example_android
+++ b/scripts/build_example_android
@@ -31,4 +31,8 @@ bazel_build_flags+=(
 
 # Use a different output_base so that we don't lose incremental state.
 # See https://docs.bazel.build/versions/master/command-line-reference.html#flag--output_base.
-bazel --output_base="${CACHE_DIR}/client-android" build "${bazel_build_flags[@]}" "//examples/${EXAMPLE}/client/android:client_app"
+if [[ "${EXAMPLE}" == "oak_functions"*  ]]; then
+  bazel --output_base="${CACHE_DIR}/client-android" build "${bazel_build_flags[@]}" "//oak_functions/client/android:client_app"
+else
+  bazel --output_base="${CACHE_DIR}/client-android" build "${bazel_build_flags[@]}" "//examples/${EXAMPLE}/client/android:client_app"
+fi

--- a/scripts/build_examples_android
+++ b/scripts/build_examples_android
@@ -4,6 +4,6 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-for example in hello_world aggregator; do
+for example in hello_world aggregator oak_functions; do
   "${SCRIPTS_DIR}/build_example_android" -e "${example}"
 done


### PR DESCRIPTION
This change:
- Adds Android Oak Functions client to the CI
- Add separate Android targets to Oak Functions, which is necessary for using Tink internally