### PR TITLE
Add test to write empty buffer to Wasm memory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache@v2
         env:
           # Increment this value to invalidate previous cache entries.
-          CACHE_VERSION: 6
+          CACHE_VERSION: 7
         with:
           path: |
             ./cargo-cache/bin


### PR DESCRIPTION
Also removes duplicate function `write_extension_result`.

Also adds function to read `u32` from Wasm memory.

Fixes #2755