### PR TITLE
Use Criterion for benchmarking

### DIFF
--- a/oak_functions/Cargo.lock
+++ b/oak_functions/Cargo.lock
@@ -202,6 +202,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +272,15 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -363,6 +384,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits 0.2.14",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +461,28 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1456,6 +1535,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "criterion",
  "futures",
  "http",
  "humantime-serde",
@@ -1535,6 +1615,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -1666,6 +1752,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits 0.2.14",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -2058,6 +2172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,6 +2205,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -2243,6 +2372,16 @@ checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -2459,6 +2598,16 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/oak_functions/examples/key_value_lookup/module/src/lib.rs
+++ b/oak_functions/examples/key_value_lookup/module/src/lib.rs
@@ -16,6 +16,10 @@
 
 //! Oak Functions key / value lookup example.
 
+#![feature(try_blocks)]
+// Required for enabling benchmark tests.
+#![feature(test)]
+
 #[cfg(test)]
 mod tests;
 

--- a/oak_functions/examples/key_value_lookup/module/src/tests.rs
+++ b/oak_functions/examples/key_value_lookup/module/src/tests.rs
@@ -13,17 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate test;
+
 use maplit::hashmap;
-use oak_functions_abi::proto::{ServerPolicy, StatusCode};
+use oak_functions_abi::proto::{Request, ServerPolicy, StatusCode};
 use oak_functions_loader::{
     grpc::{create_and_start_grpc_server, create_wasm_handler},
     logger::Logger,
     lookup::{LookupData, LookupDataAuth, LookupDataSource},
+    server::WasmHandler,
 };
 use std::{
     net::{Ipv6Addr, SocketAddr},
     sync::Arc,
+    time::Duration,
 };
+use test::Bencher;
 use test_utils::{get_config_info, make_request};
 
 #[tokio::test]
@@ -110,4 +115,51 @@ async fn test_server() {
     assert!(res.is_ok());
 
     mock_static_server_background.terminate_and_join().await;
+}
+
+#[bench]
+fn bench_wasm_handler(bencher: &mut Bencher) {
+    let mut manifest_path = std::env::current_dir().unwrap();
+    manifest_path.push("Cargo.toml");
+    let wasm_module_bytes =
+        test_utils::compile_rust_wasm(manifest_path.to_str().expect("Invalid target dir"), true)
+            .expect("Couldn't read Wasm module");
+
+    let logger = Logger::for_test();
+    let entries = hashmap! {
+        b"key_0".to_vec() => br#"value_0"#.to_vec(),
+        b"key_1".to_vec() => br#"value_1"#.to_vec(),
+        b"key_2".to_vec() => br#"value_2"#.to_vec(),
+    };
+    let lookup_data = Arc::new(LookupData::for_test(entries));
+    let wasm_handler = WasmHandler::create(&wasm_module_bytes, lookup_data, vec![], logger)
+        .expect("Couldn't create the server");
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let summary = bencher.bench(|bencher| {
+        bencher.iter(|| {
+            let request = Request {
+                body: br#"key_1"#.to_vec(),
+            };
+            let resp = rt
+                .block_on(wasm_handler.clone().handle_invoke(request))
+                .unwrap();
+            assert_eq!(resp.status, StatusCode::Success as i32);
+            assert_eq!(std::str::from_utf8(&resp.body).unwrap(), r#"value_1"#);
+        });
+    });
+
+    // When running `cargo test` this benchmark test gets executed too, but `summary` will be `None`
+    // in that case. So, here we first check that `summary` is not empty.
+    if let Some(summary) = summary {
+        // `summary.mean` is in nanoseconds, even though it is not explicitly documented in
+        // https://doc.rust-lang.org/test/stats/struct.Summary.html.
+        let elapsed = Duration::from_nanos(summary.mean as u64);
+        // We expect the `mean` time for loading the test Wasm module and running its main function
+        // to be less than a fixed threshold.
+        assert!(
+            elapsed < Duration::from_millis(5),
+            "elapsed time: {:.0?}",
+            elapsed
+        );
+    }
 }

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -55,6 +55,7 @@ wasmi = { version = "*", default-features = false, features = ["core"] }
 signal-hook = "*"
 
 [dev-dependencies]
+criterion = "*"
 lookup_data_generator = { path = "../lookup_data_generator" }
 maplit = "*"
 tempfile = "*"
@@ -65,3 +66,4 @@ oak_utils = { path = "../../oak_utils" }
 
 [[bench]]
 name = "lookup"
+harness = false

--- a/oak_functions/loader/benches/lookup.rs
+++ b/oak_functions/loader/benches/lookup.rs
@@ -14,16 +14,14 @@
 // limitations under the License.
 //
 
-#![feature(test)]
-
-extern crate test;
-
 pub mod proto {
     tonic::include_proto!("oak.functions.benchmark");
 }
 
+use criterion::{
+    criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
+};
 use lookup_data_generator::data::generate_and_serialize_random_entries;
-use maplit::hashmap;
 use oak_functions_abi::proto::{Request, StatusCode};
 use oak_functions_loader::{
     logger::Logger,
@@ -33,125 +31,201 @@ use oak_functions_loader::{
 use prost::Message;
 use proto::{benchmark_request::Action, BenchmarkRequest, LookupTest};
 use rand::SeedableRng;
-use std::{collections::HashMap, sync::Arc, time::Duration};
-use test::Bencher;
+use std::{collections::HashMap, sync::Arc};
+use tokio::runtime::Runtime;
 
 const MANIFEST_PATH: &str = "examples/benchmark/module/Cargo.toml";
+const SINGLE_REQUEST_ITERATIONS: u32 = 1;
+const MULTI_REQUEST_ITERATIONS: u32 = 101;
 
-#[bench]
-fn small_fixed_data_single_lookup(bencher: &mut Bencher) {
-    let entries = hashmap! {
-        b"key_0".to_vec() => br#"value_0"#.to_vec(),
-        b"key_1".to_vec() => br#"value_1"#.to_vec(),
-        b"key_2".to_vec() => br#"value_2"#.to_vec(),
-    };
-
-    let test_data = TestData {
-        test_key: br#"key_1"#.to_vec(),
-        expected_value: br#"value_1"#.to_vec(),
-        entries,
-    };
-
-    run_lookup_bench(bencher, test_data, 1, Duration::from_millis(5));
-}
-
-#[bench]
-fn small_fixed_data_multi_lookup(bencher: &mut Bencher) {
-    let entries = hashmap! {
-        b"key_0".to_vec() => br#"value_0"#.to_vec(),
-        b"key_1".to_vec() => br#"value_1"#.to_vec(),
-        b"key_2".to_vec() => br#"value_2"#.to_vec(),
-    };
-
-    let test_data = TestData {
-        test_key: br#"key_1"#.to_vec(),
-        expected_value: br#"value_1"#.to_vec(),
-        entries,
-    };
-
-    run_lookup_bench(bencher, test_data, 101, Duration::from_millis(10));
-}
-
-#[bench]
-fn small_random_data_single_lookup(bencher: &mut Bencher) {
-    let test_data = generate_random_test_data_for_bench(16, 16, 20);
-
-    run_lookup_bench(bencher, test_data, 1, Duration::from_millis(5));
-}
-
-#[bench]
-fn small_random_data_multi_lookup(bencher: &mut Bencher) {
-    let test_data = generate_random_test_data_for_bench(16, 16, 20);
-
-    run_lookup_bench(bencher, test_data, 101, Duration::from_millis(10));
-}
-
-#[bench]
-fn medium_random_data_single_lookup(bencher: &mut Bencher) {
-    let test_data = generate_random_test_data_for_bench(128, 256, 200_000);
-
-    run_lookup_bench(bencher, test_data, 1, Duration::from_millis(5));
-}
-
-#[bench]
-fn medium_random_data_multi_lookup(bencher: &mut Bencher) {
-    let test_data = generate_random_test_data_for_bench(128, 256, 200_000);
-
-    run_lookup_bench(bencher, test_data, 101, Duration::from_millis(10));
-}
-
-#[bench]
-fn large_random_data_single_lookup(bencher: &mut Bencher) {
-    let test_data = generate_random_test_data_for_bench(1_024, 10_240, 1_000);
-
-    run_lookup_bench(bencher, test_data, 1, Duration::from_millis(5));
-}
-
-#[bench]
-fn large_random_data_multi_lookup(bencher: &mut Bencher) {
-    let test_data = generate_random_test_data_for_bench(1_024, 10_240, 1_000);
-
-    run_lookup_bench(bencher, test_data, 101, Duration::from_millis(25));
-}
-
-fn run_lookup_bench(bencher: &mut Bencher, test_data: TestData, iterations: u32, cutoff: Duration) {
+fn key_size(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
     let wasm_module_bytes = bulid_wasm_module(MANIFEST_PATH);
-    let lookup_data = Arc::new(LookupData::for_test(test_data.entries));
-    let benchmark_request = BenchmarkRequest {
-        iterations,
-        action: Some(Action::Lookup(LookupTest {
-            key: test_data.test_key,
-        })),
-    };
-    let expected_value = test_data.expected_value;
-    let logger = Logger::for_test();
-    let wasm_handler = WasmHandler::create(&wasm_module_bytes, lookup_data, vec![], logger)
-        .expect("Couldn't create the server");
-    let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let summary = bencher.bench(|bencher| {
-        bencher.iter(|| {
-            let request = Request {
-                body: benchmark_request.encode_to_vec(),
-            };
-            let resp = rt
-                .block_on(wasm_handler.clone().handle_invoke(request))
-                .unwrap();
-            assert_eq!(resp.status, StatusCode::Success as i32);
-            assert_eq!(resp.body, expected_value);
+    let mut group = c.benchmark_group("key_size");
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    group.plot_config(plot_config);
+    for size in [16usize, 128usize, 1_024usize].iter() {
+        let TestData {
+            test_key,
+            expected_value,
+            entries,
+        } = generate_random_test_data_for_bench(size.clone(), 256, 1_000);
+        let lookup_data = Arc::new(LookupData::for_test(entries.clone()));
+        let logger = Logger::for_test();
+        let wasm_handler = WasmHandler::create(&wasm_module_bytes, lookup_data, vec![], logger)
+            .expect("Couldn't create the server");
+
+        let single_benchmark_request = BenchmarkRequest {
+            iterations: SINGLE_REQUEST_ITERATIONS,
+            action: Some(Action::Lookup(LookupTest {
+                key: test_key.clone(),
+            })),
+        }
+        .encode_to_vec();
+        let multi_benchmark_request = BenchmarkRequest {
+            iterations: MULTI_REQUEST_ITERATIONS,
+            action: Some(Action::Lookup(LookupTest {
+                key: test_key.clone(),
+            })),
+        }
+        .encode_to_vec();
+
+        group.bench_with_input(BenchmarkId::new("single", size), size, |b, _size| {
+            b.iter(|| {
+                run_lookup_iteration(
+                    &rt,
+                    &wasm_handler,
+                    &single_benchmark_request,
+                    &expected_value,
+                )
+            })
         });
-    });
-
-    // When running `cargo test` this benchmark test gets executed too, but `summary` will be `None`
-    // in that case. So, here we first check that `summary` is not empty.
-    if let Some(summary) = summary {
-        // `summary.mean` is in nanoseconds, even though it is not explicitly documented in
-        // https://doc.rust-lang.org/test/stats/struct.Summary.html.
-        let elapsed = Duration::from_nanos(summary.mean as u64);
-        // We expect the `mean` time for loading the test Wasm module and running its main function
-        // to be less than a fixed threshold.
-        assert!(elapsed <= cutoff, "elapsed time: {:.0?}", elapsed);
+        group.bench_with_input(BenchmarkId::new("multi", size), size, |b, _size| {
+            b.iter(|| {
+                run_lookup_iteration(
+                    &rt,
+                    &wasm_handler,
+                    &multi_benchmark_request,
+                    &expected_value,
+                )
+            })
+        });
     }
+    group.finish();
+}
+
+fn value_size(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let wasm_module_bytes = bulid_wasm_module(MANIFEST_PATH);
+
+    let mut group = c.benchmark_group("value_size");
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    group.plot_config(plot_config);
+    for size in [16usize, 128usize, 1_024usize, 8_192usize].iter() {
+        let TestData {
+            test_key,
+            expected_value,
+            entries,
+        } = generate_random_test_data_for_bench(32, size.clone(), 1_000);
+        let lookup_data = Arc::new(LookupData::for_test(entries.clone()));
+        let logger = Logger::for_test();
+        let wasm_handler = WasmHandler::create(&wasm_module_bytes, lookup_data, vec![], logger)
+            .expect("Couldn't create the server");
+
+        let single_benchmark_request = BenchmarkRequest {
+            iterations: SINGLE_REQUEST_ITERATIONS,
+            action: Some(Action::Lookup(LookupTest {
+                key: test_key.clone(),
+            })),
+        }
+        .encode_to_vec();
+        let multi_benchmark_request = BenchmarkRequest {
+            iterations: MULTI_REQUEST_ITERATIONS,
+            action: Some(Action::Lookup(LookupTest {
+                key: test_key.clone(),
+            })),
+        }
+        .encode_to_vec();
+
+        group.bench_with_input(BenchmarkId::new("single", size), size, |b, _size| {
+            b.iter(|| {
+                run_lookup_iteration(
+                    &rt,
+                    &wasm_handler,
+                    &single_benchmark_request,
+                    &expected_value,
+                )
+            })
+        });
+        group.bench_with_input(BenchmarkId::new("multi", size), size, |b, _size| {
+            b.iter(|| {
+                run_lookup_iteration(
+                    &rt,
+                    &wasm_handler,
+                    &multi_benchmark_request,
+                    &expected_value,
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+fn entry_count(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let wasm_module_bytes = bulid_wasm_module(MANIFEST_PATH);
+
+    let mut group = c.benchmark_group("entry_count");
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    group.plot_config(plot_config);
+    for count in [100usize, 10_000usize, 1_000_000usize].iter() {
+        let TestData {
+            test_key,
+            expected_value,
+            entries,
+        } = generate_random_test_data_for_bench(64, 256, count.clone());
+        let lookup_data = Arc::new(LookupData::for_test(entries.clone()));
+        let logger = Logger::for_test();
+        let wasm_handler = WasmHandler::create(&wasm_module_bytes, lookup_data, vec![], logger)
+            .expect("Couldn't create the server");
+
+        let single_benchmark_request = BenchmarkRequest {
+            iterations: SINGLE_REQUEST_ITERATIONS,
+            action: Some(Action::Lookup(LookupTest {
+                key: test_key.clone(),
+            })),
+        }
+        .encode_to_vec();
+        let multi_benchmark_request = BenchmarkRequest {
+            iterations: MULTI_REQUEST_ITERATIONS,
+            action: Some(Action::Lookup(LookupTest {
+                key: test_key.clone(),
+            })),
+        }
+        .encode_to_vec();
+
+        group.bench_with_input(BenchmarkId::new("single", count), count, |b, _size| {
+            b.iter(|| {
+                run_lookup_iteration(
+                    &rt,
+                    &wasm_handler,
+                    &single_benchmark_request,
+                    &expected_value,
+                )
+            })
+        });
+        group.bench_with_input(BenchmarkId::new("multi", count), count, |b, _size| {
+            b.iter(|| {
+                run_lookup_iteration(
+                    &rt,
+                    &wasm_handler,
+                    &multi_benchmark_request,
+                    &expected_value,
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, key_size, value_size, entry_count);
+criterion_main!(benches);
+
+fn run_lookup_iteration(
+    rt: &Runtime,
+    wasm_handler: &WasmHandler,
+    benchmark_request: &Vec<u8>,
+    expected_value: &Vec<u8>,
+) {
+    let request = Request {
+        body: benchmark_request.clone(),
+    };
+    let resp = rt
+        .block_on(wasm_handler.clone().handle_invoke(request))
+        .unwrap();
+    assert_eq!(resp.status, StatusCode::Success as i32);
+    assert_eq!(&resp.body, expected_value);
 }
 
 /// The test data used for benchmarking.

--- a/oak_functions/loader/benches/lookup.rs
+++ b/oak_functions/loader/benches/lookup.rs
@@ -50,7 +50,7 @@ fn key_size(c: &mut Criterion) {
             test_key,
             expected_value,
             entries,
-        } = generate_random_test_data_for_bench(size.clone(), 256, 1_000);
+        } = generate_random_test_data_for_bench(*size, 256, 1_000);
         let lookup_data = Arc::new(LookupData::for_test(entries.clone()));
         let logger = Logger::for_test();
         let wasm_handler = WasmHandler::create(&wasm_module_bytes, lookup_data, vec![], logger)
@@ -107,7 +107,7 @@ fn value_size(c: &mut Criterion) {
             test_key,
             expected_value,
             entries,
-        } = generate_random_test_data_for_bench(32, size.clone(), 1_000);
+        } = generate_random_test_data_for_bench(32, *size, 1_000);
         let lookup_data = Arc::new(LookupData::for_test(entries.clone()));
         let logger = Logger::for_test();
         let wasm_handler = WasmHandler::create(&wasm_module_bytes, lookup_data, vec![], logger)
@@ -164,7 +164,7 @@ fn entry_count(c: &mut Criterion) {
             test_key,
             expected_value,
             entries,
-        } = generate_random_test_data_for_bench(64, 256, count.clone());
+        } = generate_random_test_data_for_bench(64, 256, *count);
         let lookup_data = Arc::new(LookupData::for_test(entries.clone()));
         let logger = Logger::for_test();
         let wasm_handler = WasmHandler::create(&wasm_module_bytes, lookup_data, vec![], logger)
@@ -215,15 +215,13 @@ criterion_main!(benches);
 fn run_lookup_iteration(
     rt: &Runtime,
     wasm_handler: &WasmHandler,
-    benchmark_request: &Vec<u8>,
-    expected_value: &Vec<u8>,
+    benchmark_request: &[u8],
+    expected_value: &[u8],
 ) {
     let request = Request {
-        body: benchmark_request.clone(),
+        body: benchmark_request.to_owned(),
     };
-    let resp = rt
-        .block_on(wasm_handler.clone().handle_invoke(request))
-        .unwrap();
+    let resp = rt.block_on(wasm_handler.handle_invoke(request)).unwrap();
     assert_eq!(resp.status, StatusCode::Success as i32);
     assert_eq!(&resp.body, expected_value);
 }

--- a/oak_functions/loader/src/main.rs
+++ b/oak_functions/loader/src/main.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-// Required for enabling benchmark tests.
-#![feature(test)]
 #![feature(async_closure)]
 
 use anyhow::Context;


### PR DESCRIPTION
This change switches the Oak Functions loader benchmarks to use Criterion.

This change also moves the fixed-data lookup benchmark to the key_value_lookup example to support asserting that the bench takes less than the expected amount of time.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
