### PR TITLE
Make remote attestation public key and attestation information available outside the handshake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache@v2
         env:
           # Increment this value to invalidate previous cache entries.
-          CACHE_VERSION: 12
+          CACHE_VERSION: 13
         with:
           path: |
             ./cargo-cache/bin

--- a/experimental/oak_baremetal_runtime/schema.fbs
+++ b/experimental/oak_baremetal_runtime/schema.fbs
@@ -2,7 +2,7 @@ attribute "method_id";
 
 rpc_service TrustedRuntime {
     HandleUserRequest(UserRequest) : UserRequestResponse (method_id: 0);
-    Initialize(Initialization) : Empty (method_id: 1);
+    Initialize(Initialization) : InitializeResponse (method_id: 1);
     // Replaces the existing lookup data with the new value.
     UpdateLookupData(LookupData) : Empty (method_id: 2);
 }
@@ -23,6 +23,15 @@ table UserRequestResponse {
 table Initialization {
     wasm_module: [ubyte];
     constant_response_size: uint;
+}
+
+table InitializeResponse {
+    public_key_info: PublicKeyInfo;
+}
+
+table PublicKeyInfo {
+    public_key: [ubyte];
+    attestation: [ubyte];
 }
 
 table LookupDataEntry {

--- a/experimental/oak_baremetal_runtime/src/lib.rs
+++ b/experimental/oak_baremetal_runtime/src/lib.rs
@@ -42,7 +42,6 @@ use oak_remote_attestation::handshaker::{
     AttestationBehavior, AttestationGenerator, AttestationVerifier,
 };
 use oak_remote_attestation_sessions::SessionId;
-use remote_attestation::PublicKeyInfo;
 
 enum InitializationState<G, V>
 where

--- a/experimental/oak_baremetal_runtime/src/lib.rs
+++ b/experimental/oak_baremetal_runtime/src/lib.rs
@@ -42,6 +42,7 @@ use oak_remote_attestation::handshaker::{
     AttestationBehavior, AttestationGenerator, AttestationVerifier,
 };
 use oak_remote_attestation_sessions::SessionId;
+use remote_attestation::PublicKeyInfo;
 
 enum InitializationState<G, V>
 where
@@ -87,7 +88,8 @@ where
     fn initialize(
         &mut self,
         initialization: &schema::Initialization,
-    ) -> Result<oak_idl::utils::OwnedFlatbuffer<crate::schema::Empty>, oak_idl::Status> {
+    ) -> Result<oak_idl::utils::OwnedFlatbuffer<crate::schema::InitializeResponse>, oak_idl::Status>
+    {
         match &mut self.initialization_state {
             InitializationState::Initialized(_attestation_handler) => Err(oak_idl::Status::new(
                 oak_idl::StatusCode::FailedPrecondition,
@@ -124,13 +126,28 @@ where
                     )
                     .map_err(|_err| oak_idl::Status::new(oak_idl::StatusCode::Internal))?,
                 );
+                let public_key_info = attestation_handler.get_public_key_info();
                 self.initialization_state = InitializationState::Initialized(attestation_handler);
                 let response_message = {
                     let mut builder = oak_idl::utils::OwnedFlatbufferBuilder::default();
-                    let user_request_response =
-                        schema::Empty::create(&mut builder, &schema::EmptyArgs {});
+                    let public_key = builder.create_vector::<u8>(&public_key_info.public_key);
+                    let attestation = builder.create_vector::<u8>(&public_key_info.attestation);
+                    let public_key_info = schema::PublicKeyInfo::create(
+                        &mut builder,
+                        &schema::PublicKeyInfoArgs {
+                            public_key: Some(public_key),
+                            attestation: Some(attestation),
+                        },
+                    );
+
+                    let initialize_response = schema::InitializeResponse::create(
+                        &mut builder,
+                        &schema::InitializeResponseArgs {
+                            public_key_info: Some(public_key_info),
+                        },
+                    );
                     builder
-                        .finish(user_request_response)
+                        .finish(initialize_response)
                         .map_err(|_err| oak_idl::Status::new(oak_idl::StatusCode::Internal))?
                 };
                 Ok(response_message)

--- a/grpc_unary_attestation/proto/BUILD
+++ b/grpc_unary_attestation/proto/BUILD
@@ -27,7 +27,7 @@ package(
 proto_library(
     name = "server_proto",
     srcs = ["unary_server.proto"],
-    deps = [],
+    deps = ["@com_google_protobuf//:empty_proto"],
 )
 
 java_proto_library(

--- a/grpc_unary_attestation/proto/unary_server.proto
+++ b/grpc_unary_attestation/proto/unary_server.proto
@@ -18,6 +18,8 @@ syntax = "proto3";
 
 package oak.session.unary.v1;
 
+import "google/protobuf/empty.proto";
+
 option java_multiple_files = true;
 option java_package = "oak.session.unary.v1";
 
@@ -32,6 +34,13 @@ message UnaryRequest {
 
 message UnaryResponse {
   bytes body = 1;
+}
+
+message PublicKeyInfo {
+  // The serialized public key.
+  bytes public_key = 1;
+  // The serialized attestation report binding the public key.
+  bytes attestation = 2;
 }
 
 // Service definition for unary communication with the runtime.
@@ -58,4 +67,8 @@ service UnarySession {
   // Messages are represented as serialized messages defined in the `remote_attestation::message.rs`
   // and `com.google.oak.remote_attestation.Message`.
   rpc Message(UnaryRequest) returns (UnaryResponse);
+
+  // Gets the public key and the attestation report that binds the public key to a specific instance
+  // of the code running in a TEE.
+  rpc GetPublicKeyInfo(google.protobuf.Empty) returns (PublicKeyInfo);
 }

--- a/grpc_unary_attestation/src/server.rs
+++ b/grpc_unary_attestation/src/server.rs
@@ -17,12 +17,21 @@
 //! Server-side implementation of the bidirectional gRPC remote attestation handshake
 //! protocol.
 
-use crate::proto::{unary_session_server::UnarySession, UnaryRequest, UnaryResponse};
-use oak_remote_attestation::handshaker::{AttestationBehavior, EmptyAttestationVerifier};
+use crate::proto::{
+    unary_session_server::UnarySession, PublicKeyInfo, UnaryRequest, UnaryResponse,
+};
+use anyhow::Context;
+use oak_remote_attestation::{
+    crypto::Signer,
+    handshaker::{AttestationBehavior, AttestationGenerator, EmptyAttestationVerifier},
+};
 use oak_remote_attestation_amd::PlaceholderAmdAttestationGenerator;
 use oak_remote_attestation_sessions::{SessionId, SessionState, SessionTracker};
 use oak_utils::LogError;
-use std::{convert::TryInto, sync::Mutex};
+use std::{
+    convert::TryInto,
+    sync::{Arc, Mutex},
+};
 use tonic;
 
 /// Number of sessions that will be kept in memory.
@@ -37,6 +46,8 @@ pub struct AttestationServer<F, L: LogError> {
     error_logger: L,
     session_tracker:
         Mutex<SessionTracker<PlaceholderAmdAttestationGenerator, EmptyAttestationVerifier>>,
+    signing_public_key: Vec<u8>,
+    attestation: Vec<u8>,
 }
 
 impl<F, S, L> AttestationServer<F, L>
@@ -46,17 +57,24 @@ where
     L: Send + Sync + Clone + LogError,
 {
     pub fn create(request_handler: F, error_logger: L) -> anyhow::Result<Self> {
+        let transcript_signer = Arc::new(Signer::create().context("Couldn't create signer")?);
+        let signing_public_key = transcript_signer.public_key()?.to_vec();
+        let attestation_generator = PlaceholderAmdAttestationGenerator;
+        let attestation = attestation_generator.generate_attestation(&signing_public_key)?;
         let session_tracker = Mutex::new(SessionTracker::create(
             SESSIONS_CACHE_SIZE,
             AttestationBehavior::create(
                 PlaceholderAmdAttestationGenerator,
                 EmptyAttestationVerifier,
             ),
+            transcript_signer,
         ));
         Ok(Self {
             request_handler,
             error_logger,
             session_tracker,
+            signing_public_key,
+            attestation,
         })
     }
 }
@@ -138,6 +156,16 @@ where
             .put_session_state(session_id, session_state);
         Ok(tonic::Response::new(UnaryResponse {
             body: response_body,
+        }))
+    }
+
+    async fn get_public_key_info(
+        &self,
+        _request: tonic::Request<()>,
+    ) -> anyhow::Result<tonic::Response<PublicKeyInfo>, tonic::Status> {
+        Ok(tonic::Response::new(PublicKeyInfo {
+            public_key: self.signing_public_key.clone(),
+            attestation: self.attestation.clone(),
         }))
     }
 }

--- a/grpc_unary_attestation/src/server.rs
+++ b/grpc_unary_attestation/src/server.rs
@@ -59,14 +59,16 @@ where
     pub fn create(request_handler: F, error_logger: L) -> anyhow::Result<Self> {
         let transcript_signer = Arc::new(Signer::create().context("Couldn't create signer")?);
         let signing_public_key = transcript_signer.public_key()?.to_vec();
-        let attestation_generator = PlaceholderAmdAttestationGenerator;
-        let attestation = attestation_generator.generate_attestation(&signing_public_key)?;
+        let attestation_behavior = AttestationBehavior::create(
+            PlaceholderAmdAttestationGenerator,
+            EmptyAttestationVerifier,
+        );
+        let attestation = attestation_behavior
+            .generator
+            .generate_attestation(&signing_public_key)?;
         let session_tracker = Mutex::new(SessionTracker::create(
             SESSIONS_CACHE_SIZE,
-            AttestationBehavior::create(
-                PlaceholderAmdAttestationGenerator,
-                EmptyAttestationVerifier,
-            ),
+            attestation_behavior,
             transcript_signer,
         ));
         Ok(Self {

--- a/remote_attestation/rust/src/tests/handshaker.rs
+++ b/remote_attestation/rust/src/tests/handshaker.rs
@@ -15,14 +15,14 @@
 //
 
 use crate::{
-    crypto::{get_sha256, SHA256_HASH_LENGTH},
+    crypto::{get_sha256, Signer, SHA256_HASH_LENGTH},
     handshaker::{
         hash_concat_hash, AttestationBehavior, AttestationGenerator, AttestationVerifier,
         ClientHandshaker, ServerHandshaker,
     },
     tests::message::INVALID_MESSAGE_HEADER,
 };
-use alloc::vec;
+use alloc::{sync::Arc, vec};
 use assert_matches::assert_matches;
 
 const DATA: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -70,7 +70,11 @@ fn create_handshakers() -> (
     let bidirectional_attestation =
         AttestationBehavior::create(TestAttestationGenerator, TestAttestationVerifier);
 
-    let server_handshaker = ServerHandshaker::new(bidirectional_attestation).unwrap();
+    let server_handshaker = ServerHandshaker::new(
+        bidirectional_attestation,
+        Arc::new(Signer::create().expect("Couldn't create signer")),
+    )
+    .unwrap();
 
     (client_handshaker, server_handshaker)
 }


### PR DESCRIPTION
This change makes information about the attestation public key available to the client via a separate RPC method. This is the first step towards fixing #3096