### PR TITLE
Fix bare-metal build break

### DIFF
--- a/experimental/uefi/baremetal/Cargo.lock
+++ b/experimental/uefi/baremetal/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "anyhow",
  "atomic_refcell",
  "lazy_static",
+ "libm",
  "linked_list_allocator",
  "log",
  "runtime",

--- a/experimental/uefi/baremetal/Cargo.toml
+++ b/experimental/uefi/baremetal/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 anyhow = { version = "*", default-features = false }
 atomic_refcell = "*"
 lazy_static = { version = "*", features = ["spin_no_std"] }
+libm = "*"
 linked_list_allocator = { version = "*" }
 log = "*"
 runtime = { path = "../runtime" }

--- a/experimental/uefi/baremetal/src/main.rs
+++ b/experimental/uefi/baremetal/src/main.rs
@@ -92,3 +92,17 @@ fn test_runner(tests: &[&dyn Fn()]) {
     }
     exit_qemu(QemuExitCode::Success);
 }
+
+// Make libm implementations available to the linker.
+// The Rust compiler-builtins only does this for UEFI targets, not bare-metal.
+// See https://github.com/rust-lang/compiler-builtins/blob/master/src/math.rs#L23
+
+#[no_mangle]
+extern "C" fn fmod(a: f64, b: f64) -> f64 {
+    libm::fmod(a, b)
+}
+
+#[no_mangle]
+extern "C" fn fmodf(a: f32, b: f32) -> f32 {
+    libm::fmodf(a, b)
+}

--- a/third_party/rust-hypervisor-firmware-subset/target.json
+++ b/third_party/rust-hypervisor-firmware-subset/target.json
@@ -11,7 +11,6 @@
   "linker": "rust-lld",
   "panic-strategy": "abort",
   "disable-redzone": true,
-  "features": "-mmx,-sse,+soft-float",
   "relocation-model": "pic",
   "pre-link-args": {
     "ld.lld": ["--script=layout.ld"]


### PR DESCRIPTION
Since Wasm support has been added to the bare-metal runtime, the build fails a link time. This is because Wasmi relies on floating point features that was not supported.

This is fixed by:

- No longer disabling SIMD: kernels disable SIMD to avoid having to backup and restore floating point registers during context switching. The bare-metal runtime will not implement user-space processes or pre-emptive threading, so this is not a consideration for us.
- Making libm implementations of `fmod` and `fmodf` available to the linker. This is done by the Rust `compiler-builtins` crate, but only for UEFI on the x86_64 platform (https://github.com/rust-lang/compiler-builtins/blob/master/src/math.rs#L23). Also see https://github.com/rust-lang/rust/issues/62729