### PR TITLE
Fix invalid xtask command in docs & scripts

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,7 @@ To build and run one of the Oak example applications under Docker, run (after
 
 ```bash
 ./scripts/docker_pull  # retrieve cached Docker image for faster builds
-./scripts/docker_run xtask --logs --scope=all run-functions-examples --example-name=weather_lookup --client-variant=rust
+./scripts/docker_run xtask --logs --scope=all run-oak-functions-examples --example-name=weather_lookup --client-variant=rust
 ```
 
 This should build the Runtime, an Oak Functions Application and a client for the
@@ -137,7 +137,7 @@ Running one of the example Oak applications will confirm that all core
 prerequisites have been installed. Run one inside Docker with:
 
 ```bash
-xtask --logs --scope=all run-functions-examples --example-name=weather_lookup --client-variant=rust
+xtask --logs --scope=all run-oak-functions-examples --example-name=weather_lookup --client-variant=rust
 ```
 
 That script:
@@ -163,7 +163,7 @@ to a WebAssembly module and then serializes it into a binary application
 configuration file to be loaded to the Oak Functions Server:
 
 ```bash
-xtask --logs --scope=all run-functions-examples --example-name=weather_lookup --client-variant=none --run-server=false
+xtask --logs --scope=all run-oak-functions-examples --example-name=weather_lookup --client-variant=none --run-server=false
 ```
 
 This binary application configuration file includes the compiled Wasm code for
@@ -186,7 +186,7 @@ a specific Oak Application (which must already have been compiled into
 WebAssembly, as [described above](#build-application).
 
 ```bash
-xtask --scope=all --logs run-functions-examples --example-name=weather_lookup --client-variant=none
+xtask --scope=all --logs run-oak-functions-examples --example-name=weather_lookup --client-variant=none
 ```
 
 In the end, you should end up with an Oak server running, end with log output
@@ -207,7 +207,7 @@ client of an example Oak Application (as [described above](#build-application)),
 and runs the client code locally.
 
 ```bash
-xtask --scope=all --logs run-functions-examples --example-name=weather_lookup --run-server=false --client-variant=rust
+xtask --scope=all --logs run-oak-functions-examples --example-name=weather_lookup --run-server=false --client-variant=rust
 ```
 
 The client should run to completion and give output something like:

--- a/experimental/oak_functions_with_envoy/scripts/build.sh
+++ b/experimental/oak_functions_with_envoy/scripts/build.sh
@@ -5,7 +5,7 @@ readonly EXPERIMENTAL_SCRIPTS_DIR="$(dirname "$0")"
 source "$EXPERIMENTAL_SCRIPTS_DIR/common.sh"
 
 # Build Oak Functions server binary, and the `weather_lookup` example application built on Oak Functions.
-./scripts/docker_run ./scripts/xtask run-functions-examples \
+./scripts/docker_run ./scripts/xtask run-oak-functions-examples \
   --example-name=weather_lookup \
   --run-server=false \
   --client-variant=none

--- a/oak_functions/examples/metrics/README.md
+++ b/oak_functions/examples/metrics/README.md
@@ -60,6 +60,6 @@ To run the example, use the following:
 ```bash
 ./scripts/docker_run ./scripts/xtask \
   --logs \
-  run-functions-examples \
+  run-oak-functions-examples \
   --example-name=metrics
 ```

--- a/oak_functions/examples/weather_lookup/README.md
+++ b/oak_functions/examples/weather_lookup/README.md
@@ -148,7 +148,7 @@ To build and run this example manually follow these steps:
 Alternatively, the `xtask` could be used to run this example:
 
 ```shell
-./scripts/xtask run-functions-examples --example-name=weather_lookup
+./scripts/xtask run-oak-functions-examples --example-name=weather_lookup
 ```
 
 ## Cloud Run Deploy
@@ -156,7 +156,7 @@ Alternatively, the `xtask` could be used to run this example:
 Use the following script to deploy the service on Cloud Run.
 
 ```shell
-./oak_functions/examples/weather_lookup/scripts/cloud_run_deploy run-functions-examples --example-name=weather_lookup
+./oak_functions/examples/weather_lookup/scripts/cloud_run_deploy run-oak-functions-examples --example-name=weather_lookup
 ```
 
 The script:

--- a/oak_functions/examples/weather_lookup/client/java/README.md
+++ b/oak_functions/examples/weather_lookup/client/java/README.md
@@ -17,5 +17,5 @@ Build and run gRPC Attestation example (including server) with the following
 command:
 
 ```bash
-./scripts/xtask run-functions-examples --example-name=weather_lookup --client-variant=java
+./scripts/xtask run-oak-functions-examples --example-name=weather_lookup --client-variant=java
 ```

--- a/scripts/run_tests_coverage
+++ b/scripts/run_tests_coverage
@@ -6,7 +6,7 @@ source "$SCRIPTS_DIR/common"
 
 # Build the example client and Application in coverage mode and run them.
 export RUST_LOG=trace
-"${SCRIPTS_DIR}/xtask" --scope=all run-examples --example-name=abitest --server-variant=coverage
+"${SCRIPTS_DIR}/xtask" --scope=all run-oak-functions-examples --example-name=abitest --server-variant=coverage
 
 # Generate coverage summary
 (


### PR DESCRIPTION
This command was renamed in #2612. Our docs and scritps feature older versions that don't work.