### PR TITLE
Fix Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
   "experimental/trusted_shuffler/server",
   "experimental/trusted_shuffler/trusted_shuffler",
   "oak_functions/abi",
-  "oak_functions/client/rust/Cargo.toml",
+  "oak_functions/client/rust",
   "oak_functions/examples/benchmark/module",
   "oak_functions/examples/echo/module",
   "oak_functions/examples/fuzzable/module",


### PR DESCRIPTION
Error was introduced in a34217684954466983636ea09bb59c99759591e1

This is currently preventing dependabot from performing updates on our
repo.