### PR TITLE
Fix cargo-deny error

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,8 @@ ignore = [
   "RUSTSEC-2020-0071",
   # TODO(#2421): Remove when no longer required.
   "RUSTSEC-2021-0127",
+  # TODO(#2652): Remove when Wizer is updated.
+  "RUSTSEC-2022-0016",
 ]
 
 # Deny multiple versions unless explicitly skipped.


### PR DESCRIPTION
Temporarily ignore the advisory until an updated version of Wizer is available.

This vulnerability should not affect the runtime, as it does not use wasmtime directly. It is only used for the ahead-of-time warmup of the weather lookup example. 