### PR TITLE
Rename the former UnaryClient trait to clarify its role of abstracting networking

### DIFF
--- a/experimental/oak_baremetal_runtime/tests/integration_test.rs
+++ b/experimental/oak_baremetal_runtime/tests/integration_test.rs
@@ -29,7 +29,7 @@ use oak_remote_attestation::handshaker::{
 use oak_remote_attestation_amd::{
     PlaceholderAmdAttestationGenerator, PlaceholderAmdAttestationVerifier,
 };
-use oak_remote_attestation_sessions_client::{GenericAttestationClient, UnaryClient};
+use oak_remote_attestation_sessions_client::{AttestationTransport, GenericAttestationClient};
 
 mod schema {
     #![allow(clippy::derivable_impls, clippy::needless_borrow)]
@@ -57,7 +57,7 @@ struct TestUserClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl UnaryClient for TestUserClient {
+impl AttestationTransport for TestUserClient {
     async fn message(
         &mut self,
         session_id: oak_remote_attestation_sessions::SessionId,

--- a/experimental/web_client/src/lib.rs
+++ b/experimental/web_client/src/lib.rs
@@ -25,7 +25,7 @@ use oak_functions_abi::Response;
 use oak_remote_attestation::handshaker::{AttestationBehavior, EmptyAttestationGenerator};
 use oak_remote_attestation_amd::PlaceholderAmdAttestationVerifier;
 use oak_remote_attestation_sessions::SessionId;
-use oak_remote_attestation_sessions_client::{GenericAttestationClient, UnaryClient};
+use oak_remote_attestation_sessions_client::{AttestationTransport, GenericAttestationClient};
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 
@@ -39,7 +39,8 @@ mod proto {
     include!(concat!(env!("OUT_DIR"), "/oak.session.unary.v1.rs"));
 }
 
-/// gRPC-web implementation of a [`UnaryClient`].
+/// Implementation of the [`AttestationTransport`] trait using gRPC-web with
+/// unary messages.
 struct GrpcWebClient {
     uri: String,
 }
@@ -55,7 +56,7 @@ impl GrpcWebClient {
 // Not marked as [`Send`], as the underlying client uses JavaScript APIs for
 // networking, which are not [`Send`].
 #[async_trait(?Send)]
-impl UnaryClient for GrpcWebClient {
+impl AttestationTransport for GrpcWebClient {
     async fn message(&mut self, session_id: SessionId, body: Vec<u8>) -> anyhow::Result<Vec<u8>> {
         let reply = grpc_web::grpc_web_unary::<UnaryRequest, UnaryResponse>(
             &self.uri,

--- a/grpc_unary_attestation/src/client.rs
+++ b/grpc_unary_attestation/src/client.rs
@@ -22,11 +22,10 @@ use oak_remote_attestation::handshaker::{
 };
 use oak_remote_attestation_amd::PlaceholderAmdAttestationVerifier;
 use oak_remote_attestation_sessions::SessionId;
-use oak_remote_attestation_sessions_client::{GenericAttestationClient, UnaryClient};
+use oak_remote_attestation_sessions_client::{AttestationTransport, GenericAttestationClient};
 use tonic::transport::Channel;
 
-/// gRPC implementation of of [`UnaryClient`]. Serves as an inner of the
-/// public [`AttestationClient`].
+/// Implementation of the [`AttestationTransport`] trait using unary gRPC messages.
 struct GrpcClient {
     inner: UnarySessionClient<Channel>,
 }
@@ -45,7 +44,7 @@ impl GrpcClient {
 // Async trait requires the definition and all implementations to be marked as
 // optionally [`Send`] if one implementation is not.
 #[async_trait(?Send)]
-impl UnaryClient for GrpcClient {
+impl AttestationTransport for GrpcClient {
     async fn message(&mut self, session_id: SessionId, body: Vec<u8>) -> anyhow::Result<Vec<u8>> {
         let response = self
             .inner

--- a/remote_attestation_sessions_client/src/lib.rs
+++ b/remote_attestation_sessions_client/src/lib.rs
@@ -21,23 +21,23 @@ use oak_remote_attestation::handshaker::{
 };
 use oak_remote_attestation_sessions::SessionId;
 
-/// Abstract version of networking stub.
+/// Abstract interface for networking using a request/response pattern.
 // Async trait requires the definition and all implementations to be marked as
 // optionally [`Send`] if one implementation is not.
 #[async_trait(?Send)]
-pub trait UnaryClient {
-    /// Constructs a requests, sends it over the network, and returns the result.
+pub trait AttestationTransport {
+    /// Constructs a requests, sends it over the network, and returns the resulting response.
     async fn message(&mut self, session_id: SessionId, body: Vec<u8>) -> anyhow::Result<Vec<u8>>;
 }
 
 /// gRPC Attestation Service client implementation.
-pub struct GenericAttestationClient<T: UnaryClient> {
+pub struct GenericAttestationClient<T: AttestationTransport> {
     session_id: SessionId,
     encryptor: Encryptor,
     client: T,
 }
 
-impl<T: UnaryClient> GenericAttestationClient<T> {
+impl<T: AttestationTransport> GenericAttestationClient<T> {
     pub async fn create<G: AttestationGenerator, V: AttestationVerifier>(
         mut client: T,
         attestation_behavior: AttestationBehavior<G, V>,


### PR DESCRIPTION
Useful as soon (see #3191) we'll have an implementation of this trait using streaming gRPC. Renaming this now avoids confusion later on code related to unary gRPC. 