### PR TITLE
Remove third new string from the remote attestation docs

### DIFF
--- a/docs/remote-attestation.md
+++ b/docs/remote-attestation.md
@@ -132,7 +132,6 @@ The complete workflow of the Remote Attestation protocol looks as follows:
      closes the connection and aborts the protocol
 6. **Client** sends `ClientIdentity` to the **Trusted Runtime** which contains:
    - **Client**’s _Ephemeral_ public key
-   - New random string
    - _Transcript_: [SHA-256](https://datatracker.ietf.org/doc/html/rfc6234) hash
      of the concatenated `ClientHello`, `ServerIdentity` and current
      `ClientIdentity` (excluding the _Transcript_) signed with the **Client**'s


### PR DESCRIPTION
We don't need to send a 3rd new string alongside the Client's Identity, because the challenge response only uses 2 strings (one from Client and one from Server).