### PR TITLE
Zero-initialize BSS properly

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/src/asm/boot.s
+++ b/experimental/oak_baremetal_app_crosvm/src/asm/boot.s
@@ -49,6 +49,12 @@ _start:
     # Finally, trigger a full TLB flush by overwriting CR3, even if it is the same value.
     movq %rbx, %cr3
 
+    # Clear BSS: base address goes to RDI, value goes to AX, count goes into CX.
+    mov $bss_start, %rdi
+    mov $bss_size, %rcx
+    xor %rax, %rax
+    rep stosb
+
     mov $stack_start, %rsp
     # Push 8 bytes to fix stack alignment issue. Because we enter rust64_start with a jmp rather
     # than a call the function prologue means that the stack is no longer 16-byte aligned.

--- a/testing/sev_snp_hello_world_kernel/src/asm/boot.s
+++ b/testing/sev_snp_hello_world_kernel/src/asm/boot.s
@@ -19,6 +19,12 @@
 .code64
 
 _start:
+    # Clear BSS: base address goes to RDI, value goes to AX, count goes into CX.
+    mov $bss_start, %rdi
+    mov $bss_size, %rcx
+    xor %rax, %rax
+    rep stosb
+
     mov $stack_start, %rsp
     # Push 8 bytes to fix stack alignment issue. Because we enter rust64_start
     # with a jmp rather than a call the function prologue means that the stack


### PR DESCRIPTION
The BSS section contains static variables, and the C (and Rust's) memory model expects the memory there to be zero-initialized.

And it just happens by accident that the memory given to us by VMMs was always zero-initialized, meaning our code works. But we're well into undefined behaviour and it works by sheer luck only.

Once we tried enabling SNP, that property was no longer true (as zero doesn't necessarily decrypt to zero), and all kinds of interesting things started breaking as their internal invariants were horribly broken.

Thus: let's do what we should have always done, and manually reset the memory to zero. And x86 has a special magic instruction, `REP STOSB` to do just that, so we don't even need a loop.