### PR TITLE
Use docker image digest in VSCode dev container

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,8 +3,8 @@
 // - https://code.visualstudio.com/docs/remote/containers
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
-  // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:f71ebe2c5827ea559e4c5fd9bb668c7a23ed8d828a4344d8c3fec0714622188d",
+  // Do not modify manually. This value is automatically updated by ./scripts/docker_push .
+  "image": "gcr.io/oak-ci/oak@sha256:ff9eafaf9f64d6549039fd1e7c5a9163206d60495d0d232971c57fa5a52e7878",
   "extensions": [
     "bazelbuild.vscode-bazel",
     "bodil.prettier-toml",

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -15,4 +15,3 @@ readonly NEW_DOCKER_IMAGE_ID="$(docker images --format='{{.ID}}' --no-trunc "${D
 #
 # See https://blog.aquasec.com/docker-image-tags.
 sed --in-place "s|readonly DOCKER_IMAGE_ID=.*|readonly DOCKER_IMAGE_ID='${NEW_DOCKER_IMAGE_ID}'|" "${SCRIPTS_DIR}/common"
-sed --in-place "s|\"image\": .*|\"image\": \"${NEW_DOCKER_IMAGE_ID}\",|" ./.devcontainer.json

--- a/scripts/docker_push
+++ b/scripts/docker_push
@@ -22,3 +22,4 @@ docker push "${DOCKER_IMAGE_NAME}"
 # pulled easily.
 readonly NEW_DOCKER_IMAGE_REPO_DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' "${DOCKER_IMAGE_NAME}")"
 sed --in-place "s|readonly DOCKER_IMAGE_REPO_DIGEST=.*|readonly DOCKER_IMAGE_REPO_DIGEST='${NEW_DOCKER_IMAGE_REPO_DIGEST}'|" "${SCRIPTS_DIR}/common"
+sed --in-place "s|\"image\": .*|\"image\": \"${NEW_DOCKER_IMAGE_REPO_DIGEST}\",|" ./.devcontainer.json


### PR DESCRIPTION
The previous image id only works if the image is already pulled, but in
order to use GitHub Codespaces (https://github.com/features/codespaces)
it needs to be a valid image digest that GitHub can pull directly.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
