### PR TITLE
Change container identifier to an ARG

### DIFF
--- a/oak_functions/examples/weather_lookup/Dockerfile
+++ b/oak_functions/examples/weather_lookup/Dockerfile
@@ -1,6 +1,8 @@
-# Allow deploying the latest version for development.
-# hadolint ignore=DL3007
-FROM gcr.io/oak-ci/oak-functions:latest
+# Use an argument to specify container identifier.
+# Default to using the latest version for development.
+ARG container_identifier=:latest
+# hadolint ignore=DL3006
+FROM gcr.io/oak-ci/oak-functions${container_identifier}
 
 COPY ./bin/weather_lookup.wasm /module.wasm
 COPY ./config.toml /config.toml

--- a/oak_functions/examples/weather_lookup/Dockerfile
+++ b/oak_functions/examples/weather_lookup/Dockerfile
@@ -1,8 +1,8 @@
-# Use an argument to specify container identifier.
+# Use an argument to specify base image containing the Oak Functions loader.
 # Default to using the latest version for development.
-ARG container_identifier=:latest
+ARG base_image=gcr.io/oak-ci/oak-functions:latest
 # hadolint ignore=DL3006
-FROM gcr.io/oak-ci/oak-functions${container_identifier}
+FROM ${base_image}
 
 COPY ./bin/weather_lookup.wasm /module.wasm
 COPY ./config.toml /config.toml


### PR DESCRIPTION
This change it to support buildling the weather lookup container from a specific version of the base Oak Functions container image using build-args.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
