### PR TITLE
Add buildconfig for oak_baremetal_app_qemu

### DIFF
--- a/.xtask_bash_completion
+++ b/.xtask_bash_completion
@@ -91,12 +91,16 @@ _xtask() {
             return 0
             ;;
         xtask__build__baremetal__variants)
-            opts="-h --help"
+            opts="-h --variant --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --variant)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;

--- a/buildconfigs/oak_baremetal_app_qemu.toml
+++ b/buildconfigs/oak_baremetal_app_qemu.toml
@@ -1,0 +1,9 @@
+# This is the static build configuration that we use with the transparent
+# release tool for building the provenance of `oak_baremetal_app_qemu`.
+# To be able to use it with the build tool from Transparent Release, additional
+# information must be added. See `./scripts/generate_provenance` for more info.
+repo = "https://github.com/project-oak/oak"
+command = ["./scripts/xtask", "build-baremetal-variants", "--variant", "qemu"]
+# Even though the command above generates all variants, the provenance is only
+# generated for the qemu variant (i.e., `oak_baremetal_app_qemu`).
+output_path = "./experimental/oak_baremetal_app_qemu/target/target/release/oak_baremetal_app_qemu"

--- a/scripts/generate_provenance
+++ b/scripts/generate_provenance
@@ -79,7 +79,7 @@ rm -rf tmp
 # Copy the provenance file in `./provenance/<BINARY_HASH>/COMMIT_HASH.json`
 # if the `-s` argument is passed in.
 if $STORE ; then
-  readonly BINARY_SHA_256_HASH=$(jq -r '.subject[0].digest.sha256' './${PROV_FILE_NAME}')
+  readonly BINARY_SHA_256_HASH=$(jq -r '.subject[0].digest.sha256' ./"${PROV_FILE_NAME}")
 
   # Move the generated provenances to the correct directory, first creating
   # any required directories.

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -55,7 +55,7 @@ pub struct Opt {
 #[derive(Subcommand, Clone, Debug)]
 pub enum Command {
     RunVmTest,
-    BuildBaremetalVariants,
+    BuildBaremetalVariants(BuildBaremetalVariantsOpt),
     RunOakFunctionsExamples(RunOakExamplesOpt),
     BuildOakFunctionsExample(RunOakExamplesOpt),
     BuildOakFunctionsServerVariants(BuildServerOpt),
@@ -261,6 +261,15 @@ pub struct RunCargoFuzz {
     /// Additional `libFuzzer` arguments passed through to the binary
     #[clap(last(true))]
     pub args: Vec<String>,
+}
+
+#[derive(Parser, Clone, Debug)]
+pub struct BuildBaremetalVariantsOpt {
+    #[clap(
+        long,
+        help = "name of a specific baremetal variant (bios, or crosvm). If not specified, builds all variants."
+    )]
+    pub variant: Option<String>,
 }
 
 /// Partial representation of Cargo manifest files.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -115,7 +115,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn match_cmd(opt: &Opt) -> Step {
     match opt.cmd {
         Command::RunVmTest => vm::run_vm_test(),
-        Command::BuildBaremetalVariants => vm::build_baremetal_variants(),
+        Command::BuildBaremetalVariants(ref opts) => vm::build_baremetal_variants(opts),
         Command::RunOakFunctionsExamples(ref run_opt) => {
             run_oak_functions_examples(run_opt, &opt.scope)
         }


### PR DESCRIPTION
Follow up on #3001.
* Fixes the `scripts/generate_provenance` script
* Adds an option to `build_baremetal_variants` for specifying the variant
* Adds build config for `oak_baremetal_app_qemu`