### PR TITLE
Expose the memory translation function in simple_io crate.

### DIFF
--- a/oak_restricted_kernel/src/simpleio.rs
+++ b/oak_restricted_kernel/src/simpleio.rs
@@ -17,6 +17,7 @@
 use alloc::collections::VecDeque;
 use oak_baremetal_simple_io::RawSimpleIo;
 use sev_guest::io::RawIoPortFactory;
+use x86_64::{PhysAddr, VirtAddr};
 
 /// A communications channel using a simple IO device.
 pub struct SimpleIoChannel<'a> {
@@ -31,8 +32,10 @@ pub struct SimpleIoChannel<'a> {
 impl SimpleIoChannel<'_> {
     pub fn new() -> Self {
         let io_port_factory = RawIoPortFactory;
-        let device =
-            RawSimpleIo::new_with_defaults(io_port_factory).expect("couldn't create IO device");
+        let device = RawSimpleIo::new_with_defaults(io_port_factory, |vaddr: VirtAddr| {
+            Some(PhysAddr::new(vaddr.as_u64()))
+        })
+        .expect("couldn't create IO device");
         let pending_data = None;
         Self {
             device,


### PR DESCRIPTION
The main goal here was to expose the memory translation function to the users of the crate; for now, we still assume identity mapping in the kernel.

However, as I was in there, `cargo clippy` deemed a function with 9 arguments as too much, so I refactored how the buffer I/O port descriptors are handled into a separate struct. I think it looks cleaner this way, so can't say I disagree with `cargo clippy` in the end...