### PR TITLE
Remove cleanup flag from run-cargo-tests CI step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - build-server --server-variant=experimental
           - build-functions-server --server-variant=unsafe
           - build-functions-server --server-variant=base
-          - run-cargo-tests --cleanup
+          - run-cargo-tests
           - run-bazel-tests
           - run-tests-tsan
           - run-examples --application-variant=rust
@@ -77,6 +77,8 @@ jobs:
       # See https://doc.rust-lang.org/nightly/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
       - name: Cache Rust artifacts
         uses: actions/cache@v2
+        if: |
+          ${{ matrix.cmd == 'run-cargo-tests' || matrix.cmd == 'run-cargo-udeps' }}
         with:
           path: |
             ./cargo-cache/bin


### PR DESCRIPTION
# Checklist

- [ ] Pull request affects core Oak functionality (e.g. runtime, SDK, ABI)
  - [ ] I have written tests that cover the code changes.
  - [ ] I have checked that these tests are run by
        [Cloudbuild](/cloudbuild.yaml)
  - [ ] I have updated [documentation](/docs/) accordingly.
  - [ ] I have raised an [issue](https://github.com/project-oak/oak/issues) to
        cover any TODOs and/or unfinished work.
- [ ] Pull request includes prototype/experimental work that is under
      construction.
