### PR TITLE
Align the generated provenances with the transparent release CLI

### DIFF
--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -14,7 +14,7 @@ shift 2
 # docker user and does not pass ENV vars. Flags are intentionally a subset of
 # the ones used in `./scripts/docker_run` which proxies host cache dirs and
 # file system permissions for developer convenience.
-docker run --rm --tty --volume=$PWD:/workspace --workdir=/workspace "$DOCKER_IMAGE_ID" "${@}"
+docker run --rm --tty "--volume=${PWD}:/workspace" --workdir=/workspace "${DOCKER_IMAGE_ID}" "${@}"
 
 # Get digest of the docker image, as defined in https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md#digests
 readonly DOCKER_DIGEST=$(docker images --digests --format="{{.Digest}}" "${DOCKER_IMAGE_REPO_DIGEST}")

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -10,7 +10,11 @@ readonly OUTPUT_PATH=$2
 # Shift arguments so that the remaining arguments are the just build arguments.
 shift 2
 
-./scripts/docker_run "${@}"
+# Run the build in a simplified docker configuration that uses the default
+# docker user and does not pass ENV vars. Flags are intentionally a subset of
+# the ones used in `./scripts/docker_run` which proxies host cache dirs and
+# file system permissions for developer convenience.
+docker run --rm --tty --volume=$PWD:/workspace --workdir=/workspace "$DOCKER_IMAGE_ID" "${@}"
 
 # Get digest of the docker image, as defined in https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md#digests
 readonly DOCKER_DIGEST=$(docker images --digests --format="{{.Digest}}" "${DOCKER_IMAGE_REPO_DIGEST}")

--- a/scripts/build_provenance
+++ b/scripts/build_provenance
@@ -53,7 +53,7 @@ cat << EOF >> "./provenance/${BINARY_SHA_256_HASH}/${COMMIT_HASH}.json"
     "builder": {
       "id": "https://github.com/project-oak/transparent-release"
     },
-    "buildType": "https://github.com/project-oak/transparent-release/schema/amber-slsa-buildtype/v1.json",
+    "buildType": "https://github.com/project-oak/transparent-release/schema/amber-slsa-buildtype/v1/provenance.json",
     "buildConfig": {
       "command": ${FORMATTED_COMMAND},
       "outputPath": "${OUTPUT_PATH}"


### PR DESCRIPTION
- updates the buildType key to match https://github.com/project-oak/transparent-release/pull/26
- simplifies the docker configuration to address https://github.com/project-oak/transparent-release/issues/25

Down the road we probably want to change to change how transparent-release/amber-provenances captures the the docker config used, see @rbehjati thoughts in https://github.com/project-oak/transparent-release/pull/26. We may also want to use the transparent release CLI itself to generate provenance statements once it supports doing so (see https://github.com/project-oak/transparent-release/blob/main/common/common.go#L250). 

For now this aligns how provenances are built with how they are verified by the transparent release CLI. Conceptually that means building the binaries with minimal env flags & no caches proxied from the host. The conceptual purpose of `scripts/docker_run` becomes that of a convenience script for developing, offering extras such as using host caches, and host user file ownership.