### PR TITLE
Enable sccache

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:846d1de92e393680e6e14b8757a528e874912d5cf81bf3c9e6e1b2c0456d27f5",
+  "image": "sha256:ae870d0f6bed7316f46878c09e5b22f6e504ccc05c052e802630da7165c261bb",
   "extensions": [
     "bazelbuild.vscode-bazel",
     "bodil.prettier-toml",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           - build-server --server-variant=experimental
           - build-functions-server --server-variant=unsafe
           - build-functions-server --server-variant=base
-          - run-cargo-tests --cleanup
+          - run-cargo-tests
           - run-bazel-tests
           - run-tests-tsan
           - run-examples --application-variant=rust
@@ -104,6 +104,9 @@ jobs:
         run: |
           ./scripts/docker_run ./scripts/runner --commands ${{ matrix.cmd }}
           df --human-readable
+
+      - name: Print logs
+        run: cat ./sccache.log
 
       - name: Generate root CA certs
         run: ./scripts/docker_run ./scripts/generate_root_ca_certs

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ Makefile.conf
 
 # TensorFlow model server binary
 tensorflow_model_server
+
+/sccache.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -302,16 +302,6 @@ RUN mkdir --parents ${sccache_dir} \
   && curl --location ${sccache_location} | tar --extract --gzip --directory=${sccache_dir} --strip-components=1 \
   && chmod +x ${sccache_dir}/sccache
 
-ENV SCCACHE_GCS_BUCKET sccache-1
-ENV SCCACHE_GCS_KEY_PATH /workspace/.oak_remote_cache_key.json
-ENV SCCACHE_GCS_RW_MODE READ_WRITE
-
-# TODO(#2014): Re-enable sccache once runner runs backend binaries directly rather than using `cargo run`.
-# ENV RUSTC_WRAPPER sccache
-
-# Disable cargo incremental compilation, as it conflicts with sccache: https://github.com/mozilla/sccache#rust
-ENV CARGO_INCREMENTAL false
-
 # We use the `docker` user in order to maintain library paths on different
 # machines and to make Wasm modules reproducible.
 #
@@ -321,7 +311,7 @@ ENV CARGO_INCREMENTAL false
 RUN useradd --shell=/bin/bash --create-home --user-group docker
 
 # To make the scripts available to call from everywhere.
-ENV PATH "/workspace/scripts:${PATH}" 
+ENV PATH "/workspace/scripts:${PATH}"
 
 # Add sourcing of runner_bash_completion file to .bashrc
 RUN echo -e "\n#activate runner auto-complete\nif [ -f /workspace/.runner_bash_completion ]; then\n  source /workspace/.runner_bash_completion \nfi" >> /home/docker/.bashrc

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -681,7 +681,7 @@ fn run_cargo_fmt(mode: FormatMode, modified_crates: &ModifiedContent) -> Step {
     }
 }
 
-fn featues_excl_introspection_client(entry: &str) -> &str {
+fn features_excl_introspection_client(entry: &str) -> &str {
     // Manually exclude `oak-introspection-client` for `oak_loader` and `oak_runtime` to
     // avoid compile time errors.
     if entry.contains("oak_loader") {
@@ -709,7 +709,7 @@ fn run_cargo_test(opt: &RunTestsOpt, all_affected_crates: &ModifiedContent) -> S
                         &[
                             "test",
                             // Compile and test for all features
-                            featues_excl_introspection_client(&entry),
+                            features_excl_introspection_client(&entry),
                             &format!("--manifest-path={}", &entry),
                         ],
                     ),
@@ -800,7 +800,7 @@ fn run_cargo_clippy(commits: &Commits) -> Step {
                     &[
                         "clippy",
                         "--all-targets",
-                        featues_excl_introspection_client(&entry),
+                        features_excl_introspection_client(&entry),
                         &format!("--manifest-path={}", &entry),
                         "--",
                         "--deny=warnings",

--- a/scripts/common
+++ b/scripts/common
@@ -20,10 +20,10 @@ readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak:latest'
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:846d1de92e393680e6e14b8757a528e874912d5cf81bf3c9e6e1b2c0456d27f5'
+readonly DOCKER_IMAGE_ID='sha256:ae870d0f6bed7316f46878c09e5b22f6e504ccc05c052e802630da7165c261bb'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:f0a8d32d127ebd4b2ca1cec37fa00d6d911723880fb23498233238013fab2386'
+readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:c08a8fc5f45e9db52b42a28324424143f70f61608689ccc37b774f4a0570d655'
 
 readonly SERVER_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-server'
 

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -46,11 +46,32 @@ docker_run_flags=(
   # To do that, we map the socket from the host and add the right group
   '--volume=/var/run/docker.sock:/var/run/docker.sock'
   "--group-add=$HOST_DOCKER_GID"
+
+  # sccache flags.
+  '--env=RUSTC_WRAPPER=sccache'
+  # Disable cargo incremental compilation, as it conflicts with sccache: https://github.com/mozilla/sccache#rust
+  '--env=CARGO_INCREMENTAL=false'
+  '--env=SCCACHE_GCS_BUCKET=sccache-1'
+  # Enable logging for sccache. See https://github.com/mozilla/sccache#debugging
+  '--env=SCCACHE_ERROR_LOG=/workspace/sccache.log'
+  '--env=SCCACHE_LOG=info'
 )
 
 # Some CI systems (GitHub actions) do not run with an interactive TTY attached.
 if [[ -z "${CI:-}" ]]; then
-  docker_run_flags+=('--interactive')
+  # Local-only flags.
+  docker_run_flags+=(
+    '--interactive'
+    '--env=SCCACHE_GCS_RW_MODE=READ_WRITE'
+    '--env=SCCACHE_GCS_KEY_PATH=/workspace/.oak_remote_cache_key.json'
+  )
+else
+  # CI-only flags.
+  docker_run_flags+=(
+    # We do not have support for passing in a remote cache key, so we need to disable writing to the
+    # remote cache in CI.
+    '--env=SCCACHE_GCS_RW_MODE=READ_ONLY'
+  )
 fi
 
 # Create a new user with a fixed name but with the same uid and gid as the host user, and use that


### PR DESCRIPTION
- remove `--cleanup` flag from `run-cargo-test` (it does not seem to be
necessary any more, perhaps there is more space available on the
machines now)
- move sccache related env variables to the docker_run script, so that
changing them does not require rebuilding the docker image, and also so
that they may be set differently for local vs CI
- add a step to print out sccache logs in CI
- fix a typo in Runner
