### PR TITLE
Map last two gigabytes of virtual address space to physical 0x0

### DIFF
--- a/third_party/rust-hypervisor-firmware-boot/src/paging.rs
+++ b/third_party/rust-hypervisor-firmware-boot/src/paging.rs
@@ -39,8 +39,18 @@ pub fn setup() {
         l3[i].set_addr(phys_addr(l2), pt_flags);
     }
 
+    // Upper half hack: we point the last two entries of the L3 table to the same L2 tables as the
+    // first two entries, and then we point to the last entry of the L4 table to the same L3 table
+    // as the first entry in the L4 table. This means we get an extra identity-mapped region at
+    // -2GB of virtual memory, where the kernel will live.
+    let addr_0 = l3[0].addr();
+    let addr_1 = l3[1].addr();
+    l3[510].set_addr(addr_0, pt_flags);
+    l3[511].set_addr(addr_1, pt_flags);
+
     // Point L4 at L3
     l4[0].set_addr(phys_addr(l3), pt_flags);
+    l4[511].set_addr(phys_addr(l3), pt_flags);
 
     // Point Cr3 at L4
     let (cr3_frame, cr3_flags) = Cr3::read();


### PR DESCRIPTION
Follow-up to #3158 -- we're rewriting page tables after the kernel starts, so we need to make sure we don't pull the rug from under our feet.

This code is temporary. In the not-too-distant-future I want to replace the whole `rust_hypervisor_firmware_boot::paging` code that just sets up identity mapping with more intelligent page table construction that pays attention to where the different ELF sections should go, and what permissions those regions should get (see #2983 and #2986). But for now, this hack allows us to progress on #2984.

Steps needed to load the kernel to the upper half:
- [x]  map physical 0x0 to virtual -2G during initial boot
- [x]  keep the -2G mapping when setting up page tables in `rust_hypervisor_firmware_boot::paging::init()`
- [ ]  change the kernel virtual address to -2G in `layout.ld`