### PR TITLE
Separate Oak Invocation Protos from remote attestation logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,7 +1776,6 @@ name = "grpc_unary_attestation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "oak_functions_abi",
  "oak_remote_attestation",
  "oak_remote_attestation_sessions",
  "oak_utils",

--- a/grpc_unary_attestation/Cargo.toml
+++ b/grpc_unary_attestation/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 [dependencies]
 oak_remote_attestation = { path = "../remote_attestation/rust/" }
 oak_remote_attestation_sessions = { path = "../remote_attestation_sessions/" }
-oak_functions_abi = { path = "../oak_functions/abi/" }
 anyhow = "*"
 prost = "*"
 prost-types = "*"

--- a/grpc_unary_attestation/src/client.rs
+++ b/grpc_unary_attestation/src/client.rs
@@ -16,7 +16,6 @@
 
 use crate::proto::{unary_session_client::UnarySessionClient, UnaryRequest};
 use anyhow::Context;
-use oak_functions_abi;
 use oak_remote_attestation::handshaker::{
     AttestationBehavior, ClientHandshaker, Encryptor, ServerIdentityVerifier,
 };
@@ -89,13 +88,10 @@ impl AttestationClient {
     }
 
     /// Sends data encrypted by the [`Encryptor`] to the server and decrypts the server responses.
-    pub async fn send(
-        &mut self,
-        request: oak_functions_abi::proto::Request,
-    ) -> anyhow::Result<Option<Vec<u8>>> {
+    pub async fn send(&mut self, payload: Vec<u8>) -> anyhow::Result<Option<Vec<u8>>> {
         let encrypted_request = self
             .encryptor
-            .encrypt(&request.body)
+            .encrypt(&payload)
             .context("Couldn't encrypt request")?;
         let encrypted_response = self
             .client

--- a/oak_functions/client/rust/src/lib.rs
+++ b/oak_functions/client/rust/src/lib.rs
@@ -51,7 +51,7 @@ impl Client {
 
     pub async fn invoke(&mut self, request: Request) -> anyhow::Result<Response> {
         self.inner
-            .send(request)
+            .send(request.body)
             .await
             .context("Error invoking Oak Functions instance")?
             .ok_or_else(|| anyhow::anyhow!("Empty response"))

--- a/oak_functions/loader/fuzz/Cargo.lock
+++ b/oak_functions/loader/fuzz/Cargo.lock
@@ -355,7 +355,6 @@ name = "grpc_unary_attestation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "oak_functions_abi",
  "oak_remote_attestation",
  "oak_remote_attestation_sessions",
  "oak_utils",


### PR DESCRIPTION
Makes it so the remote attestation client expects to be invoked with binary payloads. This allows us to share it across runtimes.