### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# Default reviewer, using auto-assignment: https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment
-* @project-oak/core


### PR DESCRIPTION
It was added in 36a23872bac39e99e56d78263b879163efc2260d but I was
hoping it would help with auto-assigning reviewers in a round robin
fashion. Instead it seems to just add the team as an additional
reviewer, which does not get converted into an auto assignment.