### PR TITLE
Patch how ring gets CPU feature bits when detecting RDRAND support

### DIFF
--- a/third_party/ring/src/rand.rs
+++ b/third_party/ring/src/rand.rs
@@ -455,6 +455,20 @@ mod uefi {
             // a temporary implementation while CPU feature detection in ring is
             // undergoing wider changes.
             // Ref: https://github.com/briansmith/ring/pull/1406#discussion_r720394928
+            //
+            // Invoking the CPUID instruction with input 1 in eax to returns the
+            // relevant feature bits in ecx. See 3-236 of Vol. 2A of the Intel®
+            // 64 and IA-32 Architectures Software Developer’s Manual or page 50
+            // of the Open-Source Register Reference For AMD Family 17h
+            // Processors Models 00h-2Fh1.
+            //
+            // Safety: CPUID is supported on all x86_64 CPUs, and most x86 CPUs.
+            // Strictly speaking, cpuid leaf 1 is like any other in that it
+            // should be treated as unsupported unless the maximum leaf that’s
+            // returned in eax from cpuid leaf 0 is at least 1. In practice
+            // however it’s nearly unthinkable that any cpuid implementation
+            // doesn’t extend to leaf 1.
+            // Ref: https://www.geoffchappell.com/studies/windows/km/cpu/cpuid/00000001h/index.htm?tx=255
             let cpu_feature_bits = unsafe { core::arch::x86_64::__cpuid(1).ecx };
 
             const FLAG: u32 = 1 << 30;

--- a/third_party/ring/src/rand.rs
+++ b/third_party/ring/src/rand.rs
@@ -469,6 +469,9 @@ mod uefi {
             // however it’s nearly unthinkable that any cpuid implementation
             // doesn’t extend to leaf 1.
             // Ref: https://www.geoffchappell.com/studies/windows/km/cpu/cpuid/00000001h/index.htm?tx=255
+            // Important to note that on older AMD CPUs RDRAND is available but
+            // retuns non random data. This fn does _not_ account for that, going
+            // only what is reported by the CPU. Ref: https://github.com/nagisa/rust_rdrand/blob/f2fdd528a6103c946a2e9d0961c0592498b36493/src/lib.rs#L161
             let cpu_feature_bits = unsafe { core::arch::x86_64::__cpuid(1).ecx };
 
             const FLAG: u32 = 1 << 30;

--- a/third_party/ring/src/rand.rs
+++ b/third_party/ring/src/rand.rs
@@ -456,7 +456,7 @@ mod uefi {
             // undergoing wider changes.
             // Ref: https://github.com/briansmith/ring/pull/1406#discussion_r720394928
             //
-            // Invoking the CPUID instruction with input 1 in eax to returns the
+            // Invoking the CPUID instruction with input 1 in eax returns the
             // relevant feature bits in ecx. See 3-236 of Vol. 2A of the Intel®
             // 64 and IA-32 Architectures Software Developer’s Manual or page 50
             // of the Open-Source Register Reference For AMD Family 17h


### PR DESCRIPTION
**Please review carefully.** 

The original UEFI patch uses OpenSSL to get CPU feature bits, but it does not seem to be working, see the code comment for details. 

One way to patch it would be to use the rust core lib for this. (Another could be to try and debug the OpenSSL solution). 

I've no strong opinion on the best way to approach this, raising the PR to gather input. cc @conradgrobler 