### PR TITLE
Seperate steps in `run_cargo_tests`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,8 @@ jobs:
           - run-functions-examples --application-variant=rust
           - run-cargo-fuzz --build-deps -- -max_total_time=2
           - completion
+          - run-cargo-clippy
+
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2

--- a/.runner_bash_completion
+++ b/.runner_bash_completion
@@ -40,6 +40,9 @@ _runner() {
             run-cargo-clean)
                 cmd+="__run__cargo__clean"
                 ;;
+            run-cargo-clippy)
+                cmd+="__run__cargo__clippy"
+                ;;
             run-cargo-deny)
                 cmd+="__run__cargo__deny"
                 ;;
@@ -74,7 +77,7 @@ _runner() {
 
     case "${cmd}" in
         runner)
-            opts=" -h -V  --dry-run --commands --logs --keep-going --help --version   run-examples run-functions-examples build-functions-example build-server build-functions-server format check-format run-tests run-cargo-tests run-bazel-tests run-tests-tsan run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
+            opts=" -h -V  --dry-run --commands --logs --keep-going --help --version   run-examples run-functions-examples build-functions-example build-server build-functions-server format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-tests-tsan run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -301,6 +304,25 @@ _runner() {
             fi
             case "${prev}" in
                 
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        runner__run__cargo__clippy)
+            opts=" -h -V  --help --version --commits  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --commits)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -50,6 +50,7 @@ pub enum Command {
     Format(Commits),
     CheckFormat(Commits),
     RunTests,
+    RunCargoClippy(Commits),
     RunCargoTests(RunTestsOpt),
     RunBazelTests,
     RunTestsTsan,


### PR DESCRIPTION
Add seperate command `run_cargo_clippy`. Now we run clippy only on directly modified crates (as opposed to all affected crates).