### PR TITLE
Add TFLM dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -195,15 +195,20 @@ http_archive(
     urls = ["https://github.com/googleapis/gapic-generator/archive/8e930b79e846b9d4876462be9dc4c1dbc04e2903.zip"],
 )
 
+# TensorFlow Lite for Microcontrollers.
 http_archive(
-    name = "org_tensorflow",
-    sha256 = "4844e49a4d6ed9bceef608ce7f65f41b75e6362b2721c4e0d34a053d58753f42",
-    strip_prefix = "tensorflow-11bed638b14898cdde967f6b108e45732aa4798a",
+    name = "com_github_tensorflow_tflite_micro",
+    sha256 = "922425b778d5c9336b69f7f68b5f76ae7e6834e026d981179259993d1de5476d",
+    strip_prefix = "tflite-micro-3648cf9003d0e2d5658b1add916000ce09a4b427",
     urls = [
-        # Head commit on 2020-01-20.
-        "https://github.com/tensorflow/tensorflow/archive/11bed638b14898cdde967f6b108e45732aa4798a.tar.gz",
+        # Head commit on 2022-10-07.
+        "https://github.com/tensorflow/tflite-micro/archive/3648cf9003d0e2d5658b1add916000ce09a4b427.tar.gz",
     ],
 )
+
+load("@com_github_tensorflow_tflite_micro//tensorflow:workspace.bzl", "tf_repositories")
+
+tf_repositories()
 
 # TensorFlow dependency.
 http_archive(
@@ -423,13 +428,6 @@ emsdk_configure(name = "emsdk")
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
 
 closure_repositories()
-
-# Do not use `tf_workspace()` - it interferes with c-ares in gRPC loaded and patched
-# and causes missing `ares.h` error.
-# https://github.com/tensorflow/tensorflow/blob/25a06bc503c7d07ffc5480ac107e3c8681937971/tensorflow/workspace.bzl#L970-L975
-load("@org_tensorflow//tensorflow:workspace.bzl", "tf_repositories")
-
-tf_repositories()
 
 # Bazel rules for packaging and deployment by Grakn Labs
 http_archive(

--- a/cc/tflite_micro/BUILD
+++ b/cc/tflite_micro/BUILD
@@ -1,0 +1,30 @@
+#
+# Copyright 2022 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package(
+    default_visibility = ["//visibility:public"]
+)
+
+cc_library(
+    name = "model",
+    srcs = ["model.cc"],
+    hdrs = ["model.h"],
+    deps = [
+        "@com_github_tensorflow_tflite_micro//tensorflow/lite/micro:micro_framework",
+    ],
+    linkstatic = 1,
+)
+

--- a/cc/tflite_micro/model.cc
+++ b/cc/tflite_micro/model.cc
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "model.h"
+
+namespace oak {
+
+}  // namespace oak

--- a/cc/tflite_micro/model.h
+++ b/cc/tflite_micro/model.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CC_TFLITE_MICRO_MODEL_H_
+#define CC_TFLITE_MICRO_MODEL_H_
+
+namespace oak {
+
+}  // namespace oak
+
+#endif  // CC_TFLITE_MICRO_MODEL_H_


### PR DESCRIPTION
This PR adds:
- TensorFlow for Microcontrollers dependency in WORKSPACE
- Template C++ files that will be used by the Rust Runtime