### PR TITLE
Build all variants of Functions Server by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,7 @@ jobs:
           - check-format
           - run-cargo-deny
           - run-cargo-udeps
-          - build-functions-server --server-variant=unsafe
-          - build-functions-server --server-variant=base
+          - build-functions-server
           - run-cargo-tests
           # TODO(#2538): Re-enable when bazel tests run on the main Docker image.
           # - run-bazel-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - check-format
           - run-cargo-deny
           - run-cargo-udeps
-          - build-functions-server
+          - build-functions-server-variants
           - run-cargo-tests
           # TODO(#2538): Re-enable when bazel tests run on the main Docker image.
           # - run-bazel-tests

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -54,7 +54,7 @@ jobs:
           ./scripts/build_provenance \
           "oak_functions" \
           ./target/x86_64-unknown-linux-musl/release/oak_functions_loader_base \
-          ./scripts/xtask build-functions-server
+          ./scripts/xtask build-functions-server-variants
 
       - name: Move new provenance files to the provenance branch
         if: github.event_name == 'push'

--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -56,8 +56,7 @@ jobs:
       # Build artifacts that are supposed to be reproducible.
       - name: Build Functions server
         run: |
-          ./scripts/docker_run ./scripts/xtask build-functions-server --server-variant=base
-          ./scripts/docker_run ./scripts/xtask build-functions-server --server-variant=unsafe
+          ./scripts/docker_run ./scripts/xtask build-functions-server-variants
 
       # Generate an index of the hashes of the reproducible artifacts.
       - name: Generate Reproducibility Index

--- a/.xtask_bash_completion
+++ b/.xtask_bash_completion
@@ -15,8 +15,8 @@ _xtask() {
             build-functions-example)
                 cmd+="__build__functions__example"
                 ;;
-            build-functions-server)
-                cmd+="__build__functions__server"
+            build-functions-server-variants)
+                cmd+="__build__functions__server__variants"
                 ;;
             check-format)
                 cmd+="__check__format"
@@ -67,7 +67,7 @@ _xtask() {
 
     case "${cmd}" in
         xtask)
-            opts="-h --help --dry-run --commands --logs --keep-going --scope run-functions-examples build-functions-example build-functions-server format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
+            opts="-h --help --dry-run --commands --logs --keep-going --scope run-functions-examples build-functions-example build-functions-server-variants format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -85,7 +85,7 @@ _xtask() {
             return 0
             ;;
         xtask__build__functions__example)
-            opts="-h --application-variant --example-name --client-variant --client-rust-toolchain --client-rust-target --server-variant --server-rust-toolchain --server-rust-target --run-server --client-additional-args --server-additional-args --build-docker --help"
+            opts="-h --application-variant --example-name --client-variant --client-rust-toolchain --client-rust-target --server-rust-toolchain --server-rust-target --run-server --client-additional-args --server-additional-args --build-docker --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -108,10 +108,6 @@ _xtask() {
                     return 0
                     ;;
                 --client-rust-target)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --server-variant)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -142,17 +138,13 @@ _xtask() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        xtask__build__functions__server)
-            opts="-h --server-variant --server-rust-toolchain --server-rust-target --help"
+        xtask__build__functions__server__variants)
+            opts="-h --server-rust-toolchain --server-rust-target --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --server-variant)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --server-rust-toolchain)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -349,7 +341,7 @@ _xtask() {
             return 0
             ;;
         xtask__run__functions__examples)
-            opts="-h --application-variant --example-name --client-variant --client-rust-toolchain --client-rust-target --server-variant --server-rust-toolchain --server-rust-target --run-server --client-additional-args --server-additional-args --build-docker --help"
+            opts="-h --application-variant --example-name --client-variant --client-rust-toolchain --client-rust-target --server-rust-toolchain --server-rust-target --run-server --client-additional-args --server-additional-args --build-docker --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -372,10 +364,6 @@ _xtask() {
                     return 0
                     ;;
                 --client-rust-target)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --server-variant)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,11 +787,8 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1117,7 +1114,7 @@ dependencies = [
  "oak_utils",
  "prost",
  "prost-types",
- "rand 0.4.6",
+ "rand 0.8.5",
  "serde",
  "tokio",
  "tonic",
@@ -2845,6 +2842,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3149,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -3841,7 +3863,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 3.0.14",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "futures-core",
  "futures-util",
  "http",
@@ -3880,7 +3902,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 3.0.14",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "futures-core",
  "futures-util",
  "http",
@@ -4219,6 +4241,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_yaml",
+ "strum",
+ "strum_macros",
  "tokio",
  "toml",
  "walkdir",

--- a/docs/INSTALL-OSX.md
+++ b/docs/INSTALL-OSX.md
@@ -61,7 +61,7 @@ The Oak Functions Runtime and its dependencies are built with the following
 script:
 
 ```bash
-./scripts/xtask build-functions-server
+./scripts/xtask build-functions-server-variants
 ```
 
 Build a particular example, say `hello_world`, with:

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,7 +176,7 @@ will take some time, but subsequent builds should be cached and so run much
 faster.
 
 ```bash
-xtask build-functions-server
+xtask build-functions-server-variants
 ```
 
 ### Run Oak Functions Server

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -20,6 +20,8 @@ once_cell = "*"
 regex = "*"
 serde = { version = "*", features = ["derive"] }
 serde_yaml = "*"
+strum = "0.24"
+strum_macros = "0.24"
 tokio = { version = "*", features = [
   "fs",
   "io-util",

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -17,6 +17,7 @@
 use crate::{files::*, internal::*};
 use maplit::hashmap;
 use std::collections::HashMap;
+use strum::IntoEnumIterator;
 
 #[cfg(target_os = "macos")]
 const DEFAULT_SERVER_RUST_TARGET: &str = "x86_64-apple-darwin";
@@ -259,15 +260,10 @@ pub fn run_functions_examples(opt: &RunFunctionsExamples, scope: &Scope) -> Step
 
 /// Build every variant of the function server.
 pub fn build_functions_server_variants(opt: &BuildFunctionsServer) -> Step {
-    let variants = vec![
-        "oak_functions/oak_functions_loader_base",
-        "oak_functions/oak_functions_loader_unsafe",
-    ];
     Step::Multiple {
         name: "cargo build all variants of function server".to_string(),
-        steps: variants
-            .iter()
-            .map(|path| build_rust_binary(path, opt, &hashmap! {}))
+        steps: FunctionsServerVariant::iter()
+            .map(|variant| build_rust_binary(&variant.path_to_manifest(), opt, &hashmap! {}))
             .collect(),
     }
 }

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -257,6 +257,7 @@ pub fn run_functions_examples(opt: &RunFunctionsExamples, scope: &Scope) -> Step
     }
 }
 
+/// Build every variant of the function server.
 pub fn build_functions_server_variants(opt: &BuildFunctionsServer) -> Step {
     let variants = vec![
         "oak_functions/oak_functions_loader_base",
@@ -295,8 +296,8 @@ fn run_functions_example(example: &FunctionsExample) -> Step {
         steps: vec![
             example.construct_application_build_steps(),
             if opt.run_server.unwrap_or(true) {
-                // Build the server first so that when running it in the next step it will start up
-                // faster.
+                // Build (all variants of) the server first so that when running a variant in the
+                // next step it will start up faster.
                 vec![build_functions_server_variants(&opt.build_server)]
             } else {
                 vec![]

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -259,6 +259,8 @@ pub fn run_functions_examples(opt: &RunFunctionsExamples, scope: &Scope) -> Step
 }
 
 /// Build every variant of the function server.
+/// It's easier to always build all variants than to control which variant to build and
+/// the overhead of building all variants is acceptable.
 pub fn build_functions_server_variants(opt: &BuildFunctionsServer) -> Step {
     Step::Multiple {
         name: "cargo build all variants of function server".to_string(),

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -265,7 +265,7 @@ pub fn build_functions_server_variants(opt: &BuildFunctionsServer) -> Step {
     Step::Multiple {
         name: "cargo build all variants of function server".to_string(),
         steps: FunctionsServerVariant::iter()
-            .map(|variant| build_rust_binary(&variant.path_to_manifest(), opt, &hashmap! {}))
+            .map(|variant| build_rust_binary(variant.path_to_manifest(), opt, &hashmap! {}))
             .collect(),
     }
 }

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -57,7 +57,7 @@ pub struct Opt {
 pub enum Command {
     RunFunctionsExamples(RunFunctionsExamples),
     BuildFunctionsExample(RunFunctionsExamples),
-    BuildFunctionsServer(BuildFunctionsServer),
+    BuildFunctionsServerVariants(BuildFunctionsServer),
     Format,
     CheckFormat,
     RunTests,
@@ -198,8 +198,6 @@ impl std::str::FromStr for FunctionsServerVariant {
 
 #[derive(Parser, Clone, Debug)]
 pub struct BuildFunctionsServer {
-    #[clap(long, help = "server variant: [base, unsafe]", default_value = "base")]
-    pub server_variant: FunctionsServerVariant,
     #[clap(
         long,
         help = "rust toolchain override to use for the server compilation [e.g. stable, nightly, stage2]"

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -199,12 +199,10 @@ impl std::str::FromStr for FunctionsServerVariant {
 
 impl FunctionsServerVariant {
     // Get path to manifest for the variant.
-    pub fn path_to_manifest(&self) -> String {
+    pub fn path_to_manifest(&self) -> &'static str {
         match self {
-            FunctionsServerVariant::Base => "oak_functions/oak_functions_loader_base".to_string(),
-            FunctionsServerVariant::Unsafe => {
-                "oak_functions/oak_functions_loader_unsafe".to_string()
-            }
+            FunctionsServerVariant::Base => "oak_functions/oak_functions_loader_base",
+            FunctionsServerVariant::Unsafe => "oak_functions/oak_functions_loader_unsafe",
         }
     }
 }

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -24,6 +24,7 @@ use std::{
     path::{Path, PathBuf},
     time::Instant,
 };
+use strum_macros::EnumIter;
 use tokio::io::{empty, AsyncRead, AsyncReadExt};
 
 #[derive(Parser, Clone)]
@@ -168,7 +169,7 @@ pub struct BuildClient {
     pub client_rust_target: Option<String>,
 }
 
-#[derive(serde::Deserialize, Debug, Clone, PartialEq)]
+#[derive(serde::Deserialize, Debug, Clone, PartialEq, EnumIter)]
 pub enum FunctionsServerVariant {
     /// Production-like server variant, without logging or any of the experimental features enabled
     Base,
@@ -192,6 +193,18 @@ impl std::str::FromStr for FunctionsServerVariant {
                 "Failed to parse functions server variant {}",
                 variant
             )),
+        }
+    }
+}
+
+impl FunctionsServerVariant {
+    // Get path to manifest for the variant.
+    pub fn path_to_manifest(&self) -> String {
+        match self {
+            FunctionsServerVariant::Base => "oak_functions/oak_functions_loader_base".to_string(),
+            FunctionsServerVariant::Unsafe => {
+                "oak_functions/oak_functions_loader_unsafe".to_string()
+            }
         }
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -115,7 +115,7 @@ fn match_cmd(opt: &Opt) -> Step {
     match opt.cmd {
         Command::RunFunctionsExamples(ref run_opt) => run_functions_examples(run_opt, &opt.scope),
         Command::BuildFunctionsExample(ref opts) => build_functions_example(opts, &opt.scope),
-        Command::BuildFunctionsServer(ref opt) => build_functions_server(&opt.server_variant, opt),
+        Command::BuildFunctionsServerVariants(ref opt) => build_functions_server_variants(opt),
         Command::RunTests => run_tests(),
         Command::RunCargoClippy => run_cargo_clippy(&opt.scope),
         Command::RunCargoTests(ref run_opt) => run_cargo_tests(run_opt, &opt.scope),


### PR DESCRIPTION
- remove --server-variant flag from CI by always building all variants
- print manifest path in step to build rust binary flag 