### PR TITLE
Always compile xtask with explicit target

### DIFF
--- a/scripts/xtask
+++ b/scripts/xtask
@@ -4,7 +4,7 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
-cargo run --manifest-path="${SCRIPTS_DIR}/../xtask/Cargo.toml" -- "$@"
+cargo run --target=x86_64-unknown-linux-musl --manifest-path="${SCRIPTS_DIR}/../xtask/Cargo.toml" -- "$@"
 
 if [[ -n "${CI:-}" ]]; then
   sccache --show-stats


### PR DESCRIPTION
This prevents the cargo cache from being overwritten when some other build command is run. Currently, if you run xtask and it runs some other command, sometimes it invalidates its own binary in the cargo cache, which means the next time it is invoked it will have to be rebuilt again, which takes a few tens of extra seconds each time. Now it is instant instead.