### PR TITLE
Pin Docker image to specific hash

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,10 @@
-// See https://code.visualstudio.com/docs/remote/containers for details.
+// See
+//
+// - https://code.visualstudio.com/docs/remote/containers
+// - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
-  "image": "gcr.io/oak-ci/oak:latest",
+  // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
+  "image": "sha256:f71ebe2c5827ea559e4c5fd9bb668c7a23ed8d828a4344d8c3fec0714622188d",
   "extensions": [
     "bazelbuild.vscode-bazel",
     "bodil.prettier-toml",
@@ -19,4 +23,5 @@
   // See https://code.visualstudio.com/docs/remote/containers-advanced#_changing-the-default-source-code-mount.
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
+  "containerUser": "docker"
 }

--- a/.github/workflows/build_rust_docs.yaml
+++ b/.github/workflows/build_rust_docs.yaml
@@ -39,12 +39,11 @@ jobs:
           docker rmi $(docker image ls --all --quiet)
           df --human-readable
 
-      # Build Docker image, caching from the latest version from the remote repository.
-      - name: Docker build
-        timeout-minutes: 30
+      - name: Docker pull
+        timeout-minutes: 10
         run: |
-          docker pull gcr.io/oak-ci/oak:latest
-          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+          ./scripts/docker_pull
+          df --human-readable
 
       # Remove all files from the "out" folder.
       - name: Clear "out" folder

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,12 +59,10 @@ jobs:
           sudo rm --force /swapfile
           df --human-readable
 
-      # Build Docker image, caching from the latest version from the remote repository.
-      - name: Docker build
-        timeout-minutes: 30
+      - name: Docker pull
+        timeout-minutes: 10
         run: |
-          docker pull gcr.io/oak-ci/oak:latest
-          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+          ./scripts/docker_pull
           df --human-readable
 
       - name: Run command
@@ -127,12 +125,10 @@ jobs:
           rm --recursive --force "$AGENT_TOOLSDIRECTORY"
           df --human-readable
 
-      # Build Docker image, caching from the latest version from the remote repository.
-      - name: Docker build
-        timeout-minutes: 30
+      - name: Docker pull
+        timeout-minutes: 10
         run: |
-          docker pull gcr.io/oak-ci/oak:latest
-          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+          ./scripts/docker_pull
           df --human-readable
 
       - name: Cargo crev verification

--- a/.github/workflows/release_oak_functions.yaml
+++ b/.github/workflows/release_oak_functions.yaml
@@ -37,12 +37,11 @@ jobs:
           docker rmi $(docker image ls --all --quiet)
           df --human-readable
 
-      # Build Docker image, caching from the latest version from the remote repository.
-      - name: Docker build
-        timeout-minutes: 30
+      - name: Docker pull
+        timeout-minutes: 10
         run: |
-          docker pull gcr.io/oak-ci/oak:latest
-          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+          ./scripts/docker_pull
+          df --human-readable
 
       - name: Create release snapshot
         run: |

--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -42,12 +42,11 @@ jobs:
           docker rmi $(docker image ls --all --quiet)
           df --human-readable
 
-      # Build Docker image, caching from the latest version from the remote repository.
-      - name: Docker build
-        timeout-minutes: 30
+      - name: Docker pull
+        timeout-minutes: 10
         run: |
-          docker pull gcr.io/oak-ci/oak:latest
-          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+          ./scripts/docker_pull
+          df --human-readable
 
       # Build artifacts that are supposed to be reproducible.
       - name: Build Rust server

--- a/.github/workflows/upload_coverage.yaml
+++ b/.github/workflows/upload_coverage.yaml
@@ -27,11 +27,11 @@ jobs:
           docker rmi $(docker image ls --all --quiet)
           df --human-readable
 
-      - name: Docker build image
-        timeout-minutes: 30
+      - name: Docker pull
+        timeout-minutes: 10
         run: |
-          docker pull gcr.io/oak-ci/oak:latest
-          docker build --pull --cache-from=gcr.io/oak-ci/oak:latest --tag=gcr.io/oak-ci/oak:latest .
+          ./scripts/docker_pull
+          df --human-readable
 
       - name: Generate coverage data
         run: ./scripts/docker_run ./scripts/run_tests_coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -317,20 +317,8 @@ ENV CARGO_INCREMENTAL false
 
 # We use the `docker` user in order to maintain library paths on different
 # machines and to make Wasm modules reproducible.
-ARG USERNAME=docker
-
-# Placeholder args that are expected to be passed in at image build time.
-# See https://code.visualstudio.com/docs/remote/containers-advanced#_creating-a-nonroot-user
-ARG USER_UID=1000
-ARG USER_GID=${USER_UID}
-
-# Create the specified user and group.
 #
-# Ignore errors if the user or group already exist (it should only happen if the image is being
-# built as root, which happens on GCB).
-RUN (groupadd --gid=${USER_GID} ${USERNAME} || true) \
-  && (useradd --shell=/bin/bash --uid=${USER_UID} --gid=${USER_GID} --create-home ${USERNAME} || true)
-
-# Set the default user as the newly created one, so that any operations performed from within the
-# Docker container will appear as if performed by the outside user, instead of root.
-USER ${USER_UID}
+# We do not set this as the default user in the Docker image, because we expect its uid not to match
+# uid of the host, therefore we need to first fix the uid before actually using the user. This is
+# done by /scripts/fix_docker_user_and_run .
+RUN useradd --shell=/bin/bash --create-home --user-group docker

--- a/oak_functions/client/java/tests/com/google/oak/functions/client/ServerConfigurationVerifierTest.java
+++ b/oak_functions/client/java/tests/com/google/oak/functions/client/ServerConfigurationVerifierTest.java
@@ -19,9 +19,9 @@ package com.google.oak.functions.client;
 import com.google.oak.remote_attestation.Message.ServerIdentity;
 import oak.functions.abi.ConfigurationInfo;
 import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.Test;
 
 @RunWith(JUnit4.class)
 public class ServerConfigurationVerifierTest {

--- a/remote_attestation/java/tests/com/google/oak/remote_attestation/ClientHandshakerTest.java
+++ b/remote_attestation/java/tests/com/google/oak/remote_attestation/ClientHandshakerTest.java
@@ -16,15 +16,16 @@
 
 package com.google.oak.remote_attestation;
 
+import static org.junit.Assert.assertThrows;
+
 import com.google.oak.remote_attestation.ClientHandshaker;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import org.junit.Assert;
-import static org.junit.Assert.assertThrows;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.Test;
 
 @RunWith(JUnit4.class)
 public class ClientHandshakerTest {

--- a/remote_attestation/java/tests/com/google/oak/remote_attestation/KeyNegotiatorTest.java
+++ b/remote_attestation/java/tests/com/google/oak/remote_attestation/KeyNegotiatorTest.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.Test;
 
 @RunWith(JUnit4.class)
 public class KeyNegotiatorTest {

--- a/remote_attestation/java/tests/com/google/oak/remote_attestation/MessageTest.java
+++ b/remote_attestation/java/tests/com/google/oak/remote_attestation/MessageTest.java
@@ -20,9 +20,9 @@ import com.google.oak.remote_attestation.Message;
 import java.io.IOException;
 import java.util.Random;
 import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.Test;
 
 @RunWith(JUnit4.class)
 public class MessageTest {

--- a/scripts/common
+++ b/scripts/common
@@ -11,7 +11,20 @@ set -o pipefail
 export RUST_LOG="${RUST_LOG:-info}"
 
 # See https://pantheon.corp.google.com/gcr/images/oak-ci/GLOBAL/oak
-readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak'
+readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak:latest'
+
+# The difference between Docker image id and image digest is that the image id corresponds to the
+# hash of the contents of the image, while the image digest is a hash of the image and its metadata,
+# and it is assigned by the specific registry after pushing the image there. Therefore, we should
+# mostly rely on the image id locally, though we need to use the image digest when pulling the image
+# from a registry first.
+
+# Do not modify manually. This value is automatically updated by ./scripts/docker_build .
+readonly DOCKER_IMAGE_ID='sha256:f71ebe2c5827ea559e4c5fd9bb668c7a23ed8d828a4344d8c3fec0714622188d'
+
+# Do not modify manually. This value is automatically updated by ./scripts/docker_push .
+readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:ff9eafaf9f64d6549039fd1e7c5a9163206d60495d0d232971c57fa5a52e7878'
+
 readonly SERVER_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-server'
 
 readonly CACHE_DIR='bazel-cache'

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -1,43 +1,18 @@
 #!/usr/bin/env bash
-
-DOCKER_IMAGE_VERSION=":latest"
-DOCKER_IMAGE_TAG=":latest"
-while getopts "d:h" opt; do
-  case "${opt}" in
-    h)
-      echo -e "Usage: ${0} [-h] -d DIGEST
-
-Build Oak dev Docker image.
-
-Options:
-  -d    Docker image digest
-        If digest is not specified - the 'latest' tag is used instead
-  -h    Print Help (this message) and exit"
-      exit 0;;
-    d)
-      DOCKER_IMAGE_VERSION="@${OPTARG}"
-      DOCKER_IMAGE_TAG="";;
-    *)
-      echo "Invalid argument: ${OPTARG}"
-      exit 1;;
-  esac
-done
-
 readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "${SCRIPTS_DIR}/common"
 
-# The default user for a Docker container has uid 0 (root). To avoid creating
-# root-owned files in the build directory we tell Docker to use the current user
-# ID, if known.
-# See
-# https://github.com/googleapis/google-cloud-cpp/blob/a186208b79d900b4ec71c6f9df3acf7638f01dc6/ci/kokoro/docker/build.sh#L147-L152
-readonly DOCKER_UID="${UID:-0}"
-readonly DOCKER_GID="$(id -g)"
-
 docker build \
-  --cache-from="${DOCKER_IMAGE_NAME}${DOCKER_IMAGE_VERSION}" \
-  --tag="${DOCKER_IMAGE_NAME}${DOCKER_IMAGE_TAG}" \
-  --build-arg=USER_UID="${DOCKER_UID}" \
-  --build-arg=USER_GID="${DOCKER_GID}" \
+  --cache-from="${DOCKER_IMAGE_NAME}" \
+  --tag="${DOCKER_IMAGE_NAME}" \
   . 1>&2
+
+readonly NEW_DOCKER_IMAGE_ID="$(docker images --format='{{.ID}}' --no-trunc "${DOCKER_IMAGE_NAME}")"
+
+# Store the id (which corresponds to the SHA256 hash) of the image in the repository, so that it is
+# pinned for all other operations.
+#
+# See https://blog.aquasec.com/docker-image-tags.
+sed --in-place "s|readonly DOCKER_IMAGE_ID=.*|readonly DOCKER_IMAGE_ID='${NEW_DOCKER_IMAGE_ID}'|" "${SCRIPTS_DIR}/common"
+sed --in-place "s|\"image\": .*|\"image\": \"${NEW_DOCKER_IMAGE_ID}\",|" ./.devcontainer.json

--- a/scripts/docker_pull
+++ b/scripts/docker_pull
@@ -2,10 +2,19 @@
 
 # This script can be used by anyone, including CI, to pull a version of the image from Google
 # Container Registry, which should allow download public downloads.
+#
 # See https://pantheon.corp.google.com/gcr/settings?project=oak-ci&folder&organizationId=433637338589
+#
+# The exact version of the images to pull are specified in /scripts/common .
+#
+# Here we pull both the exact image pinned in this repository, plus the "latest" image, in case they
+# are different, for convenience, though only the pinned one is actually used by the other scripts.
+# The "latest" image may still be useful for local editor integration or other local development
+# tasks.
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-docker pull "$DOCKER_IMAGE_NAME:latest"
+docker pull "$DOCKER_IMAGE_NAME"
+docker pull "$DOCKER_IMAGE_REPO_DIGEST"

--- a/scripts/docker_push
+++ b/scripts/docker_push
@@ -14,4 +14,11 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-docker push "$DOCKER_IMAGE_NAME:latest"
+# We need to push the image to a registry in order to be able to retrieve its digest.
+# See https://github.com/moby/moby/issues/16482.
+docker push "${DOCKER_IMAGE_NAME}"
+
+# Store the full name (including repo and digest) of the image in the repository, so that it can be
+# pulled easily.
+readonly NEW_DOCKER_IMAGE_REPO_DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' "${DOCKER_IMAGE_NAME}")"
+sed --in-place "s|readonly DOCKER_IMAGE_REPO_DIGEST=.*|readonly DOCKER_IMAGE_REPO_DIGEST='${NEW_DOCKER_IMAGE_REPO_DIGEST}'|" "${SCRIPTS_DIR}/common"

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 
-# Usage: docker_run [OPTIONS] COMMAND
-#
-# Options:
-#    --detach    Run container in background and print container ID
+# This script runs the provided command in the Docker container corresponding to the currently
+# checked-in image id.
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
-
-"$SCRIPTS_DIR/docker_build"
 
 # In order for the docker-cli inside the container to use the host dockerd,
 # we need permissions for the user with the same gid as the host
@@ -22,13 +18,27 @@ fi
 mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 
+# The default user for a Docker container has uid 0 (root). To avoid creating
+# root-owned files in the build directory we tell Docker to use the current user
+# ID, if known.
+# See
+# https://github.com/googleapis/google-cloud-cpp/blob/a186208b79d900b4ec71c6f9df3acf7638f01dc6/ci/kokoro/docker/build.sh#L147-L152
+readonly HOST_UID="${UID:-0}"
+readonly HOST_GID="$(id -g)"
+
+export HOST_UID
+export HOST_GID
+
 docker_run_flags=(
   '--rm'
   '--tty'
+  '--env=TERM=xterm-256color'
   '--env=BAZEL_REMOTE_CACHE_ENABLED'
   '--env=BAZEL_GOOGLE_CREDENTIALS'
-  "--volume=$PWD/bazel-cache:/.cache/bazel"
-  "--volume=$PWD/cargo-cache:/usr/local/cargo/registry"
+  '--env=HOST_UID'
+  '--env=HOST_GID'
+  "--volume=$PWD/bazel-cache:/home/docker/.cache/bazel"
+  "--volume=$PWD/cargo-cache:/home/docker/.cargo"
   "--volume=$PWD:/workspace"
   '--workdir=/workspace'
   '--network=host'
@@ -43,9 +53,6 @@ if [[ -z "${CI:-}" ]]; then
   docker_run_flags+=('--interactive')
 fi
 
-if [[ "$1" == '--detach' ]]; then
-  docker_run_flags+=('--detach')
-  docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_NAME:latest" "${@:2}"
-else
-  docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_NAME:latest" "$@"
-fi
+# Create a new user with a fixed name but with the same uid and gid as the host user, and use that
+# user to run the provided command.
+docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_ID" ./scripts/fix_docker_user_and_run "$*"

--- a/scripts/fix_docker_user_and_run
+++ b/scripts/fix_docker_user_and_run
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# This script is meant to be invoked **inside** the Docker container.
+#
+# It assumes that a user named `docker` exists in the container, modifies it to have the same uid
+# and gid as the host user (obtained via the corresponding env variables), then switches to that
+# user to run the provided command.
+
+set -o errexit
+set -o nounset
+set -o xtrace
+set -o pipefail
+
+groupmod --gid="${HOST_GID}" docker
+usermod --uid="${HOST_UID}" --gid="${HOST_GID}" docker
+chown "${HOST_UID}":"${HOST_GID}" "/home/docker" "/home/docker/.cache"
+su docker --session-command="$*"


### PR DESCRIPTION
This ensures that each commit in the repository has a cryptographic
reference to the exact Docker image to use to build any artifacts.

Fixes #2374
