### PR TITLE
Add UwabiExtension Trait and Testing extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,15 +994,8 @@ dependencies = [
 name = "echo"
 version = "0.1.0"
 dependencies = [
- "http",
- "hyper",
- "maplit",
  "oak_functions",
  "oak_functions_abi",
- "oak_functions_loader",
- "prost 0.9.0",
- "test_utils",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "echo"
+version = "0.1.0"
+dependencies = [
+ "http",
+ "hyper",
+ "maplit",
+ "oak_functions",
+ "oak_functions_abi",
+ "oak_functions_loader",
+ "prost 0.9.0",
+ "test_utils",
+ "tokio",
+]
+
+[[package]]
 name = "ed25519"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
   "oak_functions/abi",
   "oak_functions/client/rust/Cargo.toml",
   "oak_functions/examples/benchmark/module",
+  "oak_functions/examples/echo/module",
   "oak_functions/examples/fuzzable/module",
   "oak_functions/examples/key_value_lookup/module",
   "oak_functions/examples/metrics/client/rust",

--- a/oak_functions/examples/echo/README.md
+++ b/oak_functions/examples/echo/README.md
@@ -1,0 +1,5 @@
+# Oak Functions `echo` example
+
+This example is a small Wasm module for Oak Functions that only echoes the
+request only relying on the exported Abi calls `read_request` and
+`write_response`.

--- a/oak_functions/examples/echo/module/Cargo.toml
+++ b/oak_functions/examples/echo/module/Cargo.toml
@@ -12,16 +12,4 @@ crate-type = ["cdylib", "rlib"]
 oak_functions = { path = "../../../sdk/oak_functions" }
 
 [dev-dependencies]
-oak_functions_loader = { path = "../../../loader" }
 oak_functions_abi = { path = "../../../abi" }
-http = "*"
-hyper = { version = "*", features = ["client", "http2"] }
-maplit = "*"
-prost = "*"
-test_utils = { path = "../../../sdk/test_utils" }
-tokio = { version = "*", features = [
-  "fs",
-  "macros",
-  "sync",
-  "rt-multi-thread"
-] }

--- a/oak_functions/examples/echo/module/Cargo.toml
+++ b/oak_functions/examples/echo/module/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "echo"
+version = "0.1.0"
+authors = ["Maria Schett <mschett@google.com>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+oak_functions = { path = "../../../sdk/oak_functions" }
+
+[dev-dependencies]
+oak_functions_loader = { path = "../../../loader" }
+oak_functions_abi = { path = "../../../abi" }
+http = "*"
+hyper = { version = "*", features = ["client", "http2"] }
+maplit = "*"
+prost = "*"
+test_utils = { path = "../../../sdk/test_utils" }
+tokio = { version = "*", features = [
+  "fs",
+  "macros",
+  "sync",
+  "rt-multi-thread"
+] }

--- a/oak_functions/examples/echo/module/src/lib.rs
+++ b/oak_functions/examples/echo/module/src/lib.rs
@@ -1,0 +1,24 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Oak Functions echo example.
+
+#[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn main() {
+    let request = oak_functions::read_request().expect("Couldn't read request body.");
+    let response = request;
+    oak_functions::write_response(&response).expect("Couldn't write response body.");
+}

--- a/oak_functions/loader/src/lookup.rs
+++ b/oak_functions/loader/src/lookup.rs
@@ -19,7 +19,7 @@ use crate::{
     lookup_data::LookupData,
     server::{
         format_bytes, AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory,
-        Extension, ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
+        ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
 use log::Level;
@@ -59,7 +59,7 @@ impl ExtensionFactory for LookupFactory {
             lookup_data: self.lookup_data.clone(),
             logger: self.logger.clone(),
         };
-        Ok(Extension::Native(Box::new(extension)))
+        Ok(BoxedExtension::Native(Box::new(extension)))
     }
 }
 

--- a/oak_functions/loader/src/lookup.rs
+++ b/oak_functions/loader/src/lookup.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use wasmi::ValueType;
 
 // Host function name for invoking lookup in lookup data.
-pub const LOOKUP_ABI_FUNCTION_NAME: &str = "storage_get_item";
+const LOOKUP_ABI_FUNCTION_NAME: &str = "storage_get_item";
 
 pub struct LookupExtension {
     lookup_data: Arc<LookupData>,

--- a/oak_functions/loader/src/lookup.rs
+++ b/oak_functions/loader/src/lookup.rs
@@ -19,7 +19,7 @@ use crate::{
     lookup_data::LookupData,
     server::{
         format_bytes, AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory,
-        ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
+        Extension::Native, ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
 use log::Level;
@@ -59,7 +59,7 @@ impl ExtensionFactory for LookupFactory {
             lookup_data: self.lookup_data.clone(),
             logger: self.logger.clone(),
         };
-        Ok(Box::new(extension))
+        Ok(Native(Box::new(extension)))
     }
 }
 

--- a/oak_functions/loader/src/lookup.rs
+++ b/oak_functions/loader/src/lookup.rs
@@ -19,7 +19,7 @@ use crate::{
     lookup_data::LookupData,
     server::{
         format_bytes, AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory,
-        Extension::Native, ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
+        Extension, ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
 use log::Level;
@@ -59,7 +59,7 @@ impl ExtensionFactory for LookupFactory {
             lookup_data: self.lookup_data.clone(),
             logger: self.logger.clone(),
         };
-        Ok(Native(Box::new(extension)))
+        Ok(Extension::Native(Box::new(extension)))
     }
 }
 

--- a/oak_functions/loader/src/metrics.rs
+++ b/oak_functions/loader/src/metrics.rs
@@ -17,7 +17,7 @@
 use crate::{
     logger::Logger,
     server::{
-        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, Extension::Native,
+        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, Extension,
         ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
@@ -259,7 +259,7 @@ impl ExtensionFactory for PrivateMetricsProxyFactory {
             metrics_proxy: Some(metrics_proxy),
             logger: self.logger.clone(),
         };
-        Ok(Native(Box::new(extension)))
+        Ok(Extension::Native(Box::new(extension)))
     }
 }
 

--- a/oak_functions/loader/src/metrics.rs
+++ b/oak_functions/loader/src/metrics.rs
@@ -17,8 +17,8 @@
 use crate::{
     logger::Logger,
     server::{
-        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, Extension,
-        ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
+        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, ExtensionFactory,
+        OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
 use oak_functions_abi::proto::OakStatus;
@@ -259,7 +259,7 @@ impl ExtensionFactory for PrivateMetricsProxyFactory {
             metrics_proxy: Some(metrics_proxy),
             logger: self.logger.clone(),
         };
-        Ok(Extension::Native(Box::new(extension)))
+        Ok(BoxedExtension::Native(Box::new(extension)))
     }
 }
 

--- a/oak_functions/loader/src/metrics.rs
+++ b/oak_functions/loader/src/metrics.rs
@@ -17,8 +17,8 @@
 use crate::{
     logger::Logger,
     server::{
-        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, ExtensionFactory,
-        OakApiNativeExtension, WasmState, ABI_USIZE,
+        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, Extension::Native,
+        ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
 use oak_functions_abi::proto::OakStatus;
@@ -259,7 +259,7 @@ impl ExtensionFactory for PrivateMetricsProxyFactory {
             metrics_proxy: Some(metrics_proxy),
             logger: self.logger.clone(),
         };
-        Ok(Box::new(extension))
+        Ok(Native(Box::new(extension)))
     }
 }
 

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -157,7 +157,7 @@ pub enum Extension {
 pub type BoxedExtension = Extension;
 pub type BoxedExtensionFactory = Box<dyn ExtensionFactory + Send + Sync>;
 
-/// Trait for implementing an extension which relies on uwabi.
+/// Trait for implementing an extension which relies on UWABI.
 pub trait UwabiExtension {
     /// Get the channel handle to address this extension.
     fn get_channel_handle(&self) -> ChannelHandle;

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -177,7 +177,10 @@ pub struct WasmState {
     extensions_indices: Option<HashMap<usize, BoxedExtension>>,
     /// A mapping of host function names to metadata required for resolving the function.
     extensions_metadata: HashMap<String, (usize, wasmi::Signature)>,
+    /// A mapping from channel handles to the hosted endpoints of channels.
     channel_switchboard: ChannelSwitchboard,
+    /// A mapping from channel handles to the endpoints for the Oak functions runtime.
+    // TODO(#2502) Add extension endpoints to the corresponding endpoint.
     extensions_endpoints: HashMap<ChannelHandle, Endpoint>,
 }
 
@@ -201,6 +204,7 @@ impl WasmState {
         }
     }
 
+    /// Reads the buffer starting at address `buf_ptr` with length `buf_len` from the Wasm memory.
     pub fn read_buffer_from_wasm_memory(
         &self,
         buf_ptr: AbiPointer,
@@ -217,6 +221,8 @@ impl WasmState {
             })
     }
 
+    /// Writes the buffer `source` at the address `dest` of the Wasm memory, if `source` fits in the
+    /// allocated memory.
     pub fn write_buffer_to_wasm_memory(
         &self,
         source: &[u8],
@@ -232,6 +238,7 @@ impl WasmState {
         })
     }
 
+    ///  Writes the u32 `value` at the `address` of the Wasm memory.
     pub fn write_u32_to_wasm_memory(
         &self,
         value: u32,
@@ -248,8 +255,8 @@ impl WasmState {
         })
     }
 
-    // Writes the given `buffer` by allocating `buffer.len()` Wasm memory and writing the address of
-    // the allocated memory to `dest_ptr_ptr` and the length to `dest_len_ptr`.
+    /// Writes the given `buffer` by allocating `buffer.len()` Wasm memory and writing the address
+    /// of the allocated memory to `dest_ptr_ptr` and the length to `dest_len_ptr`.
     pub fn alloc_and_write_buffer_to_wasm_memory(
         &mut self,
         buffer: Vec<u8>,

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -441,7 +441,10 @@ impl wasmi::Externals for WasmState {
                     .expect("no extensions_indices is set");
                 let extension = match extensions_indices.get_mut(&index) {
                     Some(BoxedExtension::Native(extension)) => Box::new(extension),
-                    _ => panic!("Unimplemented function at {}", index),
+                    Some(BoxedExtension::Uwabi(_)) => {
+                        panic!("Invoked Uwabi extension at index {} instead of reading/writing from channel.", index)
+                    }
+                    None => panic!("Unimplemented function at {}", index),
                 };
                 let result = map_host_errors(extension.invoke(self, args)?);
                 self.extensions_indices = Some(extensions_indices);

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -149,6 +149,8 @@ pub trait ExtensionFactory {
     fn create(&self) -> anyhow::Result<BoxedExtension>;
 }
 
+/// A BoxedExtension can either be a `Native extension called by a dedicated ABI function, or a
+/// `Uwabi` extension called by listening to a channel.
 pub enum BoxedExtension {
     Native(Box<dyn OakApiNativeExtension + Send + Sync>),
     Uwabi(Box<dyn UwabiExtension + Send + Sync>),

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -672,7 +672,7 @@ impl WasmHandler {
         let mut extensions_indices = HashMap::new();
         let mut extensions_metadata = HashMap::new();
         // Remove the extension_endpoints map as soon as we extend extensions by functionality for
-        // channels. Until then we use the (unique) ABI_FUNCTION_NAME as keys.
+        // channels. Until then we use the ChannelHandle as keys.
         let mut extensions_endpoints = HashMap::new();
 
         let mut channel_switchboard = ChannelSwitchboard::new();
@@ -720,7 +720,6 @@ impl WasmHandler {
                     native_extension.terminate()?;
                 }
                 Extension::Uwabi(_uwabi_extension) => {
-                    // TODO(mschett) figure out if that ever happens.
                     panic!("Uwabi Extension inserted in extension_indicies.")
                 }
             }
@@ -894,6 +893,7 @@ mod tests {
         }
     }
 
+    #[allow(dead_code)]
     pub struct TestingExtension {
         logger: Logger,
     }
@@ -902,36 +902,6 @@ mod tests {
         fn get_channel_handle(&self) -> oak_functions_abi::proto::ChannelHandle {
             ChannelHandle::Testing
         }
-    }
-
-    fn testing(
-        wasm_state: &mut WasmState,
-        extension: &mut TestingExtension,
-        request_ptr: AbiPointer,
-        request_len: AbiPointerOffset,
-        response_ptr_ptr: AbiPointer,
-        response_len_ptr: AbiPointer,
-    ) -> Result<(), OakStatus> {
-        let request = wasm_state
-            .read_buffer_from_wasm_memory(request_ptr, request_len)
-            .expect("testing(): Unable to read request.");
-
-        // Simply echo request.
-        wasm_state.alloc_and_write_buffer_to_wasm_memory(
-            request.clone(),
-            response_ptr_ptr,
-            response_len_ptr,
-        )?;
-
-        extension.logger.log_sensitive(
-            Level::Debug,
-            &format!(
-                "testing(): Echoed request {} as response",
-                format_bytes(&request)
-            ),
-        );
-
-        Ok(())
     }
 
     #[test]

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -871,11 +871,7 @@ impl ChannelSwitchboard {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        super::{grpc::create_wasm_handler, lookup::LookupFactory, lookup_data::LookupData},
-        *,
-    };
-    use maplit::hashmap;
+    use super::{super::grpc::create_wasm_handler, *};
 
     pub struct TestingFactory {
         logger: Logger,
@@ -1125,22 +1121,13 @@ mod tests {
     fn create_test_wasm_handler() -> WasmHandler {
         let logger = Logger::for_test();
 
-        let lookup_data = Arc::new(LookupData::for_test(hashmap! {}));
-        let lookup_factory =
-            LookupFactory::new_boxed_extension_factory(lookup_data, logger.clone())
-                .expect("Could not create LookupFactory.");
-
         let testing_factory = TestingFactory::new_boxed_extension_factory(logger.clone())
             .expect("Could not create TestingFactory.");
 
-        let wasm_module_bytes = test_utils::create_some_wasm_module_bytes();
+        let wasm_module_bytes = test_utils::create_echo_wasm_module_bytes();
 
-        create_wasm_handler(
-            &wasm_module_bytes,
-            vec![lookup_factory, testing_factory],
-            logger,
-        )
-        .expect("could not create wasm_handler")
+        create_wasm_handler(&wasm_module_bytes, vec![testing_factory], logger)
+            .expect("could not create wasm_handler")
     }
 
     fn create_test_wasm_state() -> WasmState {

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -682,6 +682,7 @@ impl WasmHandler {
         let mut extensions_metadata = HashMap::new();
         // Remove the extension_endpoints map as soon as we extend extensions by functionality for
         // channels. Until then we use the ChannelHandle as keys.
+        // TODO(#2502).
         let mut extensions_endpoints = HashMap::new();
 
         let mut channel_switchboard = ChannelSwitchboard::new();
@@ -724,13 +725,8 @@ impl WasmHandler {
             .expect("no extensions_indices is set in wasm_state")
             .into_values()
         {
-            match extension {
-                BoxedExtension::Native(mut native_extension) => {
-                    native_extension.terminate()?;
-                }
-                BoxedExtension::Uwabi(_uwabi_extension) => {
-                    panic!("Uwabi Extension inserted in extension_indicies.")
-                }
+            if let BoxedExtension::Native(mut native_extension) = extension {
+                native_extension.terminate()?;
             }
         }
         Ok(Response::create(

--- a/oak_functions/loader/src/tests.rs
+++ b/oak_functions/loader/src/tests.rs
@@ -14,18 +14,14 @@
 // limitations under the License.
 //
 
-use log::Level;
 use maplit::hashmap;
-use oak_functions_abi::proto::{ChannelHandle, OakStatus, Response, ServerPolicy, StatusCode};
+use oak_functions_abi::proto::{Response, ServerPolicy, StatusCode};
 use oak_functions_loader::{
     grpc::{create_and_start_grpc_server, create_wasm_handler},
     logger::Logger,
     lookup::LookupFactory,
     lookup_data::{parse_lookup_entries, LookupData, LookupDataAuth, LookupDataSource},
-    server::{
-        apply_policy, format_bytes, AbiPointer, AbiPointerOffset, BoxedExtension,
-        BoxedExtensionFactory, Extension::Uwabi, ExtensionFactory, UwabiExtension, WasmState,
-    },
+    server::{apply_policy, format_bytes},
 };
 use prost::Message;
 use std::{
@@ -439,63 +435,4 @@ fn test_format_bytes() {
     assert_eq!("🚀oak⭐", format_bytes("🚀oak⭐".as_bytes()));
     // Incorrect UTF-8 bytes, as per https://doc.rust-lang.org/std/string/struct.String.html#examples-3.
     assert_eq!("[0, 159, 146, 150]", format_bytes(&[0, 159, 146, 150]));
-}
-
-pub struct TestingFactory {
-    logger: Logger,
-}
-
-impl TestingFactory {
-    pub fn new_boxed_extension_factory(logger: Logger) -> anyhow::Result<BoxedExtensionFactory> {
-        Ok(Box::new(Self { logger }))
-    }
-}
-
-impl ExtensionFactory for TestingFactory {
-    fn create(&self) -> anyhow::Result<BoxedExtension> {
-        let extension = TestingExtension {
-            logger: self.logger.clone(),
-        };
-        Ok(Uwabi(Box::new(extension)))
-    }
-}
-
-pub struct TestingExtension {
-    logger: Logger,
-}
-
-impl UwabiExtension for TestingExtension {
-    fn get_channel_handle(&self) -> oak_functions_abi::proto::ChannelHandle {
-        ChannelHandle::Testing
-    }
-}
-
-fn testing(
-    wasm_state: &mut WasmState,
-    extension: &mut TestingExtension,
-    request_ptr: AbiPointer,
-    request_len: AbiPointerOffset,
-    response_ptr_ptr: AbiPointer,
-    response_len_ptr: AbiPointer,
-) -> Result<(), OakStatus> {
-    let request = wasm_state
-        .read_buffer_from_wasm_memory(request_ptr, request_len)
-        .expect("testing(): Unable to read request.");
-
-    // Simply echo request.
-    wasm_state.alloc_and_write_buffer_to_wasm_memory(
-        request.clone(),
-        response_ptr_ptr,
-        response_len_ptr,
-    )?;
-
-    extension.logger.log_sensitive(
-        Level::Debug,
-        &format!(
-            "testing(): Echoed request {} as response",
-            format_bytes(&request)
-        ),
-    );
-
-    Ok(())
 }

--- a/oak_functions/loader/src/tf.rs
+++ b/oak_functions/loader/src/tf.rs
@@ -17,7 +17,7 @@
 use crate::{
     logger::Logger,
     server::{
-        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, Extension::Native,
+        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, Extension,
         ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
@@ -255,6 +255,6 @@ impl ExtensionFactory for TensorFlowFactory {
             logger: self.logger.clone(),
         };
 
-        Ok(Native(Box::new(model)))
+        Ok(Extension::Native(Box::new(model)))
     }
 }

--- a/oak_functions/loader/src/tf.rs
+++ b/oak_functions/loader/src/tf.rs
@@ -17,8 +17,8 @@
 use crate::{
     logger::Logger,
     server::{
-        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, ExtensionFactory,
-        OakApiNativeExtension, WasmState, ABI_USIZE,
+        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, Extension::Native,
+        ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
 use anyhow::Context;
@@ -255,6 +255,6 @@ impl ExtensionFactory for TensorFlowFactory {
             logger: self.logger.clone(),
         };
 
-        Ok(Box::new(model))
+        Ok(Native(Box::new(model)))
     }
 }

--- a/oak_functions/loader/src/tf.rs
+++ b/oak_functions/loader/src/tf.rs
@@ -17,8 +17,8 @@
 use crate::{
     logger::Logger,
     server::{
-        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, Extension,
-        ExtensionFactory, OakApiNativeExtension, WasmState, ABI_USIZE,
+        AbiPointer, AbiPointerOffset, BoxedExtension, BoxedExtensionFactory, ExtensionFactory,
+        OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
 use anyhow::Context;
@@ -255,6 +255,6 @@ impl ExtensionFactory for TensorFlowFactory {
             logger: self.logger.clone(),
         };
 
-        Ok(Extension::Native(Box::new(model)))
+        Ok(BoxedExtension::Native(Box::new(model)))
     }
 }

--- a/oak_functions/proto/abi.proto
+++ b/oak_functions/proto/abi.proto
@@ -45,6 +45,7 @@ enum ChannelStatus {
 // ChannelHandle to read, write, or wait on the corresponding channel.
 enum ChannelHandle {
   CHANNEL_HANDLE_UNSPECIFIED = 0;
+  TESTING = 1;
   LOOKUP_DATA = 2;
 }
 

--- a/oak_functions/proto/abi.proto
+++ b/oak_functions/proto/abi.proto
@@ -45,7 +45,9 @@ enum ChannelStatus {
 // ChannelHandle to read, write, or wait on the corresponding channel.
 enum ChannelHandle {
   CHANNEL_HANDLE_UNSPECIFIED = 0;
+  // Handle for an extension used for testing Wasm modules.
   TESTING = 1;
+  // Handle for an extension to look up a key in the lookup data.
   LOOKUP_DATA = 2;
 }
 

--- a/oak_functions/sdk/test_utils/src/lib.rs
+++ b/oak_functions/sdk/test_utils/src/lib.rs
@@ -257,12 +257,11 @@ pub fn assert_response_body(response: Response, expected: &str) {
     )
 }
 
-// Create some valid wasm bytecode
-pub fn create_some_wasm_module_bytes() -> Vec<u8> {
+/// Create some valid Wasm bytecode only calling Abi functions `read_request` and `write_request`.
+pub fn create_echo_wasm_module_bytes() -> Vec<u8> {
     let mut manifest_path = std::env::current_dir().unwrap();
     manifest_path.pop();
-    // ramdonly picked one valid wasm module from examples
-    manifest_path.push("examples/key_value_lookup/module/Cargo.toml");
+    manifest_path.push("examples/echo/module/Cargo.toml");
     compile_rust_wasm(manifest_path.to_str().expect("Invalid target dir"), false)
         .expect("Couldn't read Wasm module")
 }


### PR DESCRIPTION
- Define trait for `Uwabi` extensions
- Change `Extensions` to be either a `Native` or `Uwabi` extension
- Define new Testing Extension which implements `Uwabi` extension
- Use Testing Extension instead of Lookup Extension for tests