### PR TITLE
Ignore RUSTSEC-2020-0159

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,8 @@ unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = [
+  # TODO(#3131): Remove when no longer required.
+  "RUSTSEC-2020-0159",
   # TODO(#2421): Remove when no longer required.
   "RUSTSEC-2021-0127",
   # We rely on flatbuffers, which generates potentially unsafe code via "safe" APIs.


### PR DESCRIPTION
Temporarily ignoring `RUSTSEC-2020-0159` until https://github.com/project-oak/oak/issues/3131 is fixed.