### PR TITLE
Add initial vsock socket implemenation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,26 +2803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5768,8 +5748,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
- "num_enum",
+ "ciborium-io",
  "rust-hypervisor-firmware-virtio",
+ "strum",
 ]
 
 [[package]]

--- a/experimental/virtio/Cargo.toml
+++ b/experimental/virtio/Cargo.toml
@@ -8,5 +8,6 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = { version = "*", default-features = false }
 bitflags = "*"
-num_enum = { version = "*", default-features = false }
+ciborium-io = { version = "*", default-features = false }
 rust-hypervisor-firmware-virtio = { path = "../../third_party/rust-hypervisor-firmware-virtio" }
+strum = { version = "*", default-features = false, features = ["derive"] }

--- a/experimental/virtio/src/lib.rs
+++ b/experimental/virtio/src/lib.rs
@@ -20,6 +20,7 @@
 //! guest-physical addresses are the same.
 
 #![no_std]
+#![feature(let_chains)]
 
 extern crate alloc;
 

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -120,9 +120,12 @@ impl VSock {
 
     /// Reads the next valid packet that matches the filter, if one is available.
     ///
+    /// If invalid packets are found it will continue reading until a valid one is found, or no more
+    /// packets are available to read.
+    ///
     /// If `reset_unmatched` is true we send RST packets in response to unmatched packets to notify
-    /// the host that the pakcets are not part of a valid connected socket (e.g. unexpected source
-    /// or destintation ports).
+    /// the host that the packets are not part of a valid connected socket (e.g. unexpected source
+    /// or destintation ports) and any related connections on the host should be disconnected.
     pub fn read_filtered_packet<F: Fn(&Packet) -> bool>(
         &mut self,
         filter: F,
@@ -213,7 +216,8 @@ impl VSock {
         Ok(())
     }
 
-    /// Sends a packet indicating that a socket is disconnected.
+    /// Sends a vsock RST packet indicating that a socket is disconnected, or must be forcibly
+    /// disconnected.
     ///
     /// This is typically done in response to a packet with unexpected source or destination ports,
     /// an invalid op for the connection state, or to confirm that a socket has been diconnected.

--- a/experimental/virtio/src/vsock/packet.rs
+++ b/experimental/virtio/src/vsock/packet.rs
@@ -362,7 +362,7 @@ mod tests {
     fn test_new_from_buffer() {
         let packet = Packet::new_data(&[1, 2, 3, 4], 0, 0).unwrap();
 
-        let packet = Packet::new(packet.buffer.clone()).unwrap();
+        let packet = Packet::new(packet.buffer).unwrap();
         assert_eq!(packet.get_payload(), &[1, 2, 3, 4]);
         assert_eq!(packet.get_len(), 4);
         assert_eq!(packet.get_type().unwrap(), VSockType::Stream);

--- a/experimental/virtio/src/vsock/packet.rs
+++ b/experimental/virtio/src/vsock/packet.rs
@@ -21,13 +21,12 @@
 //! See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-3960006>.
 
 use alloc::{vec, vec::Vec};
-use anyhow::Context;
 use bitflags::bitflags;
 use core::mem::size_of;
-use num_enum::{IntoPrimitive, TryFromPrimitive};
+use strum::{Display, FromRepr};
 
 /// The size of the packet header in bytes.
-const HEADER_SIZE: usize = 44;
+pub const HEADER_SIZE: usize = 44;
 /// The offset to the src_cid field.
 const SRC_CID_OFFSET: usize = 0;
 /// The offset to the dst_cid field.
@@ -63,24 +62,40 @@ impl Packet {
     }
 
     /// Creates a new control `Packet` with only a header.
-    pub fn new_header_only() -> Self {
-        Self::new_with_buffer_size(HEADER_SIZE)
+    pub fn new_control(src_port: u32, dst_port: u32, op: VSockOp) -> anyhow::Result<Self> {
+        let mut result = Self::new_with_buffer_size(HEADER_SIZE, src_port, dst_port)?;
+        result.set_op(op)?;
+        Ok(result)
     }
 
     /// Creates a new data `Packet` with the given payload length.
-    pub fn new_with_payload(payload_len: usize) -> Self {
-        let mut result = Self::new_with_buffer_size(HEADER_SIZE + payload_len);
+    pub fn new_data(payload: &[u8], src_port: u32, dst_port: u32) -> anyhow::Result<Self> {
+        let payload_len = payload.len();
+        let mut result = Self::new_with_buffer_size(HEADER_SIZE + payload_len, src_port, dst_port)?;
         result.set_len(payload_len as u32);
-        result.set_op(VSockOp::Rw).unwrap();
-        result
+        result.set_op(VSockOp::Rw)?;
+        result.set_payload(payload)?;
+        Ok(result)
     }
 
     /// Creates a new `Packet` with the specified buffer size.
-    fn new_with_buffer_size(buffer_len: usize) -> Self {
+    fn new_with_buffer_size(
+        buffer_len: usize,
+        src_port: u32,
+        dst_port: u32,
+    ) -> anyhow::Result<Self> {
+        if buffer_len > super::DATA_BUFFER_SIZE {
+            anyhow::bail!(
+                "Total buffer length must be less than {}",
+                super::DATA_BUFFER_SIZE
+            );
+        }
         let buffer = vec![0u8; buffer_len];
         let mut result = Self { buffer };
         result.set_type(VSockType::Stream);
-        result
+        result.set_src_port(src_port);
+        result.set_dst_port(dst_port);
+        Ok(result)
     }
 
     /// Gets the source CID.
@@ -135,29 +150,29 @@ impl Packet {
 
     /// Gets the type of socket the packet is intended for.
     pub fn get_type(&self) -> anyhow::Result<VSockType> {
-        VSockType::try_from_primitive(self.read_u16(TYPE_OFFSET))
-            .map_err(anyhow::Error::msg)
-            .context("invalid socket type")
+        VSockType::from_repr(self.read_u16(TYPE_OFFSET))
+            .ok_or_else(|| anyhow::anyhow!("Invalid socket type."))
     }
 
     /// Sets the type of socket the packet is intended for.
     fn set_type(&mut self, socket_type: VSockType) {
-        self.write_u16(TYPE_OFFSET, socket_type.into())
+        self.write_u16(TYPE_OFFSET, socket_type as u16)
     }
 
     /// Gets the op that the packet represents.
     pub fn get_op(&self) -> anyhow::Result<VSockOp> {
-        VSockOp::try_from_primitive(self.read_u16(OP_OFFSET))
-            .map_err(anyhow::Error::msg)
-            .context("invalid op")
+        VSockOp::from_repr(self.read_u16(OP_OFFSET)).ok_or_else(|| anyhow::anyhow!("Invalid op."))
     }
 
     /// Sets the op that the packet represents.
     pub fn set_op(&mut self, op: VSockOp) -> anyhow::Result<()> {
         if self.get_len() > 0 && op != VSockOp::Rw {
-            anyhow::bail!("non-empty payloads are only allowed with RW ops");
+            anyhow::bail!("Non-empty payloads are only allowed with data packets.");
         }
-        self.write_u16(OP_OFFSET, op.into());
+        if self.get_len() == 0 && op == VSockOp::Rw {
+            anyhow::bail!("Empty payloads are not allowed with the RW op.");
+        }
+        self.write_u16(OP_OFFSET, op as u16);
         Ok(())
     }
 
@@ -209,13 +224,13 @@ impl Packet {
     ///
     /// The length of the slice must match the packets configures payload length. Only usable if the
     /// packet's op is `VSockOp::Rw`.
-    pub fn set_payload(&mut self, data: &[u8]) -> anyhow::Result<()> {
+    fn set_payload(&mut self, data: &[u8]) -> anyhow::Result<()> {
         if self.get_op()? != VSockOp::Rw {
-            anyhow::bail!("non-empty payloads are only allowed with RW ops");
+            anyhow::bail!("Non-empty payloads are only allowed with data packets.");
         }
         let len = self.get_len();
         if len as usize != data.len() {
-            anyhow::bail!("data length does not match the paacket's configured payload length");
+            anyhow::bail!("Data length does not match the packet's configured payload length.");
         }
 
         self.buffer[HEADER_SIZE..(HEADER_SIZE + len as usize)].copy_from_slice(data);
@@ -262,10 +277,9 @@ impl Packet {
 }
 
 /// Vsock Ops.
-#[derive(Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[derive(Debug, Display, Eq, PartialEq, FromRepr)]
 #[repr(u16)]
 pub enum VSockOp {
-    Invalid = 0,
     /// Connection request.
     Request = 1,
     /// Connections accepted response.
@@ -299,7 +313,7 @@ bitflags! {
 }
 
 /// Socket Type.
-#[derive(Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[derive(Debug, Eq, PartialEq, Display, FromRepr)]
 #[repr(u16)]
 pub enum VSockType {
     /// Only stream sockets are currently supported in the Virtio spec.
@@ -312,13 +326,10 @@ mod tests {
 
     #[test]
     fn test_set_and_get_all_header_fields() {
-        let mut packet = Packet::new_header_only();
+        let mut packet = Packet::new_control(1023, 8888, VSockOp::Shutdown).unwrap();
         packet.set_src_cid(1234);
         packet.set_dst_cid(2);
-        packet.set_src_port(1023);
-        packet.set_dst_port(8888);
         packet.set_flags(VSockFlags::all());
-        packet.set_op(VSockOp::Shutdown).unwrap();
         packet.set_buf_alloc(4096);
         packet.set_fwd_cnt(12);
 
@@ -335,23 +346,21 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_payload() {
-        let mut packet = Packet::new_with_payload(5);
+    fn test_invalid_set_payload() {
+        let mut packet = Packet::new_data(&[1, 2, 3], 0, 0).unwrap();
         let result = packet.set_payload(&[1, 2, 3, 4]);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_valid_payload() {
-        let mut packet = Packet::new_with_payload(4);
-        let result = packet.set_payload(&[1, 2, 3, 4]);
-        assert!(result.is_ok());
+        let packet = Packet::new_data(&[1, 2, 3, 4], 0, 0);
+        assert!(packet.is_ok());
     }
 
     #[test]
     fn test_new_from_buffer() {
-        let mut packet = Packet::new_with_payload(4);
-        packet.set_payload(&[1, 2, 3, 4]).unwrap();
+        let packet = Packet::new_data(&[1, 2, 3, 4], 0, 0).unwrap();
 
         let packet = Packet::new(packet.buffer.clone()).unwrap();
         assert_eq!(packet.get_payload(), &[1, 2, 3, 4]);
@@ -363,7 +372,13 @@ mod tests {
 
     #[test]
     fn test_invalid_op() {
-        let mut packet = Packet::new_with_payload(1);
+        let mut packet = Packet::new_data(&[1], 0, 0).unwrap();
         assert!(packet.set_op(VSockOp::Rst).is_err())
+    }
+
+    #[test]
+    fn test_empty_payload() {
+        let packet = Packet::new_data(&[], 0, 0);
+        assert!(packet.is_err())
     }
 }

--- a/experimental/virtio/src/vsock/socket.rs
+++ b/experimental/virtio/src/vsock/socket.rs
@@ -1,0 +1,362 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use alloc::collections::VecDeque;
+
+use super::{
+    packet::{Packet, VSockFlags, VSockOp, HEADER_SIZE},
+    VSock, DATA_BUFFER_SIZE, QUEUE_SIZE,
+};
+use core::num::Wrapping;
+
+/// The maximum buffer size used by the socket.
+///
+/// This is used for flow-control calculations. For now we use the maximum size seeing that we don't
+/// have a fixed limit and don't want to send too many credit update packets.
+const STREAM_BUFFER_LENGTH: Wrapping<u32> = Wrapping(u32::MAX);
+
+/// The limit that triggers a voluntary credit update message to avoid stalling.
+///
+/// If the peer's calculation of our free buffer space falls below this point (e.g when we receive a
+/// lot of data without sending any packets back) we send a credit update packet to make sure the
+/// peer knows we have more space available.
+const CREDIT_UPDATE_LIMIT: Wrapping<u32> = Wrapping((DATA_BUFFER_SIZE * QUEUE_SIZE) as u32);
+
+/// The maximum size of the payload of a single packet to ensure it fits into a single buffer in the
+/// queue.
+const MAX_PAYLOAD_SIZE: usize = DATA_BUFFER_SIZE - HEADER_SIZE;
+
+/// Connector to initiate a connection to a listener on the host.
+pub struct SocketConnector {
+    /// The socket configuration.
+    config: SocketConfiguration,
+}
+
+impl SocketConnector {
+    pub fn new(vsock: VSock, host_port: u32, local_port: u32) -> Self {
+        Self {
+            config: SocketConfiguration::new(vsock, local_port, host_port),
+        }
+    }
+
+    /// Tries to connect to a listener on the host.
+    ///
+    /// Since we don't yet support timeouts it will wait indefinitely for a respone. If the
+    /// connection is refused, or it receives an unexpected packet, it will return an error.
+    pub fn connect(mut self) -> anyhow::Result<Socket> {
+        let mut packet =
+            Packet::new_control(self.config.port, self.config.host_port, VSockOp::Request)?;
+        self.config.vsock.write_packet(&mut packet);
+        let src_port = self.config.host_port;
+        let dst_port = self.config.port;
+        loop {
+            if let Some(packet) = self.config.vsock.read_filtered_packet(
+                |packet| packet.get_dst_port() == dst_port && packet.get_src_port() == src_port,
+                true,
+            ) {
+                if packet.get_op()? == VSockOp::Response {
+                    break;
+                } else {
+                    anyhow::bail!(
+                        "Invalid response to connection request: {}",
+                        packet.get_op()?
+                    );
+                }
+            }
+        }
+        Ok(Socket::new(self.config))
+    }
+}
+
+/// Listener that waits for a connection initiated from the host.
+pub struct SocketListener {
+    /// The socket configuration.
+    config: SocketConfiguration,
+}
+
+impl SocketListener {
+    pub fn new(vsock: VSock, port: u32) -> Self {
+        Self {
+            config: SocketConfiguration::new(vsock, port, 0),
+        }
+    }
+
+    /// Listens for a connection from the host on the specified port.
+    ///
+    /// Since we don't yet support timeouts it will wait indefinitely for a connection request. If
+    /// it receives an unexpected packet (anything other than a connection request) it will return
+    /// an error.
+    pub fn accept(mut self) -> anyhow::Result<Socket> {
+        let dst_port = self.config.port;
+        loop {
+            if let Some(packet) = self
+                .config
+                .vsock
+                .read_filtered_packet(|packet| packet.get_dst_port() == dst_port, true)
+            {
+                if packet.get_op()? == VSockOp::Request {
+                    self.config.host_port = packet.get_src_port();
+                    break;
+                } else {
+                    anyhow::bail!("Invalid connection request: {}", packet.get_op()?);
+                }
+            }
+        }
+
+        let mut packet =
+            Packet::new_control(self.config.port, self.config.host_port, VSockOp::Response)?;
+        self.config.vsock.write_packet(&mut packet);
+
+        Ok(Socket::new(self.config))
+    }
+}
+
+/// A connection-oriented socket.
+pub struct Socket {
+    /// The socket configuration.
+    config: SocketConfiguration,
+    /// The current state of the connection.
+    connection_state: ConnectionState,
+    /// The number of payload bytes we have processed.
+    ///
+    /// This is a free-running counter that wraps around.
+    processed_bytes: Wrapping<u32>,
+    /// The previous value of `processed_bytes` that was sent to the peer in the most recent packet
+    /// header.
+    previous_processed_bytes: Wrapping<u32>,
+    /// The number of payload bytes we have sent.
+    ///
+    /// This is a free-running counter that wraps around.
+    sent_bytes: Wrapping<u32>,
+    /// The number of payload bytes the peer has processed according to the received packet
+    /// headers.
+    peer_processed_bytes: Wrapping<u32>,
+    /// The size of the peer's stream buffer.
+    peer_buffer_size: Wrapping<u32>,
+    /// A temporary buffer to store extra data from a packet that was not fully read.
+    pending_data: Option<VecDeque<u8>>,
+}
+
+impl Socket {
+    fn new(config: SocketConfiguration) -> Self {
+        Self {
+            config,
+            connection_state: ConnectionState::Connected,
+            processed_bytes: Wrapping(0),
+            previous_processed_bytes: Wrapping(0),
+            sent_bytes: Wrapping(0),
+            peer_processed_bytes: Wrapping(0),
+            peer_buffer_size: Wrapping(0),
+            pending_data: None,
+        }
+    }
+
+    /// Shuts the connection down.
+    ///
+    /// At the moment this will cause the vsock driver to be dropped, which means that no future
+    /// connections will be possible. This should only be used if no further communications with the
+    /// host is expected.
+    pub fn shutdown(mut self) {
+        if self.connection_state == ConnectionState::Connected {
+            let mut packet =
+                Packet::new_control(self.config.port, self.config.host_port, VSockOp::Shutdown)
+                    .unwrap();
+            // Notify the host that we will not send or receive any more data packets.
+            packet.set_flags(VSockFlags::all());
+            self.config.vsock.write_packet(&mut packet);
+        }
+    }
+
+    /// Whether we should send an unsolicited credit update.
+    fn must_send_credit_update(&self) -> bool {
+        STREAM_BUFFER_LENGTH - (self.processed_bytes - self.previous_processed_bytes)
+            < CREDIT_UPDATE_LIMIT
+    }
+
+    /// Sends a control pacekt with the specified op to the host.
+    fn send_control_packet(&mut self, op: VSockOp) -> anyhow::Result<()> {
+        // For now we panic if we are disconnected.
+        assert!(self.connection_state == ConnectionState::Connected);
+        let mut packet = Packet::new_control(self.config.port, self.config.host_port, op)?;
+        self.set_credit_info(&mut packet);
+        self.config.vsock.write_packet(&mut packet);
+        Ok(())
+    }
+
+    /// Sends a data packet to the host.
+    fn send_data_packet(&mut self, data: &[u8]) -> anyhow::Result<()> {
+        // For now we panic if we are disconnected.
+        assert!(self.connection_state == ConnectionState::Connected);
+        let data_len = data.len();
+        assert!(
+            data_len <= MAX_PAYLOAD_SIZE,
+            "The data is too large for a single packet. Len: {}, Max: {}",
+            data.len(),
+            MAX_PAYLOAD_SIZE
+        );
+
+        let data_len = Wrapping(data_len as u32);
+        if data_len > self.peer_buffer_size - (self.sent_bytes - self.peer_processed_bytes) {
+            anyhow::bail!("Peer's stream buffer is full.");
+        }
+
+        self.sent_bytes += data_len;
+        let mut packet = Packet::new_data(data, self.config.port, self.config.host_port)?;
+        self.set_credit_info(&mut packet);
+        self.config.vsock.write_packet(&mut packet);
+        Ok(())
+    }
+
+    /// Updates the credit info on a packet to facilitate flow-control.
+    fn set_credit_info(&mut self, packet: &mut Packet) {
+        packet.set_buf_alloc(STREAM_BUFFER_LENGTH.0);
+        packet.set_fwd_cnt(self.processed_bytes.0);
+        self.previous_processed_bytes = self.processed_bytes;
+    }
+
+    /// Reads the payload of the next available data packet, if any are available.
+    fn read_data(&mut self) -> Option<VecDeque<u8>> {
+        // For now we panic if we are disconnected.
+        assert!(self.connection_state == ConnectionState::Connected);
+        let src_port = self.config.host_port;
+        let dst_port = self.config.port;
+        loop {
+            let packet = self.config.vsock.read_filtered_packet(
+                |packet| packet.get_dst_port() == dst_port && packet.get_src_port() == src_port,
+                true,
+            )?;
+            self.peer_buffer_size = Wrapping(packet.get_buf_alloc());
+            self.peer_processed_bytes = Wrapping(packet.get_fwd_cnt());
+            // For now we panic if we receive an invalid op.
+            match packet.get_op().expect("Invalid packet received on stream.") {
+                VSockOp::CreditRequest => {
+                    self.send_control_packet(VSockOp::CreditUpdate).unwrap();
+                }
+                VSockOp::CreditUpdate => {
+                    // We already updated our flow-control tracking data, so do nothing.
+                }
+                VSockOp::Request | VSockOp::Response => {
+                    // For now we panic if we receive an invalid op.
+                    panic!("Invalid packet received on stream.");
+                }
+                VSockOp::Rst => {
+                    self.connection_state = ConnectionState::Disconnected;
+                    return None;
+                }
+                VSockOp::Shutdown => {
+                    self.send_control_packet(VSockOp::Rst).unwrap();
+                    self.connection_state = ConnectionState::Disconnected;
+                    return None;
+                }
+                VSockOp::Rw => {
+                    let data = packet.get_payload();
+                    // TODO(#2876): Avoid copying the buffer slice if possible.
+                    let mut result = VecDeque::with_capacity(data.len());
+                    result.extend(data);
+                    return Some(result);
+                }
+            }
+        }
+    }
+
+    fn read_partial(&mut self, dest: &mut [u8]) -> Option<usize> {
+        let mut source = match self.pending_data.take() {
+            Some(data) => data,
+            None => self.read_data()?,
+        };
+
+        let len = dest.len();
+        let mut position = 0;
+        while position < len && let Some(byte) = source.pop_front() {
+            dest[position] = byte;
+            position += 1;
+        }
+
+        if !source.is_empty() {
+            self.pending_data.replace(source);
+        }
+        Some(position)
+    }
+}
+
+impl ciborium_io::Read for Socket {
+    type Error = anyhow::Error;
+
+    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
+        let len = data.len();
+        let mut count = 0;
+        while count < len {
+            count += self.read_partial(&mut data[count..]).unwrap_or(0);
+        }
+
+        self.processed_bytes += Wrapping(count as u32);
+
+        if self.must_send_credit_update() {
+            self.send_control_packet(VSockOp::CreditUpdate).unwrap();
+        }
+
+        Ok(())
+    }
+}
+
+impl ciborium_io::Write for Socket {
+    type Error = anyhow::Error;
+
+    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+        let mut start = 0;
+        let data_len = data.len();
+        while start < data_len {
+            let end = core::cmp::min(data_len, start + MAX_PAYLOAD_SIZE);
+            self.send_data_packet(&data[start..end])?;
+            start = end;
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        // We always flush on write, so do nothing.
+        Ok(())
+    }
+}
+
+/// The state of the connection.
+#[derive(PartialEq, Eq)]
+enum ConnectionState {
+    Connected,
+    Disconnected,
+}
+
+/// The configuration information for the socket.
+struct SocketConfiguration {
+    /// The vsock device driver.
+    ///
+    /// For now we only support one connection, so the driver is owned by this configuration.
+    vsock: VSock,
+    /// The local port for the connection.
+    port: u32,
+    /// The host port for the connection.
+    host_port: u32,
+}
+
+impl SocketConfiguration {
+    fn new(vsock: VSock, port: u32, host_port: u32) -> Self {
+        Self {
+            vsock,
+            port,
+            host_port,
+        }
+    }
+}

--- a/experimental/virtio/src/vsock/socket.rs
+++ b/experimental/virtio/src/vsock/socket.rs
@@ -186,7 +186,7 @@ impl Socket {
             < CREDIT_UPDATE_LIMIT
     }
 
-    /// Sends a control pacekt with the specified op to the host.
+    /// Sends a control packet with the specified op to the host.
     fn send_control_packet(&mut self, op: VSockOp) -> anyhow::Result<()> {
         // For now we panic if we are disconnected.
         assert!(self.connection_state == ConnectionState::Connected);
@@ -272,6 +272,8 @@ impl Socket {
         }
     }
 
+    /// Tries once to fill the destination with as much data as is currently available, either in
+    /// the pending buffer or from the next available data packet.
     fn read_partial(&mut self, dest: &mut [u8]) -> Option<usize> {
         let mut source = match self.pending_data.take() {
             Some(data) => data,


### PR DESCRIPTION
This is a basic socket implementation with some limitations to simplify the design for now:

- Only supports a single stream on a single port
- Can only be used once - disconnecting the stream consumes the virtio device, so the VM must be rebooted to get a new connection
- Copies data when reading packets