### PR TITLE
Refactor xtask implementation of testing the baremetal-compatible runtime

### DIFF
--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -14,6 +14,9 @@
 // limitations under the License.
 //
 
+//! Functionality for testing variants of the baremetal-compatible runtime exposed by the
+//! launcher.
+
 const CLIENT_PATH: &str = "./target/debug/oak_functions_client";
 const WASM_PATH: &str = "./experimental/oak_baremetal_launcher/key_value_lookup.wasm";
 const LOOKUP_PATH: &str = "./experimental/oak_baremetal_launcher/mock_lookup_data";
@@ -26,41 +29,47 @@ use strum_macros::{Display, EnumIter};
 use crate::internal::*;
 
 #[derive(Debug, Display, Clone, PartialEq, EnumIter)]
-pub enum Variant {
+pub enum LauncherMode {
     Qemu,
     Crosvm,
 }
 
-impl Variant {
-    pub fn payload_crate_path(&self) -> &'static str {
+impl LauncherMode {
+    /// Get the crate name of respective runtime variant
+    pub fn runtime_crate_name(&self) -> &'static str {
         match self {
-            Variant::Qemu => "./experimental/oak_baremetal_app_qemu",
-            Variant::Crosvm => "./experimental/oak_baremetal_app_crosvm",
+            LauncherMode::Qemu => "oak_baremetal_app_qemu",
+            LauncherMode::Crosvm => "oak_baremetal_app_crosvm",
         }
     }
 
-    pub fn loader_mode(&self) -> &'static str {
-        match self {
-            Variant::Qemu => "qemu",
-            Variant::Crosvm => "crosvm",
-        }
+    /// Get the path to the respective runtime variant that should be launched
+    pub fn runtime_crate_path(&self) -> String {
+        format!("./experimental/{}", self.runtime_crate_name())
     }
 
-    pub fn app_binary_path(&self) -> &'static str {
-        match self {
-            Variant::Qemu => {
-                "./experimental/oak_baremetal_app_qemu/target/x86_64-unknown-none/debug/oak_baremetal_app_qemu"
-            }
-            Variant::Crosvm => {
-                "./experimental/oak_baremetal_app_crosvm/target/x86_64-unknown-none/debug/oak_baremetal_app_crosvm"
-            }
-        }
+    /// Get the path to the respective runtime variant that should be launched
+    pub fn runtime_binary_path(&self) -> String {
+        format!(
+            "{}/target/x86_64-unknown-none/debug/{}",
+            self.runtime_crate_path(),
+            self.runtime_crate_name()
+        )
     }
 
-    pub fn vmm_binary_path(&self) -> &'static str {
+    /// Get the subcommand for launching in this mode
+    pub fn variant_subcommand(&self) -> Vec<String> {
         match self {
-            Variant::Qemu => "/usr/bin/qemu-system-x86_64",
-            Variant::Crosvm => "/usr/local/cargo/bin/crosvm",
+            LauncherMode::Qemu => vec![
+                "qemu".to_string(),
+                format!("--app-binary={}", &self.runtime_binary_path()),
+                format!("--vmm-binary={}", "/usr/bin/qemu-system-x86_64"),
+            ],
+            LauncherMode::Crosvm => vec![
+                "crosvm".to_string(),
+                format!("--app-binary={}", &self.runtime_binary_path()),
+                format!("--vmm-binary={}", "/usr/local/cargo/bin/crosvm"),
+            ],
         }
     }
 }
@@ -69,19 +78,19 @@ impl Variant {
 pub fn build_baremetal_variants(opt: &BuildBaremetalVariantsOpt) -> Step {
     Step::Multiple {
         name: "Build baremetal variants".to_string(),
-        steps: Variant::iter()
+        steps: LauncherMode::iter()
             .filter(|v| option_covers_variant(opt, v))
-            .map(|v| build_released_binary(&v.to_string(), v.payload_crate_path()))
+            .map(|v| build_released_binary(&v.to_string(), &v.runtime_crate_path()))
             .collect(),
     }
 }
 
-fn option_covers_variant(opt: &BuildBaremetalVariantsOpt, variant: &Variant) -> bool {
+fn option_covers_variant(opt: &BuildBaremetalVariantsOpt, variant: &LauncherMode) -> bool {
     match &opt.variant {
         None => true,
         Some(var) => match *variant {
-            Variant::Qemu => var == "qemu",
-            Variant::Crosvm => var == "crosvm",
+            LauncherMode::Qemu => var == "qemu",
+            LauncherMode::Crosvm => var == "crosvm",
         },
     }
 }
@@ -96,11 +105,11 @@ fn build_released_binary(name: &str, directory: &str) -> Step {
 pub fn run_vm_test() -> Step {
     Step::Multiple {
         name: "VM end-to-end test".to_string(),
-        steps: Variant::iter().map(run_variant).collect(),
+        steps: LauncherMode::iter().map(run_variant).collect(),
     }
 }
 
-fn run_variant(variant: Variant) -> Step {
+fn run_variant(variant: LauncherMode) -> Step {
     Step::Multiple {
         name: format!("run {} variant", variant),
         steps: vec![
@@ -108,10 +117,10 @@ fn run_variant(variant: Variant) -> Step {
                 "build loader binary",
                 "./experimental/oak_baremetal_launcher",
             ),
-            build_binary("build payload", variant.payload_crate_path()),
+            build_binary("build runtime", &variant.runtime_crate_path()),
             Step::WithBackground {
                 name: "background loader".to_string(),
-                background: run_loader(variant),
+                background: run_launcher(variant),
                 foreground: Box::new(run_client("test_key", "^test_value$", 300)),
             },
         ],
@@ -125,17 +134,13 @@ fn build_binary(name: &str, directory: &str) -> Step {
     }
 }
 
-fn run_loader(variant: Variant) -> Box<dyn Runnable> {
-    Cmd::new(
-        "./target/debug/oak_baremetal_launcher",
-        vec![
-            format!("--wasm={}", WASM_PATH),
-            format!("--lookup-data={}", LOOKUP_PATH),
-            variant.loader_mode().to_string(),
-            format!("--app-binary={}", variant.app_binary_path()),
-            format!("--vmm-binary={}", variant.vmm_binary_path()),
-        ],
-    )
+fn run_launcher(variant: LauncherMode) -> Box<dyn Runnable> {
+    let mut args = vec![
+        format!("--wasm={}", WASM_PATH),
+        format!("--lookup-data={}", LOOKUP_PATH),
+    ];
+    args.append(&mut variant.variant_subcommand());
+    Cmd::new("./target/debug/oak_baremetal_launcher", args)
 }
 
 fn run_client(request: &str, expected_response: &str, iterations: usize) -> Step {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -55,7 +55,7 @@ use check_license::CheckLicense;
 mod check_build_licenses;
 use check_build_licenses::CheckBuildLicenses;
 
-mod vm;
+mod launcher;
 
 static PROCESSES: Lazy<Mutex<Vec<i32>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
@@ -114,8 +114,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn match_cmd(opt: &Opt) -> Step {
     match opt.cmd {
-        Command::RunVmTest => vm::run_vm_test(),
-        Command::BuildBaremetalVariants(ref opts) => vm::build_baremetal_variants(opts),
+        Command::RunVmTest => launcher::run_vm_test(),
+        Command::BuildBaremetalVariants(ref opts) => launcher::build_baremetal_variants(opts),
         Command::RunOakFunctionsExamples(ref run_opt) => {
             run_oak_functions_examples(run_opt, &opt.scope)
         }


### PR DESCRIPTION
Refactors this code to remove references to virtual machines in preparation for testing the linux binary variant of the baremetal-compatible runtime. (Ref: https://github.com/project-oak/oak/issues/3080)