### PR TITLE
Kernel: Add simple breakpoint exception handler that logs

### DIFF
--- a/experimental/oak_baremetal_kernel/src/interrupts.rs
+++ b/experimental/oak_baremetal_kernel/src/interrupts.rs
@@ -24,8 +24,13 @@ lazy_static! {
     static ref IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
         idt.double_fault.set_handler_fn(double_fault_handler);
+        idt.breakpoint.set_handler_fn(breakpoint_handler);
         idt
     };
+}
+
+extern "x86-interrupt" fn breakpoint_handler(stack_frame: InterruptStackFrame) {
+    log::error!("EXCEPTION: BREAKPOINT\n{:#?}", stack_frame);
 }
 
 extern "x86-interrupt" fn double_fault_handler(


### PR DESCRIPTION
After this change the kernel no longer double faults when encountering a breakpoint exception and instead continues afterwards. 

Tested this manually, and appears to work fine. This PR intentionally doesn't add an automated test since baremetal tests were removed in #3034, but would be happy to add a test back for this. 

Unfortunately this does not unlock debugging in crosvm. The runtime still crashes in crosvm when continuing from a breakpoint. 