### PR TITLE
Remove build-server from the provenance generation step

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -46,14 +46,7 @@ jobs:
           ./scripts/docker_pull
           df --human-readable
 
-      - name: Build Server Provenance
-        run: |
-          ./scripts/build_provenance \
-          "oak_loader" \
-          ./oak_loader/bin/oak_loader \
-          ./scripts/runner build-server
-
-      - name: Build Functions Provenance
+      - name: Build Functions Server Provenance
         run: |
           ./scripts/build_provenance \
           "oak_functions" \

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -8,6 +8,9 @@ concurrency:
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+
 jobs:
   build_provenance:
     runs-on: ubuntu-20.04
@@ -54,9 +57,11 @@ jobs:
           ./scripts/runner build-functions-server
 
       - name: Move new provenance files to the provenance branch
+        if: github.event_name == 'push'
         run: cp -r ./provenance/. ./provenance-branch/
 
       - name: Commit new provenance files to the provenance branch
+        if: github.event_name == 'push'
         run: |
           git -C ./provenance-branch add .
           git -C ./provenance-branch status
@@ -65,4 +70,5 @@ jobs:
           git -C ./provenance-branch tag --annotate --message "record source commit" provenance-${GITHUB_SHA}
 
       - name: Push provenance branch
+        if: github.event_name == 'push'
         run: git -C ./provenance-branch push --follow-tags

--- a/docs/INSTALL-OSX.md
+++ b/docs/INSTALL-OSX.md
@@ -57,10 +57,11 @@ retrieved from a Google Cloud Docker repository.
 
 ## Building and Running
 
-The Oak Runtime and its dependencies are built with the following script:
+The Oak Functions Runtime and its dependencies are built with the following
+script:
 
 ```bash
-./scripts/runner build-server
+./scripts/runner build-functions-server
 ```
 
 Build a particular example, say `hello_world`, with:

--- a/docs/development.md
+++ b/docs/development.md
@@ -235,11 +235,12 @@ are written in C++, but there are clients in
 
 ### Build Runtime Server
 
-The following command builds the Oak Runtime server. An initial build will take
-some time, but subsequent builds should be cached and so run much faster.
+The following command builds the Oak Functions Runtime server. An initial build
+will take some time, but subsequent builds should be cached and so run much
+faster.
 
 ```bash
-./scripts/runner build-server
+./scripts/runner build-functions-server
 ```
 
 ### Run Runtime Server


### PR DESCRIPTION
* Removes the `build-server` step from the provenance generation
* Replaces `build-server` with `build-functions-server` in the docs

Ref #2543