### PR TITLE
Load the TSS structure with the other segment descriptors.

### DIFF
--- a/oak_restricted_kernel/src/descriptors.rs
+++ b/oak_restricted_kernel/src/descriptors.rs
@@ -16,6 +16,7 @@
 
 use lazy_static::lazy_static;
 use x86_64::{
+    instructions::tables::load_tss,
     registers::segmentation::*,
     structures::{
         gdt::{Descriptor, GlobalDescriptorTable},
@@ -65,5 +66,6 @@ pub fn init_gdt() {
         FS::set_reg(DESCRIPTORS.kernel_ds_selector);
         GS::set_reg(DESCRIPTORS.kernel_ds_selector);
         SS::set_reg(DESCRIPTORS.kernel_ds_selector);
+        load_tss(DESCRIPTORS.tss_selector);
     }
 }


### PR DESCRIPTION
This should have been a part of #3315 but I missed it it there.

We're not really using the TSS structure (yet), so there were/are no ill effects from the fact that we didn't load the TSS properly.