### PR TITLE
UEFI example: Use binary messages

### DIFF
--- a/experimental/uefi/app/src/main.rs
+++ b/experimental/uefi/app/src/main.rs
@@ -86,7 +86,7 @@ fn main(handle: Handle, system_table: &mut SystemTable<Boot>) -> Status {
 fn serial_echo(handle: Handle, bt: &BootServices, index: usize) -> Result<!, uefi::Error<()>> {
     let mut serial = serial::Serial::get(handle, bt, index)?;
     loop {
-        let msg: alloc::string::String = de::from_reader(&mut serial).map_err(|err| match err {
+        let msg: alloc::vec::Vec<u8> = de::from_reader(&mut serial).map_err(|err| match err {
             de::Error::Io(err) => err,
             de::Error::Syntax(idx) => {
                 error!("Error reading data at index {}", idx);

--- a/experimental/uefi/client/src/main.rs
+++ b/experimental/uefi/client/src/main.rs
@@ -40,10 +40,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for line in stdin().lock().lines() {
         let request = Request::new(EchoRequest {
-            message: line.unwrap(),
+            message: line.unwrap().as_bytes().to_vec(),
         });
         let response = client.echo(request).await?;
-        println!("Response: {:?}", response);
+        println!(
+            "Response: {:?}",
+            core::str::from_utf8(&response.into_inner().message)
+        );
     }
 
     println!("Hello, world!");

--- a/experimental/uefi/loader/src/main.rs
+++ b/experimental/uefi/loader/src/main.rs
@@ -92,11 +92,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Use a bmrng channel for serial communication. The good thing about spawning a separate
     // task for the serial communication is that it serializes (no pun intended) the communication,
     // as right now we don't have any mechanisms to track multiple requests in flight.
-    let (tx, mut rx) = bmrng::unbounded_channel::<String, anyhow::Result<String>>();
+    let (tx, mut rx) = bmrng::unbounded_channel::<Vec<u8>, anyhow::Result<Vec<u8>>>();
 
     tokio::spawn(async move {
         // Set up the CBOR codec to handle the comms.
-        let codec: Codec<String, String> = Codec::new();
+        let codec: Codec<Vec<u8>, Vec<u8>> = Codec::new();
         let mut channel = codec.framed(comms);
         while let Ok((input, responder)) = rx.recv().await {
             responder

--- a/experimental/uefi/loader/src/server.rs
+++ b/experimental/uefi/loader/src/server.rs
@@ -29,7 +29,7 @@ use proto::{
 };
 
 pub struct EchoImpl {
-    channel: UnboundedRequestSender<String, anyhow::Result<String>>,
+    channel: UnboundedRequestSender<Vec<u8>, anyhow::Result<Vec<u8>>>,
 }
 
 #[tonic::async_trait]
@@ -54,7 +54,7 @@ impl Echo for EchoImpl {
 
 pub fn server(
     addr: SocketAddr,
-    channel: UnboundedRequestSender<String, anyhow::Result<String>>,
+    channel: UnboundedRequestSender<Vec<u8>, anyhow::Result<Vec<u8>>>,
 ) -> impl Future<Output = Result<(), tonic::transport::Error>> {
     let server_impl = EchoImpl { channel };
     Server::builder()

--- a/experimental/uefi/proto/echo.proto
+++ b/experimental/uefi/proto/echo.proto
@@ -19,11 +19,11 @@ syntax = "proto3";
 package oak.experimental.uefi;
 
 message EchoRequest {
-    string message = 1;
+    bytes message = 1;
 }
 
 message EchoResponse {
-    string message = 1;
+    bytes message = 1;
 }
 
 service Echo {


### PR DESCRIPTION
Done in preparation for adding remote attestation handshake support, which takes place using messages serialized to binary using our remote attestation protocol. 
