### PR TITLE
Add Rust-like Result type

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -24,6 +24,12 @@ package(
 java_library(
     name = "client",
     srcs = glob(["src/main/java/com/google/oak/client/*.java"]),
+    deps = [":util"],
+)
+
+java_library(
+    name = "util",
+    srcs = glob(["src/main/java/com/google/oak/util/*.java"]),
     deps = [],
 )
 
@@ -31,5 +37,8 @@ java_test(
     name = "client_test",
     srcs = glob(["src/test/java/com/google/oak/client/*.java"]),
     test_class = "com.google.oak.client.OakClientTest",
-    deps = [":client"],
+    deps = [
+        ":client",
+        ":util",
+    ],
 )

--- a/java/BUILD
+++ b/java/BUILD
@@ -42,3 +42,12 @@ java_test(
         ":util",
     ],
 )
+
+java_test(
+    name = "util_test",
+    srcs = glob(["src/test/java/com/google/oak/util/*.java"]),
+    test_class = "com.google.oak.util.ResultTest",
+    deps = [
+        ":util",
+    ],
+)

--- a/java/src/main/java/com/google/oak/client/Encryptor.java
+++ b/java/src/main/java/com/google/oak/client/Encryptor.java
@@ -16,9 +16,7 @@
 
 package com.google.oak.client;
 
-import java.util.Optional;
-
-// TODO(#3063): Replace Optional<T> with Result<T> in the following.
+import com.google.oak.util.Result;
 
 /**
  * Interface representing an Encryptor. Classes implementing this interface must implement
@@ -27,15 +25,17 @@ import java.util.Optional;
 public interface Encryptor {
   /**
    * Encrypts the input byte array and returns the result as a byte array.
+   *
    * @param data the input byte array to be encrypted
-   * @return the result of encryption as a byte array wrapped in an Optional
+   * @return the result of encryption as a byte array wrapped in a {@code Result}
    */
-  Optional<byte[]> encrypt(final byte[] data);
+  Result<byte[], Exception> encrypt(final byte[] data);
 
   /**
    * Decrypts the input byte array and returns the result as a byte array.
+   *
    * @param data the input byte array to be decrypted
-   * @return the result of decryption as a byte array wrapped in an Optional
+   * @return the result of decryption as a byte array wrapped in a {@code Result}
    */
-  Optional<byte[]> decrypt(final byte[] data);
+  Result<byte[], Exception> decrypt(final byte[] data);
 }

--- a/java/src/main/java/com/google/oak/client/OakClient.java
+++ b/java/src/main/java/com/google/oak/client/OakClient.java
@@ -16,6 +16,7 @@
 
 package com.google.oak.client;
 
+import com.google.oak.util.Result;
 import java.util.Optional;
 
 /**
@@ -31,13 +32,13 @@ import java.util.Optional;
  * @param T type of the responses that this client receives
  */
 public abstract class OakClient<R, T> implements AutoCloseable {
-  // TODO(#3063): Replace return type with Result<T>
   /**
    * Sends a request to a remote server and receives the response.
+   *
    * @param request the request to send to the server
-   * @return the response received from the server wrapped in an Optional
+   * @return the response received from the server wrapped in a {@code Result}
    */
-  abstract Optional<T> send(final R request);
+  abstract Result<T, Exception> send(final R request);
 
   /**
    * Abstract builder class that allows subclasses to override it, providing customized {@code
@@ -59,6 +60,7 @@ public abstract class OakClient<R, T> implements AutoCloseable {
 
     /**
      * Configure this builder to use the given {@code EvidenceProvider}.
+     *
      * @param evidenceProvider instance that can provide an {@code Evidence} instance
      * @return this builder
      */
@@ -85,16 +87,15 @@ public abstract class OakClient<R, T> implements AutoCloseable {
   // The following functional interfaces could have individually been replaced by a Supplier<T>, but
   // to allow a single class implement more than one of these interfaces, dedicated functional
   // interfaces are preferred.
-  // TODO(#3063): Replace Optional<T> with Result<T> in the following.
 
   /**
    * An interface for providing instances of {@code RpcClient}.
    */
   public interface RpcClientProvider {
     /**
-     * @return an instance of {@code RpcClient} wrapped in an Optional.
+     * @return an instance of {@code RpcClient} wrapped in a {@code Result}
      */
-    Optional<? extends RpcClient> getRpcClient();
+    Result<? extends RpcClient, Exception> getRpcClient();
   }
 
   /**
@@ -102,18 +103,17 @@ public abstract class OakClient<R, T> implements AutoCloseable {
    */
   public interface EncryptorProvider {
     /**
-     *
      * @param signingPublicKey signing public key of the server
-     * @return an instance of Encryptor wrapped in an Optional
+     * @return an instance of Encryptor wrapped in a {@code Result}
      */
-    Optional<? extends Encryptor> getEncryptor(byte[] signingPublicKey);
+    Result<? extends Encryptor, Exception> getEncryptor(byte[] signingPublicKey);
   }
 
   /**
    * An interface for providing instances of Evidence.
    *
-   * A evidence normally includes the public key part of the server's signing key, an instance of
-   * {@code EndorsementEvidence}, and optionally some server configuration information. If the
+   * <p>An evidence normally includes the public key part of the server's signing key, an instance
+   * of {@code EndorsementEvidence}, and optionally some server configuration information. If the
    * client policy requires verification of the server configuration, then the client should be
    * built with a provider that does provide server configuration.
    */
@@ -121,8 +121,8 @@ public abstract class OakClient<R, T> implements AutoCloseable {
     /**
      * Returns evidence about the trustworthiness of a remote server.
      *
-     * @return the evidence wrapped in an Optional.
+     * @return the evidence wrapped in a {@code Result}
      */
-    Optional<? extends Evidence> getEvidence();
+    Result<? extends Evidence, Exception> getEvidence();
   }
 }

--- a/java/src/main/java/com/google/oak/client/RpcClient.java
+++ b/java/src/main/java/com/google/oak/client/RpcClient.java
@@ -16,7 +16,7 @@
 
 package com.google.oak.client;
 
-import java.util.Optional;
+import com.google.oak.util.Result;
 
 /**
  * A generic type representing a transport-agnostic RPC client that sends a request and receives a
@@ -24,11 +24,11 @@ import java.util.Optional;
  * and HTTP.
  */
 public interface RpcClient extends AutoCloseable {
-  // TODO(#3063): Replace return type with Result<T>.
   /**
    * Sends an array of bytes, and returns response as a byte array.
+   *
    * @param request the request as a byte array
-   * @return the response as a byte array
+   * @return the response as a byte array wrapped in an instance of {@code Result}
    */
-  abstract Optional<byte[]> send(final byte[] request);
+  abstract Result<byte[], Exception> send(final byte[] request);
 }

--- a/java/src/main/java/com/google/oak/util/Result.java
+++ b/java/src/main/java/com/google/oak/util/Result.java
@@ -1,0 +1,147 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.util;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Class {@code Result} is a generic class representing the result of an
+ * operation that could either succeed and produce an instance of {@code R}, or
+ * fail and produce an error of type {@code E}. An instance of {@code Result}
+ * can encapsulate both outcomes.
+ *
+ * <p>The main invariant that instances of this class maintain is that each object always either
+ * contains a non-null success value or a non-null error value.
+ */
+public class Result<R, E> {
+  private final Optional<R> success;
+  private final Optional<E> error;
+
+  /**
+   * Create and return an instance of {@code Result<E, R>} wrapping {@code success}
+   * as the success value.
+   *
+   * @param success nonnull success value
+   * @return a {@code Result} containing a success value
+   */
+  public static <R, E> Result<R, E> success(final R success) {
+    Objects.requireNonNull(success);
+    return new Result<R, E>(success, null);
+  }
+
+  /**
+   * Create and return an instance of {@code Result<E, R>} wrapping {@code error}
+   * as the error value.
+   *
+   * @param error nonnull error value
+   * @return a {@code Result} containing an error value
+   */
+  public static <R, E> Result<R, E> error(final E error) {
+    Objects.requireNonNull(error);
+    return new Result<R, E>(null, error);
+  }
+
+  /**
+   *
+   * @return true if this object represents a success value, and false otherwise
+   */
+  public boolean isSuccess() {
+    return success.isPresent();
+  }
+
+  /**
+   * @return true if this object contains an error value, and false otherwise
+   */
+  public boolean isError() {
+    return error.isPresent();
+  }
+
+  /**
+   * Wraps the success value in this {@code Result} instance as a potentially empty Optional. This
+   * is guaranteed to return a non-empty Optional if {@code isSuccess()} returns true.
+   *
+   * @return the success value wrapped in an Optional.
+   */
+  public Optional<R> success() {
+    return Optional.ofNullable(success.orElse(null));
+  }
+
+  /**
+   * Wraps the error value in this {@code Result} instance as a potentially empty Optional. This
+   * is guaranteed to return a non-empty Optional if {@code isError()} returns true.
+   *
+   * @return the error value wrapped in an Optional
+   */
+  public Optional<E> error() {
+    return Optional.ofNullable(error.orElse(null));
+  }
+
+  /**
+   * Maps a {@code Result<R, E>} to {@code Result<T, E>} by applying the input {@code function} to
+   * the contained success value, if one is present. This leaves the error value untouched. This
+   * function can be used to compose the results of two functions.
+   *
+   * @param <T> the new success value type
+   * @param function the function to apply to the success value
+   * @return the transformed result of type {@code Result<T, E>}
+   */
+  public <T> Result<T, E> map(final Function<R, T> function) {
+    return isSuccess() ? success(function.apply(success.get())) : error(error.get());
+  }
+
+  /**
+   * Maps a {@code Result<R, E>} to {@code Result<R, T>} by applying the input {@code function} to
+   * the contained error value, if one is present. This leaves the success value untouched. This
+   * function can be used to pass through a successful value while handling an error.
+   *
+   * @param <T> the new error type
+   * @param function the function to apply to the error value
+   * @return the transformed result of type {@code Result<R, T>}
+   */
+  public <T> Result<R, T> mapError(final Function<E, T> function) {
+    return isError() ? error(function.apply(error.get())) : success(success.get());
+  }
+
+  /**
+   * Applied the function on the success value, if one is present, and flattens the result.
+   * Otherwise, returns the error.
+   *
+   * <p>This function can be used for composing operations that themselves return a {@code Result}.
+   *
+   * @param <T> the new success value type
+   * @param function the function to apply to the success value
+   * @return the flattened result of applying {@code function} to this {@code Result} instance
+   */
+  public <T> Result<T, E> andThen(final Function<R, Result<T, E>> function) {
+    Result<Result<T, E>, E> result = map(function);
+    return result.isSuccess() ? result.success.get() : error(result.error.get());
+  }
+
+  // Private constructor to disallow creation of instances that could violate the invariant of this
+  // class.
+  private Result(R success, E error) {
+    if (success != null && error != null) {
+      // This should never happen, since this constructor is private and we only call
+      // it in the functions of this class, which never set both `result` and `error`.
+      throw new IllegalArgumentException();
+    }
+
+    this.success = Optional.ofNullable(success);
+    this.error = Optional.ofNullable(error);
+  }
+}

--- a/java/src/main/java/com/google/oak/util/Result.java
+++ b/java/src/main/java/com/google/oak/util/Result.java
@@ -16,6 +16,7 @@
 
 package com.google.oak.util;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 

--- a/java/src/main/java/com/google/oak/util/Result.java
+++ b/java/src/main/java/com/google/oak/util/Result.java
@@ -26,8 +26,8 @@ import java.util.function.Function;
  * fail and produce an error of type {@code E}. An instance of {@code Result}
  * can encapsulate both outcomes.
  *
- * <p>The main invariant that instances of this class maintain is that each object always either
- * contains a non-null success value or a non-null error value.
+ * <p>The main invariant that instances of this class maintain is that each object either
+ * contains a nonnull success value or a nonnull error value.
  */
 public class Result<R, E> {
   private final Optional<R> success;
@@ -119,8 +119,8 @@ public class Result<R, E> {
   }
 
   /**
-   * Applied the function on the success value, if one is present, and flattens the result.
-   * Otherwise, returns the error.
+   * Applies {@code function} on the success value, if one is present, and flattens the result.
+   * Otherwise, returns a {@code Result} containing the error value.
    *
    * <p>This function can be used for composing operations that themselves return a {@code Result}.
    *

--- a/java/src/test/java/com/google/oak/util/ResultTest.java
+++ b/java/src/test/java/com/google/oak/util/ResultTest.java
@@ -1,0 +1,115 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.oak.util.Result;
+import org.junit.Test;
+
+public class ResultTest {
+  private static String ERR_MSG = "error!";
+
+  @Test
+  public void testSuccess() {
+    Result<Integer, String> success = Result.success(1);
+    assertTrue(success.isSuccess());
+    assertEquals(1, success.success().get().intValue());
+    assertTrue(success.error().isEmpty());
+  }
+
+  @Test
+  public void testError() {
+    Result<Integer, String> error = Result.error(ERR_MSG);
+    assertTrue(error.isError());
+    assertEquals(ERR_MSG, error.error().get());
+    assertTrue(error.success().isEmpty());
+  }
+
+  @Test
+  public void testMapForSuccess() {
+    Result<Integer, String> success = Result.success(1);
+    Result<Integer, String> result = success.map(val -> val * 2);
+    assertTrue(result.isSuccess());
+    assertEquals(2, result.success().get().intValue());
+    assertTrue(result.error().isEmpty());
+  }
+
+  @Test
+  public void testMapForError() {
+    Result<Integer, String> error = Result.error(ERR_MSG);
+    Result<Integer, String> result = error.map(val -> val * 2);
+    assertTrue(result.isError());
+    assertEquals(ERR_MSG, result.error().get());
+    assertTrue(result.success().isEmpty());
+  }
+
+  @Test
+  public void testMapErrorForSuccess() {
+    Result<Integer, String> success = Result.success(1);
+    Result<Integer, Integer> result = success.mapError(val -> val.length());
+    assertTrue(result.isSuccess());
+    assertEquals(1, result.success().get().intValue());
+    assertTrue(result.error().isEmpty());
+  }
+
+  @Test
+  public void testMapErrorForError() {
+    Result<Integer, String> error = Result.error(ERR_MSG);
+    Result<Integer, Integer> result = error.mapError(val -> val.length());
+    assertTrue(result.isError());
+    assertEquals(ERR_MSG.length(), result.error().get().intValue());
+    assertTrue(result.success().isEmpty());
+  }
+
+  @Test
+  public void testAndThenForSuccessToSuccess() {
+    Result<Integer, String> success = Result.success(1);
+    Result<Integer, String> result = success.andThen(val -> Result.success(val));
+    assertTrue(result.isSuccess());
+    assertEquals(1, result.success().get().intValue());
+    assertTrue(result.error().isEmpty());
+  }
+
+  @Test
+  public void testAndThenForSuccessToError() {
+    Result<Integer, String> success = Result.success(1);
+    Result<Integer, String> result = success.andThen(val -> Result.error(ERR_MSG));
+    assertTrue(result.isError());
+    assertEquals(ERR_MSG, result.error().get());
+    assertTrue(result.success().isEmpty());
+  }
+
+  @Test
+  public void testAndThenForErrorToSuccess() {
+    Result<Integer, String> error = Result.error(ERR_MSG);
+    Result<Integer, String> result = error.andThen(val -> Result.success(1));
+    assertTrue(result.isError());
+    assertEquals(ERR_MSG, result.error().get());
+    assertTrue(result.success().isEmpty());
+  }
+
+  @Test
+  public void testAndThenForErrorToError() {
+    Result<Integer, String> error = Result.error(ERR_MSG);
+    Result<Integer, String> result = error.andThen(val -> Result.error(ERR_MSG + ERR_MSG));
+    assertTrue(result.isError());
+    assertEquals(ERR_MSG, result.error().get());
+    assertTrue(result.success().isEmpty());
+  }
+}


### PR DESCRIPTION
Adds a `Result` type in Java, and updates the client code to use it. Currently, for the error type I am using `Exception`, but this can be replaced by other, more specific error types in the future.

Fixes #3063.