### PR TITLE
Update linked-list allocator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,7 @@ updates:
       interval: 'daily'
     # We do not set an explicit reviewer, as that is already automatically assigned via CODEOWNERS.
     # reviewers
-    ignore:
-      - dependency-name: 'linked_list_allocator'
-        # Ignore buggy version of this dep. Ref: https://github.com/project-oak/oak/pull/3019
-        versions: ['0.10.0']
+
     # Explicitly trigger kokoro checks. They do not automatically run for
     # external users.
     labels:
@@ -22,8 +19,5 @@ updates:
     directory: '/experimental/oak_baremetal_app_crosvm'
     schedule:
       interval: 'daily'
-    ignore:
-      - dependency-name: 'linked_list_allocator'
-        versions: ['0.10.0']
     labels:
       - 'kokoro:run'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,9 +2349,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.9.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
+checksum = "2e8da0e6283aace40e4e0395fe5ad7a147fac6ff47bda1f038b5044fb11683c2"
 dependencies = [
  "spinning_top",
 ]

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -490,9 +490,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.9.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
+checksum = "2e8da0e6283aace40e4e0395fe5ad7a147fac6ff47bda1f038b5044fb11683c2"
 dependencies = [
  "spinning_top",
 ]

--- a/experimental/oak_baremetal_kernel/src/memory.rs
+++ b/experimental/oak_baremetal_kernel/src/memory.rs
@@ -82,7 +82,7 @@ pub fn init_allocator<E: boot::E820Entry, B: boot::BootInfo<E>>(
     info!("Using [{:#016x}..{:#016x}) for heap.", addr, addr + size);
     // This is safe as we know the memory is available based on the e820 map.
     unsafe {
-        ALLOCATOR.lock().init(addr, size);
+        ALLOCATOR.lock().init(addr as *mut u8, size);
     }
     Ok(())
 }

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -130,9 +130,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.9.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
+checksum = "2e8da0e6283aace40e4e0395fe5ad7a147fac6ff47bda1f038b5044fb11683c2"
 dependencies = [
  "spinning_top",
 ]


### PR DESCRIPTION
The linked-list allocator has been updated past the buggy 0.10.0 version, so it should be fine to update throughout now.