### PR TITLE
Expose virtio memory translation functions to the kernel

### DIFF
--- a/experimental/virtio/src/console/tests.rs
+++ b/experimental/virtio/src/console/tests.rs
@@ -16,23 +16,23 @@
 
 use super::*;
 use crate::test::{
-    new_legacy_transport, new_transport_small_queue, new_valid_transport, DeviceStatus,
-    VIRTIO_F_VERSION_1,
+    identity_map, inverse_identity_map, new_legacy_transport, new_transport_small_queue,
+    new_valid_transport, DeviceStatus, VIRTIO_F_VERSION_1,
 };
 use alloc::{vec, vec::Vec};
 
 #[test]
 fn test_legacy_device_not_supported() {
     let device = VirtioBaseDevice::new(new_legacy_transport());
-    let mut console = Console::new(device);
-    assert!(console.init().is_err());
+    let mut console = Console::new(device, identity_map);
+    assert!(console.init(identity_map, inverse_identity_map).is_err());
 }
 
 #[test]
 fn test_max_queue_size_too_small() {
     let device = VirtioBaseDevice::new(new_transport_small_queue());
-    let mut console = Console::new(device);
-    assert!(console.init().is_err());
+    let mut console = Console::new(device, identity_map);
+    assert!(console.init(identity_map, inverse_identity_map).is_err());
 }
 
 #[test]
@@ -40,8 +40,8 @@ fn test_device_init() {
     let transport = new_valid_transport();
     let config = transport.config.clone();
     let device = VirtioBaseDevice::new(transport);
-    let mut console = Console::new(device);
-    let result = console.init();
+    let mut console = Console::new(device, identity_map);
+    let result = console.init(identity_map, inverse_identity_map);
     assert!(result.is_ok());
 
     let config = config.lock().unwrap();
@@ -70,8 +70,8 @@ fn test_read_bytes() {
     let data = vec![2, 4, 6];
     let transport = new_valid_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut console = Console::new(device);
-    console.init().unwrap();
+    let mut console = Console::new(device, identity_map);
+    console.init(identity_map, inverse_identity_map).unwrap();
     transport.device_write_to_queue::<QUEUE_SIZE>(0, &data[..]);
     let bytes = console.read_bytes().unwrap();
     let bytes: Vec<u8> = bytes.into_iter().collect();
@@ -83,8 +83,8 @@ fn test_write_bytes() {
     let data = vec![7; 5];
     let transport = new_valid_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut console = Console::new(device);
-    console.init().unwrap();
+    let mut console = Console::new(device, identity_map);
+    console.init(identity_map, inverse_identity_map).unwrap();
     let len = console.write_bytes(&data[..]).unwrap();
     assert_eq!(len, 5);
     let bytes = transport
@@ -100,8 +100,8 @@ fn test_read_exact() {
     let mut second = vec![0; 3];
     let transport = new_valid_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut console = Console::new(device);
-    console.init().unwrap();
+    let mut console = Console::new(device, identity_map);
+    console.init(identity_map, inverse_identity_map).unwrap();
     transport.device_write_to_queue::<QUEUE_SIZE>(0, &data[..]);
     assert!(console.read(&mut first).is_ok());
     assert!(console.read(&mut second).is_ok());
@@ -116,8 +116,8 @@ fn test_write_all() {
     let data = vec![13; 5000];
     let transport = new_valid_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut console = Console::new(device);
-    console.init().unwrap();
+    let mut console = Console::new(device, identity_map);
+    console.init(identity_map, inverse_identity_map).unwrap();
     assert!(console.write(&data[..]).is_ok());
     let first = transport
         .device_read_once_from_queue::<QUEUE_SIZE>(1)

--- a/experimental/virtio/src/lib.rs
+++ b/experimental/virtio/src/lib.rs
@@ -22,6 +22,8 @@
 #![no_std]
 #![feature(let_chains)]
 
+use x86_64::{PhysAddr, VirtAddr};
+
 extern crate alloc;
 #[cfg(test)]
 extern crate std;
@@ -55,3 +57,9 @@ pub trait Write {
 
 /// The vendor ID for virtio PCI devices.
 const PCI_VENDOR_ID: u16 = 0x1AF4;
+
+/// Memory address translation functions.
+pub trait Translator: Fn(VirtAddr) -> Option<PhysAddr> {}
+impl<X: Fn(VirtAddr) -> Option<PhysAddr>> Translator for X {}
+pub trait InverseTranslator: Fn(PhysAddr) -> Option<VirtAddr> {}
+impl<X: Fn(PhysAddr) -> Option<VirtAddr>> InverseTranslator for X {}

--- a/experimental/virtio/src/queue/tests.rs
+++ b/experimental/virtio/src/queue/tests.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+use crate::test::identity_map;
+
 use super::*;
 
 const QUEUE_SIZE: usize = 4;
@@ -21,7 +23,7 @@ const BUFFER_SIZE: usize = 4;
 
 #[test]
 fn test_read_empty_queue() {
-    let mut queue = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new();
+    let mut queue = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
     let data = queue.read_next_used_buffer();
     assert!(data.is_none());
     assert_eq!(queue.inner.last_used_idx.0, 0);
@@ -33,13 +35,13 @@ fn test_read_empty_queue() {
 #[should_panic]
 fn test_invalid_queue_size() {
     // `QUEUE_SIZE` must be a power of 2.
-    let _ = Queue::<3, BUFFER_SIZE>::new(DescFlags::empty());
+    let _ = Queue::<3, BUFFER_SIZE>::new(DescFlags::empty(), identity_map);
 }
 
 #[test]
 fn test_read_once() {
     let data = vec![0, 1, 2];
-    let mut queue = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new();
+    let mut queue = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
 
     let result = device_write(queue.inner.virt_queue.as_mut(), &data);
     assert_eq!(Some(3), result);
@@ -57,7 +59,7 @@ fn test_read_once() {
 #[test]
 fn test_write_once() {
     let data = vec![0, 1, 2];
-    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new();
+    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
 
     let result = queue.write_buffer(&data);
     assert_eq!(Some(3), result);
@@ -71,7 +73,7 @@ fn test_write_once() {
 #[test]
 fn test_wrapping_idx() {
     let data = vec![0, 1, 2];
-    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new();
+    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
 
     // Move the indices along to the max value.
     queue.inner.virt_queue.avail.idx = Wrapping(u16::MAX);
@@ -90,7 +92,7 @@ fn test_wrapping_idx() {
 #[test]
 fn test_write_too_long() {
     let data = vec![0, 1, 2, 3, 4];
-    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new();
+    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
 
     let result = queue.write_buffer(&data);
     assert_eq!(Some(4), result);
@@ -98,7 +100,7 @@ fn test_write_too_long() {
 
 #[test]
 fn test_device_queue_exhaustion() {
-    let mut queue = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new();
+    let mut queue = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
     let data = Some(vec![0]);
     // We can write 4 times.
     let result = device_write(queue.inner.virt_queue.as_mut(), data.as_ref().unwrap());
@@ -129,7 +131,7 @@ fn test_device_queue_exhaustion() {
 
 #[test]
 fn test_driver_queue_exhaustion() {
-    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new();
+    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
     let data = Some(vec![0]);
     // We should be able to write 4 times.
     let result = queue.write_buffer(data.as_ref().unwrap());
@@ -163,8 +165,8 @@ fn test_many_echos() {
     let data_1 = Some(vec![0]);
     let data_2 = Some(vec![1, 2, 3]);
     let data_3 = Some(vec![4, 5]);
-    let mut tx = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new();
-    let mut rx = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new();
+    let mut tx = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
+    let mut rx = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
     for _ in 0..100 {
         // Run batches of 3 echos or different data lengths repeatedly.
         tx.write_buffer(data_1.as_ref().unwrap()).unwrap();

--- a/experimental/virtio/src/test.rs
+++ b/experimental/virtio/src/test.rs
@@ -297,3 +297,11 @@ pub fn new_transport_small_queue() -> TestingTransport {
     transport.config.lock().unwrap().max_queue_size = 8;
     transport
 }
+
+pub fn identity_map(addr: VirtAddr) -> Option<PhysAddr> {
+    Some(PhysAddr::new(addr.as_u64()))
+}
+
+pub fn inverse_identity_map(addr: PhysAddr) -> Option<VirtAddr> {
+    Some(VirtAddr::new(addr.as_u64()))
+}

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -17,6 +17,7 @@
 use crate::{
     queue::{DeviceWriteOnlyQueue, DriverWriteOnlyQueue},
     vsock::packet::VSockOp,
+    InverseTranslator, Translator,
 };
 use anyhow::Context;
 use packet::Packet;
@@ -25,7 +26,6 @@ use rust_hypervisor_firmware_virtio::{
     pci::{find_device, VirtioPciTransport},
     virtio::VirtioTransport,
 };
-use x86_64::{PhysAddr, VirtAddr};
 
 pub mod packet;
 pub mod socket;
@@ -92,15 +92,18 @@ pub struct VSock<T: VirtioTransport> {
 
 impl VSock<VirtioPciTransport> {
     /// Finds the virtio vsock PCI device, initialises the device, and configures the queues.
-    pub fn find_and_configure_device() -> anyhow::Result<Self> {
+    pub fn find_and_configure_device<VP: Translator, PV: InverseTranslator>(
+        translate: VP,
+        inverse: PV,
+    ) -> anyhow::Result<Self> {
         // For now we just scan the first 32 devices on PCI bus 0 to find the first one that matches
         // the vendor ID and device ID.
         let pci_device = find_device(super::PCI_VENDOR_ID, PCI_DEVICE_ID)
             .ok_or_else(|| anyhow::anyhow!("Couldn't find a virtio vsock device."))?;
         let transport = VirtioPciTransport::new(pci_device);
         let device = VirtioBaseDevice::new(transport);
-        let mut result = Self::new(device);
-        result.init()?;
+        let mut result = Self::new(device, &translate);
+        result.init(translate, inverse)?;
         // Let the device know there are available buffers in the receiver and event queues.
         result.device.notify_queue(RX_QUEUE_ID);
         result.device.notify_queue(EVENT_QUEUE_ID);
@@ -174,10 +177,10 @@ where
         self.device.get_status()
     }
 
-    fn new(device: VirtioBaseDevice<T>) -> Self {
-        let tx_queue = DriverWriteOnlyQueue::new();
-        let rx_queue = DeviceWriteOnlyQueue::new();
-        let event_queue = DeviceWriteOnlyQueue::new();
+    fn new<VP: Translator>(device: VirtioBaseDevice<T>, translate: VP) -> Self {
+        let tx_queue = DriverWriteOnlyQueue::new(&translate);
+        let rx_queue = DeviceWriteOnlyQueue::new(&translate);
+        let event_queue = DeviceWriteOnlyQueue::new(&translate);
         VSock {
             device,
             tx_queue,
@@ -188,11 +191,13 @@ where
     }
 
     /// Initializes the device and configures the queues.
-    fn init(&mut self) -> anyhow::Result<()> {
+    fn init<VP: Translator, PV: InverseTranslator>(
+        &mut self,
+        translate: VP,
+        inverse: PV,
+    ) -> anyhow::Result<()> {
         self.device
-            .start_init(DEVICE_ID as u32, |paddr: PhysAddr| {
-                Some(VirtAddr::new(paddr.as_u64()))
-            })
+            .start_init(DEVICE_ID as u32, inverse)
             .map_err(|error| anyhow::anyhow!("Virtio error: {:?}", error))
             .context("Couldn't initialize the PCI device")?;
         // We have to configure the event queue before the receive queue, otherwise the event
@@ -202,9 +207,12 @@ where
             .configure_queue(
                 EVENT_QUEUE_ID,
                 QUEUE_SIZE as u16,
-                PhysAddr::new(self.event_queue.inner.get_desc_addr().as_u64()),
-                PhysAddr::new(self.event_queue.inner.get_avail_addr().as_u64()),
-                PhysAddr::new(self.event_queue.inner.get_used_addr().as_u64()),
+                translate(self.event_queue.inner.get_desc_addr())
+                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                translate(self.event_queue.inner.get_avail_addr())
+                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                translate(self.event_queue.inner.get_used_addr())
+                    .context("Failed to translate VirtAddr to PhysAddr")?,
             )
             .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
             .context("Couldn't configure the event queue")?;
@@ -212,9 +220,12 @@ where
             .configure_queue(
                 RX_QUEUE_ID,
                 QUEUE_SIZE as u16,
-                PhysAddr::new(self.rx_queue.inner.get_desc_addr().as_u64()),
-                PhysAddr::new(self.rx_queue.inner.get_avail_addr().as_u64()),
-                PhysAddr::new(self.rx_queue.inner.get_used_addr().as_u64()),
+                translate(self.rx_queue.inner.get_desc_addr())
+                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                translate(self.rx_queue.inner.get_avail_addr())
+                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                translate(self.rx_queue.inner.get_used_addr())
+                    .context("Failed to translate VirtAddr to PhysAddr")?,
             )
             .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
             .context("Couldn't configure the receive queue")?;
@@ -222,9 +233,12 @@ where
             .configure_queue(
                 TX_QUEUE_ID,
                 QUEUE_SIZE as u16,
-                PhysAddr::new(self.tx_queue.inner.get_desc_addr().as_u64()),
-                PhysAddr::new(self.tx_queue.inner.get_avail_addr().as_u64()),
-                PhysAddr::new(self.tx_queue.inner.get_used_addr().as_u64()),
+                translate(self.tx_queue.inner.get_desc_addr())
+                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                translate(self.tx_queue.inner.get_avail_addr())
+                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                translate(self.tx_queue.inner.get_used_addr())
+                    .context("Failed to translate VirtAddr to PhysAddr")?,
             )
             .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
             .context("Couldn't configure the transmit queue")?;

--- a/experimental/virtio/src/vsock/socket/tests.rs
+++ b/experimental/virtio/src/vsock/socket/tests.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use crate::{
-    test::{new_valid_transport, TestingTransport},
+    test::{identity_map, inverse_identity_map, new_valid_transport, TestingTransport},
     vsock::{HOST_CID, QUEUE_SIZE},
     Read, Write,
 };
@@ -176,8 +176,8 @@ fn new_vsock_and_transport() -> (VSock<TestingTransport>, TestingTransport) {
     transport.write_device_config(0, GUEST_CID as u32);
 
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut vsock = VSock::new(device);
-    vsock.init().unwrap();
+    let mut vsock = VSock::new(device, identity_map);
+    vsock.init(identity_map, inverse_identity_map).unwrap();
 
     (vsock, transport)
 }


### PR DESCRIPTION
This PR builds on #3302 and is similar in purpose to #3306: move the memory mapping functions to the kernel.

As in that PR, for now we continue to assume identity mapping. But at least after this the kernel is in control, and we can switch it out in one single place.