### PR TITLE
Call CPUID to figure out whether memory encryption is supported at all

### DIFF
--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -15,47 +15,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
 name = "oak_stage0"
 version = "0.1.0"
 dependencies = [
- "sev_guest",
  "x86_64",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
-dependencies = [
- "proc-macro2",
 ]
 
 [[package]]
@@ -63,103 +26,6 @@ name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
-
-[[package]]
-name = "sev_guest"
-version = "0.1.0"
-dependencies = [
- "bitflags",
- "snafu",
- "static_assertions",
- "strum",
- "x86_64",
- "zerocopy",
-]
-
-[[package]]
-name = "snafu"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "volatile"
@@ -177,25 +43,4 @@ dependencies = [
  "bitflags",
  "rustversion",
  "volatile",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
-dependencies = [
- "proc-macro2",
- "syn",
- "synstructure",
 ]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -10,7 +10,6 @@ resolver = "2"
 members = ["."]
 
 [dependencies]
-sev_guest = { path = "../experimental/sev_guest" }
 x86_64 = "*"
 
 [[bin]]

--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -24,7 +24,7 @@ MEMORY {
 ENTRY(reset_vector)
 
 /* Segment descriptor flags.
- * See Sections 4.7 and  4.8 in AMD64 Architecture Programmer's Manual, Volume 2 for more details.
+ * See Sections 4.7 and 4.8 in AMD64 Architecture Programmer's Manual, Volume 2 for more details.
  */
 HIDDEN(SEGMENT_4K = 1 << (32 + 23)); /* G */
 HIDDEN(SEGMENT_DEFAULT_32BIT_OP = 1 << (32 + 22)); /* D/B */
@@ -39,6 +39,10 @@ HIDDEN(SEGMENT_CONFORMING = 1 << (32 + 10));
 HIDDEN(PAGE_PRESENT = 1 << 0);
 HIDDEN(PAGE_WRITABLE = 1 << 1);
 HIDDEN(PAGE_SIZE = 1 << 7);
+
+/* Gate descriptor flags */
+HIDDEN(DESCRIPTOR_PRESENT = 1 << 47);
+HIDDEN(DESCRIPTOR_INTERRUPT_GATE = 0xE << 40);
 
 SECTIONS {
     . = ORIGIN(bios);
@@ -149,8 +153,46 @@ SECTIONS {
              0xFFFF)              /* Segment Limit [15:0] */
     } > bios
 
+    /* 32-bit interrupt table */
+    /* See Section 8.2 in AMD64 Architecture Programmer's Manual, Volume 2 for more details. */
     .rodata.idt ALIGN(8) : {
-        QUAD(0)
+        QUAD(0) /*  0 - #DE */
+        QUAD(0) /*  1 - #DB */
+        QUAD(0) /*  2 - #NMI */
+        QUAD(0) /*  3 - #BP */
+        QUAD(0) /*  4 - #OF */
+        QUAD(0) /*  5 - #BR */
+        QUAD(0) /*  6 - #UD */
+        QUAD(0) /*  7 - #NM */
+        QUAD(0) /*  8 - #DF */
+        QUAD(0) /*  9 - reserved */
+        QUAD(0) /* 10 - #TS */
+        QUAD(0) /* 11 - #NP */
+        QUAD(0) /* 12 - #SS */
+        QUAD(0) /* 13 - #GP */
+        QUAD(0) /* 14 - #PF */
+        QUAD(0) /* 15 - reserved */
+        QUAD(0) /* 16 - #MF */
+        QUAD(0) /* 17 - #AC */
+        QUAD(0) /* 18 - #MC */
+        QUAD(0) /* 19 - #XF */
+        QUAD(0) /* 20 - reserved */
+        QUAD(0) /* 21 - #CP */
+        QUAD(0) /* 22 - reserved */
+        QUAD(0) /* 23 - reserved */
+        QUAD(0) /* 24 - reserved */
+        QUAD(0) /* 25 - reserved */
+        QUAD(0) /* 26 - reserved */
+        QUAD(0) /* 27 - reserved */
+        QUAD(0) /* 28 - #HV */
+        QUAD(   /* 29 - #VC */
+            (vc_handler & 0xFFFF0000) << 32 | /* target offset [31:16] */
+            DESCRIPTOR_PRESENT |
+            DESCRIPTOR_INTERRUPT_GATE |
+            cs32 << 16 |                      /* code segment selector */
+            vc_handler & 0xFFFF)              /* target offset [15:0] */
+        QUAD(0) /* 30 - #SX */
+        QUAD(0) /* 31 - reserved */
     } > bios
     
     .rodata.gdt_desc ALIGN(8) : {
@@ -159,7 +201,7 @@ SECTIONS {
     } > bios
 
     .rodata.idt_desc ALIGN(8) : {
-        SHORT(0)
+        SHORT(SIZEOF(.rodata.idt) - 1)
         LONG(ADDR(.rodata.idt))
     } > bios
 

--- a/stage0/src/asm/boot.s
+++ b/stage0/src/asm/boot.s
@@ -23,18 +23,53 @@ _start :
 
 .align 16
 .code32
+.global vc_handler
+vc_handler:
+    # For now, let's assume that the #VC interrupt is triggered when we call the CPUID instruction
+    # in the SEV detection code, below, while running under SEV-{ES, SNP}. Thus, the fact that we're
+    # in this handler altogether will suffice as evidence that we support the SEV_STATUS MSR.
+    # It's probably not worth implementing a proper interrupt handler here (that knows how to use the
+    # GHCB protocol) as it's only used in the bootstrap code.
+    pop %eax        # ignore the error code for now
+    pop %eax        # pop the return address
+    add $2, %eax    # increment it by 2 (size of the CPUID instruction)
+    push %eax       # push it back on stack for iret
+    mov $0xA, %eax  # return value for cpuid saying memory encryption is enabled
+                    # This sets bits for SEV-ES (bit 4) and SEV (bit 1) in the response.
+    iret            # go back
+
 _protected_mode_start:
     # Switch to a flat 32-bit data segment, giving us access to all 4G of memory.
     mov $ds, %eax
     mov %eax, %ds
+    mov %eax, %ss
 
-    # Determine if we're running under SEV
-    mov $0xc0010131, %ecx     # SEV_STATUS MSR
+    # Set up a basic stack, as we may get interrupts.
+    mov $stack_start, %esp
+
+    # Determine if we're running under SEV. Keep track of which bit is the encrypted bit in %rsi.
+    mov $0, %esi              # by default, no encryption
+    mov $0x8000001F, %eax     # CPUID page 8000_001Fh -- Encrypted Memory Capabilities.
+                              # See Section E.4.17 in AMD64 Architecture Programmer's Manual, Volume 3
+                              # for more details.
+    cpuid
+    and $3, %eax              # Bit 0 - Secure Memory Encryption supported
+                              # Bit 1 - Secure Encrypted Virtualization supported
+    test %eax, %eax
+    je no_encryption          # skip reading SEV_STATUS if memory encryption is not supported
+    # We're running under something capable of SEV, so it's safe to read the SEV_STATUS MSR.
+    mov $0xc0010131, %ecx     # SEV_STATUS MSR. See Section 15.34.10 in AMD64 Architecture Programmer's
+                              # Manual, Volume 2 for more details.
     rdmsr                     # EDX:EAX <- MSR[ECX]
     and $3, %eax              # eax &= 0b11;
+                              # Bit 0 - SEV enabled
+                              # Bit 1 - SEV-ES enabled
     test %eax, %eax           # is it zero?
     je no_encryption          # if yes, jump to no_encryption
+
     # Memory encryption enabled: set encrypted bits in the page tables.
+    # We assume the encrypted bit is bit 51, for now.
+    mov $51, %esi
     mov $pml4_addr, %eax
     orl $0x80000, 4(%eax)     # PML4[0] |= (1 << 51)
     mov $pdpt_addr, %eax
@@ -87,6 +122,10 @@ _long_mode_start:
     mov $bss_size, %ecx
     xor %rax, %rax
     rep stosb
+    
+    # ESI should contain the encrypted bit number. Move it to EDI, as that's the first argument
+    # according to sysv ABI.
+    mov %esi, %edi
 
     # ...and jump to Rust code.
     jmp rust64_start


### PR DESCRIPTION
We want the stage0 binary to be compatible with both machines that do support SEV, and machines that do not.

To determine whether memory encryption is enabled (and that we need to set the encrypted bit), we need to access the `SEV_STATUS` MSR.
Curveball 1: if we try to read the `SEV_STATUS` MSR on a machine that doesn't support it, we get killed with a `#GP` fault. Therefore, we need to determine via `CPUID` whether SEV is supported at all.
Curveball 2: if we're running under SEV-ES (and presumably SEV-SNP), calling `CPUID` triggers a `#VC` fault as you're supposed to use the GHCB protocol to get the CPUID values.

Thus: let's create a `#VC` handler that returns "yes, SEV is supported" (as if you're not under SEV-ES, how did you end up triggering that exception?), and then check the CPUID value before reading `SEV_STATUS`.

As reading the MSR is potentially crash-worthy, I've also removed references to that MSR from the Rust layer. Instead, let's pass in the bit number as a parameter from the assembly.