### PR TITLE
Refactor the SimpleIO device to be GHCB-compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,6 +2411,7 @@ name = "oak_baremetal_simple_io"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "sev_guest",
  "x86_64",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,7 @@ dependencies = [
  "oak_baremetal_simple_io",
  "oak_linux_boot_params",
  "rust-hypervisor-firmware-virtio",
+ "sev_guest",
  "strum",
  "uart_16550",
  "virtio",

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -274,6 +274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +659,7 @@ name = "oak_baremetal_simple_io"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "sev_guest",
  "x86_64",
 ]
 
@@ -811,6 +818,7 @@ dependencies = [
  "oak_baremetal_simple_io",
  "oak_linux_boot_params",
  "rust-hypervisor-firmware-virtio",
+ "sev_guest",
  "strum",
  "uart_16550",
  "virtio",
@@ -1099,6 +1107,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sev_guest"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "lock_api",
+ "snafu",
+ "static_assertions",
+ "strum",
+ "x86_64",
+ "zerocopy",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1158,28 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "snafu"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "spin"
@@ -1404,6 +1447,27 @@ dependencies = [
  "bitflags",
  "rustversion",
  "volatile",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]

--- a/experimental/oak_baremetal_app_crosvm/deny.toml
+++ b/experimental/oak_baremetal_app_crosvm/deny.toml
@@ -27,5 +27,5 @@ unknown-git = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = ["Apache-2.0", "BSD-3-Clause", "MIT", "MPL-2.0"]
+allow = ["Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "MIT", "MPL-2.0"]
 copyleft = "deny"

--- a/experimental/oak_baremetal_simple_io/Cargo.toml
+++ b/experimental/oak_baremetal_simple_io/Cargo.toml
@@ -7,4 +7,5 @@ license = "Apache-2.0"
 
 [dependencies]
 bitflags = "*"
+sev_guest = { path = "../sev_guest" }
 x86_64 = "*"

--- a/experimental/oak_baremetal_simple_io/src/lib.rs
+++ b/experimental/oak_baremetal_simple_io/src/lib.rs
@@ -117,7 +117,7 @@ where
     /// Reads the next available bytes from the input buffer, if any are available.
     pub fn read_bytes(&mut self) -> Option<VecDeque<u8>> {
         // Safety: we read the value as a u32 and validate it before using it.
-        let length = unsafe { self.input_length_port.try_read().unwrap() } as usize;
+        let length = unsafe { self.input_length_port.try_read().ok()? } as usize;
 
         // Use a memory fence to ensure the read from the device happens before the read from the
         // buffer.
@@ -156,7 +156,7 @@ where
 
         // Safety: this usage is safe, as we as only write an uninterpreted u32 value to the port.
         unsafe {
-            self.output_length_port.try_write(length as u32).unwrap();
+            self.output_length_port.try_write(length as u32).ok()?;
         }
 
         Some(length)

--- a/experimental/oak_baremetal_simple_io/src/lib.rs
+++ b/experimental/oak_baremetal_simple_io/src/lib.rs
@@ -14,12 +14,14 @@
 // limitations under the License.
 //
 
-//! Simple I/O driver for communications between the guest and the host via shared memory.
+//! Simple I/O driver for communication between the guest and the host via shared memory.
 
 #![no_std]
 extern crate alloc;
 
 use alloc::{collections::VecDeque, vec, vec::Vec};
+use core::{marker::PhantomData, result::Result};
+use sev_guest::io::{IoPortFactory, PortReader, PortWriter};
 use x86_64::instructions::port::{PortReadOnly, PortWriteOnly};
 
 /// The default I/O port to use for the most significant bytes of the output buffer guest-physical
@@ -45,51 +47,77 @@ pub const OUTPUT_BUFFER_LEGNTH: usize = 4096;
 /// The length of the buffer that will be used for input messages.
 pub const INPUT_BUFFER_LEGNTH: usize = 4096;
 
+/// A Simple IO device implementation that uses direct port-based IO.
+pub type RawSimpleIo<'a> = SimpleIo<'a, PortReadOnly<u32>, PortWriteOnly<u32>>;
+
 /// The simple I/O channel driver implementation.
-pub struct SimpleIo {
+pub struct SimpleIo<'a, R: PortReader<u32> + 'a, W: PortWriter<u32> + 'a> {
     output_buffer: Vec<u8>,
     input_buffer: Vec<u8>,
-    output_length_port: PortWriteOnly<u32>,
-    input_length_port: PortReadOnly<u32>,
+    output_length_port: W,
+    input_length_port: R,
+    _phantom: PhantomData<&'a W>,
 }
 
-impl SimpleIo {
-    pub fn new(
+impl<'a, R, W> SimpleIo<'a, R, W>
+where
+    R: PortReader<u32> + 'a,
+    W: PortWriter<u32> + 'a,
+{
+    pub fn new<F: IoPortFactory<'a, u32, R, W>>(
+        io_port_factory: F,
         output_buffer_msb_port: u16,
         output_buffer_lsb_port: u16,
         output_length_port: u16,
         input_buffer_msb_port: u16,
         input_buffer_lsb_port: u16,
         input_length_port: u16,
-    ) -> Self {
+    ) -> Result<Self, &'static str> {
         let output_buffer = vec![0; OUTPUT_BUFFER_LEGNTH];
         let input_buffer = vec![0; INPUT_BUFFER_LEGNTH];
-        let output_length_port = PortWriteOnly::new(output_length_port);
-        let input_length_port = PortReadOnly::new(input_length_port);
+        let output_length_port = io_port_factory.new_writer(output_length_port);
+        let input_length_port = io_port_factory.new_reader(input_length_port);
 
         write_address(
+            &io_port_factory,
             output_buffer.as_ptr(),
             output_buffer_msb_port,
             output_buffer_lsb_port,
-        );
+        )?;
         write_address(
+            &io_port_factory,
             input_buffer.as_ptr(),
             input_buffer_msb_port,
             input_buffer_lsb_port,
-        );
+        )?;
 
-        Self {
+        Ok(Self {
             output_buffer,
             input_buffer,
             output_length_port,
             input_length_port,
-        }
+            _phantom: PhantomData,
+        })
+    }
+
+    pub fn new_with_defaults<F: IoPortFactory<'a, u32, R, W>>(
+        io_port_factory: F,
+    ) -> Result<Self, &'static str> {
+        SimpleIo::new(
+            io_port_factory,
+            DEFAULT_OUTPUT_BUFFER_MSB_PORT,
+            DEFAULT_OUTPUT_BUFFER_LSB_PORT,
+            DEFAULT_OUTPUT_LENGTH_PORT,
+            DEFAULT_INPUT_BUFFER_MSB_PORT,
+            DEFAULT_INPUT_BUFFER_LSB_PORT,
+            DEFAULT_INPUT_LENGTH_PORT,
+        )
     }
 
     /// Reads the next available bytes from the input buffer, if any are available.
     pub fn read_bytes(&mut self) -> Option<VecDeque<u8>> {
         // Safety: we read the value as a u32 and validate it before using it.
-        let length = unsafe { self.input_length_port.read() } as usize;
+        let length = unsafe { self.input_length_port.try_read().unwrap() } as usize;
 
         // Use a memory fence to ensure the read from the device happens before the read from the
         // buffer.
@@ -128,35 +156,34 @@ impl SimpleIo {
 
         // Safety: this usage is safe, as we as only write an uninterpreted u32 value to the port.
         unsafe {
-            self.output_length_port.write(length as u32);
+            self.output_length_port.try_write(length as u32).unwrap();
         }
 
         Some(length)
     }
 }
 
-impl Default for SimpleIo {
-    fn default() -> Self {
-        Self::new(
-            DEFAULT_OUTPUT_BUFFER_MSB_PORT,
-            DEFAULT_OUTPUT_BUFFER_LSB_PORT,
-            DEFAULT_OUTPUT_LENGTH_PORT,
-            DEFAULT_INPUT_BUFFER_MSB_PORT,
-            DEFAULT_INPUT_BUFFER_LSB_PORT,
-            DEFAULT_INPUT_LENGTH_PORT,
-        )
-    }
-}
-
-fn write_address(buffer_pointer: *const u8, msb_port: u16, lsb_port: u16) {
+fn write_address<
+    'a,
+    R: PortReader<u32> + 'a,
+    W: PortWriter<u32> + 'a,
+    F: IoPortFactory<'a, u32, R, W>,
+>(
+    io_port_factory: &F,
+    buffer_pointer: *const u8,
+    msb_port: u16,
+    lsb_port: u16,
+) -> Result<(), &'static str> {
     // Split the 64-bit address into its least- and most significant bytes.
     let address = get_guest_physiscal_address(buffer_pointer) as u64;
     let address_msb = (address >> 32) as u32;
     let address_lsb = address as u32;
     // Safety: this usage is safe, as we as only write uninterpreted u32 values to the ports.
     unsafe {
-        PortWriteOnly::new(msb_port).write(address_msb);
-        PortWriteOnly::new(lsb_port).write(address_lsb);
+        io_port_factory
+            .new_writer(msb_port)
+            .try_write(address_msb)?;
+        io_port_factory.new_writer(lsb_port).try_write(address_lsb)
     }
 }
 

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -10,7 +10,7 @@ default = ["vsock_channel"]
 virtio_console_channel = ["virtio"]
 vsock_channel = ["virtio"]
 serial_channel = []
-simple_io_channel = ["oak_baremetal_simple_io"]
+simple_io_channel = ["oak_baremetal_simple_io", "sev_guest"]
 
 [dependencies]
 anyhow = { version = "*", default-features = false }
@@ -30,7 +30,7 @@ oak_baremetal_communication_channel = { path = "../experimental/oak_baremetal_ch
 oak_baremetal_simple_io = { path = "../experimental/oak_baremetal_simple_io", optional = true }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 rust-hypervisor-firmware-virtio = { path = "../third_party/rust-hypervisor-firmware-virtio" }
-sev_guest = { path = "../experimental/sev_guest" }
+sev_guest = { path = "../experimental/sev_guest", optional = true }
 strum = { version = "*", default-features = false, features = ["derive"] }
 uart_16550 = "*"
 virtio = { path = "../experimental/virtio", optional = true }

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -30,6 +30,7 @@ oak_baremetal_communication_channel = { path = "../experimental/oak_baremetal_ch
 oak_baremetal_simple_io = { path = "../experimental/oak_baremetal_simple_io", optional = true }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 rust-hypervisor-firmware-virtio = { path = "../third_party/rust-hypervisor-firmware-virtio" }
+sev_guest = { path = "../experimental/sev_guest" }
 strum = { version = "*", default-features = false, features = ["derive"] }
 uart_16550 = "*"
 virtio = { path = "../experimental/virtio", optional = true }

--- a/oak_tensorflow_bin/Cargo.lock
+++ b/oak_tensorflow_bin/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +87,12 @@ checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "flatbuffers"
@@ -207,6 +219,7 @@ name = "oak_baremetal_simple_io"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "sev_guest",
  "x86_64",
 ]
 
@@ -257,6 +270,7 @@ dependencies = [
  "oak_baremetal_simple_io",
  "oak_linux_boot_params",
  "rust-hypervisor-firmware-virtio",
+ "sev_guest",
  "strum",
  "uart_16550",
  "virtio",
@@ -366,10 +380,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "sev_guest"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "lock_api",
+ "snafu",
+ "static_assertions",
+ "strum",
+ "x86_64",
+ "zerocopy",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "snafu"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "spin"
@@ -426,6 +475,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +529,12 @@ name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "version_check"
@@ -517,4 +584,25 @@ dependencies = [
  "bitflags",
  "rustversion",
  "volatile",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
 ]

--- a/oak_tensorflow_bin/deny.toml
+++ b/oak_tensorflow_bin/deny.toml
@@ -27,5 +27,5 @@ unknown-git = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = ["Apache-2.0", "MIT"]
+allow = ["Apache-2.0", "BSD-2-Clause", "MIT"]
 copyleft = "deny"

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +87,12 @@ checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "flatbuffers"
@@ -207,6 +219,7 @@ name = "oak_baremetal_simple_io"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "sev_guest",
  "x86_64",
 ]
 
@@ -282,6 +295,7 @@ dependencies = [
  "oak_baremetal_simple_io",
  "oak_linux_boot_params",
  "rust-hypervisor-firmware-virtio",
+ "sev_guest",
  "strum",
  "uart_16550",
  "virtio",
@@ -367,10 +381,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "sev_guest"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "lock_api",
+ "snafu",
+ "static_assertions",
+ "strum",
+ "x86_64",
+ "zerocopy",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "snafu"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "spin"
@@ -427,6 +476,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +530,12 @@ name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "version_check"
@@ -518,4 +585,25 @@ dependencies = [
  "bitflags",
  "rustversion",
  "volatile",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
 ]

--- a/testing/oak_echo_bin/deny.toml
+++ b/testing/oak_echo_bin/deny.toml
@@ -27,5 +27,5 @@ unknown-git = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = ["Apache-2.0", "MIT"]
+allow = ["Apache-2.0", "BSD-2-Clause", "MIT"]
 copyleft = "deny"


### PR DESCRIPTION
Similar to the serial port update in #3270, this change uses the IO abstraction to make the Simple IO device compatible with either direct port-based IO (when running without encryption or with SEV) and the GHCB IOIO protocol (when running with SEV-ES and SNP).