### PR TITLE
Add support for Wasm warmup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,6 +1996,7 @@ dependencies = [
  "oak_logger",
  "oak_remote_attestation",
  "oak_utils",
+ "parity-wasm",
  "prost",
  "rand 0.8.5",
  "serde",

--- a/docs/oak_functions_abi.md
+++ b/docs/oak_functions_abi.md
@@ -47,6 +47,32 @@ memory allocated from the WebAssembly module through `alloc`.
 A canonical implementation of `alloc` is
 [provided in the Oak Functions Rust SDK](/oak_functions/sdk/oak_functions/src/lib.rs).
 
+### `warmup` - Optional
+
+- no params
+- no results
+
+If the WebAssembly module exports a function called warmup, the runtime executes
+it after initially loading the module. Once execution of `warmup` is complete
+the runtime takes a snapshot of the
+[globals](https://webassembly.github.io/spec/core/syntax/modules.html#syntax-global)
+and
+[linear memory](https://webassembly.github.io/spec/core/syntax/modules.html#syntax-mem).
+The runtime then updates the in-memory copy of the module by replacing the
+globals and data segments. A new data segment is added for every non-zero
+section of linear memory. These data sections will be used to initialise the
+linear memory for invocations of main so that the state for each instance is the
+same as it was when the warmup completed.
+
+This is inspired by [Wizer](https://github.com/bytecodealliance/wizer), but only
+updates the in-memory copy of the WebAssembly module at application startup
+rather than rewriting the module ahead of time.
+
+This is used in the
+[Weather Lookup example](/oak_functions/examples/weather_lookup/module/src/lib.rs)
+to avoid redoing the expensive initialisation done by the
+[S2 geometry library](https://github.com/yjh0502/rust-s2) for every request.
+
 ## Imported Functions
 
 Each Oak Functions WebAssembly module can rely on the the Oak Functions runtime

--- a/oak_functions/examples/weather_lookup/module/src/lib.rs
+++ b/oak_functions/examples/weather_lookup/module/src/lib.rs
@@ -100,3 +100,12 @@ pub extern "C" fn main() {
     // Write the response.
     oak_functions::write_response(&response).expect("Couldn't write the response body.");
 }
+
+#[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn warmup() {
+    // We perform a single S2 cell lookup to ensure that the lookup tables are initialised, as this
+    // initisalisation is quite expensive and we don't want to redo it for every request.
+    let level = location_utils::S2_DEFAULT_LEVEL;
+    let location = location_from_degrees(90., 45.);
+    let _ = find_cell(&location, level);
+}

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -43,6 +43,7 @@ oak_functions_tf_inference = { optional = true, path = "../experimental/tf_infer
 oak_logger = { path = "../logger" }
 oak_utils = { path = "../../oak_utils" }
 oak_remote_attestation = { path = "../../remote_attestation/rust/" }
+parity-wasm = "*"
 prost = "*"
 rand = "*"
 serde = "*"

--- a/oak_functions/loader/fuzz/Cargo.lock
+++ b/oak_functions/loader/fuzz/Cargo.lock
@@ -765,6 +765,7 @@ dependencies = [
  "oak_logger",
  "oak_remote_attestation",
  "oak_utils",
+ "parity-wasm",
  "prost",
  "rand",
  "serde",

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -807,7 +807,7 @@ fn parse_wasm_bytes(
         .map_err(anyhow::Error::msg)
         .context("couldn't process module")?;
 
-    // We need a temporary Wasm state instance with extnsions to act as an import resolver,
+    // We need a temporary Wasm state instance with extensions to act as an import resolver,
     // otherwise the module instance cannot be created.
     // TODO(#2631): Simplify code when import resolver no longer requires full WasmState instance.
     let mut extensions_indices = HashMap::new();

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -809,6 +809,7 @@ fn parse_wasm_bytes(
 
     // We need a temporary Wasm state instance with extnsions to act as an import resolver,
     // otherwise the module instance cannot be created.
+    // TODO(#2631): Simplify code when import resolver no longer requires full WasmState instance.
     let mut extensions_indices = HashMap::new();
     let mut extensions_metadata = HashMap::new();
     let channel_switchboard = ChannelSwitchboard::new();

--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -865,9 +865,10 @@ fn parse_wasm_bytes(
 /// Invokes the warmup exported function and updates the module to contain a post-warmup snapshot of
 /// the memory and globals.
 ///
-/// Inspired by ideas from https://github.com/bytecodealliance/wizer/blob/main/src/snapshot.rs, but
-/// simplified as Wasmi does not support dynamic linking of Wasm modules and only a single linear
-/// memory with index 0.
+/// Inspired by ideas from
+/// [Wazer's snapshot implementation](https://github.com/bytecodealliance/wizer/blob/main/src/snapshot.rs),
+/// but simplified as Wasmi does not support dynamic linking of Wasm modules and only a single
+/// linear memory with index 0.
 fn warmup_and_snapshot(
     mut parity_module: Module,
     instance: &wasmi::ModuleRef,


### PR DESCRIPTION
This PR adds support for a `warmup` exported function on a Wasm module. If an exported function named `warmup` (with the right signature) is found the runtime will execute the function and take a snapshot on completion. This happens at startup, before any requests are served. The Wasm instance for each request will then start from the post-warmup snapshot, rather than the initial blank state.

This is particularly useful in the weather lookup example. The S2 Geometry library that is used generates a set of lookup tables the first time a cell is looked up. This lookup table generation is quite expensive, so doing it as part of the warmup reduces the per-request benchmark time for the example from 1.4ms to 0.7ms.

