### PR TITLE
Remove env variables from xtask

### DIFF
--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -265,7 +265,7 @@ pub fn build_functions_server_variants(opt: &BuildFunctionsServer) -> Step {
     Step::Multiple {
         name: "cargo build all variants of function server".to_string(),
         steps: FunctionsServerVariant::iter()
-            .map(|variant| build_rust_binary(variant.path_to_manifest(), opt, &hashmap! {}))
+            .map(|variant| build_rust_binary(variant.path_to_manifest(), opt))
             .collect(),
     }
 }
@@ -466,7 +466,7 @@ fn run_functions_example_server(
     example_server: &ExampleServer,
     application: &ApplicationFunctions,
 ) -> Box<dyn Runnable> {
-    Cmd::new_with_env(
+    Cmd::new(
         match example_server.server_variant {
             FunctionsServerVariant::Base => {
                 "target/x86_64-unknown-linux-musl/release/oak_functions_loader_base"
@@ -479,7 +479,6 @@ fn run_functions_example_server(
             format!("--wasm-path={}", application.wasm_path),
             ...example_server.additional_args.clone(),
         ],
-        &hashmap! {},
     )
 }
 
@@ -670,14 +669,10 @@ fn run(
     }
 }
 
-fn build_rust_binary(
-    manifest_dir: &str,
-    opt: &BuildFunctionsServer,
-    env: &HashMap<String, String>,
-) -> Step {
+fn build_rust_binary(manifest_dir: &str, opt: &BuildFunctionsServer) -> Step {
     Step::Single {
         name: format!("build rust binary {}", manifest_dir),
-        command: Cmd::new_with_env(
+        command: Cmd::new(
             "cargo",
             spread![
                 ...match &opt.server_rust_toolchain {
@@ -692,7 +687,6 @@ fn build_rust_binary(
                 format!("--target={}", opt.server_rust_target.as_deref().unwrap_or(DEFAULT_SERVER_RUST_TARGET)),
                 "--release".to_string(),
             ],
-            env,
         ),
     }
 }

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -670,7 +670,6 @@ pub async fn run_step(context: &Context, step: Step, mut run_status: Status) -> 
 pub struct Cmd {
     executable: String,
     args: Vec<String>,
-    env: HashMap<String, String>,
     current_dir: Option<PathBuf>,
 }
 
@@ -683,20 +682,6 @@ impl Cmd {
         Box::new(Cmd {
             executable: executable.to_string(),
             args: args.into_iter().map(|s| s.as_ref().to_string()).collect(),
-            env: HashMap::new(),
-            current_dir: None,
-        })
-    }
-
-    pub fn new_with_env<I, S>(executable: &str, args: I, env: &HashMap<String, String>) -> Box<Self>
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<str>,
-    {
-        Box::new(Cmd {
-            executable: executable.to_string(),
-            args: args.into_iter().map(|s| s.as_ref().to_string()).collect(),
-            env: env.clone(),
             current_dir: None,
         })
     }
@@ -709,17 +694,8 @@ impl Cmd {
         Box::new(Cmd {
             executable: executable.to_string(),
             args: args.into_iter().map(|s| s.as_ref().to_string()).collect(),
-            env: HashMap::new(),
             current_dir: Some(current_dir.to_path_buf()),
         })
-    }
-}
-
-/// If environment variable `name` is set in the current environment, pass it through
-/// so the same value for `name` is visible when the command is executed.
-fn env_passthru(cmd: &mut tokio::process::Command, name: &str) {
-    if let Ok(v) = std::env::var(name) {
-        cmd.env(name, v);
     }
 }
 
@@ -733,47 +709,6 @@ impl Runnable for Cmd {
     fn run(self: Box<Self>, opt: &Opt) -> Box<dyn Running> {
         let mut cmd = tokio::process::Command::new(&self.executable);
         cmd.args(&self.args);
-
-        // Clear the parent environment. Only the variables explicitly passed below are going to be
-        // available to the command, to avoid accidentally depending on extraneous ones.
-        cmd.env_clear();
-
-        // General variables.
-        cmd.env("HOME", std::env::var("HOME").unwrap());
-        cmd.env("PATH", std::env::var("PATH").unwrap());
-        env_passthru(&mut cmd, "USER");
-
-        // Python variables.
-        env_passthru(&mut cmd, "PYTHONPATH");
-
-        // Rust compilation variables.
-        env_passthru(&mut cmd, "RUSTUP_HOME");
-        env_passthru(&mut cmd, "CARGO_HOME");
-        env_passthru(&mut cmd, "CARGO_INCREMENTAL");
-        env_passthru(&mut cmd, "RUSTC_WRAPPER");
-
-        // See https://docs.rs/prost-build/latest/prost_build/#sourcing-protoc.
-        env_passthru(&mut cmd, "PROTOC");
-        env_passthru(&mut cmd, "PROTOC_INCLUDE");
-
-        // Rust runtime variables.
-        cmd.env(
-            "RUST_LOG",
-            std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string()),
-        );
-        cmd.env("RUST_BACKTRACE", "1");
-
-        // Emscripten variables.
-        env_passthru(&mut cmd, "EMSDK");
-        env_passthru(&mut cmd, "EM_CACHE");
-        env_passthru(&mut cmd, "EM_CONFIG");
-
-        // OpenSSL variables.
-        env_passthru(&mut cmd, "PKG_CONFIG_ALLOW_CROSS");
-        env_passthru(&mut cmd, "OPENSSL_STATIC");
-        env_passthru(&mut cmd, "OPENSSL_DIR");
-
-        cmd.envs(&self.env);
 
         if opt.dry_run {
             Box::new(SingleStatusResult {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -27,7 +27,6 @@
 
 use clap::{IntoApp, Parser};
 use colored::*;
-use maplit::hashmap;
 use once_cell::sync::Lazy;
 use std::{
     path::{Path, PathBuf},
@@ -653,7 +652,7 @@ fn run_cargo_fmt(mode: FormatMode, modified_crates: &ModifiedContent) -> Step {
             .filter(|path| modified_crates.contains(path))
             .map(|entry| Step::Single {
                 name: entry.clone(),
-                command: Cmd::new_with_env(
+                command: Cmd::new(
                     "cargo",
                     spread![
                         "fmt",
@@ -663,12 +662,6 @@ fn run_cargo_fmt(mode: FormatMode, modified_crates: &ModifiedContent) -> Step {
                             FormatMode::Fix => vec![],
                         },
                     ],
-                    &hashmap! {
-                        // rustfmt emits copious debug logs, leading to multi-minute
-                        // runs if the user's env happens to have RUST_LOG=debug, so
-                        // force a higher log level.
-                        "RUST_LOG".to_string() => "warn".to_string(),
-                    },
                 ),
             })
             .collect(),


### PR DESCRIPTION
The only actually useful one was limiting the rustfmt logs, but I think
we can assume that that variable is set correctly in the Dockerfile.

Fixes #2627