### PR TITLE
Add tests for virtio devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,6 +2227,7 @@ dependencies = [
  "oak_remote_attestation",
  "runtime",
  "rust-hypervisor-firmware-boot",
+ "rust-hypervisor-firmware-virtio",
  "strum",
  "uart_16550",
  "virtio",

--- a/experimental/uefi/baremetal-crosvm/Cargo.lock
+++ b/experimental/uefi/baremetal-crosvm/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "oak_remote_attestation",
  "runtime",
  "rust-hypervisor-firmware-boot",
+ "rust-hypervisor-firmware-virtio",
  "strum",
  "uart_16550",
  "virtio",

--- a/experimental/uefi/baremetal/Cargo.lock
+++ b/experimental/uefi/baremetal/Cargo.lock
@@ -589,6 +589,7 @@ dependencies = [
  "oak_remote_attestation",
  "runtime",
  "rust-hypervisor-firmware-boot",
+ "rust-hypervisor-firmware-virtio",
  "strum",
  "uart_16550",
  "virtio",

--- a/experimental/uefi/kernel/Cargo.toml
+++ b/experimental/uefi/kernel/Cargo.toml
@@ -25,6 +25,7 @@ runtime = { path = "../runtime", default-features = false, features = [
   "rust-crypto"
 ] }
 rust-hypervisor-firmware-boot = { path = "../../../third_party/rust-hypervisor-firmware-boot" }
+rust-hypervisor-firmware-virtio = { path = "../../../third_party/rust-hypervisor-firmware-virtio" }
 strum = { version = "*", default-features = false, features = ["derive"] }
 uart_16550 = "*"
 virtio = { path = "../../virtio" }

--- a/experimental/uefi/kernel/src/lib.rs
+++ b/experimental/uefi/kernel/src/lib.rs
@@ -45,6 +45,7 @@ use oak_remote_attestation::handshaker::{
     AttestationBehavior, EmptyAttestationGenerator, EmptyAttestationVerifier,
 };
 use rust_hypervisor_firmware_boot::paging;
+use rust_hypervisor_firmware_virtio::pci::VirtioPciTransport;
 
 #[cfg(feature = "vsock_channel")]
 // The virtio vsock port on which to listen.
@@ -70,7 +71,7 @@ fn main<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
 
 // Use a virtio console device for the communications channel if we don't support virtio vsock.
 #[cfg(not(feature = "vsock_channel"))]
-fn get_channel() -> virtio::console::Console {
+fn get_channel() -> virtio::console::Console<VirtioPciTransport> {
     let console = virtio::console::Console::find_and_configure_device()
         .expect("Couldn't configure PCI virtio console device.");
     info!("Console device status: {}", console.get_status());
@@ -79,7 +80,7 @@ fn get_channel() -> virtio::console::Console {
 
 // Use virtio vsock for the communications channel.
 #[cfg(feature = "vsock_channel")]
-fn get_channel() -> virtio::vsock::socket::Socket {
+fn get_channel() -> virtio::vsock::socket::Socket<VirtioPciTransport> {
     let vsock = virtio::vsock::VSock::find_and_configure_device()
         .expect("Couldn't configure PCI virtio vsock device.");
     info!("Socket device status: {}", vsock.get_status());

--- a/experimental/virtio/src/console/tests.rs
+++ b/experimental/virtio/src/console/tests.rs
@@ -15,7 +15,10 @@
 //
 
 use super::*;
-use crate::test::{DeviceStatus, TestingTransport, VIRTIO_F_VERSION_1};
+use crate::test::{
+    new_legacy_transport, new_transport_small_queue, new_valid_transport, DeviceStatus,
+    VIRTIO_F_VERSION_1,
+};
 use alloc::{vec, vec::Vec};
 use ciborium_io::{Read, Write};
 
@@ -125,31 +128,4 @@ fn test_write_all() {
         .unwrap();
     assert_eq!(&data[..DATA_BUFFER_SIZE], &first[..]);
     assert_eq!(&data[DATA_BUFFER_SIZE..], &second[..]);
-}
-
-fn new_valid_transport() -> TestingTransport {
-    let transport = TestingTransport::default();
-    {
-        let mut config = transport.config.lock().unwrap();
-        config.features = VIRTIO_F_VERSION_1;
-        config.max_queue_size = 256;
-    }
-
-    transport
-}
-
-fn new_legacy_transport() -> TestingTransport {
-    let transport = TestingTransport::default();
-    transport.config.lock().unwrap().max_queue_size = 256;
-    transport
-}
-
-fn new_transport_small_queue() -> TestingTransport {
-    let transport = TestingTransport::default();
-    {
-        let mut config = transport.config.lock().unwrap();
-        config.features = VIRTIO_F_VERSION_1;
-        config.max_queue_size = 8;
-    }
-    transport
 }

--- a/experimental/virtio/src/console/tests.rs
+++ b/experimental/virtio/src/console/tests.rs
@@ -14,21 +14,4 @@
 // limitations under the License.
 //
 
-//! Simple virtio drivers implemented based on polling.
-//!
-//! This crate assumes that an identity mapping is used in page tables, so that guest-virtual and
-//! guest-physical addresses are the same.
-
-#![no_std]
-#![feature(let_chains)]
-
-extern crate alloc;
-
-pub mod console;
-pub mod queue;
-#[cfg(test)]
-mod test;
-pub mod vsock;
-
-/// The vendor ID for virtio PCI devices.
-const PCI_VENDOR_ID: u16 = 0x1AF4;
+use super::*;

--- a/experimental/virtio/src/console/tests.rs
+++ b/experimental/virtio/src/console/tests.rs
@@ -15,3 +15,104 @@
 //
 
 use super::*;
+use crate::test::{DeviceStatus, TestingTransport, VIRTIO_F_VERSION_1};
+use alloc::{vec, vec::Vec};
+
+#[test]
+fn test_legacy_device_not_supported() {
+    let device = VirtioBaseDevice::new(new_legacy_transport());
+    let mut console = Console::new(device);
+    assert!(console.init().is_err());
+}
+
+#[test]
+fn test_max_queue_size_too_small() {
+    let device = VirtioBaseDevice::new(new_transport_small_queue());
+    let mut console = Console::new(device);
+    assert!(console.init().is_err());
+}
+
+#[test]
+fn test_device_init() {
+    let transport = new_valid_transport();
+    let config = transport.config.clone();
+    let device = VirtioBaseDevice::new(transport);
+    let mut console = Console::new(device);
+    let result = console.init();
+    assert!(result.is_ok());
+
+    let config = config.lock().unwrap();
+    assert!(config.features == VIRTIO_F_VERSION_1);
+    let status = DeviceStatus::from_bits(config.status).unwrap();
+    assert!(status.contains(DeviceStatus::VIRTIO_STATUS_ACKNOWLEDGE));
+    assert!(status.contains(DeviceStatus::VIRTIO_STATUS_DRIVER));
+    assert!(status.contains(DeviceStatus::VIRTIO_STATUS_DRIVER_OK));
+    assert!(status.contains(DeviceStatus::VIRTIO_STATUS_FEATURES_OK));
+    assert!(!status.contains(DeviceStatus::VIRTIO_STATUS_FAILED));
+
+    let queues = &config.queues;
+    assert_eq!(queues.len(), 2);
+    for i in 0..2 {
+        let queue = queues.get(&i).unwrap();
+        assert!(queue.enabled);
+        assert_eq!(queue.queue_size as usize, QUEUE_SIZE);
+        assert!(queue.descriptor_address > 0);
+        assert!(queue.avail_ring > 0);
+        assert!(queue.used_ring > 0);
+    }
+}
+
+#[test]
+fn test_read_bytes() {
+    let data = vec![2, 4, 6];
+    let transport = new_valid_transport();
+    let device = VirtioBaseDevice::new(transport.clone());
+    let mut console = Console::new(device);
+    console.init().unwrap();
+    transport.device_write_to_queue::<QUEUE_SIZE>(0, &data[..]);
+    let bytes = console.read_bytes().unwrap();
+    let bytes: Vec<u8> = bytes.into_iter().collect();
+    assert_eq!(data, bytes);
+}
+
+#[test]
+fn test_write_bytes() {
+    let data = vec![7; 5];
+    let transport = new_valid_transport();
+    let device = VirtioBaseDevice::new(transport.clone());
+    let mut console = Console::new(device);
+    console.init().unwrap();
+    let len = console.write_bytes(&data[..]).unwrap();
+    assert_eq!(len, 5);
+    let bytes = transport
+        .device_read_once_from_queue::<QUEUE_SIZE>(1)
+        .unwrap();
+    assert_eq!(data, bytes);
+}
+
+fn new_valid_transport() -> TestingTransport {
+    let transport = TestingTransport::default();
+    {
+        let mut config = transport.config.lock().unwrap();
+        config.features = VIRTIO_F_VERSION_1;
+        config.max_queue_size = 256;
+    }
+
+    transport
+}
+
+fn new_legacy_transport() -> TestingTransport {
+    let transport = TestingTransport::default();
+    transport.config.lock().unwrap().max_queue_size = 256;
+    transport
+}
+
+fn new_transport_small_queue() -> TestingTransport {
+    let transport = TestingTransport::default();
+    {
+        let mut config = transport.config.lock().unwrap();
+        config.features = VIRTIO_F_VERSION_1;
+        config.max_queue_size = 8;
+    }
+    transport
+}

--- a/experimental/virtio/src/lib.rs
+++ b/experimental/virtio/src/lib.rs
@@ -23,6 +23,8 @@
 #![feature(let_chains)]
 
 extern crate alloc;
+#[cfg(test)]
+extern crate std;
 
 pub mod console;
 pub mod queue;

--- a/experimental/virtio/src/queue/mod.rs
+++ b/experimental/virtio/src/queue/mod.rs
@@ -18,7 +18,7 @@ use alloc::{boxed::Box, collections::vec_deque::VecDeque, vec, vec::Vec};
 use core::num::Wrapping;
 use virtq::{AvailRing, Desc, DescFlags, RingFlags, UsedElem, UsedRing, VirtQueue};
 
-mod virtq;
+pub mod virtq;
 
 /// A queue where the descriptor buffers are only writable by the driver.
 ///

--- a/experimental/virtio/src/test.rs
+++ b/experimental/virtio/src/test.rs
@@ -1,0 +1,214 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::queue::virtq::{AvailRing, Desc, DescFlags, UsedElem, UsedRing};
+use alloc::{collections::BTreeMap, vec::Vec};
+use core::{
+    cell::{Cell, RefCell},
+    mem::size_of,
+};
+use rust_hypervisor_firmware_virtio::virtio::{Error, VirtioTransport};
+
+/// A transport implementation that can be used for testing virtio device implementations.
+///
+/// Warning: we purposely use unsafe code to simulate the way the the device/VMM will interact with
+/// the memory. Tests must ensure that valid memory and offset values are provided to avoid memory
+/// safety issues.
+#[derive(Default, Debug)]
+pub struct TestingTransport {
+    pub status: Cell<u32>,
+    pub features: Cell<u64>,
+    pub queue_num: Cell<u16>,
+    pub max_queue_size: u16,
+    pub queues: RefCell<BTreeMap<u16, QueueInfo>>,
+    pub config: RefCell<BTreeMap<u64, u32>>,
+}
+
+#[derive(Default, Debug)]
+pub struct QueueInfo {
+    pub queue_size: u16,
+    pub descriptor_address: u64,
+    pub avail_ring: u64,
+    pub used_ring: u64,
+    pub enabled: bool,
+    pub notified: bool,
+}
+
+impl TestingTransport {
+    fn get_desc<const QUEUE_SIZE: usize>(&self, queue_num: u16, index: u16) -> &mut Desc {
+        assert!((index as usize) < QUEUE_SIZE);
+        let queue_info = self.queues.borrow().get(&queue_num).unwrap();
+        let address = queue_info.descriptor_address as usize + index as usize * size_of::<Desc>();
+        unsafe { &mut *(address as *mut Desc) }
+    }
+
+    fn get_avail_ring<const QUEUE_SIZE: usize>(&self, queue_num: u16) -> &AvailRing<QUEUE_SIZE> {
+        let queue_info = self.queues.borrow().get(&queue_num).unwrap();
+        let address = queue_info.avail_ring as usize;
+        unsafe { &*(address as *mut AvailRing<QUEUE_SIZE>) }
+    }
+
+    fn get_used_ring<const QUEUE_SIZE: usize>(&self, queue_num: u16) -> &mut UsedRing<QUEUE_SIZE> {
+        let queue_info = self.queues.borrow().get(&queue_num).unwrap();
+        let address = queue_info.used_ring as usize;
+        unsafe { &mut *(address as *mut UsedRing<QUEUE_SIZE>) }
+    }
+
+    pub fn device_read_once_from_queue<const QUEUE_SIZE: usize>(
+        &self,
+        queue_num: u16,
+    ) -> Option<Vec<u8>> {
+        let avail = self.get_avail_ring::<QUEUE_SIZE>(queue_num);
+        let mut used = self.get_used_ring::<QUEUE_SIZE>(queue_num);
+        if avail.idx == used.idx {
+            return None;
+        }
+
+        let ring_index = used.idx.0 as usize % QUEUE_SIZE;
+        let index = avail.ring[ring_index];
+        let desc = self.get_desc::<QUEUE_SIZE>(queue_num, index);
+
+        assert!(!desc.flags.contains(DescFlags::VIRTQ_DESC_F_WRITE));
+        let used_elem = &mut used.ring[ring_index];
+        used_elem.id = index as u32;
+        used_elem.len = 0;
+        used.idx += 1;
+        let buffer = unsafe {
+            let ptr = desc.addr as usize as *const u8;
+            let len = desc.length as usize;
+            alloc::slice::from_raw_parts(ptr, len)
+        };
+        Some(buffer.to_vec())
+    }
+
+    pub fn device_write_to_queue<const QUEUE_SIZE: usize>(
+        &self,
+        queue_num: u16,
+        data: &[u8],
+    ) -> Option<usize> {
+        let avail = self.get_avail_ring::<QUEUE_SIZE>(queue_num);
+        let used = self.get_used_ring::<QUEUE_SIZE>(queue_num);
+        if avail.idx == used.idx {
+            return None;
+        }
+
+        let ring_index = used.idx.0 as usize % QUEUE_SIZE;
+        let index = avail.ring[ring_index];
+        let desc = self.get_desc::<QUEUE_SIZE>(queue_num, index);
+        let len = core::cmp::min(data.len(), desc.length as usize);
+        assert!(desc.flags.contains(DescFlags::VIRTQ_DESC_F_WRITE));
+        let used_elem = &mut used.ring[ring_index];
+        used_elem.id = index as u32;
+        used_elem.len = 0;
+        used.idx += 1;
+        let buffer = unsafe {
+            let ptr = desc.addr as usize as *mut u8;
+            alloc::slice::from_raw_parts_mut(ptr, len)
+        };
+        buffer.copy_from_slice(data);
+        Some(len)
+    }
+}
+
+impl VirtioTransport for TestingTransport {
+    fn init(&mut self, _device_type: u32) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn get_status(&self) -> u32 {
+        self.status.get()
+    }
+
+    fn set_status(&self, status: u32) {
+        self.status.set(status);
+    }
+
+    fn add_status(&self, status: u32) {
+        self.status.set(self.status.get() | status);
+    }
+
+    fn reset(&self) {
+        self.status.set(0);
+    }
+
+    fn get_features(&self) -> u64 {
+        self.features.get()
+    }
+
+    fn set_features(&self, features: u64) {
+        self.features.set(features);
+    }
+
+    fn set_queue(&self, queue: u16) {
+        if !self.queues.borrow().contains_key(&queue) {
+            self.queues.borrow_mut().insert(queue, QueueInfo::default());
+        }
+        self.queue_num.set(queue);
+    }
+
+    fn get_queue_max_size(&self) -> u16 {
+        self.max_queue_size
+    }
+
+    fn set_queue_size(&self, queue_size: u16) {
+        assert!(queue_size <= self.max_queue_size);
+        self.queues
+            .borrow_mut()
+            .get_mut(&self.queue_num.get())
+            .unwrap()
+            .queue_size = queue_size;
+    }
+
+    fn set_descriptors_address(&self, address: u64) {
+        self.queues
+            .borrow_mut()
+            .get_mut(&self.queue_num.get())
+            .unwrap()
+            .descriptor_address = address;
+    }
+
+    fn set_avail_ring(&self, address: u64) {
+        self.queues
+            .borrow_mut()
+            .get_mut(&self.queue_num.get())
+            .unwrap()
+            .avail_ring = address;
+    }
+
+    fn set_used_ring(&self, address: u64) {
+        self.queues
+            .borrow_mut()
+            .get_mut(&self.queue_num.get())
+            .unwrap()
+            .used_ring = address;
+    }
+
+    fn set_queue_enable(&self) {
+        self.queues
+            .borrow_mut()
+            .get_mut(&self.queue_num.get())
+            .unwrap()
+            .enabled = true;
+    }
+
+    fn notify_queue(&self, queue: u16) {
+        self.queues.borrow_mut().get_mut(&queue).unwrap().notified = true;
+    }
+
+    fn read_device_config(&self, offset: u64) -> u32 {
+        *self.config.borrow_mut().get(&offset).unwrap()
+    }
+}

--- a/experimental/virtio/src/test.rs
+++ b/experimental/virtio/src/test.rs
@@ -17,10 +17,7 @@
 use crate::queue::virtq::{AvailRing, Desc, DescFlags, UsedRing};
 use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 use bitflags::bitflags;
-use core::{
-    cell::{Cell, RefCell},
-    mem::size_of,
-};
+use core::mem::size_of;
 use rust_hypervisor_firmware_virtio::virtio::{Error, VirtioTransport};
 use std::sync::Mutex;
 

--- a/experimental/virtio/src/test.rs
+++ b/experimental/virtio/src/test.rs
@@ -254,6 +254,7 @@ impl VirtioTransport for TestingTransport {
     }
 }
 
+/// Creates a new valid transport that is suitable for a basic device without configuration values.
 pub fn new_valid_transport() -> TestingTransport {
     let transport = TestingTransport::default();
     {
@@ -264,12 +265,14 @@ pub fn new_valid_transport() -> TestingTransport {
     transport
 }
 
+/// Creates a transport that only supports a legacy version of the virtio spec.
 pub fn new_legacy_transport() -> TestingTransport {
     let transport = new_valid_transport();
     transport.set_features(0);
     transport
 }
 
+/// Creates a transport where the queue is too small.
 pub fn new_transport_small_queue() -> TestingTransport {
     let transport = new_valid_transport();
     transport.config.lock().unwrap().max_queue_size = 8;

--- a/experimental/virtio/src/vsock/socket/tests.rs
+++ b/experimental/virtio/src/vsock/socket/tests.rs
@@ -14,21 +14,4 @@
 // limitations under the License.
 //
 
-//! Simple virtio drivers implemented based on polling.
-//!
-//! This crate assumes that an identity mapping is used in page tables, so that guest-virtual and
-//! guest-physical addresses are the same.
-
-#![no_std]
-#![feature(let_chains)]
-
-extern crate alloc;
-
-pub mod console;
-pub mod queue;
-#[cfg(test)]
-mod test;
-pub mod vsock;
-
-/// The vendor ID for virtio PCI devices.
-const PCI_VENDOR_ID: u16 = 0x1AF4;
+use super::*;

--- a/experimental/virtio/src/vsock/socket/tests.rs
+++ b/experimental/virtio/src/vsock/socket/tests.rs
@@ -15,3 +15,164 @@
 //
 
 use super::*;
+use crate::{
+    test::{TestingTransport, VIRTIO_F_VERSION_1},
+    vsock::HOST_CID,
+};
+use alloc::vec;
+use ciborium_io::{Read, Write};
+use rust_hypervisor_firmware_virtio::device::VirtioBaseDevice;
+
+const GUEST_CID: u64 = 3;
+const HOST_PORT: u32 = 1111;
+const GUEST_PORT: u32 = 2222;
+
+#[test]
+fn test_socket_accept() {
+    let (vsock, transport) = new_vsock_and_transport();
+    let mut packet = Packet::new_control(HOST_PORT, GUEST_PORT, VSockOp::Request).unwrap();
+    set_packet_cids_host_to_guest(&mut packet);
+    transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
+    let listener = SocketListener::new(vsock, GUEST_PORT);
+    let socket = listener.accept().unwrap();
+    assert_eq!(socket.connection_state, ConnectionState::Connected);
+    let response = Packet::new(
+        transport
+            .device_read_once_from_queue::<QUEUE_SIZE>(1)
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(response.get_op().unwrap(), VSockOp::Response);
+}
+
+#[test]
+fn test_socket_accept_invalid() {
+    let (vsock, transport) = new_vsock_and_transport();
+    let mut packet = Packet::new_control(HOST_PORT, GUEST_PORT, VSockOp::Response).unwrap();
+    set_packet_cids_host_to_guest(&mut packet);
+    transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
+    let listener = SocketListener::new(vsock, GUEST_PORT);
+    assert!(listener.accept().is_err());
+}
+
+#[test]
+fn test_socket_connect() {
+    let (vsock, transport) = new_vsock_and_transport();
+    let connector = SocketConnector::new(vsock, HOST_PORT, GUEST_PORT);
+    let mut packet = Packet::new_control(HOST_PORT, GUEST_PORT, VSockOp::Response).unwrap();
+    set_packet_cids_host_to_guest(&mut packet);
+
+    // Send the reesponse beforehand because the connector blocks.
+    transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
+    let socket = connector.connect().unwrap();
+    assert_eq!(socket.connection_state, ConnectionState::Connected);
+
+    // Read the original request from the queue and validate.
+    let request = Packet::new(
+        transport
+            .device_read_once_from_queue::<QUEUE_SIZE>(1)
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(request.get_op().unwrap(), VSockOp::Request);
+}
+
+#[test]
+fn test_socket_connect_invalid() {
+    let (vsock, transport) = new_vsock_and_transport();
+    let connector = SocketConnector::new(vsock, HOST_PORT, GUEST_PORT);
+    let mut packet = Packet::new_control(HOST_PORT, GUEST_PORT, VSockOp::Request).unwrap();
+    set_packet_cids_host_to_guest(&mut packet);
+    // Send the reesponse beforehand because the connector blocks.
+    transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
+    assert!(connector.connect().is_err());
+}
+
+#[test]
+fn test_read_exact() {
+    let data = vec![3; 17];
+    let mut packet = Packet::new_data(&data[..], HOST_PORT, GUEST_PORT).unwrap();
+    set_packet_cids_host_to_guest(&mut packet);
+    let mut first = vec![0; 11];
+    let mut second = vec![0; 2];
+    let (mut socket, transport) = new_socket_and_transport();
+    transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
+    assert!(socket.read_exact(&mut first).is_ok());
+    assert!(socket.read_exact(&mut second).is_ok());
+    assert_eq!(&data[..11], &first[..]);
+    assert_eq!(&data[11..13], &second[..]);
+    assert!(socket.pending_data.is_some());
+    assert_eq!(socket.pending_data.unwrap().len(), 4);
+}
+
+#[test]
+fn test_write_all() {
+    // Send data larger than the max payload size, so we expect 2 packets.
+    let data = vec![31; 5000];
+    let (mut socket, transport) = new_socket_and_transport();
+    assert!(socket.write_all(&data[..]).is_ok());
+    let first = Packet::new(
+        transport
+            .device_read_once_from_queue::<QUEUE_SIZE>(1)
+            .unwrap(),
+    )
+    .unwrap();
+    let second = Packet::new(
+        transport
+            .device_read_once_from_queue::<QUEUE_SIZE>(1)
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(first.get_dst_cid(), HOST_CID);
+    assert_eq!(first.get_src_cid(), GUEST_CID);
+    assert_eq!(first.get_dst_port(), HOST_PORT);
+    assert_eq!(first.get_src_port(), GUEST_PORT);
+    assert_eq!(&data[..MAX_PAYLOAD_SIZE], first.get_payload());
+    assert_eq!(second.get_dst_cid(), HOST_CID);
+    assert_eq!(second.get_src_cid(), GUEST_CID);
+    assert_eq!(second.get_dst_port(), HOST_PORT);
+    assert_eq!(second.get_src_port(), GUEST_PORT);
+    assert_eq!(&data[MAX_PAYLOAD_SIZE..], second.get_payload());
+}
+
+fn set_packet_cids_host_to_guest(packet: &mut Packet) {
+    packet.set_dst_cid(GUEST_CID);
+    packet.set_src_cid(HOST_CID);
+}
+
+fn new_vsock_and_transport() -> (VSock<TestingTransport>, TestingTransport) {
+    let transport = TestingTransport::default();
+    {
+        let mut config = transport.config.lock().unwrap();
+        config.features = VIRTIO_F_VERSION_1;
+        config.max_queue_size = 256;
+    }
+    transport.write_device_config(0, GUEST_CID as u32);
+
+    let device = VirtioBaseDevice::new(transport.clone());
+    let mut vsock = VSock::new(device);
+    vsock.init().unwrap();
+
+    (vsock, transport)
+}
+
+fn new_socket_and_transport() -> (Socket<TestingTransport>, TestingTransport) {
+    let (vsock, transport) = new_vsock_and_transport();
+    let mut packet = Packet::new_control(HOST_PORT, GUEST_PORT, VSockOp::Request).unwrap();
+    set_packet_cids_host_to_guest(&mut packet);
+    // Reports a large enough stream buffer from the peer.
+    packet.set_buf_alloc(10000);
+    transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
+    let listener = SocketListener::new(vsock, GUEST_PORT);
+    let socket = listener.accept().unwrap();
+    // Take the response packet from the queue.
+    let response = Packet::new(
+        transport
+            .device_read_once_from_queue::<QUEUE_SIZE>(1)
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(response.get_op().unwrap(), VSockOp::Response);
+
+    (socket, transport)
+}

--- a/experimental/virtio/src/vsock/socket/tests.rs
+++ b/experimental/virtio/src/vsock/socket/tests.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use crate::{
-    test::{TestingTransport, VIRTIO_F_VERSION_1},
+    test::{new_valid_transport, TestingTransport},
     vsock::HOST_CID,
 };
 use alloc::vec;
@@ -141,12 +141,7 @@ fn set_packet_cids_host_to_guest(packet: &mut Packet) {
 }
 
 fn new_vsock_and_transport() -> (VSock<TestingTransport>, TestingTransport) {
-    let transport = TestingTransport::default();
-    {
-        let mut config = transport.config.lock().unwrap();
-        config.features = VIRTIO_F_VERSION_1;
-        config.max_queue_size = 256;
-    }
+    let transport = new_valid_transport();
     transport.write_device_config(0, GUEST_CID as u32);
 
     let device = VirtioBaseDevice::new(transport.clone());

--- a/experimental/virtio/src/vsock/tests.rs
+++ b/experimental/virtio/src/vsock/tests.rs
@@ -102,25 +102,19 @@ fn new_valid_transport() -> TestingTransport {
         config.features = VIRTIO_F_VERSION_1;
         config.max_queue_size = 256;
     }
-    transport.write_device_config(0, 3);
+    transport.write_device_config(0, GUEST_CID as u32);
 
     transport
 }
 
 fn new_legacy_transport() -> TestingTransport {
-    let transport = TestingTransport::default();
-    transport.config.lock().unwrap().max_queue_size = 256;
-    transport.write_device_config(0, 3);
+    let transport = new_valid_transport();
+    transport.set_features(0);
     transport
 }
 
 fn new_transport_small_queue() -> TestingTransport {
-    let transport = TestingTransport::default();
-    {
-        let mut config = transport.config.lock().unwrap();
-        config.features = VIRTIO_F_VERSION_1;
-        config.max_queue_size = 8;
-    }
-    transport.write_device_config(0, GUEST_CID as u32);
+    let transport = new_valid_transport();
+    transport.config.lock().unwrap().max_queue_size = 8;
     transport
 }

--- a/experimental/virtio/src/vsock/tests.rs
+++ b/experimental/virtio/src/vsock/tests.rs
@@ -15,11 +15,8 @@
 //
 
 use super::*;
-use crate::{
-    test::{DeviceStatus, TestingTransport, VIRTIO_F_VERSION_1},
-    vsock,
-};
-use alloc::{vec, vec::Vec};
+use crate::test::{DeviceStatus, TestingTransport, VIRTIO_F_VERSION_1};
+use alloc::vec;
 
 const GUEST_CID: u64 = 3;
 

--- a/experimental/virtio/src/vsock/tests.rs
+++ b/experimental/virtio/src/vsock/tests.rs
@@ -14,21 +14,4 @@
 // limitations under the License.
 //
 
-//! Simple virtio drivers implemented based on polling.
-//!
-//! This crate assumes that an identity mapping is used in page tables, so that guest-virtual and
-//! guest-physical addresses are the same.
-
-#![no_std]
-#![feature(let_chains)]
-
-extern crate alloc;
-
-pub mod console;
-pub mod queue;
-#[cfg(test)]
-mod test;
-pub mod vsock;
-
-/// The vendor ID for virtio PCI devices.
-const PCI_VENDOR_ID: u16 = 0x1AF4;
+use super::*;


### PR DESCRIPTION
This PR also adds a test-specific VirtioTransport implementation to support testing of virtio devices without having to emulate a full PCI device,