### PR TITLE
Add runtime flag to specify gRPC request model

### DIFF
--- a/oak_functions/examples/fuzzable/module/src/tests.rs
+++ b/oak_functions/examples/fuzzable/module/src/tests.rs
@@ -20,7 +20,7 @@ use maplit::btreemap;
 use oak_functions_abi::proto::{ServerPolicy, StatusCode};
 
 use oak_functions_loader::{
-    grpc::{create_and_start_grpc_server, create_wasm_handler},
+    grpc::{create_and_start_grpc_server, create_wasm_handler, RequestModel},
     logger::Logger,
     lookup::LookupFactory,
     lookup_data::LookupData,
@@ -79,6 +79,7 @@ async fn test_server() {
             get_config_info(&wasm_module_bytes, policy, false, None),
             term,
             logger,
+            RequestModel::BidiStreaming,
         )
         .await
     });

--- a/oak_functions/examples/key_value_lookup/module/src/tests.rs
+++ b/oak_functions/examples/key_value_lookup/module/src/tests.rs
@@ -18,7 +18,7 @@ extern crate test;
 use maplit::hashmap;
 use oak_functions_abi::proto::{Request, ServerPolicy, StatusCode};
 use oak_functions_loader::{
-    grpc::{create_and_start_grpc_server, create_wasm_handler},
+    grpc::{create_and_start_grpc_server, create_wasm_handler, RequestModel},
     logger::Logger,
     lookup::LookupFactory,
     lookup_data::{LookupData, LookupDataAuth, LookupDataSource},
@@ -92,6 +92,7 @@ async fn test_server() {
             get_config_info(&wasm_module_bytes, policy, false, None),
             term,
             logger,
+            RequestModel::BidiStreaming,
         )
         .await
     });

--- a/oak_functions/examples/weather_lookup/module/src/tests.rs
+++ b/oak_functions/examples/weather_lookup/module/src/tests.rs
@@ -23,7 +23,7 @@ use lookup_data_generator::data::generate_and_serialize_sparse_weather_entries;
 use maplit::hashmap;
 use oak_functions_abi::proto::{Request, ServerPolicy, StatusCode};
 use oak_functions_loader::{
-    grpc::{create_and_start_grpc_server, create_wasm_handler},
+    grpc::{create_and_start_grpc_server, create_wasm_handler, RequestModel},
     logger::Logger,
     lookup::LookupFactory,
     lookup_data::{parse_lookup_entries, LookupData, LookupDataAuth, LookupDataSource},
@@ -111,6 +111,7 @@ async fn test_server() {
             get_config_info(&wasm_module_bytes, policy, false, None),
             term,
             logger,
+            RequestModel::BidiStreaming,
         )
         .await
     });

--- a/oak_functions/loader/src/grpc.rs
+++ b/oak_functions/loader/src/grpc.rs
@@ -31,6 +31,19 @@ use oak_logger::OakLogger;
 use prost::Message;
 use std::{future::Future, net::SocketAddr};
 
+#[derive(serde::Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub enum RequestModel {
+    Unary,
+    BidiStreaming,
+}
+
+impl Default for RequestModel {
+    fn default() -> Self {
+        RequestModel::BidiStreaming
+    }
+}
+
 async fn handle_request(
     wasm_handler: WasmHandler,
     policy: ServerPolicy,
@@ -70,7 +83,15 @@ pub async fn create_and_start_grpc_server<F: Future<Output = ()>>(
     config_info: ConfigurationInfo,
     terminate: F,
     logger: Logger,
+    request_model: RequestModel,
 ) -> anyhow::Result<()> {
+    if let RequestModel::Unary = request_model {
+        return Err(anyhow::anyhow!(
+            "Failed to start, support for {:?} is not yet implemented",
+            request_model
+        ));
+    }
+
     logger.log_public(
         Level::Info,
         &format!(

--- a/oak_functions/loader/src/lib.rs
+++ b/oak_functions/loader/src/lib.rs
@@ -31,7 +31,7 @@ use crate::metrics::PrivateMetricsProxyFactory;
 #[cfg(feature = "oak-tf")]
 use crate::tf::{read_model_from_path, TensorFlowFactory};
 use crate::{
-    grpc::{create_and_start_grpc_server, create_wasm_handler},
+    grpc::{create_and_start_grpc_server, create_wasm_handler, RequestModel},
     logger::Logger,
     lookup::LookupFactory,
     lookup_data::{LookupData, LookupDataAuth, LookupDataSource},
@@ -98,6 +98,9 @@ struct Config {
     #[cfg(feature = "oak-metrics")]
     #[serde(default)]
     metrics: Option<PrivateMetricsConfig>,
+    /// Request model used to accept gRPC client requests
+    #[serde(default = "RequestModel::default")]
+    grpc_request_model: RequestModel,
 }
 
 #[derive(Deserialize, Debug)]
@@ -236,6 +239,7 @@ async fn async_main(opt: Opt, config: Config, logger: Logger) -> anyhow::Result<
             config_info,
             async { notify_receiver.await.unwrap() },
             logger,
+            config.grpc_request_model,
         )
         .await
         .context("error while waiting for the server to terminate")

--- a/oak_functions/loader/src/tests.rs
+++ b/oak_functions/loader/src/tests.rs
@@ -15,7 +15,7 @@
 //
 
 use crate::{
-    grpc::{create_and_start_grpc_server, create_wasm_handler},
+    grpc::{create_and_start_grpc_server, create_wasm_handler, RequestModel},
     logger::Logger,
     lookup::LookupFactory,
     lookup_data::{parse_lookup_entries, LookupData, LookupDataAuth, LookupDataSource},
@@ -162,6 +162,7 @@ where
             get_config_info(&wasm_module_bytes, policy, false, None),
             term,
             logger,
+            RequestModel::BidiStreaming,
         )
         .await
     });


### PR DESCRIPTION
Implements the feature flag as a runtime flag as that's what we do atm for lookupdata, tensorflow etc. Worth mentioning alternatively we could make this a build time flag (ref our previous discussion in https://github.com/project-oak/oak/issues/2569). Doing so would introduce additional complexity however since we currently only have two binary variants. 

Opening this so we can decide whether we want a build time or runtime flag for this. Imo build time would be preferable in principle, but runtime is the pragmatic choice right now: It's our current model and changing it for this particular flag probs isn't worth it. This flag is transient and has limited security implications. 