### PR TITLE
Use the zero page to locate the cpuid/secrets structures in the hello world kernel

### DIFF
--- a/testing/sev_snp_hello_world_kernel/Cargo.lock
+++ b/testing/sev_snp_hello_world_kernel/Cargo.lock
@@ -63,6 +63,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_linux_boot_params"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "static_assertions",
+ "strum",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +114,7 @@ dependencies = [
  "atomic_refcell",
  "lazy_static",
  "log",
+ "oak_linux_boot_params",
  "sev_guest",
  "uart_16550",
  "x86_64",

--- a/testing/sev_snp_hello_world_kernel/Cargo.toml
+++ b/testing/sev_snp_hello_world_kernel/Cargo.toml
@@ -13,6 +13,7 @@ members = ["."]
 atomic_refcell = "*"
 lazy_static = { version = "*", features = ["spin_no_std"] }
 log = "*"
+oak_linux_boot_params = { path = "../../linux_boot_params" }
 uart_16550 = "*"
 x86_64 = "*"
 sev_guest = { path = "../../experimental/sev_guest" }

--- a/testing/sev_snp_hello_world_kernel/layout.ld
+++ b/testing/sev_snp_hello_world_kernel/layout.ld
@@ -93,14 +93,6 @@ SECTIONS {
     } : bss
     stack_start = .;
 
-    .cpuid (NOLOAD) : ALIGN(2M) {
-    } : cpuid
-    ASSERT((SIZEOF(.cpuid) == 0x1000), "cpuid page needs to be exactly 4K in size")
-
-    .secrets (NOLOAD) : ALIGN(2M) {
-    } : secrets
-    ASSERT((SIZEOF(.secrets) == 0x1000), "secrets page needs to be exactly 4K in size")
-
     /DISCARD/ : {
         *(.eh_frame*)
     }


### PR DESCRIPTION
This is complementary to https://github.com/project-oak/oak/pull/3246.

We were always printing out those data structures, even when we weren't running under SEV-SNP; as the pages weren't populated, they contained garbage anyway.

Instead, let's print out nice status messages about whether we've detected any of {SEV,SEV-ES,SNP} as enabled and print out the cpuid/zero pages only under SEV-SNP.