### PR TITLE
Use a custom implementation of Mutex instead of std (#2579)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,7 @@ dependencies = [
  "anyhow",
  "log",
  "maplit",
+ "oak_functions_util",
  "oak_logger",
  "rand 0.8.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,6 +1996,7 @@ dependencies = [
  "oak_functions_lookup",
  "oak_functions_metrics",
  "oak_functions_tf_inference",
+ "oak_functions_util",
  "oak_logger",
  "oak_remote_attestation",
  "oak_utils",
@@ -2036,6 +2037,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "maplit",
+ "oak_functions_util",
  "oak_logger",
 ]
 
@@ -2075,6 +2077,13 @@ dependencies = [
  "serde",
  "serde_derive",
  "tract-tensorflow 0.15.9-pre",
+]
+
+[[package]]
+name = "oak_functions_util"
+version = "0.1.0"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
   "oak_functions/sdk/oak_functions",
   "oak_functions/sdk/oak_functions/tests/module",
   "oak_functions/sdk/test_utils",
+  "oak_functions/util",
   "remote_attestation/rust",
   "xtask",
 ]

--- a/oak_functions/experimental/metrics/Cargo.toml
+++ b/oak_functions/experimental/metrics/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 anyhow = "*"
 log = "*"
 maplit = "*"
+oak_functions_util = { path = "../../util" }
 oak_logger = { path = "../../logger" }
 rand = "*"
 serde = { version = "*", features = ["derive"] }

--- a/oak_functions/experimental/metrics/src/lib.rs
+++ b/oak_functions/experimental/metrics/src/lib.rs
@@ -21,10 +21,9 @@ use anyhow::Context;
 use log::Level;
 use oak_logger::OakLogger;
 // TODO(#2580): Convert to `no_std` compatible random number generation.
+use oak_functions_util::sync::Mutex;
 use rand::{distributions::Open01, rngs::StdRng, thread_rng, Rng, SeedableRng};
 use serde::Deserialize;
-// TODO(#2579): Replace with no_std compatible implementation once available.
-use std::sync::Mutex;
 
 /// Configuration for differentially-private metrics reporting.
 #[derive(Deserialize, Debug)]
@@ -323,11 +322,7 @@ impl PrivateMetricsProxy {
     ///
     /// See [PrivateMetricsAggregator::report_metrics] for more details.
     fn publish(self) -> Option<(usize, Vec<(String, i64)>)> {
-        if let Ok(mut aggregator) = self.aggregator.lock() {
-            aggregator.report_metrics(self.data)
-        } else {
-            None
-        }
+        self.aggregator.lock().report_metrics(self.data)
     }
 }
 

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -38,6 +38,7 @@ humantime-serde = "*"
 log = { version = "*", features = ["max_level_off", "release_max_level_off"] }
 oak_functions_abi = { path = "../abi" }
 oak_functions_lookup = { path = "../lookup" }
+oak_functions_util = { path = "../util" }
 oak_functions_metrics = { optional = true, path = "../experimental/metrics" }
 oak_functions_tf_inference = { optional = true, path = "../experimental/tf_inference" }
 oak_logger = { path = "../logger" }

--- a/oak_functions/loader/fuzz/Cargo.lock
+++ b/oak_functions/loader/fuzz/Cargo.lock
@@ -614,6 +614,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
+name = "lock_api"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +771,7 @@ dependencies = [
  "oak_functions_abi",
  "oak_functions_lookup",
  "oak_functions_metrics",
+ "oak_functions_util",
  "oak_logger",
  "oak_remote_attestation",
  "oak_utils",
@@ -802,6 +812,7 @@ name = "oak_functions_lookup"
 version = "0.1.0"
 dependencies = [
  "log",
+ "oak_functions_util",
  "oak_logger",
 ]
 
@@ -812,9 +823,17 @@ dependencies = [
  "anyhow",
  "log",
  "maplit",
+ "oak_functions_util",
  "oak_logger",
  "rand",
  "serde",
+]
+
+[[package]]
+name = "oak_functions_util"
+version = "0.1.0"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1152,6 +1171,12 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"

--- a/oak_functions/loader/src/lib.rs
+++ b/oak_functions/loader/src/lib.rs
@@ -16,6 +16,8 @@
 
 #![feature(async_closure)]
 
+extern crate alloc;
+
 pub mod grpc;
 pub mod logger;
 pub mod lookup;

--- a/oak_functions/loader/src/metrics.rs
+++ b/oak_functions/loader/src/metrics.rs
@@ -21,11 +21,12 @@ use crate::{
         OakApiNativeExtension, WasmState, ABI_USIZE,
     },
 };
+use alloc::sync::Arc;
 use oak_functions_abi::proto::OakStatus;
 use oak_functions_metrics::{
     PrivateMetricsAggregator, PrivateMetricsConfig, PrivateMetricsExtension, PrivateMetricsProxy,
 };
-use std::sync::{Arc, Mutex};
+use oak_functions_util::sync::Mutex;
 use wasmi::ValueType;
 
 /// Host function name for reporting private metrics.

--- a/oak_functions/loader/src/metrics.rs
+++ b/oak_functions/loader/src/metrics.rs
@@ -26,6 +26,7 @@ use oak_functions_abi::proto::OakStatus;
 use oak_functions_metrics::{
     PrivateMetricsAggregator, PrivateMetricsConfig, PrivateMetricsExtension, PrivateMetricsProxy,
 };
+// TODO(#2630): Use the std version of Mutex in environments where std is available.
 use oak_functions_util::sync::Mutex;
 use wasmi::ValueType;
 

--- a/oak_functions/lookup/Cargo.toml
+++ b/oak_functions/lookup/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 [dependencies]
 log = "*"
 oak_logger = { path = "../logger" }
+oak_functions_util = { path = "../util" }
 
 [dev-dependencies]
 maplit = "*"

--- a/oak_functions/util/Cargo.toml
+++ b/oak_functions/util/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "oak_functions_util"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+lock_api = { version = "*", features = ["arc_lock"] }

--- a/oak_functions/util/src/lib.rs
+++ b/oak_functions/util/src/lib.rs
@@ -13,5 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#![no_std]
+
+extern crate alloc;
 
 pub mod sync;

--- a/oak_functions/util/src/lib.rs
+++ b/oak_functions/util/src/lib.rs
@@ -1,0 +1,17 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub mod sync;

--- a/oak_functions/util/src/sync.rs
+++ b/oak_functions/util/src/sync.rs
@@ -1,0 +1,54 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use lock_api::{GuardSend, RawMutex};
+use std::{
+    hint::spin_loop,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+pub struct SpinLock(AtomicBool);
+
+unsafe impl RawMutex for SpinLock {
+    type GuardMarker = GuardSend;
+
+    const INIT: SpinLock = SpinLock(AtomicBool::new(false));
+
+    fn lock(&self) {
+        while let Err(_) =
+            self.0
+                .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+        {
+            // While spinning to acquire the lock, we should perform a read
+            while self.0.load(Ordering::Relaxed) {
+                spin_loop()
+            }
+        }
+    }
+
+    fn try_lock(&self) -> bool {
+        self.0
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+    }
+
+    unsafe fn unlock(&self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+pub type Mutex<T> = lock_api::Mutex<SpinLock, T>;
+pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, SpinLock, T>;


### PR DESCRIPTION
This is in preparation for the Oak Functions loader compatible with no_std
in the future.

Note that the current use of RwLock was replaced by a Mutex. This is because
the critical section is extremely short: just cloning or replacing an Arc. Such
short critical sections do not need the flexibility of reader-writer lock.