### PR TITLE
Upgrade rustls and tokio-rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,10 +1662,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.20.4",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.23.3",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2460,7 +2460,7 @@ dependencies = [
  "log",
  "openssl",
  "ring",
- "rustls 0.19.1",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.10.2",
@@ -2680,12 +2680,13 @@ dependencies = [
  "hyper",
  "log",
  "oak_attestation_common",
- "rustls 0.19.1",
+ "rustls",
+ "rustls-pemfile 0.2.1",
  "serde",
  "serde_json",
  "sha2 0.10.2",
  "tokio",
- "tokio-rustls 0.22.0",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2755,10 +2756,11 @@ dependencies = [
  "hyper",
  "log",
  "oak_attestation_common",
- "rustls 0.19.1",
+ "rustls",
+ "rustls-pemfile 0.2.1",
  "sha2 0.10.2",
  "tokio",
- "tokio-rustls 0.22.0",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3533,27 +3535,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64",
- "log",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
  "log",
  "ring",
- "sct 0.7.0",
- "webpki 0.22.0",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -3656,16 +3645,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sct"
@@ -4242,24 +4221,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
- "rustls 0.20.4",
+ "rustls",
  "tokio",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -4321,7 +4289,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile 0.3.0",
  "tokio",
- "tokio-rustls 0.23.3",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -5282,16 +5250,6 @@ checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/experimental/attestation_common/Cargo.toml
+++ b/experimental/attestation_common/Cargo.toml
@@ -14,8 +14,7 @@ anyhow = "*"
 log = "*"
 openssl = "*"
 ring = "*"
-# TODO(#2544): Update rustls.
-rustls = "0.19"
+rustls = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = "*"
 sha2 = "*"

--- a/experimental/attestation_common/src/keying_material.rs
+++ b/experimental/attestation_common/src/keying_material.rs
@@ -92,9 +92,9 @@ impl KeyingMaterial {
     /// Exports `KeyingMaterial` for a given TLS `session`.
     ///
     /// <https://tools.ietf.org/html/rfc5705#section-4>
-    fn export(
+    fn export<T>(
         // TLS session used to export `KeyingMaterial` from.
-        session: &dyn rustls::Session,
+        session: &rustls::ConnectionCommon<T>,
         // Label value that is needed to distinguish between application level protocols that rely
         // on `KeyingMaterial`.
         label: &str,
@@ -127,7 +127,7 @@ pub struct KeyingMaterialBundle {
 }
 
 impl KeyingMaterialBundle {
-    pub fn export(session: &dyn rustls::Session) -> anyhow::Result<Self> {
+    pub fn export<T>(session: &rustls::ConnectionCommon<T>) -> anyhow::Result<Self> {
         Ok(Self {
             client_keying_material: KeyingMaterial::export(
                 session,

--- a/experimental/https_attestation/Cargo.toml
+++ b/experimental/https_attestation/Cargo.toml
@@ -23,8 +23,8 @@ hyper = { version = "*", features = [
 ] }
 log = "*"
 oak_attestation_common = { version = "*", path = "../attestation_common" }
-# TODO(#2544): Update rustls.
-rustls = "0.19"
+rustls = "*"
+rustls-pemfile = "*"
 serde = "*"
 serde_json = "*"
 sha2 = "*"
@@ -36,4 +36,4 @@ tokio = { version = "*", features = [
   "sync",
   "rt-multi-thread"
 ] }
-tokio-rustls = "0.22"
+tokio-rustls = "*"

--- a/experimental/https_attestation/src/main.rs
+++ b/experimental/https_attestation/src/main.rs
@@ -78,10 +78,10 @@ fn load_private_key(filename: &str) -> anyhow::Result<rustls::PrivateKey> {
         .map_err(|error| anyhow!("Couldn't open file {}: {}", filename, error))?;
     let mut reader = std::io::BufReader::new(private_key_file);
 
-    let private_keys = rustls::internal::pemfile::rsa_private_keys(&mut reader)
+    let private_keys = rustls_pemfile::rsa_private_keys(&mut reader)
         .map_err(|error| anyhow!("Couldn't parse private key: {:?}", error))?;
     if private_keys.len() == 1 {
-        Ok(private_keys[0].clone())
+        Ok(rustls::PrivateKey(private_keys[0].clone()))
     } else {
         Err(anyhow!(
             "Incorrect number of private keys provided: {}, expected 1",
@@ -96,10 +96,10 @@ fn load_certificate(filename: &str) -> anyhow::Result<rustls::Certificate> {
         .map_err(|error| anyhow!("Couldn't open file {}: {}", filename, error))?;
     let mut reader = std::io::BufReader::new(certificate_file);
 
-    let certificates = rustls::internal::pemfile::certs(&mut reader)
+    let certificates = rustls_pemfile::certs(&mut reader)
         .map_err(|error| anyhow!("Couldn't parse certificate: {:?}", error))?;
     if certificates.len() == 1 {
-        Ok(certificates[0].clone())
+        Ok(rustls::Certificate(certificates[0].clone()))
     } else {
         Err(anyhow!(
             "Incorrect number of certificates provided: {}, expected 1",

--- a/experimental/https_attestation/src/server.rs
+++ b/experimental/https_attestation/src/server.rs
@@ -178,12 +178,13 @@ pub async fn run_server(
 ) -> anyhow::Result<()> {
     // Configure TLS settings.
     let tls_config = {
-        let mut config = rustls::ServerConfig::new(rustls::NoClientAuth::new());
-        config
-            .set_single_cert(vec![certificate], private_key)
+        let mut config = rustls::ServerConfig::builder()
+            .with_safe_defaults()
+            .with_no_client_auth()
+            .with_single_cert(vec![certificate], private_key)
             .map_err(|error| anyhow!("Couldn't set TLS identity: {:?}", error))?;
-        // Configure ALPN to accept HTTP/1.1 and HTTP/2.
-        config.set_protocols(&[b"http/1.1".to_vec(), b"h2".to_vec()]);
+        config.alpn_protocols.push(b"http/1.1".to_vec());
+        config.alpn_protocols.push(b"h2".to_vec());
         std::sync::Arc::new(config)
     };
     let tls_acceptor = TlsAcceptor::from(tls_config);

--- a/experimental/tls_attestation/Cargo.toml
+++ b/experimental/tls_attestation/Cargo.toml
@@ -23,8 +23,8 @@ hyper = { version = "*", features = [
 ] }
 log = "*"
 oak_attestation_common = { version = "*", path = "../attestation_common" }
-# TODO(#2544): Update rustls.
-rustls = "0.19"
+rustls = "*"
+rustls-pemfile = "*"
 sha2 = "*"
 tokio = { version = "*", features = [
   "fs",
@@ -33,4 +33,4 @@ tokio = { version = "*", features = [
   "sync",
   "rt-multi-thread"
 ] }
-tokio-rustls = "0.22"
+tokio-rustls = "*"


### PR DESCRIPTION
Some code changes are required to bump the versions of `rustls` and `tokio-rustls` that was attempted by dependabot in #2675 and #2674.