### PR TITLE
Don't run tests on baremetal binaries.

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/Cargo.toml
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.toml
@@ -16,3 +16,8 @@ static_assertions = "*"
 flatbuffers = { git = "https://github.com/jul-sh/flatbuffers.git", rev = "a07ddee936737da89aeb5a496f9742a805537188" }
 # Ensure no_std compatibility. Dependency of flatbuffers. TODO(#2920): remove once https://github.com/bbqsrc/thiserror-core2/pull/3 is merged.
 thiserror_core2 = { git = "https://github.com/jul-sh/thiserror-core2.git", rev = "b99e1a0106623cbbd12cbb5562d01df7a3fdc22e" }
+
+[[bin]]
+name = "oak_baremetal_app_crosvm"
+test = false
+bench = false

--- a/experimental/oak_baremetal_app_crosvm/src/main.rs
+++ b/experimental/oak_baremetal_app_crosvm/src/main.rs
@@ -17,25 +17,13 @@
 #![no_std]
 #![no_main]
 #![feature(alloc_error_handler)]
-#![feature(custom_test_frameworks)]
 #![feature(core_c_str)]
 #![feature(core_ffi_c)]
-// As we're in a `no_std` environment, testing requires special handling. This
-// approach was inspired by https://os.phil-opp.com/testing/.
-#![test_runner(crate::test_runner)]
-#![reexport_test_harness_main = "test_main"]
 
 use core::panic::PanicInfo;
 
 mod asm;
 mod bootparam;
-
-#[no_mangle]
-#[cfg(test)]
-pub extern "C" fn rust64_start(_rdi: u64, _rsi: &bootparam::BootParams) -> ! {
-    test_main();
-    oak_baremetal_kernel::i8042::shutdown();
-}
 
 #[no_mangle]
 #[cfg(not(test))]
@@ -51,11 +39,4 @@ fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     oak_baremetal_kernel::panic(info);
-}
-
-#[cfg(test)]
-fn test_runner(tests: &[&dyn Fn()]) {
-    for test in tests {
-        test();
-    }
 }

--- a/experimental/oak_baremetal_app_qemu/Cargo.toml
+++ b/experimental/oak_baremetal_app_qemu/Cargo.toml
@@ -24,3 +24,8 @@ bindgen = "*"
 flatbuffers = { git = "https://github.com/jul-sh/flatbuffers.git", rev = "a07ddee936737da89aeb5a496f9742a805537188" }
 # Ensure no_std compatibility. Dependency of flatbuffers. TODO(#2920): remove once https://github.com/bbqsrc/thiserror-core2/pull/3 is merged.
 thiserror_core2 = { git = "https://github.com/jul-sh/thiserror-core2.git", rev = "b99e1a0106623cbbd12cbb5562d01df7a3fdc22e" }
+
+[[bin]]
+name = "oak_baremetal_app_qemu"
+test = false
+bench = false


### PR DESCRIPTION
Running tests in these crates is difficult as they're built against the baremetal target, and thus require special handling -- such as running the tests inside an emulator.

However, we've moved all of real code into the `oak_baremetal_kernel` crate, where it can be tested normally; these crates effectively exist only to force their dependencies to be built against bare metal, and contain no meaningful code (nor tests).

In the future, once we standardize on one boot protocol, I foresee one of these crates going away completely and the other becoming even more vestigial.

Thus, to make our lives simpler, let's disable tests for the baremetal crates.