### PR TITLE
Create a generic Vmm trait wrapper in loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,6 +5515,7 @@ name = "uefi-loader"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bmrng",
  "ciborium-io",
  "clap 3.1.18",

--- a/experimental/uefi/loader/Cargo.toml
+++ b/experimental/uefi/loader/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "*"
+async-trait = "*"
 bmrng = "*"
 clap = { version = "*", features = ["derive"] }
 command-fds = { version = "*", features = ["tokio"] }

--- a/experimental/uefi/loader/src/main.rs
+++ b/experimental/uefi/loader/src/main.rs
@@ -169,5 +169,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             log::error!("Unexpected VMM exit, status: {:?}", val);
         },
     }
+
     Ok(())
 }

--- a/experimental/uefi/loader/src/main.rs
+++ b/experimental/uefi/loader/src/main.rs
@@ -15,7 +15,7 @@
 //
 
 use clap::Parser;
-use qemu::{Qemu, QemuParams};
+use qemu::Qemu;
 use runtime::{Frame, Framed};
 use std::{
     fs,
@@ -24,9 +24,11 @@ use std::{
     path::PathBuf,
 };
 use tokio::signal;
+use vmm::{Params, Vmm};
 
 mod qemu;
 mod server;
+mod vmm;
 
 #[derive(clap::ArgEnum, Clone, Debug, PartialEq)]
 enum Mode {
@@ -48,7 +50,7 @@ struct Args {
     #[clap(long, parse(from_os_str), required_if_eq("mode", "uefi"), validator = path_exists, default_value_os_t = PathBuf::from("/usr/share/OVMF/OVMF_CODE.fd"))]
     ovmf: PathBuf,
 
-    /// Path to the UEFI app to execute.
+    /// Path to the UEFI app or kernel to execute.
     #[clap(parse(from_os_str), validator = path_exists)]
     app: PathBuf,
 }
@@ -90,20 +92,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Args::parse();
     env_logger::init();
 
-    let (console_qemu, console) = UnixStream::pair()?;
-    let (comms_qemu, mut comms) = UnixStream::pair()?;
+    let (console_vmm, console) = UnixStream::pair()?;
+    let (comms_vmm, mut comms) = UnixStream::pair()?;
 
-    let mut qemu = Qemu::start(QemuParams {
-        binary: cli.qemu.as_path(),
-        firmware: if cli.mode == Mode::Uefi {
-            Some(cli.ovmf.as_path())
-        } else {
-            None
-        },
-        app: cli.app.as_path(),
-        console: console_qemu,
-        comms: comms_qemu,
-    })?;
+    let mut vmm: Box<dyn Vmm> = match cli.mode {
+        Mode::Uefi => Box::new(Qemu::start(Params {
+            binary: cli.qemu,
+            firmware: Some(cli.ovmf),
+            app: cli.app,
+            console: console_vmm,
+            comms: comms_vmm,
+        })?),
+        Mode::Bios => Box::new(Qemu::start(Params {
+            binary: cli.qemu,
+            firmware: None,
+            app: cli.app,
+            console: console_vmm,
+            comms: comms_vmm,
+        })?),
+    };
 
     // Log everything coming over the console channel.
     tokio::spawn(async {
@@ -153,13 +160,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Wait until something dies or we get a signal to terminate.
     tokio::select! {
         _ = signal::ctrl_c() => {
-            qemu.kill().await?;
+            vmm.kill().await?;
         },
         _ = server_future => {
-            qemu.kill().await?;
+            vmm.kill().await?;
         },
-        val = qemu.wait() => {
-            log::error!("Unexpected qemu exit, status: {:?}", val);
+        val = vmm.wait() => {
+            log::error!("Unexpected VMM exit, status: {:?}", val);
         },
     }
     Ok(())

--- a/experimental/uefi/loader/src/vmm.rs
+++ b/experimental/uefi/loader/src/vmm.rs
@@ -20,11 +20,19 @@ use std::{os::unix::net::UnixStream, path::PathBuf};
 
 #[derive(Debug)]
 pub struct Params {
+    /// Path to the VMM binary to execute.
     pub binary: PathBuf,
+
+    /// Optional path to the firmware blob to pass to the VMM.
     pub firmware: Option<PathBuf>,
+
+    /// Path to the binary to load into the VM.
     pub app: PathBuf,
 
+    /// Stream to connect to the console of the VM.
     pub console: UnixStream,
+
+    /// Stream to use for communicating with the app inside the VM.
     pub comms: UnixStream,
 }
 

--- a/experimental/uefi/loader/src/vmm.rs
+++ b/experimental/uefi/loader/src/vmm.rs
@@ -1,0 +1,35 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::{os::unix::net::UnixStream, path::PathBuf};
+
+#[derive(Debug)]
+pub struct Params {
+    pub binary: PathBuf,
+    pub firmware: Option<PathBuf>,
+    pub app: PathBuf,
+
+    pub console: UnixStream,
+    pub comms: UnixStream,
+}
+
+#[async_trait]
+pub trait Vmm {
+    async fn wait(&mut self) -> Result<std::process::ExitStatus>;
+    async fn kill(self: Box<Self>) -> Result<std::process::ExitStatus>;
+}


### PR DESCRIPTION
This is in preparation of introducing a second type of VMM: crosvm.

UEFI will still use qemu, but baremetal will use crosvm.

Right now some changes are a bit silly: for example, both the `Uefi` and `Bios` branches are pretty much equivalent; this is intentional, as this means once we enable crosvm it's just a simple change to the `Bios` branch.