### PR TITLE
Add virtio vsock packet implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,7 @@ dependencies = [
  "ciborium-io",
  "getrandom 0.2.6",
  "lazy_static",
- "libm 0.1.4",
+ "libm 0.2.2",
  "linked_list_allocator",
  "log",
  "runtime",
@@ -2782,6 +2782,26 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5695,7 +5715,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 name = "virtio"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bitflags",
+ "num_enum",
 ]
 
 [[package]]

--- a/experimental/virtio/Cargo.toml
+++ b/experimental/virtio/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+anyhow = { version = "*", default-features = false }
 bitflags = "*"
+num_enum = { version = "*", default-features = false }

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -14,14 +14,4 @@
 // limitations under the License.
 //
 
-//! Simple virtio drivers implemented based on polling.
-//!
-//! This crate assumes that an identity mapping is used in page tables, so that guest-virtual and
-//! guest-physical addresses are the same.
-
-#![no_std]
-
-extern crate alloc;
-
-pub mod queue;
-pub mod vsock;
+pub mod packet;

--- a/experimental/virtio/src/vsock/packet.rs
+++ b/experimental/virtio/src/vsock/packet.rs
@@ -1,0 +1,299 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Virtio vsock packet implementation.
+//!
+//! A packet consists of a header and an optional payload.
+//!
+//! See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-3960006>.
+
+use alloc::vec::Vec;
+use anyhow::Context;
+use bitflags::bitflags;
+use core::mem::size_of;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+/// The size of the packet header in bytes.
+const HEADER_SIZE: usize = 44;
+/// The offset to the src_cid field.
+const SRC_CID_OFFSET: usize = 0;
+/// The offset to the dst_cid field.
+const DST_CID_OFFSET: usize = 8;
+/// The offset to the src_port field.
+const SRC_PORT_OFFSET: usize = 16;
+/// The offset to the dst_port field.
+const DST_PORT_OFFSET: usize = 20;
+/// The offset to the len field.
+const LEN_OFFSET: usize = 24;
+/// The offset ot the type field.
+const TYPE_OFFSET: usize = 28;
+/// The offset ot the op field.
+const OP_OFFSET: usize = 30;
+/// The offset ot the flags field.
+const FLAGS_OFFSET: usize = 32;
+/// The offset ot the buf_alloc field.
+const BUF_ALLOC_OFFSET: usize = 36;
+/// The offset ot the fwd_cnt field.
+const FWD_CNT_OFFSET: usize = 40;
+
+pub struct Packet {
+    buffer: Vec<u8>,
+}
+
+impl Packet {
+    /// Creates a new `Packet` from an existing buffer.
+    pub fn new(buffer: Vec<u8>) -> anyhow::Result<Self> {
+        if buffer.len() < HEADER_SIZE {
+            anyhow::bail!("vsock packet too short");
+        }
+        Ok(Self { buffer })
+    }
+
+    /// Creates a new control `Packet` with only a header.
+    pub fn new_header_only() -> Self {
+        let buffer = (0..HEADER_SIZE).map(|_| 0u8).collect();
+        let mut result = Self { buffer };
+        result.set_type(VSockType::Stream);
+        result
+    }
+
+    /// Creates a new data `Packet` with the given payload length.
+    pub fn new_with_payload(payload_len: usize) -> Self {
+        let buffer = (0..HEADER_SIZE + payload_len).map(|_| 0u8).collect();
+        let mut result = Self { buffer };
+        result.set_type(VSockType::Stream);
+        result.set_len(payload_len as u32);
+        result.set_op(VSockOp::Rw).unwrap();
+        result
+    }
+
+    /// Gets the source CID.
+    pub fn get_src_cid(&self) -> u64 {
+        self.read_u64(SRC_CID_OFFSET)
+    }
+
+    /// Sets the source CID.
+    pub fn set_src_cid(&mut self, src_cid: u64) {
+        self.write_u64(SRC_CID_OFFSET, src_cid);
+    }
+
+    /// Gets the destination CID.
+    pub fn get_dst_cid(&self) -> u64 {
+        self.read_u64(DST_CID_OFFSET)
+    }
+
+    /// Sets the destination CID.
+    pub fn set_dst_cid(&mut self, dst_cid: u64) {
+        self.write_u64(DST_CID_OFFSET, dst_cid);
+    }
+
+    /// Gets the source port.
+    pub fn get_src_port(&self) -> u32 {
+        self.read_u32(SRC_PORT_OFFSET)
+    }
+
+    /// Sets the source port.
+    pub fn set_src_port(&mut self, src_port: u32) {
+        self.write_u32(SRC_PORT_OFFSET, src_port);
+    }
+
+    /// Gets the destination port.
+    pub fn get_dst_port(&self) -> u32 {
+        self.read_u32(DST_PORT_OFFSET)
+    }
+
+    /// Sets the destination port.
+    pub fn set_dst_port(&mut self, dst_port: u32) {
+        self.write_u32(DST_PORT_OFFSET, dst_port);
+    }
+
+    /// Gets the payload length.
+    pub fn get_len(&self) -> u32 {
+        self.read_u32(LEN_OFFSET)
+    }
+
+    /// Sets the payload length.
+    fn set_len(&mut self, len: u32) {
+        self.write_u32(LEN_OFFSET, len);
+    }
+
+    /// Gets the type of socket the packet is intended for.
+    pub fn get_type(&self) -> anyhow::Result<VSockType> {
+        VSockType::try_from_primitive(self.read_u16(TYPE_OFFSET))
+            .map_err(anyhow::Error::msg)
+            .context("invalid socket type")
+    }
+
+    /// Sets the type of socket the packet is intended for.
+    fn set_type(&mut self, socket_type: VSockType) {
+        self.write_u16(TYPE_OFFSET, socket_type.into())
+    }
+
+    /// Gets the op that the packet represents.
+    pub fn get_op(&self) -> anyhow::Result<VSockOp> {
+        VSockOp::try_from_primitive(self.read_u16(OP_OFFSET))
+            .map_err(anyhow::Error::msg)
+            .context("invalid op")
+    }
+
+    /// Sets the op that the packet represents.
+    pub fn set_op(&mut self, op: VSockOp) -> anyhow::Result<()> {
+        if self.get_len() > 0 && op != VSockOp::Rw {
+            anyhow::bail!("non-empty payloads are only allowed with RW ops");
+        }
+        self.write_u16(OP_OFFSET, op.into());
+        Ok(())
+    }
+
+    /// Gets the flags.
+    ///
+    /// Only currently used for connection shutdown requests.
+    pub fn get_flags(&self) -> VSockFlags {
+        VSockFlags::from_bits_truncate(self.read_u32(FLAGS_OFFSET))
+    }
+
+    /// Sets the flags.
+    ///
+    /// Only currently used for connection shutdown requests.
+    pub fn set_flags(&mut self, flags: VSockFlags) {
+        self.write_u32(FLAGS_OFFSET, flags.bits());
+    }
+
+    /// Gets the size of the peer's stream buffer.
+    ///
+    /// Used to facilitate flow-control calculations.
+    pub fn get_buf_alloc(&self) -> u32 {
+        self.read_u32(BUF_ALLOC_OFFSET)
+    }
+
+    /// Sets the size of the stream buffer.
+    pub fn set_buf_alloc(&mut self, buf_alloc: u32) {
+        self.write_u32(BUF_ALLOC_OFFSET, buf_alloc);
+    }
+
+    /// Gets the number of bytes that the peer has read out of the stream buffer (hence making space
+    /// in the buffer).
+    ///
+    /// Used to facilitate flow-control calculations.
+    pub fn get_fwd_cnt(&self) -> u32 {
+        self.read_u32(FWD_CNT_OFFSET)
+    }
+
+    /// Sets the number of bytes read from the stream buffer.
+    pub fn set_fwd_cnt(&mut self, fwd_cnt: u32) {
+        self.write_u32(FWD_CNT_OFFSET, fwd_cnt);
+    }
+
+    /// Gets the payload.
+    pub fn get_payload(&self) -> &[u8] {
+        &self.buffer[HEADER_SIZE..(HEADER_SIZE + self.get_len() as usize)]
+    }
+
+    /// Sets the payload of a data packet from a slice.
+    ///
+    /// The length of the slice must match the packets configures payload length. Only usable if the
+    /// packet's op is `VSockOp::Rw`.
+    pub fn set_payload(&mut self, data: &[u8]) -> anyhow::Result<()> {
+        if self.get_op()? != VSockOp::Rw {
+            anyhow::bail!("non-empty payloads are only allowed with RW ops");
+        }
+        let len = self.get_len();
+        if len as usize != data.len() {
+            anyhow::bail!("data length does not match the paacket's configured payload length");
+        }
+
+        self.buffer[HEADER_SIZE..(HEADER_SIZE + len as usize)].copy_from_slice(data);
+        Ok(())
+    }
+
+    fn read_u16(&self, offset: usize) -> u16 {
+        let mut data = [0; size_of::<u16>()];
+        data.copy_from_slice(&self.buffer[offset..(offset + size_of::<u16>())]);
+        u16::from_le_bytes(data)
+    }
+
+    fn read_u32(&self, offset: usize) -> u32 {
+        let mut data = [0; size_of::<u32>()];
+        data.copy_from_slice(&self.buffer[offset..(offset + size_of::<u32>())]);
+        u32::from_le_bytes(data)
+    }
+
+    fn read_u64(&self, offset: usize) -> u64 {
+        let mut data = [0; size_of::<u64>()];
+        data.copy_from_slice(&self.buffer[offset..(offset + size_of::<u64>())]);
+        u64::from_le_bytes(data)
+    }
+
+    fn write_u16(&mut self, offset: usize, value: u16) {
+        let dest = &mut self.buffer[offset..(offset + size_of::<u16>())];
+        dest.copy_from_slice(&value.to_le_bytes()[..]);
+    }
+
+    fn write_u32(&mut self, offset: usize, value: u32) {
+        let dest = &mut self.buffer[offset..(offset + size_of::<u32>())];
+        dest.copy_from_slice(&value.to_le_bytes()[..]);
+    }
+
+    fn write_u64(&mut self, offset: usize, value: u64) {
+        let dest = &mut self.buffer[offset..(offset + size_of::<u64>())];
+        dest.copy_from_slice(&value.to_le_bytes()[..]);
+    }
+}
+
+/// Vsock Ops.
+#[derive(Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[repr(u16)]
+pub enum VSockOp {
+    Invalid = 0,
+    /// Connection request.
+    Request = 1,
+    /// Connections accepted response.
+    Response = 2,
+    /// Connection reset, either in reponse to a shutdown request or invalid packets received.
+    Rst = 3,
+    /// Connection shutdown request.
+    Shutdown = 4,
+    /// Represents a data packet.
+    ///
+    /// Used to send payload. Only data packets with this op can contain a payload.
+    Rw = 5,
+    /// Give update on credit to support flow control, either in response to a credit request or at
+    /// any time it might be useful to inform the peer of the state of the stream buffer.
+    CreditUpdate = 6,
+    /// Request for update on credit to calculate stream buffer availability.
+    CreditRequest = 7,
+}
+
+bitflags! {
+    /// Flags about a socket connection.
+    ///
+    /// Used in a connection shutdown request.
+    /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-4070005>.
+    pub struct VSockFlags: u32 {
+        /// Indicates that no more payload data will be received.
+        const NO_RECEIVE = 1;
+        /// Indicates that no more payload data will be senn.
+        const NO_SEND = 2;
+    }
+}
+
+/// Socket Type.
+#[derive(Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[repr(u16)]
+pub enum VSockType {
+    /// Only stream sockets are currently supported.
+    Stream = 1,
+}

--- a/experimental/virtio/src/vsock/packet.rs
+++ b/experimental/virtio/src/vsock/packet.rs
@@ -20,7 +20,7 @@
 //!
 //! See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-3960006>.
 
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use anyhow::Context;
 use bitflags::bitflags;
 use core::mem::size_of;
@@ -64,19 +64,22 @@ impl Packet {
 
     /// Creates a new control `Packet` with only a header.
     pub fn new_header_only() -> Self {
-        let buffer = (0..HEADER_SIZE).map(|_| 0u8).collect();
-        let mut result = Self { buffer };
-        result.set_type(VSockType::Stream);
-        result
+        Self::new_with_buffer_size(HEADER_SIZE)
     }
 
     /// Creates a new data `Packet` with the given payload length.
     pub fn new_with_payload(payload_len: usize) -> Self {
-        let buffer = (0..HEADER_SIZE + payload_len).map(|_| 0u8).collect();
-        let mut result = Self { buffer };
-        result.set_type(VSockType::Stream);
+        let mut result = Self::new_with_buffer_size(HEADER_SIZE + payload_len);
         result.set_len(payload_len as u32);
         result.set_op(VSockOp::Rw).unwrap();
+        result
+    }
+
+    /// Creates a new `Packet` with the specified buffer size.
+    fn new_with_buffer_size(buffer_len: usize) -> Self {
+        let buffer = vec![0u8; buffer_len];
+        let mut result = Self { buffer };
+        result.set_type(VSockType::Stream);
         result
     }
 
@@ -294,6 +297,6 @@ bitflags! {
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
 #[repr(u16)]
 pub enum VSockType {
-    /// Only stream sockets are currently supported.
+    /// Only stream sockets are currently supported in the Virtio spec.
     Stream = 1,
 }


### PR DESCRIPTION
Adds an implementation of a vsock packet based on the virtio 1.1 spec. The packet is backed by a buffer, and fields are read using an offset into the buffer.