### PR TITLE
Implement a MessageId in preparation for multiplexing

### DIFF
--- a/experimental/oak_baremetal_channel/src/client.rs
+++ b/experimental/oak_baremetal_channel/src/client.rs
@@ -1,0 +1,73 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::{InvocationChannel, Message, String, Vec};
+use ciborium_io::{Read, Write};
+
+pub struct ClientChannelHandle<T: Read + Write> {
+    inner: InvocationChannel<T>,
+}
+
+impl<T> ClientChannelHandle<T>
+where
+    T: Read<Error = anyhow::Error> + Write<Error = anyhow::Error>,
+{
+    pub fn new(socket: T) -> Self {
+        Self {
+            inner: InvocationChannel::new(socket),
+        }
+    }
+    pub fn write_request(&mut self, request: Message) -> anyhow::Result<()> {
+        self.inner.write_message(request.into())
+    }
+    pub fn read_response(&mut self) -> anyhow::Result<Message> {
+        let message = self.inner.read_message()?;
+        Ok(message.into())
+    }
+}
+
+/// Construct a [`Message`] from an [`oak_idl::Request`].
+impl<'a> From<oak_idl::Request<'a>> for Message {
+    fn from(request: oak_idl::Request) -> Message {
+        Message {
+            method_or_status: request.method_id,
+            // TODO(#2848): It'd be nice if we didn't have to reallocate here.
+            // We may be able to avoid doing so by making [`Message`] use
+            // slices and lifetimes. Or alternatively use the Bytes crate for
+            // reference counting.
+            body: request.body.to_vec(),
+        }
+    }
+}
+
+/// Construct the response to a [`oak_idl::Request`] from a [`Message`].
+impl From<Message> for Result<Vec<u8>, oak_idl::Status> {
+    fn from(frame: Message) -> Self {
+        if frame.method_or_status == oak_idl::StatusCode::Ok.into() {
+            Ok(frame.body)
+        } else {
+            Err(oak_idl::Status {
+                code: frame.method_or_status.into(),
+                message: String::from_utf8(frame.body.to_vec()).unwrap_or_else(|err| {
+                    alloc::format!(
+                        "Could not parse response error message bytes as utf8: {:?}",
+                        err
+                    )
+                }),
+            })
+        }
+    }
+}

--- a/experimental/oak_baremetal_channel/src/client.rs
+++ b/experimental/oak_baremetal_channel/src/client.rs
@@ -63,7 +63,7 @@ struct MessageIdCounter {
 impl MessageIdCounter {
     fn next_message_id(&mut self) -> MessageId {
         let next_message_id = self.next_message_id;
-        let _ = self.next_message_id.overflowing_add(1);
+        self.next_message_id = next_message_id.wrapping_add(1);
         next_message_id
     }
 }

--- a/experimental/oak_baremetal_channel/src/lib.rs
+++ b/experimental/oak_baremetal_channel/src/lib.rs
@@ -277,7 +277,6 @@ impl PartialMessage {
     }
 }
 
-/// Private struct used to send frames over an underlying channel.
 struct Framed<T: Read + Write> {
     inner: T,
 }
@@ -341,7 +340,6 @@ where
     }
 }
 
-/// Public struct used to send and receive messages over an underlying channel.
 struct InvocationChannel<T: Read + Write> {
     inner: Framed<T>,
 }

--- a/experimental/oak_baremetal_channel/src/server.rs
+++ b/experimental/oak_baremetal_channel/src/server.rs
@@ -1,0 +1,66 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::{InvocationChannel, Message, Vec};
+use ciborium_io::{Read, Write};
+
+pub struct ServerChannelHandle<T: Read + Write> {
+    inner: InvocationChannel<T>,
+}
+
+impl<T> ServerChannelHandle<T>
+where
+    T: Read<Error = anyhow::Error> + Write<Error = anyhow::Error>,
+{
+    pub fn new(socket: T) -> Self {
+        Self {
+            inner: InvocationChannel::new(socket),
+        }
+    }
+    pub fn read_request(&mut self) -> anyhow::Result<Message> {
+        let message = self.inner.read_message()?;
+        Ok(message)
+    }
+    pub fn write_response(&mut self, response: Message) -> anyhow::Result<()> {
+        self.inner.write_message(response.into())
+    }
+}
+
+/// Construct a [`oak_idl::Request`] from a [`Message`].
+impl<'a> From<&'a Message> for oak_idl::Request<'a> {
+    fn from(frame: &'a Message) -> Self {
+        oak_idl::Request {
+            method_id: frame.method_or_status,
+            body: &frame.body,
+        }
+    }
+}
+
+/// Construct a [`Message`] from an response to an [`oak_idl::Request`].
+impl From<Result<Vec<u8>, oak_idl::Status>> for Message {
+    fn from(result: Result<Vec<u8>, oak_idl::Status>) -> Message {
+        match result {
+            Ok(response) => Message {
+                method_or_status: oak_idl::StatusCode::Ok.into(),
+                body: response,
+            },
+            Err(error) => Message {
+                method_or_status: error.code.into(),
+                body: error.message.as_bytes().to_vec(),
+            },
+        }
+    }
+}

--- a/experimental/oak_baremetal_channel/src/tests.rs
+++ b/experimental/oak_baremetal_channel/src/tests.rs
@@ -30,7 +30,7 @@ fn test_message_fragmentation() {
         {
             let mut x: u8 = 0;
             let filler = || {
-                x = x.overflowing_add(1).0;
+                x = x.wrapping_add(1);
                 x
             };
             mock_body.fill_with(filler);

--- a/experimental/oak_baremetal_channel/src/tests.rs
+++ b/experimental/oak_baremetal_channel/src/tests.rs
@@ -39,6 +39,7 @@ fn test_message_fragmentation() {
     };
 
     let message = Message {
+        message_id: 0,
         method_or_status: 0,
         body: mock_body,
     };
@@ -72,6 +73,7 @@ fn test_message_fragmentation() {
 fn test_message_reconstruction_for_messages_small_messages() {
     let mock_body: Vec<u8> = vec![0; MAX_FRAME_BODY_SIZE - 1];
     let small_message = Message {
+        message_id: 0,
         method_or_status: 0,
         body: mock_body,
     };
@@ -92,6 +94,7 @@ fn test_message_reconstruction_for_messages_small_messages() {
 #[test]
 fn test_message_reconstruction_for_messages_with_an_empty_body() {
     let empty_body_message = Message {
+        message_id: 0,
         method_or_status: 0,
         body: Vec::new(),
     };
@@ -113,6 +116,7 @@ fn test_message_reconstruction_for_messages_with_an_empty_body() {
 fn test_message_reconstruction_double_start_frame() {
     let start_frame = Frame {
         method_or_status: 0,
+        message_id: 0,
         flag: Flag::MessageStart,
         body: Vec::new(),
     };
@@ -140,6 +144,7 @@ fn test_message_reconstruction_expected_start_frame() {
         Err(MessageReconstructionErrors::ExpectedStartFrame),
         PartialMessage::default().add_frame(Frame {
             method_or_status: 0,
+            message_id: 0,
             flag: Flag::MessageContinuation,
             body: Vec::new(),
         })
@@ -148,6 +153,7 @@ fn test_message_reconstruction_expected_start_frame() {
         Err(MessageReconstructionErrors::ExpectedStartFrame),
         PartialMessage::default().add_frame(Frame {
             method_or_status: 0,
+            message_id: 0,
             flag: Flag::MessageMessage,
             body: Vec::new(),
         })
@@ -158,11 +164,13 @@ fn test_message_reconstruction_expected_start_frame() {
 fn test_message_reconstruction_frame_header_mismatch() {
     let start_frame = Frame {
         method_or_status: 0,
+        message_id: 0,
         flag: Flag::MessageStart,
         body: Vec::new(),
     };
     let continuance_frame_of_a_different_method = Frame {
         method_or_status: 1,
+        message_id: 0,
         flag: Flag::MessageContinuation,
         body: Vec::new(),
     };

--- a/experimental/oak_baremetal_loader/src/main.rs
+++ b/experimental/oak_baremetal_loader/src/main.rs
@@ -18,7 +18,10 @@
 
 use clap::Parser;
 use crosvm::Crosvm;
-use oak_baremetal_communication_channel::{client::ClientChannelHandle, schema};
+use oak_baremetal_communication_channel::{
+    client::{ClientChannelHandle, RequestEncoder},
+    schema,
+};
 use qemu::Qemu;
 use std::{
     fs,
@@ -101,6 +104,7 @@ impl ciborium_io::Read for CommsChannel {
 
 pub struct ClientHandler<T: ciborium_io::Read + ciborium_io::Write> {
     inner: ClientChannelHandle<T>,
+    request_encoder: RequestEncoder,
 }
 
 impl<T> ClientHandler<T>
@@ -110,6 +114,7 @@ where
     pub fn new(inner: T) -> Self {
         Self {
             inner: ClientChannelHandle::new(inner),
+            request_encoder: RequestEncoder::default(),
         }
     }
 }
@@ -119,14 +124,23 @@ where
     T: ciborium_io::Read<Error = anyhow::Error> + ciborium_io::Write<Error = anyhow::Error>,
 {
     fn invoke(&mut self, request: oak_idl::Request) -> Result<Vec<u8>, oak_idl::Status> {
+        let request_message = self.request_encoder.encode_request(request);
+        let request_message_message_id = request_message.message_id;
         self.inner
-            .write_request(request.into())
+            .write_request(request_message)
             .map_err(|_| oak_idl::Status::new(oak_idl::StatusCode::Internal))?;
 
-        self.inner
+        let response_message = self
+            .inner
             .read_response()
-            .map_err(|_| oak_idl::Status::new(oak_idl::StatusCode::Internal))?
-            .into()
+            .map_err(|_| oak_idl::Status::new(oak_idl::StatusCode::Internal))?;
+
+        // For now all messages are sent in sequence, hence we expect that the
+        // id of the next response matches the preceeding request.
+        // TODO(#2848): Allow messages to be sent and received out of order.
+        assert_eq!(request_message_message_id, response_message.message_id);
+
+        response_message.into()
     }
 }
 

--- a/experimental/oak_baremetal_runtime/src/framing.rs
+++ b/experimental/oak_baremetal_runtime/src/framing.rs
@@ -18,7 +18,9 @@ use crate::remote_attestation::AttestationHandler;
 use alloc::vec::Vec;
 use anyhow::Context;
 use ciborium_io::{Read, Write};
-use oak_baremetal_communication_channel::{schema, schema::TrustedRuntime, InvocationChannel};
+use oak_baremetal_communication_channel::{
+    schema, schema::TrustedRuntime, server::ServerChannelHandle,
+};
 use oak_idl::Handler;
 use oak_remote_attestation::handshaker::{
     AttestationBehavior, AttestationGenerator, AttestationVerifier,
@@ -90,12 +92,12 @@ where
         attestation_handler,
     }
     .serve();
-    let invocation_channel = &mut InvocationChannel::new(channel);
+    let channel_handle = &mut ServerChannelHandle::new(channel);
     loop {
-        let message = invocation_channel
-            .read_message()
+        let message = channel_handle
+            .read_request()
             .context("couldn't receive message")?;
         let response = invocation_handler.invoke((&message).into());
-        invocation_channel.write_message(response.into())?
+        channel_handle.write_response(response.into())?
     }
 }


### PR DESCRIPTION
This PR adds a `MessageId` in preparation for implementing message multiplexing in the future. For now messages are still sent in sequence. 