### PR TITLE
Isolate runtime logic from communication channel logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,6 @@ dependencies = [
  "flatbuffers",
  "hashbrown 0.12.2",
  "log",
- "oak_baremetal_communication_channel",
  "oak_functions_abi",
  "oak_functions_lookup",
  "oak_functions_wasm",

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -625,7 +625,6 @@ dependencies = [
  "flatbuffers",
  "hashbrown 0.12.1",
  "log",
- "oak_baremetal_communication_channel",
  "oak_functions_abi",
  "oak_functions_lookup",
  "oak_functions_wasm",

--- a/experimental/oak_baremetal_channel/src/server.rs
+++ b/experimental/oak_baremetal_channel/src/server.rs
@@ -16,8 +16,28 @@
 
 use crate::{message, Channel, InvocationChannel, Vec};
 use alloc::boxed::Box;
+use anyhow::Context;
 
-pub struct ServerChannelHandle {
+/// Starts a blocking server that listens for requests on the provided channel
+/// and responds to them using the provided [`oak_idl::Handler`].
+pub fn start_blocking_server<H: oak_idl::Handler>(
+    channel: Box<dyn Channel>,
+    mut oak_idl_service_implementation: H,
+) -> anyhow::Result<!> {
+    let channel_handle = &mut ServerChannelHandle::new(channel);
+    loop {
+        let request_message = channel_handle
+            .read_request()
+            .context("couldn't receive message")?;
+        let request_message_invocation_id = request_message.invocation_id;
+        let response = oak_idl_service_implementation.invoke(request_message.into());
+        let response_message =
+            message_from_response_and_id(response, request_message_invocation_id);
+        channel_handle.write_response(response_message)?
+    }
+}
+
+struct ServerChannelHandle {
     inner: InvocationChannel,
 }
 
@@ -46,7 +66,7 @@ impl From<message::RequestMessage> for oak_idl::Request {
     }
 }
 
-pub fn message_from_response_and_id(
+fn message_from_response_and_id(
     response: Result<Vec<u8>, oak_idl::Status>,
     invocation_id: message::InvocationId,
 ) -> message::ResponseMessage {

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -97,8 +97,12 @@ fn main(protocol: &str, kernel_args: args::Args) -> ! {
     let attestation_behavior =
         AttestationBehavior::create(PlaceholderAmdAttestationGenerator, EmptyAttestationVerifier);
     let channel = get_channel(&kernel_args);
-    oak_baremetal_runtime::start(channel, attestation_behavior)
-        .expect("Runtime encountered an unrecoverable error");
+    let runtime = oak_baremetal_runtime::RuntimeImplementation::new(attestation_behavior);
+    oak_baremetal_communication_channel::server::start_blocking_server(
+        channel,
+        oak_baremetal_runtime::schema::TrustedRuntime::serve(runtime),
+    )
+    .expect("Runtime encountered an unrecoverable error");
 }
 
 fn get_channel(kernel_args: &args::Args) -> Box<dyn Channel> {

--- a/experimental/oak_baremetal_runtime/Cargo.toml
+++ b/experimental/oak_baremetal_runtime/Cargo.toml
@@ -15,7 +15,6 @@ wasm = []
 anyhow = { version = "*", default-features = false }
 hashbrown = "*"
 log = "*"
-oak_baremetal_communication_channel = { path = "../../experimental/oak_baremetal_channel" }
 oak_idl = { path = "../../oak_idl" }
 flatbuffers = { version = "*", features = ["no_std"], default-features = false }
 oak_functions_wasm = { path = "../../oak_functions/wasm" }

--- a/experimental/oak_baremetal_runtime/README.md
+++ b/experimental/oak_baremetal_runtime/README.md
@@ -1,4 +1,5 @@
 # Oak Baremetal Runtime
 
-Common business logic that should run in a VM. Implements the Oak-specific
-features on top of the kernel.
+No-std compatible implementation of the business logic of the Oak Runtime. The
+interface of the runtime is defined using the Oak IDL in `schema.rs`, the Rust
+code implements it using the Oak IDL.

--- a/experimental/oak_baremetal_runtime/src/lib.rs
+++ b/experimental/oak_baremetal_runtime/src/lib.rs
@@ -51,10 +51,14 @@ use oak_remote_attestation_sessions::SessionId;
 
 /// Sole entrypoint to the runtime. Starts the runtime and listens for requests
 /// on the provided channel.
-pub fn start<G: 'static + AttestationGenerator, V: 'static + AttestationVerifier>(
+pub fn start<G, V>(
     channel: Box<dyn Channel>,
     attestation_behavior: AttestationBehavior<G, V>,
-) -> anyhow::Result<!> {
+) -> anyhow::Result<!>
+where
+    G: 'static + AttestationGenerator,
+    V: 'static + AttestationVerifier,
+{
     let mut invocation_handler = RuntimeImplementation {
         initialization_state: InitializationState::Uninitialized(Some(attestation_behavior)),
         lookup_data_manager: Arc::new(LookupDataManager::new_empty(StandaloneLogger::default())),
@@ -78,8 +82,8 @@ pub fn start<G: 'static + AttestationGenerator, V: 'static + AttestationVerifier
 
 enum InitializationState<G, V>
 where
-    G: AttestationGenerator,
-    V: AttestationVerifier,
+    G: 'static + AttestationGenerator,
+    V: 'static + AttestationVerifier,
 {
     Uninitialized(Option<AttestationBehavior<G, V>>),
     // dyn is used as our attestation implementation uses a closure, which is
@@ -90,17 +94,17 @@ where
 
 struct RuntimeImplementation<G, V>
 where
-    G: AttestationGenerator,
-    V: AttestationVerifier,
+    G: 'static + AttestationGenerator,
+    V: 'static + AttestationVerifier,
 {
     initialization_state: InitializationState<G, V>,
     lookup_data_manager: Arc<LookupDataManager<logger::StandaloneLogger>>,
 }
 
-impl<G: 'static, V: 'static> schema::TrustedRuntime for RuntimeImplementation<G, V>
+impl<G, V> schema::TrustedRuntime for RuntimeImplementation<G, V>
 where
-    G: AttestationGenerator,
-    V: AttestationVerifier,
+    G: 'static + AttestationGenerator,
+    V: 'static + AttestationVerifier,
 {
     fn initialize(
         &mut self,

--- a/experimental/oak_baremetal_runtime/src/lib.rs
+++ b/experimental/oak_baremetal_runtime/src/lib.rs
@@ -19,7 +19,7 @@
 
 extern crate alloc;
 
-mod schema {
+pub mod schema {
     #![allow(clippy::derivable_impls, clippy::needless_borrow)]
     #![allow(dead_code, unused_imports)]
 
@@ -33,52 +33,15 @@ mod wasm;
 use crate::{
     logger::StandaloneLogger,
     remote_attestation::{AttestationHandler, AttestationSessionHandler},
-    schema::TrustedRuntime,
 };
 use alloc::{boxed::Box, sync::Arc};
 use anyhow::Context;
-use oak_baremetal_communication_channel::{
-    server::{message_from_response_and_id, ServerChannelHandle},
-    Channel,
-};
 use oak_functions_abi::Request;
 use oak_functions_lookup::LookupDataManager;
-use oak_idl::Handler;
 use oak_remote_attestation::handshaker::{
     AttestationBehavior, AttestationGenerator, AttestationVerifier,
 };
 use oak_remote_attestation_sessions::SessionId;
-
-/// Sole entrypoint to the runtime. Starts the runtime and listens for requests
-/// on the provided channel.
-pub fn start<G, V>(
-    channel: Box<dyn Channel>,
-    attestation_behavior: AttestationBehavior<G, V>,
-) -> anyhow::Result<!>
-where
-    G: 'static + AttestationGenerator,
-    V: 'static + AttestationVerifier,
-{
-    let mut invocation_handler = RuntimeImplementation {
-        initialization_state: InitializationState::Uninitialized(Some(attestation_behavior)),
-        lookup_data_manager: Arc::new(LookupDataManager::new_empty(StandaloneLogger::default())),
-    }
-    .serve();
-    let channel_handle = &mut ServerChannelHandle::new(channel);
-    loop {
-        let request_message = channel_handle
-            .read_request()
-            .context("couldn't receive message")?;
-        let request_message_invocation_id = request_message.invocation_id;
-        let response = invocation_handler.invoke(request_message.into());
-        // For now all messages are sent in sequence, hence the id of the next
-        // response always matches that of the preceeding request.
-        // TODO(#2848): Allow messages to be sent and received out of order.
-        let response_message =
-            message_from_response_and_id(response, request_message_invocation_id);
-        channel_handle.write_response(response_message)?
-    }
-}
 
 enum InitializationState<G, V>
 where
@@ -92,13 +55,28 @@ where
     Initialized(Box<dyn AttestationHandler>),
 }
 
-struct RuntimeImplementation<G, V>
+pub struct RuntimeImplementation<G, V>
 where
     G: 'static + AttestationGenerator,
     V: 'static + AttestationVerifier,
 {
     initialization_state: InitializationState<G, V>,
     lookup_data_manager: Arc<LookupDataManager<logger::StandaloneLogger>>,
+}
+
+impl<G, V> RuntimeImplementation<G, V>
+where
+    G: 'static + AttestationGenerator,
+    V: 'static + AttestationVerifier,
+{
+    pub fn new(attestation_behavior: AttestationBehavior<G, V>) -> Self {
+        Self {
+            initialization_state: InitializationState::Uninitialized(Some(attestation_behavior)),
+            lookup_data_manager: Arc::new(
+                LookupDataManager::new_empty(StandaloneLogger::default()),
+            ),
+        }
+    }
 }
 
 impl<G, V> schema::TrustedRuntime for RuntimeImplementation<G, V>

--- a/experimental/oak_functions_loader_linux_native/src/main.rs
+++ b/experimental/oak_functions_loader_linux_native/src/main.rs
@@ -60,6 +60,10 @@ fn main() -> ! {
     let attestation_behavior =
         AttestationBehavior::create(PlaceholderAmdAttestationGenerator, EmptyAttestationVerifier);
     let channel = Box::new(socket);
-    oak_baremetal_runtime::start(channel, attestation_behavior)
-        .expect("Runtime encountered an unrecoverable error");
+    let runtime = oak_baremetal_runtime::RuntimeImplementation::new(attestation_behavior);
+    oak_baremetal_communication_channel::server::start_blocking_server(
+        channel,
+        oak_baremetal_runtime::schema::TrustedRuntime::serve(runtime),
+    )
+    .expect("Runtime encountered an unrecoverable error");
 }

--- a/experimental/oak_functions_loader_linux_vsock/src/main.rs
+++ b/experimental/oak_functions_loader_linux_vsock/src/main.rs
@@ -72,6 +72,10 @@ fn main() -> ! {
     let attestation_behavior =
         AttestationBehavior::create(EmptyAttestationGenerator, EmptyAttestationVerifier);
     let channel = Box::new(Channel::new(stream));
-    oak_baremetal_runtime::start(channel, attestation_behavior)
-        .expect("Runtime encountered an unrecoverable error");
+    let runtime = oak_baremetal_runtime::RuntimeImplementation::new(attestation_behavior);
+    oak_baremetal_communication_channel::server::start_blocking_server(
+        channel,
+        oak_baremetal_runtime::schema::TrustedRuntime::serve(runtime),
+    )
+    .expect("Runtime encountered an unrecoverable error");
 }


### PR DESCRIPTION
This makes the runtime crate a pure implementation of flatbuffer service [schema](https://github.com/project-oak/oak/blob/main/experimental/oak_baremetal_runtime/schema.fbs/#L3). It does so by moving all logic for translating between flatbuffer and the communication protocol into the `oak_baremetal_channel` crate.

I think this makes most logical sense, and will make it far easier to add integration tests covering the runtime behavior (issue ref: https://github.com/project-oak/oak/issues/3136)