### PR TITLE
Document why EKEP messages use custom serialization logic

### DIFF
--- a/remote_attestation/rust/src/message.rs
+++ b/remote_attestation/rust/src/message.rs
@@ -17,8 +17,8 @@
 // Messages used to implement the Enclave Key Exchange Protocol (EKEP).
 //
 // Unlike other RPC messages these are expressed as Rust structs and serialized
-// with custom logic. The primary reason for is maintaining binary-compatibility
-// with other implementations of the Enclave Key Exchange Protocol (EKEP).
+// with custom logic. This is done to maintain binary-compatibility with other
+// implementations of the Enclave Key Exchange Protocol (EKEP).
 
 use crate::crypto::{
     KEY_AGREEMENT_ALGORITHM_KEY_LENGTH, NONCE_LENGTH, SIGNATURE_LENGTH,

--- a/remote_attestation/rust/src/message.rs
+++ b/remote_attestation/rust/src/message.rs
@@ -14,6 +14,12 @@
 // limitations under the License.
 //
 
+// Messages used to implement the Enclave Key Exchange Protocol (EKEP).
+//
+// Unlike other RPC messages these are expressed as Rust structs and serialized
+// with custom logic. The primary reason for is maintaining binary-compatibility
+// with other implementations of the Enclave Key Exchange Protocol (EKEP).
+
 use crate::crypto::{
     KEY_AGREEMENT_ALGORITHM_KEY_LENGTH, NONCE_LENGTH, SIGNATURE_LENGTH,
     SIGNING_ALGORITHM_KEY_LENGTH,

--- a/remote_attestation/rust/src/message.rs
+++ b/remote_attestation/rust/src/message.rs
@@ -14,11 +14,12 @@
 // limitations under the License.
 //
 
-// Messages used to implement the Enclave Key Exchange Protocol (EKEP).
+// Messages that implement a simplified version of the Enclave Key Exchange
+// Protocol (EKEP).
 //
 // Unlike other RPC messages these are expressed as Rust structs and serialized
 // with custom logic. This is done to maintain binary-compatibility with other
-// implementations of the Enclave Key Exchange Protocol (EKEP).
+// implementations of this protocol.
 
 use crate::crypto::{
     KEY_AGREEMENT_ALGORITHM_KEY_LENGTH, NONCE_LENGTH, SIGNATURE_LENGTH,

--- a/remote_attestation/rust/src/message.rs
+++ b/remote_attestation/rust/src/message.rs
@@ -17,9 +17,9 @@
 // Messages that implement a simplified version of the Enclave Key Exchange
 // Protocol (EKEP).
 //
-// Unlike other RPC messages these are expressed as Rust structs and serialized
-// with custom logic. This is done to maintain binary-compatibility with other
-// implementations of this protocol.
+// Unlike other messages exchanged between client & server, these are expressed
+// as Rust structs and serialized with custom logic. This is done to maintain
+// binary-compatibility with other implementations of this protocol.
 
 use crate::crypto::{
     KEY_AGREEMENT_ALGORITHM_KEY_LENGTH, NONCE_LENGTH, SIGNATURE_LENGTH,


### PR DESCRIPTION
This wasn't obvious from reading the runtime code, which apart from this piece makes heavy use of protos to define RPC messages. 