### PR TITLE
Initialize frame allocator from E820 and use it for finding memory for the heap

### DIFF
--- a/experimental/oak_baremetal_kernel/src/mm/bitmap_frame_allocator.rs
+++ b/experimental/oak_baremetal_kernel/src/mm/bitmap_frame_allocator.rs
@@ -51,7 +51,6 @@ impl<S: PageSize, const N: usize> BitmapAllocator<S, N> {
     /// Creates a new bitmap allocator for a physical frame range.
     /// Panics if N does not match the number of u64-s required to track all frames in that range.
     /// Initially, the allocator will mark the whole range as invalid.
-    #[allow(dead_code)]
     pub fn new(range: PhysFrameRangeInclusive<S>) -> Self {
         // Unfortunately there doesn't seem to be a way to hoist this to the type system.
         let expected = bitvec::mem::elts::<u64>(range.count());
@@ -74,7 +73,6 @@ impl<S: PageSize, const N: usize> BitmapAllocator<S, N> {
     /// Allocations can happen only from regions that are valid. This method does not check whether
     /// any allocations have been made from regions to be marked as invalid, and panics if the range
     /// is outside the range of the allocator.
-    #[allow(dead_code)]
     pub fn mark_valid(&mut self, range: PhysFrameRangeInclusive<S>, valid: bool) {
         if let (Some(start), Some(end)) = (self.frame_idx(range.start), self.frame_idx(range.end)) {
             self.valid.get_mut(start..end + 1).unwrap().fill(valid);
@@ -87,7 +85,6 @@ impl<S: PageSize, const N: usize> BitmapAllocator<S, N> {
     }
 
     /// Returns the largest contiguous section of unallocated memory.
-    #[allow(dead_code)]
     pub fn largest_available(&self) -> Option<PhysFrameRangeInclusive<S>> {
         self.valid
             .bitand(self.allocated.not())

--- a/experimental/oak_baremetal_kernel/src/mm/frame_allocator.rs
+++ b/experimental/oak_baremetal_kernel/src/mm/frame_allocator.rs
@@ -36,12 +36,12 @@ pub struct PhysicalMemoryAllocator<const N: usize> {
     /// When first asked for a 4K frame, we take one 2 MiB frame to hand out as 4 KiB frames; that
     /// gives us 512 4K frames to hand out. Thus, the allocator bitmap needs to be 512/64 = 8
     /// u64-s, or 64 B.
-    small_frames: Option<BitmapAllocator<Size4KiB, 1>>,
+    small_frames: Option<BitmapAllocator<Size4KiB, 8>>,
 }
 
 impl<const N: usize> PhysicalMemoryAllocator<N> {
     #[allow(dead_code)]
-    fn new(range: PhysFrameRangeInclusive<Size2MiB>) -> Self {
+    pub fn new(range: PhysFrameRangeInclusive<Size2MiB>) -> Self {
         PhysicalMemoryAllocator {
             large_frames: BitmapAllocator::new(range),
             small_frames: None,
@@ -130,7 +130,7 @@ mod tests {
     fn fill_small_frames() {
         let mut allocator =
             PhysicalMemoryAllocator::<1>::new(create_frame_range(0, Size2MiB::SIZE));
-        allocator.mark_valid(create_frame_range(0, 1 * Size2MiB::SIZE), true);
+        allocator.mark_valid(create_frame_range(0, Size2MiB::SIZE), true);
         let alloc_ref = &mut allocator as &mut dyn FrameAllocator<Size4KiB>;
         // 512 allocations should succeed (512 * 4K = 2M)
         for _ in 0..512 {

--- a/experimental/oak_baremetal_kernel/src/mm/frame_allocator.rs
+++ b/experimental/oak_baremetal_kernel/src/mm/frame_allocator.rs
@@ -26,8 +26,8 @@ use x86_64::structures::paging::{
 /// it into smaller, 4 KiB frames to satisfy demand.
 ///
 /// The parameter N needs to be set to the number of u64-s required to track the physical memory in
-/// a bitmap. For example, if we want to track 128 GiB of memory, that means 128G/2M = 65K frames,
-/// which in turn means we need 65K/64 = 1K u64-s (or: 1K * 8 = 8 kB of memory).
+/// a bitmap. For example, if we want to track 128 GiB of memory, that means 128Gi/2Mi = 65Ki
+/// frames, which in turn means we need 65Ki/64 = 1Ki u64-s (or: 1Ki * 8 = 8 KiB of memory).
 pub struct PhysicalMemoryAllocator<const N: usize> {
     /// Allocator for 2 MiB frames.
     large_frames: BitmapAllocator<Size2MiB, N>,
@@ -40,7 +40,6 @@ pub struct PhysicalMemoryAllocator<const N: usize> {
 }
 
 impl<const N: usize> PhysicalMemoryAllocator<N> {
-    #[allow(dead_code)]
     pub fn new(range: PhysFrameRangeInclusive<Size2MiB>) -> Self {
         PhysicalMemoryAllocator {
             large_frames: BitmapAllocator::new(range),
@@ -48,12 +47,10 @@ impl<const N: usize> PhysicalMemoryAllocator<N> {
         }
     }
 
-    #[allow(dead_code)]
     pub fn mark_valid(&mut self, range: PhysFrameRangeInclusive<Size2MiB>, valid: bool) {
         self.large_frames.mark_valid(range, valid)
     }
 
-    #[allow(dead_code)]
     pub fn largest_available(&mut self) -> Option<PhysFrameRangeInclusive<Size2MiB>> {
         self.large_frames.largest_available()
     }

--- a/experimental/oak_baremetal_kernel/src/mm/frame_allocator.rs
+++ b/experimental/oak_baremetal_kernel/src/mm/frame_allocator.rs
@@ -1,0 +1,142 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use super::bitmap_frame_allocator::BitmapAllocator;
+use x86_64::structures::paging::{
+    frame::PhysFrameRangeInclusive, FrameAllocator, FrameDeallocator, PageSize, PhysFrame,
+    Size2MiB, Size4KiB,
+};
+
+/// Allocator to track physical memory frames.
+///
+/// The basic unit we track is a 2 MiB frame. If necessary, we will take one 2 MiB frame and break
+/// it into smaller, 4 KiB frames to satisfy demand.
+///
+/// The parameter N needs to be set to the number of u64-s required to track the physical memory in
+/// a bitmap. For example, if we want to track 128 GiB of memory, that means 128G/2M = 65K frames,
+/// which in turn means we need 65K/64 = 1K u64-s (or: 1K * 8 = 8 kB of memory).
+pub struct PhysicalMemoryAllocator<const N: usize> {
+    /// Allocator for 2 MiB frames.
+    large_frames: BitmapAllocator<Size2MiB, N>,
+    /// Allocator for 4 KiB frames.
+    ///
+    /// When first asked for a 4K frame, we take one 2 MiB frame to hand out as 4 KiB frames; that
+    /// gives us 512 4K frames to hand out. Thus, the allocator bitmap needs to be 512/64 = 8
+    /// u64-s, or 64 B.
+    small_frames: Option<BitmapAllocator<Size4KiB, 1>>,
+}
+
+impl<const N: usize> PhysicalMemoryAllocator<N> {
+    #[allow(dead_code)]
+    fn new(range: PhysFrameRangeInclusive<Size2MiB>) -> Self {
+        PhysicalMemoryAllocator {
+            large_frames: BitmapAllocator::new(range),
+            small_frames: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn mark_valid(&mut self, range: PhysFrameRangeInclusive<Size2MiB>, valid: bool) {
+        self.large_frames.mark_valid(range, valid)
+    }
+
+    #[allow(dead_code)]
+    pub fn largest_available(&mut self) -> Option<PhysFrameRangeInclusive<Size2MiB>> {
+        self.large_frames.largest_available()
+    }
+}
+
+unsafe impl<const N: usize> FrameAllocator<Size2MiB> for PhysicalMemoryAllocator<N> {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<Size2MiB>> {
+        self.large_frames.allocate_frame()
+    }
+}
+
+impl<const N: usize> FrameDeallocator<Size2MiB> for PhysicalMemoryAllocator<N> {
+    unsafe fn deallocate_frame(&mut self, frame: PhysFrame<Size2MiB>) {
+        self.large_frames.deallocate_frame(frame)
+    }
+}
+
+unsafe impl<const N: usize> FrameAllocator<Size4KiB> for PhysicalMemoryAllocator<N> {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<Size4KiB>> {
+        let allocator = self.small_frames.get_or_insert_with(|| {
+            let frame = self.large_frames.allocate_frame().unwrap();
+            // Safety: the frame we get from the 2MiB allocator is aligned to 2 MiB, which means
+            // it's by definition aligned to 4K as well.
+            let range = PhysFrame::range_inclusive(
+                PhysFrame::from_start_address(frame.start_address()).unwrap(),
+                PhysFrame::from_start_address(
+                    frame.start_address() + frame.size() - Size4KiB::SIZE,
+                )
+                .unwrap(),
+            );
+            let mut alloc = BitmapAllocator::new(range);
+            alloc.mark_valid(range, true);
+            alloc
+        });
+        allocator.allocate_frame()
+    }
+}
+
+impl<const N: usize> FrameDeallocator<Size4KiB> for PhysicalMemoryAllocator<N> {
+    unsafe fn deallocate_frame(&mut self, frame: PhysFrame<Size4KiB>) {
+        self.small_frames.as_mut().unwrap().deallocate_frame(frame)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use x86_64::PhysAddr;
+
+    use super::*;
+
+    fn create_frame(start: u64) -> PhysFrame<Size2MiB> {
+        PhysFrame::from_start_address(PhysAddr::new(start)).unwrap()
+    }
+
+    fn create_frame_range(start: u64, end: u64) -> PhysFrameRangeInclusive<Size2MiB> {
+        PhysFrame::range_inclusive(create_frame(start), create_frame(end))
+    }
+
+    #[test]
+    fn simple_allocator() {
+        let mut allocator =
+            PhysicalMemoryAllocator::<1>::new(create_frame_range(0, 2 * Size2MiB::SIZE));
+        allocator.mark_valid(create_frame_range(0, 2 * Size2MiB::SIZE), true);
+        (&mut allocator as &mut dyn FrameAllocator<Size2MiB>)
+            .allocate_frame()
+            .unwrap();
+        (&mut allocator as &mut dyn FrameAllocator<Size4KiB>)
+            .allocate_frame()
+            .unwrap();
+    }
+
+    #[test]
+    fn fill_small_frames() {
+        let mut allocator =
+            PhysicalMemoryAllocator::<1>::new(create_frame_range(0, Size2MiB::SIZE));
+        allocator.mark_valid(create_frame_range(0, 1 * Size2MiB::SIZE), true);
+        let alloc_ref = &mut allocator as &mut dyn FrameAllocator<Size4KiB>;
+        // 512 allocations should succeed (512 * 4K = 2M)
+        for _ in 0..512 {
+            alloc_ref.allocate_frame().unwrap();
+        }
+        // and the next one shouldn't, as we've filled the page.
+        assert_eq!(None, alloc_ref.allocate_frame());
+    }
+}

--- a/experimental/oak_baremetal_kernel/src/mm/mod.rs
+++ b/experimental/oak_baremetal_kernel/src/mm/mod.rs
@@ -14,5 +14,56 @@
 // limitations under the License.
 //
 
+use crate::boot::{E820Entry, E820EntryType};
+use log::info;
+use x86_64::{
+    addr::{align_down, align_up},
+    structures::paging::{PageSize, PhysFrame, Size2MiB},
+    PhysAddr,
+};
+
 mod bitmap_frame_allocator;
-mod frame_allocator;
+pub mod frame_allocator;
+
+pub fn init<const N: usize, E: E820Entry>(
+    memory_map: &[E],
+) -> frame_allocator::PhysicalMemoryAllocator<N> {
+    // This assumes all memory is in the lower end of the address space.
+    let mut alloc = frame_allocator::PhysicalMemoryAllocator::new(PhysFrame::range_inclusive(
+        PhysFrame::from_start_address(PhysAddr::new(0x0)).unwrap(),
+        // N u64-s * 64 frames per u64 * 2 MiB per frame
+        PhysFrame::from_start_address(PhysAddr::new((N as u64 * 64 - 1) * Size2MiB::SIZE)).unwrap(),
+    ));
+
+    memory_map
+        .iter()
+        .inspect(|e| {
+            info!(
+                "E820 entry: [{:#016x}..{:#016x}) ({}), type {}",
+                e.addr(),
+                e.addr() + e.size(),
+                e.size(),
+                e.entry_type()
+            );
+        })
+        .filter(|e| e.entry_type() == E820EntryType::RAM)
+        .map(|e| {
+            // Clip both ends, if necessary, to make sure that we are aligned with 2 MiB pages.
+            (
+                PhysAddr::new(align_up(e.addr() as u64, Size2MiB::SIZE)),
+                PhysAddr::new(align_down((e.addr() + e.size()) as u64, Size2MiB::SIZE)),
+            )
+        })
+        .filter(|(start, limit)| limit > start)
+        .map(|(start, limit)| {
+            // Safety: align_down/align_up guarantees we're aligned to 2 MiB boundaries,
+            // and we know there's _something_ in the memory range.
+            PhysFrame::range_inclusive(
+                PhysFrame::from_start_address(start).unwrap(),
+                PhysFrame::from_start_address(limit).unwrap() - 1,
+            )
+        })
+        .for_each(|range| alloc.mark_valid(range, true));
+
+    alloc
+}

--- a/experimental/oak_baremetal_kernel/src/mm/mod.rs
+++ b/experimental/oak_baremetal_kernel/src/mm/mod.rs
@@ -15,3 +15,4 @@
 //
 
 mod bitmap_frame_allocator;
+mod frame_allocator;


### PR DESCRIPTION
Following up to #3168, this now makes use of the bitmap allocator.

First, we create a proper frame allocator for physical memory that is able to handle both 2M and 4K pages, as necessary.

Second, set up the frame allocator with the information from the E820 map, and use it to find the largest memory region for the heap, similar to what we do now.

This covers the basic functionality, but that's not all we need. It still relies on the magic linker variables to make sure we won't overwrite our other data structures; these reserved regions should be properly parsed from the ELF header (which we do load into memory).
And, we want the page allocator to use this frame allocator as well.

But we now do have an authoritative data structure to represent which memory regions are in use and which are not, and you can request a frame for your perusal during runtime.