### PR TITLE
Use GHCB serial port for logging when running on AMD SEV-ES

### DIFF
--- a/testing/sev_snp_hello_world_kernel/src/main.rs
+++ b/testing/sev_snp_hello_world_kernel/src/main.rs
@@ -18,11 +18,7 @@
 #![no_main]
 
 use core::{mem::MaybeUninit, panic::PanicInfo};
-use sev_guest::{
-    cpuid::CpuidPage,
-    msr::{get_sev_status, SevStatus},
-    secrets::SecretsPage,
-};
+use sev_guest::{cpuid::CpuidPage, secrets::SecretsPage};
 use x86_64::instructions::{hlt, interrupts::int3};
 
 mod asm;
@@ -37,10 +33,6 @@ static SECRETS: MaybeUninit<SecretsPage> = MaybeUninit::uninit();
 
 #[no_mangle]
 pub extern "C" fn rust64_start() -> ! {
-    let sev_status = get_sev_status().unwrap();
-    if sev_status.contains(SevStatus::SEV_ES_ENABLED) {
-        let _ = ghcb::init_ghcb(sev_status.contains(SevStatus::SNP_ACTIVE));
-    }
     serial::init_logging();
     log::info!("Hello World!");
 


### PR DESCRIPTION
This is a follow-up to #3190. It allows the Hello World test kernel to use the GHCB serial port implementation when running on AMD SEV-ES.

Enabling support for AMD SEV-SNP will be done in a later PR.