### PR TITLE
Load ELF headers into memory

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/layout.ld
+++ b/experimental/oak_baremetal_app_crosvm/layout.ld
@@ -23,6 +23,7 @@ PHDRS
      * has a sanity check that expects the section with the lowest address to come
      * first.
      */
+    hdrs    PT_LOAD FILEHDR PHDRS FLAGS(4);
     /* Executable text. */
     boot    PT_LOAD FLAGS(4 + 1); /* PF_R + PF_X */
     text    PT_LOAD FLAGS(4 + 1); /* PF_R + PF_X */
@@ -41,12 +42,19 @@ PHDRS
 KERNEL_MEM_START = 0xFFFFFFFF80000000;
 
 SECTIONS {
-    /*
+    /* Don't touch the lower 2M of memory; there be dragons there. */
+    . = 2M;
+
+    hdrs = .;
+    . += SIZEOF_HEADERS;
+    .hdrs : {
+    } : hdrs
+
+     /*
      * Boot code is executed with identity mapping; the main duty of the boot
      * code is to set up proper page tables before jumping to the kernel proper.
-     * We place that at 2M (both virtual and physical)
      */
-    .boot 0x200000 : {
+    .boot : ALIGN(4K) {
         ram_min = .;
         *(.boot)
     } : boot


### PR DESCRIPTION
This PR will make the ELF file header (`FILEHDR`) and program headers (`PHDRS`) available for us during runtime.

The program headers will be useful in the future when constructing page tables for the kernel, as they tell us (a) which sections where loaded where in the physical memory, (b) what the virtual addresses should be, and (c) what privileges (write/execute) are needed for that section. This will allow us to map executable code with just execute bit set and data with just the write bit set, for example.

The section(s) containing `FILEHDR` and `PHDRS` have to be the first ones in the file. Previously we had the boot code at the 2M boundary, this will load the headers at the 2M mark, and punt the boot code up by 4K (one page size).