### PR TITLE
Create a bitmap allocator for physical frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "assertables"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d107d80a1ae5c4e936ef0954685c3bae0bbd1a387dd474ca6ab908cb2d945973"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +383,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1452,6 +1473,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,7 +2499,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrayvec",
+ "assertables",
  "atomic_refcell",
+ "bitvec",
  "lazy_static",
  "libm 0.2.5",
  "linked_list_allocator",
@@ -3546,6 +3575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,6 +4457,12 @@ dependencies = [
  "winapi",
  "winx",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -5973,6 +6014,15 @@ dependencies = [
  "wasmparser 0.78.2",
  "wasmtime",
  "wasmtime-wasi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -91,6 +91,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +350,12 @@ dependencies = [
  "smallvec",
  "thiserror_core2",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -605,6 +623,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "atomic_refcell",
+ "bitvec",
  "lazy_static",
  "libm",
  "linked_list_allocator",
@@ -902,6 +921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1335,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"

--- a/experimental/oak_baremetal_kernel/Cargo.toml
+++ b/experimental/oak_baremetal_kernel/Cargo.toml
@@ -16,6 +16,7 @@ simple_io_channel = ["oak_baremetal_simple_io"]
 anyhow = { version = "*", default-features = false }
 arrayvec = { version = "*", default-features = false }
 atomic_refcell = "*"
+bitvec = { version = "*", default-features = false }
 lazy_static = { version = "*", features = ["spin_no_std"] }
 linked_list_allocator = { version = "*" }
 log = "*"
@@ -28,3 +29,6 @@ strum = { version = "*", default-features = false, features = ["derive"] }
 uart_16550 = "*"
 virtio = { path = "../virtio", optional = true }
 x86_64 = "*"
+
+[dev-dependencies]
+assertables = "*"

--- a/experimental/oak_baremetal_kernel/src/lib.rs
+++ b/experimental/oak_baremetal_kernel/src/lib.rs
@@ -28,7 +28,7 @@
 //!   * Implement a `#[panic_handler]` that delegates to `panic()` in this crate.
 //!   * Call `start_kernel` from the entry point of the bootloader.
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![feature(abi_x86_interrupt)]
 #![feature(core_c_str)]
 #![feature(once_cell)]
@@ -41,6 +41,7 @@ mod interrupts;
 mod libm;
 mod logging;
 mod memory;
+mod mm;
 #[cfg(feature = "serial_channel")]
 mod serial;
 #[cfg(feature = "simple_io_channel")]

--- a/experimental/oak_baremetal_kernel/src/mm/bitmap_frame_allocator.rs
+++ b/experimental/oak_baremetal_kernel/src/mm/bitmap_frame_allocator.rs
@@ -1,0 +1,347 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use bitvec::{order::Lsb0, prelude::BitArray};
+use core::{
+    ops::{BitAnd, Not},
+    option::Option,
+};
+use x86_64::structures::paging::{
+    frame::PhysFrameRangeInclusive, page::PageSize, FrameAllocator, FrameDeallocator, PhysFrame,
+};
+
+/// Basic frame allocator implementation that keeps track of PageSize-sized chunks of contiguous
+/// memory with a bitmap.
+///
+/// This implementation tracks memory using two bitmaps:
+///   - `valid`, which tracks whether a frame can be allocated at all (not all physical frames are
+///     usable memory)
+///   - `allocated`, which tracks whether a frame is currently allocated or not.
+///
+/// A frame can be in one of three states:
+///  valid = 0, allocated = _ -- the allocator will never hand out said frame.
+///  valid = 1, allocated = 0 -- the frame is eligible for allocation.
+///  valid = 1, allocated = 1 -- the frame is currently in use.
+///
+/// The BitmapAllocator itself does not use memory allocation (no heap is required), but rather
+/// expects that the const parameter N is set to the exact number of u64-s required to construct a
+/// bitmap covering the memory range.
+/// (In container-ish terms, N specifies the capacity of the allocator, which can not be resized.)
+#[derive(Debug)]
+pub(crate) struct BitmapAllocator<S: PageSize, const N: usize> {
+    allocated: BitArray<[u64; N], Lsb0>,
+    valid: BitArray<[u64; N], Lsb0>,
+    range: PhysFrameRangeInclusive<S>,
+}
+
+impl<S: PageSize, const N: usize> BitmapAllocator<S, N> {
+    /// Creates a new bitmap allocator for a physical frame range.
+    /// Panics if N does not match the number of u64-s required to track all frames in that range.
+    /// Initially, the allocator will mark the whole range as invalid.
+    #[allow(dead_code)]
+    pub fn new(range: PhysFrameRangeInclusive<S>) -> Self {
+        // Unfortunately there doesn't seem to be a way to hoist this to the type system.
+        let expected = bitvec::mem::elts::<u64>(range.count());
+        if expected != N {
+            panic!(
+                "BitmapAllocator bitmap size does not match FrameRange size; expected {}, got {}",
+                expected, N
+            );
+        }
+
+        Self {
+            allocated: BitArray::ZERO,
+            valid: BitArray::ZERO,
+            range,
+        }
+    }
+
+    /// Marks a region of memory as either valid or invalid.
+    ///
+    /// Allocations can happen only from regions that are valid. This method does not check whether
+    /// any allocations have been made from regions to be marked as invalid, and panics if the range
+    /// is outside the range of the allocator.
+    #[allow(dead_code)]
+    pub fn mark_valid(&mut self, range: PhysFrameRangeInclusive<S>, valid: bool) {
+        if let (Some(start), Some(end)) = (self.frame_idx(range.start), self.frame_idx(range.end)) {
+            self.valid.get_mut(start..end + 1).unwrap().fill(valid);
+        } else {
+            panic!(
+                "Can't mark validity for frame range that's outside our range; our range: {:?}, frame range: {:?}",
+                self.range, range
+            );
+        }
+    }
+
+    /// Returns the largest contiguous section of unallocated memory.
+    #[allow(dead_code)]
+    pub fn largest_available(&self) -> Option<PhysFrameRangeInclusive<S>> {
+        self.valid
+            .bitand(self.allocated.not())
+            .iter_ones()
+            // Identify streaks of zeroes: for example, 0100 will yield (0,0), (2,2), (2,3)
+            .scan(None, |state, idx| {
+                let start_idx = state.map_or_else(
+                    || idx,
+                    |(start_idx, end_idx)| if idx == end_idx + 1 { start_idx } else { idx },
+                );
+                *state = Some((start_idx, idx));
+                Some((start_idx, idx))
+            })
+            .max_by_key(|(start_idx, end_idx)| end_idx - start_idx)
+            .map(|(start_idx, end_idx)| {
+                PhysFrame::range_inclusive(
+                    self.frame(start_idx).unwrap(),
+                    self.frame(end_idx).unwrap(),
+                )
+            })
+    }
+
+    /// Tries to allocate a specific frame range in the range managed by the allocator.
+    ///
+    /// Returns the same frame range if the allocation was successful; None, if not.
+    ///
+    /// Panics if the frame is outside the bounds of memory that is managed by this allocator.
+    #[allow(dead_code)]
+    pub fn allocate(
+        &mut self,
+        frame_range: PhysFrameRangeInclusive<S>,
+    ) -> Option<PhysFrameRangeInclusive<S>> {
+        if let (Some(start_idx), Some(end_idx)) = (
+            self.frame_idx(frame_range.start),
+            self.frame_idx(frame_range.end),
+        ) {
+            if self.valid.bitand(self.allocated.not())[start_idx..end_idx + 1].not_all() {
+                return None;
+            }
+            self.allocated[start_idx..end_idx + 1].fill(true);
+            Some(frame_range)
+        } else {
+            panic!(
+                    "Can't allocate frame range that's outside our range; our range: {:?}, frame range: {:?}",
+                    self.range, frame_range
+                );
+        }
+    }
+
+    fn frame(&self, frame_idx: usize) -> Option<PhysFrame<S>> {
+        self.range.clone().nth(frame_idx)
+    }
+
+    fn frame_idx(&self, frame: PhysFrame<S>) -> Option<usize> {
+        if frame < self.range.start || frame > self.range.end {
+            None
+        } else {
+            Some(
+                ((frame.start_address().as_u64() - self.range.start.start_address().as_u64())
+                    / S::SIZE) as usize,
+            )
+        }
+    }
+}
+
+unsafe impl<S: PageSize, const N: usize> FrameAllocator<S> for BitmapAllocator<S, N> {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<S>> {
+        let frame_idx = self.valid.bitand(self.allocated.not()).first_one()?;
+        self.allocated.set(frame_idx, true);
+        self.frame(frame_idx)
+    }
+}
+
+impl<S: PageSize, const N: usize> FrameDeallocator<S> for BitmapAllocator<S, N> {
+    unsafe fn deallocate_frame(&mut self, frame: PhysFrame<S>) {
+        if let Some(frame_idx) = self.frame_idx(frame) {
+            if !self.valid[frame_idx] {
+                panic!("Frame {:?} is not valid in this allocator", frame);
+            }
+            if !self.allocated[frame_idx] {
+                panic!("Frame {:?} was not allocated in this allocator", frame);
+            }
+            self.allocated.set(frame_idx, false);
+        } else {
+            panic!(
+                "Can't deallocate frame that's outside our range; our range: {:?}, frame: {:?}",
+                self.range, frame
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use assertables::*;
+    use x86_64::{structures::paging::Size4KiB, PhysAddr};
+
+    fn create_allocator<const N: usize>(start: u64, end: u64) -> BitmapAllocator<Size4KiB, N> {
+        BitmapAllocator::<Size4KiB, N>::new(PhysFrame::range_inclusive(
+            PhysFrame::from_start_address(PhysAddr::new(start)).unwrap(),
+            PhysFrame::from_start_address(PhysAddr::new(end)).unwrap(),
+        ))
+    }
+
+    fn create_frame(start: u64) -> PhysFrame<Size4KiB> {
+        PhysFrame::from_start_address(PhysAddr::new(start)).unwrap()
+    }
+
+    fn create_frame_range(start: u64, end: u64) -> PhysFrameRangeInclusive<Size4KiB> {
+        PhysFrame::range_inclusive(create_frame(start), create_frame(end))
+    }
+
+    #[test]
+    fn silly_allocator_invalid() {
+        let mut alloc = create_allocator::<1>(0x0000, 0x0000);
+        // Nothing is valid yet.
+        assert_eq!(None, alloc.allocate_frame());
+    }
+
+    #[test]
+    fn silly_allocator_valid() {
+        let mut alloc = create_allocator::<1>(0x0000, 0x0000);
+        alloc.mark_valid(create_frame_range(0x0000, 0x0000), true);
+        assert_eq!(Some(create_frame(0x0000)), alloc.allocate_frame());
+    }
+
+    #[should_panic]
+    #[test]
+    fn silly_allocator_invalid_size() {
+        create_allocator::<0>(0x0000, 0x0000);
+    }
+
+    #[test]
+    fn double_allocate() {
+        let mut alloc = create_allocator::<1>(0x0000, 0x0000);
+        alloc.mark_valid(create_frame_range(0x0000, 0x0000), true);
+        assert_eq!(Some(create_frame(0x0000)), alloc.allocate_frame());
+        assert_eq!(None, alloc.allocate_frame());
+    }
+
+    #[test]
+    fn new_allocator_success() {
+        let expected_frames: Vec<PhysFrame<Size4KiB>> =
+            (0..9).map(|x| create_frame(x * 0x1000)).collect();
+
+        let mut alloc = create_allocator::<1>(0x0000, (expected_frames.len() - 1) as u64 * 0x1000);
+        alloc.mark_valid(
+            create_frame_range(0x0000, (expected_frames.len() - 1) as u64 * 0x1000),
+            true,
+        );
+
+        let got_frames: Vec<PhysFrame<Size4KiB>> = (0..expected_frames.len())
+            .map(|_| alloc.allocate_frame().unwrap())
+            .collect();
+
+        assert_set_eq!(expected_frames, got_frames);
+        assert_eq!(None, alloc.allocate_frame());
+    }
+
+    #[test]
+    fn realloc() {
+        let mut alloc = create_allocator::<1>(0x0000, 0x0000);
+        alloc.mark_valid(create_frame_range(0x0000, 0x0000), true);
+        assert_eq!(Some(create_frame(0x0000)), alloc.allocate_frame());
+        assert_eq!(None, alloc.allocate_frame());
+        unsafe {
+            alloc.deallocate_frame(create_frame(0x0000));
+        }
+        assert_eq!(Some(create_frame(0x0000)), alloc.allocate_frame());
+        assert_eq!(None, alloc.allocate_frame());
+    }
+
+    #[should_panic]
+    #[test]
+    fn dealloc_unallocated() {
+        let mut alloc = create_allocator::<1>(0x0000, 0x1000);
+        unsafe {
+            alloc.deallocate_frame(create_frame(0x0000));
+        }
+    }
+
+    #[should_panic]
+    #[test]
+    fn dealloc_outside_lo() {
+        let mut alloc = create_allocator::<1>(0x1000, 0x2000);
+        unsafe {
+            alloc.deallocate_frame(create_frame(0x0000));
+        }
+    }
+
+    #[should_panic]
+    #[test]
+    fn dealloc_outside_hi() {
+        let mut alloc = create_allocator::<1>(0x1000, 0x2000);
+        unsafe {
+            alloc.deallocate_frame(create_frame(0x2000));
+        }
+    }
+
+    #[test]
+    fn alloc_hi() {
+        let mut alloc = create_allocator::<1>(0x1000, 0x1000);
+        alloc.mark_valid(create_frame_range(0x1000, 0x1000), true);
+        assert_eq!(Some(create_frame(0x1000)), alloc.allocate_frame());
+        assert_eq!(None, alloc.allocate_frame());
+    }
+
+    #[test]
+    fn hole_in_validity() {
+        let mut alloc = create_allocator::<1>(0x0000, 0x2000);
+        let expected_frames = vec![create_frame(0x0000), create_frame(0x2000)];
+
+        expected_frames
+            .iter()
+            .for_each(|frame| alloc.mark_valid(PhysFrame::range_inclusive(*frame, *frame), true));
+        let got_frames: Vec<PhysFrame<Size4KiB>> = (0..expected_frames.len())
+            .map(|_| alloc.allocate_frame().unwrap())
+            .collect();
+        assert_set_eq!(expected_frames, got_frames);
+        assert_eq!(None, alloc.allocate_frame());
+    }
+
+    #[should_panic]
+    #[test]
+    fn valid_outside_range_lo() {
+        let mut alloc = create_allocator::<1>(0x1000, 0x2000);
+        alloc.mark_valid(create_frame_range(0x0000, 0x0000), true);
+    }
+
+    #[test]
+    fn get_largest() {
+        let mut alloc = create_allocator::<1>(0x0000, 0x3000);
+        alloc.mark_valid(create_frame_range(0x0000, 0x3000), true);
+        let range = alloc.largest_available().unwrap();
+        assert_eq!(create_frame(0x0000), range.start);
+        assert_eq!(create_frame(0x3000), range.end);
+        alloc.mark_valid(create_frame_range(0x1000, 0x1000), false);
+        let range = alloc.largest_available().unwrap();
+        assert_eq!(create_frame(0x2000), range.start);
+        assert_eq!(create_frame(0x3000), range.end);
+    }
+
+    #[test]
+    fn test_allocate_specific_region() {
+        let mut alloc = create_allocator::<1>(0x0000, 0x1000);
+        alloc.mark_valid(create_frame_range(0x0000, 0x1000), true);
+        alloc.allocate(create_frame_range(0x0000, 0x0000)).unwrap();
+        assert_eq!(None, alloc.allocate(create_frame_range(0x0000, 0x0000)));
+        assert_eq!(None, alloc.allocate(create_frame_range(0x0000, 0x1000)));
+        assert_eq!(Some(create_frame(0x1000)), alloc.allocate_frame());
+        assert_eq!(None, alloc.allocate(create_frame_range(0x0000, 0x1000)));
+        assert_eq!(None, alloc.allocate(create_frame_range(0x1000, 0x1000)));
+        assert_eq!(None, alloc.allocate_frame());
+    }
+}

--- a/experimental/oak_baremetal_kernel/src/mm/mod.rs
+++ b/experimental/oak_baremetal_kernel/src/mm/mod.rs
@@ -1,0 +1,17 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+mod bitmap_frame_allocator;

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -50,6 +50,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +92,12 @@ dependencies = [
  "smallvec",
  "thiserror_core2",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
@@ -180,6 +198,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "atomic_refcell",
+ "bitvec",
  "lazy_static",
  "libm",
  "linked_list_allocator",
@@ -272,6 +291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rust-hypervisor-firmware-boot"
 version = "0.1.0"
 dependencies = [
@@ -362,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "thiserror_core2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +458,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x86_64"


### PR DESCRIPTION
This is the first step toward better tracking of the physical memory that we have available in the kernel.

What is implemented here is a frame allocator, limited to fixed frame sizes and memory range(s). While the algorithm is... unsophisticated, the key feature of the frame allocator is that it doesn't do dynamic memory allocation itself, as the frame allocator is initialized before the heap (in fact, the heap allocator will have to ask for memory to manage from the frame allocator).

Rough outline of what needs to be done:
- [x] implement a base bitmap allocator
- [ ] implement a real frame allocator, capable of handling requests for 2 MiB and 4 KiB frames, for ~128G of memory
- [ ] initialize the frame allocator when the kernel starts up based on data in the E820 map (and the ELF header)
- [ ] change the heap initialization code to request memory from the frame allocator instead of relying on constants in the linker script