### PR TITLE
Change the kernel to be a bit more generic

### DIFF
--- a/experimental/uefi/baremetal/src/main.rs
+++ b/experimental/uefi/baremetal/src/main.rs
@@ -18,6 +18,7 @@
 #![no_main]
 #![feature(lang_items)]
 #![feature(alloc_error_handler)]
+#![feature(bench_black_box)]
 #![feature(custom_test_frameworks)]
 // As we're in a `no_std` environment, testing requires special handling. This
 // approach was inspired by https://os.phil-opp.com/testing/.
@@ -30,6 +31,9 @@ use rust_hypervisor_firmware_subset::pvh;
 #[no_mangle]
 #[cfg(test)]
 pub extern "C" fn rust64_start(_rdi: &pvh::StartInfo) -> ! {
+    // Ensure that `PVH_NOTE` is not optimized away, otherwise we won't be able to boot our
+    // kernel when testing.
+    core::hint::black_box(&pvh::PVH_NOTE);
     test_main();
     kernel::i8042::shutdown();
 }

--- a/experimental/uefi/kernel/src/lib.rs
+++ b/experimental/uefi/kernel/src/lib.rs
@@ -39,15 +39,15 @@ mod serial;
 
 use core::panic::PanicInfo;
 use log::{error, info};
-use rust_hypervisor_firmware_subset::{boot, paging, pvh};
+use rust_hypervisor_firmware_subset::{boot, paging};
 
 /// Main entry point for the kernel, to be called from bootloader.
-pub fn start_kernel(rdi: &pvh::StartInfo) -> ! {
+pub fn start_kernel(info: &dyn boot::Info) -> ! {
     avx::enable_avx();
     logging::init_logging();
     paging::setup();
-    memory::init_allocator(rdi);
-    main(rdi);
+    memory::init_allocator(info);
+    main(info);
 }
 
 fn main(info: &dyn boot::Info) -> ! {

--- a/third_party/rust-hypervisor-firmware-subset/src/pvh.rs
+++ b/third_party/rust-hypervisor-firmware-subset/src/pvh.rs
@@ -73,7 +73,7 @@ type Desc = unsafe extern "C" fn();
 // We make sure our ELF Note has an alignment of 4 for maximum compatibility.
 // Some software (QEMU) calculates padding incorectly if alignment != 4.
 #[repr(C, packed(4))]
-struct Note {
+pub struct Note {
     name_size: u32,
     desc_size: u32,
     kind: u32,
@@ -84,7 +84,7 @@ struct Note {
 // This is: ELFNOTE(Xen, XEN_ELFNOTE_PHYS32_ENTRY, .quad ram32_start)
 #[link_section = ".note"]
 #[used]
-static PVH_NOTE: Note = Note {
+pub static PVH_NOTE: Note = Note {
     name_size: size_of::<Name>() as u32,
     desc_size: size_of::<Desc>() as u32,
     kind: XEN_ELFNOTE_PHYS32_ENTRY,


### PR DESCRIPTION
As the name suggests, this makes `kernel::start_kernel` use a `&dyn boot::Info` argument, as we'll be using multiple boot protocols.

The fun bit was that after I made that change, the Rust optimizer dropped PVH code completely from the test build of the bootloader -- I guess it saw that we weren't really using anything from that crate. Unfortunately the collateral damage from that was the PVH boot note itself, which rendered test builds unloadable...

Thus, let's just print out that we're in tests to make sure everything is linked into the binary properly.