### PR TITLE
Unify creating a BoxedExentsionFactory

### DIFF
--- a/oak_functions/examples/fuzzable/module/src/tests.rs
+++ b/oak_functions/examples/fuzzable/module/src/tests.rs
@@ -56,7 +56,8 @@ async fn test_server() {
     let logger = Logger::for_test();
 
     let lookup_data = Arc::new(LookupData::new_empty(None, logger.clone()));
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
     let metrics_factory = create_metrics_factory();
 
     let tee_certificate = vec![];
@@ -148,8 +149,9 @@ fn create_metrics_factory() -> BoxedExtensionFactory {
         buckets: hashmap! {"count".to_string() => BucketConfig::Count },
     };
 
-    let metrics_factory =
-        PrivateMetricsProxyFactory::new(&metrics_config, Logger::new(log::LevelFilter::Info))
-            .expect("could not create PrivateMetricsProxyFactory");
-    Box::new(metrics_factory)
+    PrivateMetricsProxyFactory::new_boxed_extension_factory(
+        &metrics_config,
+        Logger::new(log::LevelFilter::Info),
+    )
+    .expect("could not create PrivateMetricsProxyFactory")
 }

--- a/oak_functions/examples/fuzzable/module/src/tests.rs
+++ b/oak_functions/examples/fuzzable/module/src/tests.rs
@@ -56,8 +56,8 @@ async fn test_server() {
     let logger = Logger::for_test();
 
     let lookup_data = Arc::new(LookupData::new_empty(None, logger.clone()));
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
     let metrics_factory = create_metrics_factory();
 
     let tee_certificate = vec![];

--- a/oak_functions/examples/key_value_lookup/module/src/tests.rs
+++ b/oak_functions/examples/key_value_lookup/module/src/tests.rs
@@ -76,8 +76,8 @@ async fn test_server() {
         logger.clone(),
     ));
     lookup_data.refresh().await.unwrap();
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
 
     let wasm_handler =
         create_wasm_handler(&wasm_module_bytes, vec![lookup_factory], logger.clone())
@@ -137,8 +137,8 @@ fn bench_wasm_handler(bencher: &mut Bencher) {
     };
 
     let lookup_data = Arc::new(LookupData::for_test(entries));
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&wasm_module_bytes, vec![lookup_factory], logger)
         .expect("Couldn't create the server");

--- a/oak_functions/examples/key_value_lookup/module/src/tests.rs
+++ b/oak_functions/examples/key_value_lookup/module/src/tests.rs
@@ -76,7 +76,8 @@ async fn test_server() {
         logger.clone(),
     ));
     lookup_data.refresh().await.unwrap();
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
 
     let wasm_handler =
         create_wasm_handler(&wasm_module_bytes, vec![lookup_factory], logger.clone())
@@ -136,7 +137,8 @@ fn bench_wasm_handler(bencher: &mut Bencher) {
     };
 
     let lookup_data = Arc::new(LookupData::for_test(entries));
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
 
     let wasm_handler = WasmHandler::create(&wasm_module_bytes, vec![lookup_factory], logger)
         .expect("Couldn't create the server");

--- a/oak_functions/examples/weather_lookup/module/src/tests.rs
+++ b/oak_functions/examples/weather_lookup/module/src/tests.rs
@@ -95,8 +95,8 @@ async fn test_server() {
     ));
     lookup_data.refresh().await.unwrap();
 
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
 
     let wasm_handler =
         create_wasm_handler(&wasm_module_bytes, vec![lookup_factory], logger.clone())
@@ -208,8 +208,8 @@ fn bench_wasm_handler(bencher: &mut Bencher) {
 
     let lookup_data = Arc::new(LookupData::for_test(entries));
     let logger = Logger::for_test();
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
     let wasm_handler = WasmHandler::create(&wasm_module_bytes, vec![lookup_factory], logger)
         .expect("Couldn't create the server");
 

--- a/oak_functions/examples/weather_lookup/module/src/tests.rs
+++ b/oak_functions/examples/weather_lookup/module/src/tests.rs
@@ -95,7 +95,8 @@ async fn test_server() {
     ));
     lookup_data.refresh().await.unwrap();
 
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
 
     let wasm_handler =
         create_wasm_handler(&wasm_module_bytes, vec![lookup_factory], logger.clone())
@@ -207,7 +208,8 @@ fn bench_wasm_handler(bencher: &mut Bencher) {
 
     let lookup_data = Arc::new(LookupData::for_test(entries));
     let logger = Logger::for_test();
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
     let wasm_handler = WasmHandler::create(&wasm_module_bytes, vec![lookup_factory], logger)
         .expect("Couldn't create the server");
 

--- a/oak_functions/loader/benches/lookup.rs
+++ b/oak_functions/loader/benches/lookup.rs
@@ -132,8 +132,8 @@ fn run_benchmarks_with_input<M: Measurement>(
 ) {
     let lookup_data = Arc::new(LookupData::for_test(lookup_entries));
     let logger = Logger::for_test();
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
 
     let wasm_handler = WasmHandler::create(wasm_module_bytes, vec![lookup_factory], logger)
         .expect("Couldn't create the server");

--- a/oak_functions/loader/benches/lookup.rs
+++ b/oak_functions/loader/benches/lookup.rs
@@ -132,7 +132,8 @@ fn run_benchmarks_with_input<M: Measurement>(
 ) {
     let lookup_data = Arc::new(LookupData::for_test(lookup_entries));
     let logger = Logger::for_test();
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
 
     let wasm_handler = WasmHandler::create(wasm_module_bytes, vec![lookup_factory], logger)
         .expect("Couldn't create the server");

--- a/oak_functions/loader/fuzz/fuzz_targets/wasm_invoke.rs
+++ b/oak_functions/loader/fuzz/fuzz_targets/wasm_invoke.rs
@@ -116,8 +116,8 @@ fuzz_target!(|instruction_list: Vec<ArbitraryInstruction>| {
 
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(entries));
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
     let metrics_factory = create_metrics_factory();
 
     let wasm_handler = WasmHandler::create(

--- a/oak_functions/loader/fuzz/fuzz_targets/wasm_invoke.rs
+++ b/oak_functions/loader/fuzz/fuzz_targets/wasm_invoke.rs
@@ -116,7 +116,8 @@ fuzz_target!(|instruction_list: Vec<ArbitraryInstruction>| {
 
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(entries));
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
     let metrics_factory = create_metrics_factory();
 
     let wasm_handler = WasmHandler::create(
@@ -174,7 +175,6 @@ fn create_metrics_factory() -> BoxedExtensionFactory {
         buckets: hashmap! {"count".to_string() => BucketConfig::Count },
     };
 
-    let metrics_factory = PrivateMetricsProxyFactory::new(&metrics_config, Logger::for_test())
-        .expect("could not create PrivateMetricsProxyFactory");
-    Box::new(metrics_factory)
+    PrivateMetricsProxyFactory::new_boxed_extension_factory(&metrics_config, Logger::for_test())
+        .expect("could not create PrivateMetricsProxyFactory")
 }

--- a/oak_functions/loader/src/lookup.rs
+++ b/oak_functions/loader/src/lookup.rs
@@ -41,20 +41,15 @@ pub struct LookupFactory {
 }
 
 impl LookupFactory {
-    fn new(lookup_data: Arc<LookupData>, logger: Logger) -> anyhow::Result<Self> {
-        Ok(LookupFactory {
-            lookup_data,
-            logger,
-        })
-    }
-    /// Create and return a lookup factory.
-    pub fn create(
+    pub fn new_boxed_extension_factory(
         lookup_data: Arc<LookupData>,
         logger: Logger,
     ) -> anyhow::Result<BoxedExtensionFactory> {
-        let lookup_factory = LookupFactory::new(lookup_data, logger)?;
-        let lookup_factory: BoxedExtensionFactory = Box::new(lookup_factory);
-        Ok(lookup_factory)
+        let lookup_factory = Self {
+            lookup_data,
+            logger,
+        };
+        Ok(Box::new(lookup_factory))
     }
 }
 

--- a/oak_functions/loader/src/metrics.rs
+++ b/oak_functions/loader/src/metrics.rs
@@ -17,8 +17,8 @@
 use crate::{
     logger::Logger,
     server::{
-        AbiPointer, AbiPointerOffset, BoxedExtension, ExtensionFactory, OakApiNativeExtension,
-        WasmState, ABI_USIZE,
+        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, ExtensionFactory,
+        OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
 use oak_functions_abi::proto::OakStatus;
@@ -238,13 +238,17 @@ pub struct PrivateMetricsProxyFactory {
 }
 
 impl PrivateMetricsProxyFactory {
-    pub fn new(config: &PrivateMetricsConfig, logger: Logger) -> anyhow::Result<Self> {
+    pub fn new_boxed_extension_factory(
+        config: &PrivateMetricsConfig,
+        logger: Logger,
+    ) -> anyhow::Result<BoxedExtensionFactory> {
+        config.validate()?;
         let aggregator = PrivateMetricsAggregator::new(config)?;
-
-        Ok(Self {
+        let metrics_factory = Self {
             aggregator: Arc::new(Mutex::new(aggregator)),
             logger,
-        })
+        };
+        Ok(Box::new(metrics_factory))
     }
 }
 

--- a/oak_functions/loader/src/tests.rs
+++ b/oak_functions/loader/src/tests.rs
@@ -148,7 +148,8 @@ where
     let tee_certificate = vec![];
 
     let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data.clone(), logger.clone()).unwrap();
+        LookupFactory::new_boxed_extension_factory(lookup_data.clone(), logger.clone())
+            .expect("could not create LookupFactory");
     let wasm_handler =
         create_wasm_handler(&wasm_module_bytes, vec![lookup_factory], logger.clone())
             .expect("could not create wasm_handler");

--- a/oak_functions/loader/src/tests.rs
+++ b/oak_functions/loader/src/tests.rs
@@ -147,7 +147,8 @@ where
     lookup_data.refresh().await.unwrap();
     let tee_certificate = vec![];
 
-    let lookup_factory = LookupFactory::create(lookup_data.clone(), logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data.clone(), logger.clone()).unwrap();
     let wasm_handler =
         create_wasm_handler(&wasm_module_bytes, vec![lookup_factory], logger.clone())
             .expect("could not create wasm_handler");

--- a/oak_functions/loader/src/tf.rs
+++ b/oak_functions/loader/src/tf.rs
@@ -17,8 +17,8 @@
 use crate::{
     logger::Logger,
     server::{
-        AbiPointer, AbiPointerOffset, BoxedExtension, ExtensionFactory, OakApiNativeExtension,
-        WasmState, ABI_USIZE,
+        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, ExtensionFactory,
+        OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
 use anyhow::Context;
@@ -212,7 +212,11 @@ pub struct TensorFlowFactory {
 impl TensorFlowFactory {
     /// Creates an instance of TensorFlowFactory, by loading the model from the given byte array and
     /// optimizing it using the given shape.
-    pub fn new(bytes: Bytes, shape: Vec<u8>, logger: Logger) -> anyhow::Result<Self> {
+    pub fn new_boxed_extension_factory(
+        bytes: Bytes,
+        shape: Vec<u8>,
+        logger: Logger,
+    ) -> anyhow::Result<BoxedExtensionFactory> {
         use bytes::Buf;
 
         let dim = shape
@@ -233,11 +237,13 @@ impl TensorFlowFactory {
             // make the model runnable and fix its inputs and outputs
             .into_runnable()?;
 
-        Ok(TensorFlowFactory {
+        let tf_model_factory = Self {
             model: Arc::new(model),
             shape,
             logger,
-        })
+        };
+
+        Ok(Box::new(tf_model_factory))
     }
 }
 

--- a/oak_functions/sdk/oak_functions/tests/integration_test.rs
+++ b/oak_functions/sdk/oak_functions/tests/integration_test.rs
@@ -38,8 +38,8 @@ lazy_static! {
 async fn test_read_write() {
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(hashmap! {}));
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");
@@ -55,8 +55,8 @@ async fn test_read_write() {
 async fn test_double_read() {
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(hashmap! {}));
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");
@@ -72,8 +72,8 @@ async fn test_double_read() {
 async fn test_double_write() {
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(hashmap! {}));
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");
@@ -89,8 +89,8 @@ async fn test_double_write() {
 async fn test_write_log() {
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(hashmap! {}));
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");
@@ -110,8 +110,8 @@ async fn test_storage_get_item() {
 
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(entries));
-    let lookup_factory =
-        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
+    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
+        .expect("could not create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");

--- a/oak_functions/sdk/oak_functions/tests/integration_test.rs
+++ b/oak_functions/sdk/oak_functions/tests/integration_test.rs
@@ -38,7 +38,8 @@ lazy_static! {
 async fn test_read_write() {
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(hashmap! {}));
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");
@@ -54,7 +55,8 @@ async fn test_read_write() {
 async fn test_double_read() {
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(hashmap! {}));
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");
@@ -70,7 +72,8 @@ async fn test_double_read() {
 async fn test_double_write() {
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(hashmap! {}));
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");
@@ -86,7 +89,8 @@ async fn test_double_write() {
 async fn test_write_log() {
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(hashmap! {}));
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");
@@ -106,7 +110,8 @@ async fn test_storage_get_item() {
 
     let logger = Logger::for_test();
     let lookup_data = Arc::new(LookupData::for_test(entries));
-    let lookup_factory = LookupFactory::create(lookup_data, logger.clone()).unwrap();
+    let lookup_factory =
+        LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone()).unwrap();
 
     let wasm_handler = WasmHandler::create(&WASM_MODULE_BYTES, vec![lookup_factory], logger)
         .expect("Could not instantiate WasmHandler.");


### PR DESCRIPTION
Unify creating a BoxedExentsionFactory with `new_boxed_extension_factory`

For LookupFactory:
* merge `new` and `create` to `new_boxed_extension_factory`

For PrivateMetricsFactory:
* refactor `create_metics_proxy_factory` and `new` to `new_boxed_extension_factory` by
  * inlining `validate` and boxing in `new_boxed_extension_factory`
  * checking `config` is some before creating the factory
  
For TensorFlowFactory:
* refactor `create_tensorflow_factory` and `new` to `new_boxed_extension_factory` by
  * inlining boxing in `new_boxed_extension_factory`
  * checking `config` is some and async reading the model before creating the factory