### PR TITLE
Fix gRPC UNAVAILABLE due to channel shutdownNow invoked

### DIFF
--- a/oak_functions/client/java/src/com/google/oak/functions/client/AttestationClient.java
+++ b/oak_functions/client/java/src/com/google/oak/functions/client/AttestationClient.java
@@ -203,7 +203,6 @@ public class AttestationClient {
   @Override
   public void finalize() {
     requestObserver.onCompleted();
-    channel.shutdownNow();
   }
 
   /**


### PR DESCRIPTION
This change fixes the following warning received after a gRPC channel is closed:
```
WARNING: Couldn't receive response: Status{code=UNAVAILABLE, description=Channel shutdownNow invoked, cause=null}
```