### PR TITLE
Remove tonic dep from remote_attestation crate by natively including protos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,7 +2030,6 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sha2 0.10.1",
- "tonic",
 ]
 
 [[package]]

--- a/oak_functions/loader/fuzz/Cargo.lock
+++ b/oak_functions/loader/fuzz/Cargo.lock
@@ -535,10 +535,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.20.3",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.23.2",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -819,7 +819,6 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sha2",
- "tonic",
 ]
 
 [[package]]
@@ -1092,27 +1091,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64",
- "log",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b323592e3164322f5b193dc4302e4e36cd8d37158a712d664efae1a5c2791700"
 dependencies = [
  "log",
  "ring",
- "sct 0.7.0",
- "webpki 0.22.0",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1150,16 +1136,6 @@ checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi",
-]
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -1400,24 +1376,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
- "rustls 0.20.3",
+ "rustls",
  "tokio",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -1476,7 +1441,6 @@ dependencies = [
  "prost",
  "prost-derive",
  "tokio",
- "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -1739,16 +1703,6 @@ checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/remote_attestation/rust/Cargo.toml
+++ b/remote_attestation/rust/Cargo.toml
@@ -14,7 +14,6 @@ ring = "*"
 serde = { version = "*", features = ["derive"] }
 serde-big-array = { version = "*", features = ["const-generics"] }
 sha2 = "*"
-tonic = { version = "*", features = ["tls"] }
 
 [build-dependencies]
 prost-build = "*"

--- a/remote_attestation/rust/src/lib.rs
+++ b/remote_attestation/rust/src/lib.rs
@@ -16,7 +16,7 @@
 
 pub mod proto {
     #![allow(clippy::return_self_not_must_use)]
-    tonic::include_proto!("oak.remote_attestation");
+    include!(concat!(env!("OUT_DIR"), "/oak.remote_attestation.rs"));
 }
 
 pub mod crypto;


### PR DESCRIPTION
This makes sense conceptually too, as the remote_attestation crate is not tied to a specific protocol, whereas tonic is. 

As an aside, I like how `remote_attestation` is already a seperate crate from `grpc_attestation`, makes the unary request migration a lot nicer. :) 