### PR TITLE
Rename `Translator` to `InverseTranslator` for consistency

### DIFF
--- a/third_party/rust-hypervisor-firmware-virtio/src/device.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/device.rs
@@ -20,7 +20,7 @@ use x86_64::PhysAddr;
 
 use crate::{
     virtio::{Error as VirtioError, VirtioTransport},
-    Translator,
+    InverseTranslator,
 };
 
 // Virtio Version 1 feature bit.
@@ -54,7 +54,7 @@ where
     /// Start Initialising the device.
     ///
     /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-920001>.
-    pub fn start_init<X: Translator>(
+    pub fn start_init<X: InverseTranslator>(
         &mut self,
         device_type: u32,
         translate: X,

--- a/third_party/rust-hypervisor-firmware-virtio/src/lib.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/lib.rs
@@ -15,5 +15,5 @@ pub mod mem;
 pub mod pci;
 pub mod virtio;
 
-pub trait Translator: Fn(PhysAddr) -> Option<VirtAddr> {}
-impl<X: Fn(PhysAddr) -> Option<VirtAddr>> Translator for X {}
+pub trait InverseTranslator: Fn(PhysAddr) -> Option<VirtAddr> {}
+impl<X: Fn(PhysAddr) -> Option<VirtAddr>> InverseTranslator for X {}

--- a/third_party/rust-hypervisor-firmware-virtio/src/pci.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/pci.rs
@@ -22,7 +22,7 @@ use x86_64::{
 use crate::{
     mem,
     virtio::{Error as VirtioError, VirtioTransport},
-    Translator,
+    InverseTranslator,
 };
 
 const MAX_DEVICES: u8 = 32;
@@ -269,7 +269,11 @@ impl VirtioPciTransport {
 /// le64 queue_used;                // 0x30 // read-write
 
 impl VirtioTransport for VirtioPciTransport {
-    fn init<X: Translator>(&mut self, _device_type: u32, translate: X) -> Result<(), VirtioError> {
+    fn init<X: InverseTranslator>(
+        &mut self,
+        _device_type: u32,
+        translate: X,
+    ) -> Result<(), VirtioError> {
         self.device.init();
 
         // Read status register

--- a/third_party/rust-hypervisor-firmware-virtio/src/virtio.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/virtio.rs
@@ -14,7 +14,7 @@
 
 use x86_64::PhysAddr;
 
-use crate::Translator;
+use crate::InverseTranslator;
 
 /// Virtio related errors
 #[derive(Debug)]
@@ -28,7 +28,7 @@ pub enum Error {
 
 /// Trait to allow separation of transport from block driver
 pub trait VirtioTransport {
-    fn init<X: Translator>(&mut self, device_type: u32, translate: X) -> Result<(), Error>;
+    fn init<X: InverseTranslator>(&mut self, device_type: u32, translate: X) -> Result<(), Error>;
     fn get_status(&self) -> u32;
     fn set_status(&self, status: u32);
     fn add_status(&self, status: u32);


### PR DESCRIPTION
This addresses a comment in #3307 where Conrad noted that we're using the names in an inconsistent way in different crates.