### PR TITLE
Move RekorLogEntry.java to top-level java folder

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -90,3 +90,21 @@ java_test(
         ":util",
     ],
 )
+
+java_library(
+    name = "rekor",
+    srcs = glob(["src/main/java/com/google/oak/rekor/*.java"]),
+    deps = [
+        "@com_google_code_gson_gson",
+    ],
+)
+
+java_test(
+    name = "RekorLogEntryTest",
+    srcs = ["src/test/java/com/google/oak/rekor/RekorLogEntryTest.java"],
+    data = ["//oak_functions/client/testdata:logentry.json"],
+    test_class = "com.google.oak.rekor.RekorLogEntryTest",
+    deps = [
+        ":rekor",
+    ],
+)

--- a/java/src/main/java/com/google/oak/rekor/RekorLogEntry.java
+++ b/java/src/main/java/com/google/oak/rekor/RekorLogEntry.java
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package com.google.oak.functions.client.rekor;
+package com.google.oak.rekor;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/java/src/test/java/com/google/oak/rekor/RekorLogEntryTest.java
+++ b/java/src/test/java/com/google/oak/rekor/RekorLogEntryTest.java
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package com.google.oak.functions.client.rekor;
+package com.google.oak.rekor;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/oak_functions/client/java/BUILD
+++ b/oak_functions/client/java/BUILD
@@ -15,7 +15,7 @@
 #
 
 load("@rules_android//android:rules.bzl", "android_library")
-load("@rules_java//java:defs.bzl", "java_library", "java_test")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -36,24 +36,6 @@ java_library(
         "@io_grpc_grpc_java//api",
         "@io_grpc_grpc_java//netty",
         "@io_grpc_grpc_java//stub",
-    ],
-)
-
-java_library(
-    name = "client_rekor",
-    srcs = glob(["src/com/google/oak/functions/client/rekor/*.java"]),
-    deps = [
-        "@com_google_code_gson_gson",
-    ],
-)
-
-java_test(
-    name = "RekorLogEntryTest",
-    srcs = ["tests/com/google/oak/functions/client/rekor/RekorLogEntryTest.java"],
-    data = ["//oak_functions/client/testdata:logentry.json"],
-    test_class = "com.google.oak.functions.client.rekor.RekorLogEntryTest",
-    deps = [
-        ":client_rekor",
     ],
 )
 


### PR DESCRIPTION
I am planning to endorsement verification logic to the top-level java. This PR is a pre-requisite restructuring step.