### PR TITLE
Set subject in the output of the provenance workflow

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   build_provenance:
     outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}  
+      hashes: ${{ steps.hash.outputs.hashes }}
     runs-on: ubuntu-20.04
     env:
       OAK_FUNCTIONS_BASE_PATH: './target/x86_64-unknown-linux-musl/release/oak_functions_loader_base'
@@ -152,14 +152,6 @@ jobs:
           # sha256sum generates sha256 hash for oak_functions_loader_base.
           # base64 --wrap=0 disables line wrapping, and encodes to base64 and outputs on a single line.
           echo "::set-output name=hashes::$(sha256sum oak_functions_loader_base | base64 --wrap=0)"
-
-  test_subject:
-    needs: [build_provenance]
-    runs-on: ubuntu-20.04
-    steps: 
-      - name: echo
-        run: echo "${{ needs.build_provenance.outputs.hashes }}"
-
 
   # This job calls the generic workflow to generate provenance.
   # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   build_provenance:
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}  
     runs-on: ubuntu-20.04
     env:
       OAK_FUNCTIONS_BASE_PATH: './target/x86_64-unknown-linux-musl/release/oak_functions_loader_base'
@@ -150,6 +152,14 @@ jobs:
           # sha256sum generates sha256 hash for oak_functions_loader_base.
           # base64 --wrap=0 disables line wrapping, and encodes to base64 and outputs on a single line.
           echo "::set-output name=hashes::$(sha256sum oak_functions_loader_base | base64 --wrap=0)"
+
+  test_subject:
+    needs: [build_provenance]
+    runs-on: ubuntu-20.04
+    steps: 
+      - name: echo
+        run: echo "${{ needs.build_provenance.outputs.hashes }}"
+
 
   # This job calls the generic workflow to generate provenance.
   # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -156,7 +156,8 @@ jobs:
   # This job calls the generic workflow to generate provenance.
   # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md
   provenance:
-    if: github.event_name != 'pull_request'
+    # For now only run it on workflow_dispatch events.
+    if: github.event_name == 'workflow_dispatch'
     needs: [build_provenance]
     permissions:
       actions: read


### PR DESCRIPTION
Follow up fix for #3166. The previous attempt failed with [error `expected at least one subject`](https://github.com/project-oak/oak/runs/8018867730?check_suite_focus=true#step:3:258).