### PR TITLE
Use Async IDL Client in the Untrusted Loader

### DIFF
--- a/experimental/oak_baremetal_channel/Cargo.toml
+++ b/experimental/oak_baremetal_channel/Cargo.toml
@@ -5,6 +5,12 @@ authors = ["Juliette Pretot <julsh@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = []
+std = []
+client = ["std", "oak_idl/async-clients"]
+server = []
+
 [dependencies]
 anyhow = { version = "*", default-features = false }
 oak_idl = { path = "../../oak_idl" }

--- a/experimental/oak_baremetal_channel/Cargo.toml
+++ b/experimental/oak_baremetal_channel/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 default = []
 std = []
 client = ["std", "oak_idl/async-clients"]
-server = []
 
 [dependencies]
 anyhow = { version = "*", default-features = false }

--- a/experimental/oak_baremetal_channel/build.rs
+++ b/experimental/oak_baremetal_channel/build.rs
@@ -20,5 +20,7 @@ fn main() {
     println!("cargo:rerun-if-changed={}", SCHEMA);
     oak_idl_gen_structs::compile_structs(SCHEMA);
     oak_idl_gen_services::compile_services_servers(SCHEMA);
-    oak_idl_gen_services::compile_services_clients(SCHEMA);
+    if cfg!(feature = "client") {
+        oak_idl_gen_services::compile_services_async_clients(SCHEMA);
+    }
 }

--- a/experimental/oak_baremetal_channel/src/lib.rs
+++ b/experimental/oak_baremetal_channel/src/lib.rs
@@ -14,11 +14,13 @@
 // limitations under the License.
 //
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![feature(never_type)]
 #![allow(rustdoc::private_intra_doc_links)]
 
+#[cfg(feature = "client")]
 pub mod client;
+
 pub mod server;
 
 pub mod schema {
@@ -27,7 +29,11 @@ pub mod schema {
 
     include!(concat!(env!("OUT_DIR"), "/schema_generated.rs"));
     include!(concat!(env!("OUT_DIR"), "/schema_services_servers.rs"));
-    include!(concat!(env!("OUT_DIR"), "/schema_services_clients.rs"));
+    #[cfg(feature = "client")]
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/schema_services_async_clients.rs"
+    ));
 }
 
 mod frame;

--- a/experimental/oak_baremetal_loader/Cargo.toml
+++ b/experimental/oak_baremetal_loader/Cargo.toml
@@ -28,7 +28,9 @@ tonic = "*"
 vsock = "*"
 oak_remote_attestation_sessions = { path = "../../remote_attestation_sessions" }
 oak_idl = { path = "../../oak_idl" }
-oak_baremetal_communication_channel = { path = "../../experimental/oak_baremetal_channel" }
+oak_baremetal_communication_channel = { path = "../../experimental/oak_baremetal_channel", features = [
+  "client"
+] }
 oak_functions_loader = { path = "../../oak_functions/loader" }
 hashbrown = "*"
 flatbuffers = "*"

--- a/experimental/oak_baremetal_loader/src/server.rs
+++ b/experimental/oak_baremetal_loader/src/server.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+use crate::Client;
 use bmrng::unbounded::UnboundedRequestSender;
 use futures::Future;
 use oak_baremetal_communication_channel::schema;
@@ -65,18 +66,12 @@ fn encode_request(unary_request: UnaryRequest) -> Result<Vec<u8>, oak_idl::Statu
     Ok(owned_request_flatbuffer.into_vec())
 }
 
-fn decode_response(
-    encoded_response: Result<Vec<u8>, oak_idl::Status>,
-) -> Result<UnaryResponse, tonic::Status> {
-    let encoded_response_data =
-        encoded_response.map_err(|err| tonic::Status::internal(format!("{:?}", err)))?;
-    let owned_response_flatbuffer =
-        oak_idl::utils::OwnedFlatbuffer::<schema::UserRequestResponse>::from_vec(
-            encoded_response_data,
-        )
-        .map_err(|err| tonic::Status::internal(err.to_string()))?;
+fn decode_response(encoded_response: Vec<u8>) -> Result<UnaryResponse, tonic::Status> {
+    let response =
+        oak_idl::utils::OwnedFlatbuffer::<schema::UserRequestResponse>::from_vec(encoded_response)
+            .map_err(|err| tonic::Status::internal(err.to_string()))?;
 
-    let response_body = owned_response_flatbuffer
+    let response_body = response
         .get()
         .body()
         .ok_or_else(|| tonic::Status::internal(""))?;
@@ -87,7 +82,7 @@ fn decode_response(
 }
 
 pub struct EchoImpl {
-    channel: UnboundedRequestSender<Vec<u8>, Result<Vec<u8>, oak_idl::Status>>,
+    request_dispatcher: UnboundedRequestSender<oak_idl::Request, Result<Vec<u8>, oak_idl::Status>>,
 }
 
 #[tonic::async_trait]
@@ -99,12 +94,16 @@ impl UnarySession for EchoImpl {
         let request = request.into_inner();
         let encoded_request = encode_request(request)
             .map_err(|err| tonic::Status::invalid_argument(format!("{:?}", err)))?;
-        let encoded_response = self
-            .channel
-            .send_receive(encoded_request)
+
+        let mut client = schema::TrustedRuntimeAsyncClient::new(Client {
+            request_dispatcher: self.request_dispatcher.clone(),
+        });
+
+        let encoded_response = client
+            .handle_user_request(encoded_request)
             .await
             .map_err(|err| tonic::Status::internal(format!("{:?}", err)))?;
-        let response = decode_response(encoded_response)?;
+        let response = decode_response(encoded_response.into_vec())?;
 
         Ok(Response::new(response))
     }
@@ -112,9 +111,9 @@ impl UnarySession for EchoImpl {
 
 pub fn server(
     addr: SocketAddr,
-    channel: UnboundedRequestSender<Vec<u8>, Result<Vec<u8>, oak_idl::Status>>,
+    request_dispatcher: UnboundedRequestSender<oak_idl::Request, Result<Vec<u8>, oak_idl::Status>>,
 ) -> impl Future<Output = Result<(), tonic::transport::Error>> {
-    let server_impl = EchoImpl { channel };
+    let server_impl = EchoImpl { request_dispatcher };
     Server::builder()
         .add_service(UnarySessionServer::new(server_impl))
         .serve(addr)


### PR DESCRIPTION
Updates the untrusted loader to use an async IDL client. Instead of there being a central client that is being invoked over a bmrng channel by different parts of the runtime, there will now be multiple async clients that issue invocations over the bmrng channel.

This means that we'll get the code to differentiate various messages sent over the channel for free, provided by the oak IDL. This will come in handy when implementing periodic lookup-data refreshing.

In the future async clients will also allow us to more easily support non-sequential invocations. 