### PR TITLE
Add GHCB data structure to the Hello World testing kernel

### DIFF
--- a/testing/sev_snp_hello_world_kernel/layout.ld
+++ b/testing/sev_snp_hello_world_kernel/layout.ld
@@ -83,6 +83,10 @@ SECTIONS {
         bss_size = . - bss_start;
     } : bss
 
+    .ghcb (NOLOAD) : ALIGN(2M) {
+    } : bss
+    ASSERT((SIZEOF(.ghcb) == 0x1000), "GHCB page needs to be exactly 4K in size")
+
     /* Stack grows down, so stack_start is the upper address in memory. */
     .stack (NOLOAD) : ALIGN(2M) {
         . += 512K;

--- a/testing/sev_snp_hello_world_kernel/src/ghcb.rs
+++ b/testing/sev_snp_hello_world_kernel/src/ghcb.rs
@@ -1,0 +1,43 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use core::mem::MaybeUninit;
+use sev_guest::ghcb::{Ghcb, GhcbProtocol};
+
+#[link_section = ".ghcb"]
+static mut GHCB: MaybeUninit<Ghcb> = MaybeUninit::uninit();
+
+/// Initializes the GHCB and shares it with the hypervisor.
+pub fn init_ghcb(snp_enabled: bool) -> GhcbProtocol<'static> {
+    // Safety: this data structure is placed in valid memory so we won't page fault when accessing
+    // it. We reset the value of the GHCB immediately after shareing it with the hypervisor, so it
+    // will be fine if it is not initialized.
+    let ghcb: &mut Ghcb = unsafe { GHCB.assume_init_mut() };
+    share_ghcb_with_hypervisor(ghcb, snp_enabled);
+    ghcb.reset();
+    GhcbProtocol::new(ghcb)
+}
+
+/// Sets up the page containing the GHCB data structure to be shared with the hypervisor.
+fn share_ghcb_with_hypervisor(ghcb: &Ghcb, snp_enabled: bool) {
+    // Assume identity mapping for now.
+    let ghcb_gpa = ghcb as *const Ghcb as usize;
+    if snp_enabled {
+        // This code will eventually also mark the page as shared in the RMP and use the MSR
+        // protocol to register the page with the hypervisor.
+        unimplemented!("SNP support is not yet implemented.");
+    }
+}

--- a/testing/sev_snp_hello_world_kernel/src/ghcb.rs
+++ b/testing/sev_snp_hello_world_kernel/src/ghcb.rs
@@ -23,8 +23,8 @@ use x86_64::{
     structures::paging::page_table::{PageTable, PageTableFlags},
 };
 
-/// The mask for the encrypted bit. For now we assumbe that we will be running on AMD Arcadia Milan
-/// CPUs, which uses bit 51.
+/// The mask for the encrypted bit. For now we assume that we will be running on AMD Arcadia-Milan
+/// CPUs, which use bit 51.
 const ENCRYPTED_BIT: u64 = 1 << 51;
 
 #[link_section = ".ghcb"]

--- a/testing/sev_snp_hello_world_kernel/src/ghcb.rs
+++ b/testing/sev_snp_hello_world_kernel/src/ghcb.rs
@@ -16,6 +16,16 @@
 
 use core::mem::MaybeUninit;
 use sev_guest::ghcb::{Ghcb, GhcbProtocol};
+use x86_64::{
+    addr::{PhysAddr, VirtAddr},
+    instructions::tlb::flush_all,
+    registers::control::Cr3,
+    structures::paging::page_table::{PageTable, PageTableFlags},
+};
+
+/// The mask for the encrypted bit. For now we assumbe that we will be running on AMD Arcadia Milan
+/// CPUs, which uses bit 51.
+const ENCRYPTED_BIT: u64 = 1 << 51;
 
 #[link_section = ".ghcb"]
 static mut GHCB: MaybeUninit<Ghcb> = MaybeUninit::uninit();
@@ -31,13 +41,80 @@ pub fn init_ghcb(snp_enabled: bool) -> GhcbProtocol<'static> {
     GhcbProtocol::new(ghcb)
 }
 
-/// Sets up the page containing the GHCB data structure to be shared with the hypervisor.
+/// Marks the page containing the GHCB data structure to be shared with the hypervisor.
 fn share_ghcb_with_hypervisor(ghcb: &Ghcb, snp_enabled: bool) {
-    // Assume identity mapping for now.
-    let ghcb_gpa = ghcb as *const Ghcb as usize;
+    let ghcb_address = VirtAddr::new(ghcb as *const Ghcb as usize as u64);
     if snp_enabled {
         // This code will eventually also mark the page as shared in the RMP and use the MSR
         // protocol to register the page with the hypervisor.
         unimplemented!("SNP support is not yet implemented.");
     }
+    // Mark the page as not encrypted.
+    set_encrypted_bit_for_page(&ghcb_address, false);
+}
+
+/// Sets the encrypted bit for the page that contains the address.
+///
+/// We assume for now that we will always use 2MiB huge pages.
+fn set_encrypted_bit_for_page(address: &VirtAddr, encrypted: bool) {
+    // Find the level 4 page table that is currently in use.
+    let (l4_frame, _) = Cr3::read();
+    // Safety: this is safe because we use the address of the current page table as configured in
+    // the CR3 register.
+    let l4_table = unsafe { get_mut_page_table_ref(physical_to_virtual(l4_frame.start_address())) };
+    let l4_entry = &l4_table[address.p4_index()];
+    // Make sure the entry pointing to the L3 page table is present.
+    assert!(l4_entry.flags().contains(PageTableFlags::PRESENT));
+    let l3_table_address = l4_entry.addr();
+    assert!(l3_table_address.as_u64() > 0);
+    // Safety: this is safe because we checked that the page table entry is marked as present and
+    // the physical address is non-zero.
+    let l3_table = unsafe { get_mut_page_table_ref(physical_to_virtual(l3_table_address)) };
+
+    let l3_entry = &l3_table[address.p3_index()];
+    // Make sure the entry pointing to the L2 page table is present.
+    assert!(l3_entry.flags().contains(PageTableFlags::PRESENT));
+    // Make sure it is not marked as a 1GiB huge page, so it points to an L2 page table.
+    assert!(!l3_entry.flags().contains(PageTableFlags::HUGE_PAGE));
+    let l2_table_address = l3_entry.addr();
+    assert!(l2_table_address.as_u64() > 0);
+    // Safety: this is safe because we checked that the page table entry is marked as present, not a
+    // 1GiB huge page and the physical address is non-zero.
+    let l2_table = unsafe { get_mut_page_table_ref(physical_to_virtual(l2_table_address)) };
+
+    let page_entry = &mut l2_table[address.p2_index()];
+    let flags = page_entry.flags();
+    let page_frame_address = page_entry.addr();
+    // Make sure the entry for the L2 page table is present.
+    assert!(flags.contains(PageTableFlags::PRESENT));
+    // Make sure it is marked as a 2MiB huge page.
+    assert!(flags.contains(PageTableFlags::HUGE_PAGE));
+
+    let page_frame_address = PhysAddr::new(if encrypted {
+        page_frame_address.as_u64() | ENCRYPTED_BIT
+    } else {
+        page_frame_address.as_u64() & !ENCRYPTED_BIT
+    });
+
+    page_entry.set_addr(page_frame_address, flags);
+
+    // Flush the entire TLB to make sure the old value of the encrypted bit is not cached.
+    flush_all();
+}
+
+/// Converts a physical address to a virtual address.
+///
+/// This assumes an identity mapping and corrects for the encrypted bit in case it is set.
+fn physical_to_virtual(physical: PhysAddr) -> VirtAddr {
+    let normalized = physical.as_u64() & !ENCRYPTED_BIT;
+    VirtAddr::new(normalized)
+}
+
+/// Gets a mutable reference to a page table that starts at the given address.
+///
+/// # Safety
+///
+/// The caller must provide a valid address for the start of a valid page table.
+unsafe fn get_mut_page_table_ref<'a>(start_address: VirtAddr) -> &'a mut PageTable {
+    &mut *(start_address.as_u64() as usize as *mut PageTable)
 }

--- a/testing/sev_snp_hello_world_kernel/src/main.rs
+++ b/testing/sev_snp_hello_world_kernel/src/main.rs
@@ -18,10 +18,15 @@
 #![no_main]
 
 use core::{mem::MaybeUninit, panic::PanicInfo};
-use sev_guest::{cpuid::CpuidPage, secrets::SecretsPage};
+use sev_guest::{
+    cpuid::CpuidPage,
+    msr::{get_sev_status, SevStatus},
+    secrets::SecretsPage,
+};
 use x86_64::instructions::{hlt, interrupts::int3};
 
 mod asm;
+mod ghcb;
 mod serial;
 
 #[link_section = ".cpuid"]
@@ -32,6 +37,10 @@ static SECRETS: MaybeUninit<SecretsPage> = MaybeUninit::uninit();
 
 #[no_mangle]
 pub extern "C" fn rust64_start() -> ! {
+    let sev_status = get_sev_status().unwrap();
+    if sev_status.contains(SevStatus::SEV_ES_ENABLED) {
+        let _ = ghcb::init_ghcb(sev_status.contains(SevStatus::SNP_ACTIVE));
+    }
     serial::init_logging();
     log::info!("Hello World!");
 


### PR DESCRIPTION
This is the first in a series of PRs to enable serial port based logging on AMD SEV-ES and SEV-SNP using the GHCB IOIO protocol to drive the serial port.

This PR adds the GHCB data structure to the Hello World testing kernel, initialises it and shares it with the hypervisor (only SEV-ES version at the moment which requires marking the page as unencrypted).

Actually using this data structure and the protocol to write to the serial port will be done in a follow-up PR.