### PR TITLE
Add zxh404.vscode-proto3 to the dev container.

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -11,7 +11,8 @@
     "bungcip.better-toml",
     "esbenp.prettier-vscode",
     "matklad.rust-analyzer",
-    "xaver.clang-format"
+    "xaver.clang-format",
+    "zxh404.vscode-proto3"
   ],
   "settings": {
     // Use the `rust-analyzer` binary installed in the Docker image.


### PR DESCRIPTION
Just for syntax highlighting of `.proto` files, and said plugin seems to be the most popular one.