### PR TITLE
Excise `anyhow` from the `sev_guest` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4709,7 +4709,6 @@ dependencies = [
 name = "sev_guest"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "bitflags",
  "static_assertions",
  "strum",

--- a/experimental/sev_guest/Cargo.toml
+++ b/experimental/sev_guest/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = { version = "*", default-features = false }
 bitflags = "*"
 static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }


### PR DESCRIPTION
`anyhow` uses the heap, so it requires a global allocator. We don't have one in the SEV-SNP hello world kernel.

This does the laziest thing of replacing the error with a `&'static str`; it worked for all but one location where unfortunately we will now lose the error code.

We should really introduce proper error types for this, but for now, this will let us move forward.