### PR TITLE
Make `permissions` flag optional

### DIFF
--- a/examples/aggregator/README.md
+++ b/examples/aggregator/README.md
@@ -58,7 +58,7 @@ localhost. Use the following command to connect the client to an Aggregator
 hosted at a specific domain name; in this case `aggregator.oakexamples.dev`:
 
 ```bash
-./bazel-client-bin/examples/aggregator/client/cpp/client \
+./bazel-bin/examples/aggregator/client/cpp/client \
   --address=aggregator.oakexamples.dev \
   --ca_cert_path=./examples/certs/gcp/ca.pem \
   --bucket=test \

--- a/examples/aggregator/gcp/deployment.yaml
+++ b/examples/aggregator/gcp/deployment.yaml
@@ -28,7 +28,6 @@ spec:
               readOnly: true
           args:
             - --application=aggregator.oak
-            - --permissions=permissions.toml
             - --grpc-tls-private-key=/etc/oak-secrets/gcp.key
             - --grpc-tls-certificate=/etc/oak-secrets/gcp.pem
             - --root-tls-certificate=/etc/oak-secrets/ca.pem

--- a/oak_loader/src/options.rs
+++ b/oak_loader/src/options.rs
@@ -49,8 +49,7 @@ pub struct Opt {
         not(feature = "oak-unsafe"),
         structopt(long, help = "Permissions configuration file.")
     )]
-    #[cfg(not(feature = "oak-unsafe"))]
-    permissions: String,
+    permissions: Option<String>,
     #[structopt(long, help = "Private RSA key file used by gRPC server pseudo-Nodes.")]
     grpc_tls_private_key: Option<String>,
     #[structopt(
@@ -382,19 +381,22 @@ fn create_app_config(opt: &Opt) -> anyhow::Result<ApplicationConfiguration> {
         .context("could not parse application configuration")?)
 }
 
-/// Parse permissions configuration into an instance of [`PermissionsConfiguration`].
-#[cfg(not(feature = "oak-unsafe"))]
+/// Parse permissions configuration into an instance of [`PermissionsConfiguration`], if
+/// `oak-unsafe` is not enabled. Otherwise, use a default [`PermissionsConfiguration`].
 fn create_permissions_config(opt: &Opt) -> anyhow::Result<PermissionsConfiguration> {
-    let permissions_config_data =
-        read(&opt.permissions).context("could not read permissions configuration")?;
-    let permissions: PermissionsConfiguration =
-        toml::from_str(std::str::from_utf8(permissions_config_data.as_ref())?)
-            .context("could not parse permissions configuration")?;
-    Ok(permissions)
-}
-
-/// Use a default [`PermissionsConfiguration`].
-#[cfg(feature = "oak-unsafe")]
-fn create_permissions_config(_opt: &Opt) -> anyhow::Result<PermissionsConfiguration> {
-    Ok(PermissionsConfiguration::default())
+    match &opt.permissions {
+        None => Ok(PermissionsConfiguration::default()),
+        Some(permissions) => {
+            if cfg!(feature = "oak-unsafe") {
+                // Unreachable: it should not be possible to specify the flag with `oak-unsafe`.
+                anyhow::bail!("With `oak-unsafe` the `permissions` flag is not available.");
+            };
+            let permissions_config_data =
+                read(permissions).context("could not read permissions configuration")?;
+            let permissions: PermissionsConfiguration =
+                toml::from_str(std::str::from_utf8(permissions_config_data.as_ref())?)
+                    .context("could not parse permissions configuration")?;
+            Ok(permissions)
+        }
+    }
 }

--- a/runner/src/examples.rs
+++ b/runner/src/examples.rs
@@ -720,13 +720,9 @@ fn run_example_server(
             "--http-tls-private-key=./examples/certs/local/local.key".to_string(),
             // TODO(#396): Add `--oidc-client` support.
             format!("--application={}", application_file),
-            match opt.server_variant {
-                ServerVariant::Base => format!("--permissions={}", permissions_file),
-                // server variants that have `oak-unsafe` cannot accept a `permissions` file
-                _ => "".to_string(),
-            },
             ...match opt.server_variant {
-                ServerVariant::Base => vec![],
+                // server variants that don't have `oak-unsafe` require a `permissions` file
+                ServerVariant::Base => vec![format!("--permissions={}", permissions_file)],
                 // server variants that have `oak-unsafe` need to specify `root-tls-certificate`
                 _ => vec!["--root-tls-certificate=./examples/certs/local/ca.pem".to_string()],
             },


### PR DESCRIPTION
[This `cfg_attr`](https://github.com/project-oak/oak/blob/facc62bff8ad7feed92ffd29c6a59e03838c5e1f/oak_loader/src/options.rs#L48-L51) in the Oak Loader, only applies to the name of the `permissions` flag. When compiling Oak Loader with `oak-unsafe` feature, a permissions parameter is still required: 
```
oak_loader [FLAGS] [OPTIONS] <permissions> --application <application> [--] [ARGS]
```
I tried to fix this by making the `permissions` field in the struct compile conditionally too (using `#[cfg(not(feature = "oak-unsafe"))]`), but it did not solve the problem. So, I changed the `permissions` to be an `Option<String>`.
