### PR TITLE
Add support for kernel boot arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "asn1-rs"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,11 +2872,12 @@ name = "oak_baremetal_kernel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "atomic_refcell",
  "ciborium-io",
  "getrandom 0.2.6",
  "lazy_static",
- "libm 0.1.4",
+ "libm 0.2.2",
  "linked_list_allocator",
  "log",
  "oak_baremetal_runtime",
@@ -5860,7 +5867,7 @@ dependencies = [
  "bitflags",
  "ciborium-io",
  "log",
- "rand 0.4.6",
+ "rand 0.8.5",
  "rust-hypervisor-firmware-virtio",
  "strum",
 ]

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -55,6 +55,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +599,7 @@ name = "oak_baremetal_kernel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "atomic_refcell",
  "ciborium-io",
  "getrandom",

--- a/experimental/oak_baremetal_app_crosvm/src/bootparam.rs
+++ b/experimental/oak_baremetal_app_crosvm/src/bootparam.rs
@@ -61,8 +61,7 @@ impl BootInfo<boot_e820_entry> for boot_params {
     fn args(&self) -> &CStr {
         if self.hdr.cmdline_size == 0 {
             Default::default()
-        }
-        else {
+        } else {
             // Safety: Linux boot protocol expects the pointer to be valid, even if there are no
             // args.
             unsafe { CStr::from_ptr(self.hdr.cmd_line_ptr as *const c_char) }

--- a/experimental/oak_baremetal_app_crosvm/src/bootparam.rs
+++ b/experimental/oak_baremetal_app_crosvm/src/bootparam.rs
@@ -19,6 +19,7 @@
  *   --ctypes-prefix c_types arch/x86/include/uapi/asm/bootparam.h
  */
 
+use core::ffi::{c_char, CStr};
 use oak_baremetal_kernel::boot::{BootInfo, E820Entry, E820EntryType};
 
 #[allow(non_camel_case_types)]
@@ -55,6 +56,15 @@ impl BootInfo<boot_e820_entry> for boot_params {
 
     fn e820_table(&self) -> &[boot_e820_entry] {
         &self.e820_table[..self.e820_entries as usize]
+    }
+
+    fn args(&self) -> &CStr {
+        if self.hdr.cmdline_size == 0 {
+            // We know the constant ends with a \0, so the unwrap will always succeed.
+            return CStr::from_bytes_with_nul(b"\0").unwrap();
+        }
+        // Safety: Linux boot protocol expects the pointer to be valid, even if there are no args.
+        unsafe { CStr::from_ptr(self.hdr.cmd_line_ptr as *const c_char) }
     }
 }
 

--- a/experimental/oak_baremetal_app_crosvm/src/bootparam.rs
+++ b/experimental/oak_baremetal_app_crosvm/src/bootparam.rs
@@ -60,11 +60,13 @@ impl BootInfo<boot_e820_entry> for boot_params {
 
     fn args(&self) -> &CStr {
         if self.hdr.cmdline_size == 0 {
-            // We know the constant ends with a \0, so the unwrap will always succeed.
-            return CStr::from_bytes_with_nul(b"\0").unwrap();
+            Default::default()
         }
-        // Safety: Linux boot protocol expects the pointer to be valid, even if there are no args.
-        unsafe { CStr::from_ptr(self.hdr.cmd_line_ptr as *const c_char) }
+        else {
+            // Safety: Linux boot protocol expects the pointer to be valid, even if there are no
+            // args.
+            unsafe { CStr::from_ptr(self.hdr.cmd_line_ptr as *const c_char) }
+        }
     }
 }
 

--- a/experimental/oak_baremetal_app_crosvm/src/main.rs
+++ b/experimental/oak_baremetal_app_crosvm/src/main.rs
@@ -19,6 +19,8 @@
 #![feature(lang_items)]
 #![feature(alloc_error_handler)]
 #![feature(custom_test_frameworks)]
+#![feature(core_c_str)]
+#![feature(core_ffi_c)]
 // As we're in a `no_std` environment, testing requires special handling. This
 // approach was inspired by https://os.phil-opp.com/testing/.
 #![test_runner(crate::test_runner)]

--- a/experimental/oak_baremetal_app_qemu/Cargo.lock
+++ b/experimental/oak_baremetal_app_qemu/Cargo.lock
@@ -64,6 +64,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +755,7 @@ name = "oak_baremetal_kernel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "atomic_refcell",
  "ciborium-io",
  "getrandom",

--- a/experimental/oak_baremetal_app_qemu/src/hvm_start_info.rs
+++ b/experimental/oak_baremetal_app_qemu/src/hvm_start_info.rs
@@ -52,10 +52,11 @@ impl BootInfo<hvm_memmap_table_entry> for hvm_start_info {
 
     fn args(&self) -> &CStr {
         if self.cmdline_paddr == 0 {
-            return CStr::from_bytes_with_nul(b"\0").unwrap();
+            Default::default()
+        } else {
+            // Safety: we check for a null pointer above; the PVH documentation doesn't say
+            // anything about the pointer being potentially invalid.
+            unsafe { CStr::from_ptr(self.cmdline_paddr as *const c_char) }
         }
-        // Safety: we check for a null pointer above; the PVH documentation doesn't say anything
-        // about the pointer being potentially invalid.
-        unsafe { CStr::from_ptr(self.cmdline_paddr as *const c_char) }
     }
 }

--- a/experimental/oak_baremetal_app_qemu/src/hvm_start_info.rs
+++ b/experimental/oak_baremetal_app_qemu/src/hvm_start_info.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+use core::ffi::{c_char, CStr};
 use oak_baremetal_kernel::boot::{BootInfo, E820Entry, E820EntryType};
 
 include!(concat!(env!("OUT_DIR"), "/start_info.rs"));
@@ -47,5 +48,14 @@ impl BootInfo<hvm_memmap_table_entry> for hvm_start_info {
                 self.memmap_entries.try_into().unwrap(),
             )
         }
+    }
+
+    fn args(&self) -> &CStr {
+        if self.cmdline_paddr == 0 {
+            return CStr::from_bytes_with_nul(b"\0").unwrap();
+        }
+        // Safety: we check for a null pointer above; the PVH documentation doesn't say anything
+        // about the pointer being potentially invalid.
+        unsafe { CStr::from_ptr(self.cmdline_paddr as *const c_char) }
     }
 }

--- a/experimental/oak_baremetal_app_qemu/src/main.rs
+++ b/experimental/oak_baremetal_app_qemu/src/main.rs
@@ -18,6 +18,7 @@
 #![no_main]
 #![feature(lang_items)]
 #![feature(alloc_error_handler)]
+#![feature(core_c_str)]
 #![feature(core_ffi_c)]
 #![feature(custom_test_frameworks)]
 // As we're in a `no_std` environment, testing requires special handling. This

--- a/experimental/oak_baremetal_app_qemu/src/multiboot.rs
+++ b/experimental/oak_baremetal_app_qemu/src/multiboot.rs
@@ -58,13 +58,13 @@ impl BootInfo<multiboot_mmap_entry> for multiboot_info {
     }
 
     fn args(&self) -> &CStr {
+        // Bit 2 indicates cmdline is valid.
         if self.flags & (1 << 2) == 0 {
-            // We know the constant ends with a \0, so the unwrap will always succeed.
-            return CStr::from_bytes_with_nul(b"\0").unwrap();
+            Default::default()
+        } else {
+            // Safety: the pointer is valid per Multiboot specs if the flag above is set.
+            unsafe { CStr::from_ptr(self.cmdline as *const c_char) }
         }
-
-        // Safety: the pointer is valid per Multiboot specs if the flag above is set.
-        unsafe { CStr::from_ptr(self.cmdline as *const c_char) }
     }
 }
 

--- a/experimental/oak_baremetal_kernel/Cargo.toml
+++ b/experimental/oak_baremetal_kernel/Cargo.toml
@@ -12,6 +12,7 @@ serial_channel = []
 
 [dependencies]
 anyhow = { version = "*", default-features = false }
+arrayvec = { version = "*", default-features = false }
 atomic_refcell = "*"
 ciborium-io = { version = "*", default-features = false }
 getrandom = { version = "0.2", features = ["rdrand"] }

--- a/experimental/oak_baremetal_kernel/src/args.rs
+++ b/experimental/oak_baremetal_kernel/src/args.rs
@@ -1,0 +1,74 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use atomic_refcell::AtomicRefCell;
+use core::ffi::CStr;
+use lazy_static::lazy_static;
+
+// This is a really crude analogue of CString, which we can't use, as CString requires allocation.
+// Instead of allocation, we rely on a static buffer.
+struct StaticCString {
+    buf: [u8; 512],
+
+    // Index of \0 in the buffer, above, so that we don't have to keep searching for it.
+    len: usize,
+}
+
+impl Default for StaticCString {
+    fn default() -> Self {
+        StaticCString {
+            buf: [0; 512],
+            len: 0,
+        }
+    }
+}
+
+impl StaticCString {
+    fn as_c_str(&self) -> &CStr {
+        // Safety: this is safe as initally len will be zero, resulting in an empty CStr;
+        // otherwise, the fields are initialized from init_args() from a pre-existing valid CStr.
+        unsafe { CStr::from_bytes_with_nul_unchecked(&self.buf[..self.len]) }
+    }
+}
+
+lazy_static! {
+    static ref ARGS: AtomicRefCell<StaticCString> = Default::default();
+}
+
+/// Buffers kernel arguments in a static variable.
+///
+/// This function is intended to be called fairly early in the boot process, when we don't even
+/// have memory allocation available. This also means that we can't use anyhow::Result as the
+/// return value, as anyhow relies on allocation.
+pub fn init_args(args: &CStr) -> core::result::Result<(), &str> {
+    let src = args.to_bytes_with_nul();
+    let mut dst = ARGS.borrow_mut();
+
+    if src.len() > dst.buf.len() {
+        return Err("Kernel command line too long");
+    }
+    dst.len = src.len();
+    dst.buf[..src.len()].copy_from_slice(src);
+
+    Ok(())
+}
+
+pub fn args() -> &'static CStr {
+    // Hack as the fact that ARGS is static is not immediately evident.
+    // Safety: we initialize ARGS once, with a static buffer, so the pointer will be valid and
+    // always pointing to the same memory location.
+    unsafe { ARGS.as_ptr().as_ref() }.unwrap().as_c_str()
+}

--- a/experimental/oak_baremetal_kernel/src/args.rs
+++ b/experimental/oak_baremetal_kernel/src/args.rs
@@ -27,10 +27,11 @@ static mut ARGS: ArrayString<512> = ArrayString::new_const();
 pub fn init_args(args: &CStr) -> core::result::Result<(), &str> {
     let args = args
         .to_str()
-        .map_err(|_| "Kernel arguments are not valid UTF-8")?;
+        .map_err(|core::str::Utf8Error { .. }| "Kernel arguments are not valid UTF-8")?;
     // Safety: this is called once early in the initialization process from a single thread, so
     // there will not be any concurrent writes.
-    unsafe { ARGS.try_push_str(args) }.map_err(|_| "Kernel arguments too long")
+    unsafe { ARGS.try_push_str(args) }
+        .map_err(|arrayvec::CapacityError { .. }| "Kernel arguments too long")
 }
 
 pub fn args() -> &'static str {

--- a/experimental/oak_baremetal_kernel/src/boot.rs
+++ b/experimental/oak_baremetal_kernel/src/boot.rs
@@ -55,4 +55,6 @@ pub trait BootInfo<E: E820Entry> {
     fn protocol(&self) -> &str;
     /// Slice of address range descriptors representing the memory layout of the machine.
     fn e820_table(&self) -> &[E];
+    /// Arguments passed to the kernel.
+    fn args(&self) -> &core::ffi::CStr;
 }

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -76,7 +76,7 @@ pub fn start_kernel<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
 
 fn main(protocol: &str) -> ! {
     info!("In main! Boot protocol:  {}", protocol);
-    info!("Kernel boot args: {:?}", args::args());
+    info!("Kernel boot args: {}", args::args());
     let attestation_behavior =
         AttestationBehavior::create(EmptyAttestationGenerator, EmptyAttestationVerifier);
     oak_baremetal_runtime::framing::handle_frames(get_channel(), attestation_behavior).unwrap();

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -30,7 +30,9 @@
 
 #![no_std]
 #![feature(abi_x86_interrupt)]
+#![feature(core_c_str)]
 
+mod args;
 mod avx;
 pub mod boot;
 pub mod i8042;
@@ -60,13 +62,21 @@ pub fn start_kernel<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
     logging::init_logging();
     interrupts::init_idt();
     paging::setup();
+    // We need to be done with the boot info struct before intializing memory. For example, the
+    // multiboot protocol explicitly states data can be placed anywhere in memory; therefore, it's
+    // highly likely we will overwrite some data after we initialize the heap. args::init_args()
+    // caches the arguments (as long they are of reasonable length) in a static variable, allowing
+    // us to refer to the args in the future.
+    args::init_args(info.args()).unwrap();
+
     // If we don't find memory for heap, it's ok to panic.
     memory::init_allocator(info.e820_table()).unwrap();
-    main(info);
+    main(info.protocol());
 }
 
-fn main<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
-    info!("In main! Boot protocol:  {}", info.protocol());
+fn main(protocol: &str) -> ! {
+    info!("In main! Boot protocol:  {}", protocol);
+    info!("Kernel boot args: {:?}", args::args());
     let attestation_behavior =
         AttestationBehavior::create(EmptyAttestationGenerator, EmptyAttestationVerifier);
     oak_baremetal_runtime::framing::handle_frames(get_channel(), attestation_behavior).unwrap();


### PR DESCRIPTION
The idea is that in the future we may want to pass arguments to the kernel even before we establish our communication channel: for example, whether to use serial or vsock-virtio (or vsock-console) for said communication channel to begin with.

Part of this PR is also a request for ideas: I'm not happy about `args::args()` right now, but I couldn't figure out how to convince Rust that the memory is static so that a `&'static CStr` makes sense.