### PR TITLE
scripts/git_check_diff: Check for ignored changes

### DIFF
--- a/scripts/git_check_diff
+++ b/scripts/git_check_diff
@@ -4,8 +4,15 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-# Check that any generated files match those that are checked in.
-if [[ $(git status --short) ]]; then
-    # One or more files are either modified or newly generated, exit with an error code
+# Changed files that are tracked by git.
+readonly GIT_STATUS=$(git status --short)
+# Changed files that are untracked/ignored by git.
+readonly GIT_CLEAN_STATUS=$(git clean --dry-run -x -d)
+
+if [[ "$GIT_STATUS" || "$GIT_CLEAN_STATUS" ]]; then
+    echo 'Please re-run this script from a clean commit.'
+    "$GIT_STATUS" && echo "The following tracked changes were present: $GIT_STATUS"
+    "$GIT_CLEAN_STATUS" && echo "The following untracked changes were present: $GIT_CLEAN_STATUS"
+
     exit 1
 fi

--- a/scripts/release_snapshot
+++ b/scripts/release_snapshot
@@ -17,8 +17,14 @@ source "$SCRIPTS_DIR/common"
 
 # Ensure that the working tree is clean.
 # Copied from /scripts/git_check_diff.
-if [[ $(git status --short) ]]; then
-    echo 'Please re-run this script from a clean commit'
+# Changed files that are tracked by git.
+readonly GIT_STATUS=$(git status --short)
+# Changed files that are untracked/ignored by git.
+readonly GIT_CLEAN_STATUS=$(git clean --dry-run -x -d)
+if [[ "$GIT_STATUS" || "$GIT_CLEAN_STATUS" ]]; then
+    echo 'Please re-run this script from a clean commit.'
+    "$GIT_STATUS" && echo "The following tracked changes were present: $GIT_STATUS"
+    "$GIT_CLEAN_STATUS" && echo "The following untracked changes were present: $GIT_CLEAN_STATUS"
     exit 1
 fi
 


### PR DESCRIPTION
Both ci.yaml and couldbuild.yaml specify that this script should check for both tracked and untracked changes. 
https://github.com/project-oak/oak/blob/c33c4e80e589f315c79f2b4c7fd692abab580b2a/.github/workflows/ci.yaml#L76
https://github.com/project-oak/oak/blob/e195f5188a940efeca210921948291323a56e2fc/cloudbuild.yaml#L49

Currently this script only checks tracked files, and historically has done the same. This PR implements its behavior as outlined the aforementioned files. It means checking for all changes, whether tracked or not.

# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
