### PR TITLE
Allow fetching lookup data from files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Free disk space
         run: |
           df --human-readable
-          sudo apt-get remove --yes '^ghc-8.*' '^dotnet-.*' '^llvm-.*' 'php.*' azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell
+          sudo apt-get remove --yes '^dotnet-.*' '^llvm-.*' 'php.*' azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell
           sudo apt-get autoremove --yes
           sudo apt clean
           docker rmi $(docker image ls --all --quiet)

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # Cargo cache.
 /cargo-cache/
 
+# Cargo timing files.
+cargo-timing*.html
+
 # Bazel cache.
 /.cache/
 

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -4,6 +4,6 @@ format_code_in_doc_comments = true
 max_width = 100
 normalize_doc_attributes = true
 wrap_comments = true
-merge_imports = true
+imports_granularity = "Crate"
 imports_layout = "mixed"
 edition = "2018"

--- a/oak_functions/abi/build.rs
+++ b/oak_functions/abi/build.rs
@@ -28,6 +28,6 @@ fn main() {
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
     for proto_path in file_paths.iter() {
         let file_path = std::path::Path::new(proto_path);
-        println!("cargo:rerun-if-changed={}", file_path.display());
+        println!("cargo:rerun-if-changed=../../{}", file_path.display());
     }
 }

--- a/oak_functions/examples/Cargo.lock
+++ b/oak_functions/examples/Cargo.lock
@@ -516,6 +516,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +817,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "image"
 version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1045,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,8 +1148,6 @@ dependencies = [
  "oak_functions",
  "oak_functions_abi",
  "prost 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1337,6 +1362,7 @@ dependencies = [
  "tokio",
  "toml",
  "tonic",
+ "url",
  "wasmi",
 ]
 
@@ -2588,6 +2614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2651,18 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vec_map"

--- a/oak_functions/examples/fuzzable/module/build.rs
+++ b/oak_functions/examples/fuzzable/module/build.rs
@@ -24,6 +24,6 @@ fn main() {
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
     for proto_path in file_paths.iter() {
         let file_path = std::path::Path::new(proto_path);
-        println!("cargo:rerun-if-changed={}", file_path.display());
+        println!("cargo:rerun-if-changed=../../../../{}", file_path.display());
     }
 }

--- a/oak_functions/examples/fuzzable/module/src/tests.rs
+++ b/oak_functions/examples/fuzzable/module/src/tests.rs
@@ -20,7 +20,7 @@ use oak_functions_abi::proto::StatusCode;
 use oak_functions_loader::{
     grpc::{create_and_start_grpc_server, create_wasm_handler},
     logger::Logger,
-    lookup::{LookupData, LookupDataAuth},
+    lookup::LookupData,
     server::Policy,
 };
 use prost::Message;
@@ -45,11 +45,7 @@ async fn test_server() {
 
     let logger = Logger::for_test();
 
-    let lookup_data = Arc::new(LookupData::new_empty(
-        "",
-        LookupDataAuth::default(),
-        logger.clone(),
-    ));
+    let lookup_data = Arc::new(LookupData::new_empty(None, logger.clone()));
 
     let policy = Policy {
         constant_response_size_bytes: 100,

--- a/oak_functions/examples/key_value_lookup/module/src/tests.rs
+++ b/oak_functions/examples/key_value_lookup/module/src/tests.rs
@@ -18,7 +18,7 @@ use oak_functions_abi::proto::StatusCode;
 use oak_functions_loader::{
     grpc::{create_and_start_grpc_server, create_wasm_handler},
     logger::Logger,
-    lookup::{LookupData, LookupDataAuth},
+    lookup::{LookupData, LookupDataAuth, LookupDataSource},
     server::Policy,
 };
 use std::{
@@ -60,8 +60,10 @@ async fn test_server() {
     let logger = Logger::for_test();
 
     let lookup_data = Arc::new(LookupData::new_empty(
-        &format!("http://localhost:{}", static_server_port),
-        LookupDataAuth::default(),
+        Some(LookupDataSource::Http {
+            url: format!("http://localhost:{}", static_server_port),
+            auth: LookupDataAuth::default(),
+        }),
         logger.clone(),
     ));
     lookup_data.refresh().await.unwrap();

--- a/oak_functions/examples/metrics/config.toml
+++ b/oak_functions/examples/metrics/config.toml
@@ -1,5 +1,3 @@
-lookup_data_url = "https://storage.googleapis.com/oak_lookup_data/lookup_data_weather"
-lookup_data_download_period = "10m"
 worker_threads = 4
 
 [metrics]

--- a/oak_functions/examples/mobilenet/config.toml
+++ b/oak_functions/examples/mobilenet/config.toml
@@ -1,5 +1,3 @@
-lookup_data_url = ""
-lookup_data_download_period = "10m"
 worker_threads = 4
 
 [tf_model]

--- a/oak_functions/examples/mobilenet/module/Cargo.toml
+++ b/oak_functions/examples/mobilenet/module/Cargo.toml
@@ -15,5 +15,3 @@ oak_functions = { path = "../../../sdk/oak_functions", features = [
 ] }
 oak_functions_abi = { path = "../../../abi" }
 prost = "*"
-serde = { version = "*", features = ["derive"] }
-serde_json = "*"

--- a/oak_functions/examples/weather_lookup/module/src/tests.rs
+++ b/oak_functions/examples/weather_lookup/module/src/tests.rs
@@ -22,7 +22,7 @@ use oak_functions_abi::proto::{Request, StatusCode};
 use oak_functions_loader::{
     grpc::{create_and_start_grpc_server, create_wasm_handler},
     logger::Logger,
-    lookup::{parse_lookup_entries, LookupData, LookupDataAuth},
+    lookup::{parse_lookup_entries, LookupData, LookupDataAuth, LookupDataSource},
     server::{Policy, WasmHandler},
 };
 use std::{
@@ -75,8 +75,10 @@ async fn test_server() {
     let logger = Logger::for_test();
 
     let lookup_data = Arc::new(LookupData::new_empty(
-        &format!("http://localhost:{}", static_server_port),
-        LookupDataAuth::default(),
+        Some(LookupDataSource::Http {
+            url: format!("http://localhost:{}", static_server_port),
+            auth: LookupDataAuth::default(),
+        }),
         logger.clone(),
     ));
     lookup_data.refresh().await.unwrap();

--- a/oak_functions/loader/Cargo.lock
+++ b/oak_functions/loader/Cargo.lock
@@ -444,6 +444,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +724,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +893,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matrixmultiply"
@@ -1092,11 +1119,13 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "structopt",
+ "tempfile",
  "test_utils",
  "tokio",
  "toml",
  "tonic",
  "tract-tensorflow",
+ "url",
  "wasmi",
 ]
 
@@ -2288,6 +2317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,6 +2354,18 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vec_map"

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -50,11 +50,13 @@ tokio = { version = "*", features = [
 toml = "*"
 tonic = "*"
 tract-tensorflow = { version = "*", optional = true }
+url = "*"
 wasmi = "*"
 signal-hook = "*"
 
 [dev-dependencies]
 maplit = "*"
+tempfile = "*"
 test_utils = { path = "../sdk/test_utils" }
 
 [build-dependencies]

--- a/oak_functions/loader/fuzz/Cargo.lock
+++ b/oak_functions/loader/fuzz/Cargo.lock
@@ -419,6 +419,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +699,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +878,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matrixmultiply"
@@ -1061,6 +1088,7 @@ dependencies = [
  "toml",
  "tonic",
  "tract-tensorflow",
+ "url",
  "wasmi",
 ]
 
@@ -2218,6 +2246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,6 +2283,18 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vec_map"

--- a/oak_functions/loader/fuzz/build.rs
+++ b/oak_functions/loader/fuzz/build.rs
@@ -24,6 +24,6 @@ fn main() {
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
     for proto_path in file_paths.iter() {
         let file_path = std::path::Path::new(proto_path);
-        println!("cargo:rerun-if-changed={}", file_path.display());
+        println!("cargo:rerun-if-changed=../../../{}", file_path.display());
     }
 }

--- a/oak_utils/src/lib.rs
+++ b/oak_utils/src/lib.rs
@@ -318,7 +318,11 @@ where
     for input in inputs {
         // Tell cargo to rerun this build script if the proto file has changed.
         // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-        println!("cargo:rerun-if-changed={}", input.as_ref().display());
+        println!(
+            "cargo:rerun-if-changed={}/{}",
+            repo_root.as_ref().display(),
+            input.as_ref().display()
+        );
     }
 
     let mut prost_config = prost_build::Config::new();

--- a/remote_attestation/java/src/com/google/oak/remote_attestation/Message.java
+++ b/remote_attestation/java/src/com/google/oak/remote_attestation/Message.java
@@ -177,11 +177,11 @@ public class Message {
 
       outputStream.writeByte(header);
       outputStream.writeByte(version);
-      writeFixedSizeArray(outputStream, ephemeralPublicKey, EPHEMERAL_PUBLIC_KEY_LENGTH,
-          "ephemeral public key");
+      writeFixedSizeArray(
+          outputStream, ephemeralPublicKey, EPHEMERAL_PUBLIC_KEY_LENGTH, "ephemeral public key");
       writeFixedSizeArray(outputStream, random, REPLAY_PROTECTION_ARRAY_LENGTH, "random value");
-      writeFixedSizeArray(outputStream, transcriptSignature, TRANSCRIPT_SIGNATURE_LENGTH,
-          "transcript signature");
+      writeFixedSizeArray(
+          outputStream, transcriptSignature, TRANSCRIPT_SIGNATURE_LENGTH, "transcript signature");
       writeFixedSizeArray(
           outputStream, signingPublicKey, SIGNING_PUBLIC_KEY_LENGTH, "signing public key");
       writeVariableSizeArray(outputStream, attestationInfo, "attestation info");
@@ -291,10 +291,10 @@ public class Message {
       DataOutputStream outputStream = new DataOutputStream(output);
 
       outputStream.writeByte(header);
-      writeFixedSizeArray(outputStream, ephemeralPublicKey, EPHEMERAL_PUBLIC_KEY_LENGTH,
-          "ephemeral public key");
-      writeFixedSizeArray(outputStream, transcriptSignature, TRANSCRIPT_SIGNATURE_LENGTH,
-          "transcript signature");
+      writeFixedSizeArray(
+          outputStream, ephemeralPublicKey, EPHEMERAL_PUBLIC_KEY_LENGTH, "ephemeral public key");
+      writeFixedSizeArray(
+          outputStream, transcriptSignature, TRANSCRIPT_SIGNATURE_LENGTH, "transcript signature");
       writeFixedSizeArray(
           outputStream, signingPublicKey, SIGNING_PUBLIC_KEY_LENGTH, "signing public key");
       writeVariableSizeArray(outputStream, attestationInfo, "attestation info");


### PR DESCRIPTION
Also allow empty lookup data source.

Fix build script to specify the correct paths for
`cargo:rerun-if-changed`. Previously the paths were invalid, which meant
that cargo thought that those files had been deleted and therefore was
always rerunning all the build scripts every time.


Fix #2253
Fix #2219

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
