### PR TITLE
Use cargo patch for tract-tensorflow as it is more idiomatic and selects the newest version

### DIFF
--- a/oak_functions/Cargo.lock
+++ b/oak_functions/Cargo.lock
@@ -1309,7 +1309,7 @@ dependencies = [
  "oak_functions_client",
  "prost 0.9.0",
  "tokio",
- "tract-tensorflow 0.15.4",
+ "tract-tensorflow",
 ]
 
 [[package]]
@@ -1541,7 +1541,7 @@ dependencies = [
  "tokio",
  "toml",
  "tonic",
- "tract-tensorflow 0.15.9-pre",
+ "tract-tensorflow",
  "url",
  "wasmi",
 ]
@@ -2807,32 +2807,8 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd150b9a5116a73b2d765ddf5ae8c0dcfa857733b6c195f32555fb10910ac8b6"
-dependencies = [
- "anyhow",
- "bit-set",
- "derive-new",
- "downcast-rs",
- "dyn-clone",
- "educe",
- "half",
- "lazy_static",
- "log",
- "maplit",
- "ndarray",
- "num-integer",
- "num-traits 0.2.14",
- "smallvec",
- "tract-data 0.15.4",
- "tract-linalg 0.15.4",
-]
-
-[[package]]
-name = "tract-core"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
+source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -2847,33 +2823,14 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.14",
  "smallvec",
- "tract-data 0.15.9-pre",
- "tract-linalg 0.15.9-pre",
-]
-
-[[package]]
-name = "tract-data"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da25dc8a11bdc829199b1bb776b7ad8a6e8b1ad4ad99e23baa93300ea8b9df0"
-dependencies = [
- "anyhow",
- "educe",
- "half",
- "itertools",
- "lazy_static",
- "maplit",
- "ndarray",
- "num-complex",
- "num-integer",
- "num-traits 0.2.14",
- "smallvec",
+ "tract-data",
+ "tract-linalg",
 ]
 
 [[package]]
 name = "tract-data"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
+source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
 dependencies = [
  "anyhow",
  "educe",
@@ -2890,55 +2847,19 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2387f51dd6dc030fa5d5e0a3773e6b1910a8aaae2473afdd0c6df971338b8b"
-dependencies = [
- "derive-new",
- "educe",
- "log",
- "tract-core 0.15.4",
-]
-
-[[package]]
-name = "tract-hir"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
+source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
 dependencies = [
  "derive-new",
  "educe",
  "log",
- "tract-core 0.15.9-pre",
-]
-
-[[package]]
-name = "tract-linalg"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4476dbf28c9f539696b35425fd1a87055c6b19075afc393b135e81e9364a47f"
-dependencies = [
- "cc",
- "derive-new",
- "downcast-rs",
- "dyn-clone",
- "educe",
- "half",
- "lazy_static",
- "libc",
- "liquid",
- "log",
- "num-traits 0.2.14",
- "paste",
- "smallvec",
- "tract-data 0.15.4",
- "unicode-normalization",
- "walkdir",
+ "tract-core",
 ]
 
 [[package]]
 name = "tract-linalg"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
+source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
 dependencies = [
  "cc",
  "derive-new",
@@ -2952,87 +2873,49 @@ dependencies = [
  "num-traits 0.2.14",
  "paste",
  "smallvec",
- "tract-data 0.15.9-pre",
+ "tract-data",
  "unicode-normalization",
  "walkdir",
 ]
 
 [[package]]
 name = "tract-nnef"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f06eaad232718c0a98f8d26a57d8bf18637c17e526fa84e3c899539f9a4a15b"
+version = "0.15.9-pre"
+source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
 dependencies = [
  "byteorder",
  "flate2",
  "log",
  "nom",
  "tar",
- "tract-core 0.15.4",
- "walkdir",
-]
-
-[[package]]
-name = "tract-nnef"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "byteorder",
- "flate2",
- "log",
- "nom",
- "tar",
- "tract-core 0.15.9-pre",
+ "tract-core",
  "walkdir",
 ]
 
 [[package]]
 name = "tract-pulse"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1ef09c866b1595d09eda9be5194cad431299e2bed1d08c30e2a3e1728fc525"
-dependencies = [
- "downcast-rs",
- "lazy_static",
- "tract-pulse-opl 0.15.4",
-]
-
-[[package]]
-name = "tract-pulse"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
+source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
 dependencies = [
  "downcast-rs",
  "lazy_static",
- "tract-pulse-opl 0.15.9-pre",
-]
-
-[[package]]
-name = "tract-pulse-opl"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e3c10e8ee7c2c9bfe60defd9cd39df099fab3f17304ecc006ac84d744888a7"
-dependencies = [
- "downcast-rs",
- "lazy_static",
- "tract-nnef 0.15.4",
+ "tract-pulse-opl",
 ]
 
 [[package]]
 name = "tract-pulse-opl"
 version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
+source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
 dependencies = [
  "downcast-rs",
  "lazy_static",
- "tract-nnef 0.15.9-pre",
+ "tract-nnef",
 ]
 
 [[package]]
 name = "tract-tensorflow"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e588460b9355a6f042e793ada05f90afd4fe9f4472ba1f04130cdb3187867c49"
+version = "0.15.9-pre"
+source = "git+https://github.com/sonos/tract.git?rev=95afd8d834c1e5ea23bd8b5853476f46d1a219ca#95afd8d834c1e5ea23bd8b5853476f46d1a219ca"
 dependencies = [
  "bytes",
  "derive-new",
@@ -3042,25 +2925,8 @@ dependencies = [
  "prost 0.9.0",
  "prost-build 0.9.0",
  "prost-types 0.9.0",
- "tract-hir 0.15.4",
- "tract-pulse 0.15.4",
-]
-
-[[package]]
-name = "tract-tensorflow"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "bytes",
- "derive-new",
- "educe",
- "log",
- "mapr",
- "prost 0.9.0",
- "prost-build 0.9.0",
- "prost-types 0.9.0",
- "tract-hir 0.15.9-pre",
- "tract-pulse 0.15.9-pre",
+ "tract-hir",
+ "tract-pulse",
 ]
 
 [[package]]

--- a/oak_functions/Cargo.toml
+++ b/oak_functions/Cargo.toml
@@ -18,3 +18,10 @@ members = [
   "sdk/oak_functions/tests/module",
   "sdk/test_utils",
 ]
+
+[patch.crates-io]
+# Provide cargo with version 0.15.9-pre, which includes our reproducibility
+# patch: https://github.com/sonos/tract/pull/601. Cargo will ignore this
+# once a later version is available from crates.io and which point this patch
+# should be removed.
+tract-tensorflow = { git = 'https://github.com/sonos/tract.git', rev = '95afd8d834c1e5ea23bd8b5853476f46d1a219ca' }

--- a/oak_functions/examples/mobilenet/client/rust/Cargo.toml
+++ b/oak_functions/examples/mobilenet/client/rust/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "*", features = [
   "sync",
   "rt-multi-thread"
 ] }
-tract-tensorflow = "*"
+tract-tensorflow = { version = ">= 0.15.9-pre" }

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -48,10 +48,7 @@ tokio = { version = "*", features = [
 ] }
 toml = "*"
 tonic = "*"
-# Provide cargo with version 0.15.9-pre, which includes our reproducibility
-# patch: https://github.com/sonos/tract/pull/601. Once 0.15.9 is released, we
-# should revert to loading this crate via crates.io
-tract-tensorflow = { optional = true, git = 'https://github.com/sonos/tract.git', rev = '124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4' }
+tract-tensorflow = { version = ">= 0.15.9-pre", optional = true }
 url = "*"
 # Use wasmi in `no_std` mode.
 wasmi = { version = "*", default-features = false, features = ["core"] }


### PR DESCRIPTION
We previously inlined the source as patching caused other breaking dependency updates, but this is no longer the case. Hence let's use patch.