### PR TITLE
Add Placeholder implementation for an AMD-attested Oak client

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,7 +64,7 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip",
 )
 
-# Maven for Tink crypto library.
+# Maven for Tink crypto library and testing.
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
@@ -72,6 +72,7 @@ maven_install(
         "com.google.code.findbugs:jsr305:1.3.9",
         "com.google.errorprone:error_prone_annotations:2.0.18",
         "com.google.j2objc:j2objc-annotations:1.1",
+        "org.mockito:mockito-core:3.3.3",
     ],
     repositories = [
         "https://maven.google.com",

--- a/java/BUILD
+++ b/java/BUILD
@@ -22,8 +22,29 @@ package(
 )
 
 java_library(
+    name = "amd_client",
+    srcs = glob(["src/main/java/com/google/oak/client/amd/*.java"]),
+    deps = [
+        ":client",
+        ":evidence",
+        ":util",
+        "//remote_attestation/java:remote_attestation",
+    ],
+)
+
+java_library(
     name = "client",
     srcs = glob(["src/main/java/com/google/oak/client/*.java"]),
+    deps = [
+        ":evidence",
+        ":util",
+        "//remote_attestation/java:remote_attestation",
+    ],
+)
+
+java_library(
+    name = "evidence",
+    srcs = glob(["src/main/java/com/google/oak/evidence/*.java"]),
     deps = [":util"],
 )
 
@@ -39,7 +60,21 @@ java_test(
     test_class = "com.google.oak.client.OakClientTest",
     deps = [
         ":client",
+        ":evidence",
         ":util",
+    ],
+)
+
+java_test(
+    name = "amd_client_test",
+    srcs = ["src/test/java/com/google/oak/client/amd/AmdAttestedOakClientTest.java"],
+    test_class = "com.google.oak.client.amd.AmdAttestedOakClientTest",
+    deps = [
+        ":amd_client",
+        ":client",
+        ":evidence",
+        ":util",
+        "@maven//:org_mockito_mockito_core",
     ],
 )
 

--- a/java/BUILD
+++ b/java/BUILD
@@ -45,7 +45,10 @@ java_library(
 java_library(
     name = "evidence",
     srcs = glob(["src/main/java/com/google/oak/evidence/*.java"]),
-    deps = [":util"],
+    deps = [
+        ":util",
+        "@com_google_guava_guava",
+    ],
 )
 
 java_library(
@@ -74,6 +77,7 @@ java_test(
         ":client",
         ":evidence",
         ":util",
+        "@com_google_guava_guava",
         "@maven//:org_mockito_mockito_core",
     ],
 )

--- a/java/src/main/java/com/google/oak/client/AeadEncryptor.java
+++ b/java/src/main/java/com/google/oak/client/AeadEncryptor.java
@@ -1,0 +1,49 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.client;
+
+import com.google.oak.client.Encryptor;
+import com.google.oak.util.Result;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+// TODO(#3066): Merge this with com.google.oak.remote_attestation.AeadEncryptor.
+public class AeadEncryptor implements Encryptor {
+  private final com.google.oak.remote_attestation.AeadEncryptor inner;
+
+  public AeadEncryptor(final com.google.oak.remote_attestation.AeadEncryptor inner) {
+    this.inner = inner;
+  }
+
+  @Override
+  public Result<byte[], Exception> decrypt(final byte[] data) {
+    try {
+      return Result.success(inner.decrypt(data));
+    } catch (GeneralSecurityException | IOException e) {
+      return Result.error(e);
+    }
+  }
+
+  @Override
+  public Result<byte[], Exception> encrypt(final byte[] data) {
+    try {
+      return Result.success(inner.encrypt(data));
+    } catch (GeneralSecurityException | IOException e) {
+      return Result.error(e);
+    }
+  }
+}

--- a/java/src/main/java/com/google/oak/client/OakClient.java
+++ b/java/src/main/java/com/google/oak/client/OakClient.java
@@ -16,8 +16,8 @@
 
 package com.google.oak.client;
 
+import com.google.oak.evidence.Evidence;
 import com.google.oak.util.Result;
-import java.util.Optional;
 
 /**
  * Abstract client for sending and receiving encrypted messages to a server. We recommend concrete
@@ -31,7 +31,7 @@ import java.util.Optional;
  * @param R type of the requests that this client sends
  * @param T type of the responses that this client receives
  */
-public abstract class OakClient<R, T> implements AutoCloseable {
+public interface OakClient<R, T> extends AutoCloseable {
   /**
    * Sends a request to a remote server and receives the response.
    *
@@ -64,8 +64,8 @@ public abstract class OakClient<R, T> implements AutoCloseable {
   /**
    * An interface for providing instances of Evidence.
    *
-   * <p>A evidence normally includes the public key part of the server's signing key, an instance of
-   * {@code EndorsementEvidence}, and optionally some server configuration information. If the
+   * <p>An evidence normally includes the public key part of the server's signing key, an instance
+   * of {@code EndorsementEvidence}, and optionally some server configuration information. If the
    * client policy requires verification of the server configuration, then the client should be
    * built with a provider that does provide server configuration.
    */

--- a/java/src/main/java/com/google/oak/client/OakClient.java
+++ b/java/src/main/java/com/google/oak/client/OakClient.java
@@ -20,13 +20,15 @@ import com.google.oak.evidence.Evidence;
 import com.google.oak.util.Result;
 
 /**
- * Abstract client for sending and receiving encrypted messages to a server. We recommend concrete
- * subclasses of this class to provide builders for creating instances of the class. The builders
- * should use a {@code RpcClientProvider}, an {@code EncryptorProvider}, and optionally an {@code
- * EvidenceProvider} to build a concrete instance of {@code OakClient}. If an evidence supplier is
- * provided, the client has to verify the correctness of the evidence prior to getting an instance
- * of {@code Encryptor} and sending messages to the server. In a complete, and production-ready
- * implementation, an {@code EvidenceProvider} MUST be provided and verified.
+ * Generic client interface for sending and receiving encrypted messages to a server.
+ *
+ * <p>Three additional nested interfaces are provided to facilitate instantiating concrete
+ * implementations of this interface: {@code EvidenceProvider}, {@code EncryptorProvider}, and
+ * {@code RpcClientProvider}. Implementations of {@code OakClient} first verify the {@code
+ * Evidence} provided by the {@code EvidenceProvider}. Successful verification yields a public key
+ * that will be used by the {@code EncryptorProvider} to generate an {@code Encryptor}. The {@code
+ * RpcClient} provided by the {@code RpcClientProvider} will be used to send and receive encrypted
+ * messages.
  *
  * @param R type of the requests that this client sends
  * @param T type of the responses that this client receives

--- a/java/src/main/java/com/google/oak/client/OakClient.java
+++ b/java/src/main/java/com/google/oak/client/OakClient.java
@@ -20,9 +20,9 @@ import com.google.oak.util.Result;
 import java.util.Optional;
 
 /**
- * Abstract client for sending and receiving encrypted messages to a server. This class provides an
- * abstract builder that must be implemented by concrete subclasses of this class. The builder takes
- * a {@code RpcClientProvider}, an {@code EncryptorProvider}, and optionally an {@code
+ * Abstract client for sending and receiving encrypted messages to a server. We recommend concrete
+ * subclasses of this class to provide builders for creating instances of the class. The builders
+ * should use a {@code RpcClientProvider}, an {@code EncryptorProvider}, and optionally an {@code
  * EvidenceProvider} to build a concrete instance of {@code OakClient}. If an evidence supplier is
  * provided, the client has to verify the correctness of the evidence prior to getting an instance
  * of {@code Encryptor} and sending messages to the server. In a complete, and production-ready
@@ -40,89 +40,41 @@ public abstract class OakClient<R, T> implements AutoCloseable {
    */
   abstract Result<T, Exception> send(final R request);
 
-  /**
-   * Abstract builder class that allows subclasses to override it, providing customized {@code
-   * build} and {@code self} methods.
-   */
-  abstract static class Builder<R, T, B extends Builder<R, T, B>> {
-    final EncryptorProvider encryptorProvider;
-    final RpcClientProvider rpcClientProvider;
-    Optional<EvidenceProvider> evidenceProvider = Optional.empty();
-
-    /**
-     * @param encryptorProvider instance that can provide an {@code Encryptor} instance
-     * @param rpcClientProvider instance that can provide an instance of {@code RpcClient}
-     */
-    Builder(final EncryptorProvider encryptorProvider, final RpcClientProvider rpcClientProvider) {
-      this.encryptorProvider = encryptorProvider;
-      this.rpcClientProvider = rpcClientProvider;
-    }
-
-    /**
-     * Configure this builder to use the given {@code EvidenceProvider}.
-     *
-     * @param evidenceProvider instance that can provide an {@code Evidence} instance
-     * @return this builder
-     */
-    public B withEvidenceProvider(final EvidenceProvider evidenceProvider) {
-      this.evidenceProvider = Optional.of(evidenceProvider);
-      return self();
-    }
-
-    /**
-     * Builds and returns and instance of {@code OakClient}. The build should verify any evidence
-     * provided by the {@code EvidenceProvider}, if one is present, and initialize the client with
-     * an {@code Encryptor}. Alternatively, the concrete subclass may provide additional appropriate
-     * methods for initializing the client instance before using it for sending and receiving
-     * messages. However, partial construction of the client is discouraged.
-     *
-     * @return an instance of {@code OakClient}.
-     */
-    abstract OakClient<R, T> build();
-
-    // Subclasses must override this method to return "this".
-    protected abstract B self();
-  }
-
   // The following functional interfaces could have individually been replaced by a Supplier<T>, but
   // to allow a single class implement more than one of these interfaces, dedicated functional
   // interfaces are preferred.
 
-  /**
-   * An interface for providing instances of {@code RpcClient}.
-   */
-  public interface RpcClientProvider {
+  /** An interface for providing instances of {@code RpcClient}. */
+  public interface RpcClientProvider<C extends RpcClient> {
     /**
      * @return an instance of {@code RpcClient} wrapped in a {@code Result}
      */
-    Result<? extends RpcClient, Exception> getRpcClient();
+    Result<C, Exception> getRpcClient();
   }
 
-  /**
-   * An interface for providing {@code Encryptor} instances.
-   */
-  public interface EncryptorProvider {
+  /** An interface for providing {@code Encryptor} instances. */
+  public interface EncryptorProvider<E extends Encryptor> {
     /**
      * @param signingPublicKey signing public key of the server
      * @return an instance of Encryptor wrapped in a {@code Result}
      */
-    Result<? extends Encryptor, Exception> getEncryptor(byte[] signingPublicKey);
+    Result<E, Exception> getEncryptor(byte[] signingPublicKey);
   }
 
   /**
    * An interface for providing instances of Evidence.
    *
-   * <p>An evidence normally includes the public key part of the server's signing key, an instance
-   * of {@code EndorsementEvidence}, and optionally some server configuration information. If the
+   * <p>A evidence normally includes the public key part of the server's signing key, an instance of
+   * {@code EndorsementEvidence}, and optionally some server configuration information. If the
    * client policy requires verification of the server configuration, then the client should be
    * built with a provider that does provide server configuration.
    */
-  public interface EvidenceProvider {
+  public interface EvidenceProvider<E extends Evidence> {
     /**
      * Returns evidence about the trustworthiness of a remote server.
      *
      * @return the evidence wrapped in a {@code Result}
      */
-    Result<? extends Evidence, Exception> getEvidence();
+    Result<E, Exception> getEvidence();
   }
 }

--- a/java/src/main/java/com/google/oak/client/amd/AmdAttestationReport.java
+++ b/java/src/main/java/com/google/oak/client/amd/AmdAttestationReport.java
@@ -1,0 +1,67 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.evidence;
+
+import com.google.oak.evidence.AttestationReport;
+import com.google.oak.util.Result;
+
+// TODO(#2842): This is a placeholder implementation, and must be replaced with a valid and
+// complete implementation.
+/**
+ * Placeholder implementation of the remote attestation report from AMD SEV-SNP.
+ */
+public class AmdAttestationReport implements AttestationReport {
+  // TODO(#2842): in reality, it should be extracte from the report.
+  private final byte[] publicKey;
+
+  // TODO(#2842): in reality, it should be extracte from the report.
+  private final byte[] binaryHash;
+
+  @Override
+  public Result<byte[], Exception> getServerSigningPublicKey() {
+    return Result.success(publicKey.clone());
+  }
+
+  @Override
+  public Result<byte[], Exception> getServerBinarySha256Hash() {
+    return Result.success(binaryHash.clone());
+  }
+
+  @Override
+  public Result<byte[], Exception> verify() {
+    // TODO(#2842): implement the verification logic.
+    return getServerSigningPublicKey();
+  }
+
+  // TODO(#2842): Remove once we have a valid implementation.
+  /**
+   * Creates a placeholder instance of {@code AmdAttestationReport}, with the given {@code
+   * publicKey} and {@code binaryHash}. This is suitable for testing, and will be removed when we
+   * have a complete and valid implementation of the AMD Attestation report.
+   */
+  public static AmdAttestationReport createPlaceholder(
+      final byte[] publicKey, final byte[] binaryHash) {
+    return new AmdAttestationReport(publicKey, binaryHash);
+  }
+
+  // This is a placeholder constructor and is therefore private.
+  // TODO(#2842): Remove once we have a valid implementation.
+  private AmdAttestationReport(final byte[] publicKey, final byte[] binaryHash) {
+    this.publicKey = publicKey;
+    this.binaryHash = binaryHash;
+  }
+}

--- a/java/src/main/java/com/google/oak/client/amd/AmdAttestationReport.java
+++ b/java/src/main/java/com/google/oak/client/amd/AmdAttestationReport.java
@@ -25,15 +25,15 @@ import com.google.oak.util.Result;
  * Placeholder implementation of the remote attestation report from AMD SEV-SNP.
  */
 public class AmdAttestationReport implements AttestationReport {
-  // TODO(#2842): in reality, it should be extracte from the report.
-  private final byte[] publicKey;
+  // TODO(#2842): In a valid implementation, it should be extracted from the report.
+  private final byte[] publicKeyHash;
 
-  // TODO(#2842): in reality, it should be extracte from the report.
+  // TODO(#2842): In a valid implementation, it should be extracted from the report.
   private final byte[] binaryHash;
 
   @Override
-  public Result<byte[], Exception> getServerSigningPublicKey() {
-    return Result.success(publicKey.clone());
+  public Result<byte[], Exception> getServerSigningPublicKeySha256Hash() {
+    return Result.success(publicKeyHash.clone());
   }
 
   @Override
@@ -43,25 +43,25 @@ public class AmdAttestationReport implements AttestationReport {
 
   @Override
   public Result<byte[], Exception> verify() {
-    // TODO(#2842): implement the verification logic.
-    return getServerSigningPublicKey();
+    // TODO(#2842): Implement the verification logic.
+    return getServerSigningPublicKeySha256Hash();
   }
 
   // TODO(#2842): Remove once we have a valid implementation.
   /**
    * Creates a placeholder instance of {@code AmdAttestationReport}, with the given {@code
-   * publicKey} and {@code binaryHash}. This is suitable for testing, and will be removed when we
-   * have a complete and valid implementation of the AMD Attestation report.
+   * publicKeyHash} and {@code binaryHash}. This is suitable for testing, and will be removed when
+   * we have a complete and valid implementation of the AMD Attestation report.
    */
   public static AmdAttestationReport createPlaceholder(
-      final byte[] publicKey, final byte[] binaryHash) {
-    return new AmdAttestationReport(publicKey, binaryHash);
+      final byte[] publicKeyHash, final byte[] binaryHash) {
+    return new AmdAttestationReport(publicKeyHash, binaryHash);
   }
 
   // This is a placeholder constructor and is therefore private.
   // TODO(#2842): Remove once we have a valid implementation.
-  private AmdAttestationReport(final byte[] publicKey, final byte[] binaryHash) {
-    this.publicKey = publicKey;
+  private AmdAttestationReport(final byte[] publicKeyHash, final byte[] binaryHash) {
+    this.publicKeyHash = publicKeyHash;
     this.binaryHash = binaryHash;
   }
 }

--- a/java/src/main/java/com/google/oak/client/amd/AmdAttestedOakClient.java
+++ b/java/src/main/java/com/google/oak/client/amd/AmdAttestedOakClient.java
@@ -1,0 +1,166 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.client.amd;
+
+import static com.google.oak.remote_attestation.KeyNegotiator.EncryptorType.CLIENT;
+
+import com.google.oak.client.AeadEncryptor;
+import com.google.oak.client.Encryptor;
+import com.google.oak.client.OakClient;
+import com.google.oak.client.RpcClient;
+import com.google.oak.evidence.AmdAttestationReport;
+import com.google.oak.evidence.BasicEvidence;
+import com.google.oak.evidence.EndorsementEvidence;
+import com.google.oak.remote_attestation.KeyNegotiator;
+import com.google.oak.util.Result;
+import java.security.GeneralSecurityException;
+
+/**
+ * Placeholder implementation of an AmdAttestedOakClient. To create an instance of this class, an
+ * {@code AmdAttestationReport} must be received and verified.
+ *
+ * This implementation uses {@code byte[]} as the type of the request and response.
+ */
+public class AmdAttestedOakClient<C extends RpcClient> implements OakClient<byte[], byte[]> {
+  private final C client;
+  private final Encryptor encryptor;
+
+  private AmdAttestedOakClient(final Encryptor encryptor, final C client) {
+    this.client = client;
+    this.encryptor = encryptor;
+  }
+
+  @Override
+  public Result<byte[], Exception> send(byte[] request) {
+    return encryptor.encrypt(request)
+        .andThen(bytes -> client.send(bytes))
+        .andThen(response -> encryptor.decrypt(response));
+  }
+
+  @Override
+  public void close() throws Exception {
+    client.close();
+  }
+
+  /**
+   * Builder for {@code AttestedClient}.
+   */
+  public static class Builder<C extends RpcClient> {
+    private RpcClientProvider<C> clientProvider;
+    private EvidenceProvider<BasicEvidence<AmdAttestationReport>> evidenceProvider =
+        defaultEvidenceProvider();
+    private EncryptorProvider<? extends Encryptor> encryptorProvider = defaultEncryptorProvider();
+
+    /**
+     * Configures this builder to use the given {@code RpcClientProvider}.
+     *
+     * @param clientProvider provides an instance of {@code <C>}
+     * @return this builder
+     */
+    public Builder<C> withClientProvider(RpcClientProvider<C> clientProvider) {
+      this.clientProvider = clientProvider;
+      return this;
+    }
+
+    /**
+     * Configures this builder to use the given {@code EvidenceProvider}.
+     *
+     * @param evidenceProvider provides an instance of {@code BasicEvidence<AmdAttestationReport>}
+     * @return this builder
+     */
+    public Builder<C> withEvidenceProvider(
+        EvidenceProvider<BasicEvidence<AmdAttestationReport>> evidenceProvider) {
+      this.evidenceProvider = evidenceProvider;
+      return this;
+    }
+
+    /**
+     * Configures this builder to use the given {@code EncryptorProvider}.
+     *
+     * @param encryptorProvider provides an instance of {@code Encryptor}
+     * @return this builder
+     */
+    public Builder<C> withEncryptorProvider(
+        EncryptorProvider<? extends Encryptor> encryptorProvider) {
+      this.encryptorProvider = encryptorProvider;
+      return this;
+    }
+
+    /**
+     * Verifies the evidence provided by {@code evidenceProvider}. If successful, feeds the
+     * resulting publicKey to {@code encryptorProvider} to generate an encryptor. Returns an error
+     * if any of the steps fail.
+     *
+     * <p>{@code clientProvider}, {@code evidenceProvider}, and {@code encryptorProvider} must all
+     * be non-null.
+     *
+     * @return an instance of {@code AttestedClient<C>} or an error, wrapped in a {@code Result}
+     */
+    public Result<AmdAttestedOakClient<C>, Exception> build() {
+      if (clientProvider == null || evidenceProvider == null || encryptorProvider == null) {
+        return Result.error(new Exception(String.format(
+            "nonnull values for clientProvider (%s), evidenceProvider (%s), and encryptorProvider (%s) must be provided",
+            clientProvider, evidenceProvider, encryptorProvider)));
+      }
+
+      Result<C, Exception> clientResult = clientProvider.getRpcClient();
+      Result<? extends Encryptor, Exception> encryptorResult =
+          evidenceProvider.getEvidence().andThen(evidence
+              -> evidence.verify().andThen(publicKey -> encryptorProvider.getEncryptor(publicKey)));
+
+      return Result.merge(encryptorResult, clientResult,
+          (encryptor, client) -> new AmdAttestedOakClient(encryptor, client));
+    }
+
+    /**
+     * Creates and returns a simple {@code EncryptorProvider} that resembles the Encryptor from
+     * offline attestation.
+     */
+    EncryptorProvider<Encryptor> defaultEncryptorProvider() {
+      return new EncryptorProvider<Encryptor>() {
+        @Override
+        public Result<Encryptor, Exception> getEncryptor(byte[] signingPublicKey) {
+          KeyNegotiator keyNegotiator = new KeyNegotiator();
+          try {
+            AeadEncryptor encryptor =
+                new AeadEncryptor(keyNegotiator.createEncryptor(signingPublicKey, CLIENT));
+            return Result.success(encryptor);
+          } catch (GeneralSecurityException e) {
+            return Result.error(e);
+          }
+        }
+      };
+    }
+
+    // TODO(#2842): Update this to provide a more interesting default or remove.
+    /**
+     * Creates and returns a simple {@code EvidenceProvider} that contains an empty
+     * {@code AmdAttestationReport}.
+     */
+    EvidenceProvider<BasicEvidence<AmdAttestationReport>> defaultEvidenceProvider() {
+      return new EvidenceProvider<BasicEvidence<AmdAttestationReport>>() {
+        @Override
+        public Result<BasicEvidence<AmdAttestationReport>, Exception> getEvidence() {
+          BasicEvidence<AmdAttestationReport> evidence = new BasicEvidence<>(
+              AmdAttestationReport.createPlaceholder(new byte[] {}, new byte[] {}),
+              new EndorsementEvidence());
+          return Result.success(evidence);
+        }
+      };
+    }
+  }
+}

--- a/java/src/main/java/com/google/oak/evidence/AttestationReport.java
+++ b/java/src/main/java/com/google/oak/evidence/AttestationReport.java
@@ -24,13 +24,13 @@ import com.google.oak.util.Result;
  */
 public interface AttestationReport extends Evidence {
   /**
-   * Extracts and returns the public key part of the server's signing key included in this
-   * attestation report. The client code is responsible for verifying this report before trusting
-   * the public key.
+   * Extracts and returns the SHA256 hash of the public key part of the server's signing key
+   * included in this attestation report. The client code is responsible for verifying this report
+   * before trusting the public key hash.
    *
-   * @return public key part of the remote server's signing key
+   * @return SHA256 hash of the public key part of the remote server's signing key
    */
-  Result<byte[], Exception> getServerSigningPublicKey();
+  Result<byte[], Exception> getServerSigningPublicKeySha256Hash();
 
   /**
    * Extracts and returns the SHA256 hash of the remote server's binary. The client code is
@@ -41,7 +41,7 @@ public interface AttestationReport extends Evidence {
   Result<byte[], Exception> getServerBinarySha256Hash();
 
   /**
-   * Verifies this attestation report. Returns {@code getServerSigningPublicKey()} if the
+   * Verifies this attestation report. Returns {@code getServerSigningPublicKeySha256Hash()} if the
    * verification is successful, otherwise returns an error indicating that the verification failed.
    */
   Result<byte[], Exception> verify();

--- a/java/src/main/java/com/google/oak/evidence/AttestationReport.java
+++ b/java/src/main/java/com/google/oak/evidence/AttestationReport.java
@@ -1,0 +1,48 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.evidence;
+
+import com.google.oak.util.Result;
+
+/**
+ * Interface representing an attestation report. Different implementations of this interface are
+ * required for each Trusted Execution Environment (TEE) architecture (e.g., AMD).
+ */
+public interface AttestationReport extends Evidence {
+  /**
+   * Extracts and returns the public key part of the server's signing key included in this
+   * attestation report. The client code is responsible for verifying this report before trusting
+   * the public key.
+   *
+   * @return public key part of the remote server's signing key
+   */
+  Result<byte[], Exception> getServerSigningPublicKey();
+
+  /**
+   * Extracts and returns the SHA256 hash of the remote server's binary. The client code is
+   * responsible for verifying this report before trusting returned hash.
+   *
+   * @return SHA256 hash of the trusted runtime binary running on the server
+   */
+  Result<byte[], Exception> getServerBinarySha256Hash();
+
+  /**
+   * Verifies this attestation report. Returns {@code getServerSigningPublicKey()} if the
+   * verification is successful, otherwise returns an error indicating that the verification failed.
+   */
+  Result<byte[], Exception> verify();
+}

--- a/java/src/main/java/com/google/oak/evidence/BasicEvidence.java
+++ b/java/src/main/java/com/google/oak/evidence/BasicEvidence.java
@@ -1,0 +1,72 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.evidence;
+
+import com.google.oak.evidence.AttestationReport;
+import com.google.oak.evidence.EndorsementEvidence;
+import com.google.oak.evidence.Evidence;
+import com.google.oak.util.Result;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.StackWalker.Option;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * This class encapsulates the logic for verifying minimal evidence about server's identity. It
+ * verifies an attestation report, from which the public key of the server's signing key can be
+ * retrieved. It also verifies the provided endorsement evidence. The verification is successful
+ * only if the hash of the binary in the attestation report matches the hash of the binary in the
+ * endorsement evidence. The user of this class can register additional verifiers for verifying the
+ * attestation report.
+ *
+ * @param A type of the {@code AttestationReport}
+ */
+public class BasicEvidence<A extends AttestationReport> implements Evidence {
+  private final A attestationReport;
+  private final EndorsementEvidence endorsement;
+
+  public BasicEvidence(A attestationReport, EndorsementEvidence endorsement) {
+    this.attestationReport = attestationReport;
+    this.endorsement = endorsement;
+  }
+
+  /**
+   * Verifies this evidence. If the verification is successful, returns the public key of the
+   * server's signing key. Otherwise, returns an error.
+   *
+   * @return the public key of the server's signing key, or error if verification fails
+   */
+  public Result<byte[], Exception> verify() {
+    return attestationReport.verify().andThen(publicKey
+        -> endorsement.verify().andThen(binaryHash
+            -> attestationReport.getServerBinarySha256Hash().andThen(attestedBinaryHash -> {
+      if (Arrays.equals(binaryHash, attestedBinaryHash)) {
+        return Result.success(publicKey);
+      }
+      return Result.error(
+          new Exception("evidence verification failed, binary hashes do not match"));
+    })));
+  }
+
+  public String exceptionToString(Exception exception) {
+    StringWriter sw = new StringWriter();
+    exception.printStackTrace(new PrintWriter(sw));
+    return sw.toString();
+  }
+}

--- a/java/src/main/java/com/google/oak/evidence/BasicEvidence.java
+++ b/java/src/main/java/com/google/oak/evidence/BasicEvidence.java
@@ -16,6 +16,7 @@
 
 package com.google.oak.evidence;
 
+import com.google.common.hash.Hashing;
 import com.google.oak.evidence.AttestationReport;
 import com.google.oak.evidence.EndorsementEvidence;
 import com.google.oak.evidence.Evidence;
@@ -23,27 +24,42 @@ import com.google.oak.util.Result;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.StackWalker.Option;
+import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
 
 /**
- * This class encapsulates the logic for verifying minimal evidence about server's identity. It
- * verifies an attestation report, from which the public key of the server's signing key can be
- * retrieved. It also verifies the provided endorsement evidence. The verification is successful
- * only if the hash of the binary in the attestation report matches the hash of the binary in the
- * endorsement evidence. The user of this class can register additional verifiers for verifying the
- * attestation report.
+ * This class encapsulates the logic for verifying minimal evidence about server's identity (i.e.,
+ * its public key). It verifies an attestation report, from which the SHA256 hash of the public key
+ * of the server's signing key can be retrieved. It also verifies the endorsement evidence about the
+ * server binary. The verification is successful only if the hash of the binary in the attestation
+ * report matches the hash of the binary in the endorsement evidence.
  *
  * @param A type of the {@code AttestationReport}
  */
 public class BasicEvidence<A extends AttestationReport> implements Evidence {
   private final A attestationReport;
   private final EndorsementEvidence endorsement;
+  private final PublicKeyInfo publicKeyInfo;
 
-  public BasicEvidence(A attestationReport, EndorsementEvidence endorsement) {
+  public static class PublicKeyInfo {
+    private final byte[] publicKey;
+
+    public PublicKeyInfo(final byte[] publicKey) {
+      this.publicKey = publicKey;
+    }
+
+    byte[] getPublicKeySha256Hash() {
+      return Hashing.sha256().hashBytes(publicKey).asBytes();
+    }
+  }
+
+  public BasicEvidence(
+      A attestationReport, EndorsementEvidence endorsement, final byte[] publicKey) {
     this.attestationReport = attestationReport;
     this.endorsement = endorsement;
+    this.publicKeyInfo = new PublicKeyInfo(publicKey);
   }
 
   /**
@@ -53,20 +69,15 @@ public class BasicEvidence<A extends AttestationReport> implements Evidence {
    * @return the public key of the server's signing key, or error if verification fails
    */
   public Result<byte[], Exception> verify() {
-    return attestationReport.verify().andThen(publicKey
+    return attestationReport.verify().andThen(publicKeyHash
         -> endorsement.verify().andThen(binaryHash
             -> attestationReport.getServerBinarySha256Hash().andThen(attestedBinaryHash -> {
-      if (Arrays.equals(binaryHash, attestedBinaryHash)) {
-        return Result.success(publicKey);
+      if (Arrays.equals(binaryHash, attestedBinaryHash)
+          && Arrays.equals(publicKeyHash, publicKeyInfo.getPublicKeySha256Hash())) {
+        return Result.success(publicKeyInfo.publicKey);
       }
       return Result.error(
           new Exception("evidence verification failed, binary hashes do not match"));
     })));
-  }
-
-  public String exceptionToString(Exception exception) {
-    StringWriter sw = new StringWriter();
-    exception.printStackTrace(new PrintWriter(sw));
-    return sw.toString();
   }
 }

--- a/java/src/main/java/com/google/oak/evidence/EndorsementEvidence.java
+++ b/java/src/main/java/com/google/oak/evidence/EndorsementEvidence.java
@@ -41,7 +41,7 @@ public class EndorsementEvidence implements Evidence {
    * @return SHA256 hash of the subject, or an error if the verification fails
    */
   Result<byte[], Exception> verify() {
-    // TODO(#2854): implement this method.
+    // TODO(#2854): Implement this method.
     return Result.success(new byte[] {});
   }
 }

--- a/java/src/main/java/com/google/oak/evidence/EndorsementEvidence.java
+++ b/java/src/main/java/com/google/oak/evidence/EndorsementEvidence.java
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-package com.google.oak.client;
+package com.google.oak.evidence;
+
+import com.google.oak.util.Result;
 
 /**
  * Endorsement evidence about a trusted Oak runtime. This class contains five fields:
@@ -31,4 +33,15 @@ package com.google.oak.client;
 public class EndorsementEvidence implements Evidence {
   // TODO(#2854): We probably need a Factory class for generating EndorsementEvidence from an
   // in-toto attestation with attached signature.
+
+  /**
+   * Verifies this endorsement evidence and returns the SHA256 hash of the subject of this
+   * endorsement if the verification succeeds. Otherwise returns a result containing an error.
+   *
+   * @return SHA256 hash of the subject, or an error if the verification fails
+   */
+  Result<byte[], Exception> verify() {
+    // TODO(#2854): implement this method.
+    return Result.success(new byte[] {});
+  }
 }

--- a/java/src/main/java/com/google/oak/evidence/Evidence.java
+++ b/java/src/main/java/com/google/oak/evidence/Evidence.java
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package com.google.oak.client;
+package com.google.oak.evidence;
 
 /**
  * Marker interface representing evidence about the trustworthiness of a remote server.

--- a/java/src/main/java/com/google/oak/util/Result.java
+++ b/java/src/main/java/com/google/oak/util/Result.java
@@ -18,6 +18,7 @@ package com.google.oak.util;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -131,6 +132,26 @@ public class Result<R, E> {
   public <T> Result<T, E> andThen(final Function<R, Result<T, E>> function) {
     Result<Result<T, E>, E> result = map(function);
     return result.isSuccess() ? result.success.get() : error(result.error.get());
+  }
+
+  /**
+   * Merges the success values of two instances of {@code Result} by applying {@code function} on
+   * them. The input {@code Result} instances must have the same error type.
+   *
+   * <p>If {@code first} is an error its error content will be returned, otherwise the error
+   * content of {@code second} will be returned. If neither {@code first} nor {@code second}
+   * contains an error, the result of applying {@code function} on their success values will be
+   * returned as a success value.
+   *
+   * @param <R> type of the success value in {@code first}
+   * @param <T> type of the success value in {@code second}
+   * @param <U> type of the success value of the output
+   * @param <E> type of the error value
+   * @return the result of merging {@code first} and {@code second} as described above
+   */
+  public static <R, T, U, E> Result<U, E> merge(
+      final Result<R, E> first, final Result<T, E> second, BiFunction<R, T, U> function) {
+    return first.andThen(f -> second.map(s -> function.apply(f, s)));
   }
 
   // Private constructor to disallow creation of instances that could violate the invariant of this

--- a/java/src/test/java/com/google/oak/client/OakClientTest.java
+++ b/java/src/test/java/com/google/oak/client/OakClientTest.java
@@ -19,6 +19,7 @@ package com.google.oak.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.oak.evidence.Evidence;
 import com.google.oak.util.Result;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -38,7 +39,7 @@ public class OakClientTest {
     assertEquals("Hello!", response.success().get());
   }
 
-  private static class PilotOakClient extends OakClient<String, String> {
+  private static class PilotOakClient implements OakClient<String, String> {
     final PilotRpcClient rpcClient;
     final Encryptor encryptor;
 
@@ -55,7 +56,7 @@ public class OakClientTest {
     }
 
     @Override
-    Result<String, Exception> send(final String request) {
+    public Result<String, Exception> send(final String request) {
       return encryptor.encrypt(request.getBytes())
           .andThen(rpcClient::send)
           .andThen(encryptor::decrypt)
@@ -77,7 +78,7 @@ public class OakClientTest {
 
   private static class PilotAttestationClient
       implements OakClient.EncryptorProvider<Encryptor>,
-          OakClient.RpcClientProvider<PilotRpcClient> {
+                 OakClient.RpcClientProvider<PilotRpcClient> {
     final PilotRpcClient rpcClient;
     final Encryptor encryptor = new Encryptor() {
       @Override
@@ -101,7 +102,7 @@ public class OakClientTest {
     }
 
     @Override
-    public Result<?PilotRpcClient, Exception> getRpcClient() {
+    public Result<PilotRpcClient, Exception> getRpcClient() {
       return Result.success(rpcClient);
     }
 

--- a/java/src/test/java/com/google/oak/client/amd/AmdAttestedOakClientTest.java
+++ b/java/src/test/java/com/google/oak/client/amd/AmdAttestedOakClientTest.java
@@ -1,0 +1,62 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.client.amd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.oak.client.Encryptor;
+import com.google.oak.client.RpcClient;
+import com.google.oak.evidence.Evidence;
+import com.google.oak.util.Result;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.AdditionalMatchers;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class AmdAttestedOakClientTest {
+  private RpcClient rpcClient = Mockito.mock(RpcClient.class);
+  private Encryptor encryptor = Mockito.mock(Encryptor.class);
+  static final byte[] MESSAGE_BYTES = new byte[] {'H', 'e', 'l', 'l', 'o'};
+  static final byte[] ENCRYPTED_BYTES = new byte[] {'1', '2', '3', '4', '5'};
+
+  @Before
+  public void setup() {
+    when(rpcClient.send(any(byte[].class))).thenReturn(Result.success(MESSAGE_BYTES));
+    when(encryptor.encrypt(any(byte[].class))).thenReturn(Result.success(ENCRYPTED_BYTES));
+    when(encryptor.decrypt(any(byte[].class))).thenReturn(Result.success(MESSAGE_BYTES));
+  }
+
+  @Test
+  public void testSend() {
+    AmdAttestedOakClient<RpcClient> oakClient =
+        new AmdAttestedOakClient.Builder<>()
+            .withEncryptorProvider(publicKey -> Result.success(encryptor))
+            .withClientProvider(() -> Result.success(rpcClient))
+            .build()
+            .success()
+            .get();
+    Result<byte[], Exception> response = oakClient.send(MESSAGE_BYTES);
+    assertTrue(response.isSuccess());
+    assertEquals(MESSAGE_BYTES, response.success().get());
+  }
+}

--- a/java/src/test/java/com/google/oak/util/ResultTest.java
+++ b/java/src/test/java/com/google/oak/util/ResultTest.java
@@ -112,4 +112,37 @@ public class ResultTest {
     assertEquals(ERR_MSG, result.error().get());
     assertTrue(result.success().isEmpty());
   }
+
+  @Test
+  public void testMergeSuccessAndSuccess() {
+    Result<Integer, String> first = Result.success(1);
+    Result<Integer, String> second = Result.success(2);
+
+    Result<Integer, String> result = Result.merge(first, second, (f, s) -> f + s);
+    assertTrue(result.isSuccess());
+    assertEquals(3, result.success().get().intValue());
+    assertTrue(result.error().isEmpty());
+  }
+
+  @Test
+  public void testMergeSuccessAndError() {
+    Result<Integer, String> first = Result.success(1);
+    Result<Integer, String> second = Result.error(ERR_MSG);
+
+    Result<Integer, String> result = Result.merge(first, second, (f, s) -> f + s);
+    assertTrue(result.isError());
+    assertEquals(ERR_MSG, result.error().get());
+    assertTrue(result.success().isEmpty());
+  }
+
+  @Test
+  public void testMergeErrorAndError() {
+    Result<Integer, String> first = Result.error(ERR_MSG);
+    Result<Integer, String> second = Result.error(ERR_MSG + ERR_MSG);
+
+    Result<Integer, String> result = Result.merge(first, second, (f, s) -> f + s);
+    assertTrue(result.isError());
+    assertEquals(ERR_MSG, result.error().get());
+    assertTrue(result.success().isEmpty());
+  }
 }


### PR DESCRIPTION
This PR:

- Adds placeholder implementation for `AmdAttestedOakClient`, and `AmdAttestationReport`.
- Moves classes related to `Evidence` into a separate package.
- Removes the abstract builder in `OakClient`, as a good implementation of it would require too many type parameters, and would not do much really.

Notable next steps:
- Implement Rekor logEntry verification and `verify` in `EndorsementEvidence`.
- Unifying the Rust and Java implementation. It is probably best to do this after updating the interactive remote attestation implementation. 

Ref #3066