### PR TITLE
Remove duplicate trait

### DIFF
--- a/experimental/oak_baremetal_channel/src/lib.rs
+++ b/experimental/oak_baremetal_channel/src/lib.rs
@@ -50,9 +50,27 @@ pub trait Read {
     fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()>;
 }
 
+#[cfg(feature = "std")]
+impl<T: std::io::Read> Read for T {
+    fn read(&mut self, data: &mut [u8]) -> anyhow::Result<()> {
+        self.read_exact(data).map_err(anyhow::Error::msg)
+    }
+}
+
 pub trait Write {
     fn write(&mut self, data: &[u8]) -> anyhow::Result<()>;
     fn flush(&mut self) -> anyhow::Result<()>;
+}
+
+#[cfg(feature = "std")]
+impl<T: std::io::Write> Write for T {
+    fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
+        self.write_all(data).map_err(anyhow::Error::msg)
+    }
+
+    fn flush(&mut self) -> anyhow::Result<()> {
+        std::io::Write::flush(self).map_err(anyhow::Error::msg)
+    }
 }
 
 pub trait Channel: Read + Write + Send + Sync {}

--- a/experimental/oak_baremetal_loader/src/crosvm.rs
+++ b/experimental/oak_baremetal_loader/src/crosvm.rs
@@ -14,10 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{
-    vmm::{Params, Vmm},
-    ReadWrite,
-};
+use crate::vmm::{Params, Vmm};
 use anyhow::Result;
 use async_trait::async_trait;
 use command_fds::tokio::CommandFdAsyncExt;
@@ -96,12 +93,14 @@ impl Vmm for Crosvm {
         self.wait().await
     }
 
-    async fn create_comms_channel(&self) -> Result<Box<dyn ReadWrite>> {
+    async fn create_comms_channel(
+        &self,
+    ) -> Result<Box<dyn oak_baremetal_communication_channel::Channel>> {
         // The vsock channel can only be created after the VM is booted. Hence
         // we try a few times to connect, in case the VM is currently starting
         // up. If no connetion is established after a while, we timeout.
         let task = tokio::spawn(async {
-            let stream: Box<dyn ReadWrite> = loop {
+            let stream: Box<dyn oak_baremetal_communication_channel::Channel> = loop {
                 match VsockStream::connect_with_cid_port(VSOCK_GUEST_CID, VSOCK_GUEST_PORT) {
                     Ok(stream) => {
                         break Box::new(stream);

--- a/experimental/oak_baremetal_loader/src/qemu.rs
+++ b/experimental/oak_baremetal_loader/src/qemu.rs
@@ -14,10 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{
-    vmm::{Params, Vmm},
-    ReadWrite,
-};
+use crate::vmm::{Params, Vmm};
 use anyhow::Result;
 use async_trait::async_trait;
 use command_fds::{tokio::CommandFdAsyncExt, FdMapping};
@@ -148,7 +145,9 @@ impl Vmm for Qemu {
         self.wait().await
     }
 
-    async fn create_comms_channel(&self) -> Result<Box<dyn ReadWrite>> {
+    async fn create_comms_channel(
+        &self,
+    ) -> Result<Box<dyn oak_baremetal_communication_channel::Channel>> {
         let comms_host = self.comms_host.try_clone()?;
         Ok(Box::new(comms_host))
     }

--- a/experimental/oak_baremetal_loader/src/vmm.rs
+++ b/experimental/oak_baremetal_loader/src/vmm.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-use super::ReadWrite;
 use anyhow::Result;
 use async_trait::async_trait;
 use std::{os::unix::net::UnixStream, path::PathBuf};
@@ -46,5 +45,7 @@ pub trait Vmm {
     ///
     /// Since different VMMs might use different comms channels, we leave it up to the VMM to create
     /// the channel rather than passing it in as part of the parameters.
-    async fn create_comms_channel(&self) -> Result<Box<dyn ReadWrite>>;
+    async fn create_comms_channel(
+        &self,
+    ) -> Result<Box<dyn oak_baremetal_communication_channel::Channel>>;
 }


### PR DESCRIPTION
The ReadWrite trait is equivalent to the Channel trait. The ReadWrite can be removed by providing an implementation of our Read / Write traits from the std trait. 

Simplifies the code slightly, and will come in handy for the upcoming linux wrapper of the runtime, which also uses std Read / Write traits.

