### PR TITLE
Add RustCrypto implementation of remote attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,15 +3144,22 @@ dependencies = [
 name = "oak_remote_attestation"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "assert_matches",
  "bytes",
+ "hkdf",
  "log",
+ "p256 0.9.0",
  "prost 0.10.1",
  "prost-build 0.10.1",
  "quickcheck",
  "quickcheck_macros",
+ "rand_core 0.5.1",
  "ring 0.17.0-not-released-yet",
+ "sha2 0.9.9",
+ "signature",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -6245,6 +6265,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6322,6 +6353,21 @@ name = "zeroize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zstd"

--- a/remote_attestation/rust/Cargo.toml
+++ b/remote_attestation/rust/Cargo.toml
@@ -9,13 +9,36 @@ license = "Apache-2.0"
 default = ["ring-crypto"]
 std = ["anyhow/std", "prost/std"]
 ring-crypto = ["ring"]
+rust-crypto = [
+  "aes-gcm",
+  "hkdf",
+  "p256",
+  "rand_core",
+  "sha2",
+  "signature",
+  "x25519-dalek"
+]
 
 [dependencies]
+aes-gcm = { version = "*", optional = true }
 anyhow = { version = "*", default-features = false }
 bytes = { version = "*", default-features = false }
+hkdf = { version = "*", optional = true }
 log = "*"
+p256 = { version = "*", default-features = false, optional = true, features = [
+  "ecdsa"
+] }
 prost = { version = "*", default-features = false, features = ["prost-derive"] }
+rand_core = { version = "*", optional = true, default-features = false, features = [
+  "alloc",
+  "getrandom"
+] }
 ring = { path = "../../third_party/ring", default-features = false, optional = true }
+sha2 = { version = "*", optional = true, default-features = false }
+signature = { version = "*", optional = true, default-features = false }
+x25519-dalek = { version = "*", optional = true, default-features = false, features = [
+  "u64_backend"
+] }
 
 [build-dependencies]
 prost-build = "*"

--- a/remote_attestation/rust/src/crypto/mod.rs
+++ b/remote_attestation/rust/src/crypto/mod.rs
@@ -19,16 +19,25 @@
 // Should be kept in sync with the Java implementation of the remote attestation
 // protocol.
 
-#[cfg(not(feature = "ring-crypto"))]
-compiler_error!("A cryptographic implementation must be specified.");
+#[cfg(not(any(feature = "ring-crypto", feature = "rust-crypto")))]
+compile_error!("A cryptographic implementation must be specified.");
+
+// When all both implementations are selected (e.g. when testing with all features) we use the
+// `ring` implementation.
+#[cfg(all(feature = "rust-crypto", not(feature = "ring-crypto")))]
+mod rust_crypto;
+
+#[cfg(all(feature = "rust-crypto", not(feature = "ring-crypto")))]
+pub use rust_crypto::{
+    get_random, get_sha256, AeadEncryptor, KeyNegotiator, SignatureVerifier, Signer,
+};
 
 #[cfg(feature = "ring-crypto")]
 mod ring_crypto;
 
 #[cfg(feature = "ring-crypto")]
 pub use ring_crypto::{
-    get_random, get_sha256, AeadEncryptor, KeyNegotiator, KeyNegotiatorType, SignatureVerifier,
-    Signer,
+    get_random, get_sha256, AeadEncryptor, KeyNegotiator, SignatureVerifier, Signer,
 };
 
 /// Length of the encryption nonce.
@@ -55,6 +64,17 @@ pub const SIGNING_ALGORITHM_KEY_LENGTH: usize = 65;
 /// <https://datatracker.ietf.org/doc/html/rfc6979>
 /// <https://standards.ieee.org/standard/1363-2000.html>
 pub const SIGNATURE_LENGTH: usize = 64;
+
+/// Defines the type of key negotiator and the set of session keys created by it.
+#[derive(Clone)]
+pub enum KeyNegotiatorType {
+    /// Defines a key negotiator which provides server session key for encryption and client
+    /// session key for decryption.
+    Server,
+    /// Defines a key negotiator which provides client session key for encryption and server
+    /// session key for decryption.
+    Client,
+}
 
 /// Convenience struct for passing an encryption key as an argument.
 #[derive(PartialEq)]

--- a/remote_attestation/rust/src/crypto/mod.rs
+++ b/remote_attestation/rust/src/crypto/mod.rs
@@ -22,8 +22,8 @@
 #[cfg(not(any(feature = "ring-crypto", feature = "rust-crypto")))]
 compile_error!("A cryptographic implementation must be specified.");
 
-// When all both implementations are selected (e.g. when testing with all features) we use the
-// `ring` implementation.
+// When both implementations are selected (e.g. when testing with all features) we use the `ring`
+// implementation.
 #[cfg(all(feature = "rust-crypto", not(feature = "ring-crypto")))]
 mod rust_crypto;
 

--- a/remote_attestation/rust/src/crypto/ring_crypto.rs
+++ b/remote_attestation/rust/src/crypto/ring_crypto.rs
@@ -18,9 +18,9 @@
 
 use crate::{
     crypto::{
-        DecryptionKey, EncryptionKey, AEAD_ALGORITHM_KEY_LENGTH, CLIENT_KEY_PURPOSE,
-        KEY_AGREEMENT_ALGORITHM_KEY_LENGTH, KEY_DERIVATION_SALT, NONCE_LENGTH, SERVER_KEY_PURPOSE,
-        SHA256_HASH_LENGTH, SIGNATURE_LENGTH, SIGNING_ALGORITHM_KEY_LENGTH,
+        DecryptionKey, EncryptionKey, KeyNegotiatorType, AEAD_ALGORITHM_KEY_LENGTH,
+        CLIENT_KEY_PURPOSE, KEY_AGREEMENT_ALGORITHM_KEY_LENGTH, KEY_DERIVATION_SALT, NONCE_LENGTH,
+        SERVER_KEY_PURPOSE, SHA256_HASH_LENGTH, SIGNATURE_LENGTH, SIGNING_ALGORITHM_KEY_LENGTH,
     },
     message::EncryptedData,
 };
@@ -313,17 +313,6 @@ impl KeyNegotiator {
     }
 }
 
-/// Defines the type of key negotiator and the set of session keys created by it.
-#[derive(Clone)]
-pub enum KeyNegotiatorType {
-    /// Defines a key negotiator which provides server session key for encryption and client
-    /// session key for decryption.
-    Server,
-    /// Defines a key negotiator which provides client session key for encryption and server
-    /// session key for decryption.
-    Client,
-}
-
 pub struct Signer {
     /// Parsed PKCS#8 v2 key pair representation.
     key_pair: EcdsaKeyPair,
@@ -380,10 +369,10 @@ pub struct SignatureVerifier {
 }
 
 impl SignatureVerifier {
-    pub fn new(public_key_bytes: &[u8; SIGNING_ALGORITHM_KEY_LENGTH]) -> Self {
-        Self {
+    pub fn new(public_key_bytes: &[u8; SIGNING_ALGORITHM_KEY_LENGTH]) -> anyhow::Result<Self> {
+        Ok(Self {
             public_key_bytes: *public_key_bytes,
-        }
+        })
     }
 
     /// Verifies the signature validity.

--- a/remote_attestation/rust/src/crypto/rust_crypto.rs
+++ b/remote_attestation/rust/src/crypto/rust_crypto.rs
@@ -1,0 +1,332 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Implementation of the crypto primitives used for remote attestation based on the RustCrypto and
+//! Dalek Elliptic Curve crates.
+
+use crate::{
+    crypto::{
+        DecryptionKey, EncryptionKey, KeyNegotiatorType, AEAD_ALGORITHM_KEY_LENGTH,
+        CLIENT_KEY_PURPOSE, KEY_AGREEMENT_ALGORITHM_KEY_LENGTH, KEY_DERIVATION_SALT, NONCE_LENGTH,
+        SERVER_KEY_PURPOSE, SHA256_HASH_LENGTH, SIGNATURE_LENGTH, SIGNING_ALGORITHM_KEY_LENGTH,
+    },
+    message::EncryptedData,
+};
+use aes_gcm::{
+    aead::{AeadInPlace, NewAead},
+    Aes256Gcm, Key, Nonce,
+};
+use alloc::vec::Vec;
+use anyhow::{anyhow, Context};
+use core::convert::TryInto;
+use hkdf::Hkdf;
+use p256::{
+    ecdsa::{
+        signature::{Signer as P256Signer, Verifier as P256Verifier},
+        SigningKey, VerifyingKey,
+    },
+    EncodedPoint,
+};
+use rand_core::{OsRng, RngCore};
+use sha2::{Digest, Sha256};
+use x25519_dalek::{EphemeralSecret, PublicKey};
+
+const EMPTY_ADITIONAL_DATA: &[u8] = b"";
+
+/// Implementation of Authenticated Encryption with Associated Data (AEAD).
+///
+/// <https://datatracker.ietf.org/doc/html/rfc5116>
+///
+/// This implementation uses separate keys for encrypting data and decrypting peer encrypted data.
+/// Which means that this implementation uses the same key for encryption, which peer uses for
+/// decryption.
+///
+/// It is necessary to prevent the Loopback Attack, where malicious network takes an outgoing packet
+/// and feeds it back as an incoming packet.
+pub struct AeadEncryptor {
+    /// Key used for encrypting data.
+    encryption_key: EncryptionKey,
+    /// Key used for decrypting peer encrypted data.
+    decryption_key: DecryptionKey,
+}
+
+impl AeadEncryptor {
+    pub(crate) fn new(encryption_key: EncryptionKey, decryption_key: DecryptionKey) -> Self {
+        Self {
+            encryption_key,
+            decryption_key,
+        }
+    }
+
+    /// Encrypts `data` using `AeadEncryptor::encryption_key`.
+    pub fn encrypt(&mut self, data: &[u8]) -> anyhow::Result<EncryptedData> {
+        // Generate a random nonce.
+        let nonce = Self::generate_nonce().context("Couldn't generate nonce")?;
+        let cipher = Aes256Gcm::new(Key::from_slice(&self.encryption_key.0));
+
+        let mut encrypted_data = data.to_vec();
+        // Additional authenticated data is not required for the remotely attested channel,
+        // since after session key is established client and server exchange messages with a
+        // single encrypted field.
+        // And the nonce is authenticated by the AEAD algorithm itself.
+        // https://datatracker.ietf.org/doc/html/rfc5116#section-2.1
+        cipher
+            .encrypt_in_place(
+                Nonce::from_slice(&nonce),
+                EMPTY_ADITIONAL_DATA,
+                &mut encrypted_data,
+            )
+            .map_err(|error| anyhow!("Couldn't encrypt data: {:?}", error))?;
+
+        Ok(EncryptedData::new(nonce, encrypted_data))
+    }
+
+    /// Decrypts and authenticates `data` using `AeadEncryptor::decryption_key`.
+    /// `data` must contain an encrypted message prefixed with a random nonce of [`NONCE_LENGTH`]
+    /// length.
+    pub fn decrypt(&mut self, data: &EncryptedData) -> anyhow::Result<Vec<u8>> {
+        let cipher = Aes256Gcm::new(Key::from_slice(&self.decryption_key.0));
+        let mut decrypted_data = data.data.to_vec();
+        // Additional authenticated data is not required for the remotely attested channel,
+        // since after session key is established client and server exchange messages with a
+        // single encrypted field.
+        // And the nonce is authenticated by the AEAD algorithm itself.
+        // https://datatracker.ietf.org/doc/html/rfc5116#section-2.1
+        cipher
+            .decrypt_in_place(
+                Nonce::from_slice(&data.nonce),
+                EMPTY_ADITIONAL_DATA,
+                &mut decrypted_data,
+            )
+            .map_err(|error| anyhow!("Couldn't decrypt data: {:?}", error))?;
+        Ok(decrypted_data.to_vec())
+    }
+
+    /// Generate a random nonce.
+    fn generate_nonce() -> anyhow::Result<[u8; NONCE_LENGTH]> {
+        get_random()
+    }
+}
+
+/// Implementation of the X25519 Elliptic Curve Diffie-Hellman (ECDH) key negotiation.
+///
+/// <https://datatracker.ietf.org/doc/html/rfc7748#section-6.1>
+pub struct KeyNegotiator {
+    type_: KeyNegotiatorType,
+    private_key: EphemeralSecret,
+}
+
+impl KeyNegotiator {
+    pub fn create(type_: KeyNegotiatorType) -> anyhow::Result<Self> {
+        let private_key = EphemeralSecret::new(OsRng);
+        Ok(Self { type_, private_key })
+    }
+
+    pub fn public_key(&self) -> anyhow::Result<[u8; KEY_AGREEMENT_ALGORITHM_KEY_LENGTH]> {
+        let public_key = PublicKey::from(&self.private_key);
+        Ok(public_key.to_bytes())
+    }
+
+    /// Derives session keys from self and peer public keys and creates an [`AeadEncryptor`].
+    ///
+    /// HKDF is used to derive both server and client session keys. The information string provided
+    /// to HKDF consists of a purpose string, a server public key and a client public key (in that
+    /// specific order).
+    /// Server session key uses the [`SERVER_KEY_PURPOSE`] purpose string and client session key
+    /// uses [`CLIENT_KEY_PURPOSE`].
+    ///
+    /// Depending on `encryptor_type` creates a different type of encryptor: either server encryptor
+    /// or client encryptor.
+    pub fn create_encryptor(
+        self,
+        peer_public_key: &[u8; KEY_AGREEMENT_ALGORITHM_KEY_LENGTH],
+    ) -> anyhow::Result<AeadEncryptor> {
+        let (encryption_key, decryption_key) = self
+            .derive_session_keys(peer_public_key)
+            .context("Couldn't derive session keys")?;
+        let encryptor = AeadEncryptor::new(encryption_key, decryption_key);
+        Ok(encryptor)
+    }
+
+    /// Implementation of the session keys derivation.
+    /// Returns a tuple with an encryption key and a decryption key.
+    pub(crate) fn derive_session_keys(
+        self,
+        peer_public_key: &[u8; KEY_AGREEMENT_ALGORITHM_KEY_LENGTH],
+    ) -> anyhow::Result<(EncryptionKey, DecryptionKey)> {
+        let self_public_key = self.public_key().context("Couldn't get self public key")?;
+        let parsed_public_key = PublicKey::from(*peer_public_key);
+        let key_material = self.private_key.diffie_hellman(&parsed_public_key);
+
+        match self.type_ {
+            // On the server side `self_public_key` is the server key.
+            KeyNegotiatorType::Server => {
+                let encryption_key = EncryptionKey(
+                    Self::key_derivation_function(
+                        key_material.as_bytes(),
+                        SERVER_KEY_PURPOSE,
+                        &self_public_key,
+                        peer_public_key,
+                    )
+                    .context("Couldn't derive decryption key")?,
+                );
+                let decryption_key = DecryptionKey(
+                    Self::key_derivation_function(
+                        key_material.as_bytes(),
+                        CLIENT_KEY_PURPOSE,
+                        &self_public_key,
+                        peer_public_key,
+                    )
+                    .context("Couldn't derive encryption key")?,
+                );
+                Ok((encryption_key, decryption_key))
+            }
+            // On the client side `peer_public_key` is the server key.
+            KeyNegotiatorType::Client => {
+                let encryption_key = EncryptionKey(
+                    Self::key_derivation_function(
+                        key_material.as_bytes(),
+                        CLIENT_KEY_PURPOSE,
+                        peer_public_key,
+                        &self_public_key,
+                    )
+                    .context("Couldn't derive decryption key")?,
+                );
+                let decryption_key = DecryptionKey(
+                    Self::key_derivation_function(
+                        key_material.as_bytes(),
+                        SERVER_KEY_PURPOSE,
+                        peer_public_key,
+                        &self_public_key,
+                    )
+                    .context("Couldn't derive encryption key")?,
+                );
+                Ok((encryption_key, decryption_key))
+            }
+        }
+    }
+
+    /// Derives a session key from `key_material` using HKDF.
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc5869>
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc7748#section-6.1>
+    ///
+    /// In order to derive keys, uses the information string that consists of a purpose string, a
+    /// server public key and a client public key (in that specific order).
+    pub(crate) fn key_derivation_function(
+        key_material: &[u8; KEY_AGREEMENT_ALGORITHM_KEY_LENGTH],
+        key_purpose: &str,
+        server_public_key: &[u8; KEY_AGREEMENT_ALGORITHM_KEY_LENGTH],
+        client_public_key: &[u8; KEY_AGREEMENT_ALGORITHM_KEY_LENGTH],
+    ) -> anyhow::Result<[u8; AEAD_ALGORITHM_KEY_LENGTH]> {
+        // Session key is derived from a purpose string and two public keys.
+        let mut info = Vec::with_capacity(
+            key_purpose.as_bytes().len() + server_public_key.len() + client_public_key.len(),
+        );
+        info.extend_from_slice(key_purpose.as_bytes());
+        info.extend_from_slice(server_public_key);
+        info.extend_from_slice(client_public_key);
+
+        // Initialize key derivation function.
+        let salt = KEY_DERIVATION_SALT.as_bytes();
+        let kdf = Hkdf::<Sha256>::new(Some(salt), key_material);
+
+        // Derive session key.
+        let mut session_key: [u8; AEAD_ALGORITHM_KEY_LENGTH] = Default::default();
+        kdf.expand(&info, &mut session_key).map_err(|error| {
+            anyhow!(
+                "Couldn't get the output of the HKDF-Expand operation: {:?}",
+                error
+            )
+        })?;
+        Ok(session_key)
+    }
+}
+
+pub struct Signer {
+    signing_key: SigningKey,
+    verifying_key: VerifyingKey,
+}
+
+impl Signer {
+    pub fn create() -> anyhow::Result<Self> {
+        let signing_key = SigningKey::random(&mut signature::rand_core::OsRng);
+        let verifying_key = VerifyingKey::from(&signing_key);
+
+        Ok(Self {
+            signing_key,
+            verifying_key,
+        })
+    }
+
+    pub fn public_key(&self) -> anyhow::Result<[u8; SIGNING_ALGORITHM_KEY_LENGTH]> {
+        self.verifying_key
+            .to_encoded_point(false)
+            .as_bytes()
+            .try_into()
+            .map_err(anyhow::Error::msg)
+            .context("Incorrect public key length")
+    }
+
+    pub fn sign(&self, input: &[u8]) -> anyhow::Result<[u8; SIGNATURE_LENGTH]> {
+        self.signing_key
+            .try_sign(input)
+            .map_err(|error| anyhow!("Couldn't sign input: {:?}", error))?
+            .as_ref()
+            .try_into()
+            .map_err(anyhow::Error::msg)
+            .context("Incorrect signature length")
+    }
+}
+
+pub struct SignatureVerifier {
+    verifying_key: VerifyingKey,
+}
+
+impl SignatureVerifier {
+    pub fn new(public_key_bytes: &[u8; SIGNING_ALGORITHM_KEY_LENGTH]) -> anyhow::Result<Self> {
+        let encoded_point =
+            EncodedPoint::from_bytes(public_key_bytes).map_err(anyhow::Error::msg)?;
+        let verifying_key =
+            VerifyingKey::from_encoded_point(&encoded_point).map_err(anyhow::Error::msg)?;
+        Ok(Self { verifying_key })
+    }
+
+    /// Verifies the signature validity.
+    pub fn verify(&self, input: &[u8], signature: &[u8; SIGNATURE_LENGTH]) -> anyhow::Result<()> {
+        let signature = signature[..].try_into().map_err(anyhow::Error::msg)?;
+        self.verifying_key
+            .verify(input, &signature)
+            .map_err(|error| anyhow!("Signature verification failed: {:?}", error))
+    }
+}
+
+/// Computes a SHA-256 digest of `input` and returns it in a form of raw bytes.
+pub fn get_sha256(input: &[u8]) -> [u8; SHA256_HASH_LENGTH] {
+    let mut hasher = Sha256::new();
+    hasher.update(input);
+    hasher.finalize().into()
+}
+
+/// Generates a random vector of `size` bytes.
+pub fn get_random<const L: usize>() -> anyhow::Result<[u8; L]> {
+    let mut result: [u8; L] = [Default::default(); L];
+    OsRng
+        .try_fill_bytes(&mut result[..])
+        .map_err(|error| anyhow!("Couldn't create random value: {:?}", error))?;
+    Ok(result)
+}

--- a/remote_attestation/rust/src/handshaker.rs
+++ b/remote_attestation/rust/src/handshaker.rs
@@ -240,7 +240,7 @@ impl ClientHandshaker {
             self.transcript
                 .append(&server_identity_no_signature)
                 .context("Couldn't append server identity to the transcript")?;
-            let verifier = SignatureVerifier::new(&server_identity.signing_public_key);
+            let verifier = SignatureVerifier::new(&server_identity.signing_public_key)?;
             verifier
                 .verify(
                     &self.transcript.get_sha256(),
@@ -513,7 +513,7 @@ impl ServerHandshaker {
             self.transcript
                 .append(&client_identity_no_signature)
                 .context("Couldn't append client identity to the transcript")?;
-            let verifier = SignatureVerifier::new(&client_identity.signing_public_key);
+            let verifier = SignatureVerifier::new(&client_identity.signing_public_key)?;
             verifier
                 .verify(
                     &self.transcript.get_sha256(),

--- a/remote_attestation/rust/src/tests/crypto.rs
+++ b/remote_attestation/rust/src/tests/crypto.rs
@@ -207,7 +207,7 @@ fn test_create_signer() {
 
 #[test]
 fn test_verify() {
-    let verifier = SignatureVerifier::new(&SIGNING_PUBLIC_KEY);
+    let verifier = SignatureVerifier::new(&SIGNING_PUBLIC_KEY).unwrap();
     let result = verifier.verify(&DATA, &DATA_SIGNATURE);
     assert!(result.is_ok());
     let result = verifier.verify(&DATA, &INVALID_DATA_SIGNATURE);
@@ -222,7 +222,7 @@ fn test_sign(data: Vec<u8>) -> bool {
         .expect("Couldn't get signing public key");
     let signature = signer.sign(&data).expect("Couldn't sign data");
 
-    let verifier = SignatureVerifier::new(&public_key);
+    let verifier = SignatureVerifier::new(&public_key).unwrap();
     let result = verifier.verify(&data, &signature);
     result.is_ok()
 }


### PR DESCRIPTION
This allows us to choose which implementation of the crypto primitives to use for remote attestation.

Only the `ring` implementation is currently tested in CI, but I have manually tested the RustCrypto version. The next step after this PR it to use this RustCrypto implementation for the bare-metal binary. The client will still use the `ring` version, so we will also test interoperability between the two implementations.