### PR TITLE
Experimental: Use SLSA generic workflow for generating provenances

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -18,6 +18,7 @@ jobs:
       OAK_FUNCTIONS_BASE_PATH: './target/x86_64-unknown-linux-musl/release/oak_functions_loader_base'
       OAK_FUNCTIONS_UNSAFE_PATH: './target/x86_64-unknown-linux-musl/release/oak_functions_loader_unsafe'
       OAK_BAREMETAL_CROSVM_PATH: './experimental/oak_baremetal_app_crosvm/target/x86_64-unknown-none/release/oak_baremetal_app_crosvm'
+      OAK_FUNCTIONS_RELEASE_PATH: './target/x86_64-unknown-linux-musl/release'
 
     permissions:
       # Allow the job to update the repo with the latest provenances and index.
@@ -133,3 +134,32 @@ jobs:
           OAK_FUNCTIONS_BASE_PATH: ${{ env.OAK_FUNCTIONS_BASE_PATH }}
           OAK_FUNCTIONS_UNSAFE_PATH: ${{ env.OAK_FUNCTIONS_UNSAFE_PATH }}
           OAK_BAREMETAL_CROSVM_PATH: ${{ env.OAK_BAREMETAL_CROSVM_PATH }}
+
+      # Experimental step using SLSA generic provenance generator
+      # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md
+      - name: Generate oak_functions_loader_base hash
+        id: hash
+        run: |
+          # first cd to the release path. This allows us calling sha256 on oak_functions_loader_base
+          # instead of having to provide the full path. This is fine for this experimental version,
+          # but has to be cleaned-up once we switch completely to SLSA provenance generation.
+          cd ${{ env.OAK_FUNCTIONS_RELEASE_PATH }}
+          # sha256sum generates sha256 hash for oak_functions_loader_base.
+          # base64 --wrap=0 disables line wrapping, and encodes to base64 and outputs on a single line.
+          echo "::set-output name=hashes::$(sha256sum oak_functions_loader_base | base64 --wrap=0)"
+
+  # This step calls the generic workflow to generate provenance.
+  # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md
+  provenance:
+    needs: [build_provenance]
+    permissions:
+      actions: read
+      id-token: write
+      contents: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    with:
+      base64-subjects: '${{ needs.build_provenance.outputs.hashes }}'
+      # Set a custom name for the provenance attestation.
+      attestation-name: 'oak_functions_loader_base.intoto.jsonl'
+      # Upload provenance to a new release
+      upload-assets: true

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -155,7 +155,7 @@ jobs:
     permissions:
       actions: read
       id-token: write
-      contents: read
+      contents: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
     with:
       base64-subjects: '${{ needs.build_provenance.outputs.hashes }}'

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -10,6 +10,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Temporarily add workflow_dispatch as a trigger, for experimenting with the generic SLSA provenance generator.
+  workflow_dispatch:
+    branches: [main]
 
 jobs:
   build_provenance:
@@ -148,9 +151,10 @@ jobs:
           # base64 --wrap=0 disables line wrapping, and encodes to base64 and outputs on a single line.
           echo "::set-output name=hashes::$(sha256sum oak_functions_loader_base | base64 --wrap=0)"
 
-  # This step calls the generic workflow to generate provenance.
+  # This job calls the generic workflow to generate provenance.
   # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md
   provenance:
+    if: github.event_name != 'pull_request'
     needs: [build_provenance]
     permissions:
       actions: read


### PR DESCRIPTION
This PR adds a new job to the provenance workflow to generate a signed provenance using the generic SLSA generator. This is in an experimental state, since it is not possible to trigger the generator on pull-request events. I have added `workflow_dispatch` as a trigger for the provenance workflow. Once this is merged it is possible to experiment with provenance generation. 

If that is successful, I'll cleanup and complete the added step. 