### PR TITLE
Refactoring: Improve naming of SessionsTracker method

### DIFF
--- a/grpc_unary_attestation/src/server.rs
+++ b/grpc_unary_attestation/src/server.rs
@@ -83,7 +83,7 @@ where
             self.session_tracker
                 .lock()
                 .expect("Couldn't lock session_state mutex")
-                .pop_session_state(session_id)
+                .pop_or_create_session_state(session_id)
                 .map_err(|error| {
                     error_logger.log_error(&format!("Couldn't pop session state: {:?}", error));
                     tonic::Status::internal("")

--- a/remote_attestation_sessions/src/lib.rs
+++ b/remote_attestation_sessions/src/lib.rs
@@ -60,7 +60,10 @@ impl SessionTracker {
     /// be put back into the SessionTracker. This an intentional choice meant
     /// to ensure that faulty state that leads to errors when processing
     /// a request is not persistent.
-    pub fn pop_session_state(&mut self, session_id: SessionId) -> anyhow::Result<SessionState> {
+    pub fn pop_or_create_session_state(
+        &mut self,
+        session_id: SessionId,
+    ) -> anyhow::Result<SessionState> {
         match self.known_sessions.pop(&session_id) {
             None => match AttestationBehavior::create_self_attestation(&self.tee_certificate) {
                 Ok(behavior) => Ok(SessionState::HandshakeInProgress(Box::new(
@@ -86,7 +89,7 @@ impl SessionTracker {
         }
     }
 
-    /// Record a session in the tracker. Unlike `pop_session_state` it does not
+    /// Record a session in the tracker. Unlike `pop_or_create_session_state` it does not
     /// normalize session state, instead relying on normalization occuring
     /// at retrieval time.
     pub fn put_session_state(&mut self, session_id: SessionId, session_state: SessionState) {


### PR DESCRIPTION
Adresses @conradgrobler's comment on #2742 https://github.com/project-oak/oak/pull/2742#discussion_r856095803 to improve the clarity of naming. 

Done in a separate PR as it's technically refactoring of other code; will rebase #2742 after this is merged. 