### PR TITLE
Update crosvm and simplify crosvm bootstrap code

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:18396c3d582128452dd6f3a7c5211d9e9bd4a24f2e31cb263589293b15954ab5",
+  "image": "sha256:7d7a4fe6dd67c83aa52cae904d7c5e2afe1a62a9aa1b4501eb01c245c8901603",
   "extensions": [
     "13xforever.language-x86-64-assembly",
     "bazelbuild.vscode-bazel",

--- a/Dockerfile
+++ b/Dockerfile
@@ -246,7 +246,7 @@ RUN cargo install --git https://github.com/bytecodealliance/wizer --rev 7c33b0bc
 
 # Install crosvm.
 # We're not interested in most of the features in crosvm (e.g. wayland support), but GDB support would be nice.
-RUN cargo install --git https://chromium.googlesource.com/chromiumos/platform/crosvm/ --rev df8201cfc6c9729ebe01f454f07f70e9781433f4 crosvm --no-default-features --features gdb
+RUN cargo install --git https://chromium.googlesource.com/chromiumos/platform/crosvm/ --rev 31f04e92709980a4ffc56b1631f8b4be437cc2fe crosvm --no-default-features --features gdb
 
 # Where to install rust tooling
 ARG install_dir=${rustup_dir}/bin

--- a/experimental/oak_baremetal_app_crosvm/layout.ld
+++ b/experimental/oak_baremetal_app_crosvm/layout.ld
@@ -30,12 +30,7 @@ SECTIONS {
     data_start = .;
     text_start = .;
 
-    /*
-     * The start point of execution is 0x200200, so ensure rust64_start is the
-     * first symbol in the .text section.
-     */
     .text : {
-        KEEP(*(.text.rust64_start))
         *(.text .text.*)
     } : ram
 

--- a/experimental/oak_baremetal_app_crosvm/layout.ld
+++ b/experimental/oak_baremetal_app_crosvm/layout.ld
@@ -22,11 +22,7 @@ PHDRS
 }
 
 SECTIONS {
-    /* Crosvm loads data to 0x200000 + p_addr, so we need to make the virtual
-     * address match what will be loaded into memory while keeping the physical
-     * address at 0x0.
-     */
-    .boot 0x200000 : AT(0x0) {
+    .boot 0x200000 : {
         ram_min = .;
         *(.boot)
     } : ram

--- a/experimental/oak_baremetal_app_crosvm/src/asm/boot.s
+++ b/experimental/oak_baremetal_app_crosvm/src/asm/boot.s
@@ -17,7 +17,6 @@
 .section .boot, "ax"
 .global _start
 .code64
-.fill 0x200
 
 _start:
     mov $stack_start, %rsp

--- a/scripts/common
+++ b/scripts/common
@@ -20,10 +20,10 @@ readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak:latest'
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:18396c3d582128452dd6f3a7c5211d9e9bd4a24f2e31cb263589293b15954ab5'
+readonly DOCKER_IMAGE_ID='sha256:7d7a4fe6dd67c83aa52cae904d7c5e2afe1a62a9aa1b4501eb01c245c8901603'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:899bd9c00b877c42bc545ffd692fe795333802e435b51aa748502beb66a9b6ab'
+readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:5e216ecbc19eb19b7be1d169103388834a7d67d11519c70907f067860dc67f53'
 
 readonly SERVER_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-server'
 


### PR DESCRIPTION
Crosvm has overhauled their ELF loading code, largely based on feedback from us. For example, now it loads segments to their specified physical address (instead of adding the constant `0x200000` internally) and starts executing from the correct entry point specified in the header (again, instead of having a hard-coded constant that just happened to work because the memory between that memory location and the real entry point was filled with `0x00` bytes).

Let's upgrade our crosvm and simplify our bootstrap code; equally importantly, this will also make it easier for the ELF kernel to be loaded with other VMMs.

(There were also some virtio-related changes. I feel like we should get something like dependabot to update our crosvm version every now and then automagically.)
