### PR TITLE
Import a subset of rust-hypervisor-firmware code

### DIFF
--- a/third_party/rust-hypervisor-firmware-subset/Cargo.toml
+++ b/third_party/rust-hypervisor-firmware-subset/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust-hypervisor-firmware-subset"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bitflags = "*"
+log = "*"
+x86_64 = "*"

--- a/third_party/rust-hypervisor-firmware-subset/LICENSE
+++ b/third_party/rust-hypervisor-firmware-subset/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/rust-hypervisor-firmware-subset/README.md
+++ b/third_party/rust-hypervisor-firmware-subset/README.md
@@ -1,0 +1,8 @@
+This crate contains code extracted from the Rust Hypervisor Firmware code base:
+https://github.com/cloud-hypervisor/rust-hypervisor-firmware
+
+Rust Hypervisor Firmware is, as the name suggests, designed to be firmware for
+virtual machines that is able to load other kernels. The code here is the subset
+of Rust Hypervisor Firmware code that's necessary to bootstrap something on bare
+metal, as we're interested in just getting the machine going (without relying on
+disk images) and intend to build the kernel directly on top.

--- a/third_party/rust-hypervisor-firmware-subset/layout.ld
+++ b/third_party/rust-hypervisor-firmware-subset/layout.ld
@@ -1,0 +1,50 @@
+ENTRY(ram32_start) /* coreboot uses the ELF entrypoint */
+
+PHDRS
+{
+  ram  PT_LOAD FILEHDR PHDRS ;
+  note PT_NOTE               ;
+}
+
+/* Loaders like to put stuff in low memory (< 1M), so we don't use it. */
+ram_min = 1M;
+
+SECTIONS
+{
+  /* Mapping the program headers and note into RAM makes the file smaller. */
+  . = ram_min;
+  . += SIZEOF_HEADERS;
+  .note : { *(.note) } :note :ram
+
+  /* These sections are mapped into RAM from the file. Omitting :ram from
+     later sections avoids emitting empty sections in the final binary.       */
+  data_start = .;
+  .rodata : { *(.rodata .rodata.*) } :ram
+  . = ALIGN(4K);
+  text_start = .;
+  .text   : { *(.text .text.*)     }
+  .text32 : { *(.text32)           }
+  . = ALIGN(4K);
+  text_end = .;
+  .data   : { *(.data .data.*)     }
+  data_size = . - data_start;
+
+  /* The BSS section isn't mapped from file data. It is just zeroed in RAM. */
+  .bss : {
+    bss_start = .;
+    *(.bss .bss.*)
+    bss_size = . - bss_start;
+  }
+
+  /* Our stack grows down and is page-aligned. TODO: Add stack guard pages. */
+  .stack (NOLOAD) : ALIGN(4K) { . += 128K; }
+  stack_start = .;
+  /* ram32.s only maps the first 2 MiB, and that must include the stack. */
+  ASSERT((. <= 2M), "Stack overflows initial identity-mapped memory region")
+
+  /* Strip symbols from the output binary (comment out to get symbols) */
+  /DISCARD/ : {
+    *(.symtab)
+    *(.strtab)
+  }
+}

--- a/third_party/rust-hypervisor-firmware-subset/src/asm/mod.rs
+++ b/third_party/rust-hypervisor-firmware-subset/src/asm/mod.rs
@@ -1,0 +1,5 @@
+// Derived from Cloud Hypervisor, https://github.com/cloud-hypervisor/rust-hypervisor-firmware/
+
+use core::arch::global_asm;
+
+global_asm!(include_str!("ram32.s"), options(att_syntax, raw));

--- a/third_party/rust-hypervisor-firmware-subset/src/asm/ram32.s
+++ b/third_party/rust-hypervisor-firmware-subset/src/asm/ram32.s
@@ -1,0 +1,55 @@
+.section .text32, "ax"
+.global ram32_start
+.code32
+
+ram32_start:
+    # Stash the PVH start_info struct in %rdi.
+    movl %ebx, %edi
+
+setup_page_tables:
+    # First L2 entry identity maps [0, 2 MiB)
+    movl $0b10000011, (L2_TABLES) # huge (bit 7), writable (bit 1), present (bit 0)
+    # First L3 entry points to L2 table
+    movl $L2_TABLES, %eax
+    orb  $0b00000011, %al # writable (bit 1), present (bit 0)
+    movl %eax, (L3_TABLE)
+    # First L4 entry points to L3 table
+    movl $L3_TABLE, %eax
+    orb  $0b00000011, %al # writable (bit 1), present (bit 0)
+    movl %eax, (L4_TABLE)
+
+enable_paging:
+    # Load page table root into CR3
+    movl $L4_TABLE, %eax
+    movl %eax, %cr3
+
+    # Set CR4.PAE (Physical Address Extension)
+    movl %cr4, %eax
+    orb  $0b00100000, %al # Set bit 5
+    movl %eax, %cr4
+    # Set EFER.LME (Long Mode Enable)
+    movl $0xC0000080, %ecx
+    rdmsr
+    orb  $0b00000001, %ah # Set bit 8
+    wrmsr
+    # Set CRO.PG (Paging)
+    movl %cr0, %eax
+    orl  $(1 << 31), %eax
+    movl %eax, %cr0
+
+jump_to_64bit:
+    # We are now in 32-bit compatibility mode. To enter 64-bit mode, we need to
+    # load a 64-bit code segment into our GDT.
+    lgdtl GDT64_PTR
+    # Initialize the stack pointer (Rust code always uses the stack)
+    movl $stack_start, %esp
+    # Set segment registers to a 64-bit segment.
+    movw $0x10, %ax
+    movw %ax, %ds
+    movw %ax, %es
+    movw %ax, %gs
+    movw %ax, %fs
+    movw %ax, %ss
+    # Set CS to a 64-bit segment and jump to 64-bit Rust code.
+    # PVH start_info is in %rdi, the first paramter of the System V ABI.
+    ljmpl $0x08, $rust64_start

--- a/third_party/rust-hypervisor-firmware-subset/src/boot.rs
+++ b/third_party/rust-hypervisor-firmware-subset/src/boot.rs
@@ -1,0 +1,24 @@
+// Common data needed for all boot paths
+pub trait Info {
+    // Name of for this boot protocol
+    fn name(&self) -> &str;
+    // Starting address of the Root System Descriptor Pointer
+    fn rsdp_addr(&self) -> u64;
+    // The kernel command line (not including null terminator)
+    fn cmdline(&self) -> &[u8];
+    // Methods to access the E820 Memory map
+    fn num_entries(&self) -> u8;
+    fn entry(&self, idx: u8) -> E820Entry;
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+pub struct E820Entry {
+    pub addr: u64,
+    pub size: u64,
+    pub entry_type: u32,
+}
+
+impl E820Entry {
+    pub const RAM_TYPE: u32 = 1;
+}

--- a/third_party/rust-hypervisor-firmware-subset/src/common.rs
+++ b/third_party/rust-hypervisor-firmware-subset/src/common.rs
@@ -1,0 +1,27 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SAFETY: Requires that addr point to a static, null-terminated C-string.
+// The returned slice does not include the null-terminator.
+pub unsafe fn from_cstring(addr: u64) -> &'static [u8] {
+    if addr == 0 {
+        return &[];
+    }
+    let start = addr as *const u8;
+    let mut size: usize = 0;
+    while start.add(size).read() != 0 {
+        size += 1;
+    }
+    core::slice::from_raw_parts(start, size)
+}

--- a/third_party/rust-hypervisor-firmware-subset/src/gdt.rs
+++ b/third_party/rust-hypervisor-firmware-subset/src/gdt.rs
@@ -1,0 +1,54 @@
+use core::mem::size_of;
+
+bitflags::bitflags! {
+    // An extension of x86_64::structures::gdt::DescriptorFlags
+    struct Descriptor: u64 {
+        const LIMIT_0_15 =   0xFFFF;
+        const BASE_0_23 = 0xFF_FFFF << 16;
+        const ACCESSED =          1 << 40;
+        const WRITABLE =          1 << 41;  // Only for Data-Segments
+        const READABLE =          1 << 41;  // Only for Code-Segments
+        const EXPANSION =         1 << 42;  // Only for Data-Segments
+        const CONFORMING =        1 << 42;  // Only for Code-Segments
+        const EXECUTABLE =        1 << 43;
+        const USER_SEGMENT =      1 << 44;
+        const DPL_RING_3 =        3 << 45;
+        const PRESENT =           1 << 47;
+        const LIMIT_16_19 =     0xF << 48;
+        const SOFTWARE =          1 << 52;
+        const BIT64 =             1 << 53;
+        const BIT32 =             1 << 54;
+        const GRANULARITY =       1 << 55;
+        const BASE_24_31 =     0xFF << 56;
+
+        // All segments are nonconforming, non-system, ring-0 only, and present.
+        // We set ACCESSED in advance to avoid writing to the descriptor.
+        const COMMON = Self::ACCESSED.bits | Self::USER_SEGMENT.bits | Self::PRESENT.bits;
+        // BIT32 must be 0, all other bits (not yet mentioned) are ignored.
+        const CODE64 = Self::COMMON.bits | Self::READABLE.bits | Self::EXECUTABLE.bits | Self::BIT64.bits;
+        const DATA64 = Self::COMMON.bits | Self::WRITABLE.bits | Self::BIT64.bits;
+    }
+}
+
+// An alternative to x86_64::structures::DescriptorTablePointer that avoids
+// "pointer-to-integer cast" (which rust does not support in statics).
+#[repr(C, packed)]
+struct Pointer {
+    limit: u16,
+    base: &'static Descriptor,
+}
+
+impl Pointer {
+    const fn new(gdt: &'static [Descriptor]) -> Self {
+        let size = gdt.len() * size_of::<Descriptor>();
+        Self {
+            limit: size as u16 - 1,
+            base: &gdt[0],
+        }
+    }
+}
+
+// Our 64-bit GDT lives in RAM, so it can be accessed like any other global.
+#[no_mangle]
+static GDT64_PTR: Pointer = Pointer::new(&GDT64);
+static GDT64: [Descriptor; 3] = [Descriptor::empty(), Descriptor::CODE64, Descriptor::DATA64];

--- a/third_party/rust-hypervisor-firmware-subset/src/lib.rs
+++ b/third_party/rust-hypervisor-firmware-subset/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+mod asm;
+pub mod boot;
+mod common;
+mod gdt;
+pub mod paging;
+pub mod pvh;

--- a/third_party/rust-hypervisor-firmware-subset/src/paging.rs
+++ b/third_party/rust-hypervisor-firmware-subset/src/paging.rs
@@ -1,0 +1,57 @@
+extern crate log;
+
+use x86_64::{
+    registers::control::Cr3,
+    structures::paging::{PageSize, PageTable, PageTableFlags, PhysFrame, Size2MiB},
+    PhysAddr,
+};
+
+// Amount of memory we identity map in setup(), max 512 GiB.
+const ADDRESS_SPACE_GIB: usize = 4;
+const TABLE: PageTable = PageTable::new();
+
+// Put the Page Tables in static muts to make linking easier
+#[no_mangle]
+static mut L4_TABLE: PageTable = PageTable::new();
+#[no_mangle]
+static mut L3_TABLE: PageTable = PageTable::new();
+#[no_mangle]
+static mut L2_TABLES: [PageTable; ADDRESS_SPACE_GIB] = [TABLE; ADDRESS_SPACE_GIB];
+
+pub fn setup() {
+    // SAFETY: This function is idempontent and only writes to static memory and
+    // CR3. Thus, it is safe to run multiple times or on multiple threads.
+    let (l4, l3, l2s) = unsafe { (&mut L4_TABLE, &mut L3_TABLE, &mut L2_TABLES) };
+    log::info!("Setting up {} GiB identity mapping", ADDRESS_SPACE_GIB);
+    let pt_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+
+    // Setup Identity map using L2 huge pages
+    let mut next_addr = PhysAddr::new(0);
+    for l2 in l2s.iter_mut() {
+        for l2e in l2.iter_mut() {
+            l2e.set_addr(next_addr, pt_flags | PageTableFlags::HUGE_PAGE);
+            next_addr += Size2MiB::SIZE;
+        }
+    }
+
+    // Point L3 at L2s
+    for (i, l2) in l2s.iter().enumerate() {
+        l3[i].set_addr(phys_addr(l2), pt_flags);
+    }
+
+    // Point L4 at L3
+    l4[0].set_addr(phys_addr(l3), pt_flags);
+
+    // Point Cr3 at L4
+    let (cr3_frame, cr3_flags) = Cr3::read();
+    let l4_frame = PhysFrame::from_start_address(phys_addr(l4)).unwrap();
+    if cr3_frame != l4_frame {
+        unsafe { Cr3::write(l4_frame, cr3_flags) };
+    }
+    log::info!("Page tables setup");
+}
+
+// Map a virtual address to a PhysAddr (assumes identity mapping)
+fn phys_addr<T>(virt_addr: *const T) -> PhysAddr {
+    PhysAddr::new(virt_addr as u64)
+}

--- a/third_party/rust-hypervisor-firmware-subset/src/pvh.rs
+++ b/third_party/rust-hypervisor-firmware-subset/src/pvh.rs
@@ -1,0 +1,93 @@
+use core::mem::size_of;
+
+use crate::{
+    boot::{E820Entry, Info},
+    common,
+};
+
+// Structures from xen/include/public/arch-x86/hvm/start_info.h
+#[derive(Debug)]
+#[repr(C)]
+pub struct StartInfo {
+    magic: [u8; 4],
+    version: u32,
+    flags: u32,
+    nr_modules: u32,
+    modlist_paddr: u64,
+    cmdline_paddr: u64,
+    rsdp_paddr: u64,
+    memmap_paddr: u64,
+    memmap_entries: u32,
+    _pad: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+struct MemMapEntry {
+    addr: u64,
+    size: u64,
+    entry_type: u32,
+    _pad: u32,
+}
+
+impl Info for StartInfo {
+    fn name(&self) -> &str {
+        "PVH Boot Protocol"
+    }
+    fn rsdp_addr(&self) -> u64 {
+        self.rsdp_paddr
+    }
+    fn cmdline(&self) -> &[u8] {
+        unsafe { common::from_cstring(self.cmdline_paddr) }
+    }
+    fn num_entries(&self) -> u8 {
+        // memmap_paddr and memmap_entries only exist in version 1 or later
+        if self.version < 1 || self.memmap_paddr == 0 {
+            return 0;
+        }
+        self.memmap_entries as u8
+    }
+    fn entry(&self, idx: u8) -> E820Entry {
+        assert!(idx < self.num_entries());
+        let ptr = self.memmap_paddr as *const MemMapEntry;
+        let entry = unsafe { *ptr.offset(idx as isize) };
+        E820Entry {
+            addr: entry.addr,
+            size: entry.size,
+            entry_type: entry.entry_type,
+        }
+    }
+}
+
+// The PVH Boot Protocol starts at the 32-bit entrypoint to our firmware.
+extern "C" {
+    fn ram32_start();
+}
+
+// The kind/name/desc of the PHV ELF Note are from xen/include/public/elfnote.h.
+// This is the "Physical entry point into the kernel".
+const XEN_ELFNOTE_PHYS32_ENTRY: u32 = 18;
+type Name = [u8; 4];
+type Desc = unsafe extern "C" fn();
+
+// We make sure our ELF Note has an alignment of 4 for maximum compatibility.
+// Some software (QEMU) calculates padding incorectly if alignment != 4.
+#[repr(C, packed(4))]
+struct Note {
+    name_size: u32,
+    desc_size: u32,
+    kind: u32,
+    name: Name,
+    desc: Desc,
+}
+
+// This is: ELFNOTE(Xen, XEN_ELFNOTE_PHYS32_ENTRY, .quad ram32_start)
+#[link_section = ".note"]
+#[used]
+static PVH_NOTE: Note = Note {
+    name_size: size_of::<Name>() as u32,
+    desc_size: size_of::<Desc>() as u32,
+    kind: XEN_ELFNOTE_PHYS32_ENTRY,
+    name: *b"Xen\0",
+    desc: ram32_start,
+};

--- a/third_party/rust-hypervisor-firmware-subset/target.json
+++ b/third_party/rust-hypervisor-firmware-subset/target.json
@@ -1,0 +1,19 @@
+{
+  "llvm-target": "x86_64-unknown-none",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "arch": "x86_64",
+  "target-endian": "little",
+  "target-pointer-width": "64",
+  "target-c-int-width": "32",
+  "os": "none",
+  "executables": true,
+  "linker-flavor": "ld.lld",
+  "linker": "rust-lld",
+  "panic-strategy": "abort",
+  "disable-redzone": true,
+  "features": "-mmx,-sse,+soft-float",
+  "relocation-model": "pic",
+  "pre-link-args": {
+    "ld.lld": ["--script=layout.ld"]
+  }
+}


### PR DESCRIPTION
This extracts the initial import of code out of https://github.com/project-oak/oak/pull/2766.

The code comes from https://github.com/cloud-hypervisor/rust-hypervisor-firmware as of commit e87f46211863ffdac8434293b3cad2372538149c.

Local modifications include the README file, adding `Cargo.toml` and `src/lib.rs` files. Everything else is a strict subset of the rust-hypervisor-firmware code.