### PR TITLE
Inconsistent view of in-memory lookup data while a Wasm function executes

### DIFF
--- a/oak_functions/Cargo.lock
+++ b/oak_functions/Cargo.lock
@@ -1548,8 +1548,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
 name = "oak_functions_loader-fuzz"
 version = "0.0.0"
 dependencies = [
@@ -1578,7 +1576,6 @@ dependencies = [
 ]
 
 [[package]]
->>>>>>> 19f5db7e0 (Add failing test for lookup data)
 name = "oak_functions_sdk_abi_test"
 version = "0.1.0"
 dependencies = [

--- a/oak_functions/Cargo.lock
+++ b/oak_functions/Cargo.lock
@@ -1548,23 +1548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_functions_loader-fuzz"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "arbitrary",
- "lazy_static",
- "libfuzzer-sys",
- "maplit",
- "oak_functions_abi",
- "oak_functions_loader",
- "prost 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio",
- "tonic",
-]
-
-[[package]]
 name = "oak_functions_loader_test"
 version = "0.1.0"
 dependencies = [

--- a/oak_functions/Cargo.lock
+++ b/oak_functions/Cargo.lock
@@ -1523,6 +1523,7 @@ dependencies = [
  "humantime-serde",
  "hyper",
  "hyper-rustls",
+ "lazy_static",
  "log",
  "lookup_data_generator",
  "maplit",
@@ -1547,6 +1548,37 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "oak_functions_loader-fuzz"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "arbitrary",
+ "lazy_static",
+ "libfuzzer-sys",
+ "maplit",
+ "oak_functions_abi",
+ "oak_functions_loader",
+ "prost 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "oak_functions_loader_test"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "maplit",
+ "oak_functions",
+ "oak_functions_abi",
+]
+
+[[package]]
+>>>>>>> 19f5db7e0 (Add failing test for lookup data)
 name = "oak_functions_sdk_abi_test"
 version = "0.1.0"
 dependencies = [

--- a/oak_functions/Cargo.lock
+++ b/oak_functions/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
  "oak_functions_abi",
  "oak_remote_attestation",
  "oak_utils",
+ "once_cell",
  "prost 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.4",
  "serde",

--- a/oak_functions/Cargo.toml
+++ b/oak_functions/Cargo.toml
@@ -12,6 +12,11 @@ members = [
   "examples/weather_lookup/module",
   "load_test",
   "loader",
+<<<<<<< HEAD
+=======
+  "loader/fuzz",
+  "loader/tests/module",
+>>>>>>> 19f5db7e0 (Add failing test for lookup data)
   "location_utils",
   "lookup_data_generator",
   "sdk/oak_functions",

--- a/oak_functions/Cargo.toml
+++ b/oak_functions/Cargo.toml
@@ -12,7 +12,6 @@ members = [
   "examples/weather_lookup/module",
   "load_test",
   "loader",
-  "loader/fuzz",
   "loader/tests/module",
   "location_utils",
   "lookup_data_generator",

--- a/oak_functions/Cargo.toml
+++ b/oak_functions/Cargo.toml
@@ -12,11 +12,8 @@ members = [
   "examples/weather_lookup/module",
   "load_test",
   "loader",
-<<<<<<< HEAD
-=======
   "loader/fuzz",
   "loader/tests/module",
->>>>>>> 19f5db7e0 (Add failing test for lookup data)
   "location_utils",
   "lookup_data_generator",
   "sdk/oak_functions",

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -34,6 +34,7 @@ humantime-serde = "*"
 log = { version = "*", features = ["max_level_off", "release_max_level_off"] }
 oak_functions_abi = { path = "../abi" }
 oak_remote_attestation = { path = "../../remote_attestation/rust/" }
+once_cell = "*"
 prost = "*"
 rand = "*"
 serde = "*"

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -56,6 +56,7 @@ signal-hook = "*"
 
 [dev-dependencies]
 criterion = "*"
+lazy_static = "*"
 lookup_data_generator = { path = "../lookup_data_generator" }
 maplit = "*"
 tempfile = "*"

--- a/oak_functions/loader/fuzz/Cargo.lock
+++ b/oak_functions/loader/fuzz/Cargo.lock
@@ -722,6 +722,7 @@ dependencies = [
  "oak_functions_abi",
  "oak_remote_attestation",
  "oak_utils",
+ "once_cell",
  "prost 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "serde",

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -604,10 +604,6 @@ impl WasmHandler {
         })
     }
 
-    pub async fn refresh_lookup_data(&self) -> anyhow::Result<()> {
-        self.lookup_data.refresh().await
-    }
-
     pub async fn handle_invoke(&self, request: Request) -> anyhow::Result<Response> {
         let mut extensions_indices = HashMap::new();
         let mut extensions_metadata = HashMap::new();

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -604,6 +604,10 @@ impl WasmHandler {
         })
     }
 
+    pub async fn refresh_lookup_data(&self) -> anyhow::Result<()> {
+        self.lookup_data.refresh().await
+    }
+
     pub async fn handle_invoke(&self, request: Request) -> anyhow::Result<Response> {
         let mut extensions_indices = HashMap::new();
         let mut extensions_metadata = HashMap::new();

--- a/oak_functions/loader/tests/integration_test.rs
+++ b/oak_functions/loader/tests/integration_test.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use futures::executor::block_on;
 use lazy_static::lazy_static;
 use maplit::hashmap;
 use oak_functions_abi::proto::{Request, Response};
@@ -50,7 +51,7 @@ async fn test_consistent_lookup() {
         Logger::for_test(),
     ));
 
-    lookup_data.refresh().await.unwrap();
+    let _ = block_on(lookup_data.refresh());
 
     let wasm_handler = WasmHandler::create(
         &WASM_MODULE_BYTES,
@@ -73,7 +74,7 @@ async fn test_consistent_lookup() {
     let serialized_entries = test_utils::serialize_entries(entries);
     temp_file.as_file().write_all(&serialized_entries).unwrap();
 
-    lookup_data.refresh().await.unwrap();
+    let _ = block_on(lookup_data.refresh());
 
     let request2 = Request {
         body: b"ConsistentLookup".to_vec(),

--- a/oak_functions/loader/tests/integration_test.rs
+++ b/oak_functions/loader/tests/integration_test.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 use futures::executor::block_on;
-use lazy_static::lazy_static;
 use maplit::hashmap;
 use oak_functions_abi::proto::{Request, Response};
 use oak_functions_loader::{
@@ -22,20 +21,19 @@ use oak_functions_loader::{
     lookup::{LookupData, LookupDataSource},
     server::WasmHandler,
 };
+use once_cell::sync::Lazy;
 use std::{io::Write, sync::Arc};
 use tokio;
 
-lazy_static! {
-    static ref WASM_MODULE_BYTES: Vec<u8> = {
-        let mut manifest_path = std::env::current_dir().unwrap();
-        manifest_path.push("tests");
-        manifest_path.push("module");
-        manifest_path.push("Cargo.toml");
+static WASM_MODULE_BYTES: Lazy<Vec<u8>> = Lazy::new(|| {
+    let mut manifest_path = std::env::current_dir().unwrap();
+    manifest_path.push("tests");
+    manifest_path.push("module");
+    manifest_path.push("Cargo.toml");
 
-        test_utils::compile_rust_wasm(manifest_path.to_str().unwrap(), false)
-            .expect("Could not read Wasm module")
-    };
-}
+    test_utils::compile_rust_wasm(manifest_path.to_str().unwrap(), false)
+        .expect("Could not read Wasm module")
+});
 
 #[tokio::test]
 async fn test_consistent_lookup() {

--- a/oak_functions/loader/tests/integration_test.rs
+++ b/oak_functions/loader/tests/integration_test.rs
@@ -1,0 +1,85 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use lazy_static::lazy_static;
+use maplit::hashmap;
+use oak_functions_abi::proto::{Request, Response};
+use oak_functions_loader::{
+    logger::Logger,
+    lookup::{LookupData, LookupDataSource},
+    server::WasmHandler,
+};
+use std::{io::Write, sync::Arc};
+use tokio;
+
+lazy_static! {
+    static ref WASM_MODULE_BYTES: Vec<u8> = {
+        let mut manifest_path = std::env::current_dir().unwrap();
+        manifest_path.push("tests");
+        manifest_path.push("module");
+        manifest_path.push("Cargo.toml");
+
+        test_utils::compile_rust_wasm(manifest_path.to_str().unwrap(), false)
+            .expect("Could not read Wasm module")
+    };
+}
+
+#[tokio::test]
+async fn test_consistent_lookup() {
+    let entries = hashmap! {
+       b"ConsistentLookup".to_vec() => b"Value1".to_vec(),
+    };
+    let serialized_entries = test_utils::serialize_entries(entries);
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+    temp_file.as_file().write_all(&serialized_entries).unwrap();
+
+    let lookup_data = crate::LookupData::new_empty(
+        Some(LookupDataSource::File(temp_file.path().to_path_buf())),
+        Logger::for_test(),
+    );
+    lookup_data.refresh().await.unwrap();
+
+    let wasm_handler = WasmHandler::create(
+        &WASM_MODULE_BYTES,
+        Arc::new(lookup_data),
+        vec![],
+        Logger::for_test(),
+    )
+    .expect("Could not instantiate WasmHandler.");
+
+    let request = Request {
+        body: b"ConsistentLookup".to_vec(),
+    };
+
+    let response: Response = wasm_handler.handle_invoke(request).await.unwrap();
+    assert_eq!(response.body().unwrap(), b"Value1");
+
+    let entries = hashmap! {
+       b"ConsistentLookup".to_vec() => b"Value2".to_vec(),
+    };
+    let serialized_entries = test_utils::serialize_entries(entries);
+    temp_file.as_file().write_all(&serialized_entries).unwrap();
+
+    wasm_handler.refresh_lookup_data().await.unwrap();
+
+    let request2 = Request {
+        body: b"ConsistentLookup".to_vec(),
+    };
+
+    // even though the lookup data was refreshed in the backgroud
+    // we expect the same in the wasm module
+    let response2: Response = wasm_handler.handle_invoke(request2).await.unwrap();
+    assert_eq!(response2.body().unwrap(), b"Value1");
+}

--- a/oak_functions/loader/tests/module/Cargo.toml
+++ b/oak_functions/loader/tests/module/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "oak_functions_loader_test"
+version = "0.1.0"
+authors = ["Maria Schett <mschett@google.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+anyhow = "*"
+maplit = "*"
+assert_matches = "*"
+oak_functions = { path = "../../../sdk/oak_functions" }
+oak_functions_abi = { path = "../../../abi" }

--- a/oak_functions/loader/tests/module/src/lib.rs
+++ b/oak_functions/loader/tests/module/src/lib.rs
@@ -1,0 +1,63 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::{anyhow, Context};
+use assert_matches::assert_matches;
+use maplit::hashmap;
+use std::collections::HashMap;
+
+type TestFn = fn(&str) -> ();
+
+struct TestManager<'a> {
+    tests: HashMap<&'a str, TestFn>,
+}
+
+impl TestManager<'static> {
+    fn new() -> Self {
+        Self {
+            tests: hashmap! [
+                "ConsistentLookup" => Self::test_consistent_lookup as TestFn,
+            ],
+        }
+    }
+
+    fn run_test(&self) -> anyhow::Result<()> {
+        let request = oak_functions::read_request()
+            .map_err(|error| anyhow!("Couldn't read request: {:?}", error))?;
+        let test_name = String::from_utf8(request).context("Couldn't parse request")?;
+        let test = self
+            .tests
+            .get(&test_name as &str)
+            .ok_or(anyhow!("Couldn't find test: {}", &test_name))?;
+        test(&test_name);
+        Ok(())
+    }
+
+    fn test_consistent_lookup(key: &str) {
+        let value = oak_functions::storage_get_item(key.as_bytes());
+        assert_matches!(value, Ok(_));
+        let value = value.unwrap();
+        assert_matches!(value, Some(_));
+
+        oak_functions::write_response(&value.unwrap()).expect("Failed to write response.");
+    }
+}
+
+#[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn main() {
+    let test_manager = TestManager::new();
+    test_manager.run_test().expect("Couldn't run test");
+}


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
