### PR TITLE
Get rid of ciborium_io dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,12 +662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium-io"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
-
-[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2860,7 +2854,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
- "ciborium-io",
  "flatbuffers",
  "oak_idl",
  "oak_idl_gen_services",
@@ -2875,12 +2868,12 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "atomic_refcell",
- "ciborium-io",
  "getrandom 0.2.7",
  "lazy_static",
  "libm 0.2.2",
  "linked_list_allocator",
  "log",
+ "oak_baremetal_communication_channel",
  "oak_baremetal_runtime",
  "oak_remote_attestation",
  "oak_remote_attestation_amd",
@@ -2899,7 +2892,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bmrng",
- "ciborium-io",
  "clap 3.1.18",
  "command-fds",
  "env_logger 0.9.0",
@@ -2921,7 +2913,6 @@ name = "oak_baremetal_runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ciborium-io",
  "flatbuffers",
  "hashbrown 0.12.1",
  "log",
@@ -5852,7 +5843,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
- "ciborium-io",
  "log",
  "rand 0.8.5",
  "rust-hypervisor-firmware-virtio",

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -133,12 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "ciborium-io"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
-
-[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,7 +586,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
- "ciborium-io",
  "flatbuffers",
  "oak_idl",
  "oak_idl_gen_services",
@@ -607,12 +600,12 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "atomic_refcell",
- "ciborium-io",
  "getrandom",
  "lazy_static",
  "libm",
  "linked_list_allocator",
  "log",
+ "oak_baremetal_communication_channel",
  "oak_baremetal_runtime",
  "oak_remote_attestation",
  "oak_remote_attestation_amd",
@@ -629,7 +622,6 @@ name = "oak_baremetal_runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ciborium-io",
  "flatbuffers",
  "hashbrown 0.11.2",
  "log",
@@ -1224,7 +1216,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
- "ciborium-io",
  "log",
  "rust-hypervisor-firmware-virtio",
  "strum",

--- a/experimental/oak_baremetal_app_qemu/Cargo.lock
+++ b/experimental/oak_baremetal_app_qemu/Cargo.lock
@@ -185,12 +185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "ciborium-io"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
-
-[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,7 +742,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
- "ciborium-io",
  "flatbuffers",
  "oak_idl",
  "oak_idl_gen_services",
@@ -763,12 +756,12 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "atomic_refcell",
- "ciborium-io",
  "getrandom",
  "lazy_static",
  "libm",
  "linked_list_allocator",
  "log",
+ "oak_baremetal_communication_channel",
  "oak_baremetal_runtime",
  "oak_remote_attestation",
  "oak_remote_attestation_amd",
@@ -785,7 +778,6 @@ name = "oak_baremetal_runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ciborium-io",
  "flatbuffers",
  "hashbrown 0.12.1",
  "log",
@@ -1427,7 +1419,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
- "ciborium-io",
  "log",
  "rust-hypervisor-firmware-virtio",
  "strum",

--- a/experimental/oak_baremetal_channel/Cargo.toml
+++ b/experimental/oak_baremetal_channel/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = { version = "*", default-features = false }
-ciborium-io = { version = "*", default-features = false }
 oak_idl = { path = "../../oak_idl" }
 flatbuffers = { version = "*", features = ["no_std"], default-features = false }
 static_assertions = "*"

--- a/experimental/oak_baremetal_channel/src/client.rs
+++ b/experimental/oak_baremetal_channel/src/client.rs
@@ -18,17 +18,17 @@ extern crate alloc;
 
 use crate::{
     message::{InvocationId, RequestMessage, ResponseMessage},
-    Channel, InvocationChannel,
+    InvocationChannel, Read, Write,
 };
 use alloc::{string::String, vec::Vec};
 
-pub struct ClientChannelHandle<T: Channel> {
+pub struct ClientChannelHandle<T: Read + Write> {
     inner: InvocationChannel<T>,
 }
 
 impl<T> ClientChannelHandle<T>
 where
-    T: Channel,
+    T: Read + Write,
 {
     pub fn new(socket: T) -> Self {
         Self {

--- a/experimental/oak_baremetal_channel/src/client.rs
+++ b/experimental/oak_baremetal_channel/src/client.rs
@@ -18,18 +18,17 @@ extern crate alloc;
 
 use crate::{
     message::{InvocationId, RequestMessage, ResponseMessage},
-    InvocationChannel,
+    Channel, InvocationChannel,
 };
 use alloc::{string::String, vec::Vec};
-use ciborium_io::{Read, Write};
 
-pub struct ClientChannelHandle<T: Read + Write> {
+pub struct ClientChannelHandle<T: Channel> {
     inner: InvocationChannel<T>,
 }
 
 impl<T> ClientChannelHandle<T>
 where
-    T: Read<Error = anyhow::Error> + Write<Error = anyhow::Error>,
+    T: Channel,
 {
     pub fn new(socket: T) -> Self {
         Self {

--- a/experimental/oak_baremetal_channel/src/frame.rs
+++ b/experimental/oak_baremetal_channel/src/frame.rs
@@ -18,7 +18,7 @@
 
 extern crate alloc;
 
-use crate::Channel;
+use crate::{Read, Write};
 use alloc::{format, vec, vec::Vec};
 use bitflags::bitflags;
 
@@ -78,13 +78,13 @@ impl TryFrom<Frame> for Vec<u8> {
     }
 }
 
-pub struct Framed<T: Channel> {
+pub struct Framed<T: Read + Write> {
     inner: T,
 }
 
 impl<T> Framed<T>
 where
-    T: Channel,
+    T: Read + Write,
 {
     pub fn new(socket: T) -> Self {
         Self { inner: socket }

--- a/experimental/oak_baremetal_channel/src/frame.rs
+++ b/experimental/oak_baremetal_channel/src/frame.rs
@@ -18,9 +18,9 @@
 
 extern crate alloc;
 
+use crate::Channel;
 use alloc::{format, vec, vec::Vec};
 use bitflags::bitflags;
-use ciborium_io::{Read, Write};
 
 pub const PADDING_SIZE: usize = 4;
 
@@ -78,13 +78,13 @@ impl TryFrom<Frame> for Vec<u8> {
     }
 }
 
-pub struct Framed<T: Read + Write> {
+pub struct Framed<T: Channel> {
     inner: T,
 }
 
 impl<T> Framed<T>
 where
-    T: Read<Error = anyhow::Error> + Write<Error = anyhow::Error>,
+    T: Channel,
 {
     pub fn new(socket: T) -> Self {
         Self { inner: socket }
@@ -93,11 +93,11 @@ where
     pub fn read_frame(&mut self) -> anyhow::Result<Frame> {
         {
             let mut padding_bytes = [0; PADDING_SIZE];
-            self.inner.read_exact(&mut padding_bytes)?;
+            self.inner.read(&mut padding_bytes)?;
         };
         let length: usize = {
             let mut length_bytes = [0; LENGTH_SIZE];
-            self.inner.read_exact(&mut length_bytes)?;
+            self.inner.read(&mut length_bytes)?;
             let length = Length::from_le_bytes(length_bytes).into();
             if length > MAX_SIZE {
                 return Err(anyhow::Error::msg("frame exceeds the maximum frame size"));
@@ -106,14 +106,14 @@ where
         };
         let flags = {
             let mut flags_bytes = [0; FLAGS_SIZE];
-            self.inner.read_exact(&mut flags_bytes)?;
+            self.inner.read(&mut flags_bytes)?;
             Flags::from_bits_truncate(u16::from_le_bytes(flags_bytes))
         };
 
         let body = {
             let body_length: usize = length - BODY_OFFSET;
             let mut body: Vec<u8> = vec![0; body_length];
-            self.inner.read_exact(&mut body)?;
+            self.inner.read(&mut body)?;
             body
         };
 
@@ -122,7 +122,7 @@ where
 
     pub fn write_frame(&mut self, frame: Frame) -> anyhow::Result<()> {
         let frame_bytes: Vec<u8> = frame.try_into()?;
-        self.inner.write_all(&frame_bytes)?;
+        self.inner.write(&frame_bytes)?;
         self.inner.flush()?;
         Ok(())
     }

--- a/experimental/oak_baremetal_channel/src/lib.rs
+++ b/experimental/oak_baremetal_channel/src/lib.rs
@@ -38,15 +38,20 @@ mod tests;
 extern crate alloc;
 use alloc::vec::Vec;
 use anyhow::Context;
-use ciborium_io::{Read, Write};
 
-struct InvocationChannel<T: Read + Write> {
+pub trait Channel {
+    fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()>;
+    fn write(&mut self, data: &[u8]) -> anyhow::Result<()>;
+    fn flush(&mut self) -> anyhow::Result<()>;
+}
+
+struct InvocationChannel<T: Channel> {
     inner: frame::Framed<T>,
 }
 
 impl<T> InvocationChannel<T>
 where
-    T: Read<Error = anyhow::Error> + Write<Error = anyhow::Error>,
+    T: Channel,
 {
     pub fn new(socket: T) -> Self {
         Self {

--- a/experimental/oak_baremetal_channel/src/lib.rs
+++ b/experimental/oak_baremetal_channel/src/lib.rs
@@ -39,19 +39,22 @@ extern crate alloc;
 use alloc::vec::Vec;
 use anyhow::Context;
 
-pub trait Channel {
+pub trait Read {
     fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()>;
+}
+
+pub trait Write {
     fn write(&mut self, data: &[u8]) -> anyhow::Result<()>;
     fn flush(&mut self) -> anyhow::Result<()>;
 }
 
-struct InvocationChannel<T: Channel> {
+struct InvocationChannel<T: Read + Write> {
     inner: frame::Framed<T>,
 }
 
 impl<T> InvocationChannel<T>
 where
-    T: Channel,
+    T: Read + Write,
 {
     pub fn new(socket: T) -> Self {
         Self {

--- a/experimental/oak_baremetal_channel/src/server.rs
+++ b/experimental/oak_baremetal_channel/src/server.rs
@@ -14,16 +14,15 @@
 // limitations under the License.
 //
 
-use crate::{message, InvocationChannel, Vec};
-use ciborium_io::{Read, Write};
+use crate::{message, Channel, InvocationChannel, Vec};
 
-pub struct ServerChannelHandle<T: Read + Write> {
+pub struct ServerChannelHandle<T: Channel> {
     inner: InvocationChannel<T>,
 }
 
 impl<T> ServerChannelHandle<T>
 where
-    T: Read<Error = anyhow::Error> + Write<Error = anyhow::Error>,
+    T: Channel,
 {
     pub fn new(socket: T) -> Self {
         Self {

--- a/experimental/oak_baremetal_channel/src/server.rs
+++ b/experimental/oak_baremetal_channel/src/server.rs
@@ -14,15 +14,15 @@
 // limitations under the License.
 //
 
-use crate::{message, Channel, InvocationChannel, Vec};
+use crate::{message, InvocationChannel, Read, Vec, Write};
 
-pub struct ServerChannelHandle<T: Channel> {
+pub struct ServerChannelHandle<T: Read + Write> {
     inner: InvocationChannel<T>,
 }
 
 impl<T> ServerChannelHandle<T>
 where
-    T: Channel,
+    T: Read + Write,
 {
     pub fn new(socket: T) -> Self {
         Self {

--- a/experimental/oak_baremetal_channel/src/tests.rs
+++ b/experimental/oak_baremetal_channel/src/tests.rs
@@ -78,24 +78,19 @@ struct MessageStore {
     inner: VecDeque<u8>,
 }
 
-impl ciborium_io::Read for MessageStore {
-    type Error = anyhow::Error;
-
-    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+impl Channel for MessageStore {
+    fn read(&mut self, buf: &mut [u8]) -> anyhow::Result<()> {
         buf.fill_with(|| self.inner.pop_front().unwrap());
         Ok(())
     }
-}
 
-impl ciborium_io::Write for MessageStore {
-    type Error = anyhow::Error;
-    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+    fn write(&mut self, buf: &[u8]) -> anyhow::Result<()> {
         self.inner.reserve(buf.len());
         self.inner.extend(buf);
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), Self::Error> {
+    fn flush(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/experimental/oak_baremetal_channel/src/tests.rs
+++ b/experimental/oak_baremetal_channel/src/tests.rs
@@ -78,12 +78,14 @@ struct MessageStore {
     inner: VecDeque<u8>,
 }
 
-impl Channel for MessageStore {
+impl Read for MessageStore {
     fn read(&mut self, buf: &mut [u8]) -> anyhow::Result<()> {
         buf.fill_with(|| self.inner.pop_front().unwrap());
         Ok(())
     }
+}
 
+impl Write for MessageStore {
     fn write(&mut self, buf: &[u8]) -> anyhow::Result<()> {
         self.inner.reserve(buf.len());
         self.inner.extend(buf);

--- a/experimental/oak_baremetal_kernel/Cargo.toml
+++ b/experimental/oak_baremetal_kernel/Cargo.toml
@@ -14,7 +14,6 @@ serial_channel = []
 anyhow = { version = "*", default-features = false }
 arrayvec = { version = "*", default-features = false }
 atomic_refcell = "*"
-ciborium-io = { version = "*", default-features = false }
 getrandom = { version = "0.2", features = ["rdrand"] }
 lazy_static = { version = "*", features = ["spin_no_std"] }
 linked_list_allocator = { version = "*" }
@@ -26,6 +25,7 @@ oak_remote_attestation = { path = "../../remote_attestation/rust", default-featu
 oak_remote_attestation_amd = { path = "../../oak_remote_attestation_amd", default-features = false, features = [
   "rust-crypto"
 ] }
+oak_baremetal_communication_channel = { path = "../../experimental/oak_baremetal_channel" }
 oak_baremetal_runtime = { path = "../../experimental/oak_baremetal_runtime", default-features = false, features = [
   "rust-crypto"
 ] }

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -80,7 +80,7 @@ fn main(protocol: &str) -> ! {
 }
 
 #[cfg(feature = "serial_channel")]
-fn get_channel() -> serial::Serial {
+fn get_channel() -> impl Read + Write {
     serial::Serial::new()
 }
 

--- a/experimental/oak_baremetal_kernel/src/serial.rs
+++ b/experimental/oak_baremetal_kernel/src/serial.rs
@@ -36,25 +36,19 @@ impl Serial {
     }
 }
 
-impl ciborium_io::Write for Serial {
-    type Error = anyhow::Error;
-
-    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+impl oak_baremetal_communication_channel::Channel for Serial {
+    fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
         for byte in data {
             self.port.borrow_mut().send_raw(*byte);
         }
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), Self::Error> {
+    fn flush(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
-}
 
-impl ciborium_io::Read for Serial {
-    type Error = anyhow::Error;
-
-    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
+    fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()> {
         #[allow(clippy::needless_range_loop)]
         for i in 0..data.len() {
             data[i] = self.port.borrow_mut().receive();

--- a/experimental/oak_baremetal_kernel/src/serial.rs
+++ b/experimental/oak_baremetal_kernel/src/serial.rs
@@ -36,7 +36,7 @@ impl Serial {
     }
 }
 
-impl oak_baremetal_communication_channel::Channel for Serial {
+impl oak_baremetal_communication_channel::Write for Serial {
     fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
         for byte in data {
             self.port.borrow_mut().send_raw(*byte);
@@ -47,7 +47,9 @@ impl oak_baremetal_communication_channel::Channel for Serial {
     fn flush(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
+}
 
+impl oak_baremetal_communication_channel::Read for Serial {
     fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()> {
         #[allow(clippy::needless_range_loop)]
         for i in 0..data.len() {

--- a/experimental/oak_baremetal_kernel/src/virtio.rs
+++ b/experimental/oak_baremetal_kernel/src/virtio.rs
@@ -1,0 +1,67 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use log::info;
+use oak_baremetal_communication_channel::{Read, Write};
+use rust_hypervisor_firmware_virtio::pci::VirtioPciTransport;
+
+// The virtio vsock port on which to listen.
+#[cfg(all(feature = "vsock_channel", not(feature = "serial_channel")))]
+const VSOCK_PORT: u32 = 1024;
+
+pub struct Channel<T> {
+    inner: T,
+}
+
+impl<T> Read for Channel<T>
+where
+    T: virtio::Read,
+{
+    fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()> {
+        self.inner.read(data)
+    }
+}
+
+impl<T> Write for Channel<T>
+where
+    T: virtio::Write,
+{
+    fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
+        self.inner.write(data)
+    }
+    fn flush(&mut self) -> anyhow::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(all(not(feature = "vsock_channel"), not(feature = "serial_channel")))]
+pub fn get_console_channel() -> Channel<virtio::console::Console<VirtioPciTransport>> {
+    let console = virtio::console::Console::find_and_configure_device()
+        .expect("Couldn't configure PCI virtio console device.");
+    info!("Console device status: {}", console.get_status());
+    Channel { inner: console }
+}
+
+#[cfg(all(feature = "vsock_channel", not(feature = "serial_channel")))]
+pub fn get_vsock_channel() -> Channel<virtio::vsock::socket::Socket<VirtioPciTransport>> {
+    let vsock = virtio::vsock::VSock::find_and_configure_device()
+        .expect("Couldn't configure PCI virtio vsock device.");
+    info!("Socket device status: {}", vsock.get_status());
+    let listener = virtio::vsock::socket::SocketListener::new(vsock, VSOCK_PORT);
+    Channel {
+        inner: listener.accept().expect("Couldn't accept connection."),
+    }
+}

--- a/experimental/oak_baremetal_loader/Cargo.toml
+++ b/experimental/oak_baremetal_loader/Cargo.toml
@@ -29,7 +29,6 @@ vsock = "*"
 oak_remote_attestation_sessions = { path = "../../remote_attestation_sessions" }
 oak_idl = { path = "../../oak_idl" }
 oak_baremetal_communication_channel = { path = "../../experimental/oak_baremetal_channel" }
-ciborium-io = "*"
 
 [build-dependencies]
 oak_utils = { path = "../../oak_utils" }

--- a/experimental/oak_baremetal_loader/src/main.rs
+++ b/experimental/oak_baremetal_loader/src/main.rs
@@ -78,7 +78,7 @@ struct CommsChannel {
     inner: Box<dyn ReadWrite>,
 }
 
-impl oak_baremetal_communication_channel::Channel for CommsChannel {
+impl oak_baremetal_communication_channel::Write for CommsChannel {
     fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
         self.inner.write_all(data).map_err(anyhow::Error::msg)
     }
@@ -86,7 +86,9 @@ impl oak_baremetal_communication_channel::Channel for CommsChannel {
     fn flush(&mut self) -> anyhow::Result<()> {
         self.inner.flush().map_err(anyhow::Error::msg)
     }
+}
 
+impl oak_baremetal_communication_channel::Read for CommsChannel {
     fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()> {
         self.inner.read_exact(data).map_err(anyhow::Error::msg)
     }
@@ -94,7 +96,7 @@ impl oak_baremetal_communication_channel::Channel for CommsChannel {
 
 pub struct ClientHandler<T>
 where
-    T: oak_baremetal_communication_channel::Channel,
+    T: oak_baremetal_communication_channel::Read + oak_baremetal_communication_channel::Write,
 {
     inner: ClientChannelHandle<T>,
     request_encoder: RequestEncoder,
@@ -102,7 +104,7 @@ where
 
 impl<T> ClientHandler<T>
 where
-    T: oak_baremetal_communication_channel::Channel,
+    T: oak_baremetal_communication_channel::Read + oak_baremetal_communication_channel::Write,
 {
     pub fn new(inner: T) -> Self {
         Self {
@@ -114,7 +116,7 @@ where
 
 impl<T> oak_idl::Handler for ClientHandler<T>
 where
-    T: oak_baremetal_communication_channel::Channel,
+    T: oak_baremetal_communication_channel::Read + oak_baremetal_communication_channel::Write,
 {
     fn invoke(&mut self, request: oak_idl::Request) -> Result<Vec<u8>, oak_idl::Status> {
         let request_message = self.request_encoder.encode_request(request);

--- a/experimental/oak_baremetal_runtime/Cargo.toml
+++ b/experimental/oak_baremetal_runtime/Cargo.toml
@@ -24,4 +24,3 @@ oak_functions_workload_logging = { path = "../../oak_functions/workload_logging"
 oak_remote_attestation = { path = "../../remote_attestation/rust", default-features = false }
 oak_remote_attestation_sessions = { path = "../../remote_attestation_sessions", default-features = false }
 oak_logger = { path = "../../oak_functions/logger" }
-ciborium-io = { version = "*", default-features = false }

--- a/experimental/oak_baremetal_runtime/src/framing.rs
+++ b/experimental/oak_baremetal_runtime/src/framing.rs
@@ -21,11 +21,11 @@ use crate::{
 };
 use alloc::{boxed::Box, sync::Arc};
 use anyhow::Context;
-use ciborium_io::{Read, Write};
 use oak_baremetal_communication_channel::{
     schema,
     schema::TrustedRuntime,
     server::{message_from_response_and_id, ServerChannelHandle},
+    Channel,
 };
 use oak_functions_lookup::LookupDataManager;
 use oak_idl::Handler;
@@ -181,7 +181,7 @@ pub fn handle_frames<T, G: 'static + AttestationGenerator, V: 'static + Attestat
     attestation_behavior: AttestationBehavior<G, V>,
 ) -> anyhow::Result<!>
 where
-    T: Read<Error = anyhow::Error> + Write<Error = anyhow::Error>,
+    T: Channel,
 {
     let mut invocation_handler = InvocationHandler {
         initialization_state: InitializationState::Uninitialized(Some(attestation_behavior)),

--- a/experimental/oak_baremetal_runtime/src/framing.rs
+++ b/experimental/oak_baremetal_runtime/src/framing.rs
@@ -25,7 +25,7 @@ use oak_baremetal_communication_channel::{
     schema,
     schema::TrustedRuntime,
     server::{message_from_response_and_id, ServerChannelHandle},
-    Channel,
+    Read, Write,
 };
 use oak_functions_lookup::LookupDataManager;
 use oak_idl::Handler;
@@ -181,7 +181,7 @@ pub fn handle_frames<T, G: 'static + AttestationGenerator, V: 'static + Attestat
     attestation_behavior: AttestationBehavior<G, V>,
 ) -> anyhow::Result<!>
 where
-    T: Channel,
+    T: Read + Write,
 {
     let mut invocation_handler = InvocationHandler {
         initialization_state: InitializationState::Uninitialized(Some(attestation_behavior)),

--- a/experimental/virtio/Cargo.toml
+++ b/experimental/virtio/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = { version = "*", default-features = false }
 bitflags = "*"
-ciborium-io = { version = "*", default-features = false }
 log = "*"
 rust-hypervisor-firmware-virtio = { path = "../../third_party/rust-hypervisor-firmware-virtio" }
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/experimental/virtio/src/console/mod.rs
+++ b/experimental/virtio/src/console/mod.rs
@@ -14,7 +14,10 @@
 // limitations under the License.
 //
 
-use crate::queue::{DeviceWriteOnlyQueue, DriverWriteOnlyQueue};
+use crate::{
+    queue::{DeviceWriteOnlyQueue, DriverWriteOnlyQueue},
+    Channel,
+};
 use alloc::collections::VecDeque;
 use anyhow::Context;
 use rust_hypervisor_firmware_virtio::{
@@ -196,13 +199,11 @@ where
     }
 }
 
-impl<T> ciborium_io::Read for Console<T>
+impl<T> Channel for Console<T>
 where
     T: VirtioTransport,
 {
-    type Error = anyhow::Error;
-
-    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
+    fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()> {
         let len = data.len();
         let mut count = 0;
         while count < len {
@@ -211,15 +212,8 @@ where
 
         Ok(())
     }
-}
 
-impl<T> ciborium_io::Write for Console<T>
-where
-    T: VirtioTransport,
-{
-    type Error = anyhow::Error;
-
-    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+    fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
         let mut start = 0;
         let data_len = data.len();
         while start < data_len {
@@ -229,7 +223,7 @@ where
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), Self::Error> {
+    fn flush(&mut self) -> anyhow::Result<()> {
         // We always flush on write, so do nothing.
         // TODO(#2876): We should use a buffered writer so that we don't always flush on write, and
         // provide an actual flush implementation here.

--- a/experimental/virtio/src/console/mod.rs
+++ b/experimental/virtio/src/console/mod.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     queue::{DeviceWriteOnlyQueue, DriverWriteOnlyQueue},
-    Channel,
+    Read, Write,
 };
 use alloc::collections::VecDeque;
 use anyhow::Context;
@@ -199,7 +199,7 @@ where
     }
 }
 
-impl<T> Channel for Console<T>
+impl<T> Read for Console<T>
 where
     T: VirtioTransport,
 {
@@ -212,7 +212,12 @@ where
 
         Ok(())
     }
+}
 
+impl<T> Write for Console<T>
+where
+    T: VirtioTransport,
+{
     fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
         let mut start = 0;
         let data_len = data.len();

--- a/experimental/virtio/src/console/tests.rs
+++ b/experimental/virtio/src/console/tests.rs
@@ -20,7 +20,6 @@ use crate::test::{
     VIRTIO_F_VERSION_1,
 };
 use alloc::{vec, vec::Vec};
-use ciborium_io::{Read, Write};
 
 #[test]
 fn test_legacy_device_not_supported() {
@@ -104,8 +103,8 @@ fn test_read_exact() {
     let mut console = Console::new(device);
     console.init().unwrap();
     transport.device_write_to_queue::<QUEUE_SIZE>(0, &data[..]);
-    assert!(console.read_exact(&mut first).is_ok());
-    assert!(console.read_exact(&mut second).is_ok());
+    assert!(console.read(&mut first).is_ok());
+    assert!(console.read(&mut second).is_ok());
     assert_eq!(&data[..5], &first[..]);
     assert_eq!(&data[5..8], &second[..]);
     assert!(console.pending_data.is_some());
@@ -119,7 +118,7 @@ fn test_write_all() {
     let device = VirtioBaseDevice::new(transport.clone());
     let mut console = Console::new(device);
     console.init().unwrap();
-    assert!(console.write_all(&data[..]).is_ok());
+    assert!(console.write(&data[..]).is_ok());
     let first = transport
         .device_read_once_from_queue::<QUEUE_SIZE>(1)
         .unwrap();

--- a/experimental/virtio/src/lib.rs
+++ b/experimental/virtio/src/lib.rs
@@ -32,9 +32,24 @@ pub mod queue;
 mod test;
 pub mod vsock;
 
-pub trait Channel {
+/// Read bytes from a source.
+///
+/// This trait is similar to the <std::io::Read> trait, except that this trait is pared down to a
+/// minimum and works in a `no_std` environment.
+pub trait Read {
+    /// Read bytes until `data` has been filled.
     fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()>;
+}
+
+/// Write bytes to a source.
+///
+/// This trait is similar to the <std::io::Write> trait, except that this trait is pared down to a
+/// minimum and works in a `no_std` environment.
+pub trait Write {
+    /// Write all bytes in `data`.
     fn write(&mut self, data: &[u8]) -> anyhow::Result<()>;
+
+    /// Flush any output buffers, if they exist.
     fn flush(&mut self) -> anyhow::Result<()>;
 }
 

--- a/experimental/virtio/src/lib.rs
+++ b/experimental/virtio/src/lib.rs
@@ -32,5 +32,11 @@ pub mod queue;
 mod test;
 pub mod vsock;
 
+pub trait Channel {
+    fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()>;
+    fn write(&mut self, data: &[u8]) -> anyhow::Result<()>;
+    fn flush(&mut self) -> anyhow::Result<()>;
+}
+
 /// The vendor ID for virtio PCI devices.
 const PCI_VENDOR_ID: u16 = 0x1AF4;

--- a/experimental/virtio/src/vsock/socket/mod.rs
+++ b/experimental/virtio/src/vsock/socket/mod.rs
@@ -18,7 +18,7 @@ use super::{
     packet::{Packet, VSockFlags, VSockOp, HEADER_SIZE},
     VSock, DATA_BUFFER_SIZE,
 };
-use crate::Channel;
+use crate::{Read, Write};
 use alloc::collections::VecDeque;
 use core::num::Wrapping;
 use rust_hypervisor_firmware_virtio::virtio::VirtioTransport;
@@ -333,7 +333,7 @@ where
     }
 }
 
-impl<T> Channel for Socket<T>
+impl<T> Read for Socket<T>
 where
     T: VirtioTransport,
 {
@@ -353,7 +353,12 @@ where
 
         Ok(())
     }
+}
 
+impl<T> Write for Socket<T>
+where
+    T: VirtioTransport,
+{
     fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
         let mut start = 0;
         let data_len = data.len();

--- a/experimental/virtio/src/vsock/socket/mod.rs
+++ b/experimental/virtio/src/vsock/socket/mod.rs
@@ -18,6 +18,7 @@ use super::{
     packet::{Packet, VSockFlags, VSockOp, HEADER_SIZE},
     VSock, DATA_BUFFER_SIZE,
 };
+use crate::Channel;
 use alloc::collections::VecDeque;
 use core::num::Wrapping;
 use rust_hypervisor_firmware_virtio::virtio::VirtioTransport;
@@ -332,13 +333,11 @@ where
     }
 }
 
-impl<T> ciborium_io::Read for Socket<T>
+impl<T> Channel for Socket<T>
 where
     T: VirtioTransport,
 {
-    type Error = anyhow::Error;
-
-    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
+    fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()> {
         let len = data.len();
         let mut count = 0;
         while count < len {
@@ -354,15 +353,8 @@ where
 
         Ok(())
     }
-}
 
-impl<T> ciborium_io::Write for Socket<T>
-where
-    T: VirtioTransport,
-{
-    type Error = anyhow::Error;
-
-    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+    fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
         let mut start = 0;
         let data_len = data.len();
         while start < data_len {
@@ -373,7 +365,7 @@ where
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), Self::Error> {
+    fn flush(&mut self) -> anyhow::Result<()> {
         // We always flush on write, so do nothing.
         // TODO(#2876): We should use a buffered writer so that we don't always flush on write, and
         // provide an actual flush implementation here.

--- a/experimental/virtio/src/vsock/socket/tests.rs
+++ b/experimental/virtio/src/vsock/socket/tests.rs
@@ -17,7 +17,8 @@
 use super::*;
 use crate::{
     test::{new_valid_transport, TestingTransport},
-    vsock::{Channel, HOST_CID, QUEUE_SIZE},
+    vsock::{HOST_CID, QUEUE_SIZE},
+    Read, Write,
 };
 use alloc::vec;
 use rand::RngCore;

--- a/experimental/virtio/src/vsock/socket/tests.rs
+++ b/experimental/virtio/src/vsock/socket/tests.rs
@@ -17,10 +17,9 @@
 use super::*;
 use crate::{
     test::{new_valid_transport, TestingTransport},
-    vsock::{HOST_CID, QUEUE_SIZE},
+    vsock::{Channel, HOST_CID, QUEUE_SIZE},
 };
 use alloc::vec;
-use ciborium_io::{Read, Write};
 use rand::RngCore;
 use rust_hypervisor_firmware_virtio::device::VirtioBaseDevice;
 
@@ -98,8 +97,8 @@ fn test_read_exact() {
     let mut second = vec![0; 2];
     let (mut socket, transport) = new_socket_and_transport();
     transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
-    assert!(socket.read_exact(&mut first).is_ok());
-    assert!(socket.read_exact(&mut second).is_ok());
+    assert!(socket.read(&mut first).is_ok());
+    assert!(socket.read(&mut second).is_ok());
     assert_eq!(&data[..11], &first[..]);
     assert_eq!(&data[11..13], &second[..]);
     assert!(socket.pending_data.is_some());
@@ -111,7 +110,7 @@ fn test_write_all() {
     // Send data larger than the max payload size, so we expect 2 packets.
     let data = vec![31; 5000];
     let (mut socket, transport) = new_socket_and_transport();
-    assert!(socket.write_all(&data[..]).is_ok());
+    assert!(socket.write(&data[..]).is_ok());
     let first = Packet::new(
         transport
             .device_read_once_from_queue::<QUEUE_SIZE>(1)
@@ -152,10 +151,10 @@ fn test_many_echos() {
         packet.set_fwd_cnt(i * DATA_LEN as u32);
         let mut buffer = vec![0; DATA_LEN];
         transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
-        assert!(socket.read_exact(&mut buffer).is_ok());
+        assert!(socket.read(&mut buffer).is_ok());
 
         // Echo back.
-        assert!(socket.write_all(&buffer[..]).is_ok());
+        assert!(socket.write(&buffer[..]).is_ok());
         let output = Packet::new(
             transport
                 .device_read_once_from_queue::<QUEUE_SIZE>(1)


### PR DESCRIPTION
We weren't using anything but the `Read` and `Write` traits from `ciborium_io` anyway, so let's get rid of that dependency.

I've added compatible `Read` and `Write` traits to `oak_baremetal_channel`. That seemed to be the best location for them.

I had to implement completely identical but separate traits in the `virtio` crate as well, as I didn't want to make `virtio` depend on the channel crate.

Apart from that nuance it's pretty straightforward... although I do have to say that all the bajillion conditional compilation statements in the kernel are _really_ getting out of hand. As a side effect, you never know what exactly will be built if you specify some combination of feature flags (or none at all, or --all-features). That needs to be cleaned up, but that's a separate undertaking.