### PR TITLE
Run dependabot against baremetal crates as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,22 @@ updates:
     # external users.
     labels:
       - 'kokoro:run'
+  # Keep the following two in sync with the main one, above, as the baremetal targets have their own `Cargo.lock` files.
+  - package-ecosystem: 'cargo'
+    directory: '/experimental/oak_baremetal_app_crosvm'
+    schedule:
+      interval: 'daily'
+    ignore:
+      - dependency-name: 'linked_list_allocator'
+        versions: ['0.10.0']
+    labels:
+      - 'kokoro:run'
+  - package-ecosystem: 'cargo'
+    directory: '/experimental/oak_baremetal_app_qemu'
+    schedule:
+      interval: 'daily'
+    ignore:
+      - dependency-name: 'linked_list_allocator'
+        versions: ['0.10.0']
+    labels:
+      - 'kokoro:run'


### PR DESCRIPTION
The downside is that we will get far more dependabot PRs for now.

In the future this will get better:
  - we expect one of the baremetal crates to go away (and thus one less `Cargo.lock` to maintain)
  - hopefully Rust will figure out how to include baremetal crates in the main workspace soon.