### PR TITLE
Update QEMU CPU model to lowest Intel CPU that supports RDRAND.

### DIFF
--- a/experimental/uefi/app/runner
+++ b/experimental/uefi/app/runner
@@ -27,7 +27,7 @@ qemu_flags=(
 if [[ -e "/dev/kvm" ]]; then
   qemu_flags+=(
     '-enable-kvm'
-    '-cpu' 'Broadwell-IBRS'
+    '-cpu' 'IvyBridge-IBRS,enforce'
   )
 fi
 

--- a/experimental/uefi/loader/src/qemu.rs
+++ b/experimental/uefi/loader/src/qemu.rs
@@ -74,7 +74,7 @@ impl Qemu {
         // Needed to expose advanced CPU features to the UEFI app. Specifically
         // RDRAND which is required for remote attestation.
         cmd.arg("-enable-kvm");
-        cmd.args(&["-cpu", "Broadwell-IBRS"]);
+        cmd.args(&["-cpu", "IvyBridge-IBRS,enforce"]);
         // We're going to run qemu as a noninteractive embedded program, so disable any
         // graphical outputs.
         cmd.arg("-nographic");


### PR DESCRIPTION
The previous model of Broadwell also supports other newer features like RDSEED, which we don't actually require need. This leads to issues on older hosts that don't support that feature.

The enforce flag is also added, to trigger an error if hosts don't required support CPU features.