### PR TITLE
Remove vsock devices from dev container

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -26,8 +26,6 @@
   "runArgs": [
     // Required by crosvm.
     "--device=/dev/kvm",
-    "--device=/dev/vhost-vsock",
-    "--device=/dev/vsock",
     // In order to access /dev/kvm, our user inside the container needs to be a
     // member of the group that owns /dev/kvm; the device itself is exposed
     // inside the container with the same group as outside the container.


### PR DESCRIPTION
At the moment the dev container requires the vsock devices to be present. These are only present if the required kernel modules are loaded, which seems to go missing after each reboot and needs to be reloaded before the dev container can be started.

After this change we will no longer be able to run the crosvm tests in the dev container terminal, but it will still be possible to run it using `scripts/docker_run`.