### PR TITLE
Update tract-tensorflow to finalize reproducibility fix

### DIFF
--- a/oak_functions/Cargo.lock
+++ b/oak_functions/Cargo.lock
@@ -2832,7 +2832,7 @@ dependencies = [
 [[package]]
 name = "tract-core"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
+source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "tract-data"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
+source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
 dependencies = [
  "anyhow",
  "educe",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "tract-hir"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
+source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
 dependencies = [
  "derive-new",
  "educe",
@@ -2938,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "tract-linalg"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
+source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
 dependencies = [
  "cc",
  "derive-new",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "tract-nnef"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
+source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "tract-pulse"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
+source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
 dependencies = [
  "downcast-rs",
  "lazy_static",
@@ -3021,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "tract-pulse-opl"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
+source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
 dependencies = [
  "downcast-rs",
  "lazy_static",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "tract-tensorflow"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
+source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
 dependencies = [
  "bytes",
  "derive-new",

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -51,7 +51,7 @@ tonic = "*"
 # Provide cargo with version 0.15.9-pre, which includes our reproducibility
 # patch: https://github.com/sonos/tract/pull/601. Once 0.15.9 is released, we
 # should revert to loading this crate via crates.io
-tract-tensorflow = { optional = true, git = 'https://github.com/sonos/tract.git', rev = '95afd8d834c1e5ea23bd8b5853476f46d1a219ca' }
+tract-tensorflow = { optional = true, git = 'https://github.com/sonos/tract.git', rev = '124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4' }
 url = "*"
 # Use wasmi in `no_std` mode.
 wasmi = { version = "*", default-features = false, features = ["core"] }


### PR DESCRIPTION
tract-tensorflow had another issue that we patched upstream via https://github.com/sonos/tract/pull/607

The unsafe variant of oak_functions now produces a binary of the same hash across machines, thereby solving the issue reported in b/209639154.

```
> git clean -d --force --force -x && ./scripts/docker_run ./scripts/runner build-functions-server --server-variant=unsafe && sha256sum ./oak_functions/loader/bin/oak_functions_loader

a296d50bdb301d8b7a2421c0d91fabb100bce4ec647becd93a31f4d23b8959e7  ./oak_functions/loader/bin/oak_functions_loader
```