### PR TITLE
Remove remaining references to baremetal tests

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/src/main.rs
+++ b/experimental/oak_baremetal_app_crosvm/src/main.rs
@@ -26,7 +26,6 @@ mod asm;
 mod bootparam;
 
 #[no_mangle]
-#[cfg(not(test))]
 pub extern "C" fn rust64_start(_rdi: u64, rsi: &bootparam::BootParams) -> ! {
     oak_baremetal_kernel::start_kernel(rsi);
 }

--- a/experimental/oak_baremetal_app_qemu/src/main.rs
+++ b/experimental/oak_baremetal_app_qemu/src/main.rs
@@ -23,7 +23,7 @@
 use core::panic::PanicInfo;
 
 mod hvm_start_info;
-#[cfg(all(feature = "multiboot", not(test)))]
+#[cfg(all(feature = "multiboot"))]
 mod multiboot;
 
 #[no_mangle]


### PR DESCRIPTION
As of #3034 the binaries no longer have a test entrypoint, hence it seems these references can be removed :) 