### PR TITLE
Clarify CI comments on git diff step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,8 +106,8 @@ jobs:
       - name: Generate root CA certs
         run: ./scripts/docker_run ./scripts/generate_root_ca_certs
 
-      # Check whether any of the previous steps resulted in file diffs that were not checked in or
-      # ignored by git.
+        # Ensure that the previous steps did not modify our source-code and that
+        # relevant build artifacts are ignored by git.
       - name: Git check diff
         run: ./scripts/docker_run ./scripts/git_check_diff
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,8 +46,8 @@ steps:
     entrypoint: 'bash'
     args: ['./scripts/generate_root_ca_certs']
 
-  # Check whether any of the previous steps resulted in file diffs that were not checked in or
-  # ignored by git.
+  # Ensure that the previous steps did not modify our source-code and that
+  # relevant build artifacts are ignored by git.
   - name: 'gcr.io/oak-ci/oak:latest'
     id: git_check_diff
     waitFor: ['git_init', 'runner_ci', 'generate_root_ca_certs']


### PR DESCRIPTION
See #2435 for context. This aligns the comments with what the code does, and also what we want it too.