### PR TITLE
Clean-up: we don't actually need `eh_personality`.

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/src/main.rs
+++ b/experimental/oak_baremetal_app_crosvm/src/main.rs
@@ -16,7 +16,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(lang_items)]
 #![feature(alloc_error_handler)]
 #![feature(custom_test_frameworks)]
 #![feature(core_c_str)]
@@ -53,9 +52,6 @@ fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
 fn panic(info: &PanicInfo) -> ! {
     oak_baremetal_kernel::panic(info);
 }
-
-#[lang = "eh_personality"]
-extern "C" fn eh_personality() {}
 
 #[cfg(test)]
 fn test_runner(tests: &[&dyn Fn()]) {

--- a/experimental/oak_baremetal_app_qemu/src/main.rs
+++ b/experimental/oak_baremetal_app_qemu/src/main.rs
@@ -16,7 +16,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(lang_items)]
 #![feature(alloc_error_handler)]
 #![feature(core_c_str)]
 #![feature(core_ffi_c)]
@@ -72,9 +71,6 @@ fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
 fn panic(info: &PanicInfo) -> ! {
     oak_baremetal_kernel::panic(info);
 }
-
-#[lang = "eh_personality"]
-extern "C" fn eh_personality() {}
 
 #[cfg(test)]
 fn test_runner(tests: &[&dyn Fn()]) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -665,21 +665,24 @@ fn run_cargo_clippy(scope: &Scope) -> Step {
     Step::Multiple {
         name: "cargo clippy".to_string(),
         steps: crate_manifest_files()
-            .map(to_string)
-            .filter(|path| all_affected_crates.contains(path))
+            .filter(|path| all_affected_crates.contains_path(path))
             .map(|entry| Step::Single {
-                name: entry.clone(),
-                command: Cmd::new(
+                name: entry.to_str().unwrap().to_string(),
+                command: Cmd::new_in_dir(
                     "cargo",
                     &[
                         "clippy",
                         "--all-targets",
                         "--all-features",
-                        &format!("--manifest-path={}", &entry),
+                        &format!(
+                            "--manifest-path={}",
+                            entry.file_name().unwrap().to_str().unwrap()
+                        ),
                         "--no-deps",
                         "--",
                         "--deny=warnings",
                     ],
+                    entry.parent().unwrap(),
                 ),
             })
             .collect(),


### PR DESCRIPTION
All of our bare-metal targets set panic strategy to `abort`, so `eh_personality` is not needed.

I think we added it back in the day to placate `xtask run-cargo-clippy`: as it runs `cargo clippy` in the root directory, it didn't pick up the `.cargo/config.toml` files properly.

Thus, let's fix xtask so that it runs `cargo clippy` in the directory of the crate, and drop the unnecessary `eh_personality` functions.