### PR TITLE
Update axum-core to resolve cargo-deny advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
+checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -290,6 +290,8 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -16,8 +16,6 @@ ignore = [
   # We rely on flatbuffers, which generates potentially unsafe code via "safe" APIs.
   # See https://github.com/google/flatbuffers/issues/6627
   "RUSTSEC-2021-0122",
-  # TODO(#3202): Remove when Tonic depends on a newer version of Axum.
-  "RUSTSEC-2022-0055"
 ]
 
 [bans]


### PR DESCRIPTION
Tonic has not been updated, but a fixed version of axum-core is compatible with the current version of axum.

Fixes #3202