### PR TITLE
Update lookup data checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,6 @@ dependencies = [
  "log",
  "oak_functions_abi",
  "prost",
- "rand 0.5.6",
  "serde",
 ]
 

--- a/oak_functions/lookup_data_checker/Cargo.toml
+++ b/oak_functions/lookup_data_checker/Cargo.toml
@@ -14,5 +14,4 @@ location_utils = { path = "../location_utils" }
 log = "*"
 oak_functions_abi = { path = "../abi" }
 prost = "*"
-rand = "*"
 serde = { version = "*", features = ["derive"] }

--- a/oak_functions/lookup_data_checker/src/main.rs
+++ b/oak_functions/lookup_data_checker/src/main.rs
@@ -67,11 +67,9 @@ fn main() -> anyhow::Result<()> {
         if entry.0.len() == LOCATION_SIZE {
             let location = location_from_bytes(&entry.0)
                 .with_context(|| format!("could not parse location {:?}", &entry.0))?;
-            let data = String::from_utf8(entry.1.to_vec())
-                .with_context(|| format!("could not parse data {:?}", &entry.1))?;
             weather_locations.insert(entry.0);
 
-            debug!("- {{{:?}: {:?}}} # Location", location, data);
+            debug!("- {{{:?}: {:?}}} # Location", location, entry.1.to_vec());
         } else {
             let cell_id = cell_id_from_bytes(&entry.0)
                 .with_context(|| format!("could not parse cell ID {:?}", &entry.0))?;


### PR DESCRIPTION
This change removes UTF8 parsing from the lookup data checker, since the data may be in any format.