### PR TITLE
Rename VM test logic in preparation for supporting running the runtime as a native binary

### DIFF
--- a/.xtask_bash_completion
+++ b/.xtask_bash_completion
@@ -54,14 +54,14 @@ _xtask() {
             run-ci)
                 cmd+="__run__ci"
                 ;;
+            run-launcher-test)
+                cmd+="__run__launcher__test"
+                ;;
             run-oak-functions-examples)
                 cmd+="__run__oak__functions__examples"
                 ;;
             run-tests)
                 cmd+="__run__tests"
-                ;;
-            run-vm-test)
-                cmd+="__run__vm__test"
                 ;;
             *)
                 ;;
@@ -70,7 +70,7 @@ _xtask() {
 
     case "${cmd}" in
         xtask)
-            opts="-h --help --dry-run --logs --keep-going --scope run-vm-test run-oak-functions-examples build-oak-functions-example build-oak-functions-server-variants format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
+            opts="-h --help --dry-run --logs --keep-going --scope run-launcher-test run-oak-functions-examples build-oak-functions-example build-oak-functions-server-variants format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -351,6 +351,20 @@ _xtask() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        xtask__run__launcher__test)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         xtask__run__oak__functions__examples)
             opts="-h --application-variant --example-name --client-variant --client-rust-toolchain --client-rust-target --server-variant --server-rust-toolchain --server-rust-target --run-server --client-additional-args --server-additional-args --build-docker --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
@@ -410,20 +424,6 @@ _xtask() {
             return 0
             ;;
         xtask__run__tests)
-            opts="-h --help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        xtask__run__vm__test)
             opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -17,4 +17,4 @@ sudo chown "$USER:$KVM_GID" /dev/vsock
 ./scripts/docker_pull
 
 ./scripts/docker_run ./scripts/xtask build-oak-functions-server-variants
-./scripts/docker_run ./scripts/xtask run-vm-test
+./scripts/docker_run ./scripts/xtask run-launcher-test

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -54,7 +54,7 @@ pub struct Opt {
 
 #[derive(Subcommand, Clone, Debug)]
 pub enum Command {
-    RunVmTest,
+    RunLauncherTest,
     RunOakFunctionsExamples(RunOakExamplesOpt),
     BuildOakFunctionsExample(RunOakExamplesOpt),
     BuildOakFunctionsServerVariants(BuildServerOpt),

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -74,7 +74,7 @@ impl LauncherMode {
     }
 }
 
-pub fn run_vm_test() -> Step {
+pub fn run_launcher_test() -> Step {
     Step::Multiple {
         name: "VM end-to-end test".to_string(),
         steps: LauncherMode::iter().map(run_variant).collect(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn match_cmd(opt: &Opt) -> Step {
     match opt.cmd {
-        Command::RunVmTest => launcher::run_vm_test(),
+        Command::RunLauncherTest => launcher::run_launcher_test(),
         Command::RunOakFunctionsExamples(ref run_opt) => {
             run_oak_functions_examples(run_opt, &opt.scope)
         }


### PR DESCRIPTION
Pulled out from #3106, after which these will no longer just be VM tests