### PR TITLE
Restore serial comms channel + make it an optional feature.

### DIFF
--- a/experimental/oak_baremetal_app_qemu/Cargo.toml
+++ b/experimental/oak_baremetal_app_qemu/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 default = ["pvh"]
 pvh = ["rust-hypervisor-firmware-boot/pvh"]
 multiboot = []
+serial_channel = ["kernel/serial_channel"]
 
 [dependencies]
 bitflags = "*"

--- a/experimental/oak_baremetal_app_qemu/Cargo.toml
+++ b/experimental/oak_baremetal_app_qemu/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 default = ["pvh"]
 pvh = ["rust-hypervisor-firmware-boot/pvh"]
 multiboot = []
-serial_channel = ["oak_baremetal_kernel_kernel/serial_channel"]
+serial_channel = ["oak_baremetal_kernel/serial_channel"]
 
 [dependencies]
 bitflags = "*"

--- a/experimental/oak_baremetal_app_qemu/Cargo.toml
+++ b/experimental/oak_baremetal_app_qemu/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 default = ["pvh"]
 pvh = ["rust-hypervisor-firmware-boot/pvh"]
 multiboot = []
-serial_channel = ["kernel/serial_channel"]
+serial_channel = ["oak_baremetal_kernel_kernel/serial_channel"]
 
 [dependencies]
 bitflags = "*"

--- a/experimental/oak_baremetal_kernel/Cargo.toml
+++ b/experimental/oak_baremetal_kernel/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [features]
 default = []
 vsock_channel = []
+serial_channel = []
 
 [dependencies]
 anyhow = { version = "*", default-features = false }

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -50,7 +50,7 @@ use rust_hypervisor_firmware_boot::paging;
 #[cfg(not(feature = "serial_channel"))]
 use rust_hypervisor_firmware_virtio::pci::VirtioPciTransport;
 
-#[cfg(feature = "vsock_channel")]
+#[cfg(all(feature = "vsock_channel", not(feature = "serial_channel")))]
 // The virtio vsock port on which to listen.
 const VSOCK_PORT: u32 = 1024;
 
@@ -87,7 +87,7 @@ fn get_channel() -> virtio::console::Console<VirtioPciTransport> {
 }
 
 // Use virtio vsock for the communications channel.
-#[cfg(feature = "vsock_channel")]
+#[cfg(all(feature = "vsock_channel", not(feature = "serial_channel")))]
 fn get_channel() -> virtio::vsock::socket::Socket<VirtioPciTransport> {
     let vsock = virtio::vsock::VSock::find_and_configure_device()
         .expect("Couldn't configure PCI virtio vsock device.");

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -38,6 +38,8 @@ mod interrupts;
 mod libm;
 mod logging;
 mod memory;
+#[cfg(feature = "serial_channel")]
+mod serial;
 
 use core::panic::PanicInfo;
 use log::{error, info};
@@ -45,6 +47,7 @@ use oak_remote_attestation::handshaker::{
     AttestationBehavior, EmptyAttestationGenerator, EmptyAttestationVerifier,
 };
 use rust_hypervisor_firmware_boot::paging;
+#[cfg(not(feature = "serial_channel"))]
 use rust_hypervisor_firmware_virtio::pci::VirtioPciTransport;
 
 #[cfg(feature = "vsock_channel")]
@@ -69,8 +72,13 @@ fn main<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
     oak_baremetal_runtime::framing::handle_frames(get_channel(), attestation_behavior).unwrap();
 }
 
+#[cfg(feature = "serial_channel")]
+fn get_channel() -> serial::Serial {
+    serial::Serial::new()
+}
+
 // Use a virtio console device for the communications channel if we don't support virtio vsock.
-#[cfg(not(feature = "vsock_channel"))]
+#[cfg(all(not(feature = "vsock_channel"), not(feature = "serial_channel")))]
 fn get_channel() -> virtio::console::Console<VirtioPciTransport> {
     let console = virtio::console::Console::find_and_configure_device()
         .expect("Couldn't configure PCI virtio console device.");

--- a/experimental/oak_baremetal_kernel/src/serial.rs
+++ b/experimental/oak_baremetal_kernel/src/serial.rs
@@ -1,0 +1,64 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use atomic_refcell::AtomicRefCell;
+use uart_16550::SerialPort;
+
+pub struct Serial {
+    port: AtomicRefCell<SerialPort>,
+}
+
+// Base I/O port for the second serial port in the system (colloquially known as COM2)
+static COM2_BASE: u16 = 0x2f8;
+
+impl Serial {
+    pub fn new() -> Serial {
+        // Our contract with the loader requires the second serial port to be
+        // available, so assuming the loader adheres to it, this is safe.
+        let mut port = unsafe { SerialPort::new(COM2_BASE) };
+        port.init();
+        Serial {
+            port: AtomicRefCell::new(port),
+        }
+    }
+}
+
+impl ciborium_io::Write for Serial {
+    type Error = anyhow::Error;
+
+    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+        for byte in data {
+            self.port.borrow_mut().send_raw(*byte);
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl ciborium_io::Read for Serial {
+    type Error = anyhow::Error;
+
+    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..data.len() {
+            data[i] = self.port.borrow_mut().receive();
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This partially reverts commit ed55da95cc2ff4f1490fcbdb3392a233138278aa, as one of the VMMs we want to use does not support virtio right now.

I've made it an optional feature that is not on by default.