### PR TITLE
Share environment variables between the devcontainer and our docker scripts

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -23,18 +23,14 @@
     // Crosvm wants access to syslog.
     "source=/dev/log,target=/dev/log,type=bind"
   ],
+  // Before creating the container, generate a .env file for the variables that
+  // should be set within the container.
+  "initializeCommand": "source ./scripts/docker_create_env_file",
   "runArgs": [
+    // Use the .env file generated prior to container creation.
+    "--env-file=.docker.env",
     // Required by crosvm.
-    "--device=/dev/kvm",
-    // In order to access /dev/kvm, our user inside the container needs to be a
-    // member of the group that owns /dev/kvm; the device itself is exposed
-    // inside the container with the same group as outside the container.
-    // Unfortunately this GID can differ between systems and there doesn't seem
-    // to be any good way to determine this dynamically from the host machine.
-    // Thus, hard-code 107 which is the group id used with Debian. If you use a
-    // different distribution, it's highly likely you need to adjust this value
-    // to match your environment.
-    "--group-add=107"
+    "--device=/dev/kvm"
   ],
   "settings": {
     // Use the `rust-analyzer` binary installed in the Docker image.

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ Makefile.conf
 
 # TensorFlow model server binary
 tensorflow_model_server
+
+# Generated .env file for docker
+.docker.env

--- a/scripts/docker_create_env_file
+++ b/scripts/docker_create_env_file
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# This script creates a .env file for enviroment variables we would like to
+# set in the docker image.
+# Ref: https://docs.docker.com/compose/env-file/
+
+env_variables=(
+  "TERM=xterm-256color"
+  # The default user for a Docker container has uid 0 (root). To avoid creating
+  # root-owned files in the build directory we tell Docker to use the current user
+  # ID, if known.
+  # Ref: https://github.com/googleapis/google-cloud-cpp/blob/a186208b79d900b4ec71c6f9df3acf7638f01dc6/ci/kokoro/docker/build.sh#L147-L152
+  "HOST_UID=${UID:-0}"
+  "HOST_GID=$(id -g)"
+)
+
+# Expose relevant bazel enviroment variables if they are set
+if [[ -n "${BAZEL_REMOTE_CACHE_ENABLED-}" ]]; then
+  env_variables+=(
+    "BAZEL_REMOTE_CACHE_ENABLED=${BAZEL_REMOTE_CACHE_ENABLED}"
+  )
+fi
+if [[ -n "${BAZEL_GOOGLE_CREDENTIALS-}" ]]; then
+  env_variables+=(
+    "BAZEL_GOOGLE_CREDENTIALS=${BAZEL_GOOGLE_CREDENTIALS}"
+  )
+fi
+
+# To use KVM, if exposed by the host, the docker user needs to match the host's
+# KVM group.
+if [[ -e "/dev/kvm" ]]; then
+  env_variables+=(
+    "HOST_KVM_GID=$(getent group kvm | cut -d: -f3)"
+  )
+fi
+
+printf "%s\n" "${env_variables[@]}" > .docker.env

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -19,25 +19,14 @@ mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 mkdir -p './sccache-cache'
 
-# The default user for a Docker container has uid 0 (root). To avoid creating
-# root-owned files in the build directory we tell Docker to use the current user
-# ID, if known.
-# See
-# https://github.com/googleapis/google-cloud-cpp/blob/a186208b79d900b4ec71c6f9df3acf7638f01dc6/ci/kokoro/docker/build.sh#L147-L152
-readonly HOST_UID="${UID:-0}"
-readonly HOST_GID="$(id -g)"
-
-export HOST_UID
-export HOST_GID
+# Generate .env file to use with the docker image
+source "$SCRIPTS_DIR/docker_create_env_file"
 
 docker_run_flags=(
   '--rm'
   '--tty'
-  '--env=TERM=xterm-256color'
-  '--env=BAZEL_REMOTE_CACHE_ENABLED'
-  '--env=BAZEL_GOOGLE_CREDENTIALS'
-  '--env=HOST_UID'
-  '--env=HOST_GID'
+  # Use the generated .env file
+  '--env-file=.docker.env'
   "--volume=$PWD/bazel-cache:/home/docker/.cache/bazel"
   "--volume=$PWD/cargo-cache:/home/docker/.cargo"
   "--volume=$PWD/sccache-cache:/home/docker/.cache/sccache"
@@ -56,7 +45,6 @@ if [[ -e "/dev/kvm" ]]; then
   readonly HOST_KVM_GID="$(getent group kvm | cut -d: -f3)"
   docker_run_flags+=(
     "--device=/dev/kvm"
-    "--env=HOST_KVM_GID=${HOST_KVM_GID}"
   )
 fi
 


### PR DESCRIPTION
Fixes #2717, means we can now use kvm in the dev container on system's where the docker group id is not 107.