### PR TITLE
Bump rust version to nightly-2022-04-22

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:ab889141f07b886f02ca3ec664341d7dfada94826c5538842b795b005bc1a417",
+  "image": "sha256:8a0cc4b71806df78eb6c3652e33f8c96222e1431980891173133912c492169e3",
   "extensions": [
     "bazelbuild.vscode-bazel",
     "bodil.prettier-toml",

--- a/Dockerfile
+++ b/Dockerfile
@@ -226,7 +226,7 @@ RUN curl --location https://sh.rustup.rs > /tmp/rustup \
 # We currently need the nightly version in order to be able to compile some of the examples.
 # See https://rust-lang.github.io/rustup-components-history/ for how to pick a version that supports
 # the appropriate set of components.
-ARG rust_version=nightly-2022-02-17
+ARG rust_version=nightly-2022-04-22
 RUN rustup toolchain install ${rust_version} \
   && rustup default ${rust_version}
 

--- a/scripts/common
+++ b/scripts/common
@@ -20,10 +20,10 @@ readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak:latest'
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:ab889141f07b886f02ca3ec664341d7dfada94826c5538842b795b005bc1a417'
+readonly DOCKER_IMAGE_ID='sha256:8a0cc4b71806df78eb6c3652e33f8c96222e1431980891173133912c492169e3'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:8189809db8f834acb9c56c71f7a80e5ed00f8057ea3ac014b771443356534b1d'
+readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:a90d45f072a62cad6213c82c2c017729083695575e7f38f17c4966f5f707130c'
 
 readonly SERVER_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-server'
 


### PR DESCRIPTION
The main reason for this is https://github.com/phil-opp/linked-list-allocator/issues/56; a newer nightly fixes the issue.