### PR TITLE
Allow caller to specify channel for attestation in Java attestation client

### DIFF
--- a/oak_functions/client/android/com/google/oak/functions/android/client/MainActivity.java
+++ b/oak_functions/client/android/com/google/oak/functions/android/client/MainActivity.java
@@ -66,7 +66,8 @@ public class MainActivity extends Activity {
 
     TextView resultTextView = findViewById(R.id.resultTextView);
     try {
-      AttestationClient client = new AttestationClient(uri);
+      AttestationClient client = new AttestationClient();
+      client.attest(uri);
       Response response = client.send(request);
       StatusCode responseStatus = response.getStatus();
       if (responseStatus != StatusCode.SUCCESS) {

--- a/oak_functions/client/java/src/com/google/oak/functions/client/AttestationClient.java
+++ b/oak_functions/client/java/src/com/google/oak/functions/client/AttestationClient.java
@@ -45,8 +45,7 @@ import oak.remote_attestation.EncryptedData;
 import oak.remote_attestation.ServerIdentity;
 
 /**
- * Client with remote attestation support for sending requests to an Oak
- * Functions loader application.
+ * Client with remote attestation support for sending requests to an Oak Functions application.
  */
 public class AttestationClient {
   private static final Logger logger = Logger.getLogger(AttestationClient.class.getName());
@@ -65,7 +64,7 @@ public class AttestationClient {
   /**
    * Creates a gRPC channel and creates an attested channel over it.
    *
-   * `url` must contain a protocol used for connection ("https://" or "http://").
+   * @param url must contain a protocol used for the connection ("https://" or "http://")
    */
   public void attest(String url)
       throws GeneralSecurityException, IOException, InterruptedException {
@@ -82,12 +81,13 @@ public class AttestationClient {
   }
 
   /**
-   * Creates an attested channel over the gRRC ManagedChannel.
-   *
-   * `url` must contain a protocol used for connection ("https://" or "http://").
+   * Creates an attested channel over the gRPC {@code ManagedChannel}.
    */
   public void attest(ManagedChannel channel)
       throws GeneralSecurityException, IOException, InterruptedException {
+    if (channel == null) {
+      throw new NullPointerException("Channel must not be null.");
+    }
     this.channel = channel;
     RemoteAttestationStub stub = RemoteAttestationGrpc.newStub(channel);
 
@@ -150,10 +150,15 @@ public class AttestationClient {
   @Override
   protected void finalize() throws Throwable {
     requestObserver.onCompleted();
-    channel.shutdown();
+    channel.shutdownNow();
   }
 
-  /** Encrypts and sends `message` via an attested gRPC channel to the server. */
+  /**
+   * Encrypts and sends a Request via an attested gRPC channel to the server and receives and
+   * decrypts the response.
+   *
+   * This method can only be used after the {@code attest} method has been called successfully.
+   * */
   @SuppressWarnings("ProtoParseWithRegistry")
   public Response send(Request request)
       throws GeneralSecurityException, InterruptedException, InvalidProtocolBufferException {

--- a/oak_functions/examples/weather_lookup/client/java/src/Main.java
+++ b/oak_functions/examples/weather_lookup/client/java/src/Main.java
@@ -31,7 +31,8 @@ public class Main {
       "\\{\"temperature_degrees_celsius\":.*\\}";
 
   public static void main(String[] args) throws Exception {
-    AttestationClient client = new AttestationClient("http://localhost:8080");
+    AttestationClient client = new AttestationClient();
+    client.attest("http://localhost:8080");
 
     byte[] requestBody = "{\"lat\":52,\"lon\":0}".getBytes(UTF_8);
     Request request = Request.newBuilder().setBody(ByteString.copyFrom(requestBody)).build();


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
