### PR TITLE
Add GitHub action to generate provenance files

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -67,7 +67,7 @@ jobs:
           git -C ./provenance-branch status
           git -C ./provenance-branch diff --staged
           git -C ./provenance-branch commit --allow-empty --message="Provenance files for ${GITHUB_SHA}"
-          git -C ./provenance-branch tag -a -m "record source commit" provenance-${GITHUB_SHA}
+          git -C ./provenance-branch tag --annotate --message "record source commit" provenance-${GITHUB_SHA}
 
       - name: Push provenance branch
         run: git -C ./provenance-branch push --follow-tags

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -1,0 +1,73 @@
+name: Build Provenance
+
+# See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [main]
+jobs:
+  build_provenance:
+    runs-on: ubuntu-20.04
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Mount main branch
+        uses: actions/checkout@v2
+
+      - name: Mount provenance branch
+        uses: actions/checkout@v2
+        with:
+          ref: provenance
+          path: provenance-branch
+
+      - name: Git setup
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
+      - name: free disk space
+        run: |
+          df --human-readable
+          sudo swapoff --all
+          sudo rm --force /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          df --human-readable
+
+      - name: Docker pull
+        timeout-minutes: 10
+        run: |
+          ./scripts/docker_pull
+          df --human-readable
+
+      - name: Build Server Provenance
+        run: |
+          ./scripts/build_provenance \
+          ./scripts/runner\ build-server \
+          ./oak_loader/bin/oak_loader
+
+      - name: Build Functions Provenance
+        run: |
+          ./scripts/build_provenance \
+          ./scripts/runner\ build-functions-server \
+          ./oak_functions/loader/bin/oak_functions_loader
+
+      - name: Move new provenance files to the provenance branch
+        run: cp -r ./provenance/. ./provenance-branch/
+
+      - name: Commit new provenance files to the provenance branch
+        run: |
+          git -C ./provenance-branch add .
+          git -C ./provenance-branch status
+          git -C ./provenance-branch diff --staged
+          git -C ./provenance-branch commit --allow-empty --message="Provenance files for ${GITHUB_SHA}"
+          git -C ./provenance-branch tag -a -m "record source commit" provenance-${GITHUB_SHA}
+
+      - name: Push provenance branch
+        run: git -C ./provenance-branch push --follow-tags

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -16,7 +16,7 @@ readonly COMMIT_HASH=$(git rev-parse --verify HEAD)
 mkdir -p "./provenance"
 mkdir -p "./provenance/${BINARY_SHA_256_HASH}"
 
-readonly PROVENANCE=$(cat << EOF >> "./provenance/${BINARY_SHA_256_HASH}/${COMMIT_HASH}.toml"
+cat << EOF >> "./provenance/${BINARY_SHA_256_HASH}/${COMMIT_HASH}.toml"
 repo = "https://github.com/project-oak/oak"
 commit_hash = "$(git rev-parse --verify HEAD)"
 builder_image = "${DOCKER_IMAGE_REPO_DIGEST}"
@@ -24,5 +24,4 @@ command = ["${BUILD_COMMAND}"]
 output_path = "${OUTPUT_PATH}"
 expected_binary_sha256_hash = "${BINARY_SHA_256_HASH}"
 EOF
-)
 

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -16,6 +16,11 @@ readonly COMMIT_HASH=$(git rev-parse --verify HEAD)
 mkdir -p "./provenance"
 mkdir -p "./provenance/${BINARY_SHA_256_HASH}"
 
+# Note that the command currently is a single string wrapped in an array. The
+# reason is that our transparent-release (which parses this file) expects an
+# array as the command value at its current version. There isn't much value
+# in using an array though, and in upcoming versions it will move towards
+# an unwrapped string.
 cat << EOF >> "./provenance/${BINARY_SHA_256_HASH}/${COMMIT_HASH}.toml"
 repo = "https://github.com/project-oak/oak"
 commit_hash = "$(COMMIT_HASH)"

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -22,7 +22,7 @@ mkdir -p "./provenance/${BINARY_SHA_256_HASH}"
 # an unwrapped string.
 cat << EOF >> "./provenance/${BINARY_SHA_256_HASH}/${COMMIT_HASH}.toml"
 repo = "https://github.com/project-oak/oak"
-commit_hash = "$(COMMIT_HASH)"
+commit_hash = "${COMMIT_HASH}"
 builder_image = "${DOCKER_IMAGE_REPO_DIGEST}"
 command = ["${BUILD_COMMAND}"]
 output_path = "${OUTPUT_PATH}"

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -4,11 +4,10 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-readonly BUILD_SCRIPT=$1
+readonly BUILD_COMMAND=$1
 readonly OUTPUT_PATH=$2
 
-readonly BUILD_COMMAND="./scripts/docker_run ${BUILD_SCRIPT}"
-eval "${BUILD_COMMAND}"
+eval "./scripts/docker_run ${BUILD_COMMAND}"
 readonly BINARY_SHA_256_HASH=$(sha256sum "${OUTPUT_PATH}" | cut -d " " -f 1)
 
 readonly COMMIT_HASH=$(git rev-parse --verify HEAD)

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -18,7 +18,7 @@ mkdir -p "./provenance/${BINARY_SHA_256_HASH}"
 
 cat << EOF >> "./provenance/${BINARY_SHA_256_HASH}/${COMMIT_HASH}.toml"
 repo = "https://github.com/project-oak/oak"
-commit_hash = "$(git rev-parse --verify HEAD)"
+commit_hash = "$(COMMIT_HASH)"
 builder_image = "${DOCKER_IMAGE_REPO_DIGEST}"
 command = ["${BUILD_COMMAND}"]
 output_path = "${OUTPUT_PATH}"

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+readonly SCRIPTS_DIR="$(dirname "$0")"
+# shellcheck source=scripts/common
+source "$SCRIPTS_DIR/common"
+
+readonly BUILD_SCRIPT=$1
+readonly OUTPUT_PATH=$2
+
+readonly BUILD_COMMAND="./scripts/docker_run ${BUILD_SCRIPT}"
+eval "${BUILD_COMMAND}"
+readonly BINARY_SHA_256_HASH=$(sha256sum "${OUTPUT_PATH}" | cut -d " " -f 1)
+
+readonly COMMIT_HASH=$(git rev-parse --verify HEAD)
+
+mkdir -p "./provenance"
+mkdir -p "./provenance/${BINARY_SHA_256_HASH}"
+
+readonly PROVENANCE=$(cat << EOF >> "./provenance/${BINARY_SHA_256_HASH}/${COMMIT_HASH}.toml"
+repo = "https://github.com/project-oak/oak"
+commit_hash = "$(git rev-parse --verify HEAD)"
+builder_image = "${DOCKER_IMAGE_REPO_DIGEST}"
+command = ["${BUILD_COMMAND}"]
+output_path = "${OUTPUT_PATH}"
+expected_binary_sha256_hash = "${BINARY_SHA_256_HASH}"
+EOF
+)
+


### PR DESCRIPTION
Creates provenance files (oak_loader, oak_functions_loader) for each commit added to the main branch, as outlined in: https://docs.google.com/document/d/1jWloPhrr-IykJBXtWuDdirqn9MH_FCUShBr_w0F3j3Y/edit?usp=sharing&resourcekey=0-q20m0jqEhzMyYn-kAbq_wA

This initial implementation generates provenance files as a TOML file in the shape currently used by https://github.com/project-oak/transparent-release. This will be changed to a SLSA provenance file, once our SLSA [build type](https://github.com/project-oak/transparent-release/pull/3) is fully defined, and transparent-release has been updated to parse that.