### PR TITLE
Populate GDT in Restricted Kernel

### DIFF
--- a/oak_restricted_kernel/src/descriptors.rs
+++ b/oak_restricted_kernel/src/descriptors.rs
@@ -1,0 +1,69 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use lazy_static::lazy_static;
+use x86_64::{
+    registers::segmentation::*,
+    structures::{
+        gdt::{Descriptor, GlobalDescriptorTable},
+        tss::TaskStateSegment,
+    },
+};
+
+struct Descriptors {
+    gdt: GlobalDescriptorTable,
+    kernel_cs_selector: SegmentSelector,
+    kernel_ds_selector: SegmentSelector,
+    user_cs_selector: SegmentSelector,
+    user_ds_selector: SegmentSelector,
+    tss_selector: SegmentSelector,
+}
+
+lazy_static! {
+    static ref TSS: TaskStateSegment = TaskStateSegment::new();
+    static ref DESCRIPTORS: Descriptors = {
+        let mut descriptors = Descriptors {
+            gdt: GlobalDescriptorTable::new(),
+            kernel_cs_selector: SegmentSelector::NULL,
+            kernel_ds_selector: SegmentSelector::NULL,
+            user_cs_selector: SegmentSelector::NULL,
+            user_ds_selector: SegmentSelector::NULL,
+            tss_selector: SegmentSelector::NULL,
+        };
+        descriptors.kernel_cs_selector =
+            descriptors.gdt.add_entry(Descriptor::kernel_code_segment());
+        descriptors.kernel_ds_selector =
+            descriptors.gdt.add_entry(Descriptor::kernel_data_segment());
+        descriptors.user_cs_selector = descriptors.gdt.add_entry(Descriptor::user_code_segment());
+        descriptors.user_ds_selector = descriptors.gdt.add_entry(Descriptor::user_data_segment());
+        descriptors.tss_selector = descriptors.gdt.add_entry(Descriptor::tss_segment(&TSS));
+        descriptors
+    };
+}
+
+pub fn init_gdt() {
+    DESCRIPTORS.gdt.load();
+
+    // Safety: it's safe to load these segments as we've initialized the GDT just above.
+    unsafe {
+        CS::set_reg(DESCRIPTORS.kernel_cs_selector);
+        DS::set_reg(DESCRIPTORS.kernel_ds_selector);
+        ES::set_reg(DESCRIPTORS.kernel_ds_selector);
+        FS::set_reg(DESCRIPTORS.kernel_ds_selector);
+        GS::set_reg(DESCRIPTORS.kernel_ds_selector);
+        SS::set_reg(DESCRIPTORS.kernel_ds_selector);
+    }
+}

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -34,6 +34,7 @@
 
 mod args;
 mod avx;
+mod descriptors;
 mod elf;
 pub mod i8042;
 mod interrupts;
@@ -67,6 +68,7 @@ use crate::mm::page_tables::DirectMap;
 pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     avx::enable_avx();
     logging::init_logging();
+    descriptors::init_gdt();
     interrupts::init_idt();
 
     // We need to be done with the boot info struct before intializing memory. For example, the


### PR DESCRIPTION
After we removed the identity-mapped memory, our interrupt handlers broke.

This was bit of a mystery, but boils down to the fact that when an interrupt happens the processor will try to switch segments to the one described in the IDT. However, we weren't setting up a proper new GDT in the kernel but rather relying on the one set up by the bootloader for us, which meant the GDT was somewhere in low memory that was no longer mapped.

All of our existing code worked just fine, because we don't switch between segments during normal execution. However, once an interrupt happened, the CPU triple-faulted as it couldn't find the GDT.

This PR sets up a new GDT, managed by our kernel. I've also used this opportunity to set up user code/data segments and a proper task state segment as well, although we're not using them (yet).