### PR TITLE
Validate SLSA provenance files before merging them into provenance

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -60,6 +60,12 @@ jobs:
           ./oak_functions/loader/bin/oak_functions_loader \
           ./scripts/runner build-functions-server
 
+      - name: Validate the shape of the generated provenance files
+        uses: cardinalby/schema-validator-action@v1
+        with:
+          file: './provenance/**/*.json'
+          schema: 'https://raw.githubusercontent.com/project-oak/transparent-release/main/schema/amber-slsa-buildtype/v1.json'
+
       - name: Move new provenance files to the provenance branch
         run: cp -r ./provenance/. ./provenance-branch/
 

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: cardinalby/schema-validator-action@v1
         with:
           file: './provenance/**/*.json'
-          schema: 'https://raw.githubusercontent.com/project-oak/transparent-release/main/schema/amber-slsa-buildtype/v1.json'
+          schema: 'https://raw.githubusercontent.com/project-oak/transparent-release/2c2eedca8236d45f67ee618c3bd83184d19a6bad/schema/amber-slsa-buildtype/v1.json'
 
       - name: Move new provenance files to the provenance branch
         run: cp -r ./provenance/. ./provenance-branch/


### PR DESCRIPTION
Follow up to #2524. I'm sort of ambivalent whether this is a good idea, but wanted to put it out there to see what people think. :)

I guess it's kind of nice that the build type can be validate by any producer of it, not just our tool. This goes to what @tiziano88 mentioned about not tying our build type to our specific go tooling.

Later we will also actually verify the generated provenance files (by rerunning the build) in kokoro, so this might not be needed. Happy to close this depending on feedback