### PR TITLE
Define relation between OakStatus and ChannelStatus

### DIFF
--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -47,12 +47,12 @@ pub mod proto {
         }
     }
 
-    // Converts a ChannelStatus into an OakStatus.
-    impl From<OakStatus> for ChannelStatus {
-        fn from(oak_status: OakStatus) -> Self {
-            match oak_status {
-                OakStatus::ErrInvalidArgs => ChannelStatus::ChannelInvalidArgs,
-                _ => ChannelStatus::Unspecified,
+    // Converts a OakStatus into an ChannelStatus.
+    impl From<ChannelStatus> for OakStatus {
+        fn from(channel_status: ChannelStatus) -> Self {
+            match channel_status {
+                ChannelStatus::ChannelInvalidArgs => OakStatus::ErrInvalidArgs,
+                _ => OakStatus::Unspecified,
             }
         }
     }

--- a/oak_functions/abi/src/lib.rs
+++ b/oak_functions/abi/src/lib.rs
@@ -47,7 +47,7 @@ pub mod proto {
         }
     }
 
-    // Converts a OakStatus into an ChannelStatus.
+    // Converts an OakStatus into a ChannelStatus.
     impl From<ChannelStatus> for OakStatus {
         fn from(channel_status: ChannelStatus) -> Self {
             match channel_status {

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -208,13 +208,17 @@ impl WasmState {
 
     /// Validates whether a given address range (inclusive) falls within the currently allocated
     /// range of guest memory.
-    fn validate_range(&self, addr: AbiPointer, offset: AbiPointerOffset) -> Result<(), OakStatus> {
+    fn validate_range(
+        &self,
+        addr: AbiPointer,
+        offset: AbiPointerOffset,
+    ) -> Result<(), ChannelStatus> {
         let memory_size: wasmi::memory_units::Bytes = self.get_memory().current_size().into();
         // Check whether the end address is below or equal to the size of the guest memory.
         if wasmi::memory_units::Bytes((addr as usize) + (offset as usize)) <= memory_size {
             Ok(())
         } else {
-            Err(OakStatus::ErrInvalidArgs)
+            Err(ChannelStatus::ChannelInvalidArgs)
         }
     }
 
@@ -223,7 +227,7 @@ impl WasmState {
         &self,
         buf_ptr: AbiPointer,
         buf_len: AbiPointerOffset,
-    ) -> Result<Vec<u8>, OakStatus> {
+    ) -> Result<Vec<u8>, ChannelStatus> {
         self.get_memory()
             .get(buf_ptr, buf_len as usize)
             .map_err(|err| {
@@ -231,7 +235,7 @@ impl WasmState {
                     Level::Error,
                     &format!("Unable to read buffer from guest memory: {:?}", err),
                 );
-                OakStatus::ErrInvalidArgs
+                ChannelStatus::ChannelInvalidArgs
             })
     }
 
@@ -241,14 +245,14 @@ impl WasmState {
         &self,
         source: &[u8],
         dest: AbiPointer,
-    ) -> Result<(), OakStatus> {
+    ) -> Result<(), ChannelStatus> {
         self.validate_range(dest, source.len() as u32)?;
         self.get_memory().set(dest, source).map_err(|err| {
             self.logger.log_sensitive(
                 Level::Error,
                 &format!("Unable to write buffer into guest memory: {:?}", err),
             );
-            OakStatus::ErrInvalidArgs
+            ChannelStatus::ChannelInvalidArgs
         })
     }
 
@@ -257,7 +261,7 @@ impl WasmState {
         &self,
         value: u32,
         address: AbiPointer,
-    ) -> Result<(), OakStatus> {
+    ) -> Result<(), ChannelStatus> {
         let value_bytes = &mut [0; 4];
         LittleEndian::write_u32(value_bytes, value);
         self.get_memory().set(address, value_bytes).map_err(|err| {
@@ -265,7 +269,7 @@ impl WasmState {
                 Level::Error,
                 &format!("Unable to write u32 value into guest memory: {:?}", err),
             );
-            OakStatus::ErrInvalidArgs
+            ChannelStatus::ChannelInvalidArgs
         })
     }
 
@@ -276,7 +280,7 @@ impl WasmState {
         buffer: Vec<u8>,
         dest_ptr_ptr: AbiPointer,
         dest_len_ptr: AbiPointer,
-    ) -> Result<(), OakStatus> {
+    ) -> Result<(), ChannelStatus> {
         let dest_ptr = self.alloc(buffer.len() as u32);
         self.write_buffer_to_wasm_memory(&buffer, dest_ptr)?;
         self.write_u32_to_wasm_memory(dest_ptr, dest_ptr_ptr)?;

--- a/oak_functions/loader/src/tf.rs
+++ b/oak_functions/loader/src/tf.rs
@@ -190,7 +190,8 @@ fn tf_model_infer(
     let buf_ptr = wasm_state.alloc(encoded_inference.len() as u32);
     wasm_state.write_buffer_to_wasm_memory(&encoded_inference, buf_ptr)?;
     wasm_state.write_u32_to_wasm_memory(buf_ptr, inference_ptr_ptr)?;
-    wasm_state.write_u32_to_wasm_memory(encoded_inference.len() as u32, inference_len_ptr)
+    wasm_state.write_u32_to_wasm_memory(encoded_inference.len() as u32, inference_len_ptr)?;
+    Ok(())
 }
 
 /// Read a tensorFlow model from the given path, into a byte array.


### PR DESCRIPTION
OakStatus is returned by all current ABI functions (read/write_request, get_storage_item, tf, metrics, logging).

ChannelStatus by UWABI functions channel_read/write.

For operations on the Wasm memory, we now also return a `ChannelStatus`. These operations are used by both, UWABI and current ABI functions, but when the current ABI is replaced by UWABI, then we will remove OakStatus, so we decided to return a ChannelStatus.