### PR TITLE
Make SerializedRequest an explicit type to improve readability

### DIFF
--- a/experimental/uefi/loader/src/server.rs
+++ b/experimental/uefi/loader/src/server.rs
@@ -79,7 +79,7 @@ impl UnarySession for EchoImpl {
         // ambiguous to the end user, but for now that'll do.
         let body = self
             .channel
-            .send_receive(serialized_request)
+            .send_receive(serialized_request.0)
             .await
             .map_err(|err| Status::internal(format!("{:?}", err)))?
             .map_err(|err| Status::internal(format!("{:?}", err)))?;

--- a/experimental/uefi/loader/src/server.rs
+++ b/experimental/uefi/loader/src/server.rs
@@ -18,7 +18,7 @@ use anyhow::bail;
 use bmrng::unbounded::UnboundedRequestSender;
 use futures::Future;
 use oak_remote_attestation_sessions::{SessionId, SESSION_ID_LENGTH};
-use runtime::SerializeableRequest;
+use runtime::{SerializeableRequest, SerializedRequest};
 use std::net::SocketAddr;
 use tonic::{transport::Server, Request, Response, Status};
 
@@ -69,7 +69,7 @@ impl UnarySession for EchoImpl {
         request: Request<UnaryRequest>,
     ) -> Result<Response<UnaryResponse>, Status> {
         let request = request.into_inner();
-        let serialized_request: Vec<u8> = SerializeableRequest::try_from(request)
+        let serialized_request: SerializedRequest = SerializeableRequest::try_from(request)
             .map_err(|err| Status::invalid_argument(format!("{:?}", err)))?
             .into();
 

--- a/experimental/uefi/runtime/src/framing.rs
+++ b/experimental/uefi/runtime/src/framing.rs
@@ -14,8 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{remote_attestation::AttestationHandler, Channel};
-use alloc::vec::Vec;
+use crate::{remote_attestation::AttestationHandler, Channel, SerializedRequest};
 use anyhow::Context;
 use ciborium::{de, ser};
 
@@ -45,11 +44,11 @@ pub fn handle_frames(mut channel: &mut dyn Channel) -> anyhow::Result<!> {
     let attestation_handler =
         &mut AttestationHandler::create(move |v| wasm_handler.handle_raw_invoke(v));
     loop {
-        let msg: Vec<u8> = de::from_reader(&mut channel)
+        let serialized_request: SerializedRequest = de::from_reader(&mut channel)
             .map_err(anyhow::Error::msg)
             .context("couldn't deserialize message")?;
         let response = attestation_handler
-            .message(msg)
+            .message(serialized_request)
             .context("attestation failed")?;
         ser::into_writer(&response, &mut channel)
             .map_err(anyhow::Error::msg)

--- a/experimental/uefi/runtime/src/framing.rs
+++ b/experimental/uefi/runtime/src/framing.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{remote_attestation::AttestationHandler, Channel, SerializedRequest};
+use crate::{remote_attestation::AttestationHandler, Channel, SerializedRequest, Vec};
 use anyhow::Context;
 use ciborium::{de, ser};
 
@@ -44,9 +44,10 @@ pub fn handle_frames(mut channel: &mut dyn Channel) -> anyhow::Result<!> {
     let attestation_handler =
         &mut AttestationHandler::create(move |v| wasm_handler.handle_raw_invoke(v));
     loop {
-        let serialized_request: SerializedRequest = de::from_reader(&mut channel)
+        let msg: Vec<u8> = de::from_reader(&mut channel)
             .map_err(anyhow::Error::msg)
             .context("couldn't deserialize message")?;
+        let serialized_request = SerializedRequest(msg);
         let response = attestation_handler
             .message(serialized_request)
             .context("attestation failed")?;

--- a/experimental/uefi/runtime/src/lib.rs
+++ b/experimental/uefi/runtime/src/lib.rs
@@ -38,9 +38,10 @@ pub struct SerializeableRequest {
     pub session_id: SessionId,
     pub body: Vec<u8>,
 }
+pub type SerializedRequest = Vec<u8>;
 
-impl From<SerializeableRequest> for Vec<u8> {
-    fn from(serializeable_request: SerializeableRequest) -> Vec<u8> {
+impl From<SerializeableRequest> for SerializedRequest {
+    fn from(serializeable_request: SerializeableRequest) -> SerializedRequest {
         // The payload is the request's body prepended with the 8 byte session_id.
         // This takes adavantage of the session_id's fixed size to avoid needing
         // to use a key/value pair binary serialization protocol.
@@ -55,10 +56,10 @@ impl From<SerializeableRequest> for Vec<u8> {
     }
 }
 
-impl TryFrom<&[u8]> for SerializeableRequest {
+impl TryFrom<SerializedRequest> for SerializeableRequest {
     type Error = anyhow::Error;
 
-    fn try_from(serialized_request: &[u8]) -> Result<Self, Self::Error> {
+    fn try_from(serialized_request: SerializedRequest) -> Result<Self, Self::Error> {
         if serialized_request.len() < SESSION_ID_LENGTH {
             bail!(
                 "Message too short to contain a SessionId. The length of a SessionId

--- a/experimental/uefi/runtime/src/remote_attestation.rs
+++ b/experimental/uefi/runtime/src/remote_attestation.rs
@@ -21,7 +21,7 @@
 
 extern crate alloc;
 
-use crate::SerializeableRequest;
+use crate::{SerializeableRequest, SerializedRequest};
 use alloc::vec::Vec;
 use anyhow::Context;
 use oak_remote_attestation_sessions::{SessionState, SessionTracker};
@@ -54,8 +54,8 @@ where
         }
     }
 
-    pub fn message(&mut self, msg: Vec<u8>) -> anyhow::Result<Vec<u8>> {
-        let request = SerializeableRequest::try_from(msg.as_slice())
+    pub fn message(&mut self, serialized_request: SerializedRequest) -> anyhow::Result<Vec<u8>> {
+        let request = SerializeableRequest::try_from(serialized_request)
             .context("Couldn't deserialize message")?;
 
         let mut session_state = {


### PR DESCRIPTION
This will help when we add a Frame type in #2811, which can also be converted to & from bytes