### PR TITLE
Replace temp dependency patch with upstream fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5170,8 +5170,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror_core2"
-version = "2.0.0"
-source = "git+https://github.com/jul-sh/thiserror-core2.git?rev=b99e1a0106623cbbd12cbb5562d01df7a3fdc22e#b99e1a0106623cbbd12cbb5562d01df7a3fdc22e"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f6f9e5af7ca0861a5eae30fe6e95405338f0e92c54424bb66160b01e682243"
 dependencies = [
  "core2",
  "thiserror_core2-impl",
@@ -5180,7 +5181,8 @@ dependencies = [
 [[package]]
 name = "thiserror_core2-impl"
 version = "2.0.0"
-source = "git+https://github.com/jul-sh/thiserror-core2.git?rev=b99e1a0106623cbbd12cbb5562d01df7a3fdc22e#b99e1a0106623cbbd12cbb5562d01df7a3fdc22e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c64183aeaddf559344af98f444cd2ea6685ea0136a59c17587a2c759362e523"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,5 +80,3 @@ exclude = [
 [patch.crates-io]
 # Ensure no_std compatibility. TODO(#2920): remove once https://github.com/google/flatbuffers/pull/7338 is merged.
 flatbuffers = { git = "https://github.com/jul-sh/flatbuffers.git", rev = "a07ddee936737da89aeb5a496f9742a805537188" }
-# Ensure no_std compatibility. Dependency of flatbuffers. TODO(#2920): remove once https://github.com/bbqsrc/thiserror-core2/pull/3 is merged.
-thiserror_core2 = { git = "https://github.com/jul-sh/thiserror-core2.git", rev = "b99e1a0106623cbbd12cbb5562d01df7a3fdc22e" }

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -1161,8 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror_core2"
-version = "2.0.0"
-source = "git+https://github.com/jul-sh/thiserror-core2.git?rev=b99e1a0106623cbbd12cbb5562d01df7a3fdc22e#b99e1a0106623cbbd12cbb5562d01df7a3fdc22e"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f6f9e5af7ca0861a5eae30fe6e95405338f0e92c54424bb66160b01e682243"
 dependencies = [
  "core2",
  "thiserror_core2-impl",
@@ -1171,7 +1172,8 @@ dependencies = [
 [[package]]
 name = "thiserror_core2-impl"
 version = "2.0.0"
-source = "git+https://github.com/jul-sh/thiserror-core2.git?rev=b99e1a0106623cbbd12cbb5562d01df7a3fdc22e#b99e1a0106623cbbd12cbb5562d01df7a3fdc22e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c64183aeaddf559344af98f444cd2ea6685ea0136a59c17587a2c759362e523"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/experimental/oak_baremetal_app_crosvm/Cargo.toml
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.toml
@@ -29,8 +29,6 @@ static_assertions = "*"
 [patch.crates-io]
 # Ensure no_std compatibility. TODO(#2920): remove once https://github.com/google/flatbuffers/pull/7338 is merged.
 flatbuffers = { git = "https://github.com/jul-sh/flatbuffers.git", rev = "a07ddee936737da89aeb5a496f9742a805537188" }
-# Ensure no_std compatibility. Dependency of flatbuffers. TODO(#2920): remove once https://github.com/bbqsrc/thiserror-core2/pull/3 is merged.
-thiserror_core2 = { git = "https://github.com/jul-sh/thiserror-core2.git", rev = "b99e1a0106623cbbd12cbb5562d01df7a3fdc22e" }
 
 [[bin]]
 name = "oak_baremetal_app_crosvm"


### PR DESCRIPTION
Our PR to fix the issue upstream was merged and release, we can now remove the patch: https://github.com/bbqsrc/thiserror-core2/pull/3

Patch first added in: #2931

Tracking issue: #2920