### PR TITLE
Simplify drivers using the new port wrapper enum

### DIFF
--- a/testing/sev_snp_hello_world_kernel/src/serial.rs
+++ b/testing/sev_snp_hello_world_kernel/src/serial.rs
@@ -18,31 +18,16 @@ use core::fmt::Write;
 use lazy_static::lazy_static;
 use sev_guest::{
     ghcb::{Ghcb, GhcbProtocol},
-    io::{GhcbIoFactory, RawIoPortFactory},
+    io::PortFactoryWrapper,
     msr::{get_sev_status, SevStatus},
 };
-use sev_serial::{RawSerialPort, StaticGhcbSerialPort};
-use spinning_top::{RawSpinlock, Spinlock};
+use sev_serial::SerialPort;
+use spinning_top::Spinlock;
 
 extern crate log;
 
 // Base I/O port for the first serial port in the system (colloquially known as COM1).
 static COM1_BASE: u16 = 0x3f8;
-
-/// Wrapper for the possible serial port implementations.
-pub enum SerialWrapper<'a> {
-    Raw(RawSerialPort<'a>),
-    Ghcb(StaticGhcbSerialPort<RawSpinlock>),
-}
-
-impl Write for SerialWrapper<'_> {
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        match self {
-            SerialWrapper::Raw(port) => port.write_str(s),
-            SerialWrapper::Ghcb(port) => port.write_str(s),
-        }
-    }
-}
 
 lazy_static! {
     static ref GHCB_PROTOCOL: Spinlock<GhcbProtocol<'static, Ghcb>> = {
@@ -54,24 +39,16 @@ lazy_static! {
 }
 
 lazy_static! {
-    pub static ref SERIAL1: Spinlock<SerialWrapper<'static>> = {
+    pub static ref SERIAL1: Spinlock<SerialPort> = {
         let sev_status = get_sev_status().unwrap_or(SevStatus::empty());
-        let wrapper = if sev_status.contains(SevStatus::SEV_ES_ENABLED) {
-            let ghcb_factory = GhcbIoFactory::new(&GHCB_PROTOCOL);
-            // Safety: our contract with the loader requires the first serial port to be available,
-            // so assuming the loader adheres to it, this is safe.
-            let mut port = unsafe { StaticGhcbSerialPort::new(COM1_BASE, ghcb_factory) };
-            port.init().expect("Couldn't initialize GHCB serial port");
-            SerialWrapper::Ghcb(port)
+        let factory = if sev_status.contains(SevStatus::SEV_ES_ENABLED) {
+            PortFactoryWrapper::new_ghcb(&GHCB_PROTOCOL)
         } else {
-            // Safety: our contract with the loader requires the first serial port to be available,
-            // so assuming the loader adheres to it, this is safe.
-            let mut port = unsafe { RawSerialPort::new(COM1_BASE, RawIoPortFactory) };
-            port.init().expect("Couldn't initialize raw serial port");
-            SerialWrapper::Raw(port)
+            PortFactoryWrapper::new_raw()
         };
-
-        Spinlock::new(wrapper)
+        let mut port = unsafe { SerialPort::new(COM1_BASE, factory) };
+        port.init().expect("Couldn't initialize serial port");
+        Spinlock::new(port)
     };
 }
 


### PR DESCRIPTION
The wrapper enums for IO ports and their related factories mean that we can now have simpler drivers that depend on these.