### PR TITLE
Wrap virtqueue indices

### DIFF
--- a/experimental/virtio/src/queue/mod.rs
+++ b/experimental/virtio/src/queue/mod.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+use core::num::Wrapping;
+
 use alloc::{boxed::Box, collections::vec_deque::VecDeque, vec, vec::Vec};
 use virtq::{AvailRing, Desc, DescFlags, RingFlags, UsedElem, UsedRing, VirtQueue};
 
@@ -153,7 +155,7 @@ pub struct Queue<const QUEUE_SIZE: usize, const BUFFER_SIZE: usize> {
     base_offset: u64,
 
     /// The last index that was used when popping elements from the used ring.
-    last_used_idx: u16,
+    last_used_idx: Wrapping<u16>,
 }
 
 impl<const QUEUE_SIZE: usize, const BUFFER_SIZE: usize> Queue<QUEUE_SIZE, BUFFER_SIZE> {
@@ -186,7 +188,7 @@ impl<const QUEUE_SIZE: usize, const BUFFER_SIZE: usize> Queue<QUEUE_SIZE, BUFFER
             virt_queue,
             buffer,
             base_offset,
-            last_used_idx: 0,
+            last_used_idx: Wrapping(0),
         }
     }
 
@@ -231,16 +233,16 @@ impl<const QUEUE_SIZE: usize, const BUFFER_SIZE: usize> Queue<QUEUE_SIZE, BUFFER
             None
         } else {
             self.last_used_idx += 1;
-            Some(self.virt_queue.used.ring[next_used as usize % QUEUE_SIZE])
+            Some(self.virt_queue.used.ring[next_used.0 as usize % QUEUE_SIZE])
         }
     }
 
     /// Adds a descriptor to the available ring.
     fn add_available_descriptor(&mut self, index: u16) {
         // Add the descriptor index to the available ring at the next location.
-        self.virt_queue.avail.ring[self.virt_queue.avail.idx as usize % QUEUE_SIZE] = index;
+        self.virt_queue.avail.ring[self.virt_queue.avail.idx.0 as usize % QUEUE_SIZE] = index;
         // Increment the available ring index to use next time.
-        let next = self.virt_queue.avail.idx + 1;
+        let next = self.virt_queue.avail.idx + Wrapping(1);
         let idx = &mut self.virt_queue.avail.idx;
         // Memory fence to ensure the device will not see the index update before the available ring
         // entry update.

--- a/experimental/virtio/src/queue/mod.rs
+++ b/experimental/virtio/src/queue/mod.rs
@@ -14,9 +14,8 @@
 // limitations under the License.
 //
 
-use core::num::Wrapping;
-
 use alloc::{boxed::Box, collections::vec_deque::VecDeque, vec, vec::Vec};
+use core::num::Wrapping;
 use virtq::{AvailRing, Desc, DescFlags, RingFlags, UsedElem, UsedRing, VirtQueue};
 
 mod virtq;

--- a/experimental/virtio/src/queue/virtq.rs
+++ b/experimental/virtio/src/queue/virtq.rs
@@ -15,6 +15,7 @@
 //
 
 use bitflags::bitflags;
+use core::num::Wrapping;
 
 bitflags! {
     /// Flags about a descriptor.
@@ -92,8 +93,9 @@ pub struct AvailRing<const QUEUE_SIZE: usize> {
     pub flags: RingFlags,
     /// The next index that will be used in the ring (modulo `QUEUE_SIZE`).
     ///
-    /// Starts at 0 and always increments. Must never be decremented.
-    pub idx: u16,
+    /// Starts at 0 and always increments. Must never be decremented. Wraps naturally when at the
+    /// maximum `u16` value.
+    pub idx: Wrapping<u16>,
     /// The ring-buffer containing indices of the heads of available descriptor chains.
     pub ring: [u16; QUEUE_SIZE],
 }
@@ -103,7 +105,7 @@ impl<const QUEUE_SIZE: usize> Default for AvailRing<QUEUE_SIZE> {
         Self {
             // We implement all drivers via polling, so don't want notifications.
             flags: RingFlags::NO_NOTIFY,
-            idx: 0,
+            idx: Wrapping(0),
             ring: [0; QUEUE_SIZE],
         }
     }
@@ -118,8 +120,9 @@ pub struct UsedRing<const QUEUE_SIZE: usize> {
     pub flags: RingFlags,
     /// The next index that will be used in the ring (modulo `QUEUE_SIZE`).
     ///
-    /// Starts at 0 and always increments. Must never be decremented.
-    pub idx: u16,
+    /// Starts at 0 and always increments. Must never be decremented. Wraps naturally when at the
+    /// maximum `u16` value.
+    pub idx: Wrapping<u16>,
     /// The ring-buffer containing the used elements.
     pub ring: [UsedElem; QUEUE_SIZE],
 }
@@ -128,7 +131,7 @@ impl<const QUEUE_SIZE: usize> Default for UsedRing<QUEUE_SIZE> {
     fn default() -> Self {
         Self {
             flags: RingFlags::empty(),
-            idx: 0,
+            idx: Wrapping(0),
             ring: [(); QUEUE_SIZE].map(|_| UsedElem::default()),
         }
     }


### PR DESCRIPTION
Use wrapping values for virtqueue ring indices to ensure the queue keeps operating once the max value has been reached.