### PR TITLE
Refactor running of examples

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - check-format
           - run-cargo-deny
           - run-cargo-udeps
-          - build-functions-server-variants
+          - build-oak-functions-server-variants
           - run-cargo-tests
           # TODO(#2538): Re-enable when bazel tests run on the main Docker image.
           # - run-bazel-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           - run-cargo-tests
           # TODO(#2538): Re-enable when bazel tests run on the main Docker image.
           # - run-bazel-tests
-          - run-functions-examples --application-variant=rust
+          - run-oak-functions-examples --application-variant=rust
           - run-cargo-fuzz --build-deps -- -max_total_time=2
           - completion
           - run-cargo-clippy

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -54,7 +54,7 @@ jobs:
           ./scripts/build_provenance \
           "oak_functions" \
           ./target/x86_64-unknown-linux-musl/release/oak_functions_loader_base \
-          ./scripts/xtask build-functions-server-variants
+          ./scripts/xtask build-oak-functions-server-variants
 
       - name: Move new provenance files to the provenance branch
         if: github.event_name == 'push'

--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -56,7 +56,7 @@ jobs:
       # Build artifacts that are supposed to be reproducible.
       - name: Build Functions server
         run: |
-          ./scripts/docker_run ./scripts/xtask build-functions-server-variants
+          ./scripts/docker_run ./scripts/xtask build-oak-functions-server-variants
 
       # Generate an index of the hashes of the reproducible artifacts.
       - name: Generate Reproducibility Index

--- a/.xtask_bash_completion
+++ b/.xtask_bash_completion
@@ -15,8 +15,8 @@ _xtask() {
             build-oak-functions-example)
                 cmd+="__build__oak__functions__example"
                 ;;
-            build-oak-functions-server)
-                cmd+="__build__oak__functions__server"
+            build-oak-functions-server-variants)
+                cmd+="__build__oak__functions__server__variants"
                 ;;
             check-format)
                 cmd+="__check__format"
@@ -67,7 +67,7 @@ _xtask() {
 
     case "${cmd}" in
         xtask)
-            opts="-h --help --dry-run --commands --logs --keep-going --scope run-oak-functions-examples build-oak-functions-example build-oak-functions-server format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
+            opts="-h --help --dry-run --commands --logs --keep-going --scope run-oak-functions-examples build-oak-functions-example build-oak-functions-server-variants format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -142,7 +142,7 @@ _xtask() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        xtask__build__oak__functions__server)
+        xtask__build__oak__functions__server__variants)
             opts="-h --server-variant --server-rust-toolchain --server-rust-target --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/.xtask_bash_completion
+++ b/.xtask_bash_completion
@@ -12,11 +12,11 @@ _xtask() {
             "$1")
                 cmd="xtask"
                 ;;
-            build-functions-example)
-                cmd+="__build__functions__example"
+            build-oak-functions-example)
+                cmd+="__build__oak__functions__example"
                 ;;
-            build-functions-server-variants)
-                cmd+="__build__functions__server__variants"
+            build-oak-functions-server)
+                cmd+="__build__oak__functions__server"
                 ;;
             check-format)
                 cmd+="__check__format"
@@ -54,8 +54,8 @@ _xtask() {
             run-ci)
                 cmd+="__run__ci"
                 ;;
-            run-functions-examples)
-                cmd+="__run__functions__examples"
+            run-oak-functions-examples)
+                cmd+="__run__oak__functions__examples"
                 ;;
             run-tests)
                 cmd+="__run__tests"
@@ -67,7 +67,7 @@ _xtask() {
 
     case "${cmd}" in
         xtask)
-            opts="-h --help --dry-run --commands --logs --keep-going --scope run-functions-examples build-functions-example build-functions-server-variants format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
+            opts="-h --help --dry-run --commands --logs --keep-going --scope run-oak-functions-examples build-oak-functions-example build-oak-functions-server format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -84,8 +84,8 @@ _xtask() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        xtask__build__functions__example)
-            opts="-h --application-variant --example-name --client-variant --client-rust-toolchain --client-rust-target --server-rust-toolchain --server-rust-target --run-server --client-additional-args --server-additional-args --build-docker --help"
+        xtask__build__oak__functions__example)
+            opts="-h --application-variant --example-name --client-variant --client-rust-toolchain --client-rust-target --server-variant --server-rust-toolchain --server-rust-target --run-server --client-additional-args --server-additional-args --build-docker --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -108,6 +108,10 @@ _xtask() {
                     return 0
                     ;;
                 --client-rust-target)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --server-variant)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -138,13 +142,17 @@ _xtask() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        xtask__build__functions__server__variants)
-            opts="-h --server-rust-toolchain --server-rust-target --help"
+        xtask__build__oak__functions__server)
+            opts="-h --server-variant --server-rust-toolchain --server-rust-target --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --server-variant)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --server-rust-toolchain)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -340,8 +348,8 @@ _xtask() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        xtask__run__functions__examples)
-            opts="-h --application-variant --example-name --client-variant --client-rust-toolchain --client-rust-target --server-rust-toolchain --server-rust-target --run-server --client-additional-args --server-additional-args --build-docker --help"
+        xtask__run__oak__functions__examples)
+            opts="-h --application-variant --example-name --client-variant --client-rust-toolchain --client-rust-target --server-variant --server-rust-toolchain --server-rust-target --run-server --client-additional-args --server-additional-args --build-docker --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -364,6 +372,10 @@ _xtask() {
                     return 0
                     ;;
                 --client-rust-target)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --server-variant)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/docs/INSTALL-OSX.md
+++ b/docs/INSTALL-OSX.md
@@ -61,7 +61,7 @@ The Oak Functions Runtime and its dependencies are built with the following
 script:
 
 ```bash
-./scripts/xtask build-functions-server-variants
+./scripts/xtask build-oak-functions-server-variants
 ```
 
 Build a particular example, say `hello_world`, with:

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,7 +176,7 @@ will take some time, but subsequent builds should be cached and so run much
 faster.
 
 ```bash
-xtask build-functions-server-variants
+xtask build-oak-functions-server-variants
 ```
 
 ### Run Oak Functions Server

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 ./scripts/docker_pull
-./scripts/docker_run ./scripts/xtask build-functions-server-variants
+./scripts/docker_run ./scripts/xtask build-oak-functions-server-variants

--- a/oak_functions/examples/echo/example.toml
+++ b/oak_functions/examples/echo/example.toml
@@ -3,7 +3,7 @@ name = "echo"
 [applications]
 
 [applications.rust]
-type = "Functions"
+type = "OakFunctions"
 wasm_path = "bin/echo.wasm"
 target = { Cargo = { cargo_manifest = "oak_functions/examples/echo/module/Cargo.toml" } }
 

--- a/oak_functions/examples/key_value_lookup/example.toml
+++ b/oak_functions/examples/key_value_lookup/example.toml
@@ -3,7 +3,7 @@ name = "key_value_lookup"
 [applications]
 
 [applications.rust]
-type = "Functions"
+type = "OakFunctions"
 wasm_path = "bin/key_value_lookup.wasm"
 target = { Cargo = { cargo_manifest = "oak_functions/examples/key_value_lookup/module/Cargo.toml" } }
 

--- a/oak_functions/examples/metrics/example.toml
+++ b/oak_functions/examples/metrics/example.toml
@@ -3,7 +3,7 @@ name = "metrics"
 [applications]
 
 [applications.rust]
-type = "Functions"
+type = "OakFunctions"
 wasm_path = "bin/metrics.wasm"
 target = { Cargo = { cargo_manifest = "oak_functions/examples/metrics/module/Cargo.toml" } }
 

--- a/oak_functions/examples/mobilenet/example.toml
+++ b/oak_functions/examples/mobilenet/example.toml
@@ -3,7 +3,7 @@ name = "mobilenet"
 [applications]
 
 [applications.rust]
-type = "Functions"
+type = "OakFunctions"
 wasm_path = "bin/mobilenet.wasm"
 target = { Cargo = { cargo_manifest = "oak_functions/examples/mobilenet/module/Cargo.toml" } }
 

--- a/oak_functions/examples/weather_lookup/example.toml
+++ b/oak_functions/examples/weather_lookup/example.toml
@@ -3,7 +3,7 @@ name = "weather_lookup"
 [applications]
 
 [applications.rust]
-type = "Functions"
+type = "OakFunctions"
 wasm_path = "bin/weather_lookup_init.wasm"
 target = { Cargo = { cargo_manifest = "oak_functions/examples/weather_lookup/module/Cargo.toml" } }
 wizer = { input = "bin/weather_lookup.wasm", output = "bin/weather_lookup_init.wasm" }

--- a/scripts/deploy_oak_functions_loader
+++ b/scripts/deploy_oak_functions_loader
@@ -8,7 +8,7 @@ source "$SCRIPTS_DIR/common"
 source "$SCRIPTS_DIR/gcp_common"
 
 # Build Oak Functions server binary and the example application, and the client to test the connection.
-./scripts/docker_run ./scripts/xtask build-functions-example \
+./scripts/docker_run ./scripts/xtask build-oak-functions-example \
   --example-name="${EXAMPLE_NAME}" \
   --client-variant=rust
 

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -480,7 +480,7 @@ fn run_functions_example_server(
     application: &OakFunctionsApplication,
 ) -> Box<dyn Runnable> {
     Cmd::new(
-        &server.server_variant.path_to_executable(),
+        server.server_variant.path_to_executable(),
         spread![
             format!("--wasm-path={}", application.wasm_path),
             ...server.additional_args.clone(),

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -152,12 +152,6 @@ trait OakExampleSteps {
 
     fn get_build_client(&self) -> &BuildClient;
 
-    /// Get the directory of the server manifest depending on the server variant.
-    fn get_server_manifest(server_variant: &ServerVariant) -> &'static str;
-
-    /// Get the server binary depending on the server variant.
-    fn get_server_binary(server_variant: &ServerVariant) -> &'static str;
-
     /// Constructs application build steps.
     fn construct_application_build_steps(&self) -> Vec<Step>;
 
@@ -239,24 +233,6 @@ impl OakExampleSteps for OakFunctionsExample<'_> {
         match self.applications.get(app_variant) {
             None => run_clients,
             Some(app) => app.construct_server_run_step(self, run_clients),
-        }
-    }
-
-    fn get_server_manifest(server_variant: &ServerVariant) -> &'static str {
-        match server_variant {
-            ServerVariant::Base => "./oak_functions/oak_functions_loader_base",
-            ServerVariant::Unsafe => "./oak_functions/oak_functions_loader_unsafe",
-        }
-    }
-
-    fn get_server_binary(server_variant: &ServerVariant) -> &'static str {
-        match server_variant {
-            ServerVariant::Base => {
-                "./target/x86_64-unknown-linux-musl/release/oak_functions_loader_base"
-            }
-            ServerVariant::Unsafe => {
-                "./target/x86_64-unknown-linux-musl/release/oak_functions_loader_unsafe"
-            }
         }
     }
 }
@@ -504,7 +480,7 @@ fn run_functions_example_server(
     application: &OakFunctionsApplication,
 ) -> Box<dyn Runnable> {
     Cmd::new(
-        OakFunctionsExample::get_server_binary(&server.server_variant),
+        &server.server_variant.path_to_executable(),
         spread![
             format!("--wasm-path={}", application.wasm_path),
             ...server.additional_args.clone(),

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -32,47 +32,40 @@ const DEFAULT_EXAMPLE_BACKEND_RUST_TARGET: &str = "x86_64-unknown-linux-gnu";
 pub const ALL_CLIENTS: &str = "all";
 pub const NO_CLIENTS: &str = "none";
 
+/// Holds the components for running an example in Oak: a `server` running the given
+/// `applications` listening to the `clients` and passing requests to `backends`.
+/// Configured through `example.toml` files.
 #[derive(serde::Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
-pub struct Example {
+pub struct OakExample {
     name: String,
     #[serde(default)]
-    server: ExampleServer,
+    server: Server,
     #[serde(default)]
     backends: HashMap<String, Executable>,
     applications: HashMap<String, Application>,
     clients: HashMap<String, Executable>,
 }
 
-impl Example {
-    fn has_classic_app(&self) -> bool {
+impl OakExample {
+    fn has_oak_functions_application(&self) -> bool {
         self.applications.values().any(|app| match app {
-            Application::Functions(_) => false,
-        })
-    }
-
-    fn has_functions_app(&self) -> bool {
-        self.applications.values().any(|app| match app {
-            Application::Functions(_) => true,
+            Application::OakFunctions(_) => true,
         })
     }
 }
 
-/// A construct representing either an Oak Classic or an Oak Functions application.
-///
-/// The condition that only one of `classic` or `functions` should be non-empty is
-/// checked in each operation of this struct. If neither or both are empty, the
-/// operation panics with an error message.
+/// Identify the application the server runs.
 #[derive(serde::Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "type")]
 enum Application {
-    Functions(ApplicationFunctions),
+    OakFunctions(OakFunctionsApplication),
 }
 
 #[derive(serde::Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
-struct ApplicationFunctions {
+struct OakFunctionsApplication {
     wasm_path: String,
     target: Target,
     wizer: Option<WizerOpt>,
@@ -87,11 +80,11 @@ struct WizerOpt {
 
 #[derive(serde::Deserialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
-struct ExampleServer {
+struct Server {
     #[serde(default)]
     additional_args: Vec<String>,
     #[serde(default)]
-    server_variant: FunctionsServerVariant,
+    server_variant: ServerVariant,
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -124,7 +117,7 @@ struct Executable {
     additional_args: Vec<String>,
 }
 
-impl ApplicationFunctions {
+impl OakFunctionsApplication {
     fn construct_application_build_steps(&self, example_name: &str) -> Vec<Step> {
         let mut result = vec![build_wasm_module(example_name, &self.target, example_name)];
         // If Wizer configuration is specified, run Wizer after the build.
@@ -134,13 +127,9 @@ impl ApplicationFunctions {
         result
     }
 
-    fn construct_example_server_run_step(
-        &self,
-        example: &FunctionsExample,
-        run_clients: Step,
-    ) -> Step {
+    fn construct_server_run_step(&self, example: &OakFunctionsExample, run_clients: Step) -> Step {
         let opt = &example.options;
-        let run_server = run_functions_example_server(&example.example.server, self);
+        let run_server = run_oak_functions_server(&example.example.server, self);
 
         if opt.build_client.client_variant == NO_CLIENTS {
             Step::Single {
@@ -157,16 +146,23 @@ impl ApplicationFunctions {
     }
 }
 
-trait OakExample {
+/// Construct run and build steps an `OakExample`.
+trait OakExampleSteps {
     fn get_backends(&self) -> &HashMap<String, Executable>;
 
     fn get_build_client(&self) -> &BuildClient;
+
+    /// Get the directory of the server manifest depending on the server variant.
+    fn get_server_manifest(server_variant: &ServerVariant) -> &'static str;
+
+    /// Get the server binary depending on the server variant.
+    fn get_server_binary(server_variant: &ServerVariant) -> &'static str;
 
     /// Constructs application build steps.
     fn construct_application_build_steps(&self) -> Vec<Step>;
 
     /// Constructs run step for the example server.
-    fn construct_example_server_run_step(&self, run_clients: Step) -> Step;
+    fn construct_server_run_step(&self, run_clients: Step) -> Step;
 
     /// Constructs build steps for the backends.
     fn construct_backend_build_steps(&self) -> Vec<Step> {
@@ -194,26 +190,26 @@ trait OakExample {
             })
     }
 }
-pub struct FunctionsExample<'a> {
-    example: &'a Example,
-    applications: HashMap<String, &'a ApplicationFunctions>,
-    options: RunFunctionsExamples,
+pub struct OakFunctionsExample<'a> {
+    example: &'a OakExample,
+    applications: HashMap<String, &'a OakFunctionsApplication>,
+    options: RunOakExamplesOpt,
 }
 
-impl<'a> FunctionsExample<'a> {
-    fn new(example: &'a Example, options: RunFunctionsExamples) -> Self {
+impl<'a> OakFunctionsExample<'a> {
+    fn new(example: &'a OakExample, options: RunOakExamplesOpt) -> Self {
         let applications =
             example
                 .applications
                 .iter()
                 .fold(hashmap! {}, |mut apps, app| match app {
-                    (name, Application::Functions(ref app)) => {
+                    (name, Application::OakFunctions(ref app)) => {
                         apps.insert(name.clone(), app);
                         apps
                     }
                 });
 
-        FunctionsExample {
+        OakFunctionsExample {
             example,
             applications,
             options,
@@ -221,7 +217,7 @@ impl<'a> FunctionsExample<'a> {
     }
 }
 
-impl OakExample for FunctionsExample<'_> {
+impl OakExampleSteps for OakFunctionsExample<'_> {
     fn get_backends(&self) -> &HashMap<String, Executable> {
         &self.example.backends
     }
@@ -238,23 +234,41 @@ impl OakExample for FunctionsExample<'_> {
         }
     }
 
-    fn construct_example_server_run_step(&self, run_clients: Step) -> Step {
+    fn construct_server_run_step(&self, run_clients: Step) -> Step {
         let app_variant = self.options.application_variant.as_str();
         match self.applications.get(app_variant) {
             None => run_clients,
-            Some(app) => app.construct_example_server_run_step(self, run_clients),
+            Some(app) => app.construct_server_run_step(self, run_clients),
+        }
+    }
+
+    fn get_server_manifest(server_variant: &ServerVariant) -> &'static str {
+        match server_variant {
+            ServerVariant::Base => "./oak_functions/oak_functions_loader_base",
+            ServerVariant::Unsafe => "./oak_functions/oak_functions_loader_unsafe",
+        }
+    }
+
+    fn get_server_binary(server_variant: &ServerVariant) -> &'static str {
+        match server_variant {
+            ServerVariant::Base => {
+                "./target/x86_64-unknown-linux-musl/release/oak_functions_loader_base"
+            }
+            ServerVariant::Unsafe => {
+                "./target/x86_64-unknown-linux-musl/release/oak_functions_loader_unsafe"
+            }
         }
     }
 }
 
-pub fn run_functions_examples(opt: &RunFunctionsExamples, scope: &Scope) -> Step {
-    let examples: Vec<Example> = example_toml_files(scope)
+pub fn run_oak_functions_examples(opt: &RunOakExamplesOpt, scope: &Scope) -> Step {
+    let examples: Vec<OakExample> = example_toml_files(scope)
         .map(|path| {
             toml::from_str(&read_file(&path)).unwrap_or_else(|err| {
                 panic!("could not parse example manifest file {:?}: {}", path, err)
             })
         })
-        .filter(|example: &Example| example.has_functions_app() && !example.has_classic_app())
+        .filter(|example: &OakExample| example.has_oak_functions_application())
         .collect();
 
     Step::Multiple {
@@ -265,8 +279,8 @@ pub fn run_functions_examples(opt: &RunFunctionsExamples, scope: &Scope) -> Step
                 Some(example_name) => &example.name == example_name,
                 None => true,
             })
-            .map(|example| FunctionsExample::new(example, opt.clone()))
-            .map(|example| run_functions_example(&example))
+            .map(|example| OakFunctionsExample::new(example, opt.clone()))
+            .map(|example| run_oak_functions_example(&example))
             .collect(),
     }
 }
@@ -274,16 +288,16 @@ pub fn run_functions_examples(opt: &RunFunctionsExamples, scope: &Scope) -> Step
 /// Build every variant of the function server.
 /// It's easier to always build all variants than to control which variant to build and
 /// the overhead of building all variants is acceptable.
-pub fn build_functions_server_variants(opt: &BuildFunctionsServer) -> Step {
+pub fn build_oak_functions_server_variants(opt: &BuildServerOpt) -> Step {
     Step::Multiple {
         name: "cargo build all variants of function server".to_string(),
-        steps: FunctionsServerVariant::iter()
+        steps: ServerVariant::iter()
             .map(|variant| build_rust_binary(variant.path_to_manifest(), opt))
             .collect(),
     }
 }
 
-fn run_functions_example(example: &FunctionsExample) -> Step {
+fn run_oak_functions_example(example: &OakFunctionsExample) -> Step {
     let opt = &example.options;
 
     // Build steps for running clients
@@ -296,7 +310,7 @@ fn run_functions_example(example: &FunctionsExample) -> Step {
     // Build any backend server
     #[allow(clippy::collapsible_if)]
     let run_backend_server_clients: Step = if opt.run_server.unwrap_or(true) {
-        let run_server_clients = example.construct_example_server_run_step(run_clients);
+        let run_server_clients = example.construct_server_run_step(run_clients);
         example.construct_backend_run_steps(run_server_clients)
     } else {
         run_clients
@@ -309,7 +323,7 @@ fn run_functions_example(example: &FunctionsExample) -> Step {
             if opt.run_server.unwrap_or(true) {
                 // Build (all variants of) the server first so that when running a variant in the
                 // next step it will start up faster.
-                vec![build_functions_server_variants(&opt.build_server)]
+                vec![build_oak_functions_server_variants(&opt.build_server)]
             } else {
                 vec![]
             },
@@ -330,21 +344,21 @@ fn run_functions_example(example: &FunctionsExample) -> Step {
     }
 }
 
-pub fn build_functions_example(opt: &RunFunctionsExamples, scope: &Scope) -> Step {
+pub fn build_oak_functions_example(opt: &RunOakExamplesOpt, scope: &Scope) -> Step {
     let example_name = &opt
         .example_name
         .as_ref()
         .expect("--example-name must be specified")
         .clone();
 
-    let example: Example = example_toml_files(scope)
+    let example: OakExample = example_toml_files(scope)
         .map(|path| {
             toml::from_str(&read_file(&path)).unwrap_or_else(|err| {
                 panic!("could not parse example manifest file {:?}: {}", path, err)
             })
         })
-        .find(|example: &Example| &example.name == example_name)
-        .filter(|example| example.has_functions_app())
+        .find(|example: &OakExample| &example.name == example_name)
+        .filter(|example| example.has_oak_functions_application())
         .expect("could not find the specified functions example, try with `--scope=all`");
 
     // Build steps for building clients
@@ -364,21 +378,21 @@ pub fn build_functions_example(opt: &RunFunctionsExamples, scope: &Scope) -> Ste
             .collect(),
     };
 
-    let functions_example = FunctionsExample::new(&example, opt.clone());
+    let oak_functions_example = OakFunctionsExample::new(&example, opt.clone());
 
     Step::Multiple {
         name: example.name.to_string(),
         steps: vec![
-            functions_example.construct_application_build_steps(),
+            oak_functions_example.construct_application_build_steps(),
             // Build the server first so that when running it in the next step it will start up
             // faster.
-            vec![build_functions_server_variants(&opt.build_server)],
+            vec![build_oak_functions_server_variants(&opt.build_server)],
             if opt.build_docker {
                 vec![build_docker(&example)]
             } else {
                 vec![]
             },
-            functions_example.construct_backend_build_steps(),
+            oak_functions_example.construct_backend_build_steps(),
             vec![build_client],
         ]
         .into_iter()
@@ -402,7 +416,6 @@ pub fn build_wasm_module(name: &str, target: &Target, example_name: &str) -> Ste
                 command: Cmd::new(
                     "cargo",
                     // Keep this in sync with `/oak_functions/sdk/test/utils/src/lib.rs`.
-                    // Keep this in sync with `/sdk/rust/oak_tests/src/lib.rs`.
                     spread![
                         // `--out-dir` is unstable and requires `-Zunstable-options`.
                         "-Zunstable-options".to_string(),
@@ -487,27 +500,20 @@ fn run_wizer(input: &str, output: &str) -> Step {
 }
 
 fn run_functions_example_server(
-    example_server: &ExampleServer,
-    application: &ApplicationFunctions,
+    server: &Server,
+    application: &OakFunctionsApplication,
 ) -> Box<dyn Runnable> {
     Cmd::new(
-        match example_server.server_variant {
-            FunctionsServerVariant::Base => {
-                "target/x86_64-unknown-linux-musl/release/oak_functions_loader_base"
-            }
-            FunctionsServerVariant::Unsafe => {
-                "target/x86_64-unknown-linux-musl/release/oak_functions_loader_unsafe"
-            }
-        },
+        OakFunctionsExample::get_server_binary(&server.server_variant),
         spread![
             format!("--wasm-path={}", application.wasm_path),
-            ...example_server.additional_args.clone(),
+            ...server.additional_args.clone(),
         ],
     )
 }
 
 fn run_clients(
-    example: &Example,
+    example: &OakExample,
     build_client: &BuildClient,
     client_additional_args: Vec<String>,
 ) -> Step {
@@ -548,7 +554,7 @@ fn run_client(
     }
 }
 
-fn build_docker(example: &Example) -> Step {
+fn build_docker(example: &OakExample) -> Step {
     Step::Multiple {
         name: "docker".to_string(),
         steps: vec![
@@ -693,7 +699,7 @@ fn run(
     }
 }
 
-fn build_rust_binary(manifest_dir: &str, opt: &BuildFunctionsServer) -> Step {
+fn build_rust_binary(manifest_dir: &str, opt: &BuildServerOpt) -> Step {
     Step::Single {
         name: format!("build rust binary {}", manifest_dir),
         command: Cmd::new(

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -262,7 +262,7 @@ pub fn run_oak_functions_examples(opt: &RunOakExamplesOpt, scope: &Scope) -> Ste
 }
 
 /// Build every variant of the function server.
-/// It's easier to always build all variants than to control which variant to build and
+/// It's easier to always build all variants than to keep track of which variant to build and
 /// the overhead of building all variants is acceptable.
 pub fn build_oak_functions_server_variants(opt: &BuildServerOpt) -> Step {
     Step::Multiple {
@@ -475,7 +475,7 @@ fn run_wizer(input: &str, output: &str) -> Step {
     }
 }
 
-fn run_functions_example_server(
+fn run_oak_functions_server(
     server: &Server,
     application: &OakFunctionsApplication,
 ) -> Box<dyn Runnable> {

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -202,8 +202,8 @@ impl ServerVariant {
     // Get path to manifest for the variant.
     pub fn path_to_manifest(&self) -> &'static str {
         match self {
-            ServerVariant::Base => "oak_functions/oak_functions_loader_base",
-            ServerVariant::Unsafe => "oak_functions/oak_functions_loader_unsafe",
+            ServerVariant::Base => "./oak_functions/oak_functions_loader_base",
+            ServerVariant::Unsafe => "./oak_functions/oak_functions_loader_unsafe",
         }
     }
 

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -58,7 +58,7 @@ pub struct Opt {
 pub enum Command {
     RunOakFunctionsExamples(RunOakExamplesOpt),
     BuildOakFunctionsExample(RunOakExamplesOpt),
-    BuildOakFunctionsServer(BuildServerOpt),
+    BuildOakFunctionsServerVariants(BuildServerOpt),
     Format,
     CheckFormat,
     RunTests,

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -206,6 +206,18 @@ impl ServerVariant {
             ServerVariant::Unsafe => "oak_functions/oak_functions_loader_unsafe",
         }
     }
+
+    /// Get path to the executable server binary for the server variant.
+    pub fn path_to_executable(&self) -> &'static str {
+        match self {
+            ServerVariant::Base => {
+                "./target/x86_64-unknown-linux-musl/release/oak_functions_loader_base"
+            }
+            ServerVariant::Unsafe => {
+                "./target/x86_64-unknown-linux-musl/release/oak_functions_loader_unsafe"
+            }
+        }
+    }
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -56,9 +56,9 @@ pub struct Opt {
 
 #[derive(Subcommand, Clone, Debug)]
 pub enum Command {
-    RunFunctionsExamples(RunFunctionsExamples),
-    BuildFunctionsExample(RunFunctionsExamples),
-    BuildFunctionsServerVariants(BuildFunctionsServer),
+    RunOakFunctionsExamples(RunOakExamplesOpt),
+    BuildOakFunctionsExample(RunOakExamplesOpt),
+    BuildOakFunctionsServer(BuildServerOpt),
     Format,
     CheckFormat,
     RunTests,
@@ -85,8 +85,9 @@ pub struct Completion {
     pub file_name: PathBuf,
 }
 
+/// Holds the options for running the example.
 #[derive(Parser, Clone, Debug)]
-pub struct RunFunctionsExamples {
+pub struct RunOakExamplesOpt {
     #[clap(
         long,
         help = "application variant: [rust, cpp]",
@@ -102,7 +103,7 @@ pub struct RunFunctionsExamples {
     #[clap(flatten)]
     pub build_client: BuildClient,
     #[clap(flatten)]
-    pub build_server: BuildFunctionsServer,
+    pub build_server: BuildServerOpt,
     #[clap(long, help = "run server [default: true]")]
     pub run_server: Option<bool>,
     #[clap(long, help = "additional arguments to pass to clients")]
@@ -170,25 +171,25 @@ pub struct BuildClient {
 }
 
 #[derive(serde::Deserialize, Debug, Clone, PartialEq, EnumIter)]
-pub enum FunctionsServerVariant {
+pub enum ServerVariant {
     /// Production-like server variant, without logging or any of the experimental features enabled
     Base,
     /// Debug server with logging and experimental features enabled
     Unsafe,
 }
 
-impl Default for FunctionsServerVariant {
+impl Default for ServerVariant {
     fn default() -> Self {
-        FunctionsServerVariant::Base
+        ServerVariant::Base
     }
 }
 
-impl std::str::FromStr for FunctionsServerVariant {
+impl std::str::FromStr for ServerVariant {
     type Err = String;
     fn from_str(variant: &str) -> Result<Self, Self::Err> {
         match variant {
-            "base" => Ok(FunctionsServerVariant::Base),
-            "unsafe" => Ok(FunctionsServerVariant::Unsafe),
+            "base" => Ok(ServerVariant::Base),
+            "unsafe" => Ok(ServerVariant::Unsafe),
             _ => Err(format!(
                 "Failed to parse functions server variant {}",
                 variant
@@ -197,18 +198,20 @@ impl std::str::FromStr for FunctionsServerVariant {
     }
 }
 
-impl FunctionsServerVariant {
+impl ServerVariant {
     // Get path to manifest for the variant.
     pub fn path_to_manifest(&self) -> &'static str {
         match self {
-            FunctionsServerVariant::Base => "oak_functions/oak_functions_loader_base",
-            FunctionsServerVariant::Unsafe => "oak_functions/oak_functions_loader_unsafe",
+            ServerVariant::Base => "oak_functions/oak_functions_loader_base",
+            ServerVariant::Unsafe => "oak_functions/oak_functions_loader_unsafe",
         }
     }
 }
 
 #[derive(Parser, Clone, Debug)]
-pub struct BuildFunctionsServer {
+pub struct BuildServerOpt {
+    #[clap(long, help = "server variant: [base, unsafe]", default_value = "base")]
+    pub server_variant: ServerVariant,
     #[clap(
         long,
         help = "rust toolchain override to use for the server compilation [e.g. stable, nightly, stage2]"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -112,9 +112,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn match_cmd(opt: &Opt) -> Step {
     match opt.cmd {
-        Command::RunFunctionsExamples(ref run_opt) => run_functions_examples(run_opt, &opt.scope),
-        Command::BuildFunctionsExample(ref opts) => build_functions_example(opts, &opt.scope),
-        Command::BuildFunctionsServerVariants(ref opt) => build_functions_server_variants(opt),
+        Command::RunOakFunctionsExamples(ref run_opt) => {
+            run_oak_functions_examples(run_opt, &opt.scope)
+        }
+        Command::BuildOakFunctionsExample(ref opts) => {
+            build_oak_functions_example(opts, &opt.scope)
+        }
+        Command::BuildOakFunctionsServer(ref opt) => build_oak_functions_server_variants(opt),
         Command::RunTests => run_tests(),
         Command::RunCargoClippy => run_cargo_clippy(&opt.scope),
         Command::RunCargoTests(ref run_opt) => run_cargo_tests(run_opt, &opt.scope),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -118,7 +118,9 @@ fn match_cmd(opt: &Opt) -> Step {
         Command::BuildOakFunctionsExample(ref opts) => {
             build_oak_functions_example(opts, &opt.scope)
         }
-        Command::BuildOakFunctionsServer(ref opt) => build_oak_functions_server_variants(opt),
+        Command::BuildOakFunctionsServerVariants(ref opt) => {
+            build_oak_functions_server_variants(opt)
+        }
         Command::RunTests => run_tests(),
         Command::RunCargoClippy => run_cargo_clippy(&opt.scope),
         Command::RunCargoTests(ref run_opt) => run_cargo_tests(run_opt, &opt.scope),


### PR DESCRIPTION
To re-use the infrastructure for running an example with a client/server/backend, we refactor to extract Oak Functions-specific functionality.