### PR TITLE
Align all sections to 2M boundaries, and add an explicit load offset.

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/layout.ld
+++ b/experimental/oak_baremetal_app_crosvm/layout.ld
@@ -24,6 +24,7 @@ PHDRS
      * first.
      */
     /* Executable text. */
+    boot    PT_LOAD FLAGS(4 + 1); /* PF_R + PF_X */
     text    PT_LOAD FLAGS(4 + 1); /* PF_R + PF_X */
     /* Read-only data. */
     rodata  PT_LOAD FLAGS(4); /* PF_R */
@@ -36,39 +37,54 @@ PHDRS
     secrets PT_LOAD FLAGS(1 << 24);
 }
 
+/* To set kernel VMA to high memory, set this to 0xFFFFFFFF80000000. */
+KERNEL_MEM_START = 0x0;
+
 SECTIONS {
+    /*
+     * Boot code is executed with identity mapping; the main duty of the boot
+     * code is to set up proper page tables before jumping to the kernel proper.
+     * We place that at 2M (both virtual and physical)
+     */
     .boot 0x200000 : {
         ram_min = .;
         *(.boot)
-    } : text
+    } : boot
+
+    /*
+     * Load the rest of the kernel after KERNEL_MEM_START. The idea is that the initial
+     * boot code should set map KERNEL_MEM_START to physical address 0; therefore, all
+     * VMAs will be LMA + KERNEL_MEM_START.
+     */
+    . += KERNEL_MEM_START;
 
     data_start = .;
     text_start = .;
 
-    .text : {
+    .text ALIGN(2M) : AT(ADDR(.text) - KERNEL_MEM_START) {
         *(.text .text.*)
     } : text
 
     text_end = .;
 
-    .rodata : {
+    .rodata ALIGN(2M) : {
         *(.rodata .rodata.*)
     } : rodata
 
-    .data : {
+    .data ALIGN(2M) : {
         *(.data .data.*)
     } : data
 
     data_end = .;
 
-    .bss : {
+    .bss : ALIGN(2M) {
         bss_start = .;
         *(.bss .bss.*)
         bss_size = . - bss_start;
     } : bss
 
     /* Stack grows down, so stack_start is the upper address in memory. */
-    .stack (NOLOAD) : ALIGN(4K) {
+    .stack (NOLOAD) : ALIGN(2M) {
         . += 512K;
     } : bss
     stack_start = .;
@@ -80,4 +96,8 @@ SECTIONS {
     .secrets (NOLOAD) : ALIGN(2M) {
         . += 4K;
     } : secrets
+
+    /DISCARD/ : {
+        *(.eh_frame*)
+    }
 }


### PR DESCRIPTION
Baby steps toward a higher-half kernel and setting up proper page tables with memory protection.

First, this will align all data structures at 2M boundaries, so that we can set up page tables more easily.

Second, this will add an explicit `KERNEL_MEM_START` to set the kernel offset. Right now we're in the lower half, so it's zero, but eventually this will be the upper half (more precisely, the last 2GB of virtual memory aka -2G).

Example of segments with `KERNEL_MEM_START = 0`:
```
Section Headers:
  [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            0000000000000000 000000 000000 00      0   0  0
  [ 1] .boot             PROGBITS        0000000000200000 001000 00000e 00  AX  0   0  1
  [ 2] .text             PROGBITS        0000000000400000 002000 06fc92 00  AX  0   0 16
  [ 3] .rodata           PROGBITS        0000000000600000 072000 01e100 00  AM  0   0 32
  [ 4] .data             PROGBITS        0000000000800000 091000 000038 00  WA  0   0  8
  [ 5] .got              PROGBITS        0000000000800038 091038 000028 00  WA  0   0  8
  [ 6] .bss              NOBITS          0000000000a00000 200000 008010 00  WA  0   0 2097152
  [ 7] .stack            NOBITS          0000000000c00000 200000 080000 00  WA  0   0 2097152
  [ 8] .cpuid            NOBITS          0000000000e00000 200000 001000 00  WA  0   0 2097152
  [ 9] .secrets          NOBITS          0000000001000000 200000 001000 00  WA  0   0 2097152
  [10] .comment          PROGBITS        0000000000000000 091060 000013 01  MS  0   0  1
  [11] .shstrtab         STRTAB          0000000000000000 091073 00004f 00      0   0  1

Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  LOAD           0x001000 0x0000000000200000 0x0000000000200000 0x00000e 0x00000e R E 0x1000
  LOAD           0x002000 0x0000000000400000 0x0000000000400000 0x06fc92 0x06fc92 R E 0x1000
  LOAD           0x072000 0x0000000000600000 0x0000000000600000 0x01e100 0x01e100 R   0x1000
  LOAD           0x091000 0x0000000000800000 0x0000000000800000 0x000060 0x000060 RW  0x1000
  LOAD           0x000000 0x0000000000a00000 0x0000000000a00000 0x000000 0x280000 RW  0x200000
  LOAD           0x000000 0x0000000000e00000 0x0000000000e00000 0x000000 0x001000     0x200000
  LOAD           0x000000 0x0000000001000000 0x0000000001000000 0x000000 0x001000     0x200000

 Section to Segment mapping:
  Segment Sections...
   00     .boot 
   01     .text 
   02     .rodata 
   03     .data .got 
   04     .bss .stack 
   05     .cpuid 
   06     .secrets 
```

Example with `KERNEL_MEM_START = 0xFFFFFFFF80000000`:
```
Section Headers:
  [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            0000000000000000 000000 000000 00      0   0  0
  [ 1] .boot             PROGBITS        0000000000200000 001000 00000e 00  AX  0   0  1
  [ 2] .text             PROGBITS        ffffffff80400000 002000 06fc92 00  AX  0   0 16
  [ 3] .rodata           PROGBITS        ffffffff80600000 072000 01e100 00  AM  0   0 32
  [ 4] .data             PROGBITS        ffffffff80800000 091000 000038 00  WA  0   0  8
  [ 5] .got              PROGBITS        ffffffff80800038 091038 000028 00  WA  0   0  8
  [ 6] .bss              NOBITS          ffffffff80a00000 200000 008010 00  WA  0   0 2097152
  [ 7] .stack            NOBITS          ffffffff80c00000 200000 080000 00  WA  0   0 2097152
  [ 8] .cpuid            NOBITS          ffffffff80e00000 200000 001000 00  WA  0   0 2097152
  [ 9] .secrets          NOBITS          ffffffff81000000 200000 001000 00  WA  0   0 2097152
  [10] .comment          PROGBITS        0000000000000000 091060 000013 01  MS  0   0  1
  [11] .shstrtab         STRTAB          0000000000000000 091073 00004f 00      0   0  1

Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  LOAD           0x001000 0x0000000000200000 0x0000000000200000 0x00000e 0x00000e R E 0x1000
  LOAD           0x002000 0xffffffff80400000 0x0000000000400000 0x06fc92 0x06fc92 R E 0x1000
  LOAD           0x072000 0xffffffff80600000 0x0000000000600000 0x01e100 0x01e100 R   0x1000
  LOAD           0x091000 0xffffffff80800000 0x0000000000800000 0x000060 0x000060 RW  0x1000
  LOAD           0x000000 0xffffffff80a00000 0x0000000000a00000 0x000000 0x280000 RW  0x200000
  LOAD           0x000000 0xffffffff80e00000 0x0000000000e00000 0x000000 0x001000     0x200000
  LOAD           0x000000 0xffffffff81000000 0x0000000001000000 0x000000 0x001000     0x200000

 Section to Segment mapping:
  Segment Sections...
   00     .boot 
   01     .text 
   02     .rodata 
   03     .data .got 
   04     .bss .stack 
   05     .cpuid 
   06     .secrets 
```

`.boot` stays where it is, as that needs to set up page tables, while the VMAs of everything else gets shifted by the offset while the physical addresses stay the same.