### PR TITLE
Clean-up: enter protected mode and stay there.

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -130,7 +130,23 @@ SECTIONS {
              SEGMENT_USER |
              SEGMENT_WRITABLE |
              (0xF << (32 + 16)) | /* Segment Limit [19:16] */
-             0xFFFF); /* Segment Limit [15:0] */
+             0xFFFF)              /* Segment Limit [15:0] */
+        /* 32-bit code segment, although we only need it for a really short time (see Section 4.7.2):
+         *  - G=1 (limit field is in 4K blocks)
+         *  - D=1 (default operations are 32-bit)
+         *  - P=1 (present)
+         *  - S=1 (user)
+         *  - C/D=1 (code segment)
+         *  - limit = 0xFFFFF (in 4K blocks because G=1)
+         */
+        cs32 = . - ADDR(.rodata.gdt);
+        QUAD(SEGMENT_4K |
+             SEGMENT_DEFAULT_32BIT_OP |
+             SEGMENT_PRESENT |
+             SEGMENT_USER |
+             SEGMENT_CODE |
+             (0xF << (32 + 16)) | /* Segment Limit [19:16] */
+             0xFFFF)              /* Segment Limit [15:0] */
     } > bios
 
     .rodata.idt ALIGN(8) : {


### PR DESCRIPTION
Instead of entering 16-bit "unreal mode" (with a flat data segment), let's just enter 32-bit protected mode w/ said flat memory segment. As an additional bonus, by using a 32-bit code segment, `IP` values make sense in a debugger.

This means we're out of 16-bit mode in ~10 instructions. I think we could shave off a few more instructions (do we really need an IDT, for example?) but I think this is good enough to get from the 1970s to the 1980s in 10 instructions. (And then to the 2000s in ~30 instructions.)