### PR TITLE
Specify Docker digest in docker_build

### DIFF
--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -1,8 +1,31 @@
 #!/usr/bin/env bash
 
+DOCKER_IMAGE_VERSION=":latest"
+DOCKER_IMAGE_TAG=":latest"
+while getopts "d:h" opt; do
+  case "${opt}" in
+    h)
+      echo -e "Usage: ${0} [-h] -d DIGEST
+
+Build Oak dev Docker image.
+
+Options:
+  -d    Docker image digest
+        If digest is not specified - the 'latest' tag is used instead
+  -h    Print Help (this message) and exit"
+      exit 0;;
+    d)
+      DOCKER_IMAGE_VERSION="@${OPTARG}"
+      DOCKER_IMAGE_TAG="";;
+    *)
+      echo "Invalid argument: ${OPTARG}"
+      exit 1;;
+  esac
+done
+
 readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
-source "$SCRIPTS_DIR/common"
+source "${SCRIPTS_DIR}/common"
 
 # The default user for a Docker container has uid 0 (root). To avoid creating
 # root-owned files in the build directory we tell Docker to use the current user
@@ -13,8 +36,8 @@ readonly DOCKER_UID="${UID:-0}"
 readonly DOCKER_GID="$(id -g)"
 
 docker build \
-  --cache-from="$DOCKER_IMAGE_NAME:latest" \
-  --tag="$DOCKER_IMAGE_NAME:latest" \
-  --build-arg=USER_UID="$DOCKER_UID" \
-  --build-arg=USER_GID="$DOCKER_GID" \
+  --cache-from="${DOCKER_IMAGE_NAME}${DOCKER_IMAGE_VERSION}" \
+  --tag="${DOCKER_IMAGE_NAME}${DOCKER_IMAGE_TAG}" \
+  --build-arg=USER_UID="${DOCKER_UID}" \
+  --build-arg=USER_GID="${DOCKER_GID}" \
   . 1>&2


### PR DESCRIPTION
This change adds the ability to specify a Docker digest when building Oak dev Docker image.