### PR TITLE
Add wrappers for IO ports and related factories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4024,6 +4024,7 @@ dependencies = [
  "bitflags",
  "lock_api",
  "snafu",
+ "spinning_top",
  "static_assertions",
  "strum",
  "x86_64",

--- a/experimental/sev_guest/Cargo.toml
+++ b/experimental/sev_guest/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 bitflags = "*"
 lock_api = "*"
+spinning_top = "*"
 static_assertions = "*"
 snafu = { version = "*", default-features = false }
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/experimental/sev_guest/src/io.rs
+++ b/experimental/sev_guest/src/io.rs
@@ -163,7 +163,7 @@ where
     }
 }
 
-/// Factory for creating port reader and writers that perform direct raw IO operations.
+/// Factory for creating port reader and writers that perform direct IO operations.
 pub struct RawIoPortFactory;
 
 impl<'a, T> IoPortFactory<'a, T, Port<T>, Port<T>> for RawIoPortFactory
@@ -207,8 +207,8 @@ impl PortWriter<u32> for Port<u32> {
     }
 }
 
-/// An IO port reader and writer implementation that uses the GHCB protocol, static references and a
-/// spinlock for synchronisation.
+/// An IO port reader and writer implementation that uses the GHCB IOIO protocol, static references
+/// and a spinlock for synchronisation.
 pub type StaticGhcbIoPort = GhcbIoPort<'static, RawSpinlock, GhcbProtocol<'static, Ghcb>, Ghcb>;
 
 /// Wrapper implementation that can either create IO ports that perform direct IO or IO ports that

--- a/oak_functions_freestanding_bin/Cargo.lock
+++ b/oak_functions_freestanding_bin/Cargo.lock
@@ -1113,6 +1113,7 @@ dependencies = [
  "bitflags",
  "lock_api",
  "snafu",
+ "spinning_top",
  "static_assertions",
  "strum",
  "x86_64",

--- a/oak_simple_io/src/lib.rs
+++ b/oak_simple_io/src/lib.rs
@@ -22,10 +22,7 @@ extern crate alloc;
 use alloc::{collections::VecDeque, vec, vec::Vec};
 use core::{marker::PhantomData, result::Result};
 use sev_guest::io::{IoPortFactory, PortReader, PortWriter};
-use x86_64::{
-    instructions::port::{PortReadOnly, PortWriteOnly},
-    PhysAddr, VirtAddr,
-};
+use x86_64::{instructions::port::Port, PhysAddr, VirtAddr};
 
 /// I/O port descriptor for a buffer.
 pub struct BufferDescriptor {
@@ -57,7 +54,7 @@ pub const OUTPUT_BUFFER_LEGNTH: usize = 4096;
 pub const INPUT_BUFFER_LEGNTH: usize = 4096;
 
 /// A Simple IO device implementation that uses direct port-based IO.
-pub type RawSimpleIo<'a> = SimpleIo<'a, PortReadOnly<u32>, PortWriteOnly<u32>>;
+pub type RawSimpleIo<'a> = SimpleIo<'a, Port<u32>, Port<u32>>;
 
 /// Memory address translation function.
 pub trait Translator: Fn(VirtAddr) -> Option<PhysAddr> {}

--- a/oak_tensorflow_freestanding_bin/Cargo.lock
+++ b/oak_tensorflow_freestanding_bin/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "bitflags",
  "lock_api",
  "snafu",
+ "spinning_top",
  "static_assertions",
  "strum",
  "x86_64",

--- a/sev_serial/src/lib.rs
+++ b/sev_serial/src/lib.rs
@@ -21,7 +21,7 @@ use sev_guest::{
     ghcb::{Ghcb, GhcbProtocol},
     io::{GhcbIoFactory, GhcbIoPort, IoPortFactory, PortReader, PortWriter, RawIoPortFactory},
 };
-use x86_64::instructions::port::{PortReadOnly, PortWriteOnly};
+use x86_64::instructions::port::Port;
 
 /// The offset from the base address to the interrupt register.
 const INTERRUPT_ENABLE: u16 = 1;
@@ -62,7 +62,7 @@ const DATA_TERMINAL_READY_AND_REQUEST_TO_SEND: u8 = 3;
 const OUTPUT_EMPTY: u8 = 1 << 5;
 
 /// A serial port implementation that uses direct port-based IO.
-pub type RawSerialPort<'a> = SerialPort<'a, PortReadOnly<u8>, PortWriteOnly<u8>, RawIoPortFactory>;
+pub type RawSerialPort<'a> = SerialPort<'a, Port<u8>, Port<u8>, RawIoPortFactory>;
 
 /// A serial port implementation that uses the GHCB IOIO protocol and static references.
 pub type StaticGhcbSerialPort<R> = SerialPort<

--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "bitflags",
  "lock_api",
  "snafu",
+ "spinning_top",
  "static_assertions",
  "strum",
  "x86_64",
@@ -152,6 +153,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "bitflags",
  "lock_api",
  "snafu",
+ "spinning_top",
  "static_assertions",
  "strum",
  "x86_64",

--- a/testing/sev_snp_hello_world_kernel/Cargo.lock
+++ b/testing/sev_snp_hello_world_kernel/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "bitflags",
  "lock_api",
  "snafu",
+ "spinning_top",
  "static_assertions",
  "strum",
  "x86_64",


### PR DESCRIPTION
This change adds wrapper enums around the IO port implementations (raw and GHCB-based) and the related IO port factories. This will be used in follow-up PRs to simplify the drivers that depend on these port implementations.