### PR TITLE
Add release workflow to CI

### DIFF
--- a/.github/workflows/release_oak_functions.yaml
+++ b/.github/workflows/release_oak_functions.yaml
@@ -1,0 +1,53 @@
+# This workflow simulates the steps necessary in order to release a new version of
+# `oak_functions_loader`, but without actually releasing anything externally.
+#
+# For an actual release, the same steps would be followed, the resulting hash compared to that
+# emitted by the last step here, and then the resulting binary and / or Docker image pushed
+# externally.
+
+name: Release Oak Functions
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  release_oak_functions:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      # We need to set up git user details before we can perform git operations.
+      - name: Git setup
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
+      - name: free disk space
+        run: |
+          df --human-readable
+          sudo swapoff --all
+          sudo rm --force /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          df --human-readable
+
+      # Build Docker image, caching from the latest version from the remote repository.
+      - name: Docker build
+        timeout-minutes: 30
+        run: |
+          docker pull gcr.io/oak-ci/oak:latest
+          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+
+      - name: Create release snapshot
+        run: |
+          ./scripts/docker_run ./scripts/release_snapshot
+
+      - name: Build Oak Functions Loader
+        run: |
+          ./scripts/docker_run ./scripts/release_build_oak_functions


### PR DESCRIPTION
This follows the same steps that we would need to execute for an actual
release, and provides us a way to double check that the release process
is reproducible, even though we will rely on GCB for the actual
release.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
