### PR TITLE
Use gRPC status codes in the oak IDL

### DIFF
--- a/experimental/uefi/channel/src/lib.rs
+++ b/experimental/uefi/channel/src/lib.rs
@@ -139,12 +139,9 @@ impl<'a> From<&'a Frame> for oak_idl::Request<'a> {
 
 impl From<Result<Vec<u8>, oak_idl::Status>> for Frame {
     fn from(result: Result<Vec<u8>, oak_idl::Status>) -> Frame {
-        // In response frames, the status code `0` indicates a succesful
-        // response. Values above `0` represent an error code as defined
-        // in the oak_idl.
         match result {
             Ok(response) => Frame {
-                method_or_status: 0,
+                method_or_status: oak_idl::StatusCode::Ok.into(),
                 body: response,
             },
             Err(error) => Frame {
@@ -157,12 +154,10 @@ impl From<Result<Vec<u8>, oak_idl::Status>> for Frame {
 
 impl From<Frame> for Result<Vec<u8>, oak_idl::Status> {
     fn from(frame: Frame) -> Self {
-        // In response frames, the status code `0` indicates a succesful
-        // response. Values above `0` represent an error code as defined
-        // in the oak_idl.
-        match frame.method_or_status {
-            0 => Ok(frame.body),
-            _ => Err(oak_idl::Status {
+        if frame.method_or_status == oak_idl::StatusCode::Ok.into() {
+            Ok(frame.body)
+        } else {
+            Err(oak_idl::Status {
                 code: frame.method_or_status.into(),
                 message: String::from_utf8(frame.body).unwrap_or_else(|err| {
                     alloc::format!(
@@ -170,7 +165,7 @@ impl From<Frame> for Result<Vec<u8>, oak_idl::Status> {
                         err
                     )
                 }),
-            }),
+            })
         }
     }
 }

--- a/experimental/uefi/channel/src/lib.rs
+++ b/experimental/uefi/channel/src/lib.rs
@@ -137,8 +137,8 @@ impl<'a> From<&'a Frame> for oak_idl::Request<'a> {
     }
 }
 
-impl From<Result<Vec<u8>, oak_idl::Error>> for Frame {
-    fn from(result: Result<Vec<u8>, oak_idl::Error>) -> Frame {
+impl From<Result<Vec<u8>, oak_idl::Status>> for Frame {
+    fn from(result: Result<Vec<u8>, oak_idl::Status>) -> Frame {
         // In response frames, the status code `0` indicates a succesful
         // response. Values above `0` represent an error code as defined
         // in the oak_idl.
@@ -155,14 +155,14 @@ impl From<Result<Vec<u8>, oak_idl::Error>> for Frame {
     }
 }
 
-impl From<Frame> for Result<Vec<u8>, oak_idl::Error> {
+impl From<Frame> for Result<Vec<u8>, oak_idl::Status> {
     fn from(frame: Frame) -> Self {
         // In response frames, the status code `0` indicates a succesful
         // response. Values above `0` represent an error code as defined
         // in the oak_idl.
         match frame.method_or_status {
             0 => Ok(frame.body),
-            _ => Err(oak_idl::Error {
+            _ => Err(oak_idl::Status {
                 code: frame.method_or_status.into(),
                 message: String::from_utf8(frame.body).unwrap_or_else(|err| {
                     alloc::format!(

--- a/experimental/uefi/loader/src/server.rs
+++ b/experimental/uefi/loader/src/server.rs
@@ -30,11 +30,11 @@ use proto::{
     UnaryRequest, UnaryResponse,
 };
 
-fn encode_request(unary_request: UnaryRequest) -> Result<Vec<u8>, oak_idl::Error> {
+fn encode_request(unary_request: UnaryRequest) -> Result<Vec<u8>, oak_idl::Status> {
     let mut session_id: SessionId = [0; SESSION_ID_LENGTH];
     if unary_request.session_id.len() != SESSION_ID_LENGTH {
-        return Err(oak_idl::Error::new_with_message(
-            oak_idl::ErrorCode::InvalidRequest,
+        return Err(oak_idl::Status::new_with_message(
+            oak_idl::StatusCode::Internal,
             format!(
                 "session_id must be {} bytes in length, found a length of {} bytes instead",
                 SESSION_ID_LENGTH,
@@ -57,7 +57,7 @@ fn encode_request(unary_request: UnaryRequest) -> Result<Vec<u8>, oak_idl::Error
             },
         );
         builder.finish(message).map_err(|err| {
-            oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidRequest, err.to_string())
+            oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, err.to_string())
         })?
     };
 
@@ -66,7 +66,7 @@ fn encode_request(unary_request: UnaryRequest) -> Result<Vec<u8>, oak_idl::Error
 }
 
 pub struct EchoImpl {
-    channel: UnboundedRequestSender<Vec<u8>, Result<Vec<u8>, oak_idl::Error>>,
+    channel: UnboundedRequestSender<Vec<u8>, Result<Vec<u8>, oak_idl::Status>>,
 }
 
 #[tonic::async_trait]
@@ -96,7 +96,7 @@ impl UnarySession for EchoImpl {
 
 pub fn server(
     addr: SocketAddr,
-    channel: UnboundedRequestSender<Vec<u8>, Result<Vec<u8>, oak_idl::Error>>,
+    channel: UnboundedRequestSender<Vec<u8>, Result<Vec<u8>, oak_idl::Status>>,
 ) -> impl Future<Output = Result<(), tonic::transport::Error>> {
     let server_impl = EchoImpl { channel };
     Server::builder()

--- a/experimental/uefi/runtime/src/framing.rs
+++ b/experimental/uefi/runtime/src/framing.rs
@@ -43,20 +43,20 @@ where
     fn handle_user_request(
         &mut self,
         request_message: &schema::UserRequest,
-    ) -> Result<oak_idl::utils::Message<schema::UserRequestResponse>, oak_idl::Error> {
+    ) -> Result<oak_idl::utils::Message<schema::UserRequestResponse>, oak_idl::Status> {
         let session_id: SessionId = request_message
             .session_id()
-            .ok_or_else(|| oak_idl::Error::new(oak_idl::ErrorCode::BadRequest))?
+            .ok_or_else(|| oak_idl::Status::new(oak_idl::StatusCode::InvalidArgument))?
             .value()
             .into();
         let request_body: &[u8] = request_message
             .body()
-            .ok_or_else(|| oak_idl::Error::new(oak_idl::ErrorCode::BadRequest))?;
+            .ok_or_else(|| oak_idl::Status::new(oak_idl::StatusCode::InvalidArgument))?;
 
         let response = self
             .attestation_handler
             .message(session_id, request_body)
-            .map_err(|_| oak_idl::Error::new(oak_idl::ErrorCode::InternalError))?;
+            .map_err(|_| oak_idl::Status::new(oak_idl::StatusCode::Internal))?;
 
         let response_message = {
             let mut builder = oak_idl::utils::MessageBuilder::default();
@@ -67,7 +67,7 @@ where
             );
             builder
                 .finish(user_request_response)
-                .map_err(|_| oak_idl::Error::new(oak_idl::ErrorCode::InternalError))?
+                .map_err(|_| oak_idl::Status::new(oak_idl::StatusCode::Internal))?
         };
         Ok(response_message)
     }

--- a/oak_idl/src/lib.rs
+++ b/oak_idl/src/lib.rs
@@ -24,25 +24,22 @@ use core::fmt::Debug;
 
 pub mod utils;
 
-// TODO(#2500): Align with gRPC Status.
-// Ref: https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto
-/// Logical error model.
 #[derive(Debug)]
-pub struct Error {
-    pub code: ErrorCode,
+pub struct Status {
+    pub code: StatusCode,
     /// English message that helps developers understand and resolve the error.
     pub message: String,
 }
 
-impl Error {
-    pub fn new(code: ErrorCode) -> Self {
+impl Status {
+    pub fn new(code: StatusCode) -> Self {
         Self {
             code,
             message: "".to_string(),
         }
     }
 
-    pub fn new_with_message(code: ErrorCode, message: impl Into<String>) -> Self {
+    pub fn new_with_message(code: StatusCode, message: impl Into<String>) -> Self {
         Self {
             code,
             message: message.into(),
@@ -50,44 +47,94 @@ impl Error {
     }
 }
 
-// TODO(#2500): Align these with gRPC status codes.
-/// Basic error code to categorize the error. Error codes are represented as an
-/// u32 id. The id `0` is reserved, as it may be used to indicate an "Ok" status
-/// in transport implementations.
-#[repr(u32)]
+/// gRPC status codes used by [`Status`].
+///
+/// These variants match the [gRPC status codes].
+///
+/// [gRPC status codes]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc
+// Based on tonic's status code struct: https://github.com/hyperium/tonic/blob/91b73f9fc3c1bc281e85177808721b3efe37ece0/tonic/src/status.rs
 #[derive(Debug)]
-pub enum ErrorCode {
-    /// The request message could not be deserialized correctly.
-    InvalidRequest = 1,
-    /// The response message could not be deserialized correctly.
-    InvalidResponse = 2,
-    /// The method id provided for the invocation was not implemented by the server.
-    InvalidMethodId = 3,
-    /// The request was deserialized correctly but contained invalid values.
-    BadRequest = 4,
-    /// An error occured while invoking the method on the server.
-    InternalError = 5,
+pub enum StatusCode {
+    /// The operation completed successfully.
+    Ok = 0,
+
+    /// The operation was cancelled.
+    Cancelled = 1,
+
     /// Unknown error.
-    Unknown = 6,
+    Unknown = 2,
+
+    /// Client specified an invalid argument.
+    InvalidArgument = 3,
+
+    /// Deadline expired before operation could complete.
+    DeadlineExceeded = 4,
+
+    /// Some requested entity was not found.
+    NotFound = 5,
+
+    /// Some entity that we attempted to create already exists.
+    AlreadyExists = 6,
+
+    /// The caller does not have permission to execute the specified operation.
+    PermissionDenied = 7,
+
+    /// Some resource has been exhausted.
+    ResourceExhausted = 8,
+
+    /// The system is not in a state required for the operation's execution.
+    FailedPrecondition = 9,
+
+    /// The operation was aborted.
+    Aborted = 10,
+
+    /// Operation was attempted past the valid range.
+    OutOfRange = 11,
+
+    /// Operation is not implemented or not supported.
+    Unimplemented = 12,
+
+    /// Internal error.
+    Internal = 13,
+
+    /// The service is currently unavailable.
+    Unavailable = 14,
+
+    /// Unrecoverable data loss or corruption.
+    DataLoss = 15,
+
+    /// The request does not have valid authentication credentials
+    Unauthenticated = 16,
 }
 
-impl From<u32> for ErrorCode {
+impl From<u32> for StatusCode {
     fn from(i: u32) -> Self {
         match i {
-            1 => ErrorCode::InvalidRequest,
-            2 => ErrorCode::InvalidResponse,
-            3 => ErrorCode::InvalidMethodId,
-            4 => ErrorCode::BadRequest,
-            5 => ErrorCode::InternalError,
-            6 => ErrorCode::Unknown,
+            0 => StatusCode::Ok,
+            1 => StatusCode::Cancelled,
+            2 => StatusCode::Unknown,
+            3 => StatusCode::InvalidArgument,
+            4 => StatusCode::DeadlineExceeded,
+            5 => StatusCode::NotFound,
+            6 => StatusCode::AlreadyExists,
+            7 => StatusCode::PermissionDenied,
+            8 => StatusCode::ResourceExhausted,
+            9 => StatusCode::FailedPrecondition,
+            10 => StatusCode::Aborted,
+            11 => StatusCode::OutOfRange,
+            12 => StatusCode::Unimplemented,
+            13 => StatusCode::Internal,
+            14 => StatusCode::Unavailable,
+            15 => StatusCode::DataLoss,
+            16 => StatusCode::Unauthenticated,
 
-            _ => ErrorCode::Unknown,
+            _ => StatusCode::Unknown,
         }
     }
 }
 
-impl From<ErrorCode> for u32 {
-    fn from(code: ErrorCode) -> u32 {
+impl From<StatusCode> for u32 {
+    fn from(code: StatusCode) -> u32 {
         code as u32
     }
 }
@@ -115,5 +162,5 @@ pub struct Request<'a> {
 /// This is conceptually similar to a method that takes `&[u8]` as input but returns `Vec<u8>` as
 /// output.
 pub trait Handler {
-    fn invoke(&mut self, request: Request) -> Result<Vec<u8>, Error>;
+    fn invoke(&mut self, request: Request) -> Result<Vec<u8>, StatusCode>;
 }

--- a/oak_idl/src/lib.rs
+++ b/oak_idl/src/lib.rs
@@ -162,5 +162,5 @@ pub struct Request<'a> {
 /// This is conceptually similar to a method that takes `&[u8]` as input but returns `Vec<u8>` as
 /// output.
 pub trait Handler {
-    fn invoke(&mut self, request: Request) -> Result<Vec<u8>, StatusCode>;
+    fn invoke(&mut self, request: Request) -> Result<Vec<u8>, Status>;
 }

--- a/oak_idl_gen_services/src/lib.rs
+++ b/oak_idl_gen_services/src/lib.rs
@@ -253,7 +253,7 @@ fn generate_client_method(rpc_call: &RPCCall) -> anyhow::Result<Vec<String>> {
         format!("            body: request_body,"),
         format!("        }};"),
         format!("        let response_body = self.handler.invoke(request)?;"),
-        format!("        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!(\"Client failed to deserialize the response: {{:?}}\", err)))?;"),
+        format!("        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!(\"Client failed to deserialize the response: {{:?}}\", err)))"),
         format!("    }}"),
     ])
 }

--- a/oak_idl_gen_services/src/lib.rs
+++ b/oak_idl_gen_services/src/lib.rs
@@ -151,7 +151,7 @@ fn generate_service(service: &Service) -> anyhow::Result<String> {
         format!(""),
         format!("extern crate alloc;"),
         format!(""),
-        format!("use alloc::string::ToString;"),
+        format!("use alloc::{{format, string::ToString}};"),
         format!(""),
         format!(
             "pub struct {}<T: oak_idl::Handler> {{",

--- a/oak_idl_gen_services/src/lib.rs
+++ b/oak_idl_gen_services/src/lib.rs
@@ -187,7 +187,7 @@ fn generate_service(service: &Service) -> anyhow::Result<String> {
             service_name(service),
             server_name(service)
         ),
-        format!("    fn invoke(&mut self, request: oak_idl::Request) -> Result<alloc::vec::Vec<u8>, oak_idl::Error> {{"),
+        format!("    fn invoke(&mut self, request: oak_idl::Request) -> Result<alloc::vec::Vec<u8>, oak_idl::Status> {{"),
         format!("        match request.method_id {{"),
     ]);
     lines.extend(
@@ -202,7 +202,7 @@ fn generate_service(service: &Service) -> anyhow::Result<String> {
             .flatten(),
     );
     lines.extend(vec![
-        format!("            _ => Err(oak_idl::Error::new(oak_idl::ErrorCode::InvalidMethodId))"),
+        format!("            _ => Err(oak_idl::Status::new(oak_idl::StatusCode::Unimplemented))"),
         format!("        }}"),
         format!("    }}"),
         format!("}}"),
@@ -240,12 +240,12 @@ fn generate_client_method(rpc_call: &RPCCall) -> anyhow::Result<Vec<String>> {
     // much benefit.
     Ok(vec![
         format!(
-            "    pub fn {}(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::Message<{}>, oak_idl::Error> {{",
+            "    pub fn {}(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::Message<{}>, oak_idl::Status> {{",
             method_name(rpc_call),
             response_type(rpc_call)
         ),
         format!(
-            "        flatbuffers::root::<{}>(request_body).map_err(|err| oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidRequest, err.to_string()))?;",
+            "        flatbuffers::root::<{}>(request_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!(\"Client failed to deserialize the request: {{:?}}\", err)))?;",
             request_type(rpc_call)
         ),
         format!("        let request = oak_idl::Request {{"),
@@ -253,7 +253,7 @@ fn generate_client_method(rpc_call: &RPCCall) -> anyhow::Result<Vec<String>> {
         format!("            body: request_body,"),
         format!("        }};"),
         format!("        let response_body = self.handler.invoke(request)?;"),
-        format!("        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidResponse, err.to_string()))"),
+        format!("        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!(\"Client failed to deserialize the response: {{:?}}\", err)))?;"),
         format!("    }}"),
     ])
 }
@@ -266,7 +266,7 @@ fn generate_server_handler(rpc_call: &RPCCall) -> anyhow::Result<Vec<String>> {
     Ok(vec![
         format!("            {} => {{", method_id(rpc_call)?),
         format!(
-            "                let request = flatbuffers::root::<{}>(request.body).map_err(|err| oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidRequest, err.to_string()))?;",
+            "                let request = flatbuffers::root::<{}>(request.body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!(\"Service failed to deserialize the request: {{:?}}\", err)))?;",
             request_type(rpc_call),
         ),
         format!(
@@ -285,7 +285,7 @@ fn generate_service_method(rpc_call: &RPCCall) -> Vec<String> {
     // implementation of this method, therefore needs to be wrapped in `oak_idl::Message` in order
     // to transfer its ownership to the caller.
     vec![format!(
-        "    fn {}(&mut self, request: &{}) -> Result<oak_idl::utils::Message<{}>, oak_idl::Error>;",
+        "    fn {}(&mut self, request: &{}) -> Result<oak_idl::utils::Message<{}>, oak_idl::Status>;",
         method_name(rpc_call),
         request_type(rpc_call),
         response_type(rpc_call)

--- a/oak_idl_tests/test_schema_services.rs.txt
+++ b/oak_idl_tests/test_schema_services.rs.txt
@@ -3,7 +3,7 @@
 
 extern crate alloc;
 
-use alloc::string::ToString;
+use alloc::{format, string::ToString};
 
 pub struct TestServiceClient<T: oak_idl::Handler> {
     handler: T

--- a/oak_idl_tests/test_schema_services.rs.txt
+++ b/oak_idl_tests/test_schema_services.rs.txt
@@ -13,23 +13,23 @@ impl <T: oak_idl::Handler>TestServiceClient<T> {
             handler
         }
     }
-    pub fn lookup_data(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::Error> {
-        flatbuffers::root::<LookupDataRequest>(request_body).map_err(|err| oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidRequest, err.to_string()))?;
+    pub fn lookup_data(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::Status> {
+        flatbuffers::root::<LookupDataRequest>(request_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the request: {:?}", err)))?;
         let request = oak_idl::Request {
             method_id: 222,
             body: request_body,
         };
         let response_body = self.handler.invoke(request)?;
-        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidResponse, err.to_string()))
+        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
     }
-    pub fn log(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::Error> {
-        flatbuffers::root::<LogRequest>(request_body).map_err(|err| oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidRequest, err.to_string()))?;
+    pub fn log(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::Status> {
+        flatbuffers::root::<LogRequest>(request_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the request: {:?}", err)))?;
         let request = oak_idl::Request {
             method_id: 223,
             body: request_body,
         };
         let response_body = self.handler.invoke(request)?;
-        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidResponse, err.to_string()))
+        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
     }
 }
 
@@ -38,28 +38,28 @@ pub struct TestServiceServer<S> {
 }
 
 impl <S: TestService> oak_idl::Handler for TestServiceServer<S> {
-    fn invoke(&mut self, request: oak_idl::Request) -> Result<alloc::vec::Vec<u8>, oak_idl::Error> {
+    fn invoke(&mut self, request: oak_idl::Request) -> Result<alloc::vec::Vec<u8>, oak_idl::Status> {
         match request.method_id {
             222 => {
-                let request = flatbuffers::root::<LookupDataRequest>(request.body).map_err(|err| oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidRequest, err.to_string()))?;
+                let request = flatbuffers::root::<LookupDataRequest>(request.body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Service failed to deserialize the request: {:?}", err)))?;
                 let response = self.service.lookup_data(&request)?;
                 let response_body = response.buf().to_vec();
                 Ok(response_body)
             }
             223 => {
-                let request = flatbuffers::root::<LogRequest>(request.body).map_err(|err| oak_idl::Error::new_with_message(oak_idl::ErrorCode::InvalidRequest, err.to_string()))?;
+                let request = flatbuffers::root::<LogRequest>(request.body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Service failed to deserialize the request: {:?}", err)))?;
                 let response = self.service.log(&request)?;
                 let response_body = response.buf().to_vec();
                 Ok(response_body)
             }
-            _ => Err(oak_idl::Error::new(oak_idl::ErrorCode::InvalidMethodId))
+            _ => Err(oak_idl::Status::new(oak_idl::StatusCode::Unimplemented))
         }
     }
 }
 
 pub trait TestService: Sized {
-    fn lookup_data(&mut self, request: &LookupDataRequest) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::Error>;
-    fn log(&mut self, request: &LogRequest) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::Error>;
+    fn lookup_data(&mut self, request: &LookupDataRequest) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::Status>;
+    fn log(&mut self, request: &LogRequest) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::Status>;
     fn serve(self) -> TestServiceServer<Self> {
         TestServiceServer { service : self }
     }

--- a/oak_idl_tests/tests/test_schema.rs
+++ b/oak_idl_tests/tests/test_schema.rs
@@ -31,7 +31,7 @@ impl test_schema::TestService for TestServiceImpl {
     fn lookup_data(
         &mut self,
         request: &test_schema::LookupDataRequest,
-    ) -> Result<oak_idl::utils::Message<test_schema::LookupDataResponse>, oak_idl::Error> {
+    ) -> Result<oak_idl::utils::Message<test_schema::LookupDataResponse>, oak_idl::Status> {
         let h = maplit::hashmap! {
             vec![14, 12] => vec![19, 88]
         };
@@ -44,8 +44,8 @@ impl test_schema::TestService for TestServiceImpl {
             &test_schema::LookupDataResponseArgs { value },
         );
         let b = b.finish(m).map_err(|err| {
-            oak_idl::Error::new_with_message(
-                oak_idl::ErrorCode::InternalError,
+            oak_idl::Status::new_with_message(
+                oak_idl::StatusCode::Internal,
                 format!("failed to build response: {:?}", err),
             )
         })?;
@@ -55,13 +55,13 @@ impl test_schema::TestService for TestServiceImpl {
     fn log(
         &mut self,
         request: &test_schema::LogRequest,
-    ) -> Result<oak_idl::utils::Message<test_schema::LogResponse>, oak_idl::Error> {
+    ) -> Result<oak_idl::utils::Message<test_schema::LogResponse>, oak_idl::Status> {
         eprintln!("log: {}", request.entry().unwrap());
         let mut b = oak_idl::utils::MessageBuilder::default();
         let m = test_schema::LogResponse::create(&mut b, &test_schema::LogResponseArgs {});
         let b = b.finish(m).map_err(|err| {
-            oak_idl::Error::new_with_message(
-                oak_idl::ErrorCode::InternalError,
+            oak_idl::Status::new_with_message(
+                oak_idl::StatusCode::Internal,
                 format!("failed to build response: {:?}", err),
             )
         })?;


### PR DESCRIPTION
Tiziano proposed this earlier, and I agree it's probably a good idea. Crucially gRPC Status codes include a definition of a status code. This is nice, as it means we can use status codes as is in the framing implementation, doing away with what's a somewhat dodgy implementation rn. 

The downside is that technically an invocation could error with an Ok status, which wouldn't make sense. That's the same type / error signature as used by tonic though, so it's probably fine