### PR TITLE
Add gRPC connection timeout in Java client

### DIFF
--- a/oak_functions/client/android/com/google/oak/functions/android/client/MainActivity.java
+++ b/oak_functions/client/android/com/google/oak/functions/android/client/MainActivity.java
@@ -31,12 +31,15 @@ import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.net.URL;
+import java.time.Duration;
 import oak.functions.invocation.Request;
 import oak.functions.invocation.Response;
 import oak.functions.invocation.StatusCode;
 
 /** Main class for the Oak Functions Client application. */
 public class MainActivity extends Activity {
+  private static final long CONNECTION_TIMEOUT_SECONDS = 5;
+
   /** Handles initial setup on creation of the activity. */
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -77,7 +80,8 @@ public class MainActivity extends Activity {
       ManagedChannel channel = builder.build();
 
       // Attest a gRPC channel.
-      AttestationClient client = new AttestationClient();
+      AttestationClient client =
+          new AttestationClient(Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS));
       client.attest(channel, (config) -> !config.getMlInference());
 
       // Send a request.

--- a/oak_functions/client/java/src/com/google/oak/functions/client/AttestationClient.java
+++ b/oak_functions/client/java/src/com/google/oak/functions/client/AttestationClient.java
@@ -36,9 +36,11 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -61,6 +63,7 @@ public class AttestationClient {
   // https://cloud.google.com/apis/docs/system-parameters
   // https://cloud.google.com/docs/authentication/api-keys
   private static final String API_KEY_HEADER = "x-goog-api-key";
+  private final Duration connectionTimeout;
   private ManagedChannel channel;
   private StreamObserver<StreamingRequest> requestObserver;
   private BlockingQueue<StreamingResponse> messageQueue;
@@ -90,6 +93,15 @@ public class AttestationClient {
     return builder.intercept(interceptors);
   }
 
+  /**
+   * Creates an unattested AttestationClient instance.
+   *
+   * @param connectionTimeout contains an inactivity threshold for gRPC connections.
+   */
+  public AttestationClient(Duration connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+  }
+
   // TODO(#2356): Change the return type to `AttestationResult` instead of throwing exceptions.
   /**
    * Creates an attested channel over the gRPC channel.
@@ -98,7 +110,7 @@ public class AttestationClient {
    * @param verifier checks that the ServerIdentity contains the expected attestation info as
    * described in {@code ServerIdentityVerifier::verifyAttestationInfo}.
    */
-  public void attest(ManagedChannel channel, Predicate<ConfigurationInfo> verifier)
+  public void attest(ManagedChannel channel, Predicate<ConfigurationInfo> verifiers)
       throws GeneralSecurityException, IOException, InterruptedException, VerificationException {
     if (channel == null) {
       throw new NullPointerException("Channel must not be null.");
@@ -142,7 +154,8 @@ public class AttestationClient {
     requestObserver.onNext(clientHelloRequest);
 
     // Receive server attestation identity containing server's ephemeral public key.
-    StreamingResponse serverIdentityResponse = messageQueue.take();
+    StreamingResponse serverIdentityResponse =
+        messageQueue.poll(connectionTimeout.getSeconds(), TimeUnit.SECONDS);
     byte[] serverIdentity = serverIdentityResponse.getBody().toByteArray();
 
     // Verify ServerIdentity, including its configuration and proof of its inclusion in Rekor.
@@ -223,7 +236,8 @@ public class AttestationClient {
         StreamingRequest.newBuilder().setBody(ByteString.copyFrom(encryptedData)).build();
 
     requestObserver.onNext(streamingRequest);
-    StreamingResponse streamingResponse = messageQueue.take();
+    StreamingResponse streamingResponse =
+        messageQueue.poll(connectionTimeout.getSeconds(), TimeUnit.SECONDS);
 
     byte[] responsePayload = streamingResponse.getBody().toByteArray();
     byte[] decryptedResponse = encryptor.decrypt(responsePayload);


### PR DESCRIPTION
This change adds a 5 second inactivity timeout for gRPC connections in Java client.
Fixes a problem, where Android application could hang because of instable connection.