### PR TITLE
Change how we pass flags to crosvm

### DIFF
--- a/experimental/oak_baremetal_loader/src/crosvm.rs
+++ b/experimental/oak_baremetal_loader/src/crosvm.rs
@@ -56,12 +56,16 @@ impl Crosvm {
         // Don't bother running devices in sandboxed processes.
         cmd.arg("--disable-sandbox");
         // First serial port: this will be used by the console
-        cmd.arg(format!(
-            "--serial=num=1,hardware=serial,type=file,path=/proc/self/fd/{},console,earlycon",
-            params.console.as_raw_fd()
-        ));
-        cmd.arg(format!("--cid={}", VSOCK_GUEST_CID));
-        cmd.arg("--params=channel=virtio_vsock");
+        cmd.args(&[
+            "--serial",
+            format!(
+                "num=1,hardware=serial,type=file,path=/proc/self/fd/{},console,earlycon",
+                params.console.as_raw_fd()
+            )
+            .as_str(),
+        ]);
+        cmd.args(["--cid", VSOCK_GUEST_CID.to_string().as_str()]);
+        cmd.args(["--params", "channel=virtio_vsock"]);
         cmd.arg(params.app);
 
         info!("Executing: {:?}", cmd);


### PR DESCRIPTION
crosvm says the current way we pass flags to it is deprecated:

```
`--serial=num=1,hardware=serial,type=file,path=/proc/self/fd/9,console,earlycon` is deprecated, please use `--serial num=1,hardware=serial,type=file,path=/proc/self/fd/9,console,earlycon`
`--cid=3` is deprecated, please use `--cid 3`
`--params=channel=virtio_vsock` is deprecated, please use `--params channel=virtio_vsock`
```

Well, let's do that, then.