### PR TITLE
Switch to a newer Buster snapshot and rate-limit apt-get

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:c38f47fa7b57be7dd2dd7a5e0807f8db1cb381fc1d0edb4a185eb5a8b66828d1",
+  "image": "sha256:36961e933e061162299aa9b237c171d314fe8ccbbe30f054410f3a1082175cee",
   "extensions": [
     "bazelbuild.vscode-bazel",
     "bodil.prettier-toml",

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # > /etc/apt/sources.list
 
 # Getting curl and certificates dependecies.
+# We're rate-limiting HTTP requests to 500 kB/s as otherwise we may get timeout errors
+# when downloading from snapshot.debian.org.
 RUN apt-get --yes update \
-  && apt-get install --no-install-recommends --yes \
+  && apt-get install --no-install-recommends --yes --option Acquire::http::Dl-Limit=500 \
   apt-transport-https \
   build-essential \
   ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use fixed snapshot of Debian to create a deterministic environment.
 # Snapshot tags can be found at https://hub.docker.com/r/debian/snapshot/tags
-ARG debian_snapshot=sha256:eeed67d1ae0846429668170fdab5e8f7ed884234db1b2c8075471bd8365cf3a7
+ARG debian_snapshot=sha256:89f4b36d2e15a87382699808a2ca96c6da5f1db928eb0a5cd8bfa38e4edcc189
 FROM debian/snapshot@${debian_snapshot}
 
 # Set the SHELL option -o pipefail before RUN with a pipe in.

--- a/scripts/common
+++ b/scripts/common
@@ -20,10 +20,10 @@ readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak:latest'
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:c38f47fa7b57be7dd2dd7a5e0807f8db1cb381fc1d0edb4a185eb5a8b66828d1'
+readonly DOCKER_IMAGE_ID='sha256:36961e933e061162299aa9b237c171d314fe8ccbbe30f054410f3a1082175cee'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:43ebcd2fea8dc27a0b038b5c8e99f0665d7f292045824829519ba7dbe118c7e4'
+readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:d409c6f1213dfd1dc32caf9e7dcd03bc2fa30f1df2bec4245d4a6dc5dcc1f27f'
 
 readonly SERVER_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-server'
 


### PR DESCRIPTION
Right now rebuilding the Oak docker image often fails when running `apt-get`; this PR attempts to alleviate that.

First, switch the base to debian/snapshot:buster-20220228. The original idea was that maybe our previous snapshot was too old, but that doesn't seem to be the case.
Second, add a rate-limit to `apt-get`. That seems to make things better.

