### PR TITLE
Move instance implementations into a subdirectory.

### DIFF
--- a/experimental/oak_baremetal_launcher/src/instance/mod.rs
+++ b/experimental/oak_baremetal_launcher/src/instance/mod.rs
@@ -14,6 +14,9 @@
 // limitations under the License.
 //
 
+pub mod crosvm;
+pub mod native;
+
 use anyhow::Result;
 use async_trait::async_trait;
 


### PR DESCRIPTION
Let's do some bikeshedding :)

Case in point, I don't like using underscores as kind of namespace delineators when we have a perfectly fine `/` that natively works as one.

Thus, here's my proposal: move `instance_*.rs` to `instance/*.rs`. I think this code is cleaner[*], but as it's a matter of taste I'm willing to entertain other opinions.

[*] -- having to include `crate::path_exists` is ugly, but then again, I'm surprised something like that doesn't exist in some other crate we could include.