### PR TITLE
Setup docker scripts to allow the image to use KVM

### DIFF
--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -15,6 +15,11 @@ else
   readonly HOST_DOCKER_GID="$(getent group docker | cut -d: -f3)"
 fi
 
+# In order to use KVM inside docker we need permissions for the user with the
+# same KVM gid as the host
+readonly HOST_KVM_GID="$(getent group kvm | cut -d: -f3)"
+export HOST_KVM_GID
+
 mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 mkdir -p './sccache-cache'
@@ -48,6 +53,9 @@ docker_run_flags=(
   # To do that, we map the socket from the host and add the right group
   '--volume=/var/run/docker.sock:/var/run/docker.sock'
   "--group-add=$HOST_DOCKER_GID"
+  #
+  "--device=/dev/kvm"
+  '--env=HOST_KVM_GID'
 )
 
 # Some CI systems (GitHub actions) do not run with an interactive TTY attached.

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -15,11 +15,6 @@ else
   readonly HOST_DOCKER_GID="$(getent group docker | cut -d: -f3)"
 fi
 
-# In order to use KVM inside docker we need permissions for the user with the
-# same KVM gid as the host
-readonly HOST_KVM_GID="$(getent group kvm | cut -d: -f3)"
-export HOST_KVM_GID
-
 mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 mkdir -p './sccache-cache'
@@ -53,10 +48,16 @@ docker_run_flags=(
   # To do that, we map the socket from the host and add the right group
   '--volume=/var/run/docker.sock:/var/run/docker.sock'
   "--group-add=$HOST_DOCKER_GID"
-  #
-  "--device=/dev/kvm"
-  '--env=HOST_KVM_GID'
 )
+
+# If the host supports KVM, allow the image to use it
+if [[ -e "/dev/kvm" ]]; then
+  readonly HOST_KVM_GID="$(getent group kvm | cut -d: -f3)"
+  docker_run_flags+=(
+    "--device=/dev/kvm"
+    "--env=HOST_KVM_GID=${HOST_KVM_GID}"
+  )
+fi
 
 # Some CI systems (GitHub actions) do not run with an interactive TTY attached.
 if [[ -z "${CI:-}" ]]; then

--- a/scripts/fix_docker_user_and_run
+++ b/scripts/fix_docker_user_and_run
@@ -12,6 +12,7 @@ set -o xtrace
 set -o pipefail
 
 groupmod --gid="${HOST_GID}" docker
-usermod --uid="${HOST_UID}" --gid="${HOST_GID}" docker
+groupadd --gid="${HOST_KVM_GID}" kvm
+usermod --uid="${HOST_UID}" --gid="${HOST_GID}" --groups="${HOST_KVM_GID}" docker
 chown "${HOST_UID}":"${HOST_GID}" "/home/docker" "/home/docker/.cache"
 su docker --session-command="$*"

--- a/scripts/fix_docker_user_and_run
+++ b/scripts/fix_docker_user_and_run
@@ -13,6 +13,11 @@ set -o pipefail
 
 groupmod --gid="${HOST_GID}" docker
 groupadd --gid="${HOST_KVM_GID}" kvm
-usermod --uid="${HOST_UID}" --gid="${HOST_GID}" --groups="${HOST_KVM_GID}" docker
+usermod --uid="${HOST_UID}" --gid="${HOST_GID}" docker
+
+if [[ -n "${HOST_KVM_GID}" ]]; then
+  usermod --groups="${HOST_KVM_GID}" docker
+fi
+
 chown "${HOST_UID}":"${HOST_GID}" "/home/docker" "/home/docker/.cache"
 su docker --session-command="$*"

--- a/scripts/fix_docker_user_and_run
+++ b/scripts/fix_docker_user_and_run
@@ -12,10 +12,10 @@ set -o xtrace
 set -o pipefail
 
 groupmod --gid="${HOST_GID}" docker
-groupadd --gid="${HOST_KVM_GID}" kvm
 usermod --uid="${HOST_UID}" --gid="${HOST_GID}" docker
 
 if [[ -n "${HOST_KVM_GID}" ]]; then
+  groupadd --gid="${HOST_KVM_GID}" kvm
   usermod --groups="${HOST_KVM_GID}" docker
 fi
 

--- a/scripts/fix_docker_user_and_run
+++ b/scripts/fix_docker_user_and_run
@@ -14,7 +14,7 @@ set -o pipefail
 groupmod --gid="${HOST_GID}" docker
 usermod --uid="${HOST_UID}" --gid="${HOST_GID}" docker
 
-if ! [[ -z "${HOST_KVM_GID}" ]]; then
+if ! [[ -z "${HOST_KVM_GID+x}" ]]; then
   groupadd --gid="${HOST_KVM_GID}" kvm
   usermod --groups="${HOST_KVM_GID}" docker
 fi

--- a/scripts/fix_docker_user_and_run
+++ b/scripts/fix_docker_user_and_run
@@ -14,7 +14,7 @@ set -o pipefail
 groupmod --gid="${HOST_GID}" docker
 usermod --uid="${HOST_UID}" --gid="${HOST_GID}" docker
 
-if [[ -n "${HOST_KVM_GID}" ]]; then
+if ! [[ -z "${HOST_KVM_GID}" ]]; then
   groupadd --gid="${HOST_KVM_GID}" kvm
   usermod --groups="${HOST_KVM_GID}" docker
 fi


### PR DESCRIPTION
This only applies when running docker via our scripts, which are not (yet) invoked by the VSCode dev container. Supporting the dev container is likely best done by configuring it to use our docker scripts, added https://github.com/project-oak/oak/issues/2717 to track that. 