### PR TITLE
Fix docker parent image by its digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use fixed snapshot of Debian to create a deterministic environment.
 # Snapshot tags can be found at https://hub.docker.com/r/debian/snapshot/tags
-ARG debian_snapshot=buster-20210927
-FROM debian/snapshot:${debian_snapshot}
+ARG debian_snapshot=sha256:eeed67d1ae0846429668170fdab5e8f7ed884234db1b2c8075471bd8365cf3a7
+FROM debian/snapshot@${debian_snapshot}
 
 # Set the SHELL option -o pipefail before RUN with a pipe in.
 # See https://github.com/hadolint/hadolint/wiki/DL4006


### PR DESCRIPTION
Previously we just used a tag. Tags are mutable and don't describe the actual image. The image described by a tag could be swapped out on the registry. Using the digest means we use CaS and ask for the specific image we expect.