### PR TITLE
Change heap allocator to take (virtual) pages, not (physical) frames.

### DIFF
--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -1396,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958cd5cb28e720db2f59ee9dc4235b5f82a183d079fb0e6caf43ad074cfdc66a"
+checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/oak_restricted_kernel/src/memory.rs
+++ b/oak_restricted_kernel/src/memory.rs
@@ -17,7 +17,7 @@
 use core::result::Result;
 use linked_list_allocator::LockedHeap;
 use log::info;
-use x86_64::structures::paging::{frame::PhysFrameRangeInclusive, Size2MiB};
+use x86_64::structures::paging::{page::PageRange, PageSize};
 
 #[cfg(not(test))]
 #[global_allocator]
@@ -31,9 +31,9 @@ static ALLOCATOR: LockedHeap = LockedHeap::empty();
 /// Pointers to addresses in the memory area (or references to data contained within the slice) must
 /// be considered invalid after calling this function, as the allocator may overwrite the data at
 /// any point.
-pub fn init_allocator(range: PhysFrameRangeInclusive<Size2MiB>) -> Result<(), &'static str> {
+pub fn init_allocator<S: PageSize>(range: PageRange<S>) -> Result<(), &'static str> {
     let start = range.start.start_address().as_u64() as usize;
-    let limit = (range.end.start_address().as_u64() + range.end.size()) as usize;
+    let limit = range.end.start_address().as_u64() as usize;
 
     info!("Using [{:#016x}..{:#016x}) for heap.", start, limit);
     // This is safe as we know the memory is available based on the e820 map.

--- a/oak_tensorflow_bin/Cargo.lock
+++ b/oak_tensorflow_bin/Cargo.lock
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958cd5cb28e720db2f59ee9dc4235b5f82a183d079fb0e6caf43ad074cfdc66a"
+checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958cd5cb28e720db2f59ee9dc4235b5f82a183d079fb0e6caf43ad074cfdc66a"
+checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
 dependencies = [
  "bit_field",
  "bitflags",


### PR DESCRIPTION
For now, we've always assumed that there's an identity mapping; that is, you can freely convert between physical and virtual addresses by just using the raw pointer value.

This is the first step in moving away from that assumption: as the heap initialization deals in virtual memory, make that use (virtual) `Page`-s rather than (physical) `Frame`-s.