### PR TITLE
Create separate sections in the ELF file for parts of the program that should have different permissions.

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/layout.ld
+++ b/experimental/oak_baremetal_app_crosvm/layout.ld
@@ -18,7 +18,20 @@ ENTRY(_start)
 
 PHDRS
 {
-    ram     PT_LOAD FLAGS(5);
+    /* Note that the permissions flags are currently not respected. */
+    /* Keep the sections here sorted from lowest memory address to largest; crosvm
+     * has a sanity check that expects the section with the lowest address to come
+     * first.
+     */
+    /* Executable text. */
+    text    PT_LOAD FLAGS(4 + 1); /* PF_R + PF_X */
+    /* Read-only data. */
+    rodata  PT_LOAD FLAGS(4); /* PF_R */
+    /* Initialized read-write data. */
+    data    PT_LOAD FLAGS(4 + 2); /* PF_R + PF_W */
+    /* Uninitialized read-write data. */
+    bss     PT_LOAD FLAGS(4 + 2); /* PF_R + PF_W */
+    /* Special sections for SEV-SNP. */
     cpuid   PT_LOAD FLAGS(1 << 23);
     secrets PT_LOAD FLAGS(1 << 24);
 }
@@ -27,24 +40,24 @@ SECTIONS {
     .boot 0x200000 : {
         ram_min = .;
         *(.boot)
-    } : ram
+    } : text
 
     data_start = .;
     text_start = .;
 
     .text : {
         *(.text .text.*)
-    } : ram
+    } : text
 
     text_end = .;
 
     .rodata : {
         *(.rodata .rodata.*)
-    } : ram
+    } : rodata
 
     .data : {
         *(.data .data.*)
-    } : ram
+    } : data
 
     data_end = .;
 
@@ -52,12 +65,12 @@ SECTIONS {
         bss_start = .;
         *(.bss .bss.*)
         bss_size = . - bss_start;
-    } : ram
+    } : bss
 
     /* Stack grows down, so stack_start is the upper address in memory. */
     .stack (NOLOAD) : ALIGN(4K) {
         . += 512K;
-    } : ram
+    } : bss
     stack_start = .;
 
     .cpuid (NOLOAD) : ALIGN(2M) {


### PR DESCRIPTION
None of the flags are actually respected right now, as the ELF loaders in the VMMs don't set up permissions (or page tables) for us.

But it's a first step toward setting up page tables with proper permissions.