### PR TITLE
Use negative logo in dark mode to ensure readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# ![Project Oak](docs/oak-logo/svgs/oak-logo.svg?sanitize=true)
+<!-- Oak Logo Start -->
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/oak-logo/svgs/oak-logo-negative.svg?sanitize=true">
+    <source media="(prefers-color-scheme: light)" srcset="docs/oak-logo/svgs/oak-logo.svg?sanitize=true">
+    <img alt="Project Oak Logo" src="docs/oak-logo/svgs/oak-logo.svg?sanitize=true">
+  </picture>
+</h1>
+<!-- Oak Logo End -->
 
 [![Build Status](https://img.shields.io/github/workflow/status/project-oak/oak/Continuous%20Integration/main?style=for-the-badge)](https://github.com/project-oak/oak/actions?query=workflow%3A%22Continuous+Integration%22+branch%3Amain)
 [![codecov](https://img.shields.io/codecov/c/github/project-oak/oak?style=for-the-badge)](https://codecov.io/gh/project-oak/oak)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 <!-- Oak Logo Start -->
-<h1>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/oak-logo/svgs/oak-logo-negative.svg?sanitize=true">
-    <source media="(prefers-color-scheme: light)" srcset="docs/oak-logo/svgs/oak-logo.svg?sanitize=true">
-    <img alt="Project Oak Logo" src="docs/oak-logo/svgs/oak-logo.svg?sanitize=true">
-  </picture>
-</h1>
+<!-- An HTML element is intentionally used since GitHub recommends this approach to handle different images in dark/light modes. Ref: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to -->
+<!-- markdownlint-disable-next-line MD033 -->
+<h1><picture><source media="(prefers-color-scheme: dark)" srcset="docs/oak-logo/svgs/oak-logo-negative.svg?sanitize=true"><source media="(prefers-color-scheme: light)" srcset="docs/oak-logo/svgs/oak-logo.svg?sanitize=true"><img alt="Project Oak Logo" src="docs/oak-logo/svgs/oak-logo.svg?sanitize=true"></picture></h1>
 <!-- Oak Logo End -->
 
 [![Build Status](https://img.shields.io/github/workflow/status/project-oak/oak/Continuous%20Integration/main?style=for-the-badge)](https://github.com/project-oak/oak/actions?query=workflow%3A%22Continuous+Integration%22+branch%3Amain)


### PR DESCRIPTION
Small tweak: GitHub recommends using the HTML picture element for this: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to :) 


Preview on the source branch: https://github.com/jul-sh/oak/tree/dark-mode-image