### PR TITLE
Add multiboot1 protocol support

### DIFF
--- a/experimental/uefi/baremetal/Cargo.toml
+++ b/experimental/uefi/baremetal/Cargo.toml
@@ -5,9 +5,14 @@ authors = ["Andri Saar <andrisaar@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = ["pvh"]
+pvh = ["rust-hypervisor-firmware-boot/pvh"]
+multiboot = []
+
 [dependencies]
 kernel = { path = "../kernel" }
-rust-hypervisor-firmware-boot = { path = "../../../third_party/rust-hypervisor-firmware-boot" }
+rust-hypervisor-firmware-boot = { path = "../../../third_party/rust-hypervisor-firmware-boot", default-features = false }
 
 [build-dependencies]
 bindgen = "*"

--- a/experimental/uefi/baremetal/build.rs
+++ b/experimental/uefi/baremetal/build.rs
@@ -21,6 +21,7 @@ use std::{env, path::PathBuf};
 fn main() {
     println!("cargo:rerun-if-changed=target.json");
     println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../../../third_party/rust-hypervisor-boot/layout.ld");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
@@ -38,5 +39,19 @@ fn main() {
         .unwrap();
     bindings
         .write_to_file(out_path.join("start_info.rs"))
+        .unwrap();
+
+    let bindings = bindgen::Builder::default()
+        .clang_arg("--target=x86_64-pc-linux-gnu")
+        .header("src/multiboot.h")
+        .allowlist_type("multiboot_info")
+        .allowlist_type("multiboot_mmap_entry")
+        .use_core()
+        .ctypes_prefix("::core::ffi")
+        .layout_tests(false)
+        .generate()
+        .unwrap();
+    bindings
+        .write_to_file(out_path.join("multiboot.rs"))
         .unwrap();
 }

--- a/experimental/uefi/baremetal/src/asm/mod.rs
+++ b/experimental/uefi/baremetal/src/asm/mod.rs
@@ -1,0 +1,22 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Even if we ask for the feature, _don't_ include the multiboot header in the
+// test builds. Otherwise, the tests will fail as qemu will notice the
+// multiboot header, and refuse to load the binary (as it's a 64-bit ELF binary
+// and multiboot is nominally a 32-bit protocol.)
+
+core::arch::global_asm!(include_str!("multiboot.s"), options(raw));

--- a/experimental/uefi/baremetal/src/asm/multiboot.s
+++ b/experimental/uefi/baremetal/src/asm/multiboot.s
@@ -1,0 +1,11 @@
+.section .multiboot_header, "a"
+.code32
+.align 4
+
+MULTIBOOT_HEADER_MAGIC = 0x1BADB002
+MULTIBOOT_HEADER_FLAGS = (1 << 1)
+
+multiboot_header:
+    .long MULTIBOOT_HEADER_MAGIC
+    .long MULTIBOOT_HEADER_FLAGS
+    .long -(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FLAGS)

--- a/experimental/uefi/baremetal/src/multiboot.h
+++ b/experimental/uefi/baremetal/src/multiboot.h
@@ -1,0 +1,24 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <stdint.h>
+
+#define multiboot_uint8_t uint8_t
+#define multiboot_uint16_t uint16_t
+#define multiboot_uint32_t uint32_t
+#define multiboot_uint64_t uint64_t
+
+#include "../../../../third_party/grub/include/multiboot.h"

--- a/experimental/uefi/baremetal/src/multiboot.rs
+++ b/experimental/uefi/baremetal/src/multiboot.rs
@@ -1,0 +1,57 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Required as Bindgen-generated code doesn't follow idiomatic Rust style.
+#![allow(non_camel_case_types)]
+
+use kernel::boot::{BootInfo, E820Entry, E820EntryType};
+
+include!(concat!(env!("OUT_DIR"), "/multiboot.rs"));
+
+impl E820Entry for multiboot_mmap_entry {
+    fn entry_type(&self) -> E820EntryType {
+        E820EntryType::from_repr(self.type_).unwrap()
+    }
+
+    fn addr(&self) -> usize {
+        self.addr.try_into().unwrap()
+    }
+
+    fn size(&self) -> usize {
+        self.len.try_into().unwrap()
+    }
+}
+
+impl BootInfo<multiboot_mmap_entry> for multiboot_info {
+    fn protocol(&self) -> &str {
+        "Multiboot1 Protocol"
+    }
+
+    fn e820_table(&self) -> &[multiboot_mmap_entry] {
+        // Bit 6 indicates mmap_* fields are valid.
+        assert!(self.flags & (1 << 6) != 0 && self.mmap_length > 0);
+        // This is safe as it follows the multiboot protocol, and we panic above if the pointer is
+        // clearly invalid or we don't have memory information according to flags.
+        // Each entry is 24 bytes (4*u32) and mmap_length is in bytes, thus we have to do the
+        // division.
+        unsafe {
+            core::slice::from_raw_parts(
+                self.mmap_addr as *const multiboot_mmap_entry,
+                (self.mmap_length / 24).try_into().unwrap(),
+            )
+        }
+    }
+}

--- a/third_party/grub/include/multiboot.h
+++ b/third_party/grub/include/multiboot.h
@@ -1,0 +1,264 @@
+/*  multiboot.h - Multiboot header file.  */
+/*  Copyright (C) 1999,2003,2007,2008,2009,2010  Free Software Foundation, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL ANY
+ *  DEVELOPER OR DISTRIBUTOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ *  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MULTIBOOT_HEADER
+#define MULTIBOOT_HEADER 1
+
+/* How many bytes from the start of the file we search for the header.  */
+#define MULTIBOOT_SEARCH 8192
+#define MULTIBOOT_HEADER_ALIGN 4
+
+/* The magic field should contain this.  */
+#define MULTIBOOT_HEADER_MAGIC 0x1BADB002
+
+/* This should be in %eax.  */
+#define MULTIBOOT_BOOTLOADER_MAGIC 0x2BADB002
+
+/* Alignment of multiboot modules.  */
+#define MULTIBOOT_MOD_ALIGN 0x00001000
+
+/* Alignment of the multiboot info structure.  */
+#define MULTIBOOT_INFO_ALIGN 0x00000004
+
+/* Flags set in the 'flags' member of the multiboot header.  */
+
+/* Align all boot modules on i386 page (4KB) boundaries.  */
+#define MULTIBOOT_PAGE_ALIGN 0x00000001
+
+/* Must pass memory information to OS.  */
+#define MULTIBOOT_MEMORY_INFO 0x00000002
+
+/* Must pass video information to OS.  */
+#define MULTIBOOT_VIDEO_MODE 0x00000004
+
+/* This flag indicates the use of the address fields in the header.  */
+#define MULTIBOOT_AOUT_KLUDGE 0x00010000
+
+/* Flags to be set in the 'flags' member of the multiboot info structure.  */
+
+/* is there basic lower/upper memory information? */
+#define MULTIBOOT_INFO_MEMORY 0x00000001
+/* is there a boot device set? */
+#define MULTIBOOT_INFO_BOOTDEV 0x00000002
+/* is the command-line defined? */
+#define MULTIBOOT_INFO_CMDLINE 0x00000004
+/* are there modules to do something with? */
+#define MULTIBOOT_INFO_MODS 0x00000008
+
+/* These next two are mutually exclusive */
+
+/* is there a symbol table loaded? */
+#define MULTIBOOT_INFO_AOUT_SYMS 0x00000010
+/* is there an ELF section header table? */
+#define MULTIBOOT_INFO_ELF_SHDR 0X00000020
+
+/* is there a full memory map? */
+#define MULTIBOOT_INFO_MEM_MAP 0x00000040
+
+/* Is there drive info?  */
+#define MULTIBOOT_INFO_DRIVE_INFO 0x00000080
+
+/* Is there a config table?  */
+#define MULTIBOOT_INFO_CONFIG_TABLE 0x00000100
+
+/* Is there a boot loader name?  */
+#define MULTIBOOT_INFO_BOOT_LOADER_NAME 0x00000200
+
+/* Is there a APM table?  */
+#define MULTIBOOT_INFO_APM_TABLE 0x00000400
+
+/* Is there video information?  */
+#define MULTIBOOT_INFO_VBE_INFO 0x00000800
+#define MULTIBOOT_INFO_FRAMEBUFFER_INFO 0x00001000
+
+#ifndef ASM_FILE
+
+/*
+typedef unsigned char multiboot_uint8_t;
+typedef unsigned short multiboot_uint16_t;
+typedef unsigned int multiboot_uint32_t;
+typedef unsigned long long multiboot_uint64_t;
+*/
+
+struct multiboot_header {
+  /* Must be MULTIBOOT_MAGIC - see above.  */
+  multiboot_uint32_t magic;
+
+  /* Feature flags.  */
+  multiboot_uint32_t flags;
+
+  /* The above fields plus this one must equal 0 mod 2^32. */
+  multiboot_uint32_t checksum;
+
+  /* These are only valid if MULTIBOOT_AOUT_KLUDGE is set.  */
+  multiboot_uint32_t header_addr;
+  multiboot_uint32_t load_addr;
+  multiboot_uint32_t load_end_addr;
+  multiboot_uint32_t bss_end_addr;
+  multiboot_uint32_t entry_addr;
+
+  /* These are only valid if MULTIBOOT_VIDEO_MODE is set.  */
+  multiboot_uint32_t mode_type;
+  multiboot_uint32_t width;
+  multiboot_uint32_t height;
+  multiboot_uint32_t depth;
+};
+
+/* The symbol table for a.out.  */
+struct multiboot_aout_symbol_table {
+  multiboot_uint32_t tabsize;
+  multiboot_uint32_t strsize;
+  multiboot_uint32_t addr;
+  multiboot_uint32_t reserved;
+};
+typedef struct multiboot_aout_symbol_table multiboot_aout_symbol_table_t;
+
+/* The section header table for ELF.  */
+struct multiboot_elf_section_header_table {
+  multiboot_uint32_t num;
+  multiboot_uint32_t size;
+  multiboot_uint32_t addr;
+  multiboot_uint32_t shndx;
+};
+typedef struct multiboot_elf_section_header_table multiboot_elf_section_header_table_t;
+
+struct multiboot_info {
+  /* Multiboot info version number */
+  multiboot_uint32_t flags;
+
+  /* Available memory from BIOS */
+  multiboot_uint32_t mem_lower;
+  multiboot_uint32_t mem_upper;
+
+  /* "root" partition */
+  multiboot_uint32_t boot_device;
+
+  /* Kernel command line */
+  multiboot_uint32_t cmdline;
+
+  /* Boot-Module list */
+  multiboot_uint32_t mods_count;
+  multiboot_uint32_t mods_addr;
+
+  union {
+    multiboot_aout_symbol_table_t aout_sym;
+    multiboot_elf_section_header_table_t elf_sec;
+  } u;
+
+  /* Memory Mapping buffer */
+  multiboot_uint32_t mmap_length;
+  multiboot_uint32_t mmap_addr;
+
+  /* Drive Info buffer */
+  multiboot_uint32_t drives_length;
+  multiboot_uint32_t drives_addr;
+
+  /* ROM configuration table */
+  multiboot_uint32_t config_table;
+
+  /* Boot Loader Name */
+  multiboot_uint32_t boot_loader_name;
+
+  /* APM table */
+  multiboot_uint32_t apm_table;
+
+  /* Video */
+  multiboot_uint32_t vbe_control_info;
+  multiboot_uint32_t vbe_mode_info;
+  multiboot_uint16_t vbe_mode;
+  multiboot_uint16_t vbe_interface_seg;
+  multiboot_uint16_t vbe_interface_off;
+  multiboot_uint16_t vbe_interface_len;
+
+  multiboot_uint64_t framebuffer_addr;
+  multiboot_uint32_t framebuffer_pitch;
+  multiboot_uint32_t framebuffer_width;
+  multiboot_uint32_t framebuffer_height;
+  multiboot_uint8_t framebuffer_bpp;
+#define MULTIBOOT_FRAMEBUFFER_TYPE_INDEXED 0
+#define MULTIBOOT_FRAMEBUFFER_TYPE_RGB 1
+#define MULTIBOOT_FRAMEBUFFER_TYPE_EGA_TEXT 2
+  multiboot_uint8_t framebuffer_type;
+  union {
+    struct {
+      multiboot_uint32_t framebuffer_palette_addr;
+      multiboot_uint16_t framebuffer_palette_num_colors;
+    };
+    struct {
+      multiboot_uint8_t framebuffer_red_field_position;
+      multiboot_uint8_t framebuffer_red_mask_size;
+      multiboot_uint8_t framebuffer_green_field_position;
+      multiboot_uint8_t framebuffer_green_mask_size;
+      multiboot_uint8_t framebuffer_blue_field_position;
+      multiboot_uint8_t framebuffer_blue_mask_size;
+    };
+  };
+};
+typedef struct multiboot_info multiboot_info_t;
+
+struct multiboot_color {
+  multiboot_uint8_t red;
+  multiboot_uint8_t green;
+  multiboot_uint8_t blue;
+};
+
+struct multiboot_mmap_entry {
+  multiboot_uint32_t size;
+  multiboot_uint64_t addr;
+  multiboot_uint64_t len;
+#define MULTIBOOT_MEMORY_AVAILABLE 1
+#define MULTIBOOT_MEMORY_RESERVED 2
+#define MULTIBOOT_MEMORY_ACPI_RECLAIMABLE 3
+#define MULTIBOOT_MEMORY_NVS 4
+#define MULTIBOOT_MEMORY_BADRAM 5
+  multiboot_uint32_t type;
+} __attribute__((packed));
+typedef struct multiboot_mmap_entry multiboot_memory_map_t;
+
+struct multiboot_mod_list {
+  /* the memory used goes from bytes 'mod_start' to 'mod_end-1' inclusive */
+  multiboot_uint32_t mod_start;
+  multiboot_uint32_t mod_end;
+
+  /* Module command line */
+  multiboot_uint32_t cmdline;
+
+  /* padding to take it to 16 bytes (must be zero) */
+  multiboot_uint32_t pad;
+};
+typedef struct multiboot_mod_list multiboot_module_t;
+
+/* APM BIOS info.  */
+struct multiboot_apm_info {
+  multiboot_uint16_t version;
+  multiboot_uint16_t cseg;
+  multiboot_uint32_t offset;
+  multiboot_uint16_t cseg_16;
+  multiboot_uint16_t dseg;
+  multiboot_uint16_t flags;
+  multiboot_uint16_t cseg_len;
+  multiboot_uint16_t cseg_16_len;
+  multiboot_uint16_t dseg_len;
+};
+
+#endif /* ! ASM_FILE */
+
+#endif /* ! MULTIBOOT_HEADER */

--- a/third_party/rust-hypervisor-firmware-boot/Cargo.toml
+++ b/third_party/rust-hypervisor-firmware-boot/Cargo.toml
@@ -3,6 +3,10 @@ name = "rust-hypervisor-firmware-boot"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+pvh = []
+default = ["pvh"]
+
 [dependencies]
 bitflags = "*"
 log = "*"

--- a/third_party/rust-hypervisor-firmware-boot/layout.ld
+++ b/third_party/rust-hypervisor-firmware-boot/layout.ld
@@ -19,7 +19,10 @@ SECTIONS
   /* These sections are mapped into RAM from the file. Omitting :ram from
      later sections avoids emitting empty sections in the final binary.       */
   data_start = .;
-  .rodata : { *(.rodata .rodata.*) } :ram
+  .rodata : {
+    KEEP(*(.multiboot_header .multiboot_header.*))
+    *(.rodata .rodata.*)
+  } :ram
   . = ALIGN(4K);
   text_start = .;
   .text   : { *(.text .text.*)     }

--- a/third_party/rust-hypervisor-firmware-boot/src/asm/ram32.s
+++ b/third_party/rust-hypervisor-firmware-boot/src/asm/ram32.s
@@ -3,8 +3,10 @@
 .code32
 
 ram32_start:
-    # Stash the PVH start_info struct in %rdi.
+    # Stash the boot metadata struct in %rdi.
     movl %ebx, %edi
+    # If present, the multiboot magic is in %eax; move it to %esi.
+    movl %eax, %esi
 
 setup_page_tables:
     # First L3 entry identity maps [0, 1 GiB)

--- a/third_party/rust-hypervisor-firmware-boot/src/lib.rs
+++ b/third_party/rust-hypervisor-firmware-boot/src/lib.rs
@@ -14,6 +14,8 @@ mod asm;
 pub mod common;
 mod gdt;
 pub mod paging;
+
+#[cfg(feature = "pvh")]
 pub mod pvh;
 
 extern "C" {


### PR DESCRIPTION
Highly experimental, but I've added multiboot1 support as that's what... a certain VMM nominally supports natively.

As it stands, it's untestable in our current framework as Qemu refuses to boot ELF64 binaries which have a multiboot header (as multiboot is nominally a 32-bit only protocol). You have to recompile qemu if you want to remove that check; if you do, the code seems to work. But I don't really want to build a patched qemu in our container.

However, as it stands, it _should_ be enough to test whether (claimed) multiboot1 support works or not in that other VMM, so I'm inclined to merge it even with the known large caveats.

I've left it as an optional feature, off by default, as otherwise qemu will try using multiboot (and fail because we're a 64-bit binary) before even trying to boot with PVH.

(Technically, PVH is also a 32-bit protocol, so qemu should reject ELF64 binaries here as well... but let's not ask too many questions here.)