### PR TITLE
Add a second serial port to the system.

### DIFF
--- a/experimental/uefi/.cargo/config.toml
+++ b/experimental/uefi/.cargo/config.toml
@@ -7,7 +7,7 @@ runner = "qemu-system-x86_64 -nodefaults -nographic -bios /usr/share/OVMF/OVMF_C
 
 # Otherwise, (a) the first serial port gets routed to a log, and (b) the second serial gets attached to stdio.
 [target.'cfg(not(test))']
-runner = "qemu-system-x86_64 -nodefaults -nographic -bios /usr/share/OVMF/OVMF_CODE.fd -serial file:console.log -serial stdio -machine q35 -device isa-debug-exit,iobase=0xf4,iosize=0x04 -kernel"
+runner = "qemu-system-x86_64 -nodefaults -nographic -bios /usr/share/OVMF/OVMF_CODE.fd -serial file:target/console.log -serial stdio -machine q35 -device isa-debug-exit,iobase=0xf4,iosize=0x04 -kernel"
 
 [unstable]
 build-std = ["core", "alloc"]

--- a/experimental/uefi/.cargo/config.toml
+++ b/experimental/uefi/.cargo/config.toml
@@ -1,9 +1,14 @@
 [build]
 target = "x86_64-unknown-uefi"
 
-[target.x86_64-unknown-uefi]
+# Test runners get only one serial port, routed to stdio.
+[target.'cfg(test)']
 runner = "qemu-system-x86_64 -nodefaults -nographic -bios /usr/share/OVMF/OVMF_CODE.fd -serial stdio -machine q35 -device isa-debug-exit,iobase=0xf4,iosize=0x04 -kernel"
 
+# Otherwise, (a) the first serial port gets routed to a log, and (b) the second serial gets attached to stdio.
+[target.'cfg(not(test))']
+runner = "qemu-system-x86_64 -nodefaults -nographic -bios /usr/share/OVMF/OVMF_CODE.fd -serial file:console.log -serial stdio -machine q35 -device isa-debug-exit,iobase=0xf4,iosize=0x04 -kernel"
+
 [unstable]
-build-std = ["core"]
+build-std = ["core", "alloc"]
 build-std-features = ["compiler-builtins-mem"]

--- a/experimental/uefi/Cargo.lock
+++ b/experimental/uefi/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
@@ -46,18 +46,18 @@ checksum = "9ff023245bfcc73fb890e1f8d5383825b3131cc920020a5c487d6f113dfc428a"
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e59d925cf59d8151f25a3bedf97c9c157597c9df7324d32d68991cc399ed08b"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.14.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21398a404f6fa14f6df34756714874eccdf73587eba863cb5bd55d8bada7496"
+checksum = "2043be244ce96de3ca04cdb64b29993928c2327121a8314e2a6f50379580cd7d"
 dependencies = [
  "bitflags",
  "log",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-macros"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7006b85ae8acaf2b448c5f1630a434caaacaedcc0907f12404e4e31c9dafcdb3"
+checksum = "a9271b66bf83671563773e54b178f1022ac2dab87dc197f80be51885a5e1a2f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-services"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7840bddc6477dc443cc5652ca9683de9f10bd173691151c3160d734521bef3bd"
+checksum = "184cf782871dde6efd6335c0ed0dd7c48a7070f6ba73e1d148fc580a548dfe3d"
 dependencies = [
  "cfg-if",
  "log",
@@ -112,6 +112,7 @@ dependencies = [
 name = "uefi-simple"
 version = "0.1.0"
 dependencies = [
+ "log",
  "uefi",
  "uefi-services",
 ]

--- a/experimental/uefi/Cargo.toml
+++ b/experimental/uefi/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-uefi = "*"
+uefi = { version = "*", features = ["exts"] }
 uefi-services = "*"
+log = { version = "*" }
 
 [dev-dependencies]
 uefi-services = { version = "*", features = ["qemu"] }

--- a/experimental/uefi/src/main.rs
+++ b/experimental/uefi/src/main.rs
@@ -17,13 +17,24 @@
 #![no_main]
 #![no_std]
 #![feature(abi_efiapi)]
+#![feature(never_type)]
 #![feature(custom_test_frameworks)]
 // As we're in a `no_std` environment, testing requires special handling. This
 // approach was inspired by https://os.phil-opp.com/testing/.
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
-use uefi::{prelude::*, table::runtime::ResetType, ResultExt};
+#[macro_use]
+extern crate log;
+
+use uefi::{
+    prelude::*,
+    proto::console::serial::Serial,
+    table::{
+        boot::{OpenProtocolAttributes, OpenProtocolParams},
+        runtime::ResetType,
+    },
+};
 
 // The main entry point of the UEFI application.
 //
@@ -32,7 +43,7 @@ use uefi::{prelude::*, table::runtime::ResetType, ResultExt};
 // dependency graph.
 #[entry]
 fn _start(_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
-    uefi_services::init(&mut system_table).unwrap_success();
+    uefi_services::init(&mut system_table).unwrap();
 
     // As we're not relying on the normal Rust test harness, we need to call
     // the tests ourselves if necessary.
@@ -51,14 +62,60 @@ fn _start(_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
         .reset(ResetType::Shutdown, status, None);
 }
 
-fn main(_handle: Handle, system_table: &mut SystemTable<Boot>) -> Status {
+fn main(handle: Handle, system_table: &mut SystemTable<Boot>) -> Status {
     use core::fmt::Write;
 
-    let status = writeln!(system_table.stdout(), "Hello World!");
+    writeln!(system_table.stdout(), "Hello World!").unwrap();
 
-    status
-        .map(|_| Status::SUCCESS)
-        .unwrap_or(Status::DEVICE_ERROR)
+    serial_echo(handle, system_table.boot_services()).unwrap();
+}
+
+fn echo_loop(serial: &mut uefi::proto::console::serial::Serial) -> Result<!, uefi::Error<()>> {
+    let mut buf: [u8; 1024] = [0; 1024];
+
+    loop {
+        // read() returns Ok if it managed to fill the whole buffer, or the error will contain
+        // the number of bytes read. The only error we're fine with is TIMEOUT, as we can simply
+        // retry that (and we'll keep getting TIMEOUTs when nobody is talking to us). In case of
+        // any other error, bail out.
+        let len = serial
+            .read(&mut buf)
+            .and_then(|_| Ok(buf.len()))
+            .or_else(|err| {
+                if err.status() == Status::TIMEOUT {
+                    Ok(*err.data())
+                } else {
+                    Err(err.status())
+                }
+            })?;
+
+        // Write out what we read; if we get any errors, propagate them.
+        if len > 0 {
+            info!("Read data: {:?}", &buf[..len]);
+            serial.write(&buf[..len]).discard_errdata()?;
+        }
+    }
+}
+
+fn serial_echo(handle: Handle, bt: &BootServices) -> Result<!, uefi::Error<()>> {
+    // Expect (at least) two serial ports on the system; the first will be used
+    // for stdio, and we can use the second one for our echo example. If we don't
+    // seem to have a second serial port, err out with the (arbitrarily chosen)
+    // NO_MAPPING error.
+    let serial_handles = bt.find_handles::<Serial>()?;
+    let serial_handle = serial_handles.get(1).ok_or(Status::NO_MAPPING)?;
+    let serial = bt.open_protocol::<Serial>(
+        OpenProtocolParams {
+            handle: *serial_handle,
+            agent: handle,
+            controller: None,
+        },
+        OpenProtocolAttributes::Exclusive,
+    )?;
+    // Dereference the raw pointer we get to the serial interface.
+    let mut serial = unsafe { &mut *serial.interface.get() };
+
+    echo_loop(&mut serial)
 }
 
 #[cfg(test)]

--- a/experimental/uefi/src/main.rs
+++ b/experimental/uefi/src/main.rs
@@ -70,7 +70,7 @@ fn main(handle: Handle, system_table: &mut SystemTable<Boot>) -> Status {
     serial_echo(handle, system_table.boot_services()).unwrap();
 }
 
-fn echo_loop(serial: &mut uefi::proto::console::serial::Serial) -> Result<!, uefi::Error<()>> {
+fn echo_loop(serial: &mut Serial) -> Result<!, uefi::Error<()>> {
     let mut buf: [u8; 1024] = [0; 1024];
 
     loop {
@@ -109,7 +109,9 @@ fn serial_echo(handle: Handle, bt: &BootServices) -> Result<!, uefi::Error<()>> 
         },
         OpenProtocolAttributes::Exclusive,
     )?;
-    // Dereference the raw pointer we get to the serial interface.
+    // Dereference the raw pointer (*mut Serial) we get to the serial interface.
+    // This is safe as according to the UEFI spec for the OpenProtocol call to succeed the
+    // interface must not be null (see Section 7.3 in the UEFI Specification, Version 2.9).
     let serial = unsafe { &mut *serial.interface.get() };
 
     echo_loop(serial)


### PR DESCRIPTION
The first serial port we have is used for the UEFI stdio, so let's add a second port that's under our control. Right now it just echos everything it receives back to the sender, and writes the bytes received into the log (which will be written to stdio, so the first serial port).