### PR TITLE
Distinguish between `VirtAddr` and `PhysAddr` in the virtio crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5050,6 +5050,7 @@ dependencies = [
  "rand 0.8.5",
  "rust-hypervisor-firmware-virtio",
  "strum",
+ "x86_64",
 ]
 
 [[package]]

--- a/experimental/oak_baremetal_app_crosvm/Cargo.lock
+++ b/experimental/oak_baremetal_app_crosvm/Cargo.lock
@@ -1305,6 +1305,7 @@ dependencies = [
  "log",
  "rust-hypervisor-firmware-virtio",
  "strum",
+ "x86_64",
 ]
 
 [[package]]

--- a/experimental/virtio/Cargo.toml
+++ b/experimental/virtio/Cargo.toml
@@ -11,6 +11,7 @@ bitflags = "*"
 log = "*"
 rust-hypervisor-firmware-virtio = { path = "../../third_party/rust-hypervisor-firmware-virtio" }
 strum = { version = "*", default-features = false, features = ["derive"] }
+x86_64 = "*"
 
 [dev-dependencies]
 rand = { version = "*", features = ["std_rng"] }

--- a/experimental/virtio/src/console/mod.rs
+++ b/experimental/virtio/src/console/mod.rs
@@ -25,6 +25,7 @@ use rust_hypervisor_firmware_virtio::{
     pci::{find_device, VirtioPciTransport},
     virtio::VirtioTransport,
 };
+use x86_64::PhysAddr;
 
 /// The number of buffer descriptors in each of the queues.
 const QUEUE_SIZE: usize = 16;
@@ -144,9 +145,9 @@ where
             .configure_queue(
                 RX_QUEUE_ID,
                 QUEUE_SIZE as u16,
-                self.rx_queue.inner.get_desc_addr(),
-                self.rx_queue.inner.get_avail_addr(),
-                self.rx_queue.inner.get_used_addr(),
+                PhysAddr::new(self.rx_queue.inner.get_desc_addr().as_u64()),
+                PhysAddr::new(self.rx_queue.inner.get_avail_addr().as_u64()),
+                PhysAddr::new(self.rx_queue.inner.get_used_addr().as_u64()),
             )
             .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
             .context("Couldn't configure the receive queue.")?;
@@ -154,9 +155,9 @@ where
             .configure_queue(
                 TX_QUEUE_ID,
                 QUEUE_SIZE as u16,
-                self.tx_queue.inner.get_desc_addr(),
-                self.tx_queue.inner.get_avail_addr(),
-                self.tx_queue.inner.get_used_addr(),
+                PhysAddr::new(self.tx_queue.inner.get_desc_addr().as_u64()),
+                PhysAddr::new(self.tx_queue.inner.get_avail_addr().as_u64()),
+                PhysAddr::new(self.tx_queue.inner.get_used_addr().as_u64()),
             )
             .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
             .context("Couldn't configure the transmit queue.")?;

--- a/experimental/virtio/src/console/tests.rs
+++ b/experimental/virtio/src/console/tests.rs
@@ -59,9 +59,9 @@ fn test_device_init() {
         let queue = queues.get(&i).unwrap();
         assert!(queue.enabled);
         assert_eq!(queue.queue_size as usize, QUEUE_SIZE);
-        assert!(queue.descriptor_address > 0);
-        assert!(queue.avail_ring > 0);
-        assert!(queue.used_ring > 0);
+        assert!(!queue.descriptor_address.is_null());
+        assert!(!queue.avail_ring.is_null());
+        assert!(!queue.used_ring.is_null());
     }
 }
 

--- a/experimental/virtio/src/queue/tests.rs
+++ b/experimental/virtio/src/queue/tests.rs
@@ -204,7 +204,7 @@ fn device_read_once<const QUEUE_SIZE: usize>(
     // with the memory. We treat the contents of the slice as data only and ensure we only pass
     // valid addresses and sizes from the tests.
     let buffer = unsafe {
-        let ptr = desc.addr as usize as *const u8;
+        let ptr = desc.addr.as_u64() as usize as *const u8;
         let len = desc.length as usize;
         alloc::slice::from_raw_parts(ptr, len)
     };
@@ -232,7 +232,7 @@ fn device_write<const QUEUE_SIZE: usize>(
     // with the memory. We treat the contents of the slice as data only and ensure we only pass
     // valid addresses and lengths from the tests.
     let buffer = unsafe {
-        let ptr = desc.addr as usize as *mut u8;
+        let ptr = desc.addr.as_u64() as usize as *mut u8;
         alloc::slice::from_raw_parts_mut(ptr, len)
     };
     buffer.copy_from_slice(data);

--- a/experimental/virtio/src/queue/virtq.rs
+++ b/experimental/virtio/src/queue/virtq.rs
@@ -16,6 +16,7 @@
 
 use bitflags::bitflags;
 use core::num::Wrapping;
+use x86_64::PhysAddr;
 
 bitflags! {
     /// Flags about a descriptor.
@@ -42,9 +43,7 @@ bitflags! {
 #[derive(Debug)]
 pub struct Desc {
     /// The guest-physical address of the buffer.
-    ///
-    /// We use an identity mapping, so it is also the guest virtual address.
-    pub addr: u64,
+    pub addr: PhysAddr,
     /// The lengths of the buffer.
     pub length: u32,
     /// Flags providing more info about this descriptor.
@@ -57,7 +56,7 @@ pub struct Desc {
 }
 
 impl Desc {
-    pub fn new(flags: DescFlags, addr: u64, length: u32) -> Self {
+    pub fn new(flags: DescFlags, addr: PhysAddr, length: u32) -> Self {
         assert!(
             !flags.contains(DescFlags::VIRTQ_DESC_F_INDIRECT),
             "Indirect descriptors not supported."

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -25,6 +25,7 @@ use rust_hypervisor_firmware_virtio::{
     pci::{find_device, VirtioPciTransport},
     virtio::VirtioTransport,
 };
+use x86_64::PhysAddr;
 
 pub mod packet;
 pub mod socket;
@@ -199,9 +200,9 @@ where
             .configure_queue(
                 EVENT_QUEUE_ID,
                 QUEUE_SIZE as u16,
-                self.event_queue.inner.get_desc_addr(),
-                self.event_queue.inner.get_avail_addr(),
-                self.event_queue.inner.get_used_addr(),
+                PhysAddr::new(self.event_queue.inner.get_desc_addr().as_u64()),
+                PhysAddr::new(self.event_queue.inner.get_avail_addr().as_u64()),
+                PhysAddr::new(self.event_queue.inner.get_used_addr().as_u64()),
             )
             .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
             .context("Couldn't configure the event queue")?;
@@ -209,9 +210,9 @@ where
             .configure_queue(
                 RX_QUEUE_ID,
                 QUEUE_SIZE as u16,
-                self.rx_queue.inner.get_desc_addr(),
-                self.rx_queue.inner.get_avail_addr(),
-                self.rx_queue.inner.get_used_addr(),
+                PhysAddr::new(self.rx_queue.inner.get_desc_addr().as_u64()),
+                PhysAddr::new(self.rx_queue.inner.get_avail_addr().as_u64()),
+                PhysAddr::new(self.rx_queue.inner.get_used_addr().as_u64()),
             )
             .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
             .context("Couldn't configure the receive queue")?;
@@ -219,9 +220,9 @@ where
             .configure_queue(
                 TX_QUEUE_ID,
                 QUEUE_SIZE as u16,
-                self.tx_queue.inner.get_desc_addr(),
-                self.tx_queue.inner.get_avail_addr(),
-                self.tx_queue.inner.get_used_addr(),
+                PhysAddr::new(self.tx_queue.inner.get_desc_addr().as_u64()),
+                PhysAddr::new(self.tx_queue.inner.get_avail_addr().as_u64()),
+                PhysAddr::new(self.tx_queue.inner.get_used_addr().as_u64()),
             )
             .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
             .context("Couldn't configure the transmit queue")?;

--- a/experimental/virtio/src/vsock/tests.rs
+++ b/experimental/virtio/src/vsock/tests.rs
@@ -62,9 +62,9 @@ fn test_device_init() {
         let queue = queues.get(&i).unwrap();
         assert!(queue.enabled);
         assert_eq!(queue.queue_size as usize, QUEUE_SIZE);
-        assert!(queue.descriptor_address > 0);
-        assert!(queue.avail_ring > 0);
-        assert!(queue.used_ring > 0);
+        assert!(!queue.descriptor_address.is_null());
+        assert!(!queue.avail_ring.is_null());
+        assert!(!queue.used_ring.is_null());
     }
 }
 

--- a/oak_tensorflow_bin/Cargo.lock
+++ b/oak_tensorflow_bin/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "log",
  "rust-hypervisor-firmware-virtio",
  "strum",
+ "x86_64",
 ]
 
 [[package]]

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "log",
  "rust-hypervisor-firmware-virtio",
  "strum",
+ "x86_64",
 ]
 
 [[package]]

--- a/third_party/rust-hypervisor-firmware-virtio/src/device.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/device.rs
@@ -16,6 +16,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use x86_64::PhysAddr;
+
 use crate::virtio::{Error as VirtioError, VirtioTransport};
 
 // Virtio Version 1 feature bit.
@@ -92,9 +94,9 @@ where
         &mut self,
         queue_id: u16,
         queue_size: u16,
-        desc_addr: u64,
-        avail_addr: u64,
-        used_addr: u64,
+        desc_addr: PhysAddr,
+        avail_addr: PhysAddr,
+        used_addr: PhysAddr,
     ) -> Result<(), VirtioError> {
         self.transport.set_queue(queue_id);
 

--- a/third_party/rust-hypervisor-firmware-virtio/src/pci.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/pci.rs
@@ -14,7 +14,10 @@
 
 use atomic_refcell::AtomicRefCell;
 use log::debug;
-use x86_64::instructions::port::{PortReadOnly, PortWriteOnly};
+use x86_64::{
+    instructions::port::{PortReadOnly, PortWriteOnly},
+    PhysAddr,
+};
 
 use crate::{
     mem,
@@ -380,19 +383,19 @@ impl VirtioTransport for VirtioPciTransport {
         self.region.io_write_u16(0x18, queue_size);
     }
 
-    fn set_descriptors_address(&self, addr: u64) {
+    fn set_descriptors_address(&self, addr: PhysAddr) {
         // queue_desc: 0x20
-        self.region.io_write_u64(0x20, addr);
+        self.region.io_write_u64(0x20, addr.as_u64());
     }
 
-    fn set_avail_ring(&self, addr: u64) {
+    fn set_avail_ring(&self, addr: PhysAddr) {
         // queue_avail: 0x28
-        self.region.io_write_u64(0x28, addr);
+        self.region.io_write_u64(0x28, addr.as_u64());
     }
 
-    fn set_used_ring(&self, addr: u64) {
+    fn set_used_ring(&self, addr: PhysAddr) {
         // queue_used: 0x30
-        self.region.io_write_u64(0x30, addr);
+        self.region.io_write_u64(0x30, addr.as_u64());
     }
 
     fn set_queue_enable(&self) {

--- a/third_party/rust-hypervisor-firmware-virtio/src/virtio.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/virtio.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use x86_64::PhysAddr;
+
 /// Virtio related errors
 #[derive(Debug)]
 pub enum Error {
@@ -33,9 +35,9 @@ pub trait VirtioTransport {
     fn set_queue(&self, queue: u16);
     fn get_queue_max_size(&self) -> u16;
     fn set_queue_size(&self, queue_size: u16);
-    fn set_descriptors_address(&self, address: u64);
-    fn set_avail_ring(&self, address: u64);
-    fn set_used_ring(&self, address: u64);
+    fn set_descriptors_address(&self, address: PhysAddr);
+    fn set_avail_ring(&self, address: PhysAddr);
+    fn set_used_ring(&self, address: PhysAddr);
     fn set_queue_enable(&self);
     fn notify_queue(&self, queue: u16);
     fn read_device_config(&self, offset: u64) -> u32;


### PR DESCRIPTION
Right now the code assumes identity mapping (that is, `VirtAddr == PhysAddr`) and passes around naked `u64`-s everywhere.

We want to break the assumption that virtual addresses are identity mapped to physical addresses, and as the first step we should distinguish what `u64` is exactly what.

In short: if you use `as_ptr()` or anything like that, you get a `VirtAddr`. And any communication to the VMM needs to use `PhysAddr`s.

For now, the translation still assumes identity translation (we do `PhysAddr::new(VirtAddr.as_u64())`), but this makes the conversion between virtual and physical addresses explicit, and gives us a point where we need to apply a transformation function in the future.