### PR TITLE
Populate locations of SEV secrets/cpuid pages in zero page.

### DIFF
--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -33,9 +33,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
+name = "oak_linux_boot_params"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "static_assertions",
+ "strum",
+]
+
+[[package]]
 name = "oak_stage0"
 version = "0.1.0"
 dependencies = [
+ "oak_linux_boot_params",
  "sev_guest",
  "x86_64",
 ]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 members = ["."]
 
 [dependencies]
+oak_linux_boot_params = { path = "../linux_boot_params" }
 sev_guest = { path = "../experimental/sev_guest" }
 x86_64 = "*"
 

--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -81,6 +81,7 @@ SECTIONS {
     .boot.zero_page 0x7000 (NOLOAD) : {
         *(.boot.zero_page)
     } > ram_low
+    ASSERT(SIZEOF(.boot.zero_page) == 4K, "Zero page has to be exactly one page in size")
 
     boot_stack_pointer = 0x8000;
 
@@ -110,6 +111,13 @@ SECTIONS {
         KEEP(*(.boot.cpuid))
     } > ram_low
     ASSERT(SIZEOF(.boot.cpuid) == 4K, "CPUID section has to be exactly one page in size")
+
+    .boot ALIGN(4K) (NOLOAD) : {
+        boot_data_structs_start = .;
+        KEEP(*(.boot))
+        . = ALIGN(4K);
+        boot_data_structs_end = .;
+    } > ram_low
 
     ASSERT(. < 640K, "Boot data structures overflow low memory")
 

--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -97,11 +97,6 @@ SECTIONS {
         *(.boot.pd)
     } > ram_low
 
-    .boot.unmeasured 0xC000 (NOLOAD) : {
-        KEEP(*(.boot.unmeasured))
-    } > ram_low
-    ASSERT(SIZEOF(.boot.unmeasured) == 4K, "Unmeasured section has to be exactly one page in size")
-
     .boot.secrets 0xD000 (NOLOAD) : {
         KEEP(*(.boot.secrets))
     } > ram_low
@@ -113,10 +108,8 @@ SECTIONS {
     ASSERT(SIZEOF(.boot.cpuid) == 4K, "CPUID section has to be exactly one page in size")
 
     .boot ALIGN(4K) (NOLOAD) : {
-        boot_data_structs_start = .;
         KEEP(*(.boot))
         . = ALIGN(4K);
-        boot_data_structs_end = .;
     } > ram_low
 
     ASSERT(. < 640K, "Boot data structures overflow low memory")
@@ -313,8 +306,8 @@ SECTIONS {
          * Thankfully none of these clashed with existing data structures that we're setting up.
          */
         /* Unmeasured page location */
-        LONG(ADDR(.boot.unmeasured))
-        LONG(SIZEOF(.boot.unmeasured))
+        LONG(ADDR(.boot))
+        LONG(SIZEOF(.boot))
         LONG(SEV_SECTION_UNMEASURED)
         /* Secrets page location */
         LONG(ADDR(.boot.secrets))

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -17,7 +17,13 @@
 #![no_std]
 #![no_main]
 
-use core::{arch::asm, ffi::c_void, mem::MaybeUninit, panic::PanicInfo};
+use core::{
+    arch::asm,
+    ffi::c_void,
+    mem::{size_of, zeroed, MaybeUninit},
+    panic::PanicInfo,
+};
+use oak_linux_boot_params::BootParams;
 use sev_guest::instructions::{pvalidate, InstructionError, PageSize as SevPageSize, Validation};
 use x86_64::{
     instructions::{hlt, interrupts::int3, segmentation::Segment},
@@ -42,6 +48,8 @@ mod asm;
 static mut BOOT_GDT: MaybeUninit<GlobalDescriptorTable> = MaybeUninit::uninit();
 #[link_section = ".boot.idt"]
 static mut BOOT_IDT: MaybeUninit<InterruptDescriptorTable> = MaybeUninit::uninit();
+#[link_section = ".boot.zero_page"]
+static mut BOOT_ZERO_PAGE: MaybeUninit<BootParams> = MaybeUninit::uninit();
 #[link_section = ".boot.pml4"]
 static mut BOOT_PML4: MaybeUninit<PageTable> = MaybeUninit::uninit();
 #[link_section = ".boot.pdpt"]
@@ -52,11 +60,15 @@ static mut BOOT_PD: MaybeUninit<PageTable> = MaybeUninit::uninit();
 #[used]
 static mut SEV_UNMEASURED: MaybeUninit<[u8; 4096]> = MaybeUninit::uninit();
 #[link_section = ".boot.secrets"]
-#[used]
 static mut SEV_SECRETS: MaybeUninit<sev_guest::secrets::SecretsPage> = MaybeUninit::uninit();
 #[link_section = ".boot.cpuid"]
-#[used]
 static mut SEV_CPUID: MaybeUninit<sev_guest::cpuid::CpuidPage> = MaybeUninit::uninit();
+
+#[link_section = ".boot"]
+static mut CC_BLOB_SEV_INFO: MaybeUninit<oak_linux_boot_params::CCBlobSevInfo> =
+    MaybeUninit::uninit();
+#[link_section = ".boot"]
+static mut CC_SETUP_DATA: MaybeUninit<oak_linux_boot_params::CCSetupData> = MaybeUninit::uninit();
 
 extern "C" {
     #[link_name = "pd_addr"]
@@ -64,6 +76,12 @@ extern "C" {
 
     #[link_name = "boot_stack_pointer"]
     static BOOT_STACK_POINTER: c_void;
+
+    #[link_name = "boot_data_structs_start"]
+    static BOOT_DATA_STRUCTS_START: c_void;
+
+    #[link_name = "boot_data_structs_end"]
+    static BOOT_DATA_STRUCTS_END: c_void;
 }
 
 /// Creates page tables that identity-map the first 1GiB of memory using 2MiB hugepages.
@@ -111,11 +129,12 @@ pub unsafe fn jump_to_kernel(entry_point: VirtAddr) -> ! {
         // Boot stack pointer
         "mov {1}, %rsp",
         // Zero page address
-        "mov $0x7000, %rsi",
+        "mov {2}, %rsi",
         // ...and away we go!
         "jmp *{0}",
         in(reg) entry_point.as_u64(),
         in(reg) &BOOT_STACK_POINTER as *const _ as u64,
+        in(reg) BOOT_ZERO_PAGE.as_ptr() as u64,
         options(noreturn, att_syntax)
     );
 }
@@ -283,6 +302,45 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
         );
     }
     /* TODO(#3198): interrogate qemu for memory areas and set up the zero page. */
+
+    // Safety: We assume the VMM has filled in the basic zero page for us. This is not true with
+    // qemu. In the future, construction of the full zero page should be in here, and instead of
+    // `assume_init_mut` we will use the safe `write` to zero it out and get a mutable reference.
+    let zero_page = unsafe { BOOT_ZERO_PAGE.assume_init_mut() };
+
+    if snp {
+        PhysFrame::<Size4KiB>::range(
+            PhysFrame::from_start_address(PhysAddr::new(
+                unsafe { &BOOT_DATA_STRUCTS_START } as *const _ as u64
+            ))
+            .unwrap(),
+            PhysFrame::from_start_address(PhysAddr::new(
+                unsafe { &BOOT_DATA_STRUCTS_END } as *const _ as u64
+            ))
+            .unwrap(),
+        )
+        .pvalidate(Validation::Validated)
+        .unwrap();
+
+        let setup_data = unsafe { CC_SETUP_DATA.write(zeroed()) };
+        let cc_blob = unsafe { CC_BLOB_SEV_INFO.write(zeroed()) };
+
+        setup_data.header.type_ = oak_linux_boot_params::SetupDataType::CCBlob;
+        setup_data.header.len = (size_of::<oak_linux_boot_params::CCSetupData>()
+            - size_of::<oak_linux_boot_params::SetupData>()) as u32;
+        setup_data.cc_blob_address = cc_blob as *const _ as u32;
+
+        cc_blob.magic = oak_linux_boot_params::CC_BLOB_SEV_INFO_MAGIC;
+        cc_blob.version = 1;
+        cc_blob.secrets_phys = unsafe { SEV_SECRETS.as_ptr() } as usize;
+        cc_blob.secrets_len = size_of::<sev_guest::secrets::SecretsPage>() as u32;
+        cc_blob.cpuid_phys = unsafe { SEV_CPUID.as_ptr() } as usize;
+        cc_blob.cpuid_len = size_of::<sev_guest::cpuid::CpuidPage>() as u32;
+
+        // Put our header as the first element in the linked list.
+        setup_data.header.next = zero_page.hdr.setup_data;
+        zero_page.hdr.setup_data = &setup_data.header as *const oak_linux_boot_params::SetupData;
+    }
 
     // Temporary hack: PVALIDATE [2..32] MiB of physical memory, ignoring any failures to update
     // the status for now. In the future, after we have determined the physical memory


### PR DESCRIPTION
We were hoping to use magic ELF sections in the kernel itself to designate where the secrets and CPUID pages should go, but that won't work with the stage0 approach.

Instead of that, if stage0 detects we're running under SEV, let's add an extended setup_data arg to the zero page that points to the locations of those magic pages.

This is also how the location information is handed to the Linux kernel itself.

For now, we'll assume that the VMM has populated (the rest of) the zero page for us; in the hopefully not-too-distant future, the whole zero page will be created in stage0.