### PR TITLE
Implement InternalError in IDL

### DIFF
--- a/oak_idl/src/lib.rs
+++ b/oak_idl/src/lib.rs
@@ -32,18 +32,6 @@ pub enum Error {
     /// The method id provided for the invocation was not implemented by the server.
     InvalidMethodId,
     /// An error occured while invoking the method on the server.
-    MethodError(MethodError),
-}
-
-impl From<MethodError> for Error {
-    fn from(e: MethodError) -> Self {
-        Error::MethodError(e)
-    }
-}
-
-#[derive(Debug)]
-pub enum MethodError {
-    /// An error occured when invoking the method.
     InternalError,
 }
 

--- a/oak_idl/src/lib.rs
+++ b/oak_idl/src/lib.rs
@@ -31,6 +31,20 @@ pub enum Error {
     InvalidResponse,
     /// The method id provided for the invocation was not implemented by the server.
     InvalidMethodId,
+    /// An error occured while invoking the method on the server.
+    MethodError(MethodError),
+}
+
+impl From<MethodError> for Error {
+    fn from(e: MethodError) -> Self {
+        Error::MethodError(e)
+    }
+}
+
+#[derive(Debug)]
+pub enum MethodError {
+    /// An error occured when invoking the method.
+    InternalError,
 }
 
 /// Unique identifier of a method within a service.

--- a/oak_idl_gen_services/src/lib.rs
+++ b/oak_idl_gen_services/src/lib.rs
@@ -282,7 +282,7 @@ fn generate_service_method(rpc_call: &RPCCall) -> Vec<String> {
     // implementation of this method, therefore needs to be wrapped in `oak_idl::Message` in order
     // to transfer its ownership to the caller.
     vec![format!(
-        "    fn {}(&self, request: &{}) -> Result<oak_idl::utils::Message<{}>, oak_idl::MethodError>;",
+        "    fn {}(&self, request: &{}) -> Result<oak_idl::utils::Message<{}>, oak_idl::Error>;",
         method_name(rpc_call),
         request_type(rpc_call),
         response_type(rpc_call)

--- a/oak_idl_gen_services/src/lib.rs
+++ b/oak_idl_gen_services/src/lib.rs
@@ -267,7 +267,7 @@ fn generate_server_handler(rpc_call: &RPCCall) -> anyhow::Result<Vec<String>> {
             request_type(rpc_call),
         ),
         format!(
-            "                let response = self.service.{}(&request);",
+            "                let response = self.service.{}(&request)?;",
             method_name(rpc_call),
         ),
         format!("                let response_body = response.buf().to_vec();"),
@@ -282,7 +282,7 @@ fn generate_service_method(rpc_call: &RPCCall) -> Vec<String> {
     // implementation of this method, therefore needs to be wrapped in `oak_idl::Message` in order
     // to transfer its ownership to the caller.
     vec![format!(
-        "    fn {}(&self, request: &{}) -> oak_idl::utils::Message<{}>;",
+        "    fn {}(&self, request: &{}) -> Result<oak_idl::utils::Message<{}>, oak_idl::MethodError>;",
         method_name(rpc_call),
         request_type(rpc_call),
         response_type(rpc_call)

--- a/oak_idl_tests/test_schema_services.rs.txt
+++ b/oak_idl_tests/test_schema_services.rs.txt
@@ -40,13 +40,13 @@ impl <S: TestService> oak_idl::Handler for TestServiceServer<S> {
         match request.method_id {
             222 => {
                 let request = flatbuffers::root::<LookupDataRequest>(request.body).map_err(|_err| oak_idl::Error::InvalidRequest)?;
-                let response = self.service.lookup_data(&request);
+                let response = self.service.lookup_data(&request)?;
                 let response_body = response.buf().to_vec();
                 Ok(response_body)
             }
             223 => {
                 let request = flatbuffers::root::<LogRequest>(request.body).map_err(|_err| oak_idl::Error::InvalidRequest)?;
-                let response = self.service.log(&request);
+                let response = self.service.log(&request)?;
                 let response_body = response.buf().to_vec();
                 Ok(response_body)
             }
@@ -56,8 +56,8 @@ impl <S: TestService> oak_idl::Handler for TestServiceServer<S> {
 }
 
 pub trait TestService: Sized {
-    fn lookup_data(&self, request: &LookupDataRequest) -> oak_idl::utils::Message<LookupDataResponse>;
-    fn log(&self, request: &LogRequest) -> oak_idl::utils::Message<LogResponse>;
+    fn lookup_data(&self, request: &LookupDataRequest) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::MethodError>;
+    fn log(&self, request: &LogRequest) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::MethodError>;
     fn serve(self) -> TestServiceServer<Self> {
         TestServiceServer { service : self }
     }

--- a/oak_idl_tests/test_schema_services.rs.txt
+++ b/oak_idl_tests/test_schema_services.rs.txt
@@ -56,8 +56,8 @@ impl <S: TestService> oak_idl::Handler for TestServiceServer<S> {
 }
 
 pub trait TestService: Sized {
-    fn lookup_data(&self, request: &LookupDataRequest) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::MethodError>;
-    fn log(&self, request: &LogRequest) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::MethodError>;
+    fn lookup_data(&self, request: &LookupDataRequest) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::Error>;
+    fn log(&self, request: &LogRequest) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::Error>;
     fn serve(self) -> TestServiceServer<Self> {
         TestServiceServer { service : self }
     }

--- a/oak_idl_tests/tests/test_schema.rs
+++ b/oak_idl_tests/tests/test_schema.rs
@@ -31,7 +31,8 @@ impl test_schema::TestService for TestServiceImpl {
     fn lookup_data(
         &self,
         request: &test_schema::LookupDataRequest,
-    ) -> oak_idl::utils::Message<test_schema::LookupDataResponse> {
+    ) -> Result<oak_idl::utils::Message<test_schema::LookupDataResponse>, oak_idl::MethodError>
+    {
         let h = maplit::hashmap! {
             vec![14, 12] => vec![19, 88]
         };
@@ -43,17 +44,23 @@ impl test_schema::TestService for TestServiceImpl {
             &mut b,
             &test_schema::LookupDataResponseArgs { value },
         );
-        b.finish(m).unwrap()
+        let b = b
+            .finish(m)
+            .map_err(|_| oak_idl::MethodError::InternalError)?;
+        Ok(b)
     }
 
     fn log(
         &self,
         request: &test_schema::LogRequest,
-    ) -> oak_idl::utils::Message<test_schema::LogResponse> {
+    ) -> Result<oak_idl::utils::Message<test_schema::LogResponse>, oak_idl::MethodError> {
         eprintln!("log: {}", request.entry().unwrap());
         let mut b = oak_idl::utils::MessageBuilder::default();
         let m = test_schema::LogResponse::create(&mut b, &test_schema::LogResponseArgs {});
-        b.finish(m).unwrap()
+        let b = b
+            .finish(m)
+            .map_err(|_| oak_idl::MethodError::InternalError)?;
+        Ok(b)
     }
 }
 

--- a/oak_idl_tests/tests/test_schema.rs
+++ b/oak_idl_tests/tests/test_schema.rs
@@ -31,8 +31,7 @@ impl test_schema::TestService for TestServiceImpl {
     fn lookup_data(
         &self,
         request: &test_schema::LookupDataRequest,
-    ) -> Result<oak_idl::utils::Message<test_schema::LookupDataResponse>, oak_idl::MethodError>
-    {
+    ) -> Result<oak_idl::utils::Message<test_schema::LookupDataResponse>, oak_idl::Error> {
         let h = maplit::hashmap! {
             vec![14, 12] => vec![19, 88]
         };
@@ -44,22 +43,18 @@ impl test_schema::TestService for TestServiceImpl {
             &mut b,
             &test_schema::LookupDataResponseArgs { value },
         );
-        let b = b
-            .finish(m)
-            .map_err(|_| oak_idl::MethodError::InternalError)?;
+        let b = b.finish(m).map_err(|_| oak_idl::Error::InternalError)?;
         Ok(b)
     }
 
     fn log(
         &self,
         request: &test_schema::LogRequest,
-    ) -> Result<oak_idl::utils::Message<test_schema::LogResponse>, oak_idl::MethodError> {
+    ) -> Result<oak_idl::utils::Message<test_schema::LogResponse>, oak_idl::Error> {
         eprintln!("log: {}", request.entry().unwrap());
         let mut b = oak_idl::utils::MessageBuilder::default();
         let m = test_schema::LogResponse::create(&mut b, &test_schema::LogResponseArgs {});
-        let b = b
-            .finish(m)
-            .map_err(|_| oak_idl::MethodError::InternalError)?;
+        let b = b.finish(m).map_err(|_| oak_idl::Error::InternalError)?;
         Ok(b)
     }
 }


### PR DESCRIPTION
The server should be able to indicate that a method invocation failed. The alteratives would be panicking (the tests do this at the moment) or silently failing by sending an empty / default value. Conceptually equivalent to a 500 status code in HTTP https://http.cat/500