### PR TITLE
Use virtio vsock socket as comms channel on crosvm

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -24,6 +24,8 @@
   "runArgs": [
     // Required by crosvm.
     "--device=/dev/kvm",
+    "--device=/dev/vhost-vsock",
+    "--device=/dev/vsock",
     // In order to access /dev/kvm, our user inside the container needs to be a
     // member of the group that owns /dev/kvm; the device itself is exposed
     // inside the container with the same group as outside the container.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,6 +2229,7 @@ dependencies = [
  "rust-hypervisor-firmware-boot",
  "strum",
  "uart_16550",
+ "virtio",
  "x86_64",
 ]
 
@@ -2680,6 +2681,19 @@ name = "nix"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
@@ -5690,6 +5704,7 @@ dependencies = [
  "serde",
  "tokio",
  "tonic",
+ "vsock",
 ]
 
 [[package]]
@@ -5799,6 +5814,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "ciborium-io",
+ "log",
  "rust-hypervisor-firmware-virtio",
  "strum",
 ]
@@ -5808,6 +5824,16 @@ name = "volatile"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ca98349dda8a60ae74e04fd90c7fb4d6a4fbe01e6d3be095478aa0b76f6c0c"
+
+[[package]]
+name = "vsock"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32675ee2b3ce5df274c0ab52d19b28789632406277ca26bffee79a8e27dc133"
+dependencies = [
+ "libc",
+ "nix 0.23.1",
+]
 
 [[package]]
 name = "walkdir"

--- a/experimental/uefi/baremetal-crosvm/Cargo.lock
+++ b/experimental/uefi/baremetal-crosvm/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "rust-hypervisor-firmware-boot",
  "strum",
  "uart_16550",
+ "virtio",
  "x86_64",
 ]
 
@@ -848,6 +849,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-hypervisor-firmware-virtio"
+version = "0.1.0"
+dependencies = [
+ "atomic_refcell",
+ "bitflags",
+ "log",
+ "x86_64",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1060,18 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtio"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "ciborium-io",
+ "log",
+ "rust-hypervisor-firmware-virtio",
+ "strum",
+]
 
 [[package]]
 name = "volatile"

--- a/experimental/uefi/baremetal-crosvm/Cargo.toml
+++ b/experimental/uefi/baremetal-crosvm/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-kernel = { path = "../kernel" }
+kernel = { path = "../kernel", features = ["vsock_channel"] }

--- a/experimental/uefi/channel/src/lib.rs
+++ b/experimental/uefi/channel/src/lib.rs
@@ -74,6 +74,7 @@ where
         };
         self.inner.write_all(&length_bytes)?;
         self.inner.write_all(&frame.body)?;
+        self.inner.flush()?;
         Ok(())
     }
 }

--- a/experimental/uefi/kernel/Cargo.toml
+++ b/experimental/uefi/kernel/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Andri Saar <andrisaar@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = []
+vsock_channel = ["virtio"]
+
 [dependencies]
 anyhow = { version = "*", default-features = false }
 atomic_refcell = "*"
@@ -23,4 +27,5 @@ runtime = { path = "../runtime", default-features = false, features = [
 rust-hypervisor-firmware-boot = { path = "../../../third_party/rust-hypervisor-firmware-boot" }
 strum = { version = "*", default-features = false, features = ["derive"] }
 uart_16550 = "*"
+virtio = { path = "../../virtio", optional = true }
 x86_64 = "*"

--- a/experimental/uefi/kernel/src/lib.rs
+++ b/experimental/uefi/kernel/src/lib.rs
@@ -63,24 +63,26 @@ pub fn start_kernel<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
     main(info);
 }
 
-#[cfg(feature = "vsock_channel")]
 fn main<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
     info!("In main! Boot protocol:  {}", info.protocol());
+    let attestation_behavior =
+        AttestationBehavior::create(EmptyAttestationGenerator, EmptyAttestationVerifier);
+    runtime::framing::handle_frames(get_channel(), attestation_behavior).unwrap();
+}
+
+#[cfg(not(feature = "vsock_channel"))]
+fn get_channel() -> serial::Serial {
+    serial::Serial::new()
+}
+
+#[cfg(feature = "vsock_channel")]
+fn get_channel() -> virtio::vsock::socket::Socket {
     let vsock = virtio::vsock::VSock::find_and_configure_device()
         .expect("Couldn't configure PCI virtio vsock device.");
     info!("Socket device status: {}", vsock.get_status());
     let listener = virtio::vsock::socket::SocketListener::new(vsock, VSOCK_PORT);
     let socket = listener.accept().unwrap();
-    runtime::framing::handle_frames(socket).unwrap();
-}
-
-#[cfg(not(feature = "vsock_channel"))]
-fn main<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
-    info!("In main! Boot protocol:  {}", info.protocol());
-    let serial = serial::Serial::new();
-    let attestation_behavior =
-        AttestationBehavior::create(EmptyAttestationGenerator, EmptyAttestationVerifier);
-    runtime::framing::handle_frames(serial, attestation_behavior).unwrap();
+    socket
 }
 
 /// Common panic routine for the kernel. This needs to be wrrapped in a

--- a/experimental/uefi/kernel/src/lib.rs
+++ b/experimental/uefi/kernel/src/lib.rs
@@ -81,8 +81,7 @@ fn get_channel() -> virtio::vsock::socket::Socket {
         .expect("Couldn't configure PCI virtio vsock device.");
     info!("Socket device status: {}", vsock.get_status());
     let listener = virtio::vsock::socket::SocketListener::new(vsock, VSOCK_PORT);
-    let socket = listener.accept().unwrap();
-    socket
+    listener.accept().expect("Couldn't accept connection.")
 }
 
 /// Common panic routine for the kernel. This needs to be wrrapped in a

--- a/experimental/uefi/kernel/src/lib.rs
+++ b/experimental/uefi/kernel/src/lib.rs
@@ -70,11 +70,13 @@ fn main<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
     runtime::framing::handle_frames(get_channel(), attestation_behavior).unwrap();
 }
 
+// Use a serial port for the communications channel if we don't support virtio vsock.
 #[cfg(not(feature = "vsock_channel"))]
 fn get_channel() -> serial::Serial {
     serial::Serial::new()
 }
 
+// Use virtio vsock for the communications channel.
 #[cfg(feature = "vsock_channel")]
 fn get_channel() -> virtio::vsock::socket::Socket {
     let vsock = virtio::vsock::VSock::find_and_configure_device()

--- a/experimental/uefi/loader/Cargo.toml
+++ b/experimental/uefi/loader/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "*", features = [
   "sync",
 ] }
 tonic = "*"
+vsock = "*"
 oak_remote_attestation_sessions = { path = "../../../remote_attestation_sessions" }
 channel = { path = "../../../experimental/uefi/channel" }
 ciborium-io = "*"

--- a/experimental/uefi/loader/src/crosvm.rs
+++ b/experimental/uefi/loader/src/crosvm.rs
@@ -30,10 +30,10 @@ use std::{
 };
 use vsock::VsockStream;
 
-/// The guest VM context ID for virtio vsock connecitons.
+// The guest VM context ID for virtio vsock connections.
 const VSOCK_GUEST_CID: u32 = 3;
 
-/// The guest VM virtio vsock port.
+// The guest VM virtio vsock port.
 const VSOCK_GUEST_PORT: u32 = 1024;
 
 pub struct Crosvm {
@@ -51,7 +51,8 @@ pub struct VsockStreamChannel {
 }
 
 impl VsockStreamChannel {
-    /// Ensures that the inner stream is connected to the VM.
+    /// Ensures that the inner stream is connected to the VM. If the stream is not connected it will
+    /// try to conect to the VM.
     fn ensure_stream(&mut self) -> std::io::Result<()> {
         if self.stream.is_none() {
             let stream = VsockStream::connect_with_cid_port(VSOCK_GUEST_CID, VSOCK_GUEST_PORT)?;
@@ -133,6 +134,8 @@ impl Vmm for Crosvm {
     }
 
     fn create_comms_channel(&self) -> Result<Box<dyn ReadWrite>> {
+        // Create the channel in a disconnected state as it can only be connected later, after the
+        // VM has booted up.
         Ok(Box::new(VsockStreamChannel { stream: None }))
     }
 }

--- a/experimental/uefi/loader/src/crosvm.rs
+++ b/experimental/uefi/loader/src/crosvm.rs
@@ -14,31 +14,79 @@
 // limitations under the License.
 //
 
-use crate::vmm::{Params, Vmm};
+use crate::{
+    vmm::{Params, Vmm},
+    ReadWrite,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use command_fds::tokio::CommandFdAsyncExt;
 use log::info;
 use std::{
+    io::{Error, ErrorKind, Read, Write},
     net::Shutdown,
-    os::unix::{
-        io::{AsRawFd, OwnedFd},
-        net::UnixStream,
-    },
+    os::unix::{io::AsRawFd, net::UnixStream},
     process::Stdio,
 };
+use vsock::VsockStream;
+
+/// The guest VM context ID for virtio vsock connecitons.
+const VSOCK_GUEST_CID: u32 = 3;
+
+/// The guest VM virtio vsock port.
+const VSOCK_GUEST_PORT: u32 = 1024;
 
 pub struct Crosvm {
     console: UnixStream,
     instance: tokio::process::Child,
 }
 
+pub struct VsockStreamChannel {
+    stream: Option<VsockStream>,
+}
+
+impl VsockStreamChannel {
+    fn ensure_stream(&mut self) -> std::io::Result<()> {
+        if self.stream.is_none() {
+            let stream = VsockStream::connect_with_cid_port(VSOCK_GUEST_CID, VSOCK_GUEST_PORT)?;
+            self.stream.replace(stream);
+        }
+        Ok(())
+    }
+}
+
+impl Write for VsockStreamChannel {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        self.ensure_stream()?;
+        self.stream
+            .as_mut()
+            .ok_or_else(|| Error::from(ErrorKind::NotConnected))?
+            .write(data)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.ensure_stream()?;
+        self.stream
+            .as_mut()
+            .ok_or_else(|| Error::from(ErrorKind::NotConnected))?
+            .flush()
+    }
+}
+
+impl Read for VsockStreamChannel {
+    fn read(&mut self, data: &mut [u8]) -> std::io::Result<usize> {
+        self.ensure_stream()?;
+        self.stream
+            .as_mut()
+            .ok_or_else(|| Error::from(ErrorKind::NotConnected))?
+            .read(data)
+    }
+}
+
 impl Crosvm {
     pub fn start(params: Params) -> Result<Self> {
         let mut cmd = tokio::process::Command::new(params.binary);
 
-        cmd.stdin(OwnedFd::from(params.comms.try_clone()?));
-        cmd.stdout(OwnedFd::from(params.comms));
         cmd.stderr(Stdio::inherit());
         cmd.preserved_fds(vec![params.console.as_raw_fd()]);
 
@@ -51,7 +99,7 @@ impl Crosvm {
             "--serial=num=1,hardware=serial,type=file,path=/proc/self/fd/{},console,earlycon",
             params.console.as_raw_fd()
         ));
-        cmd.arg("--serial=num=2,hardware=serial,type=stdout,stdin");
+        cmd.arg("--cid=3");
         cmd.arg(params.app);
 
         info!("Executing: {:?}", cmd);
@@ -74,5 +122,9 @@ impl Vmm for Crosvm {
         self.console.shutdown(Shutdown::Both)?;
         self.instance.start_kill()?;
         self.wait().await
+    }
+
+    fn create_comms_channel(&self) -> Result<Box<dyn ReadWrite>> {
+        Ok(Box::new(VsockStreamChannel { stream: None }))
     }
 }

--- a/experimental/uefi/loader/src/crosvm.rs
+++ b/experimental/uefi/loader/src/crosvm.rs
@@ -105,7 +105,7 @@ impl Crosvm {
             "--serial=num=1,hardware=serial,type=file,path=/proc/self/fd/{},console,earlycon",
             params.console.as_raw_fd()
         ));
-        cmd.arg("--cid=3");
+        cmd.arg(format!("--cid={}", VSOCK_GUEST_CID));
         cmd.arg(params.app);
 
         info!("Executing: {:?}", cmd);

--- a/experimental/uefi/loader/src/crosvm.rs
+++ b/experimental/uefi/loader/src/crosvm.rs
@@ -94,6 +94,8 @@ impl Crosvm {
         let mut cmd = tokio::process::Command::new(params.binary);
 
         cmd.stderr(Stdio::inherit());
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::inherit());
         cmd.preserved_fds(vec![params.console.as_raw_fd()]);
 
         // Construct the command-line arguments for `crosvm`.

--- a/experimental/uefi/loader/src/crosvm.rs
+++ b/experimental/uefi/loader/src/crosvm.rs
@@ -41,11 +41,17 @@ pub struct Crosvm {
     instance: tokio::process::Child,
 }
 
+/// A wrapper for a vsock stream that can be used as a communication channel between the loader and
+/// the guest VM.
+///
+/// The vsock channel can only be created after the VM is booted, so we start without a stream and
+/// only connect later when we try to use it for the first time.
 pub struct VsockStreamChannel {
     stream: Option<VsockStream>,
 }
 
 impl VsockStreamChannel {
+    /// Ensures that the inner stream is connected to the VM.
     fn ensure_stream(&mut self) -> std::io::Result<()> {
         if self.stream.is_none() {
             let stream = VsockStream::connect_with_cid_port(VSOCK_GUEST_CID, VSOCK_GUEST_PORT)?;

--- a/experimental/uefi/loader/src/qemu.rs
+++ b/experimental/uefi/loader/src/qemu.rs
@@ -24,35 +24,10 @@ use command_fds::{tokio::CommandFdAsyncExt, FdMapping};
 use log::info;
 use std::{
     ffi::OsStr,
-    io::{Read, Write},
     net::Shutdown,
     os::unix::{io::AsRawFd, net::UnixStream},
     process::Stdio,
 };
-
-struct UnixStreamChannel {
-    inner: UnixStream,
-}
-
-impl ciborium_io::Write for UnixStreamChannel {
-    type Error = anyhow::Error;
-
-    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
-        self.inner.write_all(data).map_err(anyhow::Error::msg)
-    }
-
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        self.inner.flush().map_err(anyhow::Error::msg)
-    }
-}
-
-impl ciborium_io::Read for UnixStreamChannel {
-    type Error = anyhow::Error;
-
-    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
-        self.inner.read_exact(data).map_err(anyhow::Error::msg)
-    }
-}
 
 pub struct Qemu {
     console: UnixStream,

--- a/experimental/uefi/loader/src/vmm.rs
+++ b/experimental/uefi/loader/src/vmm.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+use super::ReadWrite;
 use anyhow::Result;
 use async_trait::async_trait;
 use std::{os::unix::net::UnixStream, path::PathBuf};
@@ -31,13 +32,14 @@ pub struct Params {
 
     /// Stream to connect to the console of the VM.
     pub console: UnixStream,
-
-    /// Stream to use for communicating with the app inside the VM.
-    pub comms: UnixStream,
 }
 
 #[async_trait]
 pub trait Vmm {
+    /// Waits for the guest VM to finish.
     async fn wait(&mut self) -> Result<std::process::ExitStatus>;
+    /// Kills the guest VM.
     async fn kill(self: Box<Self>) -> Result<std::process::ExitStatus>;
+    /// Creates a channel to communicate with the VM.
+    fn create_comms_channel(&self) -> Result<Box<dyn ReadWrite>>;
 }

--- a/experimental/uefi/loader/src/vmm.rs
+++ b/experimental/uefi/loader/src/vmm.rs
@@ -38,8 +38,13 @@ pub struct Params {
 pub trait Vmm {
     /// Waits for the guest VM to finish.
     async fn wait(&mut self) -> Result<std::process::ExitStatus>;
+
     /// Kills the guest VM.
     async fn kill(self: Box<Self>) -> Result<std::process::ExitStatus>;
+
     /// Creates a channel to communicate with the VM.
+    ///
+    /// Since different VMMs might use different comms channels, we leave it up to the VMM to create
+    /// the channel rather than passing it in as part of the parameters.
     fn create_comms_channel(&self) -> Result<Box<dyn ReadWrite>>;
 }

--- a/experimental/virtio/Cargo.toml
+++ b/experimental/virtio/Cargo.toml
@@ -9,5 +9,6 @@ license = "Apache-2.0"
 anyhow = { version = "*", default-features = false }
 bitflags = "*"
 ciborium-io = { version = "*", default-features = false }
+log = "*"
 rust-hypervisor-firmware-virtio = { path = "../../third_party/rust-hypervisor-firmware-virtio" }
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/experimental/virtio/src/queue/virtq.rs
+++ b/experimental/virtio/src/queue/virtq.rs
@@ -96,6 +96,8 @@ pub struct AvailRing<const QUEUE_SIZE: usize> {
     pub idx: u16,
     /// The ring-buffer containing indices of the heads of available descriptor chains.
     pub ring: [u16; QUEUE_SIZE],
+    /// Event details. Only used if VIRTIO_F_EVENT_IDX has been negotiated.
+    pub used_event: u16,
 }
 
 impl<const QUEUE_SIZE: usize> Default for AvailRing<QUEUE_SIZE> {
@@ -105,6 +107,7 @@ impl<const QUEUE_SIZE: usize> Default for AvailRing<QUEUE_SIZE> {
             flags: RingFlags::NO_NOTIFY,
             idx: 0,
             ring: [0; QUEUE_SIZE],
+            used_event: 0,
         }
     }
 }
@@ -122,6 +125,8 @@ pub struct UsedRing<const QUEUE_SIZE: usize> {
     pub idx: u16,
     /// The ring-buffer containing the used elements.
     pub ring: [UsedElem; QUEUE_SIZE],
+    /// Event details. Only used if VIRTIO_F_EVENT_IDX has been negotiated.
+    pub avail_event: u16,
 }
 
 impl<const QUEUE_SIZE: usize> Default for UsedRing<QUEUE_SIZE> {
@@ -130,6 +135,7 @@ impl<const QUEUE_SIZE: usize> Default for UsedRing<QUEUE_SIZE> {
             flags: RingFlags::empty(),
             idx: 0,
             ring: [(); QUEUE_SIZE].map(|_| UsedElem::default()),
+            avail_event: 0,
         }
     }
 }

--- a/experimental/virtio/src/queue/virtq.rs
+++ b/experimental/virtio/src/queue/virtq.rs
@@ -96,7 +96,8 @@ pub struct AvailRing<const QUEUE_SIZE: usize> {
     pub idx: u16,
     /// The ring-buffer containing indices of the heads of available descriptor chains.
     pub ring: [u16; QUEUE_SIZE],
-    /// Event details. Only used if VIRTIO_F_EVENT_IDX has been negotiated.
+    /// Event details. Only used if VIRTIO_F_EVENT_IDX has been negotiated, which we don't
+    /// currently support. The field is only added to act as padding for now.
     pub used_event: u16,
 }
 
@@ -125,7 +126,8 @@ pub struct UsedRing<const QUEUE_SIZE: usize> {
     pub idx: u16,
     /// The ring-buffer containing the used elements.
     pub ring: [UsedElem; QUEUE_SIZE],
-    /// Event details. Only used if VIRTIO_F_EVENT_IDX has been negotiated.
+    /// Event details. Only used if VIRTIO_F_EVENT_IDX has been negotiated, which we don't
+    /// currently support. The field is only added to act as padding for now.
     pub avail_event: u16,
 }
 

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -160,6 +160,8 @@ impl VSock {
     }
 
     /// Gets the device status.
+    ///
+    /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-100001>.
     pub fn get_status(&self) -> u32 {
         self.device.get_status()
     }

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -75,10 +75,10 @@ const HOST_CID: u64 = 2;
 pub struct VSock {
     /// The base virtio-over-PCI device used for configuration and notification.
     device: VirtioBaseDevice<VirtioPciTransport>,
-    /// The transmit queue.
-    tx_queue: DriverWriteOnlyQueue<QUEUE_SIZE, DATA_BUFFER_SIZE>,
     /// The receive queue.
     rx_queue: DeviceWriteOnlyQueue<QUEUE_SIZE, DATA_BUFFER_SIZE>,
+    /// The transmit queue.
+    tx_queue: DriverWriteOnlyQueue<QUEUE_SIZE, DATA_BUFFER_SIZE>,
     /// The event queue used by the device to notify the driver that the guest CID has changed. We
     /// ignore it for now as we don't support live migration, but it still must exist and be
     /// configured.
@@ -98,6 +98,9 @@ impl VSock {
         let device = VirtioBaseDevice::new(transport);
         let mut result = Self::new(device);
         result.init()?;
+        // Let the device know there are available buffers in the receiver and event queues.
+        result.device.notify_queue(RX_QUEUE_ID);
+        result.device.notify_queue(EVENT_QUEUE_ID);
         Ok(result)
     }
 
@@ -156,6 +159,11 @@ impl VSock {
         }
     }
 
+    /// Gets the device status.
+    pub fn get_status(&self) -> u32 {
+        self.device.get_status()
+    }
+
     fn new(device: VirtioBaseDevice<VirtioPciTransport>) -> Self {
         let tx_queue = DriverWriteOnlyQueue::new();
         let rx_queue = DeviceWriteOnlyQueue::new();
@@ -175,6 +183,19 @@ impl VSock {
             .start_init(DEVICE_ID as u32)
             .map_err(|error| anyhow::anyhow!("Virtio error: {:?}", error))
             .context("Couldn't initialize the PCI device")?;
+        // We have to configure the event queue before the receive queue, otherwise the event
+        // queue's configuration interferes with the receiver queue. This seems to be related to
+        // something specific in the Linux kernel vhost vsock implementation.
+        self.device
+            .configure_queue(
+                EVENT_QUEUE_ID,
+                QUEUE_SIZE as u16,
+                self.event_queue.inner.get_desc_addr(),
+                self.event_queue.inner.get_avail_addr(),
+                self.event_queue.inner.get_used_addr(),
+            )
+            .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
+            .context("Couldn't configure the event queue")?;
         self.device
             .configure_queue(
                 RX_QUEUE_ID,
@@ -195,16 +216,6 @@ impl VSock {
             )
             .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
             .context("Couldn't configure the transmit queue")?;
-        self.device
-            .configure_queue(
-                EVENT_QUEUE_ID,
-                QUEUE_SIZE as u16,
-                self.event_queue.inner.get_desc_addr(),
-                self.event_queue.inner.get_avail_addr(),
-                self.event_queue.inner.get_used_addr(),
-            )
-            .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
-            .context("Couldn't configure the event queue")?;
         self.device
             .complete_init()
             .map_err(|error| anyhow::anyhow!("Device activation error: {:?}", error))

--- a/experimental/virtio/src/vsock/socket.rs
+++ b/experimental/virtio/src/vsock/socket.rs
@@ -356,7 +356,8 @@ impl ciborium_io::Write for Socket {
 
     fn flush(&mut self) -> Result<(), Self::Error> {
         // We always flush on write, so do nothing.
-        // TODO(#2876): Don't always flush on write.
+        // TODO(#2876): We should use a bufferd writer so that we don't always flush on write, and
+        // provide and actual flush implementation here.
         Ok(())
     }
 }

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# On Kokoro instances /dev/kvm, dev/vhost-vsock and dev/vsock are owned by root:root.
-# Let's fix the permissions so that it's owned by group `kvm` as our scripts expect it to.
+# On Kokoro instances /dev/kvm, /dev/vhost-vsock and /dev/vsock are owned by root:root.
+# Set the permissions so that these are owned by the `kvm` group as our scripts expect it to be.
 readonly KVM_GID="$(getent group kvm | cut -d: -f3)"
 sudo chown "$USER:$KVM_GID" /dev/kvm
 sudo chown "$USER:$KVM_GID" /dev/vhost-vsock

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-# On Kokoro instances /dev/kvm is owned by root:root. Let's fix the permissions
-# so that it's owned by group `kvm` as our scripts expect it to.
+# On Kokoro instances /dev/kvm, dev/vhost-vsock and dev/vsock are owned by root:root.
+# Let's fix the permissions so that it's owned by group `kvm` as our scripts expect it to.
 readonly KVM_GID="$(getent group kvm | cut -d: -f3)"
 sudo chown "$USER:$KVM_GID" /dev/kvm
+sudo chown "$USER:$KVM_GID" /dev/vhost-vsock
+sudo chown "$USER:$KVM_GID" /dev/vsock
 
 ./scripts/docker_pull
 

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -60,6 +60,20 @@ if [[ -e "/dev/kvm" ]]; then
   )
 fi
 
+# If the host supports virtio vhost vsock, allow the image to use it
+if [[ -e "/dev/vhost-vsock" ]]; then
+  docker_run_flags+=(
+    "--device=/dev/vhost-vsock"
+  )
+fi
+
+# If the host supports the vsock device, allow the image to use it.
+if [[ -e "/dev/vsock" ]]; then
+  docker_run_flags+=(
+    "--device=/dev/vsock"
+  )
+fi
+
 # Some CI systems (GitHub actions) do not run with an interactive TTY attached.
 if [[ -z "${CI:-}" ]]; then
   docker_run_flags+=('--interactive')

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -46,12 +46,12 @@ docker_run_flags=(
   '--workdir=/workspace'
   '--network=host'
   # We need to use Docker from inside the container, but only for build.
-  # To do that, we map the socket from the host and add the right group
+  # To do that, we map the socket from the host and add the right group.
   '--volume=/var/run/docker.sock:/var/run/docker.sock'
   "--group-add=$HOST_DOCKER_GID"
 )
 
-# If the host supports KVM, allow the image to use it
+# If the host supports KVM, allow the docker image to use it.
 if [[ -e "/dev/kvm" ]]; then
   readonly HOST_KVM_GID="$(getent group kvm | cut -d: -f3)"
   docker_run_flags+=(
@@ -60,14 +60,14 @@ if [[ -e "/dev/kvm" ]]; then
   )
 fi
 
-# If the host supports virtio vhost vsock, allow the image to use it
+# If the host supports virtio vhost vsock, allow the docker image to use it.
 if [[ -e "/dev/vhost-vsock" ]]; then
   docker_run_flags+=(
     "--device=/dev/vhost-vsock"
   )
 fi
 
-# If the host supports the vsock device, allow the image to use it.
+# If the host supports the vsock device, allow the docker image to use it.
 if [[ -e "/dev/vsock" ]]; then
   docker_run_flags+=(
     "--device=/dev/vsock"

--- a/third_party/rust-hypervisor-firmware-virtio/src/device.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/device.rs
@@ -136,6 +136,11 @@ where
         self.transport.read_device_config(offset)
     }
 
+    /// Gets the device status.
+    pub fn get_status(&self) -> u32 {
+        self.transport.get_status()
+    }
+
     /// Notifies the device that a queue has been updated.
     pub fn notify_queue(&mut self, queue_id: u16) {
         self.transport.notify_queue(queue_id)

--- a/third_party/rust-hypervisor-firmware-virtio/src/device.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/device.rs
@@ -137,6 +137,8 @@ where
     }
 
     /// Gets the device status.
+    ///
+    /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-100001>.
     pub fn get_status(&self) -> u32 {
         self.transport.get_status()
     }

--- a/third_party/rust-hypervisor-firmware-virtio/src/pci.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/pci.rs
@@ -391,7 +391,7 @@ impl VirtioTransport for VirtioPciTransport {
     }
 
     fn set_used_ring(&self, addr: u64) {
-        // queue_used: 0x28
+        // queue_used: 0x30
         self.region.io_write_u64(0x30, addr);
     }
 


### PR DESCRIPTION
This PR changes the crosvm-compatible bare-metal implementation to use a virtio vsock channel for host-to-guest communication.

The vsock channel can only be connected after the VM has booted when using crosvm. When using a serial port on QEMU for the comms the loader's comms channel for connecting to the serial port (a unix domain socket) must be created before the VM boots. To work around this, a wrapper struct for the VsockStream has been added so that it can be connected later, the first time we try to use it for actual comms. It is now also up to the VMM to create the comms channel, rather than passing it in as part of the VMM startup parameters.