### PR TITLE
Add placeholder cpuid and secrets sections to the ELF kernel.

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/layout.ld
+++ b/experimental/oak_baremetal_app_crosvm/layout.ld
@@ -18,7 +18,9 @@ ENTRY(_start)
 
 PHDRS
 {
-    ram  PT_LOAD FLAGS(5);
+    ram     PT_LOAD FLAGS(5);
+    cpuid   PT_LOAD FLAGS(1 << 23);
+    secrets PT_LOAD FLAGS(1 << 24);
 }
 
 SECTIONS {
@@ -50,11 +52,19 @@ SECTIONS {
         bss_start = .;
         *(.bss .bss.*)
         bss_size = . - bss_start;
-    }
+    } : ram
 
     /* Stack grows down, so stack_start is the upper address in memory. */
     .stack (NOLOAD) : ALIGN(4K) {
         . += 512K;
-    }
+    } : ram
     stack_start = .;
+
+    .cpuid (NOLOAD) : ALIGN(2M) {
+        . += 4K;
+    } : cpuid
+
+    .secrets (NOLOAD) : ALIGN(2M) {
+        . += 4K;
+    } : secrets
 }


### PR DESCRIPTION
For now, these do nothing, but will be used to denote locations in the memory where the SEV-SNP cpuid and secrets pages will be placed.

Although these are supposed to be page-sized (4K) I aligned the structures at 2M boundaries, as we've yet to figure out what page size do we want to use in the kernel (2M hugepages vs 4K pages), so that'll make it compatible with both at the cost of some wasted memory.