### PR TITLE
Update tract-tensorflow crate source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,46 +1907,15 @@ checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "liquid"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e930310cf4334c4936ae18737500a57739c69442b5c42bae114d619af54b82"
-dependencies = [
- "doc-comment",
- "kstring",
- "liquid-core 0.23.2",
- "liquid-derive 0.23.1",
- "liquid-lib 0.23.1",
- "serde",
-]
-
-[[package]]
-name = "liquid"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb6e6551b4c8a2045351f0853b54807b21080176a055b754dc0ad29428edf293"
 dependencies = [
  "doc-comment",
  "kstring",
- "liquid-core 0.24.1",
- "liquid-derive 0.24.0",
- "liquid-lib 0.24.0",
- "serde",
-]
-
-[[package]]
-name = "liquid-core"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eae470f061bfc53607283906de925ab67ed57a341e827146e3b241699a1dcde"
-dependencies = [
- "anymap2",
- "chrono",
- "itertools",
- "kstring",
- "liquid-derive 0.23.1",
- "num-traits 0.2.14",
- "pest",
- "pest_derive",
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
  "serde",
 ]
 
@@ -1959,23 +1928,12 @@ dependencies = [
  "anymap2",
  "itertools",
  "kstring",
- "liquid-derive 0.24.0",
+ "liquid-derive",
  "num-traits 0.2.14",
  "pest",
  "pest_derive",
  "serde",
  "time 0.3.9",
-]
-
-[[package]]
-name = "liquid-derive"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6510e456700da1afe07603913b0da5a2595f2482656ade07abf719aae7501f0a"
-dependencies = [
- "proc-macro2",
- "proc-quote",
- "syn",
 ]
 
 [[package]]
@@ -1991,29 +1949,13 @@ dependencies = [
 
 [[package]]
 name = "liquid-lib"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6341259f779ff663bdf1fc478bddb2ca51fda25414006dc69395eddfac07e0a4"
-dependencies = [
- "chrono",
- "itertools",
- "kstring",
- "liquid-core 0.23.2",
- "once_cell",
- "percent-encoding",
- "regex",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "liquid-lib"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8256326835eae262affdc6df8743d9e1b917354ba3c8c380e6238426a8097564"
 dependencies = [
  "itertools",
  "kstring",
- "liquid-core 0.24.1",
+ "liquid-core",
  "once_cell",
  "percent-encoding",
  "regex",
@@ -2255,7 +2197,7 @@ dependencies = [
  "oak_functions_client",
  "prost 0.10.0",
  "tokio",
- "tract-tensorflow 0.16.3",
+ "tract-tensorflow",
 ]
 
 [[package]]
@@ -2671,7 +2613,7 @@ dependencies = [
  "prost 0.10.0",
  "serde",
  "serde_derive",
- "tract-tensorflow 0.15.9-pre",
+ "tract-tensorflow",
 ]
 
 [[package]]
@@ -4489,28 +4431,6 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "anyhow",
- "bit-set",
- "derive-new",
- "downcast-rs",
- "dyn-clone",
- "educe",
- "lazy_static",
- "log",
- "maplit",
- "ndarray",
- "num-integer",
- "num-traits 0.2.14",
- "smallvec",
- "tract-data 0.15.9-pre",
- "tract-linalg 0.15.9-pre",
-]
-
-[[package]]
-name = "tract-core"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9594754f9e42e8e3118b48ebbd035afb647e2167c2fd63f0d8df704aa0dd2516"
@@ -4528,26 +4448,8 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.14",
  "smallvec",
- "tract-data 0.16.3",
- "tract-linalg 0.16.3",
-]
-
-[[package]]
-name = "tract-data"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "anyhow",
- "educe",
- "half",
- "itertools",
- "lazy_static",
- "maplit",
- "ndarray",
- "num-complex",
- "num-integer",
- "num-traits 0.2.14",
- "smallvec",
+ "tract-data",
+ "tract-linalg",
 ]
 
 [[package]]
@@ -4571,17 +4473,6 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "derive-new",
- "educe",
- "log",
- "tract-core 0.15.9-pre",
-]
-
-[[package]]
-name = "tract-hir"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc2ed4817da3e2bd1847b999a9748cde5b34fc785a31ee5e589e51bf2a078dac"
@@ -4589,29 +4480,7 @@ dependencies = [
  "derive-new",
  "educe",
  "log",
- "tract-core 0.16.3",
-]
-
-[[package]]
-name = "tract-linalg"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "cc",
- "derive-new",
- "downcast-rs",
- "dyn-clone",
- "educe",
- "lazy_static",
- "libc",
- "liquid 0.23.1",
- "log",
- "num-traits 0.2.14",
- "paste",
- "smallvec",
- "tract-data 0.15.9-pre",
- "unicode-normalization",
- "walkdir",
+ "tract-core",
 ]
 
 [[package]]
@@ -4627,28 +4496,14 @@ dependencies = [
  "educe",
  "lazy_static",
  "libc",
- "liquid 0.24.0",
+ "liquid",
  "log",
  "num-traits 0.2.14",
  "paste",
  "scan_fmt",
  "smallvec",
- "tract-data 0.16.3",
+ "tract-data",
  "unicode-normalization",
- "walkdir",
-]
-
-[[package]]
-name = "tract-nnef"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "byteorder",
- "flate2",
- "log",
- "nom",
- "tar",
- "tract-core 0.15.9-pre",
  "walkdir",
 ]
 
@@ -4663,18 +4518,8 @@ dependencies = [
  "log",
  "nom",
  "tar",
- "tract-core 0.16.3",
+ "tract-core",
  "walkdir",
-]
-
-[[package]]
-name = "tract-pulse"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "downcast-rs",
- "lazy_static",
- "tract-pulse-opl 0.15.9-pre",
 ]
 
 [[package]]
@@ -4685,17 +4530,7 @@ checksum = "87e590b96bd8d2dd695e28bd652a7c29820a783f81b396c8a37fc7491b0efcf1"
 dependencies = [
  "downcast-rs",
  "lazy_static",
- "tract-pulse-opl 0.16.3",
-]
-
-[[package]]
-name = "tract-pulse-opl"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "downcast-rs",
- "lazy_static",
- "tract-nnef 0.15.9-pre",
+ "tract-pulse-opl",
 ]
 
 [[package]]
@@ -4706,24 +4541,7 @@ checksum = "66c8a14d0d91d2de7fe08dc1a99cad6902c68cd0b11d067dbbf243c03bd37ec9"
 dependencies = [
  "downcast-rs",
  "lazy_static",
- "tract-nnef 0.16.3",
-]
-
-[[package]]
-name = "tract-tensorflow"
-version = "0.15.9-pre"
-source = "git+https://github.com/sonos/tract.git?rev=124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4#124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4"
-dependencies = [
- "bytes",
- "derive-new",
- "educe",
- "log",
- "mapr",
- "prost 0.9.0",
- "prost-build 0.9.0",
- "prost-types 0.9.0",
- "tract-hir 0.15.9-pre",
- "tract-pulse 0.15.9-pre",
+ "tract-nnef",
 ]
 
 [[package]]
@@ -4740,8 +4558,8 @@ dependencies = [
  "prost 0.9.0",
  "prost-build 0.9.0",
  "prost-types 0.9.0",
- "tract-hir 0.16.3",
- "tract-pulse 0.16.3",
+ "tract-hir",
+ "tract-pulse",
 ]
 
 [[package]]

--- a/oak_functions/examples/mobilenet/client/rust/src/main.rs
+++ b/oak_functions/examples/mobilenet/client/rust/src/main.rs
@@ -80,7 +80,7 @@ async fn main() -> anyhow::Result<()> {
         .context("Could not invoke Oak Functions")?;
 
     let response_body = std::str::from_utf8(response.body().unwrap()).unwrap();
-    assert_eq!(response_body, "Best result: Some((0.1752324, 789))");
+    assert_eq!(response_body, "Best result: Some((0.17523259, 789))");
 
     Ok(())
 }

--- a/oak_functions/experimental/tf_inference/Cargo.toml
+++ b/oak_functions/experimental/tf_inference/Cargo.toml
@@ -14,7 +14,4 @@ oak_logger = { path = "../../logger" }
 prost = "*"
 serde = "*"
 serde_derive = "*"
-# Provide cargo with version 0.15.9-pre, which includes our reproducibility
-# patch: https://github.com/sonos/tract/pull/601. Once 0.15.9 is released, we
-# should revert to loading this crate via crates.io
-tract-tensorflow = { git = 'https://github.com/sonos/tract.git', rev = '124dc4c8d31f01ae73a2ec3cc02c0cf3db7a13d4' }
+tract-tensorflow = "*"


### PR DESCRIPTION
We depended on a pre-release commit that incorporated our reproducibility fix: https://github.com/sonos/tract/pull/601

This fix has been incorporated into the released version.