### PR TITLE
Exclude deps from clippy

### DIFF
--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -802,6 +802,7 @@ fn run_cargo_clippy(commits: &Commits) -> Step {
                         "--all-targets",
                         featues_excl_introspection_client(&entry),
                         &format!("--manifest-path={}", &entry),
+                        "--no-deps",
                         "--",
                         "--deny=warnings",
                     ],


### PR DESCRIPTION
We already run it on all our crates, and there is the risk that it will
start failing because of some dep we don't have control over.