### PR TITLE
Remove cleanup step in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           - build-server --server-variant=experimental
           - build-functions-server --server-variant=unsafe
           - build-functions-server --server-variant=base
-          - run-cargo-tests --cleanup
+          - run-cargo-tests
           - run-bazel-tests
           - run-tests-tsan
           - run-examples --application-variant=rust
@@ -47,24 +47,6 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
-
-      # The runner comes with all this software pre-installed: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
-      # so we delete some large packages to make sure we have more space available.
-      #
-      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
-      # and https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
-      - name: Free disk space
-        run: |
-          df --human-readable
-          sudo apt-get remove --yes '^dotnet-.*' '^llvm-.*' 'php.*' azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell
-          sudo apt-get autoremove --yes
-          sudo apt clean
-          docker rmi $(docker image ls --all --quiet)
-          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-          rm --recursive --force /usr/local/share/boost
-          sudo swapoff --all
-          sudo rm --force /swapfile
-          df --human-readable
 
       - name: Docker pull
         timeout-minutes: 10


### PR DESCRIPTION
It seems not necessary any more. I guess they increased the disk size of
the machines? We can revert this commit if it becomes a problem again,
but for now it shaves 3 mins from each build.