### PR TITLE
Fix message size and socket blocks in Oak Functions Linux wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3106,7 +3106,6 @@ dependencies = [
  "assert_matches",
  "clap 3.2.10",
  "libc",
- "log",
  "oak_baremetal_communication_channel",
  "oak_baremetal_runtime",
  "oak_remote_attestation",

--- a/experimental/oak_functions_loader_linux_vsock/Cargo.toml
+++ b/experimental/oak_functions_loader_linux_vsock/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 anyhow = { version = "*", default-features = false }
 clap = { version = "*", features = ["derive"] }
 libc = "*"
-log = "*"
 oak_remote_attestation = { path = "../../remote_attestation/rust", default-features = false, features = [
   "rust-crypto"
 ] }

--- a/experimental/oak_functions_loader_linux_vsock/src/channel.rs
+++ b/experimental/oak_functions_loader_linux_vsock/src/channel.rs
@@ -72,10 +72,7 @@ where
                 // Read Protobuf message.
                 let mut message_buffer: Vec<u8> = vec![0; size];
                 self.stream.read(&mut message_buffer).map_err(|error| {
-                    anyhow!(
-                        "Couldn't read Protobuf message from stream: {:?}",
-                        error
-                    )
+                    anyhow!("Couldn't read Protobuf message from stream: {:?}", error)
                 })?;
 
                 let message = Request::decode(&*message_buffer)

--- a/experimental/oak_functions_loader_linux_vsock/src/channel.rs
+++ b/experimental/oak_functions_loader_linux_vsock/src/channel.rs
@@ -66,7 +66,7 @@ where
                     error
                 )
             })?;
-            let size = usize::from_be_bytes(size_buffer);
+            let size = usize::from_le_bytes(size_buffer);
 
             if size > 0 {
                 // Read Protobuf message.
@@ -107,7 +107,7 @@ where
             .map_err(|error| anyhow!("Couldn't encode proto message: {:?}", error))?;
 
         // Write Protobuf message size.
-        let size_buffer: [u8; size_of::<u64>()] = (message_buffer.len() as u64).to_be_bytes();
+        let size_buffer: [u8; size_of::<u64>()] = (message_buffer.len() as u64).to_le_bytes();
         self.stream
             .write_all(&size_buffer)
             .map_err(|error| anyhow!("Couldn't write into stream: {:?}", error))?;

--- a/experimental/oak_functions_loader_linux_vsock/src/channel.rs
+++ b/experimental/oak_functions_loader_linux_vsock/src/channel.rs
@@ -66,7 +66,7 @@ where
                     error
                 )
             })?;
-            let size = usize::from_le_bytes(size_buffer);
+            let size = usize::from_ne_bytes(size_buffer);
 
             if size > 0 {
                 // Read Protobuf message.
@@ -107,7 +107,7 @@ where
             .map_err(|error| anyhow!("Couldn't encode proto message: {:?}", error))?;
 
         // Write Protobuf message size.
-        let size_buffer: [u8; size_of::<u64>()] = (message_buffer.len() as u64).to_le_bytes();
+        let size_buffer: [u8; size_of::<u64>()] = (message_buffer.len() as u64).to_ne_bytes();
         self.stream
             .write_all(&size_buffer)
             .map_err(|error| anyhow!("Couldn't write into stream: {:?}", error))?;

--- a/experimental/oak_functions_loader_linux_vsock/src/channel.rs
+++ b/experimental/oak_functions_loader_linux_vsock/src/channel.rs
@@ -62,7 +62,7 @@ where
             let mut size_buffer: [u8; size_of::<u64>()] = [0; size_of::<u64>()];
             self.stream.read(&mut size_buffer).map_err(|error| {
                 anyhow!(
-                    "Couldn't read Protobuf message size from cached buffer: {:?}",
+                    "Couldn't read Protobuf message size from stream: {:?}",
                     error
                 )
             })?;
@@ -73,7 +73,7 @@ where
                 let mut message_buffer: Vec<u8> = vec![0; size];
                 self.stream.read(&mut message_buffer).map_err(|error| {
                     anyhow!(
-                        "Couldn't read Protobuf message from cached buffer: {:?}",
+                        "Couldn't read Protobuf message from stream: {:?}",
                         error
                     )
                 })?;

--- a/experimental/oak_functions_loader_linux_vsock/src/main.rs
+++ b/experimental/oak_functions_loader_linux_vsock/src/main.rs
@@ -32,7 +32,6 @@ mod tests;
 
 use crate::channel::Channel;
 use clap::Parser;
-use log::info;
 use oak_remote_attestation::handshaker::{
     AttestationBehavior, EmptyAttestationGenerator, EmptyAttestationVerifier,
 };
@@ -60,7 +59,7 @@ fn main() -> ! {
     let opt = Opt::parse();
 
     let stream = create_vsock_stream(opt.file_descriptor).expect("Couldn't create channel");
-    info!(
+    println!(
         "Connected to the {}",
         stream.peer_addr().expect("Couldn't get peer address")
     );

--- a/experimental/oak_functions_loader_linux_vsock/src/main.rs
+++ b/experimental/oak_functions_loader_linux_vsock/src/main.rs
@@ -30,6 +30,7 @@ pub mod channel;
 #[cfg(test)]
 mod tests;
 
+use anyhow::anyhow;
 use crate::channel::Channel;
 use clap::Parser;
 use oak_remote_attestation::handshaker::{
@@ -52,6 +53,9 @@ pub struct Opt {
 // Connect to the file descriptor created by Bedebox using vsock.
 pub fn create_vsock_stream(file_descriptor: RawFd) -> anyhow::Result<VsockStream> {
     let stream = unsafe { VsockStream::from_raw_fd(file_descriptor) };
+    // Blocking is set in order to not return an error when the host hasn't written anything yet.
+    stream.set_nonblocking(false)
+        .map_err(|error| anyhow!("Couldn't set socket into blocking mode: {}", error))?;
     Ok(stream)
 }
 

--- a/experimental/oak_functions_loader_linux_vsock/src/main.rs
+++ b/experimental/oak_functions_loader_linux_vsock/src/main.rs
@@ -30,8 +30,8 @@ pub mod channel;
 #[cfg(test)]
 mod tests;
 
-use anyhow::anyhow;
 use crate::channel::Channel;
+use anyhow::anyhow;
 use clap::Parser;
 use oak_remote_attestation::handshaker::{
     AttestationBehavior, EmptyAttestationGenerator, EmptyAttestationVerifier,
@@ -54,7 +54,8 @@ pub struct Opt {
 pub fn create_vsock_stream(file_descriptor: RawFd) -> anyhow::Result<VsockStream> {
     let stream = unsafe { VsockStream::from_raw_fd(file_descriptor) };
     // Blocking is set in order to not return an error when the host hasn't written anything yet.
-    stream.set_nonblocking(false)
+    stream
+        .set_nonblocking(false)
         .map_err(|error| anyhow!("Couldn't set socket into blocking mode: {}", error))?;
     Ok(stream)
 }


### PR DESCRIPTION
This PR fixes:
- Vsock channel message sizes were read as BigEndian instead of NativeEndian
- Socket was set into the non-blocking mode by default causing the runtime to receive an error when reading an empty channel