### PR TITLE
Expose a memory translator function in rust-hypervisor-firmware-virtio.

### DIFF
--- a/experimental/virtio/src/console/mod.rs
+++ b/experimental/virtio/src/console/mod.rs
@@ -25,7 +25,7 @@ use rust_hypervisor_firmware_virtio::{
     pci::{find_device, VirtioPciTransport},
     virtio::VirtioTransport,
 };
-use x86_64::PhysAddr;
+use x86_64::{PhysAddr, VirtAddr};
 
 /// The number of buffer descriptors in each of the queues.
 const QUEUE_SIZE: usize = 16;
@@ -138,7 +138,9 @@ where
     /// Initializes the device and configures the queues.
     fn init(&mut self) -> anyhow::Result<()> {
         self.device
-            .start_init(DEVICE_ID as u32)
+            .start_init(DEVICE_ID as u32, |paddr: PhysAddr| {
+                Some(VirtAddr::new(paddr.as_u64()))
+            })
             .map_err(|error| anyhow::anyhow!("Virtio error: {:?}", error))
             .context("Couldn't initialize the PCI device.")?;
         self.device

--- a/experimental/virtio/src/test.rs
+++ b/experimental/virtio/src/test.rs
@@ -20,7 +20,7 @@ use bitflags::bitflags;
 use core::mem::size_of;
 use rust_hypervisor_firmware_virtio::virtio::{Error, VirtioTransport};
 use std::sync::Mutex;
-use x86_64::PhysAddr;
+use x86_64::{PhysAddr, VirtAddr};
 
 /// Virtio Version 1 feature bit.
 /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-4100006>.
@@ -178,7 +178,11 @@ impl TestingTransport {
 }
 
 impl VirtioTransport for TestingTransport {
-    fn init(&mut self, _device_type: u32) -> Result<(), Error> {
+    fn init<X: Fn(PhysAddr) -> Option<VirtAddr>>(
+        &mut self,
+        _device_type: u32,
+        _translator: X,
+    ) -> Result<(), Error> {
         Ok(())
     }
 

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -25,7 +25,7 @@ use rust_hypervisor_firmware_virtio::{
     pci::{find_device, VirtioPciTransport},
     virtio::VirtioTransport,
 };
-use x86_64::PhysAddr;
+use x86_64::{PhysAddr, VirtAddr};
 
 pub mod packet;
 pub mod socket;
@@ -190,7 +190,9 @@ where
     /// Initializes the device and configures the queues.
     fn init(&mut self) -> anyhow::Result<()> {
         self.device
-            .start_init(DEVICE_ID as u32)
+            .start_init(DEVICE_ID as u32, |paddr: PhysAddr| {
+                Some(VirtAddr::new(paddr.as_u64()))
+            })
             .map_err(|error| anyhow::anyhow!("Virtio error: {:?}", error))
             .context("Couldn't initialize the PCI device")?;
         // We have to configure the event queue before the receive queue, otherwise the event

--- a/third_party/rust-hypervisor-firmware-virtio/src/device.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/device.rs
@@ -18,7 +18,10 @@
 
 use x86_64::PhysAddr;
 
-use crate::virtio::{Error as VirtioError, VirtioTransport};
+use crate::{
+    virtio::{Error as VirtioError, VirtioTransport},
+    Translator,
+};
 
 // Virtio Version 1 feature bit.
 // See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-4100006>.
@@ -51,9 +54,13 @@ where
     /// Start Initialising the device.
     ///
     /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-920001>.
-    pub fn start_init(&mut self, device_type: u32) -> Result<(), VirtioError> {
+    pub fn start_init<X: Translator>(
+        &mut self,
+        device_type: u32,
+        translate: X,
+    ) -> Result<(), VirtioError> {
         // Initialise the transport.
-        self.transport.init(device_type)?;
+        self.transport.init(device_type, translate)?;
 
         // Reset device.
         self.transport.set_status(VIRTIO_STATUS_RESET);

--- a/third_party/rust-hypervisor-firmware-virtio/src/lib.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/lib.rs
@@ -8,7 +8,12 @@
 
 #![no_std]
 
+use x86_64::{PhysAddr, VirtAddr};
+
 pub mod device;
 pub mod mem;
 pub mod pci;
 pub mod virtio;
+
+pub trait Translator: Fn(PhysAddr) -> Option<VirtAddr> {}
+impl<X: Fn(PhysAddr) -> Option<VirtAddr>> Translator for X {}

--- a/third_party/rust-hypervisor-firmware-virtio/src/virtio.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/virtio.rs
@@ -14,6 +14,8 @@
 
 use x86_64::PhysAddr;
 
+use crate::Translator;
+
 /// Virtio related errors
 #[derive(Debug)]
 pub enum Error {
@@ -21,11 +23,12 @@ pub enum Error {
     LegacyOnly,
     FeatureNegotiationFailed,
     QueueTooSmall,
+    AddressTranslationFailure(PhysAddr),
 }
 
 /// Trait to allow separation of transport from block driver
 pub trait VirtioTransport {
-    fn init(&mut self, device_type: u32) -> Result<(), Error>;
+    fn init<X: Translator>(&mut self, device_type: u32, translate: X) -> Result<(), Error>;
     fn get_status(&self) -> u32;
     fn set_status(&self, status: u32);
     fn add_status(&self, status: u32);


### PR DESCRIPTION
As with many other crates, the assumption that virtual addresses are the same as physical was baked deep into the virtio crate.

This PR cleans up the code by using `PhysAddr` and `VirtAddr` where appriopriate (instead of naked `u64`-s), and exposes a translator function to the API users in case we're not running under identity-mapped memory.

For now, the assumption (of running under identity mapping) is still true, so in the `virtio` crate we just pass in a dummy translator. But this gives us a hook to use later when we move away from identity mapping.