### PR TITLE
Plumb an explicit virtual->physical translation function through virtio and simple_io

### DIFF
--- a/experimental/virtio/src/vsock/socket/tests.rs
+++ b/experimental/virtio/src/vsock/socket/tests.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use crate::{
-    test::{new_valid_transport, TestingTransport},
+    test::{new_valid_transport, TestTranslate, TestingTransport},
     vsock::{HOST_CID, QUEUE_SIZE},
     Read, Write,
 };
@@ -176,8 +176,8 @@ fn new_vsock_and_transport() -> (VSock<TestingTransport>, TestingTransport) {
     transport.write_device_config(0, GUEST_CID as u32);
 
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut vsock = VSock::new(device);
-    vsock.init().unwrap();
+    let mut vsock = VSock::new(device, &TestTranslate {});
+    vsock.init(&TestTranslate {}, |_| None).unwrap();
 
     (vsock, transport)
 }

--- a/experimental/virtio/src/vsock/tests.rs
+++ b/experimental/virtio/src/vsock/tests.rs
@@ -17,7 +17,7 @@
 use super::*;
 use crate::test::{
     new_legacy_transport, new_transport_small_queue, new_valid_transport, DeviceStatus,
-    TestingTransport, VIRTIO_F_VERSION_1,
+    TestTranslate, TestingTransport, VIRTIO_F_VERSION_1,
 };
 use alloc::vec;
 
@@ -26,15 +26,15 @@ const GUEST_CID: u64 = 3;
 #[test]
 fn test_legacy_device_not_supported() {
     let device = VirtioBaseDevice::new(new_legacy_transport());
-    let mut vsock = VSock::new(device);
-    assert!(vsock.init().is_err());
+    let mut vsock = VSock::new(device, &TestTranslate {});
+    assert!(vsock.init(&TestTranslate {}, |_| None).is_err());
 }
 
 #[test]
 fn test_max_queue_size_too_small() {
     let device = VirtioBaseDevice::new(new_transport_small_queue());
-    let mut vsock = VSock::new(device);
-    assert!(vsock.init().is_err());
+    let mut vsock = VSock::new(device, &TestTranslate {});
+    assert!(vsock.init(&TestTranslate {}, |_| None).is_err());
 }
 
 #[test]
@@ -42,8 +42,8 @@ fn test_device_init() {
     let transport = new_configured_transport();
     let config = transport.config.clone();
     let device = VirtioBaseDevice::new(transport);
-    let mut vsock = VSock::new(device);
-    let result = vsock.init();
+    let mut vsock = VSock::new(device, &TestTranslate {});
+    let result = vsock.init(&TestTranslate {}, |_| None);
     assert!(result.is_ok());
 
     let config = config.lock().unwrap();
@@ -76,8 +76,8 @@ fn test_read_packet() {
     packet.set_src_cid(HOST_CID);
     let transport = new_configured_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut vsock = VSock::new(device);
-    vsock.init().unwrap();
+    let mut vsock = VSock::new(device, &TestTranslate {});
+    vsock.init(&TestTranslate {}, |_| None).unwrap();
     transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
     let result = vsock.read_packet().unwrap();
     assert_eq!(packet.as_slice(), result.as_slice());
@@ -89,8 +89,8 @@ fn test_write_packet() {
     let mut packet = Packet::new_data(&data[..], 1, 2).unwrap();
     let transport = new_configured_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut vsock = VSock::new(device);
-    vsock.init().unwrap();
+    let mut vsock = VSock::new(device, &TestTranslate {});
+    vsock.init(&TestTranslate {}, |_| None).unwrap();
     vsock.write_packet(&mut packet);
     let bytes = transport
         .device_read_once_from_queue::<QUEUE_SIZE>(1)

--- a/oak_restricted_kernel/src/simpleio.rs
+++ b/oak_restricted_kernel/src/simpleio.rs
@@ -17,6 +17,7 @@
 use alloc::collections::VecDeque;
 use oak_baremetal_simple_io::RawSimpleIo;
 use sev_guest::io::RawIoPortFactory;
+use x86_64::structures::paging::Translate;
 
 /// A communications channel using a simple IO device.
 pub struct SimpleIoChannel<'a> {
@@ -29,10 +30,10 @@ pub struct SimpleIoChannel<'a> {
 }
 
 impl SimpleIoChannel<'_> {
-    pub fn new() -> Self {
+    pub fn new<T: Translate>(translate: &T) -> Self {
         let io_port_factory = RawIoPortFactory;
-        let device =
-            RawSimpleIo::new_with_defaults(io_port_factory).expect("couldn't create IO device");
+        let device = RawSimpleIo::new_with_defaults(io_port_factory, translate)
+            .expect("couldn't create IO device");
         let pending_data = None;
         Self {
             device,

--- a/oak_restricted_kernel/src/virtio.rs
+++ b/oak_restricted_kernel/src/virtio.rs
@@ -17,6 +17,7 @@
 use log::info;
 use oak_baremetal_communication_channel::{Read, Write};
 use rust_hypervisor_firmware_virtio::pci::VirtioPciTransport;
+use x86_64::{structures::paging::Translate, PhysAddr, VirtAddr};
 
 // The virtio vsock port on which to listen.
 #[cfg(feature = "vsock_channel")]
@@ -48,16 +49,21 @@ where
 }
 
 #[cfg(feature = "virtio_console_channel")]
-pub fn get_console_channel() -> Channel<virtio::console::Console<VirtioPciTransport>> {
-    let console = virtio::console::Console::find_and_configure_device()
+pub fn get_console_channel<T: Translate>(
+    translate: &T,
+) -> Channel<virtio::console::Console<VirtioPciTransport>> {
+    let console = virtio::console::Console::find_and_configure_device(translate)
         .expect("Couldn't configure PCI virtio console device.");
     info!("Console device status: {}", console.get_status());
     Channel { inner: console }
 }
 
 #[cfg(feature = "vsock_channel")]
-pub fn get_vsock_channel() -> Channel<virtio::vsock::socket::Socket<VirtioPciTransport>> {
-    let vsock = virtio::vsock::VSock::find_and_configure_device()
+pub fn get_vsock_channel<T: Translate, L: Fn(PhysAddr) -> Option<VirtAddr>>(
+    translate: &T,
+    inverse: L,
+) -> Channel<virtio::vsock::socket::Socket<VirtioPciTransport>> {
+    let vsock = virtio::vsock::VSock::find_and_configure_device(translate, inverse)
         .expect("Couldn't configure PCI virtio vsock device.");
     info!("Socket device status: {}", vsock.get_status());
     let listener = virtio::vsock::socket::SocketListener::new(vsock, VSOCK_PORT);

--- a/third_party/rust-hypervisor-firmware-virtio/src/device.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/device.rs
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use x86_64::PhysAddr;
+use x86_64::{PhysAddr, VirtAddr};
 
 use crate::virtio::{Error as VirtioError, VirtioTransport};
 
@@ -51,9 +51,13 @@ where
     /// Start Initialising the device.
     ///
     /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-920001>.
-    pub fn start_init(&mut self, device_type: u32) -> Result<(), VirtioError> {
+    pub fn start_init<X: Fn(PhysAddr) -> Option<VirtAddr>>(
+        &mut self,
+        device_type: u32,
+        translate: X,
+    ) -> Result<(), VirtioError> {
         // Initialise the transport.
-        self.transport.init(device_type)?;
+        self.transport.init(device_type, translate)?;
 
         // Reset device.
         self.transport.set_status(VIRTIO_STATUS_RESET);

--- a/third_party/rust-hypervisor-firmware-virtio/src/mem.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/mem.rs
@@ -14,22 +14,31 @@
 
 #![allow(dead_code)]
 
-#[derive(Default)]
+use x86_64::VirtAddr;
+
 /// Provides a checked way to access memory offsets from a range of raw memory
 pub struct MemoryRegion {
-    base: u64,
+    base: VirtAddr,
     length: u64,
+}
+impl Default for MemoryRegion {
+    fn default() -> Self {
+        Self {
+            base: VirtAddr::zero(),
+            length: Default::default(),
+        }
+    }
 }
 
 impl MemoryRegion {
-    pub const fn new(base: u64, length: u64) -> MemoryRegion {
+    pub const fn new(base: VirtAddr, length: u64) -> MemoryRegion {
         MemoryRegion { base, length }
     }
 
     /// Read a value at given offset with a mechanism suitable for MMIO
     fn io_read<T>(&self, offset: u64) -> T {
         assert!((offset + (core::mem::size_of::<T>() - 1) as u64) < self.length);
-        unsafe { core::ptr::read_volatile((self.base + offset) as *const T) }
+        unsafe { core::ptr::read_volatile((self.base + offset).as_ptr()) }
     }
 
     /// Read a single byte at given offset with a mechanism suitable for MMIO
@@ -56,7 +65,7 @@ impl MemoryRegion {
     fn io_write<T>(&self, offset: u64, value: T) {
         assert!((offset + (core::mem::size_of::<T>() - 1) as u64) < self.length);
         unsafe {
-            core::ptr::write_volatile((self.base + offset) as *mut T, value);
+            core::ptr::write_volatile((self.base + offset).as_mut_ptr(), value);
         }
     }
 

--- a/third_party/rust-hypervisor-firmware-virtio/src/virtio.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/virtio.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use x86_64::PhysAddr;
+use x86_64::{PhysAddr, VirtAddr};
 
 /// Virtio related errors
 #[derive(Debug)]
@@ -21,11 +21,16 @@ pub enum Error {
     LegacyOnly,
     FeatureNegotiationFailed,
     QueueTooSmall,
+    AddressTranslationFailure,
 }
 
 /// Trait to allow separation of transport from block driver
 pub trait VirtioTransport {
-    fn init(&mut self, device_type: u32) -> Result<(), Error>;
+    fn init<X: Fn(PhysAddr) -> Option<VirtAddr>>(
+        &mut self,
+        device_type: u32,
+        translate: X,
+    ) -> Result<(), Error>;
     fn get_status(&self) -> u32;
     fn set_status(&self, status: u32);
     fn add_status(&self, status: u32);


### PR DESCRIPTION
Both these crates convert freely between `VirtAddr` and `PhysAddr`, as the assumption is that we have identity-mapped memory.

This PR makes the translation explicit: instead of converting a `VirtAddr` to `PhysAddr` directly (or, well, via an `u64`) use a separate translator to do the translation.

The translator itself still uses identity mapping, for now, but the hope is that now we can just change the translator when we move away from identity mapping memory and it should all still just work.