### PR TITLE
Run VM test under Kokoro

### DIFF
--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -2,3 +2,4 @@
 
 ./scripts/docker_pull
 ./scripts/docker_run ./scripts/xtask build-oak-functions-server-variants
+./scripts/docker_run ./scripts/xtask run-vm-test

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 
-./scripts/docker_pull
-
-ls -l /dev/kvm
-# Fix the permissions of /dev/kvm.
+# On Kokoro instances /dev/kvm is owned by root:root. Let's fix the permissions
+# so that it's owned by group `kvm` as our scripts expect it to.
 readonly KVM_GID="$(getent group kvm | cut -d: -f3)"
 sudo chown "$USER:$KVM_GID" /dev/kvm
-ls -l /dev/kvm
-./scripts/docker_run ls -l /dev/kvm
+
+./scripts/docker_pull
 
 ./scripts/docker_run ./scripts/xtask build-oak-functions-server-variants
 ./scripts/docker_run ./scripts/xtask run-vm-test

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
 ./scripts/docker_pull
+
+ls -l /dev/kvm
+sudo chwon "$USER" /dev/kvm
+ls -l /dev/kvm
+./scripts/docker_run ls -l /dev/kvm
+
 ./scripts/docker_run ./scripts/xtask build-oak-functions-server-variants
 ./scripts/docker_run ./scripts/xtask run-vm-test

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -3,7 +3,9 @@
 ./scripts/docker_pull
 
 ls -l /dev/kvm
-sudo chwon "$USER" /dev/kvm
+# Fix the permissions of /dev/kvm.
+readonly KVM_GID="$(getent group kvm | cut -d: -f3)"
+sudo chown "$USER:$KVM_GID" /dev/kvm
 ls -l /dev/kvm
 ./scripts/docker_run ls -l /dev/kvm
 


### PR DESCRIPTION
This was easier than expected, but not without its warts: namely, on Kokoro machines `/dev/kvm` was owned by `root:root`. However, that's nothing a quick `sudo chown` can't fix.

You can see the test logs if you go look at the Kokoro output -- unfortunately right now it requires corp credentials.

Steps for the future: (a) make the test run in Kokoro `prod`, not `qa` and (b) look into Resultstore so that we could make the build logs available without requiring Google corp credentials.