### PR TITLE
Check if we have a ELF header at 0x200000 in stage0

### DIFF
--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -27,6 +27,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "goblin"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
+dependencies = [
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,10 +55,17 @@ dependencies = [
 name = "oak_stage0"
 version = "0.1.0"
 dependencies = [
+ "goblin",
  "oak_linux_boot_params",
  "sev_guest",
  "x86_64",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
@@ -73,6 +90,12 @@ name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 
 [[package]]
 name = "sev_guest"

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 members = ["."]
 
 [dependencies]
+goblin = { version = "*", default-features = false, features = ["elf64"] }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 sev_guest = { path = "../experimental/sev_guest" }
 x86_64 = "*"


### PR DESCRIPTION
Our hello world kernel had its entry point at `0x200000`, so we blindly jumped to that address. However, our real Restricted Kernel has its entry point at `0x201000`, as it first loads its own ELF file header to address `0x200000`.

Thus, let's check if we have a valid ELF header at that address. If yes, look up the entry point address from the header. If we don't find an ELF header at that address, assume it's code and just jump there.

Strictly speaking there is no standard that requires there to be either code or ELF header at 0x200000, it's just a convention we follow. I suspect we need to do something more clever here if we ever want to make the Linux kernel boot with our stage0.

Fixes #3199 