### PR TITLE
oak_idl: Allow service implementations to mutate themselves

### DIFF
--- a/oak_idl_gen_services/src/lib.rs
+++ b/oak_idl_gen_services/src/lib.rs
@@ -285,7 +285,7 @@ fn generate_service_method(rpc_call: &RPCCall) -> Vec<String> {
     // implementation of this method, therefore needs to be wrapped in `oak_idl::Message` in order
     // to transfer its ownership to the caller.
     vec![format!(
-        "    fn {}(&self, request: &{}) -> Result<oak_idl::utils::Message<{}>, oak_idl::Error>;",
+        "    fn {}(&mut self, request: &{}) -> Result<oak_idl::utils::Message<{}>, oak_idl::Error>;",
         method_name(rpc_call),
         request_type(rpc_call),
         response_type(rpc_call)

--- a/oak_idl_tests/test_schema_services.rs.txt
+++ b/oak_idl_tests/test_schema_services.rs.txt
@@ -58,8 +58,8 @@ impl <S: TestService> oak_idl::Handler for TestServiceServer<S> {
 }
 
 pub trait TestService: Sized {
-    fn lookup_data(&self, request: &LookupDataRequest) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::Error>;
-    fn log(&self, request: &LogRequest) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::Error>;
+    fn lookup_data(&mut self, request: &LookupDataRequest) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::Error>;
+    fn log(&mut self, request: &LogRequest) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::Error>;
     fn serve(self) -> TestServiceServer<Self> {
         TestServiceServer { service : self }
     }

--- a/oak_idl_tests/tests/test_schema.rs
+++ b/oak_idl_tests/tests/test_schema.rs
@@ -29,7 +29,7 @@ struct TestServiceImpl;
 /// An implementation of the [`test_schema::TestService`] service trait for testing.
 impl test_schema::TestService for TestServiceImpl {
     fn lookup_data(
-        &self,
+        &mut self,
         request: &test_schema::LookupDataRequest,
     ) -> Result<oak_idl::utils::Message<test_schema::LookupDataResponse>, oak_idl::Error> {
         let h = maplit::hashmap! {
@@ -48,7 +48,7 @@ impl test_schema::TestService for TestServiceImpl {
     }
 
     fn log(
-        &self,
+        &mut self,
         request: &test_schema::LogRequest,
     ) -> Result<oak_idl::utils::Message<test_schema::LogResponse>, oak_idl::Error> {
         eprintln!("log: {}", request.entry().unwrap());


### PR DESCRIPTION
Needed to implement remote attestation handling