### PR TITLE
Build the base server variant for the reproducibility index

### DIFF
--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -51,7 +51,7 @@ jobs:
       # Build artifacts that are supposed to be reproducible.
       - name: Build Rust server
         run: |
-          ./scripts/docker_run ./scripts/runner build-server --server-variant=unsafe
+          ./scripts/docker_run ./scripts/runner build-server
 
       - name: Build examples
         run: |
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build Functions server
         run: |
-          ./scripts/docker_run ./scripts/runner build-functions-server --server-variant=unsafe
+          ./scripts/docker_run ./scripts/runner build-functions-server
 
       # Generate an index of the hashes of the reproducible artifacts.
       - name: Generate Reproducibility Index


### PR DESCRIPTION
This change was suggested in my debugging reproducibility thread: https://github.com/project-oak/oak/pull/2438#issuecomment-998160165. It also seems sensible, given that the unsafe flag is intended for experimental purposes