### PR TITLE
Fix `cargo deny` issue related to `chrono` and `time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
  "num-traits 0.2.15",
  "rusticata-macros",
  "thiserror",
- "time 0.3.9",
+ "time",
 ]
 
 [[package]]
@@ -660,7 +660,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.15",
- "time 0.1.43",
  "winapi",
 ]
 
@@ -2346,7 +2345,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
- "time 0.3.9",
+ "time",
 ]
 
 [[package]]
@@ -2372,7 +2371,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "regex",
- "time 0.3.9",
+ "time",
  "unicode-segmentation",
 ]
 
@@ -4974,16 +4973,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
@@ -6531,7 +6520,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.9",
+ "time",
 ]
 
 [[package]]

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -15,7 +15,10 @@ async-stream = "*"
 bincode = "*"
 bytes = "*"
 byteorder = { version = "*", default-features = false }
-chrono = "*"
+chrono = { version = "*", default-features = false, features = [
+  "std",
+  "clock"
+] }
 clap = { version = "*", features = ["derive"] }
 futures = "*"
 grpc_unary_attestation = { path = "../../grpc_unary_attestation/" }

--- a/oak_functions/loader/fuzz/Cargo.lock
+++ b/oak_functions/loader/fuzz/Cargo.lock
@@ -146,7 +146,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
@@ -1384,16 +1383,6 @@ name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "tinyvec"

--- a/oak_functions/testing/Cargo.toml
+++ b/oak_functions/testing/Cargo.toml
@@ -8,7 +8,10 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "*"
 bincode = "*"
-chrono = "*"
+chrono = { version = "*", default-features = false, features = [
+  "std",
+  "clock"
+] }
 oak_logger = { path = "../logger" }
 oak_functions_abi = { path = "../abi" }
 oak_functions_extension = { path = "../extension" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,7 +9,10 @@ license = "Apache-2.0"
 async-recursion = "*"
 async-trait = "*"
 cargo_metadata = "*"
-chrono = "*"
+chrono = { version = "*", default-features = false, features = [
+  "std",
+  "clock"
+] }
 clap = { version = "*", features = ["derive"] }
 clap_complete = "*"
 colored = "*"


### PR DESCRIPTION
`chrono` includes an old version of `time` by default, which is affected by  https://rustsec.org/advisories/RUSTSEC-2020-0071.

We don't seem to need the `oldtime` feature; therefore, let's disable it.