### PR TITLE
Use generic gRPC encapsulation rather than explicit protos in Remote Attestation Proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4494,9 +4494,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
+ "bytes",
  "env_logger 0.9.0",
  "futures",
  "grpc_attestation",
+ "http",
  "log",
  "oak_functions_abi",
  "oak_remote_attestation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4482,6 +4482,7 @@ dependencies = [
  "oak_functions_client",
  "oak_utils",
  "prost 0.8.0",
+ "prost-types 0.8.0",
  "reqwest",
  "structopt",
  "tokio",

--- a/experimental/tf_proxy/client/Cargo.toml
+++ b/experimental/tf_proxy/client/Cargo.toml
@@ -14,6 +14,7 @@ maplit = "*"
 oak_functions_abi = { path = "../../../oak_functions/abi" }
 oak_functions_client = { path = "../../../oak_functions/client/rust" }
 prost = "*"
+prost-types = "*"
 reqwest = "*"
 structopt = "*"
 tokio = { version = "*", features = [

--- a/experimental/tf_proxy/client/build.rs
+++ b/experimental/tf_proxy/client/build.rs
@@ -22,11 +22,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // the import statements of the third party protos.
         "../../../third_party/google",
         &["tensorflow_serving/apis/predict.proto"],
-        CodegenOptions {
-            build_client: false,
-            build_server: false,
-            extern_paths: vec![],
-        },
+        CodegenOptions::default(),
+    )?;
+
+    generate_grpc_code(
+        "../../../",
+        &[
+            "oak_services/proto/grpc_encap.proto",
+            "third_party/google/rpc/code.proto",
+            "third_party/google/rpc/status.proto",
+        ],
+        CodegenOptions::default(),
     )?;
 
     Ok(())

--- a/experimental/tf_proxy/server/Cargo.toml
+++ b/experimental/tf_proxy/server/Cargo.toml
@@ -8,9 +8,11 @@ license = "Apache-2.0"
 [dependencies]
 async-stream = "*"
 anyhow = "*"
+bytes = "*"
 env_logger = "*"
 futures = "*"
 grpc_attestation = { path = "../../../grpc_attestation/" }
+http = "*"
 log = "*"
 oak_functions_abi = { path = "../../../oak_functions/abi" }
 oak_remote_attestation = { path = "../../../remote_attestation/rust/" }

--- a/experimental/tf_proxy/server/build.rs
+++ b/experimental/tf_proxy/server/build.rs
@@ -18,16 +18,13 @@ use oak_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        // We would normally use `../../..` as the `proto_path`, but that would require modifying
-        // the import statements of the third party protos.
-        "../../../third_party/google",
-        &["tensorflow_serving/apis/prediction_service.proto"],
-        CodegenOptions {
-            build_client: true,
-            build_server: false,
-            extern_paths: vec![],
-        },
+        "../../../",
+        &[
+            "oak_services/proto/grpc_encap.proto",
+            "third_party/google/rpc/code.proto",
+            "third_party/google/rpc/status.proto",
+        ],
+        CodegenOptions::default(),
     )?;
-
     Ok(())
 }

--- a/experimental/tf_proxy/server/src/main.rs
+++ b/experimental/tf_proxy/server/src/main.rs
@@ -16,6 +16,19 @@
 
 #![feature(async_closure)]
 
+pub mod proto {
+    pub mod google {
+        pub mod rpc {
+            tonic::include_proto!("google.rpc");
+        }
+    }
+    pub mod oak {
+        pub mod encap {
+            tonic::include_proto!("oak.encap");
+        }
+    }
+}
+
 use crate::grpc::handle_request;
 use anyhow::Context;
 use grpc_attestation::{


### PR DESCRIPTION
The Remote Attestation Proxy instance currently has an explicit dependency on the service/proto definitions of the backend (TensorFlow Serving). To make it more generic and reusable this change moves it to a model where it receives a generic gRPC encapsulation request and just passes the bytes through to the backend.