### PR TITLE
Remove cargo-deny git source warnings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,10 @@ ignore = [
 multiple-versions = "allow"
 wildcards = "allow"
 
+# Allow git repositories.
+[sources]
+unknown-git = "allow"
+
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]

--- a/experimental/oak_baremetal_app_crosvm/deny.toml
+++ b/experimental/oak_baremetal_app_crosvm/deny.toml
@@ -20,6 +20,10 @@ ignore = [
 multiple-versions = "allow"
 wildcards = "allow"
 
+# Allow git repositories.
+[sources]
+unknown-git = "allow"
+
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]

--- a/oak_functions/loader/fuzz/deny.toml
+++ b/oak_functions/loader/fuzz/deny.toml
@@ -19,6 +19,10 @@ ignore = [
 multiple-versions = "allow"
 wildcards = "allow"
 
+# Allow git repositories.
+[sources]
+unknown-git = "allow"
+
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]

--- a/stage0/deny.toml
+++ b/stage0/deny.toml
@@ -16,6 +16,10 @@ ignore = []
 multiple-versions = "allow"
 wildcards = "allow"
 
+# Allow git repositories.
+[sources]
+unknown-git = "allow"
+
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]

--- a/testing/oak_echo_bin/deny.toml
+++ b/testing/oak_echo_bin/deny.toml
@@ -20,6 +20,10 @@ ignore = [
 multiple-versions = "allow"
 wildcards = "allow"
 
+# Allow git repositories.
+[sources]
+unknown-git = "allow"
+
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]

--- a/testing/sev_snp_hello_world_kernel/deny.toml
+++ b/testing/sev_snp_hello_world_kernel/deny.toml
@@ -16,6 +16,10 @@ ignore = []
 multiple-versions = "allow"
 wildcards = "allow"
 
+# Allow git repositories.
+[sources]
+unknown-git = "allow"
+
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]


### PR DESCRIPTION
At the moment cargo-deny raises warnings if we use git source directly in Cargo.toml files without explicitly adding them to an allow list. I don't think we need these warnings and have been ignoring them anyway.