### PR TITLE
Add CBOR framing to the serial channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -4259,12 +4259,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-serde-cbor"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c8004e322e2509b9c7c4c0a48b7770a9657d8f1772791ea7c2f6c39e82568e"
+dependencies = [
+ "bytes",
+ "serde",
+ "serde_cbor",
+ "tokio-util 0.6.9",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -4319,7 +4345,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4372,7 +4398,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4796,8 +4822,10 @@ dependencies = [
  "env_logger 0.9.0",
  "futures",
  "log",
+ "serde",
  "tokio",
- "tokio-util",
+ "tokio-serde-cbor",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]

--- a/experimental/uefi/app/Cargo.lock
+++ b/experimental/uefi/app/Cargo.lock
@@ -45,6 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+<<<<<<< HEAD
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +126,39 @@ name = "libc"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+
+[[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "log"
@@ -300,6 +334,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
+=======
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+>>>>>>> cd1a2b552 (Add CBOR framing to the serial channel)
 name = "syn"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +428,8 @@ dependencies = [
 name = "uefi-simple"
 version = "0.1.0"
 dependencies = [
+ "ciborium",
+ "ciborium-io",
  "log",
  "oak_remote_attestation",
  "uefi",

--- a/experimental/uefi/app/Cargo.lock
+++ b/experimental/uefi/app/Cargo.lock
@@ -45,7 +45,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-<<<<<<< HEAD
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +100,12 @@ name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -126,39 +158,6 @@ name = "libc"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
-
-[[package]]
-name = "ciborium"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
-name = "half"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "log"
@@ -328,13 +327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
-
-[[package]]
-=======
 name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,7 +347,12 @@ dependencies = [
 ]
 
 [[package]]
->>>>>>> cd1a2b552 (Add CBOR framing to the serial channel)
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
 name = "syn"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/experimental/uefi/app/Cargo.toml
+++ b/experimental/uefi/app/Cargo.toml
@@ -9,6 +9,8 @@ license = "Apache-2.0"
 uefi = { version = "*", features = ["exts"] }
 uefi-services = "*"
 log = { version = "*" }
+ciborium = { version = "*", default-features = false }
+ciborium-io = "*"
 oak_remote_attestation = { path = "../../../remote_attestation/rust" }
 
 [dev-dependencies]

--- a/experimental/uefi/app/src/main.rs
+++ b/experimental/uefi/app/src/main.rs
@@ -26,15 +26,12 @@
 
 #[macro_use]
 extern crate log;
+extern crate alloc;
 
-use uefi::{
-    prelude::*,
-    proto::console::serial::Serial,
-    table::{
-        boot::{OpenProtocolAttributes, OpenProtocolParams},
-        runtime::ResetType,
-    },
-};
+use ciborium::{de, ser};
+use uefi::{prelude::*, table::runtime::ResetType};
+
+mod serial;
 
 // The main entry point of the UEFI application.
 //
@@ -70,51 +67,29 @@ fn main(handle: Handle, system_table: &mut SystemTable<Boot>) -> Status {
     serial_echo(handle, system_table.boot_services()).unwrap();
 }
 
-fn echo_loop(serial: &mut Serial) -> Result<!, uefi::Error<()>> {
-    let mut buf: [u8; 1024] = [0; 1024];
-
+fn serial_echo(handle: Handle, bt: &BootServices) -> Result<!, uefi::Error<()>> {
+    let mut serial = serial::Serial::get(handle, bt, 1)?;
     loop {
-        // read() returns Ok if it managed to fill the whole buffer, or the error will contain
-        // the number of bytes read. The only error we're fine with is TIMEOUT, as we can simply
-        // retry that (and we'll keep getting TIMEOUTs when nobody is talking to us). In case of
-        // any other error, bail out.
-        let len = serial.read(&mut buf).map(|_| buf.len()).or_else(|err| {
-            if err.status() == Status::TIMEOUT {
-                Ok(*err.data())
-            } else {
-                Err(err.status())
+        let msg: alloc::string::String = de::from_reader(&mut serial).map_err(|err| match err {
+            de::Error::Io(err) => err,
+            de::Error::Syntax(idx) => {
+                error!("Error reading data at index {}", idx);
+                uefi::Error::from(Status::INVALID_PARAMETER)
+            }
+            de::Error::Semantic(_, err) => {
+                error!("Error parsing cbor data: {:?}", err);
+                uefi::Error::from(Status::INVALID_PARAMETER)
+            }
+            de::Error::RecursionLimitExceeded => uefi::Error::from(Status::ABORTED),
+        })?;
+        ser::into_writer(&msg, &mut serial).map_err(|err| match err {
+            ser::Error::Io(err) => err,
+            ser::Error::Value(msg) => {
+                error!("Error serializing value: {}", msg);
+                uefi::Error::from(Status::INVALID_PARAMETER)
             }
         })?;
-
-        // Write out what we read; if we get any errors, propagate them.
-        if len > 0 {
-            info!("Read data: {:?}", &buf[..len]);
-            serial.write(&buf[..len]).discard_errdata()?;
-        }
     }
-}
-
-fn serial_echo(handle: Handle, bt: &BootServices) -> Result<!, uefi::Error<()>> {
-    // Expect (at least) two serial ports on the system; the first will be used
-    // for stdio, and we can use the second one for our echo example. If we don't
-    // seem to have a second serial port, err out with the (arbitrarily chosen)
-    // NO_MAPPING error.
-    let serial_handles = bt.find_handles::<Serial>()?;
-    let serial_handle = serial_handles.get(1).ok_or(Status::NO_MAPPING)?;
-    let serial = bt.open_protocol::<Serial>(
-        OpenProtocolParams {
-            handle: *serial_handle,
-            agent: handle,
-            controller: None,
-        },
-        OpenProtocolAttributes::Exclusive,
-    )?;
-    // Dereference the raw pointer (*mut Serial) we get to the serial interface.
-    // This is safe as according to the UEFI spec for the OpenProtocol call to succeed the
-    // interface must not be null (see Section 7.3 in the UEFI Specification, Version 2.9).
-    let serial = unsafe { &mut *serial.interface.get() };
-
-    echo_loop(serial)
 }
 
 #[cfg(test)]

--- a/experimental/uefi/app/src/main.rs
+++ b/experimental/uefi/app/src/main.rs
@@ -67,8 +67,12 @@ fn main(handle: Handle, system_table: &mut SystemTable<Boot>) -> Status {
     serial_echo(handle, system_table.boot_services()).unwrap();
 }
 
+// Run the echo on the first serial port in the system (the UEFI console will
+// use the first serial port in the system)
+const ECHO_SERIAL_PORT_INDEX: usize = 1;
+
 fn serial_echo(handle: Handle, bt: &BootServices) -> Result<!, uefi::Error<()>> {
-    let mut serial = serial::Serial::get(handle, bt, 1)?;
+    let mut serial = serial::Serial::get(handle, bt, ECHO_SERIAL_PORT_INDEX)?;
     loop {
         let msg: alloc::string::String = de::from_reader(&mut serial).map_err(|err| match err {
             de::Error::Io(err) => err,

--- a/experimental/uefi/app/src/serial.rs
+++ b/experimental/uefi/app/src/serial.rs
@@ -1,0 +1,99 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use uefi::{
+    prelude::*,
+    proto::console::serial,
+    table::boot::{OpenProtocolAttributes, OpenProtocolParams},
+    Error, Handle, ResultExt, Status,
+};
+
+pub struct Serial<'boot> {
+    serial: &'boot mut serial::Serial<'boot>,
+}
+
+impl<'boot> Serial<'boot> {
+    pub fn get(handle: Handle, bt: &BootServices, index: usize) -> Result<Serial, Error<()>> {
+        // Expect (at least) two serial ports on the system; the first will be used
+        // for stdio, and we can use the second one for our echo example. If we don't
+        // seem to have a second serial port, err out with the (arbitrarily chosen)
+        // NO_MAPPING error.
+        let serial_handles = bt.find_handles::<serial::Serial>()?;
+        let serial_handle = serial_handles.get(index).ok_or(Status::NO_MAPPING)?;
+        let serial = bt.open_protocol::<serial::Serial>(
+            OpenProtocolParams {
+                handle: *serial_handle,
+                agent: handle,
+                controller: None,
+            },
+            OpenProtocolAttributes::Exclusive,
+        )?;
+        // Dereference the raw pointer (*mut Serial) we get to the serial interface.
+        // This is safe as according to the UEFI spec for the OpenProtocol call to succeed the
+        // interface must not be null (see Section 7.3 in the UEFI Specification, Version 2.9).
+        let serial = unsafe { &mut *serial.interface.get() };
+
+        // Increase the FIFO size from the default 1 byte to something bigger. Experiments with
+        // qemu suggest 16 is the best we can do.
+        let mut io_mode = *serial.io_mode();
+        io_mode.receive_fifo_depth = 16;
+        serial.set_attributes(&io_mode)?;
+        Ok(Serial { serial })
+    }
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Status> {
+        // read() returns Ok if it managed to fill the whole buffer, or the error will contain
+        // the number of bytes read. The only error we're fine with is TIMEOUT, as we can simply
+        // retry that (and we'll keep getting TIMEOUTs when nobody is talking to us). In case of
+        // any other error, bail out.
+        self.serial.read(buf).map(|_| buf.len()).or_else(|err| {
+            if err.status() == Status::TIMEOUT {
+                Ok(*err.data())
+            } else {
+                Err(err.status())
+            }
+        })
+    }
+}
+
+impl<'boot> ciborium_io::Write for Serial<'boot> {
+    type Error = Error<()>;
+
+    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+        self.serial.write(data).discard_errdata()
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'boot> ciborium_io::Read for Serial<'boot> {
+    type Error = Error<()>;
+
+    // Try to fill the buffer, ignoring any timeout errors. Any other errors
+    // are propagated upward.
+    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
+        let mut bytes_read = 0;
+        while bytes_read < data.len() {
+            let len = self.read(&mut data[bytes_read..])?;
+            if len > 0 {
+                bytes_read += len;
+            }
+        }
+        Ok(())
+    }
+}

--- a/experimental/uefi/loader/Cargo.toml
+++ b/experimental/uefi/loader/Cargo.toml
@@ -12,6 +12,7 @@ command-fds = { version = "*", features = ["tokio"] }
 futures = "*"
 log = "*"
 env_logger = "*"
+serde = "*"
 tokio = { version = "*", features = [
   "io-std",
   "io-util",
@@ -21,4 +22,6 @@ tokio = { version = "*", features = [
   "process",
   "signal",
 ] }
-tokio-util = { version = "*", features = ["codec"] }
+tokio-serde-cbor = "*"
+# fixed to 0.6 because of tokio-serde-cbor
+tokio-util = { version = "~0.6", features = ["codec"] }

--- a/experimental/uefi/loader/src/main.rs
+++ b/experimental/uefi/loader/src/main.rs
@@ -80,8 +80,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    // Unfortunately OVMF writes some garbage (clear screen etc?) + our Hello World to the
-    // other serial port, so let's skip some bytes before we set up the CBOR codec.
+    // TODO(#2709): Unfortunately OVMF writes some garbage (clear screen etc?) + our Hello
+    // World to the other serial port, so let's skip some bytes before we set up the CBOR codec.
+    // The length of 71 characters has been determined experimentally and will change if we
+    // change what we write to stdout in the UEFI app.
     let mut junk = [0; 71];
     let mut len = 0;
     while len < junk.len() {

--- a/experimental/uefi/loader/src/main.rs
+++ b/experimental/uefi/loader/src/main.rs
@@ -17,14 +17,15 @@
 use std::{fs, path::PathBuf};
 
 use clap::Parser;
-use futures::stream::StreamExt;
+use futures::{stream::StreamExt, SinkExt};
 use log::info;
 use qemu::{Qemu, QemuParams};
 use tokio::{
-    io::{self, AsyncReadExt, AsyncWriteExt},
+    io::{self, AsyncReadExt},
     net::UnixStream,
     signal,
 };
+use tokio_serde_cbor::Codec;
 use tokio_util::codec::Decoder;
 mod qemu;
 
@@ -57,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     let (console_qemu, console) = UnixStream::pair()?;
-    let (comms_qemu, comms) = UnixStream::pair()?;
+    let (comms_qemu, mut comms) = UnixStream::pair()?;
 
     let qemu = Qemu::start(QemuParams {
         binary: cli.qemu.as_path(),
@@ -79,16 +80,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    // Unfortunately OVMF writes some garbage (clear screen etc?) + our Hello World to the
+    // other serial port, so let's skip some bytes before we set up the CBOR codec.
+    let mut junk = [0; 71];
+    let mut len = 0;
+    while len < junk.len() {
+        len += comms.read(&mut junk[len..]).await.unwrap();
+    }
+    info!("Leading junk on comms: {:?}", std::str::from_utf8(&junk));
+
+    // Set up the CBOR codec to handle the comms.
+    let codec: Codec<std::string::String, std::string::String> = Codec::new();
+    let (mut sink, mut stream) = codec.framed(comms).split();
+
     // Bit hacky, but it's only temporary and turns out console I/O is complex.
-    let (mut rh, mut wh) = comms.into_split();
     tokio::spawn(async move {
-        let mut buf = [0; 1024];
         loop {
-            let result = rh.read(&mut buf).await.unwrap();
-            if result == 0 {
-                break;
-            } else {
-                info!("rx: {:?}", &buf[..result]);
+            if let Some(result) = stream.next().await {
+                match result {
+                    Ok(msg) => info!("rx: {:?}", msg),
+                    Err(e) => {
+                        info!("recv error: {:?}", e);
+                    }
+                };
             }
         }
     });
@@ -99,8 +113,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if result == 0 {
                 break;
             } else {
-                info!("tx: {:?}", &buf[..result]);
-                wh.write_all(&buf[..result]).await.unwrap();
+                let msg = std::str::from_utf8(&buf[..result]).unwrap().to_string();
+                info!("tx: {:?}", &msg);
+                sink.send(msg).await.unwrap();
             }
         }
     });


### PR DESCRIPTION
In preparation for proper gRPC request/response flow this change adds some basic framing to the serial data channel: instead of just sending bytes back and forth, we use CBOR as a framing mechanism.

For now, we're still sending strings back and forth, though.

Also, while I was in there, I moved the serial-specific stuff in the UEFI app into its own file.