### PR TITLE
Move the kernel to the upper half of VMA

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/layout.ld
+++ b/experimental/oak_baremetal_app_crosvm/layout.ld
@@ -37,8 +37,8 @@ PHDRS
     secrets PT_LOAD FLAGS(1 << 24);
 }
 
-/* To set kernel VMA to high memory, set this to 0xFFFFFFFF80000000. */
-KERNEL_MEM_START = 0x0;
+/* To set kernel VMA to low memory, set this to 0x0. */
+KERNEL_MEM_START = 0xFFFFFFFF80000000;
 
 SECTIONS {
     /*

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -65,6 +65,7 @@ pub fn start_kernel<E: boot::E820Entry, B: boot::BootInfo<E>>(info: B) -> ! {
     logging::init_logging();
     interrupts::init_idt();
     paging::setup();
+    log::info!("here");
     // We need to be done with the boot info struct before intializing memory. For example, the
     // multiboot protocol explicitly states data can be placed anywhere in memory; therefore, it's
     // highly likely we will overwrite some data after we initialize the heap. args::init_args()

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -65,7 +65,6 @@ pub fn start_kernel<E: boot::E820Entry, B: boot::BootInfo<E>>(info: B) -> ! {
     logging::init_logging();
     interrupts::init_idt();
     paging::setup();
-    log::info!("here");
     // We need to be done with the boot info struct before intializing memory. For example, the
     // multiboot protocol explicitly states data can be placed anywhere in memory; therefore, it's
     // highly likely we will overwrite some data after we initialize the heap. args::init_args()

--- a/experimental/oak_baremetal_kernel/src/memory.rs
+++ b/experimental/oak_baremetal_kernel/src/memory.rs
@@ -46,10 +46,12 @@ pub fn init_allocator<E: boot::E820Entry, B: boot::BootInfo<E>>(
     let text_end = rust_hypervisor_firmware_boot::text_end();
     let stack_start = rust_hypervisor_firmware_boot::stack_start();
 
-    info!("RAM_MIN: {}", ram_min);
-    info!("TEXT_START: {}", text_start);
-    info!("TEXT_END: {}", text_end);
-    info!("STACK_START: {}", stack_start);
+    info!("RAM_MIN: {:#X}", ram_min);
+    info!("TEXT_START: {:#X}", text_start);
+    info!("TEXT_END: {:#X}", text_end);
+    info!("STACK_START: {:#X}", stack_start);
+
+    let stack_start = stack_start - 0xFFFFFFFF80000000;
 
     // Find the largest slice of memory and use that for the heap.
     let largest = info

--- a/third_party/rust-hypervisor-firmware-boot/src/paging.rs
+++ b/third_party/rust-hypervisor-firmware-boot/src/paging.rs
@@ -38,6 +38,11 @@ pub fn setup() {
     for (i, l2) in l2s.iter().enumerate() {
         l3[i].set_addr(phys_addr(l2), pt_flags);
     }
+    // Upper half hack.
+    let addr_0 = l3[0].addr();
+    let addr_1 = l3[1].addr();
+    l3[510].set_addr(addr_0, pt_flags);
+    l3[511].set_addr(addr_1, pt_flags);
 
     // Upper half hack: we point the last two entries of the L3 table to the same L2 tables as the
     // first two entries, and then we point to the last entry of the L4 table to the same L3 table

--- a/third_party/rust-hypervisor-firmware-boot/src/paging.rs
+++ b/third_party/rust-hypervisor-firmware-boot/src/paging.rs
@@ -38,11 +38,6 @@ pub fn setup() {
     for (i, l2) in l2s.iter().enumerate() {
         l3[i].set_addr(phys_addr(l2), pt_flags);
     }
-    // Upper half hack.
-    let addr_0 = l3[0].addr();
-    let addr_1 = l3[1].addr();
-    l3[510].set_addr(addr_0, pt_flags);
-    l3[511].set_addr(addr_1, pt_flags);
 
     // Upper half hack: we point the last two entries of the L3 table to the same L2 tables as the
     // first two entries, and then we point to the last entry of the L4 table to the same L3 table

--- a/third_party/rust-hypervisor-firmware-boot/src/paging.rs
+++ b/third_party/rust-hypervisor-firmware-boot/src/paging.rs
@@ -68,5 +68,5 @@ pub fn setup() {
 
 // Map a virtual address to a PhysAddr (assumes identity mapping)
 fn phys_addr<T>(virt_addr: *const T) -> PhysAddr {
-    PhysAddr::new(virt_addr as u64)
+    PhysAddr::new(virt_addr as u64 - 0xFFFFFFFF80000000)
 }


### PR DESCRIPTION
This builds on #3158 and #3159 by actually setting the kernel virtual addresses to the kernel half of the address space.
Unfortunately Github doesn't have the concept of "this PR is dependent on those two", so this change contains changes from both of these. The core change here is the two-line change in `layout.ld`:

https://github.com/project-oak/oak/blob/fe8a7f0aecc3bf319ba7a3045155fb52a5d88783/experimental/oak_baremetal_app_crosvm/layout.ld#L40-41

Closes #2984.

Steps needed to load the kernel to the upper half:
- [x]  map physical 0x0 to virtual -2G during initial boot
- [x]  keep the -2G mapping when setting up page tables in `rust_hypervisor_firmware_boot::paging::init()`
- [x]  change the kernel virtual address to -2G in `layout.ld`