### PR TITLE
Update deploy script of Trusted Shuffler

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,8 @@ jobs:
           - build-oak-functions-server-variants
           - run-cargo-tests
           - run-bazel-tests
-          - run-oak-functions-examples --application-variant=rust
+          - run-oak-functions-examples --application-variant=rust -
+            run-trusted-shuffler
           - run-cargo-fuzz -- -max_total_time=2
           - completion
           - run-cargo-clippy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,8 @@ jobs:
           - build-oak-functions-server-variants
           - run-cargo-tests
           - run-bazel-tests
-          - run-oak-functions-examples --application-variant=rust -
-            run-trusted-shuffler
+          - run-oak-functions-examples --application-variant=rust
+          - run-trusted-shuffler
           - run-cargo-fuzz -- -max_total_time=2
           - completion
           - run-cargo-clippy

--- a/.xtask_bash_completion
+++ b/.xtask_bash_completion
@@ -66,6 +66,9 @@ _xtask() {
             run-tests)
                 cmd+="__run__tests"
                 ;;
+            run-trusted-shuffler)
+                cmd+="__run__trusted__shuffler"
+                ;;
             *)
                 ;;
         esac
@@ -73,7 +76,7 @@ _xtask() {
 
     case "${cmd}" in
         xtask)
-            opts="-h --help --dry-run --logs --keep-going --scope run-launcher-test build-baremetal-variants run-oak-functions-examples build-oak-functions-example build-oak-functions-server-variants format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion help"
+            opts="-h --help --dry-run --logs --keep-going --scope run-launcher-test build-baremetal-variants run-oak-functions-examples build-oak-functions-example build-oak-functions-server-variants format check-format run-tests run-cargo-clippy run-cargo-tests run-bazel-tests run-cargo-fuzz run-cargo-deny run-cargo-udeps run-ci run-cargo-clean completion run-trusted-shuffler help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -445,6 +448,20 @@ _xtask() {
             return 0
             ;;
         xtask__run__tests)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        xtask__run__trusted__shuffler)
             opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/experimental/trusted_shuffler/Dockerfile
+++ b/experimental/trusted_shuffler/Dockerfile
@@ -1,14 +1,13 @@
 # Holds the Trusted Shuffler.
 # 
 # To run locally:
-# $ docker run --network=host gcr.io/oak-ci/trusted-shuffler
-FROM gcr.io/distroless/static:latest
+# $ docker run -it -e BACKEND_URL="http://localhost:8888" -e K="1" -e LISTEN_ADDRESS="[::]:8080" --network=host gcr.io/oak-ci/trusted-shuffler
+ARG debian_snapshot=sha256:fb7e04be4c79a9eab9c259fd5049f4a1bec321843040184a706bbecdaaacbd32
+FROM debian/snapshot@${debian_snapshot}
 
 COPY ./bin/trusted_shuffler_server /trusted_shuffler_server
 
-ENTRYPOINT [ \
-    "/trusted_shuffler_server", \
-    "--backend-url=http://localhost:8888", \
-    "--k=1", \
-    "--listen-address=[::]:8080" \
-    ]
+ENTRYPOINT /trusted_shuffler_server \
+    --backend-url="${BACKEND_URL}" \
+    --k="${K}" \
+    --listen-address="${LISTEN_ADDRESS}"

--- a/experimental/trusted_shuffler/Dockerfile
+++ b/experimental/trusted_shuffler/Dockerfile
@@ -7,6 +7,12 @@ FROM debian/snapshot@${debian_snapshot}
 
 COPY ./bin/trusted_shuffler_server /trusted_shuffler_server
 
+# Ignoring the linter to use JSON notation, because with JSON notation 
+# the environment variables $K, $BACKEND_URL, and $LISTEN_ADDRESS are not expanded,
+# and environment variables are the way we give (and modify) the arguments
+# on Google Cloud Run.
+# 
+# hadolint ignore=DL3025
 ENTRYPOINT /trusted_shuffler_server \
     --backend-url="${BACKEND_URL}" \
     --k="${K}" \

--- a/experimental/trusted_shuffler/Dockerfile
+++ b/experimental/trusted_shuffler/Dockerfile
@@ -1,10 +1,14 @@
-FROM gcr.io/distroless/static@sha256:73c8aadbd4ca392807a8707944cd94098f4336e2a74a96a1c4e94e5bf4546570
+# Holds the Trusted Shuffler.
+# 
+# To run locally:
+# $ docker run --network=host gcr.io/oak-ci/trusted-shuffler
+FROM gcr.io/distroless/static:latest
 
 COPY ./bin/trusted_shuffler_server /trusted_shuffler_server
 
 ENTRYPOINT [ \
     "/trusted_shuffler_server", \
     "--backend-url=http://localhost:8888", \
-    "--k=10", \
+    "--k=1", \
     "--listen-address=[::]:8080" \
     ]

--- a/experimental/trusted_shuffler/scripts/common
+++ b/experimental/trusted_shuffler/scripts/common
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # Unused variables OK as this script is `source`d.
+# shellcheck disable=SC2034  
+# Unused variables OK as this script is `source`d.
 
 set -o errexit
 set -o nounset

--- a/experimental/trusted_shuffler/scripts/deploy
+++ b/experimental/trusted_shuffler/scripts/deploy
@@ -10,4 +10,7 @@ gcloud run deploy "${DEPLOYMENT}" \
     --region=europe-west1 \
     --image="${DOCKER_IMAGE}" \
     --use-http2 \
-    --allow-unauthenticated
+    --allow-unauthenticated \
+    --set-env-vars "BACKEND_URL=http://localhost:8888" \
+    --set-env-vars "K=1" \
+    --set-env-vars "LISTEN_ADDRESS=[::]:8080" 

--- a/experimental/trusted_shuffler/scripts/deploy
+++ b/experimental/trusted_shuffler/scripts/deploy
@@ -11,6 +11,6 @@ gcloud run deploy "${DEPLOYMENT}" \
     --image="${DOCKER_IMAGE}" \
     --use-http2 \
     --allow-unauthenticated \
-    --set-env-vars "BACKEND_URL=http://localhost:8888" \
-    --set-env-vars "K=1" \
-    --set-env-vars "LISTEN_ADDRESS=[::]:8080" 
+    --set-env-vars BACKEND_URL=http://localhost:8888 \
+    --set-env-vars K=1 \
+    --set-env-vars LISTEN_ADDRESS=[::]:8080

--- a/experimental/trusted_shuffler/scripts/deploy
+++ b/experimental/trusted_shuffler/scripts/deploy
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2101 # False positive on [::] in LISTEN_ADDRESS.
 
 readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common

--- a/experimental/trusted_shuffler/scripts/docker_build
+++ b/experimental/trusted_shuffler/scripts/docker_build
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
+# Build the Docker image running Trusted Shuffler for Google Cloud.
+# Note, the script cannot be run within a Docker image.
+
 readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-cargo build \
+# Use Docker builder image to build the Trusted Shuffler binary.
+./scripts/docker_run cargo build \
     --manifest-path=experimental/trusted_shuffler/server/Cargo.toml \
     --target=x86_64-unknown-linux-musl \
     --release

--- a/experimental/trusted_shuffler/server/src/http.rs
+++ b/experimental/trusted_shuffler/server/src/http.rs
@@ -53,7 +53,10 @@ impl RequestHandler for HttpRequestHandler {
         // And extend the URL to the backend.
         let new_uri = format!("{}{}", self.backend_url, path)
             .parse::<Uri>()
-            .expect("Couldn't parse URI for backend.");
+            .expect(&format!(
+                "Couldn't parse URI for backend: {}{}.",
+                self.backend_url, path
+            ));
         let uri = request.uri_mut();
         *uri = new_uri;
 

--- a/experimental/trusted_shuffler/server/src/http.rs
+++ b/experimental/trusted_shuffler/server/src/http.rs
@@ -51,12 +51,10 @@ impl RequestHandler for HttpRequestHandler {
         // let new_uri = Uri::from_parts(parts).expect("Failed to create new URI");
         let path = request.uri().path();
         // And extend the URL to the backend.
-        let new_uri = format!("{}{}", self.backend_url, path)
-            .parse::<Uri>()
-            .expect(&format!(
-                "Couldn't parse URI for backend: {}{}.",
-                self.backend_url, path
-            ));
+        let new_uri = match  format!("{}{}", self.backend_url, path).parse::<Uri>() {
+            Ok(new_uri) => new_uri,
+            Err(error) => return Err(anyhow!("Couldn't parse URI for backend: {:?}", error))
+        };
         let uri = request.uri_mut();
         *uri = new_uri;
 

--- a/experimental/trusted_shuffler/server/src/http.rs
+++ b/experimental/trusted_shuffler/server/src/http.rs
@@ -51,9 +51,9 @@ impl RequestHandler for HttpRequestHandler {
         // let new_uri = Uri::from_parts(parts).expect("Failed to create new URI");
         let path = request.uri().path();
         // And extend the URL to the backend.
-        let new_uri = match  format!("{}{}", self.backend_url, path).parse::<Uri>() {
+        let new_uri = match format!("{}{}", self.backend_url, path).parse::<Uri>() {
             Ok(new_uri) => new_uri,
-            Err(error) => return Err(anyhow!("Couldn't parse URI for backend: {:?}", error))
+            Err(error) => return Err(anyhow!("Couldn't parse URI for backend: {:?}", error)),
         };
         let uri = request.uri_mut();
         *uri = new_uri;

--- a/experimental/trusted_shuffler/server/src/http.rs
+++ b/experimental/trusted_shuffler/server/src/http.rs
@@ -51,10 +51,9 @@ impl RequestHandler for HttpRequestHandler {
         // let new_uri = Uri::from_parts(parts).expect("Failed to create new URI");
         let path = request.uri().path();
         // And extend the URL to the backend.
-        let new_uri = match format!("{}{}", self.backend_url, path).parse::<Uri>() {
-            Ok(new_uri) => new_uri,
-            Err(error) => return Err(anyhow!("Couldn't parse URI for backend: {:?}", error)),
-        };
+        let new_uri = format!("{}{}", self.backend_url, path)
+            .parse::<Uri>()
+            .map_err(|error| anyhow!("Couldn't parse URI for backend: {:?}", error))?;
         let uri = request.uri_mut();
         *uri = new_uri;
 

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -16,7 +16,7 @@
 
 use crate::{files::*, internal::*};
 use maplit::hashmap;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 use strum::IntoEnumIterator;
 
 #[cfg(target_os = "macos")]
@@ -482,6 +482,55 @@ fn run_oak_functions_server(server: &Server) -> Box<dyn Runnable> {
             ...server.additional_args.clone(),
         ],
     )
+}
+
+pub fn run_trusted_shuffler() -> Step {
+    let path_to_trusted_shuffler_scripts: PathBuf = [
+        env!("WORKSPACE_ROOT"),
+        "experimental",
+        "trusted_shuffler",
+        "scripts",
+    ]
+    .iter()
+    .collect();
+
+    // Run gRPC Trusted Shuffler.
+
+    // Build and run the echo gRPC backend.
+    let mut path_to_backend: PathBuf = path_to_trusted_shuffler_scripts.clone();
+    path_to_backend.push("run_grpc_backend");
+
+    let backend_cmd = Cmd::new("bash", &["-c", path_to_backend.to_str().unwrap()]);
+
+    // Build and run the Trusted Shuffler.
+    let mut path_to_trusted_shuffler: PathBuf = path_to_trusted_shuffler_scripts.clone();
+    path_to_trusted_shuffler.push("run_trusted_shuffler");
+
+    let trusted_shuffler_cmd =
+        Cmd::new("bash", &["-c", path_to_trusted_shuffler.to_str().unwrap()]);
+
+    // Build and run the echo gRPC client.
+    let mut path_to_client: PathBuf = path_to_trusted_shuffler_scripts;
+    path_to_client.push("run_single_grpc_client");
+
+    let client_cmd = Cmd::new("bash", &["-c", path_to_client.to_str().unwrap()]);
+
+    let client_step = Step::Single {
+        name: "Client".to_string(),
+        command: client_cmd,
+    };
+
+    let trusted_shuffler_step = Step::WithBackground {
+        name: "Trusted Shufflder and Backend".to_string(),
+        foreground: Box::new(client_step),
+        background: trusted_shuffler_cmd,
+    };
+
+    Step::WithBackground {
+        name: "Run echo gRPC Trusted Shuffler with k=1".to_string(),
+        foreground: Box::new(trusted_shuffler_step),
+        background: backend_cmd,
+    }
 }
 
 fn run_clients(

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -72,6 +72,7 @@ pub enum Command {
     RunCargoClean,
     #[clap(about = "generate bash completion script to stdout")]
     Completion(Completion),
+    RunTrustedShuffler,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -137,6 +137,7 @@ fn match_cmd(opt: &Opt) -> Step {
         Command::RunCargoDeny => run_cargo_deny(),
         Command::RunCargoUdeps => run_cargo_udeps(&opt.scope),
         Command::RunCargoClean => run_cargo_clean(),
+        Command::RunTrustedShuffler => run_trusted_shuffler(),
     }
 }
 


### PR DESCRIPTION
To allow for environment variables, which can be updated on Google Cloud, we don't use distroless docker any more. 

We also build the Rust binary with the builder Docker, so we don't rely on the host having Rust installed.