### PR TITLE
Derive target.json from `x86_64-unknown-none`

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/build.rs
+++ b/experimental/oak_baremetal_app_crosvm/build.rs
@@ -17,4 +17,5 @@
 fn main() {
     println!("cargo:rerun-if-changed=target.json");
     println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rustc-link-arg=--script=layout.ld");
 }

--- a/experimental/oak_baremetal_app_crosvm/target.json
+++ b/experimental/oak_baremetal_app_crosvm/target.json
@@ -1,18 +1,24 @@
 {
   "arch": "x86_64",
-  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "code-model": "kernel",
+  "cpu": "x86-64",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   "disable-redzone": true,
   "executables": true,
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
-  "llvm-target": "x86_64-unknown-none",
-  "os": "none",
+  "llvm-target": "x86_64-unknown-none-elf",
+  "max-atomic-width": 64,
   "panic-strategy": "abort",
+  "position-independent-executables": true,
   "pre-link-args": {
     "ld.lld": ["--script=layout.ld"]
   },
-  "relocation-model": "pic",
-  "target-c-int-width": "32",
-  "target-endian": "little",
+  "relocation-model": "static",
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "call"
+  },
+  "static-position-independent-executables": true,
   "target-pointer-width": "64"
 }

--- a/experimental/oak_baremetal_app_crosvm/target.json
+++ b/experimental/oak_baremetal_app_crosvm/target.json
@@ -11,9 +11,6 @@
   "max-atomic-width": 64,
   "panic-strategy": "abort",
   "position-independent-executables": true,
-  "pre-link-args": {
-    "ld.lld": ["--script=layout.ld"]
-  },
   "relocation-model": "static",
   "relro-level": "full",
   "stack-probes": {

--- a/experimental/oak_baremetal_app_qemu/build.rs
+++ b/experimental/oak_baremetal_app_qemu/build.rs
@@ -18,4 +18,5 @@ fn main() {
     println!("cargo:rerun-if-changed=target.json");
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rerun-if-changed=../../third_party/rust-hypervisor-boot/layout.ld");
+    println!("cargo:rustc-link-arg=--script=layout.ld");
 }

--- a/experimental/oak_baremetal_app_qemu/target.json
+++ b/experimental/oak_baremetal_app_qemu/target.json
@@ -1,18 +1,24 @@
 {
   "arch": "x86_64",
-  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "code-model": "kernel",
+  "cpu": "x86-64",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   "disable-redzone": true,
   "executables": true,
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
-  "llvm-target": "x86_64-unknown-none",
-  "os": "none",
+  "llvm-target": "x86_64-unknown-none-elf",
+  "max-atomic-width": 64,
   "panic-strategy": "abort",
+  "position-independent-executables": true,
   "pre-link-args": {
     "ld.lld": ["--script=layout.ld"]
   },
-  "relocation-model": "pic",
-  "target-c-int-width": "32",
-  "target-endian": "little",
+  "relocation-model": "static",
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "call"
+  },
+  "static-position-independent-executables": true,
   "target-pointer-width": "64"
 }

--- a/experimental/oak_baremetal_app_qemu/target.json
+++ b/experimental/oak_baremetal_app_qemu/target.json
@@ -11,9 +11,6 @@
   "max-atomic-width": 64,
   "panic-strategy": "abort",
   "position-independent-executables": true,
-  "pre-link-args": {
-    "ld.lld": ["--script=layout.ld"]
-  },
   "relocation-model": "static",
   "relro-level": "full",
   "stack-probes": {


### PR DESCRIPTION
For reference, this is the target spec from `x86_64-unknown-none`:
```
$ rustc -Z unstable-options --target=x86_64-unknown-none --print target-spec-json
{
  "arch": "x86_64",
  "code-model": "kernel",
  "cpu": "x86-64",
  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
  "disable-redzone": true,
  "executables": true,
  "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
  "is-builtin": true,
  "linker": "rust-lld",
  "linker-flavor": "ld.lld",
  "llvm-target": "x86_64-unknown-none-elf",
  "max-atomic-width": 64,
  "panic-strategy": "abort",
  "position-independent-executables": true,
  "relro-level": "full",
  "stack-probes": {
    "kind": "call"
  },
  "static-position-independent-executables": true,
  "target-pointer-width": "64"
}
```

Key differences between this vs our `target.json`:

  - Removed `features`, as we need AVX et al
  - Removed `is-builtin`, because, well, we're not a built-in target
  - Changed `relocation-model` to `static` for things to link, for now. We still have some 32-bit code around in the `rust-hypervisor-firmware-boot` crate that seems to confuse things; getting rid of that is a future TODO.
 
Plus, `pre-link-args` pointing to our linker script moved to `build.rs`.

All of this gets us closer to switching over to the standard target in an incremental, piecemeal fashion.