### PR TITLE
Fix queue size mismatch and add tests

### DIFF
--- a/experimental/virtio/src/queue/virtq.rs
+++ b/experimental/virtio/src/queue/virtq.rs
@@ -119,6 +119,7 @@ impl<const QUEUE_SIZE: usize> Default for AvailRing<QUEUE_SIZE> {
 ///
 /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-430008>.
 #[repr(C, align(4))]
+#[derive(Debug)]
 pub struct UsedRing<const QUEUE_SIZE: usize> {
     /// Device-specific flags for the queue.
     pub flags: RingFlags,
@@ -149,7 +150,7 @@ impl<const QUEUE_SIZE: usize> Default for UsedRing<QUEUE_SIZE> {
 ///
 /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-430008>.
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug)]
 pub struct UsedElem {
     /// The index of the head of the used descriptor chain.
     pub id: u32,

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -30,7 +30,11 @@ pub mod packet;
 pub mod socket;
 
 /// The number of buffer descriptors in each of the queues.
-const QUEUE_SIZE: usize = 16;
+///
+/// Note: We match the CrosVM max size for vhost vsock, as it seems CrosVM sets the number of
+/// descriptors to the maximum queue size rather than the negotiated size.
+/// See <https://chromium.googlesource.com/chromiumos/platform/crosvm/+/d4505a7f1c9e4aa502ff49367863aedeadbafb9d/devices/src/virtio/vhost/worker.rs#74>.
+const QUEUE_SIZE: usize = 256;
 
 /// The size of each of the buffers used by the transmit and receive queues.
 const DATA_BUFFER_SIZE: usize = 4096;

--- a/xtask/src/vm.rs
+++ b/xtask/src/vm.rs
@@ -74,7 +74,7 @@ fn run_variant(variant: Variant) -> Step {
             Step::WithBackground {
                 name: "background loader".to_string(),
                 background: run_loader(variant),
-                foreground: Box::new(run_client("test")),
+                foreground: Box::new(run_client("test", 300)),
             },
         ],
     }
@@ -97,7 +97,7 @@ fn run_loader(variant: Variant) -> Box<dyn Runnable> {
     )
 }
 
-fn run_client(message: &str) -> Step {
+fn run_client(message: &str, iterations: usize) -> Step {
     Step::Multiple {
         name: "build and run client".to_string(),
         steps: vec![
@@ -106,7 +106,11 @@ fn run_client(message: &str) -> Step {
                 name: "run client".to_string(),
                 command: Cmd::new(
                     "./target/debug/uefi-client",
-                    vec!["--request", message, "--expected-response", message],
+                    vec![
+                        format!("--request={}", message),
+                        format!("--expected-response={}", message),
+                        format!("--iterations={}", iterations),
+                    ],
                 ),
             },
         ],


### PR DESCRIPTION
The vsock implementation failed after 16 buffers were used in the receive queue. This happened because of a mismatch in the believed number of available descriptors.

When configuring the vhost vsock device, CrosVM uses the maximum queue size rather than the negotiated size (https://chromium.googlesource.com/chromiumos/platform/crosvm/+/d4505a7f1c9e4aa502ff49367863aedeadbafb9d/devices/src/virtio/vhost/worker.rs#74).

For now the vsock device just uses the CrosVM maximum queue size of 256. This is not compatible with QEMU, which has a maximum size of 128, but we use the virtio console comms channel on QEMU, rather than vsock.

This PR also adds some tests to ensure we go past the maximum queue size to detect similar issues in future.