### PR TITLE
Re-enable clippy warnings

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3410,7 +3410,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "expect"
-version = "0.1.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -66,7 +66,6 @@ translator_common = { path = "translator/common" }
 translator_grpc = { path = "translator/grpc" }
 trusted_database_client = { path = "trusted_database/client/rust" }
 # Third party.
-expect = { path = "../third_party/expect" }
 roughenough = { path = "../third_party/roughenough" }
 prost = { path = "../third_party/prost" }
 prost-build = { path = "../third_party/prost/prost-build" }

--- a/experimental/tf_proxy/client/src/data.rs
+++ b/experimental/tf_proxy/client/src/data.rs
@@ -159,7 +159,7 @@ fn parse_images(image_buffer: &[u8]) -> anyhow::Result<Images> {
     let cols = read_be_u32(&image_buffer[12..16])
         .context("couldn't read number of columns per image")? as usize;
     info!("number of cols: {}", cols);
-    if image_buffer.len() != num_images * rows * cols + 16 as usize {
+    if image_buffer.len() != num_images * rows * cols + 16_usize {
         anyhow::bail!("image buffer is invalid");
     }
 
@@ -183,7 +183,7 @@ fn parse_labels(label_buffer: &[u8]) -> anyhow::Result<Vec<u8>> {
     let num_labels =
         read_be_u32(&label_buffer[4..8]).context("couldn't read number of labels")? as usize;
     info!("number of labels: {}", num_labels);
-    if label_buffer.len() != num_labels + 8 as usize {
+    if label_buffer.len() != num_labels + 8_usize {
         anyhow::bail!("label buffer is invalid");
     }
     Ok(label_buffer[8..].to_vec())

--- a/experimental/tf_proxy/client/src/main.rs
+++ b/experimental/tf_proxy/client/src/main.rs
@@ -29,6 +29,8 @@ use structopt::StructOpt;
 
 mod data;
 mod proto {
+    // Suppress warning: `all variants have the same prefix: `Dt``.
+    #![allow(clippy::enum_variant_names)]
     tonic::include_proto!("tensorflow");
     pub mod serving {
         tonic::include_proto!("tensorflow.serving");
@@ -96,8 +98,9 @@ async fn main() -> anyhow::Result<()> {
         let scores = predict_response
             .outputs
             .get("scores")
-            .ok_or(anyhow::anyhow!("no scores returned in result"))?;
-        let label = arg_max(&scores.float_val).ok_or(anyhow::anyhow!("scores vector is empty"))?;
+            .ok_or_else(|| anyhow::anyhow!("no scores returned in result"))?;
+        let label =
+            arg_max(&scores.float_val).ok_or_else(|| anyhow::anyhow!("scores vector is empty"))?;
         debug!("predicted label:{}", label);
 
         count += 1;

--- a/experimental/tf_proxy/server/src/grpc.rs
+++ b/experimental/tf_proxy/server/src/grpc.rs
@@ -15,6 +15,8 @@
 //
 
 pub mod proto {
+    // Suppress warning: `large size difference between variants`.
+    #![allow(clippy::large_enum_variant)]
     tonic::include_proto!("tensorflow");
     pub mod serving {
         tonic::include_proto!("tensorflow.serving");

--- a/oak_functions/loader/src/tests.rs
+++ b/oak_functions/loader/src/tests.rs
@@ -434,7 +434,7 @@ fn test_format_bytes() {
 
 #[test]
 fn test_start_from_empty_endpoints() {
-    fn check_empty(endpoint: &mut Endpoint) -> () {
+    fn check_empty(endpoint: &mut Endpoint) {
         let receiver = &mut endpoint.receiver;
         assert_eq!(TryRecvError::Empty, receiver.try_recv().unwrap_err());
     }
@@ -445,7 +445,7 @@ fn test_start_from_empty_endpoints() {
 
 #[tokio::test]
 async fn test_crossed_write_read() {
-    async fn check_crossed_write_read(endpoint1: &mut Endpoint, endpoint2: &mut Endpoint) -> () {
+    async fn check_crossed_write_read(endpoint1: &mut Endpoint, endpoint2: &mut Endpoint) {
         let message = String::from("Message").into_bytes();
         let sender = &endpoint1.sender;
         let send_result = sender.send(message.clone()).await;

--- a/oak_functions/sdk/oak_functions/tests/integration_test.rs
+++ b/oak_functions/sdk/oak_functions/tests/integration_test.rs
@@ -19,7 +19,6 @@ use maplit::hashmap;
 use oak_functions_abi::proto::{Request, Response};
 use oak_functions_loader::{logger::Logger, lookup::LookupData, server::WasmHandler};
 use std::sync::Arc;
-use tokio;
 
 lazy_static! {
     static ref WASM_MODULE_BYTES: Vec<u8> = {

--- a/oak_functions/sdk/oak_functions/tests/module/src/lib.rs
+++ b/oak_functions/sdk/oak_functions/tests/module/src/lib.rs
@@ -47,7 +47,7 @@ impl TestManager<'static> {
         let test = self
             .tests
             .get(&test_name as &str)
-            .ok_or(anyhow!("Couldn't find test: {}", &test_name))?;
+            .ok_or_else(|| anyhow!("Couldn't find test: {}", &test_name))?;
         test(&test_name);
         Ok(())
     }

--- a/oak_sign/src/lib.rs
+++ b/oak_sign/src/lib.rs
@@ -22,6 +22,7 @@ use ring::{
     rand,
     signature::{self, Ed25519KeyPair},
 };
+#[allow(unused_imports)]
 use simple_asn1::{ASN1Block, BigUint, OID};
 use std::{
     collections::HashMap,

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -154,12 +154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,12 +480,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "dtoa",
  "indexmap",
+ "ryu",
  "serde",
  "yaml-rust",
 ]

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -28,7 +28,6 @@
 use colored::*;
 use maplit::hashmap;
 use once_cell::sync::Lazy;
-use serde_yaml;
 use std::{
     path::{Path, PathBuf},
     sync::Mutex,
@@ -795,6 +794,8 @@ fn run_cargo_clippy(all_affected_crates: &ModifiedContent) -> Step {
                         "clippy",
                         "--all-targets",
                         &format!("--manifest-path={}", &entry),
+                        "--",
+                        "--deny=warnings",
                     ],
                 ),
             })


### PR DESCRIPTION
Also fix all of the remaining ones.

I think this was accidentally disabled in 183407a71b30a670f645525fd698ba1d2306a5f1.