### PR TITLE
Add GHCB MSR protocol unit tests

### DIFF
--- a/experimental/sev_guest/src/msr.rs
+++ b/experimental/sev_guest/src/msr.rs
@@ -465,6 +465,12 @@ pub fn read_msr() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    //! These tests check the conversion logic between convenience request and response structs, and
+    //! the u64 values used for the MSR protocol.
+    //!
+    //! See section 2.3.1 in <https://developer.amd.com/wp-content/resources/56421.pdf> for details of
+    //! how the requests and responses are represented as u64 values.
+
     use super::*;
 
     #[test]
@@ -591,13 +597,13 @@ mod tests {
     #[test]
     fn test_snp_page_state_change_response() {
         let error_code = 1u64;
-        let invalid = 0x15u64 | (error_code << 31);
-        let invalid2 = 0x16u64 | (error_code << 32);
+        let invalid_misaligned_data = 0x15u64 | (error_code << 31);
+        let invalid_info = 0x16u64 | (error_code << 32);
         let valid = 0x15u64 | (error_code << 32);
 
-        let error: Result<SnpPageStateChangeResponse> = invalid.try_into();
+        let error: Result<SnpPageStateChangeResponse> = invalid_misaligned_data.try_into();
         assert!(error.is_err());
-        let error: Result<SnpPageStateChangeResponse> = invalid2.try_into();
+        let error: Result<SnpPageStateChangeResponse> = invalid_info.try_into();
         assert!(error.is_err());
 
         let correct: SnpPageStateChangeResponse = valid.try_into().unwrap();


### PR DESCRIPTION
This PR adds unit tests for the conversion of the MSR protocol request objects to u64 values and u64 values to response objects.

See section 2.3.1 of [SEV-ES Guest-Hypervisor Communication Block Standardization](https://developer.amd.com/wp-content/resources/56421.pdf) for the specification.
