### PR TITLE
Rename the oak IDL Message struct to something more descriptive

### DIFF
--- a/experimental/oak_baremetal_loader/src/lookup.rs
+++ b/experimental/oak_baremetal_loader/src/lookup.rs
@@ -21,8 +21,8 @@ use std::fs;
 
 pub fn encode_lookup_data<'a>(
     mut data: HashMap<Vec<u8>, Vec<u8>>,
-) -> anyhow::Result<oak_idl::utils::Message<schema::LookupData<'a>>> {
-    let mut builder = oak_idl::utils::MessageBuilder::default();
+) -> anyhow::Result<oak_idl::utils::OwnedFlatbuffer<schema::LookupData<'a>>> {
+    let mut builder = oak_idl::utils::OwnedFlatbufferBuilder::default();
     let entries: Vec<flatbuffers::WIPOffset<schema::LookupDataEntry>> = data
         .drain()
         .map(|(key, value)| {
@@ -38,11 +38,11 @@ pub fn encode_lookup_data<'a>(
         })
         .collect();
     let items = builder.create_vector(&entries);
-    let message =
+    let flatbuffer =
         schema::LookupData::create(&mut builder, &schema::LookupDataArgs { items: Some(items) });
-    builder.finish(message).map_err(|error| {
+    builder.finish(flatbuffer).map_err(|error| {
         anyhow!(
-            "errored when encoding the lookup data as a flatbuffer message: {}",
+            "errored when encoding the lookup data as a flatbuffer: {}",
             error
         )
     })

--- a/experimental/oak_baremetal_loader/src/main.rs
+++ b/experimental/oak_baremetal_loader/src/main.rs
@@ -214,10 +214,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let wasm_bytes = fs::read(&cli.wasm)
             .with_context(|| format!("Couldn't read Wasm file {}", &cli.wasm.display()))
             .unwrap();
-        let initialization_message = {
-            let mut builder = oak_idl::utils::MessageBuilder::default();
+        let owned_initialization_flatbuffer = {
+            let mut builder = oak_idl::utils::OwnedFlatbufferBuilder::default();
             let wasm_module = builder.create_vector::<u8>(&wasm_bytes);
-            let message = schema::Initialization::create(
+            let initialization_flatbuffer = schema::Initialization::create(
                 &mut builder,
                 &schema::InitializationArgs {
                     wasm_module: Some(wasm_module),
@@ -225,10 +225,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
 
             builder
-                .finish(message)
+                .finish(initialization_flatbuffer)
                 .expect("errored when creating initialization message")
         };
-        if let Err(err) = client.initialize(initialization_message.buf()) {
+        if let Err(err) = client.initialize(owned_initialization_flatbuffer.buf()) {
             panic!("failed to initialize the runtime: {:?}", err)
         }
 

--- a/experimental/oak_baremetal_runtime/src/framing.rs
+++ b/experimental/oak_baremetal_runtime/src/framing.rs
@@ -65,7 +65,7 @@ where
         &mut self,
         initialization: &schema::Initialization,
     ) -> Result<
-        oak_idl::utils::Message<oak_baremetal_communication_channel::schema::Empty>,
+        oak_idl::utils::OwnedFlatbuffer<oak_baremetal_communication_channel::schema::Empty>,
         oak_idl::Status,
     > {
         match &mut self.initialization_state {
@@ -95,7 +95,7 @@ where
                 ));
                 self.initialization_state = InitializationState::Initialized(attestation_handler);
                 let response_message = {
-                    let mut builder = oak_idl::utils::MessageBuilder::default();
+                    let mut builder = oak_idl::utils::OwnedFlatbufferBuilder::default();
                     let user_request_response =
                         schema::Empty::create(&mut builder, &schema::EmptyArgs {});
                     builder
@@ -110,7 +110,7 @@ where
     fn handle_user_request(
         &mut self,
         request_message: &schema::UserRequest,
-    ) -> Result<oak_idl::utils::Message<schema::UserRequestResponse>, oak_idl::Status> {
+    ) -> Result<oak_idl::utils::OwnedFlatbuffer<schema::UserRequestResponse>, oak_idl::Status> {
         match &mut self.initialization_state {
             InitializationState::Uninitialized(_attestation_behavior) => Err(oak_idl::Status::new(
                 oak_idl::StatusCode::FailedPrecondition,
@@ -130,7 +130,7 @@ where
                     .map_err(|_err| oak_idl::Status::new(oak_idl::StatusCode::Internal))?;
 
                 let response_message = {
-                    let mut builder = oak_idl::utils::MessageBuilder::default();
+                    let mut builder = oak_idl::utils::OwnedFlatbufferBuilder::default();
                     let body = builder.create_vector::<u8>(&response);
                     let user_request_response = schema::UserRequestResponse::create(
                         &mut builder,
@@ -149,7 +149,7 @@ where
         &mut self,
         lookup_data: &schema::LookupData,
     ) -> Result<
-        oak_idl::utils::Message<oak_baremetal_communication_channel::schema::Empty>,
+        oak_idl::utils::OwnedFlatbuffer<oak_baremetal_communication_channel::schema::Empty>,
         oak_idl::Status,
     > {
         let data = lookup_data
@@ -172,7 +172,7 @@ where
 
         self.lookup_data_manager.update_data(data);
         let response_message = {
-            let mut builder = oak_idl::utils::MessageBuilder::default();
+            let mut builder = oak_idl::utils::OwnedFlatbufferBuilder::default();
             let user_request_response = schema::Empty::create(&mut builder, &schema::EmptyArgs {});
             builder
                 .finish(user_request_response)

--- a/oak_idl/src/utils.rs
+++ b/oak_idl/src/utils.rs
@@ -21,10 +21,10 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-/// A helper struct to facilitate building a [`Message`].
+/// A helper struct to facilitate building a [`OwnedFlatbuffer`].
 ///
-/// [`MessageBuilder`] delegates to the underlying [`flatbuffers::FlatBufferBuilder`] instance, and
-/// it adds a [`MessageBuilder::finish`] method that returns a completed [`Message`] instance which
+/// [`OwnedFlatbufferBuilder`] delegates to the underlying [`flatbuffers::FlatBufferBuilder`] instance, and
+/// it adds a [`OwnedFlatbufferBuilder::finish`] method that returns a completed [`OwnedFlatbuffer`] instance which
 /// owns the underlying buffer.
 ///
 /// We need to have an instance of [`PhantomData`] in the struct in order to use the type paramter
@@ -64,19 +64,19 @@ use core::{
 /// #     pub value: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
 /// # }
 /// #
-/// let mut b = oak_idl::utils::MessageBuilder::<Request>::default();
+/// let mut b = oak_idl::utils::OwnedFlatbufferBuilder::<Request>::default();
 /// let v = b.create_vector::<u8>(&[14, 12]);
 /// let req = Request::create(&mut b, &RequestArgs {
 ///     value: Some(v),
 /// });
 /// let m = b.finish(req);
 /// ```
-pub struct MessageBuilder<'a, T> {
+pub struct OwnedFlatbufferBuilder<'a, T> {
     buf: flatbuffers::FlatBufferBuilder<'a>,
     _phantom: PhantomData<T>,
 }
 
-impl<'a, T: flatbuffers::Verifiable + flatbuffers::Follow<'a>> Default for MessageBuilder<'a, T> {
+impl<'a, T: flatbuffers::Verifiable + flatbuffers::Follow<'a>> Default for OwnedFlatbufferBuilder<'a, T> {
     fn default() -> Self {
         Self {
             buf: flatbuffers::FlatBufferBuilder::default(),
@@ -85,19 +85,19 @@ impl<'a, T: flatbuffers::Verifiable + flatbuffers::Follow<'a>> Default for Messa
     }
 }
 
-impl<'a, T: flatbuffers::Verifiable + flatbuffers::Follow<'a>> MessageBuilder<'a, T> {
+impl<'a, T: flatbuffers::Verifiable + flatbuffers::Follow<'a>> OwnedFlatbufferBuilder<'a, T> {
     pub fn finish(
         self,
         offset: flatbuffers::WIPOffset<T>,
-    ) -> Result<Message<T>, flatbuffers::InvalidFlatbuffer> {
+    ) -> Result<OwnedFlatbuffer<T>, flatbuffers::InvalidFlatbuffer> {
         let mut s = self;
         s.buf.finish(offset, None);
-        Message::from_vec(s.buf.finished_data().to_vec())
+        OwnedFlatbuffer::from_vec(s.buf.finished_data().to_vec())
     }
 }
 
-/// Delegate to the underlying [`MessageBuilder`].
-impl<'a, T> Deref for MessageBuilder<'a, T> {
+/// Delegate to the underlying [`OwnedFlatbufferBuilder`].
+impl<'a, T> Deref for OwnedFlatbufferBuilder<'a, T> {
     type Target = flatbuffers::FlatBufferBuilder<'a>;
 
     fn deref(&self) -> &Self::Target {
@@ -105,20 +105,20 @@ impl<'a, T> Deref for MessageBuilder<'a, T> {
     }
 }
 
-/// Delegate to the underlying [`MessageBuilder`].
-impl<'a, T> DerefMut for MessageBuilder<'a, T> {
+/// Delegate to the underlying [`OwnedFlatbufferBuilder`].
+impl<'a, T> DerefMut for OwnedFlatbufferBuilder<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.buf
     }
 }
 
 /// An owned flatbuffer message, which owns the underlying buffer.
-pub struct Message<T> {
+pub struct OwnedFlatbuffer<T> {
     buf: Vec<u8>,
     _phantom: PhantomData<T>,
 }
 
-impl<T: flatbuffers::Verifiable> Message<T> {
+impl<T: flatbuffers::Verifiable> OwnedFlatbuffer<T> {
     pub fn from_vec(buf: Vec<u8>) -> Result<Self, flatbuffers::InvalidFlatbuffer> {
         use flatbuffers::Verifiable;
         let opts = flatbuffers::VerifierOptions::default();
@@ -131,7 +131,7 @@ impl<T: flatbuffers::Verifiable> Message<T> {
     }
 }
 
-impl<T> Message<T> {
+impl<T> OwnedFlatbuffer<T> {
     /// Returns a reference to the underlying owned buffer.
     pub fn buf(&self) -> &[u8] {
         &self.buf
@@ -142,7 +142,7 @@ impl<T> Message<T> {
     }
 }
 
-impl<'a, T: flatbuffers::Follow<'a> + flatbuffers::Verifiable> Message<T> {
+impl<'a, T: flatbuffers::Follow<'a> + flatbuffers::Verifiable> OwnedFlatbuffer<T> {
     /// Returns a reference to the flatbuffer object, pointing within the underlying owned buffer.
     pub fn get(&'a self) -> T::Inner {
         flatbuffers::root::<T>(&self.buf).unwrap()

--- a/oak_idl/src/utils.rs
+++ b/oak_idl/src/utils.rs
@@ -23,9 +23,9 @@ use core::{
 
 /// A helper struct to facilitate building a [`OwnedFlatbuffer`].
 ///
-/// [`OwnedFlatbufferBuilder`] delegates to the underlying [`flatbuffers::FlatBufferBuilder`] instance, and
-/// it adds a [`OwnedFlatbufferBuilder::finish`] method that returns a completed [`OwnedFlatbuffer`] instance which
-/// owns the underlying buffer.
+/// [`OwnedFlatbufferBuilder`] delegates to the underlying [`flatbuffers::FlatBufferBuilder`]
+/// instance, and it adds a [`OwnedFlatbufferBuilder::finish`] method that returns a completed
+/// [`OwnedFlatbuffer`] instance which owns the underlying buffer.
 ///
 /// We need to have an instance of [`PhantomData`] in the struct in order to use the type paramter
 /// `T`.
@@ -76,7 +76,9 @@ pub struct OwnedFlatbufferBuilder<'a, T> {
     _phantom: PhantomData<T>,
 }
 
-impl<'a, T: flatbuffers::Verifiable + flatbuffers::Follow<'a>> Default for OwnedFlatbufferBuilder<'a, T> {
+impl<'a, T: flatbuffers::Verifiable + flatbuffers::Follow<'a>> Default
+    for OwnedFlatbufferBuilder<'a, T>
+{
     fn default() -> Self {
         Self {
             buf: flatbuffers::FlatBufferBuilder::default(),

--- a/oak_idl_gen_services/src/lib.rs
+++ b/oak_idl_gen_services/src/lib.rs
@@ -242,7 +242,7 @@ fn generate_client_method(rpc_call: &RPCCall) -> anyhow::Result<Vec<String>> {
     // much benefit.
     Ok(vec![
         format!(
-            "    pub fn {}(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::Message<{}>, oak_idl::Status> {{",
+            "    pub fn {}(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::OwnedFlatbuffer<{}>, oak_idl::Status> {{",
             method_name(rpc_call),
             response_type(rpc_call)
         ),
@@ -255,7 +255,7 @@ fn generate_client_method(rpc_call: &RPCCall) -> anyhow::Result<Vec<String>> {
         format!("            body: request_body,"),
         format!("        }};"),
         format!("        let response_body = self.handler.invoke(request)?;"),
-        format!("        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!(\"Client failed to deserialize the response: {{:?}}\", err)))"),
+        format!("        oak_idl::utils::OwnedFlatbuffer::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!(\"Client failed to deserialize the response: {{:?}}\", err)))"),
         format!("    }}"),
     ])
 }
@@ -287,7 +287,7 @@ fn generate_service_method(rpc_call: &RPCCall) -> Vec<String> {
     // implementation of this method, therefore needs to be wrapped in `oak_idl::Message` in order
     // to transfer its ownership to the caller.
     vec![format!(
-        "    fn {}(&mut self, request: &{}) -> Result<oak_idl::utils::Message<{}>, oak_idl::Status>;",
+        "    fn {}(&mut self, request: &{}) -> Result<oak_idl::utils::OwnedFlatbuffer<{}>, oak_idl::Status>;",
         method_name(rpc_call),
         request_type(rpc_call),
         response_type(rpc_call)

--- a/oak_idl_tests/test_schema_services.rs.txt
+++ b/oak_idl_tests/test_schema_services.rs.txt
@@ -15,23 +15,23 @@ impl <T: oak_idl::Handler>TestServiceClient<T> {
             handler
         }
     }
-    pub fn lookup_data(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::Status> {
+    pub fn lookup_data(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::OwnedFlatbuffer<LookupDataResponse>, oak_idl::Status> {
         flatbuffers::root::<LookupDataRequest>(request_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the request: {:?}", err)))?;
         let request = oak_idl::Request {
             method_id: 222,
             body: request_body,
         };
         let response_body = self.handler.invoke(request)?;
-        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+        oak_idl::utils::OwnedFlatbuffer::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
     }
-    pub fn log(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::Status> {
+    pub fn log(&mut self, request_body: &[u8]) -> Result<oak_idl::utils::OwnedFlatbuffer<LogResponse>, oak_idl::Status> {
         flatbuffers::root::<LogRequest>(request_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the request: {:?}", err)))?;
         let request = oak_idl::Request {
             method_id: 223,
             body: request_body,
         };
         let response_body = self.handler.invoke(request)?;
-        oak_idl::utils::Message::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+        oak_idl::utils::OwnedFlatbuffer::from_vec(response_body).map_err(|err| oak_idl::Status::new_with_message(oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
     }
 }
 
@@ -60,8 +60,8 @@ impl <S: TestService> oak_idl::Handler for TestServiceServer<S> {
 }
 
 pub trait TestService: Sized {
-    fn lookup_data(&mut self, request: &LookupDataRequest) -> Result<oak_idl::utils::Message<LookupDataResponse>, oak_idl::Status>;
-    fn log(&mut self, request: &LogRequest) -> Result<oak_idl::utils::Message<LogResponse>, oak_idl::Status>;
+    fn lookup_data(&mut self, request: &LookupDataRequest) -> Result<oak_idl::utils::OwnedFlatbuffer<LookupDataResponse>, oak_idl::Status>;
+    fn log(&mut self, request: &LogRequest) -> Result<oak_idl::utils::OwnedFlatbuffer<LogResponse>, oak_idl::Status>;
     fn serve(self) -> TestServiceServer<Self> {
         TestServiceServer { service : self }
     }

--- a/oak_idl_tests/tests/test_schema.rs
+++ b/oak_idl_tests/tests/test_schema.rs
@@ -31,41 +31,42 @@ impl test_schema::TestService for TestServiceImpl {
     fn lookup_data(
         &mut self,
         request: &test_schema::LookupDataRequest,
-    ) -> Result<oak_idl::utils::Message<test_schema::LookupDataResponse>, oak_idl::Status> {
+    ) -> Result<oak_idl::utils::OwnedFlatbuffer<test_schema::LookupDataResponse>, oak_idl::Status>
+    {
         let h = maplit::hashmap! {
             vec![14, 12] => vec![19, 88]
         };
-        let mut b = oak_idl::utils::MessageBuilder::default();
+        let mut b = oak_idl::utils::OwnedFlatbufferBuilder::default();
         let value = h
             .get(request.key().unwrap())
             .map(|v| b.create_vector::<u8>(v));
-        let m = test_schema::LookupDataResponse::create(
+        let flatbuffer = test_schema::LookupDataResponse::create(
             &mut b,
             &test_schema::LookupDataResponseArgs { value },
         );
-        let b = b.finish(m).map_err(|err| {
+        let owned_flatbuffer = b.finish(flatbuffer).map_err(|err| {
             oak_idl::Status::new_with_message(
                 oak_idl::StatusCode::Internal,
                 format!("failed to build response: {:?}", err),
             )
         })?;
-        Ok(b)
+        Ok(owned_flatbuffer)
     }
 
     fn log(
         &mut self,
         request: &test_schema::LogRequest,
-    ) -> Result<oak_idl::utils::Message<test_schema::LogResponse>, oak_idl::Status> {
+    ) -> Result<oak_idl::utils::OwnedFlatbuffer<test_schema::LogResponse>, oak_idl::Status> {
         eprintln!("log: {}", request.entry().unwrap());
-        let mut b = oak_idl::utils::MessageBuilder::default();
-        let m = test_schema::LogResponse::create(&mut b, &test_schema::LogResponseArgs {});
-        let b = b.finish(m).map_err(|err| {
+        let mut b = oak_idl::utils::OwnedFlatbufferBuilder::default();
+        let flatbuffer = test_schema::LogResponse::create(&mut b, &test_schema::LogResponseArgs {});
+        let owned_flatbuffer = b.finish(flatbuffer).map_err(|err| {
             oak_idl::Status::new_with_message(
                 oak_idl::StatusCode::Internal,
                 format!("failed to build response: {:?}", err),
             )
         })?;
-        Ok(b)
+        Ok(owned_flatbuffer)
     }
 }
 
@@ -76,25 +77,25 @@ fn test_lookup_data() {
     let handler = service.serve();
     let mut client = test_schema::TestServiceClient::new(handler);
     {
-        let mut builder = oak_idl::utils::MessageBuilder::default();
+        let mut builder = oak_idl::utils::OwnedFlatbufferBuilder::default();
         let key = builder.create_vector::<u8>(&[14, 12]);
-        let request = test_schema::LookupDataRequest::create(
+        let flatbuffer = test_schema::LookupDataRequest::create(
             &mut builder,
             &test_schema::LookupDataRequestArgs { key: Some(key) },
         );
-        let message = builder.finish(request).unwrap();
-        let response = client.lookup_data(message.buf()).unwrap();
+        let owned_flatbuffer = builder.finish(flatbuffer).unwrap();
+        let response = client.lookup_data(owned_flatbuffer.buf()).unwrap();
         assert_eq!(Some([19, 88].as_ref()), response.get().value());
     }
     {
-        let mut builder = oak_idl::utils::MessageBuilder::default();
+        let mut builder = oak_idl::utils::OwnedFlatbufferBuilder::default();
         let key = builder.create_vector::<u8>(&[10, 00]);
-        let request = test_schema::LookupDataRequest::create(
+        let flatbuffer = test_schema::LookupDataRequest::create(
             &mut builder,
             &test_schema::LookupDataRequestArgs { key: Some(key) },
         );
-        let message = builder.finish(request).unwrap();
-        let response = client.lookup_data(message.buf()).unwrap();
+        let owned_flatbuffer = builder.finish(flatbuffer).unwrap();
+        let response = client.lookup_data(owned_flatbuffer.buf()).unwrap();
         assert_eq!(None, response.get().value());
     }
 }


### PR DESCRIPTION
Helps delineate it from Messages on the communication layer. The new name is `OwnedFlatbuffer`, as being an owned flatbuffer is in essence what this struct does. It's not that specific to our IDL logic. :) 