### PR TITLE
Add traits for IO port access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4186,6 +4186,7 @@ name = "sev_guest"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "lock_api",
  "snafu",
  "static_assertions",
  "strum",

--- a/experimental/sev_guest/Cargo.toml
+++ b/experimental/sev_guest/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 bitflags = "*"
+lock_api = "*"
 static_assertions = "*"
 snafu = { version = "*", default-features = false }
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/experimental/sev_guest/src/io.rs
+++ b/experimental/sev_guest/src/io.rs
@@ -126,7 +126,7 @@ where
     }
 }
 
-/// Factory for create port reader and writers that perform direct raw IO operations.
+/// Factory for creating port reader and writers that perform direct raw IO operations.
 pub struct RawIoPortFactory;
 
 impl<T> IoPortFactory<T, PortReadOnly<T>, PortWriteOnly<T>> for RawIoPortFactory

--- a/experimental/sev_guest/src/io.rs
+++ b/experimental/sev_guest/src/io.rs
@@ -1,0 +1,170 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use lock_api::{Mutex, RawMutex};
+use x86_64::instructions::port::{PortReadOnly, PortWriteOnly};
+
+use crate::ghcb::GhcbProtocol;
+
+/// Factory for instantiating IO port readers and writers.
+///
+/// The typical usage is to either create raw instances that peform direct IO on the ports, or
+/// instances that use the GHCB IOIO protocol.
+pub trait IoPortFactory<T, R: PortReader<T>, W: PortWriter<T>> {
+    /// Creates a new IO port reader instance.
+    fn new_reader(&self, port: u16) -> R;
+    /// Creates a new IO port writer instance.
+    fn new_writer(&self, port: u16) -> W;
+}
+
+/// Reader that can be used to read values from a port.
+pub trait PortReader<T> {
+    /// Tries to read from the port.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because port access could have unsafe side-effects.
+    unsafe fn try_read(&mut self) -> Result<T, &'static str>;
+}
+
+/// Writer that can be used to write values to a port.
+pub trait PortWriter<T> {
+    /// Tries to write a value to the port.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because port access could have unsafe side-effects.
+    unsafe fn try_write(&mut self, value: T) -> Result<(), &'static str>;
+}
+
+/// A factory for creating port readers and writers that use the GHCB IOIO protocol.
+pub struct GhcbIoFactory<R: RawMutex + 'static> {
+    ghcb_protocol: &'static Mutex<R, GhcbProtocol<'static>>,
+}
+
+impl<R> GhcbIoFactory<R>
+where
+    R: RawMutex + 'static,
+{
+    pub fn new(ghcb_protocol: &'static Mutex<R, GhcbProtocol<'static>>) -> Self {
+        GhcbIoFactory { ghcb_protocol }
+    }
+}
+
+impl<T, R> IoPortFactory<T, GhcbIoPort<R>, GhcbIoPort<R>> for GhcbIoFactory<R>
+where
+    R: RawMutex + 'static,
+    GhcbIoPort<R>: PortReader<T> + PortWriter<T>,
+{
+    fn new_reader(&self, port: u16) -> GhcbIoPort<R> {
+        GhcbIoPort {
+            ghcb_protocol: self.ghcb_protocol,
+            port,
+        }
+    }
+
+    fn new_writer(&self, port: u16) -> GhcbIoPort<R> {
+        GhcbIoPort {
+            ghcb_protocol: self.ghcb_protocol,
+            port,
+        }
+    }
+}
+
+/// GHCB-based wrapper for a single IO port.
+pub struct GhcbIoPort<R: RawMutex + 'static> {
+    ghcb_protocol: &'static Mutex<R, GhcbProtocol<'static>>,
+    port: u16,
+}
+
+impl<R> PortReader<u8> for GhcbIoPort<R>
+where
+    R: RawMutex + 'static,
+{
+    unsafe fn try_read(&mut self) -> Result<u8, &'static str> {
+        self.ghcb_protocol.lock().io_read_u8(self.port)
+    }
+}
+
+impl<R> PortReader<u32> for GhcbIoPort<R>
+where
+    R: RawMutex + 'static,
+{
+    unsafe fn try_read(&mut self) -> Result<u32, &'static str> {
+        self.ghcb_protocol.lock().io_read_u32(self.port)
+    }
+}
+
+impl<R> PortWriter<u8> for GhcbIoPort<R>
+where
+    R: RawMutex + 'static,
+{
+    unsafe fn try_write(&mut self, value: u8) -> Result<(), &'static str> {
+        self.ghcb_protocol.lock().io_write_u8(self.port, value)
+    }
+}
+
+impl<R> PortWriter<u32> for GhcbIoPort<R>
+where
+    R: RawMutex + 'static,
+{
+    unsafe fn try_write(&mut self, value: u32) -> Result<(), &'static str> {
+        self.ghcb_protocol.lock().io_write_u32(self.port, value)
+    }
+}
+
+/// Factory for create port reader and writers that perform direct raw IO operations.
+pub struct RawIoPortFactory;
+
+impl<T> IoPortFactory<T, PortReadOnly<T>, PortWriteOnly<T>> for RawIoPortFactory
+where
+    PortReadOnly<T>: PortReader<T>,
+    PortWriteOnly<T>: PortWriter<T>,
+{
+    fn new_reader(&self, port: u16) -> PortReadOnly<T> {
+        PortReadOnly::<T>::new(port)
+    }
+
+    fn new_writer(&self, port: u16) -> PortWriteOnly<T> {
+        PortWriteOnly::<T>::new(port)
+    }
+}
+
+impl PortReader<u8> for PortReadOnly<u8> {
+    unsafe fn try_read(&mut self) -> Result<u8, &'static str> {
+        Ok(self.read())
+    }
+}
+
+impl PortReader<u32> for PortReadOnly<u32> {
+    unsafe fn try_read(&mut self) -> Result<u32, &'static str> {
+        Ok(self.read())
+    }
+}
+
+impl PortWriter<u8> for PortWriteOnly<u8> {
+    unsafe fn try_write(&mut self, value: u8) -> Result<(), &'static str> {
+        self.write(value);
+        Ok(())
+    }
+}
+
+impl PortWriter<u32> for PortWriteOnly<u32> {
+    unsafe fn try_write(&mut self, value: u32) -> Result<(), &'static str> {
+        self.write(value);
+        Ok(())
+    }
+}

--- a/experimental/sev_guest/src/lib.rs
+++ b/experimental/sev_guest/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod cpuid;
 pub mod ghcb;
 pub mod instructions;
+pub mod io;
 pub mod msr;
 pub mod secrets;
 pub mod serial;

--- a/experimental/sev_guest/src/serial.rs
+++ b/experimental/sev_guest/src/serial.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use crate::ghcb::GhcbProtocol;
+use crate::ghcb::{Ghcb, GhcbProtocol};
 use core::fmt::Write;
 
 /// The offset from the base address to the interrupt register.
@@ -62,7 +62,7 @@ const OUTPUT_EMPTY: u8 = 1 << 5;
 pub struct SerialPort<'a> {
     /// The base address of the serial port.
     base_address: u16,
-    ghcb_protocol: GhcbProtocol<'a>,
+    ghcb_protocol: GhcbProtocol<'a, Ghcb>,
 }
 
 impl<'a> SerialPort<'a> {
@@ -72,7 +72,7 @@ impl<'a> SerialPort<'a> {
     ///
     /// This function is unsafe as callers must make sure that the base address represents a
     /// valid serial port device.
-    pub unsafe fn new(base_address: u16, ghcb_protocol: GhcbProtocol<'a>) -> Self {
+    pub unsafe fn new(base_address: u16, ghcb_protocol: GhcbProtocol<'a, Ghcb>) -> Self {
         Self {
             base_address,
             ghcb_protocol,

--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +47,16 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "oak_linux_boot_params"
@@ -92,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +124,7 @@ name = "sev_guest"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "lock_api",
  "snafu",
  "static_assertions",
  "strum",

--- a/testing/sev_snp_hello_world_kernel/Cargo.lock
+++ b/testing/sev_snp_hello_world_kernel/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b5e5f48b927f04e952dedc932f31995a65a0bf65ec971c74436e51bf6e970d"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +60,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,10 +112,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "sev_guest"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "lock_api",
  "snafu",
  "static_assertions",
  "strum",

--- a/testing/sev_snp_hello_world_kernel/src/ghcb.rs
+++ b/testing/sev_snp_hello_world_kernel/src/ghcb.rs
@@ -41,7 +41,7 @@ const ENCRYPTED_BIT: u64 = 1 << 51;
 static mut GHCB: MaybeUninit<Ghcb> = MaybeUninit::uninit();
 
 /// Initializes the GHCB and shares it with the hypervisor.
-pub fn init_ghcb(snp_enabled: bool) -> GhcbProtocol<'static> {
+pub fn init_ghcb(snp_enabled: bool) -> GhcbProtocol<'static, Ghcb> {
     // Safety: this data structure is placed in valid memory so we won't page fault when accessing
     // it. We reset the value of the GHCB immediately after shareing it with the hypervisor, so it
     // will be fine if it is not initialized.


### PR DESCRIPTION
This implements an abstraction for IO ports so that our guest devices can be updated to use either direct IO access (when running without encryption or with SEV) or the GHCB IOIO protocol (when running with SEV-ES or SEV-SNP).

This PR also makes the GHCB-related code more generic so that is could be used with static references when there is no allocator, or with `Box` and `Arc` when an allocator is available.