### PR TITLE
Add initial SEV-SNP guest helper code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4622,6 +4622,7 @@ name = "sev_guest"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "static_assertions",
  "strum",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4618,6 +4618,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sev_guest"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "strum",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "experimental/oak_baremetal_kernel",
   "experimental/oak_baremetal_loader",
   "experimental/oak_baremetal_runtime",
+  "experimental/sev_guest",
   "experimental/virtio",
   "experimental/vsock/echo",
   "experimental/web_client",

--- a/experimental/sev_guest/Cargo.toml
+++ b/experimental/sev_guest/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sev_guest"
+version = "0.1.0"
+authors = ["Conrad Grobler <grobler@google.com>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+bitflags = "*"
+strum = { version = "*", default-features = false, features = ["derive"] }

--- a/experimental/sev_guest/Cargo.toml
+++ b/experimental/sev_guest/Cargo.toml
@@ -7,4 +7,5 @@ license = "Apache-2.0"
 
 [dependencies]
 bitflags = "*"
+static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/experimental/sev_guest/README.md
+++ b/experimental/sev_guest/README.md
@@ -1,0 +1,5 @@
+# AMD SEV-SNP Guest Library
+
+This library implements Rust wrappers for new CPU instructions inroduced for AMD
+SEV, SEV-ES and SEV-SNP. It also adds structs that represent data structures
+used by AMD SEV-ES and SEV-SNP.

--- a/experimental/sev_guest/README.md
+++ b/experimental/sev_guest/README.md
@@ -1,5 +1,15 @@
 # AMD SEV-SNP Guest Library
 
-This library implements Rust wrappers for new CPU instructions inroduced for AMD
-SEV, SEV-ES and SEV-SNP. It also adds structs that represent data structures
-used by AMD SEV-ES and SEV-SNP.
+This library implements Rust wrappers for new CPU instructions introduced for
+AMD SEV-ES and SEV-SNP. It also adds structs that represent data structures used
+by AMD SEV-ES and SEV-SNP.
+
+For more information see:
+
+- [https://developer.amd.com/sev/](https://developer.amd.com/sev/)
+- [AMD64 Architecture Programmer’s Manual, Volume 2: System Programming](https://www.amd.com/system/files/TechDocs/24593.pdf) -
+  Sections 15.34 - 15.36
+- [SEV-ES Guest-Hypervisor Communication Block Standardization](https://developer.amd.com/wp-content/resources/56421.pdf)
+- [SEV Secure Nested Paging Firmware ABI Specification](https://www.amd.com/system/files/TechDocs/56860.pdf)
+- Whitepaper:
+  [AMD SEV-SNP: Strengthening VM Isolation with Integrity Protection and More](https://www.amd.com/system/files/TechDocs/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more.pdf)

--- a/experimental/sev_guest/src/instructions.rs
+++ b/experimental/sev_guest/src/instructions.rs
@@ -15,11 +15,12 @@
 //
 
 //! Rust instruction wrappers managing page state and interacting with the hypervisor.
+
 use bitflags::bitflags;
 use core::arch::asm;
 use strum::FromRepr;
 
-/// Whether a pages is in validated state or not.
+/// Whether a page is in the validated state or not.
 #[derive(Debug, FromRepr)]
 #[repr(u32)]
 pub enum Validation {
@@ -29,7 +30,7 @@ pub enum Validation {
     Validated = 1,
 }
 
-/// The size of the memory page.
+/// The size of a memory page.
 #[derive(Debug, FromRepr)]
 #[repr(u32)]
 pub enum PageSize {
@@ -39,7 +40,7 @@ pub enum PageSize {
     Page2MiB = 1,
 }
 
-/// The result from calling the PVALIDATE instructions.
+/// The result from calling the PVALIDATE or RMPADJUST instructions.
 #[derive(Debug, FromRepr)]
 #[repr(u32)]
 pub enum InstructionResult {
@@ -61,7 +62,7 @@ pub fn pvalidate(page_addr: u64, page_size: PageSize, validated: Validation) -> 
     let page_size = page_size as u32;
     let validated = validated as u32;
     let result: u32;
-    // Safety: this call does not modify the guest memory contents, so can not violate memory
+    // Safety: this call does not modify the guest memory contents, so does not violate memory
     // safety.
     unsafe {
         asm!(
@@ -134,7 +135,7 @@ pub fn rmpadjust(
     let page_size = page_size as u64;
     let permission: u64 = permission.into();
     let result: u64;
-    // Safety: this call does not modify the guest memory contents, so can not violate memory
+    // Safety: this call does not modify the guest memory contents, so does not violate memory
     // safety.
     unsafe {
         asm!(
@@ -153,11 +154,11 @@ pub fn rmpadjust(
 ///
 /// See the VMGEXIT instruction in <https://www.amd.com/system/files/TechDocs/24594.pdf> for more details.
 pub fn vmgexit() {
-    // Safety: this call does not modify the guest memory contents, so can not violate memory
+    // Safety: this call does not modify the guest memory contents, so does not violate memory
     // safety.
     unsafe {
         // The REP instruction modifier changes the VMMCALL instruction to be equivalent to the
-        // VMGEXIT call. this is used as the assembler does not understand the VMGEXIT mnemonic.
+        // VMGEXIT call. this is used as the assembler does not recognise the VMGEXIT mnemonic.
         asm!("rep vmmcall", options(nomem, nostack, preserves_flags));
     }
 }

--- a/experimental/sev_guest/src/instructions.rs
+++ b/experimental/sev_guest/src/instructions.rs
@@ -1,0 +1,159 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Rust instruction wrappers managing page state and interacting with the hypervisor.
+use bitflags::bitflags;
+use core::arch::asm;
+use strum::FromRepr;
+
+/// Whether a pages is in validated state or not.
+#[derive(Debug, FromRepr)]
+#[repr(u32)]
+pub enum Validation {
+    /// The page is not validated.
+    Unvalidated = 0,
+    /// The page is validated.
+    Validated = 1,
+}
+
+/// The size of the memory page.
+#[derive(Debug, FromRepr)]
+#[repr(u32)]
+pub enum PageSize {
+    /// The page is a 4KiB page.
+    Page4KiB = 0,
+    /// The page is a 2MiB page.
+    Page2MiB = 1,
+}
+
+/// The result from calling the PVALIDATE instructions.
+#[derive(Debug, FromRepr)]
+#[repr(u32)]
+pub enum InstructionResult {
+    /// The operation was successful.
+    Success = 0,
+    /// The input parameters were invalid.
+    FailInput = 1,
+    /// Insufficient permissions.
+    FailPermission = 2,
+    /// The page size does not match the page size entry in the RMP.
+    FailSizeMismatch = 6,
+}
+
+/// Marks a page as validated or unvalidated in the RMP.
+///
+/// See the PVALIDATE instruction in <https://www.amd.com/system/files/TechDocs/24594.pdf> for more details.
+///
+/// Safety: The caller must ensure that the page address is a valid guest-physical address that is
+/// page-aligned for the specified page size.
+#[inline]
+pub unsafe fn pvalidate(
+    page_addr: u64,
+    page_size: PageSize,
+    validated: Validation,
+) -> InstructionResult {
+    let page_size = page_size as u32;
+    let validated = validated as u32;
+    let result: u32;
+    asm!(
+        "pvalidate",
+        in("rax") page_addr,
+        in("ecx") page_size,
+        in("edx") validated,
+        lateout("eax") result,
+        options(nomem, nostack)
+    );
+    InstructionResult::from_repr(result).expect("Invalid result from PVALIDATE instruction")
+}
+
+bitflags! {
+    /// Permission mask used by the RMP.
+    ///
+    /// See the RMPADJUST instruction in <https://www.amd.com/system/files/TechDocs/24594.pdf> for more details.
+    pub struct PermissionMask: u8 {
+        /// The target VMPL can read the page.
+        const READ = 1;
+        /// The target VMPL can write to the page.
+        const WRITE = 2;
+        /// Code in the page can be executed at CPL3.
+        const EXECUTE_USER = 4;
+        /// Code in the page can be executed at CPL0..2
+        const EXECUTE_SUPERVISOR = 8;
+    }
+}
+
+/// Whether the page can be used as a VM save area.
+#[derive(Debug, FromRepr)]
+#[repr(u8)]
+pub enum Vmsa {
+    /// The page cannot be used as a VM save area.
+    No = 0,
+    /// The page can be used as a VM save area.
+    Yes = 1,
+}
+
+/// Representation of the RMP permission used by the RMPADJST instruction.
+pub struct RmpPermission {
+    /// The target VMPL to which the permission applies.
+    target_vmpl: u8,
+    /// The bit mask specifying the permission.
+    perm_mask: PermissionMask,
+    /// Whether this page can be used as a VM save area.
+    vmsa: Vmsa,
+}
+
+impl From<RmpPermission> for u64 {
+    fn from(permission: RmpPermission) -> u64 {
+        let mut buffer = [0u8; 8];
+        buffer[0] = permission.target_vmpl;
+        buffer[1] = permission.perm_mask.bits;
+        buffer[2] = permission.vmsa as u8;
+        u64::from_be_bytes(buffer)
+    }
+}
+
+/// Adjusts the permissions of a page in the RMP.
+///
+/// See the RMPADJUST instruction in <https://www.amd.com/system/files/TechDocs/24594.pdf> for more details.
+///
+/// Safety: The caller must ensure that the page address is a valid guest-physical address that is
+/// page-aligned for the specified page size.
+#[inline]
+pub unsafe fn rmpadjust(
+    page_addr: u64,
+    page_size: PageSize,
+    permission: RmpPermission,
+) -> InstructionResult {
+    let page_size = page_size as u64;
+    let permission: u64 = permission.into();
+    let result: u64;
+    asm!(
+        "rmpadjust",
+        in("rax") page_addr,
+        in("rcx") page_size,
+        in("rdx") permission,
+        lateout("rax") result,
+        options(nomem, nostack)
+    );
+    InstructionResult::from_repr(result as u32).expect("Invalid result from RMPADJUST instruction")
+}
+
+/// Unconditionally exits from the guest to the hypervisor.
+pub unsafe fn vmgexit() {
+    // The REP instruction is repurposed to modify the VMMCALL instruction to change it into a
+    // VMGEXIT call, seeing that the assembler does not understand the VMGEXIT mnemonic.
+    asm!("rep vmmcall", options(nomem, nostack, preserves_flags));
+}

--- a/experimental/sev_guest/src/instructions.rs
+++ b/experimental/sev_guest/src/instructions.rs
@@ -60,7 +60,7 @@ pub enum InstructionError {
 /// See the PVALIDATE instruction in <https://www.amd.com/system/files/TechDocs/24594.pdf> for more details.
 #[inline]
 pub fn pvalidate(
-    page_addr: u64,
+    page_guest_physical_address: usize,
     page_size: PageSize,
     validated: Validation,
 ) -> Result<(), InstructionError> {
@@ -74,7 +74,7 @@ pub fn pvalidate(
         asm!(
             "pvalidate",
             "setc dl",
-            in("rax") page_addr,
+            in("rax") page_guest_physical_address,
             in("ecx") page_size,
             in("edx") validated,
             lateout("eax") result,
@@ -152,7 +152,7 @@ impl From<RmpPermission> for u64 {
 /// See the RMPADJUST instruction in <https://www.amd.com/system/files/TechDocs/24594.pdf> for more details.
 #[inline]
 pub fn rmpadjust(
-    page_addr: u64,
+    page_guest_physical_address: usize,
     page_size: PageSize,
     permission: RmpPermission,
 ) -> Result<(), InstructionError> {
@@ -164,7 +164,7 @@ pub fn rmpadjust(
     unsafe {
         asm!(
             "rmpadjust",
-            in("rax") page_addr,
+            in("rax") page_guest_physical_address,
             in("rcx") page_size,
             in("rdx") permission,
             lateout("rax") result,

--- a/experimental/sev_guest/src/instructions.rs
+++ b/experimental/sev_guest/src/instructions.rs
@@ -106,11 +106,11 @@ pub enum Vmsa {
 /// Representation of the RMP permission used by the RMPADJST instruction.
 pub struct RmpPermission {
     /// The target VMPL to which the permission applies.
-    target_vmpl: u8,
+    pub target_vmpl: u8,
     /// The bit mask specifying the permission.
-    perm_mask: PermissionMask,
+    pub perm_mask: PermissionMask,
     /// Whether this page can be used as a VM save area.
-    vmsa: Vmsa,
+    pub vmsa: Vmsa,
 }
 
 impl From<RmpPermission> for u64 {

--- a/experimental/sev_guest/src/instructions.rs
+++ b/experimental/sev_guest/src/instructions.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-//! Rust instruction wrappers managing page state and interacting with the hypervisor.
+//! Rust instruction wrappers for managing page state and interacting with the hypervisor.
 
 use bitflags::bitflags;
 use core::arch::asm;
@@ -86,9 +86,9 @@ bitflags! {
         const READ = 1;
         /// The target VMPL can write to the page.
         const WRITE = 2;
-        /// Code in the page can be executed at CPL3.
+        /// Code in the page can be executed in ring 3.
         const EXECUTE_USER = 4;
-        /// Code in the page can be executed at CPL0..2
+        /// Code in the page can be executed in rings 0..2.
         const EXECUTE_SUPERVISOR = 8;
     }
 }
@@ -158,7 +158,7 @@ pub fn vmgexit() {
     // safety.
     unsafe {
         // The REP instruction modifier changes the VMMCALL instruction to be equivalent to the
-        // VMGEXIT call. this is used as the assembler does not recognise the VMGEXIT mnemonic.
+        // VMGEXIT call. This is used as the assembler does not recognise the VMGEXIT mnemonic.
         asm!("rep vmmcall", options(nomem, nostack, preserves_flags));
     }
 }

--- a/experimental/sev_guest/src/instructions.rs
+++ b/experimental/sev_guest/src/instructions.rs
@@ -98,7 +98,7 @@ pub fn pvalidate(
 bitflags! {
     /// Permission mask used by the RMP.
     ///
-    /// See the RMPADJUST instruction in <https://www.amd.com/system/files/TechDocs/24594.pdf> for more details.
+    /// See Table 15-38 in <https://www.amd.com/system/files/TechDocs/24593.pdf> for more details.
     pub struct PermissionMask: u8 {
         /// The target VMPL can read the page.
         const READ = 1;

--- a/experimental/sev_guest/src/instructions.rs
+++ b/experimental/sev_guest/src/instructions.rs
@@ -121,7 +121,7 @@ pub enum Vmsa {
     Yes = 1,
 }
 
-/// Representation of the RMP permission used by the RMPADJST instruction.
+/// Representation of the RMP permission used by the RMPADJUST instruction.
 #[repr(C, align(8))]
 pub struct RmpPermission {
     /// The target VMPL to which the permission applies.

--- a/experimental/sev_guest/src/lib.rs
+++ b/experimental/sev_guest/src/lib.rs
@@ -1,0 +1,22 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Rust wrappers for instructions and structs for use by SNP-active guests to manage page state and
+//! interact with the hypervisor and the secure processor.
+
+#![no_std]
+
+pub mod instructions;


### PR DESCRIPTION
This is the first of a series of PRs that will add Rust helper code to support running as a guest under AMD SEV-SNP. It provides impelementations of the new RMPADJUST, PVALIDATE and VMGEXIT instructions and related data structures.