### PR TITLE
Revert "Bump linked_list_allocator from 0.9.1 to 0.10.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,9 +2287,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222d00bf23b303e0c82c7a4d5f04dc90f33a58b26a3adb1a09c6fbcf56cbd2a9"
+checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
 dependencies = [
  "spinning_top",
 ]

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -490,9 +490,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222d00bf23b303e0c82c7a4d5f04dc90f33a58b26a3adb1a09c6fbcf56cbd2a9"
+checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
 dependencies = [
  "spinning_top",
 ]

--- a/experimental/oak_baremetal_app_qemu/Cargo.lock
+++ b/experimental/oak_baremetal_app_qemu/Cargo.lock
@@ -627,9 +627,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222d00bf23b303e0c82c7a4d5f04dc90f33a58b26a3adb1a09c6fbcf56cbd2a9"
+checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
 dependencies = [
  "spinning_top",
 ]

--- a/experimental/oak_baremetal_kernel/src/memory.rs
+++ b/experimental/oak_baremetal_kernel/src/memory.rs
@@ -80,7 +80,7 @@ pub fn init_allocator<E: boot::E820Entry, B: boot::BootInfo<E>>(
     info!("Using [{:#016x}..{:#016x}) for heap.", addr, addr + size);
     // This is safe as we know the memory is available based on the e820 map.
     unsafe {
-        ALLOCATOR.lock().init(addr as *mut u8, size);
+        ALLOCATOR.lock().init(addr, size);
     }
     Ok(())
 }


### PR DESCRIPTION
Reverts project-oak/oak#3005. Post this commit the baremetal runtime panic when starting up, with "ERROR: PANIC: panicked at 'Freed node aliases existing hole! Bad free?', /home/docker/.cargo/registry/src/github.com-1ecc6299db9ec823/linked_list_allocator-0.10.0/src/hole.rs:439:17\n". Kokoro CI is likewise failing. 

Kokoro didn't run against the initial PR (it does not run against PRs from non project-oak users). However one can force it to run, by adding the tag `kokoro:force-run`