### PR TITLE
Added timings flags in runner

### DIFF
--- a/runner/src/examples.rs
+++ b/runner/src/examples.rs
@@ -431,7 +431,7 @@ pub fn build_server(opt: &BuildServer, additional_features: Vec<String>) -> Step
                         "CARGO_INCREMENTAL".to_string() => "0".to_string(),
                         "RUSTDOCFLAGS".to_string() => "-Cpanic=abort".to_string(),
                         // grcov instructions suggest also including `-Cpanic=abort` in RUSTFLAGS, but this causes our build.rs scripts to fail.
-                        "RUSTFLAGS".to_string() => "-Z timings -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic-abort_tests".to_string(),
+                        "RUSTFLAGS".to_string() => "-Ztimings -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic-abort_tests".to_string(),
                     }
                 } else {
                     hashmap! {}
@@ -655,7 +655,7 @@ pub fn build_wasm_module(name: &str, target: &Target, example_name: &str) -> Ste
                         // `--out-dir` is unstable and requires `-Zunstable-options`.
                         "-Zunstable-options".to_string(),
                         "build".to_string(),
-                        "-Z timings --target=wasm32-unknown-unknown".to_string(),
+                        "-Ztimings --target=wasm32-unknown-unknown".to_string(),
                         // Use a fixed `--target-dir`, because it influences the SHA256 hash of the
                         // Wasm module.
                         //
@@ -889,7 +889,7 @@ fn build(target: &Target, opt: &BuildClient) -> Box<dyn Runnable> {
             "cargo",
             spread![
                 "build".to_string(),
-                "-Z timings --release".to_string(),
+                "-Ztimings --release".to_string(),
                 format!(
                     "--target={}",
                     opt.client_rust_target

--- a/runner/src/examples.rs
+++ b/runner/src/examples.rs
@@ -431,7 +431,7 @@ pub fn build_server(opt: &BuildServer, additional_features: Vec<String>) -> Step
                         "CARGO_INCREMENTAL".to_string() => "0".to_string(),
                         "RUSTDOCFLAGS".to_string() => "-Cpanic=abort".to_string(),
                         // grcov instructions suggest also including `-Cpanic=abort` in RUSTFLAGS, but this causes our build.rs scripts to fail.
-                        "RUSTFLAGS".to_string() => "-Ztimings -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic-abort_tests".to_string(),
+                        "RUSTFLAGS".to_string() => "-Z timings -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic-abort_tests".to_string(),
                     }
                 } else {
                     hashmap! {}
@@ -655,7 +655,8 @@ pub fn build_wasm_module(name: &str, target: &Target, example_name: &str) -> Ste
                         // `--out-dir` is unstable and requires `-Zunstable-options`.
                         "-Zunstable-options".to_string(),
                         "build".to_string(),
-                        "-Ztimings --target=wasm32-unknown-unknown".to_string(),
+                        "-Z timings".to_string(),
+                        "--target=wasm32-unknown-unknown".to_string(),
                         // Use a fixed `--target-dir`, because it influences the SHA256 hash of the
                         // Wasm module.
                         //
@@ -889,7 +890,7 @@ fn build(target: &Target, opt: &BuildClient) -> Box<dyn Runnable> {
             "cargo",
             spread![
                 "build".to_string(),
-                "-Ztimings --release".to_string(),
+                "-Z timings --release".to_string(),
                 format!(
                     "--target={}",
                     opt.client_rust_target

--- a/runner/src/examples.rs
+++ b/runner/src/examples.rs
@@ -431,7 +431,7 @@ pub fn build_server(opt: &BuildServer, additional_features: Vec<String>) -> Step
                         "CARGO_INCREMENTAL".to_string() => "0".to_string(),
                         "RUSTDOCFLAGS".to_string() => "-Cpanic=abort".to_string(),
                         // grcov instructions suggest also including `-Cpanic=abort` in RUSTFLAGS, but this causes our build.rs scripts to fail.
-                        "RUSTFLAGS".to_string() => "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic-abort_tests".to_string(),
+                        "RUSTFLAGS".to_string() => "-Z timings -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic-abort_tests".to_string(),
                     }
                 } else {
                     hashmap! {}
@@ -655,7 +655,7 @@ pub fn build_wasm_module(name: &str, target: &Target, example_name: &str) -> Ste
                         // `--out-dir` is unstable and requires `-Zunstable-options`.
                         "-Zunstable-options".to_string(),
                         "build".to_string(),
-                        "--target=wasm32-unknown-unknown".to_string(),
+                        "-Z timings --target=wasm32-unknown-unknown".to_string(),
                         // Use a fixed `--target-dir`, because it influences the SHA256 hash of the
                         // Wasm module.
                         //
@@ -889,7 +889,7 @@ fn build(target: &Target, opt: &BuildClient) -> Box<dyn Runnable> {
             "cargo",
             spread![
                 "build".to_string(),
-                "--release".to_string(),
+                "-Z timings --release".to_string(),
                 format!(
                     "--target={}",
                     opt.client_rust_target


### PR DESCRIPTION
# Checklist

- [x] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [x] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.

Greetings of the day @tiziano88,

Please review the pr and let me know in case of any changes if required.

Thanks & Regards
Shikhar Vashistha

Fixes : #2280
References : [here](https://matklad.github.io/2021/09/04/fast-rust-builds.html) && [here](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#timings) 