### PR TITLE
Ensure Kokoro runs against dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       interval: 'daily'
     # We do not set an explicit reviewer, as that is already automatically assigned via CODEOWNERS.
     # reviewers
-    # Explicitly trigger kokoro checks. They do not automatically run for
-    # external users.
+    # Explicitly trigger kokoro checks. They do not automatically run for PRs
+    # by external users.
     labels:
       - "kokoro:run"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     schedule:
       interval: 'daily'
     # We do not set an explicit reviewer, as that is already automatically assigned via CODEOWNERS.
+    # reviewers
+    # Explicitly trigger kokoro checks. They do not automatically run for
+    # external users.
+    labels:
+      - "kokoro:run"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
     # Explicitly trigger kokoro checks. They do not automatically run for PRs
     # by external users.
     labels:
-      - "kokoro:run"
+      - 'kokoro:run'


### PR DESCRIPTION
By default kokoro checks are only triggered for PRs from users that belong to the same org as the repo. Other PRs can trigger kokoro if they include a certain label. Adds this label for all dependabot PRs.


Related to https://github.com/project-oak/oak/pull/3019, hopefully this can prevent similar build breaks 