### PR TITLE
Add definitions of Wasm host functions based on channels

### DIFF
--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -86,10 +86,10 @@ extern "C" {
         inference_len_ptr: *mut usize,
     ) -> u32;
 
-    /// Reads a message, i.e., `dest_buf_len_ptr` bytes, from the channel with `channel_handle` into
-    /// the buffer at `dest_buf_ptr_ptr`. After a successful call to `channel_read`
-    /// the buffer at `dest_buf_ptr_ptr` holds bytes encoding a message taken from the specified
-    /// channel.
+    /// Allocates a buffer on the callers memory to write a message from the channel with
+    /// `channel_handle`. After a successful call `dest_buf_ptr_ptr` holds the address of the
+    /// buffer and `dest_buf_len_ptr` holds its length. The caller can then read
+    /// the message from `dest_buf_ptr_ptr`.
     ///
     /// Returns a status code to indicate success. In particular, returns immediately
     /// with an appropriate status code, if no message is available on the channel.

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -108,7 +108,7 @@ extern "C" {
     /// until the `deadline_ms` expires. After a successful call to `channel_wait`, the buffer at
     /// `ready_channel_handle_buf_ptr` holds the channel handles with at least one message to read.
     ///
-    /// Returns a status code to indicate success or whether the deadline.
+    /// Returns a status code to indicate success or deadline expiration.
     pub fn channel_wait(
         channel_handle_buf_ptr: *mut i32,
         channel_handle_buf_len: usize,

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -99,7 +99,7 @@ extern "C" {
         dest_buf_len_ptr: *mut usize,
     ) -> u32;
 
-    /// Writes a message, i.e., `src_buf_len` bytes),from `scr_buf_ptr` into the channel with
+    /// Writes a message, i.e., `src_buf_len` bytes, from `scr_buf_ptr` into the channel with
     /// `channel_handle`.
     ///
     /// Returns a status code to indicate success.

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -113,6 +113,8 @@ extern "C" {
     /// `channel_handle_buf_ptr` has a message to read, or
     /// until the `deadline_ms` expires. After a successful call to `channel_wait`, the buffer at
     /// `ready_channel_handle_buf_ptr` holds the channel handles with at least one message to read.
+    /// Both, `channel_handle_buf_len` and `ready_channel_handle_buf_len` hold the length of the
+    /// respective buffers in bytes.
     ///
     /// Returns a status code to indicate success or deadline expiration.
     pub fn channel_wait(

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -18,6 +18,7 @@
 //! binary interface (ABI).
 
 type ChannelHandle = u32;
+type StatusCode = u32;
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/oak.functions.abi.rs"));
@@ -97,7 +98,7 @@ extern "C" {
         channel_handle: ChannelHandle,
         dest_buf_ptr_ptr: *mut *mut u8,
         dest_buf_len_ptr: *mut usize,
-    ) -> u32;
+    ) -> StatusCode;
 
     /// Writes a message, i.e., `src_buf_len` bytes, from `scr_buf_ptr` into the channel with
     /// `channel_handle`.
@@ -107,7 +108,7 @@ extern "C" {
         channel_handle: ChannelHandle,
         src_buf_ptr: *const u8,
         src_buf_len: usize,
-    ) -> u32;
+    ) -> StatusCode;
 
     /// Waits until at least one of the channels from the channel handles in the buffer at
     /// `channel_handle_buf_ptr` has a message to read, or
@@ -123,5 +124,5 @@ extern "C" {
         ready_channel_handle_buf_ptr: *mut *mut i32,
         ready_channel_handle_buf_len: *mut usize,
         deadline_ms: u32,
-    ) -> u32;
+    ) -> StatusCode;
 }

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -104,7 +104,7 @@ extern "C" {
     pub fn channel_write(channel_handle: i32, src_buf_ptr: *mut u8, src_buf_len: usize) -> u32;
 
     /// Waits until at least one of the channels from the channel handles in the buffer at
-    /// `channel_handle_buf_ptr` has a message to read---or
+    /// `channel_handle_buf_ptr` has a message to read, or
     /// until the `deadline_ms` expires. After a successful call to `channel_wait`, the buffer at
     /// `ready_channel_handle_buf_ptr` holds the channel handles with at least one message to read.
     ///

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -105,7 +105,7 @@ extern "C" {
     /// Returns a status code to indicate success.
     pub fn channel_write(
         channel_handle: ChannelHandle,
-        src_buf_ptr: *mut u8,
+        src_buf_ptr: *const u8,
         src_buf_len: usize,
     ) -> u32;
 
@@ -116,7 +116,7 @@ extern "C" {
     ///
     /// Returns a status code to indicate success or deadline expiration.
     pub fn channel_wait(
-        channel_handle_buf_ptr: *mut ChannelHandle,
+        channel_handle_buf_ptr: *const ChannelHandle,
         channel_handle_buf_len: usize,
         ready_channel_handle_buf_ptr: *mut *mut i32,
         ready_channel_handle_buf_len: *mut usize,

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -83,4 +83,37 @@ extern "C" {
         inference_ptr_ptr: *mut *mut u8,
         inference_len_ptr: *mut usize,
     ) -> u32;
+
+    /// Reads a message, i.e., `dest_buf_len_ptr` bytes, from the channel with `channel_handle` into
+    /// the buffer at `dest_buf_ptr_ptr`. After a successful call to `channel_read`
+    /// the buffer at `dest_buf_ptr_ptr` holds bytes encoding a message taken from the specified
+    /// channel.
+    ///
+    /// Returns a status code to indicate success. In particular, returns immediately
+    /// with an appropriate status code, if no message is available on the channel.
+    pub fn channel_read(
+        channel_handle: i32,
+        dest_buf_ptr_ptr: *mut *mut u8,
+        dest_buf_len_ptr: *mut usize,
+    ) -> u32;
+
+    /// Writes a message, i.e., `src_buf_len` bytes),from `scr_buf_ptr` into the channel with
+    /// `channel_handle`.
+    ///
+    /// Returns a status code to indicate success.
+    pub fn channel_write(channel_handle: i32, src_buf_ptr: *mut u8, src_buf_len: usize) -> u32;
+
+    /// Waits until at least one of the channels from the channel handles in the buffer at
+    /// `channel_handle_buf_ptr` has a message to read---or
+    /// until the `deadline_ms` expires. After a successful call to `channel_wait`, the buffer at
+    /// `ready_channel_handle_buf_ptr` holds the channel handles with at least one message to read.
+    ///
+    /// Returns a status code to indicate success or whether the deadline.
+    pub fn channel_wait(
+        channel_handle_buf_ptr: *mut i32,
+        channel_handle_buf_len: usize,
+        ready_channel_handle_buf_ptr: *mut *mut i32,
+        ready_channel_handle_buf_len: *mut usize,
+        deadline_ms: u32,
+    ) -> u32;
 }

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -17,6 +17,8 @@
 //! Type, constant and Wasm host function definitions for the Oak-Functions application
 //! binary interface (ABI).
 
+type ChannelHandle = u32;
+
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/oak.functions.abi.rs"));
     include!(concat!(env!("OUT_DIR"), "/oak.functions.lookup_data.rs"));
@@ -92,7 +94,7 @@ extern "C" {
     /// Returns a status code to indicate success. In particular, returns immediately
     /// with an appropriate status code, if no message is available on the channel.
     pub fn channel_read(
-        channel_handle: i32,
+        channel_handle: ChannelHandle,
         dest_buf_ptr_ptr: *mut *mut u8,
         dest_buf_len_ptr: *mut usize,
     ) -> u32;
@@ -101,7 +103,11 @@ extern "C" {
     /// `channel_handle`.
     ///
     /// Returns a status code to indicate success.
-    pub fn channel_write(channel_handle: i32, src_buf_ptr: *mut u8, src_buf_len: usize) -> u32;
+    pub fn channel_write(
+        channel_handle: ChannelHandle,
+        src_buf_ptr: *mut u8,
+        src_buf_len: usize,
+    ) -> u32;
 
     /// Waits until at least one of the channels from the channel handles in the buffer at
     /// `channel_handle_buf_ptr` has a message to read, or
@@ -110,7 +116,7 @@ extern "C" {
     ///
     /// Returns a status code to indicate success or deadline expiration.
     pub fn channel_wait(
-        channel_handle_buf_ptr: *mut i32,
+        channel_handle_buf_ptr: *mut ChannelHandle,
         channel_handle_buf_len: usize,
         ready_channel_handle_buf_ptr: *mut *mut i32,
         ready_channel_handle_buf_len: *mut usize,


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
