### PR TITLE
When printing out the full command to run, also show the directory.

### DIFF
--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -766,7 +766,17 @@ impl Cmd {
 
 impl Runnable for Cmd {
     fn description(&self) -> String {
-        format!("{} {}", self.executable, self.args.join(" "))
+        format!(
+            "{} {}{}",
+            self.executable,
+            self.args.join(" "),
+            self.current_dir
+                .as_ref()
+                .map_or("".to_string(), |dir| format!(
+                    " (in directory {})",
+                    dir.display()
+                ))
+        )
     }
     /// Run the provided command, printing a status message with the current prefix.
     /// TODO(#396): Return one of three results: pass, fail, or internal error (e.g. if the binary


### PR DESCRIPTION
Sometimes (especially for the no_std binaries) we need to specify the directory we have to run the command in (so that we would pick up the correct `.cargo/config.toml` file). If the runtime directory is specified, let's print that out as well in addition to the command itself.