### PR TITLE
Update baremetal runtime to generate the same attestation as the linux runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,6 +2882,7 @@ dependencies = [
  "log",
  "oak_baremetal_runtime",
  "oak_remote_attestation",
+ "oak_remote_attestation_amd",
  "rust-hypervisor-firmware-boot",
  "rust-hypervisor-firmware-virtio",
  "strum",

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -468,6 +468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +615,7 @@ dependencies = [
  "log",
  "oak_baremetal_runtime",
  "oak_remote_attestation",
+ "oak_remote_attestation_amd",
  "rust-hypervisor-firmware-boot",
  "rust-hypervisor-firmware-virtio",
  "strum",
@@ -719,6 +726,16 @@ dependencies = [
  "sha2 0.10.2",
  "signature",
  "x25519-dalek",
+]
+
+[[package]]
+name = "oak_remote_attestation_amd"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "oak_remote_attestation",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -934,6 +951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +992,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/experimental/oak_baremetal_app_qemu/Cargo.lock
+++ b/experimental/oak_baremetal_app_qemu/Cargo.lock
@@ -589,6 +589,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +771,7 @@ dependencies = [
  "log",
  "oak_baremetal_runtime",
  "oak_remote_attestation",
+ "oak_remote_attestation_amd",
  "rust-hypervisor-firmware-boot",
  "rust-hypervisor-firmware-virtio",
  "strum",
@@ -875,6 +882,16 @@ dependencies = [
  "sha2 0.10.2",
  "signature",
  "x25519-dalek",
+]
+
+[[package]]
+name = "oak_remote_attestation_amd"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "oak_remote_attestation",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1110,6 +1127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1168,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/experimental/oak_baremetal_client/src/main.rs
+++ b/experimental/oak_baremetal_client/src/main.rs
@@ -17,7 +17,6 @@
 use anyhow::Context;
 use clap::Parser;
 use grpc_unary_attestation::client::AttestationClient;
-use oak_remote_attestation::handshaker::EmptyAttestationVerifier;
 use std::io::{stdin, BufRead};
 
 #[derive(Parser, Debug)]
@@ -54,10 +53,9 @@ async fn chat(client: &mut AttestationClient, message: String) -> anyhow::Result
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Args::parse();
 
-    let mut client =
-        AttestationClient::create_with_attestation_verifier(&cli.server, EmptyAttestationVerifier)
-            .await
-            .context("Could not create client")?;
+    let mut client = AttestationClient::create(&cli.server)
+        .await
+        .context("Could not create client")?;
 
     match (cli.request, cli.expected_response, cli.iterations) {
         (Some(request), Some(expected_response), Some(iterations)) => {

--- a/experimental/oak_baremetal_kernel/Cargo.toml
+++ b/experimental/oak_baremetal_kernel/Cargo.toml
@@ -23,6 +23,9 @@ libm = "*"
 oak_remote_attestation = { path = "../../remote_attestation/rust", default-features = false, features = [
   "rust-crypto"
 ] }
+oak_remote_attestation_amd = { path = "../../oak_remote_attestation_amd", default-features = false, features = [
+  "rust-crypto"
+] }
 oak_baremetal_runtime = { path = "../../experimental/oak_baremetal_runtime", default-features = false, features = [
   "rust-crypto"
 ] }

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -45,9 +45,8 @@ mod serial;
 
 use core::panic::PanicInfo;
 use log::{error, info};
-use oak_remote_attestation::handshaker::{
-    AttestationBehavior, EmptyAttestationGenerator, EmptyAttestationVerifier,
-};
+use oak_remote_attestation::handshaker::{AttestationBehavior, EmptyAttestationVerifier};
+use oak_remote_attestation_amd::PlaceholderAmdAttestationGenerator;
 use rust_hypervisor_firmware_boot::paging;
 #[cfg(not(feature = "serial_channel"))]
 use rust_hypervisor_firmware_virtio::pci::VirtioPciTransport;
@@ -79,7 +78,7 @@ fn main(protocol: &str) -> ! {
     info!("In main! Boot protocol:  {}", protocol);
     info!("Kernel boot args: {}", args::args());
     let attestation_behavior =
-        AttestationBehavior::create(EmptyAttestationGenerator, EmptyAttestationVerifier);
+        AttestationBehavior::create(PlaceholderAmdAttestationGenerator, EmptyAttestationVerifier);
     oak_baremetal_runtime::framing::handle_frames(get_channel(), attestation_behavior).unwrap();
 }
 

--- a/oak_remote_attestation_amd/Cargo.toml
+++ b/oak_remote_attestation_amd/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "*", default-features = false, features = [
   "alloc",
   "derive"
 ] }
-serde_json = "*"
+serde_json = { version = "*", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
…Previously it used the EmptyAttestationGenerator. Now it uses the PlaceholderAmdAttestationGenerator. This change will make it easier to share clients between the runtimes in the future