### PR TITLE
Add local file loading for Functions

### DIFF
--- a/oak_functions/examples/key_value_lookup/config.toml
+++ b/oak_functions/examples/key_value_lookup/config.toml
@@ -1,4 +1,4 @@
-lookup_data_url = "https://storage.googleapis.com/oak_lookup_data/lookup_data_weather"
+lookup_data = { Url = "https://storage.googleapis.com/oak_lookup_data/lookup_data_weather" }
 lookup_data_download_period = "10m"
 worker_threads = 4
 

--- a/oak_functions/examples/weather_lookup/config.toml
+++ b/oak_functions/examples/weather_lookup/config.toml
@@ -1,4 +1,4 @@
-lookup_data_url = "https://storage.googleapis.com/oak_lookup_data/lookup_data_weather_sparse_s2"
+lookup_data = { Url = "https://storage.googleapis.com/oak_lookup_data/lookup_data_weather_sparse_s2" }
 lookup_data_download_period = "10m"
 worker_threads = 4
 


### PR DESCRIPTION
Adds the ability to specify files for `lookup_data`.
Added because current logic with `file://` schemas required full paths.

Ref https://github.com/project-oak/oak/issues/2306