### PR TITLE
Update credit calculation constants

### DIFF
--- a/experimental/virtio/src/vsock/socket/mod.rs
+++ b/experimental/virtio/src/vsock/socket/mod.rs
@@ -16,7 +16,7 @@
 
 use super::{
     packet::{Packet, VSockFlags, VSockOp, HEADER_SIZE},
-    VSock, DATA_BUFFER_SIZE, QUEUE_SIZE,
+    VSock, DATA_BUFFER_SIZE,
 };
 use alloc::collections::VecDeque;
 use core::num::Wrapping;

--- a/experimental/virtio/src/vsock/socket/mod.rs
+++ b/experimental/virtio/src/vsock/socket/mod.rs
@@ -24,16 +24,16 @@ use rust_hypervisor_firmware_virtio::virtio::VirtioTransport;
 
 /// The maximum buffer size used by the socket.
 ///
-/// This is used for flow-control calculations. For now we use the maximum size seeing that we don't
-/// have a fixed limit and don't want to send too many credit update packets.
-const STREAM_BUFFER_LENGTH: Wrapping<u32> = Wrapping(u32::MAX);
+/// This is used for flow-control calculations. Seeing that we don't use an actual streambuffer,
+/// this is currently an arbitrary value that seems to avoid stalling.
+const STREAM_BUFFER_LENGTH: Wrapping<u32> = Wrapping(1024 * 1024);
 
 /// The limit that triggers a voluntary credit update message to avoid stalling.
 ///
 /// If the peer's calculation of our free buffer space falls below this point (e.g when we receive a
 /// lot of data without sending any packets back) we send a credit update packet to make sure the
 /// peer knows we have more space available.
-const CREDIT_UPDATE_LIMIT: Wrapping<u32> = Wrapping((DATA_BUFFER_SIZE * QUEUE_SIZE) as u32);
+const CREDIT_UPDATE_LIMIT: Wrapping<u32> = Wrapping(512 * 1024);
 
 /// The maximum size of the payload of a single packet to ensure it fits into a single buffer in the
 /// queue.

--- a/experimental/virtio/src/vsock/socket/tests.rs
+++ b/experimental/virtio/src/vsock/socket/tests.rs
@@ -17,7 +17,7 @@
 use super::*;
 use crate::{
     test::{new_valid_transport, TestingTransport},
-    vsock::HOST_CID,
+    vsock::{HOST_CID, QUEUE_SIZE},
 };
 use alloc::vec;
 use ciborium_io::{Read, Write};


### PR DESCRIPTION
The original choice of stream buffer length that we chose caused the comms to stall if we received a lot of data without sending any packets back, even though it indicated a very large capacity.

This updates value seems to avoid stalling without sending too many credit update packets.