### PR TITLE
Remove explicit reviewers from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,4 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    reviewers:
-      - 'project-oak/core'
+    # We do not set an explicit reviewer, as that is already automatically assigned via CODEOWNERS.


### PR DESCRIPTION
Currently I think dependabot gets confused because it tries to add its
own reviewer, even though CODEOWNERS already specifies the same
reviewer, and therefore we end up with two reviewers (one auto-assigned,
one left as team) in each PR (e.g. see
https://github.com/project-oak/oak/pull/2781)

I am not 100% sure this will work, but it's worth a try.