### PR TITLE
SEV-SNP enlightentment: `PVALIDATE` a chunk of memory.

### DIFF
--- a/experimental/sev_guest/src/instructions.rs
+++ b/experimental/sev_guest/src/instructions.rs
@@ -21,7 +21,7 @@ use core::arch::asm;
 use strum::FromRepr;
 
 /// Whether a page is in the validated state or not.
-#[derive(Debug, FromRepr)]
+#[derive(Clone, Copy, Debug, FromRepr)]
 #[repr(u32)]
 pub enum Validation {
     /// The page is not validated.
@@ -52,7 +52,7 @@ pub enum InstructionError {
     FailSizeMismatch = 6,
     /// The page validation status was not updated. This value is software defined and will not be
     /// returned by the hardware instruction.
-    ValdationStatusNotUpdated = 255,
+    ValidationStatusNotUpdated = 255,
 }
 
 /// Marks a page as validated or unvalidated in the RMP.
@@ -87,7 +87,7 @@ pub fn pvalidate(
             Ok(())
         } else {
             // If the carry flag is not 0, it indicates that the validated state was not changed.
-            Err(InstructionError::ValdationStatusNotUpdated)
+            Err(InstructionError::ValidationStatusNotUpdated)
         }
     } else {
         Err(InstructionError::from_repr(result)


### PR DESCRIPTION
This is a bit hacky, but I got the hello world kernel to run under SEV-SNP with these changes.

For future:
  - This blindly attempts to `PVALIDATE` all memory, no matter whether it's already marked or not. Either we need to be more clever (read the ELF header of the kernel and skip sections that should have been covered by the VMM), or add a sanity check that if the system says that it didn't change the value, then make sure it's indeed valid.
  - Obviously cover all of the valid physical memory and not the arbitrary 32 MiB like I did here.