### PR TITLE
Stop test_long_response_time from failing often

### DIFF
--- a/oak_functions/loader/src/server.rs
+++ b/oak_functions/loader/src/server.rs
@@ -596,13 +596,15 @@ where
 {
     // Use tokio::spawn to actually run the tasks in parallel, for more accurate measurement
     // of time.
-    let task = tokio::spawn(async move { function() });
-    // Sleep until the policy times out
-    tokio::time::sleep(Duration::from_millis(
+    let sleep = tokio::spawn(tokio::time::sleep(Duration::from_millis(
         policy.constant_processing_time_ms.into(),
-    ))
-    .await;
+    )));
+    let task = tokio::spawn(async move { function() });
 
+    // Sleep until the policy times out
+    sleep.await?;
+
+    // Get the result whether the task has finnished or not.
     let function_response = task.now_or_never();
 
     let response = match function_response {


### PR DESCRIPTION
This change spawns the policy timeout sleeping task earlier in an attempt to stop `test_long_response_time` from failing frequently because the policy is not getting applied consistently.