### PR TITLE
Add a page fault handler in addition to double fault handler

### DIFF
--- a/experimental/oak_baremetal_kernel/src/interrupts.rs
+++ b/experimental/oak_baremetal_kernel/src/interrupts.rs
@@ -18,12 +18,16 @@ use crate::i8042;
 use core::ops::Deref;
 use lazy_static::lazy_static;
 use log::error;
-use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
+use x86_64::{
+    registers::control::Cr2,
+    structures::idt::{InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode},
+};
 
 lazy_static! {
     static ref IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
         idt.double_fault.set_handler_fn(double_fault_handler);
+        idt.page_fault.set_handler_fn(page_fault_handler);
         idt.breakpoint.set_handler_fn(breakpoint_handler);
         idt
     };
@@ -31,6 +35,20 @@ lazy_static! {
 
 extern "x86-interrupt" fn breakpoint_handler(stack_frame: InterruptStackFrame) {
     log::error!("EXCEPTION: BREAKPOINT\n{:#?}", stack_frame);
+}
+
+extern "x86-interrupt" fn page_fault_handler(
+    stack_frame: InterruptStackFrame,
+    error_code: PageFaultErrorCode,
+) {
+    error!("KERNEL PANIC: PAGE FAULT");
+    error!(
+        "Instruction pointer: {:#016x}",
+        stack_frame.deref().instruction_pointer.as_u64()
+    );
+    error!("Faulting virtual address: {:#018x}", Cr2::read());
+    error!("Error code: {:?}", error_code);
+    i8042::shutdown();
 }
 
 extern "x86-interrupt" fn double_fault_handler(


### PR DESCRIPTION
Debugging paging issues with just the double fault handler is annoying, as it doesn't look like there's a way to find out _what_ caused the double fault.

This handler will still crash and try to shut down the machine, but prints out more useful information:
```
ERROR: KERNEL PANIC: PAGE FAULT
ERROR: Instruction pointer: 0xffffffff8057c091\n
ERROR: Faulting virtual address: 0x00000000d0810014\n
ERROR: Error code: CAUSED_BY_WRITE\n
```