### PR TITLE
Use rootless docker

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:2e64a98711d1957d1208bfb9d557552f337823adcc4b63ba1876a4bd567380f9",
+  "image": "sha256:215d9b11115a46f799341852ab6c43147f43414cb5e02be35d0abd63ed75cbb6",
   "extensions": [
     "13xforever.language-x86-64-assembly",
     "bazelbuild.vscode-bazel",

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:d80eb0bfeece9c94d3d56ff9ec2ee3f866ed4f828d83887e5e7d6c6e3397b9e2",
+  "image": "sha256:2e64a98711d1957d1208bfb9d557552f337823adcc4b63ba1876a4bd567380f9",
   "extensions": [
     "13xforever.language-x86-64-assembly",
     "bazelbuild.vscode-bazel",
@@ -46,5 +46,6 @@
   // See https://code.visualstudio.com/docs/remote/containers-advanced#_changing-the-default-source-code-mount.
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "containerUser": "docker"
+  // We do not need to fix the UID when running in rootless Docker.
+  "updateRemoteUserUID": false
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -376,7 +376,7 @@ ENV CARGO_INCREMENTAL false
 ENV PATH "/workspace/scripts:${PATH}"
 
 # Add sourcing of xtask_bash_completion file to .bashrc
-RUN echo -e "\n#activate xtask auto-complete\nif [ -f /workspace/.xtask_bash_completion ]; then\n  source /workspace/.xtask_bash_completion \nfi" >> ${HOME}/.bashrc
+RUN echo -e "\n#activate xtask auto-complete\nif [ -f /workspace/.xtask_bash_completion ]; then\n  source /workspace/.xtask_bash_completion \nfi" >> "${HOME}/.bashrc"
 
 # Define alias
-RUN echo -e "\nalias ll='ls -l'\n" >> ${HOME}/.bashrc
+RUN echo -e "\nalias ll='ls -l'\n" >> "${HOME}/.bashrc"

--- a/Dockerfile
+++ b/Dockerfile
@@ -372,19 +372,11 @@ ENV RUSTC_WRAPPER sccache
 # Disable cargo incremental compilation, as it conflicts with sccache: https://github.com/mozilla/sccache#rust
 ENV CARGO_INCREMENTAL false
 
-# We use the `docker` user in order to maintain library paths on different
-# machines and to make Wasm modules reproducible.
-#
-# We do not set this as the default user in the Docker image, because we expect its uid not to match
-# uid of the host, therefore we need to first fix the uid before actually using the user. This is
-# done by /scripts/fix_docker_user_and_run .
-RUN useradd --shell=/bin/bash --create-home --user-group docker
-
 # To make the scripts available to call from everywhere.
 ENV PATH "/workspace/scripts:${PATH}"
 
 # Add sourcing of xtask_bash_completion file to .bashrc
-RUN echo -e "\n#activate xtask auto-complete\nif [ -f /workspace/.xtask_bash_completion ]; then\n  source /workspace/.xtask_bash_completion \nfi" >> /home/docker/.bashrc
+RUN echo -e "\n#activate xtask auto-complete\nif [ -f /workspace/.xtask_bash_completion ]; then\n  source /workspace/.xtask_bash_completion \nfi" >> ${HOME}/.bashrc
 
 # Define alias
-RUN echo -e "\nalias ll='ls -l'\n" >> /home/docker/.bashrc
+RUN echo -e "\nalias ll='ls -l'\n" >> ${HOME}/.bashrc

--- a/docs/development.md
+++ b/docs/development.md
@@ -119,6 +119,46 @@ recommended, since it requires a lot of effort to manually install all the tool
 natively on your machine and keeping them up to date to the exact same version
 specified in Docker.
 
+## rootless Docker
+
+In order to run Docker without root privileges, follow the guide at
+https://docs.docker.com/engine/security/rootless/ .
+
+Below is a quick summary of the relevant steps.
+
+1. Install `uidmap`.
+
+   ```bash
+   sudo apt install uidmap
+   ```
+
+1. Add a range of subids for the current user.
+
+   ```bash
+   sudo usermod --add-subuids 500000-565535 --add-subgids 500000-565535 $USER
+   ```
+
+1. Download the install script for rootless docker, and run it as the current
+   user.
+
+   ```bash
+   curl -fSSL https://get.docker.com/rootless > $HOME/rootless
+   sh $HOME/rootless
+   ```
+
+1. Add the generated environment variables to your shell.
+
+   ```bash
+   export PATH=$HOME/bin:$PATH
+   export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
+   ```
+
+1. Test whether everything works correctly.
+
+   ```bash
+   docker run hello-world
+   ```
+
 ## xtask
 
 `xtask` is a utility binary to perform a number of common tasks within the Oak

--- a/docs/development.md
+++ b/docs/development.md
@@ -161,6 +161,27 @@ Below is a quick summary of the relevant steps.
    export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
    ```
 
+   **As an alternative** to setting the `DOCKER_HOST` environment variable, it
+   is possible to instead run the following command to set the Docker context.
+
+   ```bash
+   docker context use rootless
+   ```
+
+   In either case, running the following command should show the current status.
+
+   ```console
+   $ docker context ls
+   NAME        DESCRIPTION                               DOCKER ENDPOINT                       KUBERNETES ENDPOINT   ORCHESTRATOR
+   default *   Current DOCKER_HOST based configuration   unix:///run/user/152101/docker.sock                         swarm
+   rootless    Rootless mode                             unix:///run/user/152101/docker.sock
+   Warning: DOCKER_HOST environment variable overrides the active context. To use a context, either set the global --context flag, or unset DOCKER_HOST environment variable.
+   ```
+
+   This should show either that the default context is selected and is using the
+   user-local docker endpoint from the `DOCKER_HOST` variable, or that the
+   `rootless` context is selected.
+
 1. Test whether everything works correctly.
 
    ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -126,6 +126,14 @@ https://docs.docker.com/engine/security/rootless/ .
 
 Below is a quick summary of the relevant steps.
 
+1. If you have an existing version of Docker running as root, uninstall that
+   first.
+
+   ```
+   sudo systemctl disable --now docker.service docker.socket
+   sudo apt remove docker-ce docker-engine docker-runc docker-containerd
+   ```
+
 1. Install `uidmap`.
 
    ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,7 +129,7 @@ Below is a quick summary of the relevant steps.
 1. If you have an existing version of Docker running as root, uninstall that
    first.
 
-   ```
+   ```bash
    sudo systemctl disable --now docker.service docker.socket
    sudo apt remove docker-ce docker-engine docker-runc docker-containerd
    ```
@@ -166,6 +166,12 @@ Below is a quick summary of the relevant steps.
    ```bash
    docker run hello-world
    ```
+
+If you rely on VSCode remote / dev container support, that should also keep
+working, but you need to make sure that your VSCode instance sees the update
+environment variables so that it connects to the correct Docker host socket. The
+simplest way of doing this is to invoke `code` from a shell with the updated
+environment variables.
 
 ## xtask
 

--- a/scripts/common
+++ b/scripts/common
@@ -20,7 +20,7 @@ readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak:latest'
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:2e64a98711d1957d1208bfb9d557552f337823adcc4b63ba1876a4bd567380f9'
+readonly DOCKER_IMAGE_ID='sha256:215d9b11115a46f799341852ab6c43147f43414cb5e02be35d0abd63ed75cbb6'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
 readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:c714d3a51299e3256f58855a1d6c97c5ff4309d9d80aae22458adafd46ef779f'

--- a/scripts/common
+++ b/scripts/common
@@ -20,10 +20,10 @@ readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak:latest'
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:d80eb0bfeece9c94d3d56ff9ec2ee3f866ed4f828d83887e5e7d6c6e3397b9e2'
+readonly DOCKER_IMAGE_ID='sha256:2e64a98711d1957d1208bfb9d557552f337823adcc4b63ba1876a4bd567380f9'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:79583772bd8e4f5c9b188e057b6b1925e2bef606331ed3005b4e1765ae53e82e'
+readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:c714d3a51299e3256f58855a1d6c97c5ff4309d9d80aae22458adafd46ef779f'
 
 readonly SERVER_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-server'
 

--- a/scripts/common
+++ b/scripts/common
@@ -23,7 +23,7 @@ readonly DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak:latest'
 readonly DOCKER_IMAGE_ID='sha256:215d9b11115a46f799341852ab6c43147f43414cb5e02be35d0abd63ed75cbb6'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:c714d3a51299e3256f58855a1d6c97c5ff4309d9d80aae22458adafd46ef779f'
+readonly DOCKER_IMAGE_REPO_DIGEST='gcr.io/oak-ci/oak@sha256:9e6f478527ad452a83ebfc56e3e0fe2550f164e43bb9810ab989bddf4923f163'
 
 readonly SERVER_DOCKER_IMAGE_NAME='gcr.io/oak-ci/oak-server'
 

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -6,7 +6,9 @@ source "${SCRIPTS_DIR}/common"
 # Enable BuildKit for improved performance and storage management.
 #
 # See https://docs.docker.com/develop/develop-images/build_enhancements/.
-export DOCKER_BUILDKIT=1
+#
+# TODO(#3225): Re-enable buildkit support when it is compatible with rootless Docker.
+# export DOCKER_BUILDKIT=1
 
 docker build \
   --cache-from="${DOCKER_IMAGE_NAME}" \

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -7,14 +7,6 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-# In order for the docker-cli inside the container to use the host dockerd,
-# we need permissions for the user with the same gid as the host
-if [[ "${OSTYPE}" == "darwin"*  ]]; then
-  readonly HOST_DOCKER_GID="$(dscl . -read /Groups/staff | awk '($1 == "PrimaryGroupID:") { print $2 }')"
-else
-  readonly HOST_DOCKER_GID="$(getent group docker | cut -d: -f3)"
-fi
-
 mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 mkdir -p './sccache-cache'
@@ -66,4 +58,4 @@ if [[ -z "${CI:-}" ]]; then
 fi
 
 # Run the provided command.
-docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_ID" $*
+docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_ID" "$@"

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -19,25 +19,12 @@ mkdir -p './bazel-cache'
 mkdir -p './cargo-cache'
 mkdir -p './sccache-cache'
 
-# The default user for a Docker container has uid 0 (root). To avoid creating
-# root-owned files in the build directory we tell Docker to use the current user
-# ID, if known.
-# See
-# https://github.com/googleapis/google-cloud-cpp/blob/a186208b79d900b4ec71c6f9df3acf7638f01dc6/ci/kokoro/docker/build.sh#L147-L152
-readonly HOST_UID="${UID:-0}"
-readonly HOST_GID="$(id -g)"
-
-export HOST_UID
-export HOST_GID
-
 docker_run_flags=(
   '--rm'
   '--tty'
   '--env=TERM=xterm-256color'
   '--env=BAZEL_REMOTE_CACHE_ENABLED'
   '--env=BAZEL_GOOGLE_CREDENTIALS'
-  '--env=HOST_UID'
-  '--env=HOST_GID'
   "--volume=$PWD/bazel-cache:/home/docker/.cache/bazel"
   "--volume=$PWD/cargo-cache:/home/docker/.cargo"
   "--volume=$PWD/sccache-cache:/home/docker/.cache/sccache"
@@ -46,9 +33,8 @@ docker_run_flags=(
   '--workdir=/workspace'
   '--network=host'
   # We need to use Docker from inside the container, but only for build.
-  # To do that, we map the socket from the host and add the right group.
-  '--volume=/var/run/docker.sock:/var/run/docker.sock'
-  "--group-add=$HOST_DOCKER_GID"
+  # To do that, we map the socket from the host.
+  "--volume=$XDG_RUNTIME_DIR/docker.sock:/var/run/docker.sock"
 )
 
 # If the host supports KVM, allow the docker image to use it.
@@ -79,6 +65,5 @@ if [[ -z "${CI:-}" ]]; then
   docker_run_flags+=('--interactive')
 fi
 
-# Create a new user with a fixed name but with the same uid and gid as the host user, and use that
-# user to run the provided command.
-docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_ID" ./scripts/fix_docker_user_and_run "$*"
+# Run the provided command.
+docker run "${docker_run_flags[@]}" "$DOCKER_IMAGE_ID" $*


### PR DESCRIPTION
Required disabling buildkit support, which seems incompatible with
rootless for some reason (needs further investigation in https://github.com/project-oak/oak/issues/3225).

The next step (if no one complains) will be to remove the
`fix_docker_user_and_run` script, in another PR.

This should not affect CI, since CI usually already runs under root
anyways (Docker is not a security boundary, so it would be unlikely that
any CI would run the Docker daemon as root but the CI steps as a
different user).

Fix https://github.com/project-oak/oak/issues/2602