### PR TITLE
Don't expect floats to be exactly the same

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,6 +2540,7 @@ dependencies = [
  "oak_functions_abi",
  "oak_functions_client",
  "prost 0.10.1",
+ "regex",
  "tokio",
  "tract-tensorflow",
 ]

--- a/oak_functions/examples/mobilenet/client/rust/Cargo.toml
+++ b/oak_functions/examples/mobilenet/client/rust/Cargo.toml
@@ -12,6 +12,7 @@ image = "*"
 oak_functions_abi = { path = "../../../../abi" }
 oak_functions_client = { path = "../../../../client/rust" }
 prost = "*"
+regex = "*"
 tokio = { version = "*", features = [
   "fs",
   "macros",

--- a/oak_functions/examples/mobilenet/client/rust/src/main.rs
+++ b/oak_functions/examples/mobilenet/client/rust/src/main.rs
@@ -80,6 +80,8 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("Could not invoke Oak Functions")?;
 
+    // Allow some small variance in the result, as the number can change slightly between different
+    // versions of libraries. We still want the test to fail for any significant changes, though.
     let response_body = std::str::from_utf8(response.body().unwrap()).unwrap();
     let regex = Regex::new(r"^Best result: Some\(\(0.175232\d+, 789\)\)$").unwrap();
     assert!(

--- a/oak_functions/examples/mobilenet/client/rust/src/main.rs
+++ b/oak_functions/examples/mobilenet/client/rust/src/main.rs
@@ -19,6 +19,7 @@
 use anyhow::Context;
 use oak_functions_abi::proto::{ConfigurationInfo, Request};
 use oak_functions_client::Client;
+use regex::Regex;
 use tract_tensorflow::prelude::*;
 
 // Shape of the input tensor
@@ -80,7 +81,13 @@ async fn main() -> anyhow::Result<()> {
         .context("Could not invoke Oak Functions")?;
 
     let response_body = std::str::from_utf8(response.body().unwrap()).unwrap();
-    assert_eq!(response_body, "Best result: Some((0.17523259, 789))");
+    let regex = Regex::new(r"^Best result: Some\(\(0.175232\d+, 789\)\)$").unwrap();
+    assert!(
+        regex.is_match(response_body),
+        "Response \"{}\" does not match regex \"{}\"",
+        response_body,
+        regex.as_str()
+    );
 
     Ok(())
 }


### PR DESCRIPTION
If you look at, say, https://github.com/project-oak/oak/pull/2801 where Dependabot tries to update the version of `tract-tensorflow`, the tests fail because:
```
[14:56:07 ✓:1,✗:0,⠇:4] │││││││ ╔════════════════════════
[14:56:07 ✓:1,✗:0,⠇:4] │││││││ ║ ════╡ stderr ╞════
[14:56:07 ✓:1,✗:0,⠇:4] │││││││ ║     Finished release [optimized] target(s) in 0.25s
[14:56:07 ✓:1,✗:0,⠇:4] │││││││ ║      Running `target/x86_64-unknown-linux-gnu/release/mobilenet_client`
[14:56:07 ✓:1,✗:0,⠇:4] │││││││ ║ thread 'main' panicked at 'assertion failed: `(left == right)`
[14:56:07 ✓:1,✗:0,⠇:4] │││││││ ║   left: `"Best result: Some((0.1752324, 789))"`,
[14:56:07 ✓:1,✗:0,⠇:4] │││││││ ║  right: `"Best result: Some((0.17523259, 789))"`', oak_functions/examples/mobilenet/client/rust/src/main.rs:83:5
[14:56:07 ✓:1,✗:0,⠇:4] │││││││ ║ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[14:56:07 ✓:1,✗:0,⠇:4] │││││││ ╚════════════════════════
```

Expecting floats always to be exactly the same goes against best practice; you should allow some variation. Unfortunately we're comparing strings in the test, so... let's try matching against a regex that allows some variance after the 7th significant digit.