### PR TITLE
Create kernel page map entries based on ELF program headers

### DIFF
--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -71,7 +71,7 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     // Physical frame allocator: support up to 128 GiB of memory, for now.
     let mut frame_allocator = mm::init::<1024>(info.e820_table(), program_headers);
 
-    mm::init_paging(&mut frame_allocator).unwrap();
+    mm::init_paging(&mut frame_allocator, program_headers).unwrap();
     // We need to be done with the boot info struct before intializing memory. For example, the
     // multiboot protocol explicitly states data can be placed anywhere in memory; therefore, it's
     // highly likely we will overwrite some data after we initialize the heap. args::init_args()


### PR DESCRIPTION
Previously we just blindly mapped all of the lowest 2GiB of physical memory to the last 2 GiB of virtual memory, and marked everything as executable and writeable.

This is bad for multiple reasons. First, you don't need access to all of the memory; second, sections containing code should _not_ be writable by default and sections containing data should _not_ be executable by default.

As a reminder, this is the memory map of the kernel right now:
```
Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
[...]
  LOAD           0x002000 0xffffffff80400000 0x0000000000400000 0x268eeb 0x268eeb R E 0x1000
  LOAD           0x26b000 0xffffffff80800000 0x0000000000800000 0x04a460 0x04a460 R   0x1000
  LOAD           0x2b6000 0xffffffff80a00000 0x0000000000a00000 0x000068 0x000068 RW  0x1000
  LOAD           0x400000 0xffffffff80c00000 0x0000000000c00000 0x000000 0x280000 RW  0x200000

```

The first section there contains executable data (`.text`): it has `PF_X` set, but not `PF_W`, marking it read-only.
The second section is `.rodata` -- it's just readable.
The third and fourth sections are for `.data`, `.bss` and `.stack`. Those are writable, but not executable.

In the future we should (a) break the `.stack` off `.bss` and (b) ensure there's at least 4K between all the different sections, so that we don't risk overwriting any data structures. In particular, we have dealt with the stack going over the limits before, with often bizarre results; thus, there should be an unmapped page between the stack and any other data structure (see #2986).

For now, this fixes #2983.
