### PR TITLE
Use Split launcher to run examples

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -59,10 +59,6 @@ jobs:
           ./scripts/docker_pull
           df --human-readable
 
-      - name: Generate provenacne for Base Oak Functions Server
-        run: |
-          ./scripts/generate_provenance -c buildconfigs/oak_functions_loader_base.toml -s
-
       - name: Generate provenance for crosvm Baremetal binary
         run: |
           ./scripts/generate_provenance -c buildconfigs/oak_baremetal_app_crosvm.toml -s

--- a/buildconfigs/oak_functions_loader_base.toml
+++ b/buildconfigs/oak_functions_loader_base.toml
@@ -1,9 +1,0 @@
-# This is the static build configuration that we use with the transparent
-# release tool for building the provenance of `oak_functions_loader_base`.
-# To be able to use it with the build tool from Transparent Release, additional
-# information must be added. See `./scripts/generate_provenance` for more info.
-repo = "https://github.com/project-oak/oak"
-command = ["./scripts/xtask", "build-oak-functions-server-variants"]
-# Even though the command above generates all variants, the provenance is only
-# generated for the Base variant (i.e., `oak_functions_loader_base`).
-output_path = "./target/x86_64-unknown-linux-musl/release/oak_functions_loader_base"

--- a/oak_functions/examples/echo/config.toml
+++ b/oak_functions/examples/echo/config.toml
@@ -1,5 +1,0 @@
-wasm_path = "bin/echo.wasm"
-
-[policy]
-constant_response_size_bytes = 90
-constant_processing_time = "20ms"

--- a/oak_functions/examples/echo/example.toml
+++ b/oak_functions/examples/echo/example.toml
@@ -7,7 +7,9 @@ type = "OakFunctions"
 target = { Cargo = { cargo_manifest = "oak_functions/examples/echo/module/Cargo.toml" } }
 
 [server]
-additional_args = ["--config-path=./oak_functions/examples/echo/config.toml"]
+wasm_path = "bin/echo.wasm"
+constant_response_size_bytes = 90
+lookup_data = "experimental/oak_baremetal_launcher/mock_lookup_data"
 
 [clients]
 # Test request coordinates are defined in `oak_functions/lookup_data_generator/src/data.rs`.
@@ -17,4 +19,5 @@ rust = { Cargo = { cargo_manifest = "oak_functions/client/rust/Cargo.toml" }, ad
   "--expected-response-pattern=test"
 ] }
 # The web client tests are tailored for the echo example.
-web = { Shell = { build_script = "", run_script = "wasm-pack test --chrome --headless experimental/web_client" } }
+# TODO(#3256): Re-enable web client when it is compatible with the split launcher.
+# web = { Shell = { build_script = "", run_script = "wasm-pack test --chrome --headless experimental/web_client" } }

--- a/oak_functions/examples/key_value_lookup/config.toml
+++ b/oak_functions/examples/key_value_lookup/config.toml
@@ -1,9 +1,0 @@
-wasm_path = "bin/key_value_lookup.wasm"
-
-[load_lookup_data]
-lookup_data = { Url = "https://storage.googleapis.com/oak_lookup_data/lookup_data_weather" }
-lookup_data_download_period = "10m"
-
-[policy]
-constant_response_size_bytes = 90
-constant_processing_time = "20ms"

--- a/oak_functions/examples/key_value_lookup/example.toml
+++ b/oak_functions/examples/key_value_lookup/example.toml
@@ -7,13 +7,13 @@ type = "OakFunctions"
 target = { Cargo = { cargo_manifest = "oak_functions/examples/key_value_lookup/module/Cargo.toml" } }
 
 [server]
-additional_args = [
-  "--config-path=./oak_functions/examples/key_value_lookup/config.toml"
-]
+wasm_path = "bin/key_value_lookup.wasm"
+constant_response_size_bytes = 90
+lookup_data = "experimental/oak_baremetal_launcher/mock_lookup_data"
 
 [clients]
-# Test request coordinates are defined in `oak_functions/lookup_data_generator/src/data.rs`.
 rust = { Cargo = { cargo_manifest = "oak_functions/client/rust/Cargo.toml" }, additional_args = [
   "--uri=http://localhost:8080",
-  "--request={\"lat\":0,\"lng\":0}"
+  "--request=test_key",
+  "--expected-response-pattern=test_value"
 ] }

--- a/oak_functions/examples/weather_lookup/config.toml
+++ b/oak_functions/examples/weather_lookup/config.toml
@@ -1,9 +1,0 @@
-wasm_path = "bin/weather_lookup_init.wasm"
-
-[load_lookup_data]
-lookup_data = { Url = "https://storage.googleapis.com/oak_lookup_data/lookup_data_weather_sparse_s2" }
-lookup_data_download_period = "10m"
-
-[policy]
-constant_response_size_bytes = 900
-constant_processing_time = "1s"

--- a/oak_functions/examples/weather_lookup/example.toml
+++ b/oak_functions/examples/weather_lookup/example.toml
@@ -8,9 +8,9 @@ target = { Cargo = { cargo_manifest = "oak_functions/examples/weather_lookup/mod
 wizer = { input = "bin/weather_lookup.wasm", output = "bin/weather_lookup_init.wasm" }
 
 [server]
-additional_args = [
-  "--config-path=./oak_functions/examples/weather_lookup/config.toml"
-]
+wasm_path = "bin/weather_lookup_init.wasm"
+constant_response_size_bytes = 900
+lookup_data = "oak_functions/examples/weather_lookup/testdata/lookup_data_weather_sparse_s2"
 
 [clients]
 # Test request coordinates are defined in `oak_functions/lookup_data_generator/src/data.rs`.

--- a/remote_attestation/rust/src/handshaker.rs
+++ b/remote_attestation/rust/src/handshaker.rs
@@ -478,7 +478,6 @@ impl<G: AttestationGenerator, V: AttestationVerifier> ServerHandshaker<G, V> {
             .append(&client_identity_no_signature)
             .context("Couldn't append client identity to the transcript")?;
         let client_signing_public_key = &client_identity.signing_public_key;
-        let transcript_signature_verifier = SignatureVerifier::new(client_signing_public_key)?;
 
         // TODO(#2918): Remove this check when the Java client generates a non-empty signature, and
         // always verify the signature.
@@ -487,6 +486,7 @@ impl<G: AttestationGenerator, V: AttestationVerifier> ServerHandshaker<G, V> {
             // client.
             // Until this is fixed, this version of the server must not be used in production.
         } else {
+            let transcript_signature_verifier = SignatureVerifier::new(client_signing_public_key)?;
             transcript_signature_verifier
                 .verify(
                     &self.transcript.get_sha256(),

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -203,7 +203,7 @@ impl ServerVariant {
     // Get path to manifest for the variant.
     pub fn path_to_manifest(&self) -> &'static str {
         match self {
-            ServerVariant::Base => "./oak_functions/oak_functions_loader_base",
+            ServerVariant::Base => "./experimental/oak_baremetal_launcher",
         }
     }
 
@@ -211,7 +211,7 @@ impl ServerVariant {
     pub fn path_to_executable(&self) -> &'static str {
         match self {
             ServerVariant::Base => {
-                "./target/x86_64-unknown-linux-musl/release/oak_functions_loader_base"
+                "./target/x86_64-unknown-linux-musl/release/oak_baremetal_launcher"
             }
         }
     }


### PR DESCRIPTION
Change logic in `xtask` to parse the config values (e.g. wasm module
location, constant size) from the example.toml file directly, since the
split launcher accepts them as separate flags instead of a single config
file.

The web client does not seem to work with the split launcher, so I
temporarily disabled it and created #3256 to follow up.

The Java client was also initially not working, but I tracked that down
to the server trying to parse the transcript signing key, but the Java
client only providing zeros for it at the moment. That work is already
tracked in #2918.

Fix #3241