### PR TITLE
Remove invalid test runner variation in the UEFI app

### DIFF
--- a/experimental/uefi/app/.cargo/config.toml
+++ b/experimental/uefi/app/.cargo/config.toml
@@ -1,12 +1,7 @@
 [build]
 target = "x86_64-unknown-uefi"
 
-# Test runners get only one serial port, routed to stdio.
-[target.'cfg(test)']
-runner = "qemu-system-x86_64 -nodefaults -nographic -bios /usr/share/OVMF/OVMF_CODE.fd -serial stdio -machine q35 -device isa-debug-exit,iobase=0xf4,iosize=0x04 -kernel"
-
-# Otherwise, (a) the first serial port gets routed to a log, and (b) the second serial gets attached to stdio.
-[target.'cfg(not(test))']
+[target.x86_64-unknown-uefi]
 runner = "qemu-system-x86_64 -nodefaults -nographic -bios /usr/share/OVMF/OVMF_CODE.fd -serial file:target/console.log -serial stdio -machine q35 -device isa-debug-exit,iobase=0xf4,iosize=0x04 -kernel"
 
 [unstable]


### PR DESCRIPTION
This config does not behave as intended, as (somewhat counterintuitively) cfg in the config does not have access to all the usual values, including features or in this case test. As result, the `[target.'cfg(test)']` runner is never actually used.

See the tracking cargo https://github.com/rust-lang/cargo/issues/8170.

Imo we probably also do not need 