### PR TITLE
Accept an array of arguments when building the provenance

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -49,14 +49,14 @@ jobs:
       - name: Build Server Provenance
         run: |
           ./scripts/build_provenance \
-          ./scripts/runner\ build-server \
-          ./oak_loader/bin/oak_loader
+          ./oak_loader/bin/oak_loader \
+          ./scripts/runner build-server
 
       - name: Build Functions Provenance
         run: |
           ./scripts/build_provenance \
-          ./scripts/runner\ build-functions-server \
-          ./oak_functions/loader/bin/oak_functions_loader
+          ./oak_functions/loader/bin/oak_functions_loader \
+          ./scripts/runner build-functions-server
 
       - name: Move new provenance files to the provenance branch
         run: cp -r ./provenance/. ./provenance-branch/

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -10,7 +10,7 @@ readonly OUTPUT_PATH=$1
 # build arguments.
 shift
 
-eval ./scripts/docker_run "${@}"
+./scripts/docker_run "${@}"
 readonly BINARY_SHA_256_HASH=$(sha256sum "${OUTPUT_PATH}" | cut -d " " -f 1)
 
 readonly COMMIT_HASH=$(git rev-parse --verify HEAD)

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -10,7 +10,7 @@ readonly OUTPUT_PATH=$1
 # build arguments.
 shift
 
-eval "./scripts/docker_run ${@}"
+eval ./scripts/docker_run "${@}"
 readonly BINARY_SHA_256_HASH=$(sha256sum "${OUTPUT_PATH}" | cut -d " " -f 1)
 
 readonly COMMIT_HASH=$(git rev-parse --verify HEAD)

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -4,13 +4,24 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-readonly BUILD_COMMAND=$1
-readonly OUTPUT_PATH=$2
+readonly OUTPUT_PATH=$1
 
-eval "./scripts/docker_run ${BUILD_COMMAND}"
+# Shift arguments to omit the output path. The remaining arguments are the
+# build arguments.
+shift
+
+eval "./scripts/docker_run ${@}"
 readonly BINARY_SHA_256_HASH=$(sha256sum "${OUTPUT_PATH}" | cut -d " " -f 1)
 
 readonly COMMIT_HASH=$(git rev-parse --verify HEAD)
+
+# Format the build arguments as a TOML array.
+FORMATTED_COMMAND=""
+for arg in "${@}"; do
+  FORMATTED_COMMAND+="\"${arg}\", "
+done
+FORMATTED_COMMAND=${FORMATTED_COMMAND::-2}
+FORMATTED_COMMAND="[ ${FORMATTED_COMMAND} ]"
 
 mkdir -p "./provenance"
 mkdir -p "./provenance/${BINARY_SHA_256_HASH}"
@@ -24,7 +35,7 @@ cat << EOF >> "./provenance/${BINARY_SHA_256_HASH}/${COMMIT_HASH}.toml"
 repo = "https://github.com/project-oak/oak"
 commit_hash = "${COMMIT_HASH}"
 builder_image = "${DOCKER_IMAGE_REPO_DIGEST}"
-command = ["${BUILD_COMMAND}"]
+command = ${FORMATTED_COMMAND}
 output_path = "${OUTPUT_PATH}"
 expected_binary_sha256_hash = "${BINARY_SHA_256_HASH}"
 EOF


### PR DESCRIPTION
This aligns the invocation of the provenance script with the provenance file, which stores build arguments as an array.

Previously the build_provenance script accepted exactly two arguments 1) exactly one build arg, 2) the output path.

Now it accepts 1) the output path, followed by one or multiple build args. 