### PR TITLE
Add `cargo-binutils` to our development image.

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:a8d92718a13d9401e82750b98bd5c68413d156aae6475a50b609bb355f7bf1b5",
+  "image": "sha256:89faf5a73d06fa92a77fe5087ef59bf5503b7031d4d2f75e4856e96bdbc667da",
   "extensions": [
     "13xforever.language-x86-64-assembly",
     "bazelbuild.vscode-bazel",

--- a/Dockerfile
+++ b/Dockerfile
@@ -220,9 +220,10 @@ RUN rustup target add wasm32-unknown-unknown
 # Install musl target for Rust (for statically linked binaries).
 RUN rustup target add x86_64-unknown-linux-musl
 
-# Install rustfmt and clippy.
+# Install various components we need.
 RUN rustup component add \
   clippy \
+  llvm-tools-preview \
   rust-src \
   rustfmt
 
@@ -237,6 +238,10 @@ RUN cargo install --version=${deadlinks_version} cargo-deadlinks
 # change cargo-fuzz to the following to avoid a recent failure
 # cf. https://github.com/rust-fuzz/cargo-fuzz/pull/277
 RUN cargo install --git https://github.com/rust-fuzz/cargo-fuzz/ --rev 8c964bf183c93cd49ad655eb2f3faecf543d0012
+
+# Install cargo-binutils.
+ARG binutils_version=0.3.6
+RUN cargo install --version=${binutils_version} cargo-binutils
 
 # Install Wizer.
 # To allow running warmup initialisation on example Wasm modules.

--- a/scripts/common
+++ b/scripts/common
@@ -20,10 +20,10 @@ readonly DOCKER_IMAGE_NAME='europe-west2-docker.pkg.dev/oak-ci/oak-development/o
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:a8d92718a13d9401e82750b98bd5c68413d156aae6475a50b609bb355f7bf1b5'
+readonly DOCKER_IMAGE_ID='sha256:89faf5a73d06fa92a77fe5087ef59bf5503b7031d4d2f75e4856e96bdbc667da'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development@sha256:eb1c4c68733347209d837228d6ffdfe834ee8f6d530bc3774adc06d5a891fccc'
+readonly DOCKER_IMAGE_REPO_DIGEST='europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development@sha256:57c61ccdd2eb4214cb86bf8d0b7f5817acdc5becffbab3b36a8544913559d323'
 
 readonly CACHE_DIR='bazel-cache'
 readonly SERVER_BIN_DIR="${PWD}/oak_loader/bin"


### PR DESCRIPTION
`binutils` comes with various utilities to manage binaries, such as `objcopy` which can be used to turn ELF files into headerless binary blobs.

We need `objcopy` for `stage0`: namely, `cargo build` gives us an ELF file, but `qemu` and other VMMs expect the BIOS image to be a headerless blob.

Instead of doing `cargo build` + manually invoking objcopy on the target file, using `cargo-binutils` we can do it in one step:
```
cargo objcopy -- -O binary stage0.bin
```