### PR TITLE
Expose remote attestation endpoint for webclients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,6 +2365,7 @@ dependencies = [
  "tokio",
  "toml",
  "tonic",
+ "tonic-web",
  "url",
  "wasmi",
 ]
@@ -4013,6 +4014,24 @@ dependencies = [
  "prost-build",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5802af338d3f01590a5c0777783f0e0897df05e9b053ac0084e310a9319a456"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project",
+ "tonic",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -58,7 +58,7 @@ tokio = { version = "*", features = [
 ] }
 toml = "*"
 tonic = "*"
-tonic-web = {version = "*", optional = true}
+tonic-web = { version = "*", optional = true }
 url = "*"
 # Use wasmi in `no_std` mode.
 wasmi = { version = "*", default-features = false, features = ["core"] }

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -8,10 +8,11 @@ license = "Apache-2.0"
 [features]
 # Feature that allows logging of potentially sensitive content, or using experimental features.
 # Should only be used for debugging purposes or enabling experimental features.
-oak-unsafe = ["oak-tf", "oak-metrics"]
+oak-unsafe = ["oak-tf", "oak-metrics", "oak-web"]
 default = []
 oak-tf = ["oak_functions_tf_inference"]
 oak-metrics = ["oak_functions_metrics"]
+oak-web = ["tonic-web"]
 
 [dependencies]
 anyhow = "*"
@@ -57,6 +58,7 @@ tokio = { version = "*", features = [
 ] }
 toml = "*"
 tonic = "*"
+tonic-web = {version = "*", optional = true}
 url = "*"
 # Use wasmi in `no_std` mode.
 wasmi = { version = "*", default-features = false, features = ["core"] }

--- a/oak_functions/loader/src/grpc.rs
+++ b/oak_functions/loader/src/grpc.rs
@@ -27,6 +27,7 @@ use oak_logger::OakLogger;
 use oak_utils::LogError;
 use prost::Message;
 use std::{future::Future, net::SocketAddr};
+use tonic_web;
 
 async fn handle_request(
     wasm_handler: WasmHandler,

--- a/oak_functions/loader/src/grpc.rs
+++ b/oak_functions/loader/src/grpc.rs
@@ -27,7 +27,6 @@ use oak_logger::OakLogger;
 use oak_utils::LogError;
 use prost::Message;
 use std::{future::Future, net::SocketAddr};
-use tonic_web;
 
 async fn handle_request(
     wasm_handler: WasmHandler,
@@ -98,6 +97,7 @@ pub async fn create_and_start_grpc_server<F: Future<Output = ()>>(
     // and start is handled entirely witin each respective conditional arm, as
     // the added service alters the type signature of the created server.
     if cfg!(feature = "oak-web") {
+        #[cfg(feature = "oak-web")]
         tonic::transport::Server::builder()
             .accept_http1(true)
             .add_service(grpc_unary_attestation_service.clone())

--- a/oak_functions/loader/src/grpc.rs
+++ b/oak_functions/loader/src/grpc.rs
@@ -99,6 +99,7 @@ pub async fn create_and_start_grpc_server<F: Future<Output = ()>>(
     // the added service alters the type signature of the created server.
     if cfg!(feature = "oak-web") {
         tonic::transport::Server::builder()
+            .accept_http1(true)
             .add_service(grpc_unary_attestation_service.clone())
             .add_service(tonic_web::enable(grpc_unary_attestation_service))
             .serve_with_shutdown(*address, terminate)

--- a/oak_functions/loader/src/grpc.rs
+++ b/oak_functions/loader/src/grpc.rs
@@ -100,7 +100,6 @@ pub async fn create_and_start_grpc_server<F: Future<Output = ()>>(
         #[cfg(feature = "oak-web")]
         tonic::transport::Server::builder()
             .accept_http1(true)
-            .add_service(grpc_unary_attestation_service.clone())
             .add_service(tonic_web::enable(grpc_unary_attestation_service))
             .serve_with_shutdown(*address, terminate)
             .await


### PR DESCRIPTION
This adds an endpoint for future web clients to communicate with the runtime directly, by exposing a [grpc-web](https://github.com/grpc/grpc-web) endpoint. grpc-web is an adaption of the gRPC protocol that supports wire formats that web clients can use. 

We'll be using the binary format, see the OSS description here: https://github.com/grpc/grpc-web#wire-format-mode. Defacto this means that requests are sent as unary HTTP/1 requests, with the body consisting of binary encoded protobuf messages. 

Imo this is a nice approach to supporting OSS web clients in the linux-binary version of the runtime. The runtime itself will expose compatible endpoints, with no need to spin up a separate translation layer server. 

In prod deployments too secret to discuss in depth here we'd use a translation service. 
In the bare-metal version of the runtime the companion app will expose this endpoint. 

