### PR TITLE
Add struct to interpret SEV-SNP pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4624,6 +4624,7 @@ dependencies = [
  "bitflags",
  "static_assertions",
  "strum",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6647,6 +6648,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]

--- a/experimental/sev_guest/Cargo.toml
+++ b/experimental/sev_guest/Cargo.toml
@@ -9,3 +9,4 @@ license = "Apache-2.0"
 bitflags = "*"
 static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
+zerocopy = "*"

--- a/experimental/sev_guest/src/cpuid.rs
+++ b/experimental/sev_guest/src/cpuid.rs
@@ -1,0 +1,68 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! This module contains structs that can be used to interpret the contents of the CPUID page that
+//! is provisioned during SEV-SNP startup.
+
+use zerocopy::FromBytes;
+
+/// The maximum number of CPUID functions that can be included in the page.
+pub const CPUID_COUNT_MAX: usize = 64;
+/// The size of the CPUID page.
+pub const CPUID_PAGE_SIZE: usize = 4096;
+
+/// The CPUID functions result of a CPUID invocation for a specific leaf and subleaf.
+///
+/// See: Table 14 in <https://www.amd.com/system/files/TechDocs/56860.pdf>
+#[repr(C)]
+#[derive(Debug, FromBytes)]
+pub struct CpuidFunction {
+    /// The input value of the EAX register when CPUID was called. This representd the CPUID leaf.
+    pub eax_in: u32,
+    /// The input value of the ECX register when CPUID was called. This represents the CPUID
+    /// sub-leaf.
+    pub ecx_in: u32,
+    /// The value of the XCR0 control register when CPUID was called.
+    pub xcr0_in: u64,
+    /// The value of the IA32_XSS model-specific register when CPUID was called.
+    pub xss_in: u64,
+    /// The EAX register outpur from calling CPUID.
+    pub eax: u32,
+    /// The EBX register outpur from calling CPUID.
+    pub ebx: u32,
+    /// The ECX register outpur from calling CPUID.
+    pub ecx: u32,
+    /// The EDX register outpur from calling CPUID.
+    pub edx: u32,
+    /// Reserved padding that must be 0.
+    _reserved: u64,
+}
+
+/// Representation of the CPUID page.
+///
+/// See: Table 69 in <https://www.amd.com/system/files/TechDocs/56860.pdf>
+#[repr(C, align(4096))]
+#[derive(Debug, FromBytes)]
+pub struct CpuidPage {
+    /// The number of CPUID function results included in the page. Must not be greated than
+    /// `CPUID_COUNT_MAX`.
+    pub count: u32,
+    _reserved: [u8; 12],
+    /// The CPUID function results.
+    pub cpuid_data: [CpuidFunction; CPUID_COUNT_MAX],
+}
+
+static_assertions::assert_eq_size!(CpuidPage, [u8; CPUID_PAGE_SIZE]);

--- a/experimental/sev_guest/src/ghcb.rs
+++ b/experimental/sev_guest/src/ghcb.rs
@@ -1,0 +1,81 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! This module contains an implementation of the guest-host communications block (GHCB) page that
+//! can be used for communicating with the hypervisor.
+
+use zerocopy::FromBytes;
+
+/// The size of the GHCB page.
+pub const GHCB_PAGE_SIZE: usize = 4096;
+
+/// The version of the GHCB protocol and page layout that the we expect to use.
+pub const GHCB_PROTOCOL_VERSION: u16 = 2;
+
+/// The guest-host communications block.
+///
+/// See: Table 3 in <https://developer.amd.com/wp-content/resources/56421.pdf>
+#[repr(C, align(4096))]
+#[derive(Debug, FromBytes)]
+pub struct Ghcb {
+    _reserved_0: [u8; 203],
+    /// The current privilege level of the executing code.
+    pub cpl: u8,
+    _reserved_1: [u8; 116],
+    /// The value of the IA32_XSS model-specific reqister.
+    pub xss: u64,
+    _reserved_2: [u8; 24],
+    /// The value of the DR7 debug register.
+    pub dr7: u64,
+    _reserved_3: [u8; 144],
+    /// The value of the RAX register.
+    pub rax: u64,
+    _reserved_4: [u8; 264],
+    /// The value of the RBX register.
+    pub rbx: u64,
+    /// The value of the RCX register.
+    pub rcx: u64,
+    /// The value of the RDX register.
+    pub rdx: u64,
+    _reserved_5: [u8; 112],
+    /// Guest-controlled exit code.
+    pub sw_exit_code: u64,
+    /// Guest-controlled exit information 1.
+    pub sw_exit_info_1: u64,
+    /// Guest-controlled exit information 2.
+    pub sw_exit_info_2: u64,
+    /// Guest-controlled additional information.
+    pub sw_scratch: u64,
+    _reserved_6: [u8; 56],
+    /// Value of the XCR0 extended control register.
+    pub xcr0: u64,
+    /// Bitmap indicating which quadwords of the save state area are valid in the range from offset
+    /// 0x000 through to offset 0x3ef.
+    pub valid_bitmap: [u8; 16],
+    /// The guest-physical address of the page that containing the x87-related saved state.
+    pub x87_state_gpa: u64,
+    _reserved_7: [u8; 1016],
+    /// Area that can be used as a shared buffer for communicating additional information.
+    pub shared_buffer: [u8; 2032],
+    _reserved_8: [u8; 10],
+    /// The version of the GHCB protocol and page layout in use.
+    pub protocol_version: u16,
+    /// The usage of the GHCB page. A value of 0 indicates the usage is in line with the definition
+    /// as specified in this struct. Any other value indicates a hypervisor-defined usage.
+    pub ghcb_usage: u32,
+}
+
+static_assertions::assert_eq_size!(Ghcb, [u8; GHCB_PAGE_SIZE]);

--- a/experimental/sev_guest/src/lib.rs
+++ b/experimental/sev_guest/src/lib.rs
@@ -19,4 +19,7 @@
 
 #![no_std]
 
+pub mod cpuid;
+pub mod ghcb;
 pub mod instructions;
+pub mod secrets;

--- a/experimental/sev_guest/src/secrets.rs
+++ b/experimental/sev_guest/src/secrets.rs
@@ -1,0 +1,64 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! This module contains structs that can be used to interpret the contents of the secrets page that
+//! is provisioned during SEV-SNP startup.
+
+use zerocopy::FromBytes;
+
+/// The size of the secrets page.
+pub const SECRETS_PAGE_SIZE: usize = 4096;
+
+/// The version of the secrets pages the we expect to receive.
+pub const SECRETS_PAGE_VERSION: u32 = 3;
+
+/// Representation of the secrets page.
+///
+/// See: Table 68 in <https://www.amd.com/system/files/TechDocs/56860.pdf>
+#[repr(C, align(4096))]
+#[derive(Debug, FromBytes)]
+pub struct SecretsPage {
+    /// The version of the secrets page.
+    pub version: u32,
+    /// The least significant bit indicates where an initial imigration image is enabled in the
+    /// guest context. All other bits are reserved and must be zero.
+    pub imi_en: u32,
+    /// The family, model and stepping of the CPU as reported in CPUID Fn0000_0001_EAX.
+    pub fms: u32,
+    _reserved_0: u32,
+    /// Guest-OS-visible workarounds provided by the hypervisor during SNP_LAUNCH_START. The format
+    /// is hypervisor-defined.
+    pub gosv: [u8; 16],
+    /// VM-platform communication key 0. AES key used for encrypting messages to the platform.
+    pub vmpck_0: [u8; 32],
+    /// VM-platform communication key 1. AES key used for encrypting messages to the platform.
+    pub vmpck_1: [u8; 32],
+    /// VM-platform communication key 2. AES key used for encrypting messages to the platform.
+    pub vmpck_2: [u8; 32],
+    /// VM-platform communication key 3. AES key used for encrypting messages to the platform.
+    pub vmpck_3: [u8; 32],
+    /// Area reserved for guest OS use.
+    pub guest_area_0: [u8; 96],
+    /// Bitmap indicating which quadwords of the VM Save Area have been tweaked. This is only used
+    /// if the VMSA Register Protection feature is enabled.
+    pub vmsa_tweak_bitmap: [u8; 64],
+    /// Area reserved for guest OS use.
+    pub guest_area_1: [u8; 32],
+    /// Scaling factor that can be used for calculating the real CPU frequency.
+    pub tsc_factor: u32,
+}
+
+static_assertions::assert_eq_size!(SecretsPage, [u8; SECRETS_PAGE_SIZE]);


### PR DESCRIPTION
This PR adds struct that can be used to interact with memory pages related to SEV-SNP:

- The secrets page
- The CPUID page
- The guest-host communications block