### PR TITLE
Experimenting with running partial CI 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # The runner comes with all this software pre-installed: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
       # so we delete some large packages to make sure we have more space available.

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -651,13 +651,13 @@ pub fn format_bytes(v: &[u8]) -> String {
         .unwrap_or_else(|_| format!("{:?}", v))
 }
 
-// The Endpoint of a birectional channel. Sender and Receiver are exposed.
+// The Endpoint of a bidirectional channel. Sender and Receiver are exposed.
 pub struct Endpoint {
     pub sender: Sender<AbiMessage>,
     pub receiver: Receiver<AbiMessage>,
 }
 
-/// Create a channel with two symmetrial endpoints. The [`AbiMessage`] sent from one [`Endpoint`]
+/// Create a channel with two symmetrical endpoints. The [`AbiMessage`] sent from one [`Endpoint`]
 /// are received at the other [`Endpoint`] and vice versa by connecting two unidirectional
 /// [tokio::mpsc channels](https://docs.rs/tokio/0.1.16/tokio/sync/mpsc/index.html).
 ///

--- a/runner/src/diffs.rs
+++ b/runner/src/diffs.rs
@@ -49,7 +49,7 @@ impl ModifiedContent {
 // If it is zero or negative, only the last commit will be considered for finding the modified
 // files. If `commits.commits` is not present, all files will be considered.
 pub fn modified_files(commits: &Commits) -> ModifiedContent {
-    let files = commits.commits.map(|commits| {
+    let files = Some(commits.commits).map(|commits| {
         let vec = Command::new("git")
             .args(&[
                 "diff",

--- a/runner/src/internal.rs
+++ b/runner/src/internal.rs
@@ -145,10 +145,20 @@ pub struct RunFunctionsExamples {
     pub commits: Commits,
 }
 
-#[derive(StructOpt, Clone, Debug, Default)]
+#[derive(StructOpt, Clone, Debug)]
 pub struct Commits {
-    #[structopt(long, help = "number of past commits to include in the diff")]
-    pub commits: Option<u8>,
+    #[structopt(
+        long,
+        help = "number of past commits to include in the diff",
+        default_value = "1"
+    )]
+    pub commits: u8,
+}
+
+impl Default for Commits {
+    fn default() -> Self {
+        Self { commits: 1 }
+    }
 }
 
 #[derive(StructOpt, Clone, Debug)]


### PR DESCRIPTION
Note that this is just a hack, and therefore several steps are failing (probably because the required files are not built). This PR is just an experiment to see how much speedup we can get by only running the CI steps that are relevant to the change. The `run-cargo-test` which is the slowest step, usually taking over an hour, has completed in about 13 mins. 

Ref #2455 