### PR TITLE
SEV enlightenment: set the encrypted bit if we're running under SEV-{,ES}.

### DIFF
--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -15,10 +15,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "oak_stage0"
 version = "0.1.0"
 dependencies = [
+ "sev_guest",
  "x86_64",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -26,6 +63,103 @@ name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
+name = "sev_guest"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "snafu",
+ "static_assertions",
+ "strum",
+ "x86_64",
+ "zerocopy",
+]
+
+[[package]]
+name = "snafu"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "volatile"
@@ -43,4 +177,25 @@ dependencies = [
  "bitflags",
  "rustversion",
  "volatile",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
 ]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 members = ["."]
 
 [dependencies]
+sev_guest = { path = "../experimental/sev_guest" }
 x86_64 = "*"
 
 [[bin]]

--- a/stage0/deny.toml
+++ b/stage0/deny.toml
@@ -19,5 +19,5 @@ wildcards = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = ["Apache-2.0", "MIT"]
+allow = ["Apache-2.0", "BSD-2-Clause", "MIT", "Unicode-DFS-2016"]
 copyleft = "deny"

--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -24,8 +24,10 @@ MEMORY {
 ENTRY(reset_vector)
 
 /* Segment descriptor flags.
- * See Section 4.8 in AMD64 Architecture Programmer's Manual, Volume 2 for more details.
+ * See Sections 4.7 and  4.8 in AMD64 Architecture Programmer's Manual, Volume 2 for more details.
  */
+HIDDEN(SEGMENT_4K = 1 << (32 + 23)); /* G */
+HIDDEN(SEGMENT_DEFAULT_32BIT_OP = 1 << (32 + 22)); /* D/B */
 HIDDEN(SEGMENT_LONG = 1 << (32 + 21));
 HIDDEN(SEGMENT_PRESENT = 1 << (32 + 15)); /* P */
 HIDDEN(SEGMENT_USER = 1 << (32 + 12)); /* S */
@@ -45,7 +47,7 @@ SECTIONS {
         QUAD(ADDR(.rodata.pdpt) | PAGE_PRESENT | PAGE_WRITABLE) /* 0..512 GiB */
     } > bios
 
-    pml4_offset = ADDR(.rodata.pml4);
+    pml4_addr = ADDR(.rodata.pml4);
 
     .rodata.pdpt ALIGN(4K) : {
         QUAD(ADDR(.rodata.pd) | PAGE_PRESENT | PAGE_WRITABLE) /* 0..1 GiB */
@@ -54,6 +56,8 @@ SECTIONS {
         QUAD(ADDR(.rodata.pd) | PAGE_PRESENT | PAGE_WRITABLE) /* 3..4 GiB */
     } > bios
 
+    pdpt_addr = ADDR(.rodata.pdpt);
+
     .rodata.pd ALIGN(4K) : {
         QUAD(0 | PAGE_PRESENT | PAGE_WRITABLE | PAGE_SIZE) /* 0 .. 2 MiB */
         FILL(0x00)
@@ -61,7 +65,7 @@ SECTIONS {
         QUAD((TOP - 2M) | PAGE_PRESENT | PAGE_WRITABLE | PAGE_SIZE) /* (4GiB - 2MiB) .. 4 GiB */
     } > bios
 
-    pd_offset = ADDR(.rodata.pd);
+    pd_addr = ADDR(.rodata.pd);
 
     .rodata : {
         KEEP(*(.rodata .rodata.*))
@@ -111,11 +115,22 @@ SECTIONS {
          *  - P=1 (present)
          *  - S=1 (user)
          *  - C/D=0 (data)
+         * ...and for 32-bit compatibility (see Section 4.7.3):
+         *  - G=1 (limit field is in 4K blocks)
+         *  - D/S=1 (default operations are 32-bit)
+         *  - limit = 0xFFFFF (in 4K blocks because G=1)
+         *
          * Although according to the manual in 64-bit mode WRITABLE should be ignored, at least qemu
          * will cause a #GP if we try to load SS with a segment descriptor that doesn't have it set.
          */
         ds = . - ADDR(.rodata.gdt);
-        QUAD(SEGMENT_PRESENT | SEGMENT_USER | SEGMENT_WRITABLE)
+        QUAD(SEGMENT_4K |
+             SEGMENT_DEFAULT_32BIT_OP |
+             SEGMENT_PRESENT |
+             SEGMENT_USER |
+             SEGMENT_WRITABLE |
+             (0xF << (32 + 16)) | /* Segment Limit [19:16] */
+             0xFFFF); /* Segment Limit [15:0] */
     } > bios
 
     .rodata.idt ALIGN(8) : {

--- a/stage0/src/asm/boot.s
+++ b/stage0/src/asm/boot.s
@@ -15,8 +15,35 @@ _start :
     mov $idt_desc_offset, %si
     lidtl %cs:(%si)
 
+    # Determine if we're running under SEV
+    mov $0xc0010131, %ecx     # SEV_STATUS MSR
+    rdmsr                     # EDX:EAX <- MSR[ECX]
+    and $3, %eax              # eax &= 0b11;
+    test %eax, %eax           # is it zero?
+    je no_encryption          # if yes, jump to no_encryption
+    # Memory encryption enabled: set encrypted bits in the page tables.
+
+    # Load a flat 32-bit DS by jumping through protected mode.
+    mov %cr0, %eax
+    or $1, %al
+    mov %eax, %cr0
+    mov $ds, %bx
+    mov %bx, %ds
+    or $0xFE, %al
+    mov %eax, %cr0
+
+    mov $pml4_addr, %eax
+    orl $0x80000, 4(%eax)     # PML4[0] |= (1 << 51)
+    mov $pdpt_addr, %eax
+    orl $0x80000, 4(%eax)     # PDPT[0] |= (1 << 51)
+    orl $0x80000, 4092(%eax)  # PDPT[511] |= (1 << 51)
+    mov $pd_addr, %eax
+    orl $0x80000, 4(%eax)     # PD[0] |= (1 << 51)
+    orl $0x80000, 4092(%eax)  # PD[511] |= (1 << 51)
+no_encryption:
+
     # Load PML4
-    mov $pml4_offset, %eax
+    mov $pml4_addr, %eax
     mov %eax, %cr3
 
     # PAE + PGE


### PR DESCRIPTION
This automatically detects whether we're running under SEV or not, and if memory encryption is required, sets the correct bit in the page tables.

To do that, we first need to enter unreal mode -- real mode with a 32-bit data segment -- so that we can access the memory near the 4G boundary, where the page tables live.