### PR TITLE
Clean-up: remove references to special CPUID/secrets ELF sections.

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/layout.ld
+++ b/experimental/oak_baremetal_app_crosvm/layout.ld
@@ -33,9 +33,6 @@ PHDRS
     data    PT_LOAD FLAGS(4 + 2); /* PF_R + PF_W */
     /* Uninitialized read-write data. */
     bss     PT_LOAD FLAGS(4 + 2); /* PF_R + PF_W */
-    /* Special sections for SEV-SNP. */
-    cpuid   PT_LOAD FLAGS(1 << 23);
-    secrets PT_LOAD FLAGS(1 << 24);
 }
 
 /* To set kernel VMA to low memory, set this to 0x0. */
@@ -96,14 +93,6 @@ SECTIONS {
         . += 512K;
     } : bss
     stack_start = .;
-
-    .cpuid (NOLOAD) : ALIGN(2M) {
-        . += 4K;
-    } : cpuid
-
-    .secrets (NOLOAD) : ALIGN(2M) {
-        . += 4K;
-    } : secrets
 
     /DISCARD/ : {
         *(.eh_frame*)

--- a/testing/oak_echo_bin/layout.ld
+++ b/testing/oak_echo_bin/layout.ld
@@ -33,9 +33,6 @@ PHDRS
     data    PT_LOAD FLAGS(4 + 2); /* PF_R + PF_W */
     /* Uninitialized read-write data. */
     bss     PT_LOAD FLAGS(4 + 2); /* PF_R + PF_W */
-    /* Special sections for SEV-SNP. */
-    cpuid   PT_LOAD FLAGS(1 << 23);
-    secrets PT_LOAD FLAGS(1 << 24);
 }
 
 /* To set kernel VMA to low memory, set this to 0x0. */
@@ -96,14 +93,6 @@ SECTIONS {
         . += 512K;
     } : bss
     stack_start = .;
-
-    .cpuid (NOLOAD) : ALIGN(2M) {
-        . += 4K;
-    } : cpuid
-
-    .secrets (NOLOAD) : ALIGN(2M) {
-        . += 4K;
-    } : secrets
 
     /DISCARD/ : {
         *(.eh_frame*)

--- a/testing/sev_snp_hello_world_kernel/layout.ld
+++ b/testing/sev_snp_hello_world_kernel/layout.ld
@@ -32,9 +32,6 @@ PHDRS
     data    PT_LOAD FLAGS(4 + 2); /* PF_R + PF_W */
     /* Uninitialized read-write data. */
     bss     PT_LOAD FLAGS(4 + 2); /* PF_R + PF_W */
-    /* Special sections for SEV-SNP. */
-    cpuid   PT_LOAD FLAGS(1 << 23);
-    secrets PT_LOAD FLAGS(1 << 24);
 }
 
 /* To set kernel VMA to high memory, set this to 0xFFFFFFFF80000000. */


### PR DESCRIPTION
Our original plan was to determine what memory regions to use for the SEV-SNP secrets pages based on data in the ELF files (special magic sections), but as we're heading down the route of using stage0 that approach won't work.

The physical memory locations of the SEV-SNP secrets pages will be provided to the kernel during runtime in the `boot_info` structure.

Therefore, let's clean up the stray references to the sections that are neither used right now nor will never be.