### PR TITLE
Add an end-to-end test for bare metal/UEFI using xtask

### DIFF
--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -54,6 +54,7 @@ pub struct Opt {
 
 #[derive(Subcommand, Clone, Debug)]
 pub enum Command {
+    RunVmTest,
     RunOakFunctionsExamples(RunOakExamplesOpt),
     BuildOakFunctionsExample(RunOakExamplesOpt),
     BuildOakFunctionsServerVariants(BuildServerOpt),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -55,6 +55,8 @@ use check_license::CheckLicense;
 mod check_build_licenses;
 use check_build_licenses::CheckBuildLicenses;
 
+mod vm;
+
 static PROCESSES: Lazy<Mutex<Vec<i32>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
 #[tokio::main]
@@ -112,6 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn match_cmd(opt: &Opt) -> Step {
     match opt.cmd {
+        Command::RunVmTest => vm::run_vm_test(),
         Command::RunOakFunctionsExamples(ref run_opt) => {
             run_oak_functions_examples(run_opt, &opt.scope)
         }

--- a/xtask/src/vm.rs
+++ b/xtask/src/vm.rs
@@ -1,0 +1,108 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::path::Path;
+
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter};
+
+use crate::internal::*;
+
+#[derive(Debug, Display, Clone, PartialEq, EnumIter)]
+enum Variant {
+    Uefi,
+    Baremetal,
+}
+
+impl Variant {
+    pub fn payload_crate_path(&self) -> &'static str {
+        match self {
+            Variant::Uefi => "./experimental/uefi/app",
+            Variant::Baremetal => "./experimental/uefi/baremetal",
+        }
+    }
+
+    pub fn loader_mode(&self) -> &'static str {
+        match self {
+            Variant::Uefi => "uefi",
+            Variant::Baremetal => "bios",
+        }
+    }
+
+    pub fn binary_path(&self) -> &'static str {
+        match self {
+            Variant::Uefi => {
+                "./experimental/uefi/app/target/x86_64-unknown-uefi/debug/uefi-simple.efi"
+            }
+            Variant::Baremetal => "./experimental/uefi/baremetal/target/target/debug/baremetal",
+        }
+    }
+}
+
+pub fn run_vm_test() -> Step {
+    Step::Multiple {
+        name: "VM end-to-end test".to_string(),
+        steps: Variant::iter().map(run_variant).collect(),
+    }
+}
+
+fn run_variant(variant: Variant) -> Step {
+    Step::Multiple {
+        name: format!("run {} variant", variant),
+        steps: vec![
+            build_binary("build loader binary", "./experimental/uefi/loader"),
+            build_binary("build payload", variant.payload_crate_path()),
+            Step::WithBackground {
+                name: "background loader".to_string(),
+                background: run_loader(variant),
+                foreground: Box::new(run_client()),
+            },
+        ],
+    }
+}
+
+fn build_binary(name: &str, directory: &str) -> Step {
+    Step::Single {
+        name: name.to_string(),
+        command: Cmd::new_in_dir("cargo", vec!["build"], Path::new(directory)),
+    }
+}
+
+fn run_loader(variant: Variant) -> Box<dyn Runnable> {
+    Cmd::new(
+        "./target/debug/uefi-loader",
+        vec![
+            format!("--mode={}", variant.loader_mode()),
+            variant.binary_path().to_string(),
+        ],
+    )
+}
+
+fn run_client() -> Step {
+    Step::Multiple {
+        name: "build and run client".to_string(),
+        steps: vec![
+            build_binary("build client binary", "./experimental/uefi/client"),
+            Step::Single {
+                name: "run client".to_string(),
+                command: Cmd::new(
+                    "./target/debug/uefi-client",
+                    vec!["--request", "test", "--response", "test"],
+                ),
+            },
+        ],
+    }
+}


### PR DESCRIPTION
This comes with multiple caveats:

  * KVM is required, so you can't run it in the VS Code container nor any of our current CI environments
  * Bare-metal binary doesn't build, so that branch is untested (but as we know it'd fail anyway due to ring)