### PR TITLE
Refactor launcher in preparation for supporting a runtime linux binary

### DIFF
--- a/experimental/oak_baremetal_launcher/README.MD
+++ b/experimental/oak_baremetal_launcher/README.MD
@@ -11,9 +11,11 @@ The baremetal app may be loaded in QEMU via
 ```shell
 (cd experimental/oak_baremetal_app_qemu && cargo build) \
 && RUST_LOG=debug cargo run --package oak_baremetal_launcher -- \
---mode qemu \
---app experimental/oak_baremetal_app_qemu/target/target/debug/oak_baremetal_app_qemu \
---wasm experimental/oak_baremetal_launcher/key_value_lookup.wasm
+--wasm experimental/oak_baremetal_launcher/key_value_lookup.wasm \
+--lookup-data experimental/oak_baremetal_launcher/mock_lookup_data \
+qemu \
+--vmm-binary /usr/bin/qemu-system-x86_64 \
+--app-binary experimental/oak_baremetal_app_qemu/target/x86_64-unknown-none/debug/oak_baremetal_app_qemu
 ```
 
 The baremetal app may be loaded in crosvm via
@@ -21,7 +23,11 @@ The baremetal app may be loaded in crosvm via
 ```shell
 (cd experimental/oak_baremetal_app_crosvm && cargo build) \
 && RUST_LOG=debug cargo run --package oak_baremetal_launcher -- \
---mode crosvm \
---app experimental/oak_baremetal_app_crosvm/target/target/debug/oak_baremetal_app_crosvm \
---wasm experimental/oak_baremetal_launcher/key_value_lookup.wasm
+--wasm experimental/oak_baremetal_launcher/key_value_lookup.wasm \
+--lookup-data experimental/oak_baremetal_launcher/mock_lookup_data \
+crosvm \
+--vmm-binary /usr/local/cargo/bin/crosvm \
+--app-binary experimental/oak_baremetal_app_crosvm/target/x86_64-unknown-none/debug/oak_baremetal_app_crosvm
 ```
+
+See also the See the task integration at `xtask/src/vm.rs`. Additionally a documentation is available via `cargo run --package oak_baremetal_launcher -- --help`.

--- a/experimental/oak_baremetal_launcher/src/instance.rs
+++ b/experimental/oak_baremetal_launcher/src/instance.rs
@@ -16,32 +16,19 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use std::{os::unix::net::UnixStream, path::PathBuf};
 
-#[derive(Debug)]
-pub struct Params {
-    /// Path to the VMM binary to execute.
-    pub binary: PathBuf,
-
-    /// Path to the binary to load into the VM.
-    pub app: PathBuf,
-
-    /// Stream to connect to the console of the VM.
-    pub console: UnixStream,
-
-    /// Port to use for debugging with gdb
-    pub gdb: Option<u16>,
-}
-
+/// Defines the interface of a launched runtime instance. Standardizes the interface of different
+/// implementations, e.g. a VM in which the runtime is running or the runtime running directly as a
+/// unix binary.
 #[async_trait]
-pub trait Vmm {
-    /// Waits for the guest VM to finish.
+pub trait LaunchedInstance {
+    /// Wait for the runtime instance process to finish.
     async fn wait(&mut self) -> Result<std::process::ExitStatus>;
 
-    /// Kills the guest VM.
+    /// Kill the runtime instance.
     async fn kill(self: Box<Self>) -> Result<std::process::ExitStatus>;
 
-    /// Creates a channel to communicate with the VM.
+    /// Creates a channel to communicate with the runtime instance.
     ///
     /// Since different VMMs might use different comms channels, we leave it up to the VMM to create
     /// the channel rather than passing it in as part of the parameters.

--- a/xtask/src/vm.rs
+++ b/xtask/src/vm.rs
@@ -46,7 +46,7 @@ impl Variant {
         }
     }
 
-    pub fn binary_path(&self) -> &'static str {
+    pub fn app_binary_path(&self) -> &'static str {
         match self {
             Variant::Qemu => {
                 "./experimental/oak_baremetal_app_qemu/target/x86_64-unknown-none/debug/oak_baremetal_app_qemu"
@@ -54,6 +54,13 @@ impl Variant {
             Variant::Crosvm => {
                 "./experimental/oak_baremetal_app_crosvm/target/x86_64-unknown-none/debug/oak_baremetal_app_crosvm"
             }
+        }
+    }
+
+    pub fn vmm_binary_path(&self) -> &'static str {
+        match self {
+            Variant::Qemu => "/usr/bin/qemu-system-x86_64",
+            Variant::Crosvm => "/usr/local/cargo/bin/crosvm",
         }
     }
 }
@@ -122,10 +129,11 @@ fn run_loader(variant: Variant) -> Box<dyn Runnable> {
     Cmd::new(
         "./target/debug/oak_baremetal_launcher",
         vec![
-            format!("--mode={}", variant.loader_mode()),
-            format!("--app={}", variant.binary_path()),
             format!("--wasm={}", WASM_PATH),
             format!("--lookup-data={}", LOOKUP_PATH),
+            variant.loader_mode().to_string(),
+            format!("--app-binary={}", variant.app_binary_path()),
+            format!("--vmm-binary={}", variant.vmm_binary_path()),
         ],
     )
 }


### PR DESCRIPTION
Soon the launcher will launch not just VMs, hence this removes references to VMs and VMMs where they're not needed. In preparation for #3080.