### PR TITLE
Consume boot info when initializing memory

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/src/bootparam.rs
+++ b/experimental/oak_baremetal_app_crosvm/src/bootparam.rs
@@ -49,8 +49,8 @@ impl E820Entry for boot_e820_entry {
     }
 }
 
-impl BootInfo<boot_e820_entry> for boot_params {
-    fn protocol(&self) -> &str {
+impl BootInfo<boot_e820_entry> for &boot_params {
+    fn protocol(&self) -> &'static str {
         "Linux Boot Protocol"
     }
 

--- a/experimental/oak_baremetal_app_qemu/src/hvm_start_info.rs
+++ b/experimental/oak_baremetal_app_qemu/src/hvm_start_info.rs
@@ -33,8 +33,8 @@ impl E820Entry for hvm_memmap_table_entry {
     }
 }
 
-impl BootInfo<hvm_memmap_table_entry> for hvm_start_info {
-    fn protocol(&self) -> &str {
+impl BootInfo<hvm_memmap_table_entry> for &hvm_start_info {
+    fn protocol(&self) -> &'static str {
         "PVH Boot Protocol"
     }
 

--- a/experimental/oak_baremetal_app_qemu/src/multiboot.rs
+++ b/experimental/oak_baremetal_app_qemu/src/multiboot.rs
@@ -37,8 +37,8 @@ impl E820Entry for multiboot_mmap_entry {
     }
 }
 
-impl BootInfo<multiboot_mmap_entry> for multiboot_info {
-    fn protocol(&self) -> &str {
+impl BootInfo<multiboot_mmap_entry> for &multiboot_info {
+    fn protocol(&self) -> &'static str {
         "Multiboot1 Protocol"
     }
 

--- a/experimental/oak_baremetal_kernel/src/boot.rs
+++ b/experimental/oak_baremetal_kernel/src/boot.rs
@@ -52,7 +52,7 @@ pub trait E820Entry {
 /// loader.
 pub trait BootInfo<E: E820Entry> {
     /// Human-readable name of the boot protocol.
-    fn protocol(&self) -> &str;
+    fn protocol(&self) -> &'static str;
     /// Slice of address range descriptors representing the memory layout of the machine.
     fn e820_table(&self) -> &[E];
     /// Arguments passed to the kernel.

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -57,7 +57,7 @@ use rust_hypervisor_firmware_virtio::pci::VirtioPciTransport;
 const VSOCK_PORT: u32 = 1024;
 
 /// Main entry point for the kernel, to be called from bootloader.
-pub fn start_kernel<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
+pub fn start_kernel<E: boot::E820Entry, B: boot::BootInfo<E>>(info: B) -> ! {
     avx::enable_avx();
     logging::init_logging();
     interrupts::init_idt();
@@ -69,9 +69,10 @@ pub fn start_kernel<E: boot::E820Entry, B: boot::BootInfo<E>>(info: &B) -> ! {
     // us to refer to the args in the future.
     args::init_args(info.args()).unwrap();
 
+    let protocol = info.protocol();
     // If we don't find memory for heap, it's ok to panic.
-    memory::init_allocator(info.e820_table()).unwrap();
-    main(info.protocol());
+    memory::init_allocator(info).unwrap();
+    main(protocol);
 }
 
 fn main(protocol: &str) -> ! {

--- a/experimental/oak_baremetal_kernel/src/memory.rs
+++ b/experimental/oak_baremetal_kernel/src/memory.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use crate::boot::{self, E820Entry};
+use crate::boot;
 use core::result::Result;
 use linked_list_allocator::LockedHeap;
 use log::info;
@@ -26,7 +26,7 @@ static ALLOCATOR: LockedHeap = LockedHeap::empty();
 #[cfg(test)]
 static ALLOCATOR: LockedHeap = LockedHeap::empty();
 
-pub fn init_allocator<E: E820Entry>(e820_table: &[E]) -> Result<(), &str> {
+pub fn init_allocator<E: boot::E820Entry, B: boot::BootInfo<E>>(info: B) -> Result<(), &'static str> {
     let ram_min = rust_hypervisor_firmware_boot::ram_min();
     let text_start = rust_hypervisor_firmware_boot::text_start();
     let text_end = rust_hypervisor_firmware_boot::text_end();
@@ -38,7 +38,7 @@ pub fn init_allocator<E: E820Entry>(e820_table: &[E]) -> Result<(), &str> {
     info!("STACK_START: {}", stack_start);
 
     // Find the largest slice of memory and use that for the heap.
-    let largest = e820_table
+    let largest = info.e820_table()
         .iter()
         .inspect(|e| {
             info!(

--- a/experimental/oak_baremetal_kernel/src/memory.rs
+++ b/experimental/oak_baremetal_kernel/src/memory.rs
@@ -26,6 +26,18 @@ static ALLOCATOR: LockedHeap = LockedHeap::empty();
 #[cfg(test)]
 static ALLOCATOR: LockedHeap = LockedHeap::empty();
 
+/// Initializes the global allocator from the largest contiguous slice of available memory.
+///
+/// Pointers to addresses in the memory area (or references to data contained within the slice) must
+/// be considered invalid after calling this function, as the allocator may overwrite the data at
+/// any point.
+///
+/// We ensure that data up address specified by `.stack_start` in the linker script is untouched,
+/// even if it falls within the largest slice of memory.
+///
+/// Case in point, boot metadata is often stored somewhere in the memory area, so calling this takes
+/// ownership of the `boot:BootInfo`, as the data provided to us by the bootloader will get
+/// clobbered after initializing the heap.
 pub fn init_allocator<E: boot::E820Entry, B: boot::BootInfo<E>>(
     info: B,
 ) -> Result<(), &'static str> {

--- a/experimental/oak_baremetal_kernel/src/memory.rs
+++ b/experimental/oak_baremetal_kernel/src/memory.rs
@@ -26,7 +26,9 @@ static ALLOCATOR: LockedHeap = LockedHeap::empty();
 #[cfg(test)]
 static ALLOCATOR: LockedHeap = LockedHeap::empty();
 
-pub fn init_allocator<E: boot::E820Entry, B: boot::BootInfo<E>>(info: B) -> Result<(), &'static str> {
+pub fn init_allocator<E: boot::E820Entry, B: boot::BootInfo<E>>(
+    info: B,
+) -> Result<(), &'static str> {
     let ram_min = rust_hypervisor_firmware_boot::ram_min();
     let text_start = rust_hypervisor_firmware_boot::text_start();
     let text_end = rust_hypervisor_firmware_boot::text_end();
@@ -38,7 +40,8 @@ pub fn init_allocator<E: boot::E820Entry, B: boot::BootInfo<E>>(info: B) -> Resu
     info!("STACK_START: {}", stack_start);
 
     // Find the largest slice of memory and use that for the heap.
-    let largest = info.e820_table()
+    let largest = info
+        .e820_table()
         .iter()
         .inspect(|e| {
             info!(


### PR DESCRIPTION
As I found out in one of my other PRs, initializing the memory allocator can trash the contents of the boot metadata provided to us by the boot loader (as the metadata is stored _somewhere_ in valid memory, which may be overwritten at any point after we enable allocation).

Thus: let's make `memory::init_allocator()` take ownership of the reference, so that we know that it can't be used after we call the function.