### PR TITLE
Make remote_attestation crate no_std compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,6 +1084,7 @@ dependencies = [
  "oak_utils",
  "prost",
  "prost-types",
+ "serde",
  "tokio",
  "tonic",
  "tower",
@@ -2020,16 +2021,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "bincode",
+ "bytes",
  "log",
  "prost",
  "prost-build",
  "quickcheck",
  "quickcheck_macros",
  "ring",
- "serde",
- "serde-big-array",
- "sha2 0.10.1",
 ]
 
 [[package]]
@@ -2884,16 +2882,6 @@ version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde-big-array"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
-dependencies = [
- "serde",
  "serde_derive",
 ]
 

--- a/grpc_attestation/Cargo.toml
+++ b/grpc_attestation/Cargo.toml
@@ -13,6 +13,7 @@ oak_remote_attestation = { path = "../remote_attestation/rust/" }
 oak_functions_abi = { path = "../oak_functions/abi/" }
 prost = "*"
 prost-types = "*"
+serde = { version = "*", features = ["derive"] }
 tokio = { version = "*", features = [
   "fs",
   "macros",

--- a/oak_functions/loader/fuzz/Cargo.lock
+++ b/oak_functions/loader/fuzz/Cargo.lock
@@ -97,15 +97,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,24 +186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,16 +194,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -366,16 +329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +351,7 @@ dependencies = [
  "oak_utils",
  "prost",
  "prost-types",
+ "serde",
  "tokio",
  "tonic",
  "tower",
@@ -811,14 +765,11 @@ name = "oak_remote_attestation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bincode",
+ "bytes",
  "log",
  "prost",
  "prost-build",
  "ring",
- "serde",
- "serde-big-array",
- "sha2",
 ]
 
 [[package]]
@@ -1181,16 +1132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,17 +1151,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -1543,12 +1473,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "typenum"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-bidi"

--- a/remote_attestation/rust/Cargo.toml
+++ b/remote_attestation/rust/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-default = ["alloc"]
+default = []
 std = ["anyhow/std", "prost/std"]
-alloc = []
 
 [dependencies]
 anyhow = { version = "*", default-features = false }

--- a/remote_attestation/rust/Cargo.toml
+++ b/remote_attestation/rust/Cargo.toml
@@ -5,15 +5,17 @@ authors = ["Ivan Petrov <ivanpetrov@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = ["alloc"]
+std = ["anyhow/std", "prost/std"]
+alloc = []
+
 [dependencies]
-anyhow = "*"
-bincode = "*"
+anyhow = { version = "*", default-features = false }
+bytes = { version = "*", default-features = false }
 log = "*"
-prost = "*"
+prost = { version = "*", default-features = false, features = ["prost-derive"] }
 ring = "*"
-serde = { version = "*", features = ["derive"] }
-serde-big-array = { version = "*", features = ["const-generics"] }
-sha2 = "*"
 
 [build-dependencies]
 prost-build = "*"

--- a/remote_attestation/rust/build.rs
+++ b/remote_attestation/rust/build.rs
@@ -14,11 +14,10 @@
 // limitations under the License.
 //
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     prost_build::compile_protos(
         &["remote_attestation/proto/remote_attestation.proto"],
         &["../.."],
     )
     .expect("Proto compilation failed");
-    Ok(())
 }

--- a/remote_attestation/rust/src/crypto.rs
+++ b/remote_attestation/rust/src/crypto.rs
@@ -20,7 +20,7 @@
 // protocol.
 
 use crate::message::EncryptedData;
-use alloc::vec::Vec;
+use alloc::{format, vec, vec::Vec};
 use anyhow::{anyhow, Context};
 use core::convert::TryInto;
 use ring::{
@@ -194,7 +194,7 @@ impl KeyNegotiator {
             .map_err(|error| anyhow!("Couldn't get public key: {:?}", error))?
             .as_ref()
             .to_vec();
-        public_key.as_slice().try_into().context(alloc::format!(
+        public_key.as_slice().try_into().context(format!(
             "Incorrect public key length, expected {}, found {}",
             KEY_AGREEMENT_ALGORITHM_KEY_LENGTH,
             public_key.len()
@@ -235,7 +235,7 @@ impl KeyNegotiator {
             &agreement::UnparsedPublicKey::new(KEY_AGREEMENT_ALGORITHM, peer_public_key),
             anyhow!("Couldn't derive session keys"),
             |key_material| {
-                let key_material = key_material.try_into().context(alloc::format!(
+                let key_material = key_material.try_into().context(format!(
                     "Incorrect key material length, expected {}, found {}",
                     KEY_AGREEMENT_ALGORITHM_KEY_LENGTH,
                     key_material.len()
@@ -299,7 +299,7 @@ impl KeyNegotiator {
         client_public_key: &[u8; KEY_AGREEMENT_ALGORITHM_KEY_LENGTH],
     ) -> anyhow::Result<[u8; AEAD_ALGORITHM_KEY_LENGTH]> {
         // Session key is derived from a purpose string and two public keys.
-        let info = alloc::vec![key_purpose.as_bytes(), server_public_key, client_public_key];
+        let info = vec![key_purpose.as_bytes(), server_public_key, client_public_key];
 
         // Initialize key derivation function.
         let salt = Salt::new(HKDF_SHA256, KEY_DERIVATION_SALT.as_bytes());
@@ -352,7 +352,7 @@ impl Signer {
 
     pub fn public_key(&self) -> anyhow::Result<[u8; SIGNING_ALGORITHM_KEY_LENGTH]> {
         let public_key = self.key_pair.public_key().as_ref().to_vec();
-        public_key.as_slice().try_into().context(alloc::format!(
+        public_key.as_slice().try_into().context(format!(
             "Incorrect public key length, expected {}, found {}",
             SIGNING_ALGORITHM_KEY_LENGTH,
             public_key.len()
@@ -367,7 +367,7 @@ impl Signer {
             .map_err(|error| anyhow!("Couldn't sign input: {:?}", error))?
             .as_ref()
             .to_vec();
-        signature.as_slice().try_into().context(alloc::format!(
+        signature.as_slice().try_into().context(format!(
             "Incorrect signature length, expected {}, found {}",
             SIGNATURE_LENGTH,
             signature.len()

--- a/remote_attestation/rust/src/handshaker.rs
+++ b/remote_attestation/rust/src/handshaker.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     proto::{AttestationInfo, AttestationReport},
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 use anyhow::{anyhow, Context};
 use prost::Message;
 
@@ -304,7 +304,7 @@ impl ClientHandshaker {
                 // Signing public key.
                 [Default::default(); SIGNING_ALGORITHM_KEY_LENGTH],
                 // Attestation info.
-                alloc::vec![],
+                vec![],
             )
         };
 
@@ -485,9 +485,9 @@ impl ServerHandshaker {
                 // Signing public key.
                 [Default::default(); SIGNING_ALGORITHM_KEY_LENGTH],
                 // Attestation info.
-                alloc::vec![],
+                vec![],
                 // Additional info.
-                alloc::vec![],
+                vec![],
             )
         };
 
@@ -681,9 +681,7 @@ struct Transcript {
 
 impl Transcript {
     pub fn new() -> Self {
-        Self {
-            value: alloc::vec![],
-        }
+        Self { value: vec![] }
     }
 
     /// Appends a serialized `message` to the end of [`Transcript::value`].

--- a/remote_attestation/rust/src/handshaker.rs
+++ b/remote_attestation/rust/src/handshaker.rs
@@ -34,6 +34,7 @@ use crate::{
     },
     proto::{AttestationInfo, AttestationReport},
 };
+use alloc::{boxed::Box, vec::Vec};
 use anyhow::{anyhow, Context};
 use prost::Message;
 
@@ -54,8 +55,8 @@ impl Default for ClientHandshakerState {
     }
 }
 
-impl std::fmt::Debug for ClientHandshakerState {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for ClientHandshakerState {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Self::Initializing => write!(f, "Initializing"),
             Self::ExpectingServerIdentity(_) => write!(f, "ExpectingServerIdentity"),
@@ -81,8 +82,8 @@ impl Default for ServerHandshakerState {
     }
 }
 
-impl std::fmt::Debug for ServerHandshakerState {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for ServerHandshakerState {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Self::ExpectingClientHello => write!(f, "ExpectingClientHello"),
             Self::ExpectingClientIdentity(_) => write!(f, "ExpectingClientIdentity"),
@@ -131,7 +132,7 @@ impl ClientHandshaker {
             deserialize_message(message).context("Couldn't deserialize message")?;
         match deserialized_message {
             MessageWrapper::ServerIdentity(server_identity) => {
-                match std::mem::take(&mut self.state) {
+                match core::mem::take(&mut self.state) {
                     ClientHandshakerState::ExpectingServerIdentity(key_negotiator) => {
                         let client_identity = self
                             .process_server_identity(server_identity, key_negotiator)
@@ -303,7 +304,7 @@ impl ClientHandshaker {
                 // Signing public key.
                 [Default::default(); SIGNING_ALGORITHM_KEY_LENGTH],
                 // Attestation info.
-                vec![],
+                alloc::vec![],
             )
         };
 
@@ -380,7 +381,7 @@ impl ServerHandshaker {
                 )),
             },
             MessageWrapper::ClientIdentity(client_identity) => {
-                match std::mem::take(&mut self.state) {
+                match core::mem::take(&mut self.state) {
                     ServerHandshakerState::ExpectingClientIdentity(key_negotiator) => {
                         self.process_client_identity(client_identity, key_negotiator)
                             .context("Couldn't process client identity message")?;
@@ -484,9 +485,9 @@ impl ServerHandshaker {
                 // Signing public key.
                 [Default::default(); SIGNING_ALGORITHM_KEY_LENGTH],
                 // Attestation info.
-                vec![],
+                alloc::vec![],
                 // Additional info.
-                vec![],
+                alloc::vec![],
             )
         };
 
@@ -602,8 +603,8 @@ pub struct AttestationBehavior {
     signer: Option<Signer>,
 }
 
-impl std::fmt::Debug for AttestationBehavior {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for AttestationBehavior {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match (
             self.contains_peer_attestation(),
             self.contains_self_attestation(),
@@ -680,7 +681,9 @@ struct Transcript {
 
 impl Transcript {
     pub fn new() -> Self {
-        Self { value: vec![] }
+        Self {
+            value: alloc::vec![],
+        }
     }
 
     /// Appends a serialized `message` to the end of [`Transcript::value`].
@@ -732,6 +735,7 @@ pub fn verify_attestation_info(
     expected_tee_measurement: &[u8],
 ) -> anyhow::Result<()> {
     let attestation_info = AttestationInfo::decode(attestation_info_bytes)
+        .map_err(anyhow::Error::msg)
         .context("Couldn't decode attestation info Protobuf message")?;
 
     // TODO(#1867): Add remote attestation support, use real TEE reports and check that
@@ -760,6 +764,7 @@ pub fn serialize_protobuf<M: prost::Message>(message: &M) -> anyhow::Result<Vec<
     let mut message_bytes = Vec::new();
     message
         .encode(&mut message_bytes)
+        .map_err(anyhow::Error::msg)
         .context("Couldn't serialize Protobuf message to bytes")?;
     Ok(message_bytes)
 }

--- a/remote_attestation/rust/src/lib.rs
+++ b/remote_attestation/rust/src/lib.rs
@@ -14,6 +14,10 @@
 // limitations under the License.
 //
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 pub mod proto {
     #![allow(clippy::return_self_not_must_use)]
     include!(concat!(env!("OUT_DIR"), "/oak.remote_attestation.rs"));

--- a/remote_attestation/rust/src/lib.rs
+++ b/remote_attestation/rust/src/lib.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 extern crate alloc;
 

--- a/remote_attestation/rust/src/report.rs
+++ b/remote_attestation/rust/src/report.rs
@@ -23,7 +23,7 @@ impl AttestationReport {
     /// Placeholder function for collecting TEE measurement of remotely attested TEEs.
     pub fn new(data: &[u8]) -> Self {
         Self {
-            measurement: TEST_TEE_MEASUREMENT.to_string().as_bytes().to_vec(),
+            measurement: TEST_TEE_MEASUREMENT.as_bytes().to_vec(),
             data: data.to_vec(),
             ..Default::default()
         }

--- a/remote_attestation/rust/src/tests/crypto.rs
+++ b/remote_attestation/rust/src/tests/crypto.rs
@@ -23,6 +23,7 @@ use crate::{
     },
     message::EncryptedData,
 };
+use alloc::vec::Vec;
 use quickcheck_macros::quickcheck;
 
 // Keys are only used for test purposes.

--- a/remote_attestation/rust/src/tests/handshaker.rs
+++ b/remote_attestation/rust/src/tests/handshaker.rs
@@ -33,7 +33,7 @@ fn create_handshakers() -> (ClientHandshaker, ServerHandshaker) {
             .unwrap();
     let client_handshaker = ClientHandshaker::new(
         bidirectional_attestation,
-        Box::new(|server_identity| {
+        alloc::boxed::Box::new(|server_identity| {
             if !server_identity.additional_info.is_empty() {
                 Ok(())
             } else {
@@ -113,7 +113,7 @@ fn test_handshake() {
 #[test]
 fn test_invalid_message_after_initialization() {
     let (mut client_handshaker, mut server_handshaker) = create_handshakers();
-    let invalid_message = vec![INVALID_MESSAGE_HEADER];
+    let invalid_message = alloc::vec![INVALID_MESSAGE_HEADER];
 
     let result = client_handshaker.next_step(&invalid_message);
     assert_matches!(result, Err(_));
@@ -129,7 +129,7 @@ fn test_invalid_message_after_initialization() {
 #[test]
 fn test_invalid_message_after_hello() {
     let (mut client_handshaker, mut server_handshaker) = create_handshakers();
-    let invalid_message = vec![INVALID_MESSAGE_HEADER];
+    let invalid_message = alloc::vec![INVALID_MESSAGE_HEADER];
 
     let client_hello = client_handshaker.create_client_hello().unwrap();
     let result = client_handshaker.next_step(&invalid_message);
@@ -148,7 +148,7 @@ fn test_invalid_message_after_hello() {
 #[test]
 fn test_invalid_message_after_identities() {
     let (mut client_handshaker, mut server_handshaker) = create_handshakers();
-    let invalid_message = vec![INVALID_MESSAGE_HEADER];
+    let invalid_message = alloc::vec![INVALID_MESSAGE_HEADER];
 
     let client_hello = client_handshaker.create_client_hello().unwrap();
     let server_identity = server_handshaker.next_step(&client_hello).unwrap().unwrap();

--- a/remote_attestation/rust/src/tests/handshaker.rs
+++ b/remote_attestation/rust/src/tests/handshaker.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     tests::message::INVALID_MESSAGE_HEADER,
 };
+use alloc::{boxed::Box, vec};
 use assert_matches::assert_matches;
 
 const TEE_MEASUREMENT: &str = "Test TEE measurement";
@@ -33,7 +34,7 @@ fn create_handshakers() -> (ClientHandshaker, ServerHandshaker) {
             .unwrap();
     let client_handshaker = ClientHandshaker::new(
         bidirectional_attestation,
-        alloc::boxed::Box::new(|server_identity| {
+        Box::new(|server_identity| {
             if !server_identity.additional_info.is_empty() {
                 Ok(())
             } else {
@@ -113,7 +114,7 @@ fn test_handshake() {
 #[test]
 fn test_invalid_message_after_initialization() {
     let (mut client_handshaker, mut server_handshaker) = create_handshakers();
-    let invalid_message = alloc::vec![INVALID_MESSAGE_HEADER];
+    let invalid_message = vec![INVALID_MESSAGE_HEADER];
 
     let result = client_handshaker.next_step(&invalid_message);
     assert_matches!(result, Err(_));
@@ -129,7 +130,7 @@ fn test_invalid_message_after_initialization() {
 #[test]
 fn test_invalid_message_after_hello() {
     let (mut client_handshaker, mut server_handshaker) = create_handshakers();
-    let invalid_message = alloc::vec![INVALID_MESSAGE_HEADER];
+    let invalid_message = vec![INVALID_MESSAGE_HEADER];
 
     let client_hello = client_handshaker.create_client_hello().unwrap();
     let result = client_handshaker.next_step(&invalid_message);
@@ -148,7 +149,7 @@ fn test_invalid_message_after_hello() {
 #[test]
 fn test_invalid_message_after_identities() {
     let (mut client_handshaker, mut server_handshaker) = create_handshakers();
-    let invalid_message = alloc::vec![INVALID_MESSAGE_HEADER];
+    let invalid_message = vec![INVALID_MESSAGE_HEADER];
 
     let client_hello = client_handshaker.create_client_hello().unwrap();
     let server_identity = server_handshaker.next_step(&client_hello).unwrap().unwrap();

--- a/remote_attestation/rust/src/tests/message.rs
+++ b/remote_attestation/rust/src/tests/message.rs
@@ -25,6 +25,7 @@ use crate::{
         MAXIMUM_MESSAGE_SIZE, REPLAY_PROTECTION_ARRAY_LENGTH, SERVER_IDENTITY_HEADER,
     },
 };
+use alloc::vec::Vec;
 use anyhow::{anyhow, Context};
 use assert_matches::assert_matches;
 use quickcheck::{quickcheck, TestResult};
@@ -35,7 +36,7 @@ const INVALID_PROTOCOL_VERSION: u8 = 2;
 /// Creates a zero initialized array.
 fn default_array<T, const L: usize>() -> [T; L]
 where
-    T: std::marker::Copy + std::default::Default,
+    T: core::marker::Copy + core::default::Default,
 {
     [Default::default(); L]
 }
@@ -43,11 +44,11 @@ where
 /// Converts slices to arrays (expands with zeroes).
 fn to_array<T, const L: usize>(input: &[T]) -> anyhow::Result<[T; L]>
 where
-    T: std::marker::Copy + std::default::Default,
+    T: core::marker::Copy + core::default::Default,
 {
     if input.len() <= L {
         // `Default` is only implemented for a limited number of array sizes.
-        // https://doc.rust-lang.org/std/primitive.array.html#impl-Default
+        // https://doc.rust-lang.org/core/primitive.array.html#impl-Default
         let mut result: [T; L] = default_array();
         result[..input.len()].copy_from_slice(&input[..input.len()]);
         Ok(result)
@@ -200,8 +201,8 @@ fn test_deserialize_message() {
         default_array(),
         default_array(),
         default_array(),
-        vec![],
-        vec![],
+        alloc::vec![],
+        alloc::vec![],
     );
     let deserialized_server_identity = deserialize_message(&server_identity.serialize().unwrap());
     assert_matches!(deserialized_server_identity, Ok(_));
@@ -210,7 +211,7 @@ fn test_deserialize_message() {
         MessageWrapper::ServerIdentity(server_identity)
     );
 
-    let client_identity = ClientIdentity::new(default_array(), default_array(), vec![]);
+    let client_identity = ClientIdentity::new(default_array(), default_array(), alloc::vec![]);
     let deserialized_client_identity = deserialize_message(&client_identity.serialize().unwrap());
     assert_matches!(deserialized_client_identity, Ok(_));
     assert_eq!(
@@ -218,7 +219,7 @@ fn test_deserialize_message() {
         MessageWrapper::ClientIdentity(client_identity)
     );
 
-    let encrypted_data = EncryptedData::new(default_array(), vec![]);
+    let encrypted_data = EncryptedData::new(default_array(), alloc::vec![]);
     let deserialized_encrypted_data = deserialize_message(&encrypted_data.serialize().unwrap());
     assert_matches!(deserialized_encrypted_data, Ok(_));
     assert_eq!(
@@ -226,7 +227,7 @@ fn test_deserialize_message() {
         MessageWrapper::EncryptedData(encrypted_data)
     );
 
-    let invalid_message = vec![INVALID_MESSAGE_HEADER];
+    let invalid_message = alloc::vec![INVALID_MESSAGE_HEADER];
     let deserialized_invalid_message = deserialize_message(&invalid_message);
     assert_matches!(deserialized_invalid_message, Err(_));
 
@@ -248,7 +249,7 @@ fn test_deserialize_message() {
     assert_matches!(deserialized_big_client_identity, Err(_));
 
     let big_encrypted_data =
-        EncryptedData::new([0; NONCE_LENGTH], vec![0; MAXIMUM_MESSAGE_SIZE + 1])
+        EncryptedData::new([0; NONCE_LENGTH], alloc::vec![0; MAXIMUM_MESSAGE_SIZE + 1])
             .serialize()
             .unwrap();
     let deserialized_big_encrypted_data = deserialize_message(&big_encrypted_data);

--- a/remote_attestation/rust/src/tests/message.rs
+++ b/remote_attestation/rust/src/tests/message.rs
@@ -25,7 +25,7 @@ use crate::{
         MAXIMUM_MESSAGE_SIZE, REPLAY_PROTECTION_ARRAY_LENGTH, SERVER_IDENTITY_HEADER,
     },
 };
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use anyhow::{anyhow, Context};
 use assert_matches::assert_matches;
 use quickcheck::{quickcheck, TestResult};
@@ -201,8 +201,8 @@ fn test_deserialize_message() {
         default_array(),
         default_array(),
         default_array(),
-        alloc::vec![],
-        alloc::vec![],
+        vec![],
+        vec![],
     );
     let deserialized_server_identity = deserialize_message(&server_identity.serialize().unwrap());
     assert_matches!(deserialized_server_identity, Ok(_));
@@ -211,7 +211,7 @@ fn test_deserialize_message() {
         MessageWrapper::ServerIdentity(server_identity)
     );
 
-    let client_identity = ClientIdentity::new(default_array(), default_array(), alloc::vec![]);
+    let client_identity = ClientIdentity::new(default_array(), default_array(), vec![]);
     let deserialized_client_identity = deserialize_message(&client_identity.serialize().unwrap());
     assert_matches!(deserialized_client_identity, Ok(_));
     assert_eq!(
@@ -219,7 +219,7 @@ fn test_deserialize_message() {
         MessageWrapper::ClientIdentity(client_identity)
     );
 
-    let encrypted_data = EncryptedData::new(default_array(), alloc::vec![]);
+    let encrypted_data = EncryptedData::new(default_array(), vec![]);
     let deserialized_encrypted_data = deserialize_message(&encrypted_data.serialize().unwrap());
     assert_matches!(deserialized_encrypted_data, Ok(_));
     assert_eq!(
@@ -227,7 +227,7 @@ fn test_deserialize_message() {
         MessageWrapper::EncryptedData(encrypted_data)
     );
 
-    let invalid_message = alloc::vec![INVALID_MESSAGE_HEADER];
+    let invalid_message = vec![INVALID_MESSAGE_HEADER];
     let deserialized_invalid_message = deserialize_message(&invalid_message);
     assert_matches!(deserialized_invalid_message, Err(_));
 
@@ -249,7 +249,7 @@ fn test_deserialize_message() {
     assert_matches!(deserialized_big_client_identity, Err(_));
 
     let big_encrypted_data =
-        EncryptedData::new([0; NONCE_LENGTH], alloc::vec![0; MAXIMUM_MESSAGE_SIZE + 1])
+        EncryptedData::new([0; NONCE_LENGTH], vec![0; MAXIMUM_MESSAGE_SIZE + 1])
             .serialize()
             .unwrap();
     let deserialized_big_encrypted_data = deserialize_message(&big_encrypted_data);


### PR DESCRIPTION
This PR reduces dependencies of the `remote_attestation` crate and makes it usable in `no_std` environments.

Reducing the dependencies should simplify future code audits. An important part of the change is to move away from the `bincode` crate to manual serialization of the handshake messages. The `bincode` crate requires `std`, and manual serialization will also provide more control over the structure of these handshake messages.

Fixes #2294