### PR TITLE
Replace Channel with Read Write Traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4095,6 +4101,7 @@ name = "runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ciborium-io",
  "log",
  "oak_functions_wasm",
  "oak_functions_workload_logging",
@@ -5502,6 +5509,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bmrng",
+ "ciborium-io",
  "clap 3.1.18",
  "command-fds",
  "env_logger 0.9.0",

--- a/experimental/uefi/app/Cargo.lock
+++ b/experimental/uefi/app/Cargo.lock
@@ -62,6 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +467,7 @@ name = "runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ciborium-io",
  "log",
  "oak_functions_wasm",
  "oak_functions_workload_logging",
@@ -565,6 +572,7 @@ name = "uefi-simple"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ciborium-io",
  "runtime",
  "uefi",
  "uefi-services",

--- a/experimental/uefi/app/Cargo.toml
+++ b/experimental/uefi/app/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { version = "*", default-features = false }
 runtime = { path = "../runtime" }
 uefi = { version = "*", features = ["exts"] }
 uefi-services = "*"
+ciborium-io = { version = "*", default-features = false }
 
 [dev-dependencies]
 uefi-services = { version = "*", features = ["qemu"] }

--- a/experimental/uefi/baremetal/Cargo.lock
+++ b/experimental/uefi/baremetal/Cargo.lock
@@ -72,6 +72,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atomic_refcell",
+ "ciborium-io",
  "getrandom",
  "lazy_static",
  "libm",
@@ -143,6 +144,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 
 [[package]]
 name = "cipher"
@@ -809,6 +816,7 @@ name = "runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ciborium-io",
  "log",
  "oak_functions_wasm",
  "oak_functions_workload_logging",

--- a/experimental/uefi/baremetal/Cargo.toml
+++ b/experimental/uefi/baremetal/Cargo.toml
@@ -20,3 +20,4 @@ runtime = { path = "../runtime", default-features = false, features = [
 uart_16550 = "*"
 rust-hypervisor-firmware-subset = { path = "../../../third_party/rust-hypervisor-firmware-subset" }
 x86_64 = "*"
+ciborium-io = { version = "*", default-features = false }

--- a/experimental/uefi/baremetal/src/serial.rs
+++ b/experimental/uefi/baremetal/src/serial.rs
@@ -36,15 +36,25 @@ impl Serial {
     }
 }
 
-impl runtime::Channel for Serial {
-    fn send(&mut self, data: &[u8]) -> anyhow::Result<()> {
+impl ciborium_io::Write for Serial {
+    type Error = anyhow::Error;
+
+    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
         for byte in data {
             self.port.borrow_mut().send_raw(*byte);
         }
         Ok(())
     }
 
-    fn recv(&mut self, data: &mut [u8]) -> anyhow::Result<()> {
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl ciborium_io::Read for Serial {
+    type Error = anyhow::Error;
+
+    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
         #[allow(clippy::needless_range_loop)]
         for i in 0..data.len() {
             data[i] = self.port.borrow_mut().receive();

--- a/experimental/uefi/loader/Cargo.toml
+++ b/experimental/uefi/loader/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "*", features = [
 tonic = "*"
 oak_remote_attestation_sessions = { path = "../../../remote_attestation_sessions" }
 runtime = { path = "../../../experimental/uefi/runtime" }
+ciborium-io = "*"
 
 [build-dependencies]
 oak_utils = { path = "../../../oak_utils" }

--- a/experimental/uefi/loader/src/main.rs
+++ b/experimental/uefi/loader/src/main.rs
@@ -16,7 +16,7 @@
 
 use clap::Parser;
 use qemu::{Qemu, QemuParams};
-use runtime::{Channel, Frame, Framed};
+use runtime::{Frame, Framed};
 use std::{
     fs,
     io::{BufRead, BufReader, Read, Write},
@@ -65,11 +65,22 @@ struct CommsChannel {
     inner: UnixStream,
 }
 
-impl Channel for CommsChannel {
-    fn send(&mut self, data: &[u8]) -> anyhow::Result<()> {
+impl ciborium_io::Write for CommsChannel {
+    type Error = anyhow::Error;
+
+    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
         self.inner.write_all(data).map_err(anyhow::Error::msg)
     }
-    fn recv(&mut self, data: &mut [u8]) -> anyhow::Result<()> {
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.inner.flush().map_err(anyhow::Error::msg)
+    }
+}
+
+impl ciborium_io::Read for CommsChannel {
+    type Error = anyhow::Error;
+
+    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
         self.inner.read_exact(data).map_err(anyhow::Error::msg)
     }
 }

--- a/experimental/uefi/runtime/Cargo.toml
+++ b/experimental/uefi/runtime/Cargo.toml
@@ -18,3 +18,4 @@ oak_functions_wasm = { path = "../../../oak_functions/wasm" }
 oak_functions_workload_logging = { path = "../../../oak_functions/workload_logging" }
 oak_remote_attestation_sessions = { path = "../../../remote_attestation_sessions", default-features = false }
 oak_logger = { path = "../../../oak_functions/logger" }
+ciborium-io = { version = "*", default-features = false }

--- a/experimental/uefi/runtime/src/framing.rs
+++ b/experimental/uefi/runtime/src/framing.rs
@@ -14,13 +14,16 @@
 // limitations under the License.
 //
 
-use crate::{remote_attestation::AttestationHandler, Channel, Frame, Framed};
+use crate::{remote_attestation::AttestationHandler, Frame, Framed};
 use anyhow::Context;
+use ciborium_io::{Read, Write};
 
 // Processes incoming frames.
 pub fn handle_frames<T>(channel: T) -> anyhow::Result<!>
 where
-    T: Channel,
+    T: Read + Write,
+    anyhow::Error: From<<T as ciborium_io::Read>::Error>,
+    anyhow::Error: From<<T as ciborium_io::Write>::Error>,
 {
     let wasm_handler = crate::wasm::new_wasm_handler()?;
     let attestation_handler =

--- a/experimental/uefi/runtime/src/framing.rs
+++ b/experimental/uefi/runtime/src/framing.rs
@@ -21,9 +21,7 @@ use ciborium_io::{Read, Write};
 // Processes incoming frames.
 pub fn handle_frames<T>(channel: T) -> anyhow::Result<!>
 where
-    T: Read + Write,
-    anyhow::Error: From<<T as ciborium_io::Read>::Error>,
-    anyhow::Error: From<<T as ciborium_io::Write>::Error>,
+    T: Read<Error = anyhow::Error> + Write<Error = anyhow::Error>,
 {
     let wasm_handler = crate::wasm::new_wasm_handler()?;
     let attestation_handler =

--- a/experimental/uefi/runtime/src/lib.rs
+++ b/experimental/uefi/runtime/src/lib.rs
@@ -43,9 +43,7 @@ pub struct Framed<T: Read + Write> {
 
 impl<T> Framed<T>
 where
-    T: Read + Write,
-    anyhow::Error: From<<T as ciborium_io::Read>::Error>,
-    anyhow::Error: From<<T as ciborium_io::Write>::Error>,
+    T: Read<Error = anyhow::Error> + Write<Error = anyhow::Error>,
 {
     pub fn new(channel: T) -> Self {
         Self { inner: channel }


### PR DESCRIPTION
This replaces our custom channel train with more standard `Read + Write` traits by refactoring the runtime, UEFI & bare metal implementation. Follows up to @tiziano88 suggestion in #2811: abstraction: https://github.com/project-oak/oak/pull/2811#discussion_r866690458. :) 


Traits from ciborium_io, since they are well maintained and fairly minimal. 

Other options were std (no_std env), acid_io (depends on libc), core-io (does not support our nightly), core2 (not well maintained).
