### PR TITLE
Use split Oak Functions server for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "duct"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc6a0a59ed0888e0041cf708e66357b7ae1a82f1c67247e1f93b5e0818f7d8d"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,15 +1993,11 @@ dependencies = [
 name = "key_value_lookup"
 version = "0.1.0"
 dependencies = [
- "hashbrown 0.12.2",
+ "hashbrown 0.11.2",
  "http",
- "hyper",
  "maplit",
  "oak_functions",
  "oak_functions_abi",
- "oak_functions_loader",
- "oak_functions_lookup",
- "prost 0.10.4",
  "test_utils",
  "tokio",
 ]
@@ -2377,6 +2385,7 @@ dependencies = [
  "oak_functions_loader",
  "oak_functions_lookup",
  "oak_functions_testing_extension",
+ "oak_functions_wasm",
  "oak_functions_workload_logging",
  "prost 0.10.4",
  "serde",
@@ -2445,7 +2454,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "flatbuffers",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.2",
  "log",
  "oak_functions_abi",
  "oak_functions_lookup",
@@ -2553,7 +2562,6 @@ dependencies = [
  "hyper-rustls",
  "log",
  "lookup_data_generator",
- "maplit",
  "oak_functions_abi",
  "oak_functions_extension",
  "oak_functions_lookup",
@@ -2832,7 +2840,7 @@ dependencies = [
  "bitvec",
  "goblin",
  "lazy_static",
- "libm 0.1.4",
+ "libm 0.2.5",
  "linked_list_allocator",
  "log",
  "oak_channel",
@@ -2998,6 +3006,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_pipe"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4088,6 +4106,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "shellexpand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4335,14 +4363,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "duct",
  "http",
  "hyper",
  "log",
+ "nix 0.22.3",
  "oak_functions_abi",
  "oak_functions_client",
  "oak_remote_attestation",
  "port_check",
  "prost 0.10.4",
+ "tempfile",
  "tokio",
 ]
 
@@ -5554,16 +5585,11 @@ dependencies = [
 name = "weather_lookup"
 version = "0.1.0"
 dependencies = [
- "http",
  "location_utils",
  "lookup_data_generator",
  "maplit",
  "oak_functions",
  "oak_functions_abi",
- "oak_functions_loader",
- "oak_functions_lookup",
- "oak_functions_workload_logging",
- "prost 0.10.4",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/oak_functions/examples/key_value_lookup/module/Cargo.toml
+++ b/oak_functions/examples/key_value_lookup/module/Cargo.toml
@@ -13,13 +13,9 @@ oak_functions = { path = "../../../sdk/oak_functions" }
 
 [dev-dependencies]
 oak_functions_abi = { path = "../../../abi" }
-oak_functions_loader = { path = "../../../loader" }
-oak_functions_lookup = { path = "../../../lookup" }
 hashbrown = "*"
 http = "*"
-hyper = { version = "*", features = ["client", "http2"] }
 maplit = "*"
-prost = "*"
 test_utils = { path = "../../../sdk/test_utils" }
 tokio = { version = "*", features = [
   "fs",

--- a/oak_functions/examples/weather_lookup/module/Cargo.toml
+++ b/oak_functions/examples/weather_lookup/module/Cargo.toml
@@ -15,14 +15,9 @@ serde = { version = "*", features = ["derive"] }
 serde_json = "*"
 
 [dev-dependencies]
-http = "*"
 lookup_data_generator = { path = "../../../lookup_data_generator" }
 oak_functions_abi = { path = "../../../abi" }
-oak_functions_loader = { path = "../../../loader" }
-oak_functions_lookup = { path = "../../../lookup" }
-oak_functions_workload_logging = { path = "../../../workload_logging" }
 maplit = "*"
-prost = "*"
 rand = "*"
 test_utils = { path = "../../../sdk/test_utils" }
 tokio = { version = "*", features = [

--- a/oak_functions/loader/Cargo.toml
+++ b/oak_functions/loader/Cargo.toml
@@ -70,7 +70,6 @@ signal-hook = "*"
 [dev-dependencies]
 criterion = "*"
 lookup_data_generator = { path = "../lookup_data_generator" }
-maplit = "*"
 tempfile = "*"
 test_utils = { path = "../sdk/test_utils" }
 

--- a/oak_functions/loader/src/tests.rs
+++ b/oak_functions/loader/src/tests.rs
@@ -15,168 +15,17 @@
 //
 
 use crate::{
-    grpc::{create_and_start_grpc_server, create_wasm_handler},
     logger::Logger,
     lookup_data::{parse_lookup_entries, LookupDataAuth, LookupDataRefresher, LookupDataSource},
     server::apply_policy,
 };
-use maplit::hashmap;
 use oak_functions_abi::{proto::ServerPolicy, Response, StatusCode};
-use oak_functions_lookup::{LookupDataManager, LookupFactory};
-use oak_functions_workload_logging::WorkloadLoggingFactory;
+use oak_functions_lookup::LookupDataManager;
 use prost::Message;
 use std::{
     io::{Seek, Write},
-    net::{Ipv6Addr, SocketAddr},
     sync::Arc,
-    time::Duration,
 };
-use test_utils::make_request;
-
-const MANIFEST_PATH: &str = "examples/key_value_lookup/module/Cargo.toml";
-
-#[tokio::test]
-async fn test_valid_policy() {
-    // Policy values are large enough to allow successful serving of the request, and responding
-    // with the actual response from the Wasm module.
-    let constant_processing_time = Duration::from_millis(500);
-    let policy = ServerPolicy {
-        constant_response_size_bytes: 100,
-        constant_processing_time_ms: constant_processing_time.as_millis().try_into().unwrap(),
-    };
-
-    let scenario = |server_port: u16| async move {
-        let result = make_request(server_port, br#"key_1"#).await;
-        // Check that the processing time is within a reasonable range of
-        // `constant_processing_time` specified in the policy.
-        assert!(result.elapsed > constant_processing_time);
-        assert!(
-            (result.elapsed.as_millis() as f64)
-                < 1.05 * constant_processing_time.as_millis() as f64,
-            "elapsed time is: {:?}",
-            result.elapsed
-        );
-
-        let response = result.response;
-        assert_eq!(StatusCode::Success, response.status);
-        assert_eq!(
-            std::str::from_utf8(response.body().unwrap()).unwrap(),
-            r#"value_1"#
-        );
-    };
-
-    run_scenario_with_policy(scenario, policy).await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_long_response_time() {
-    // The `constant_processing_time` is too low.
-    let constant_processing_time = Duration::from_millis(5);
-    let policy = ServerPolicy {
-        constant_response_size_bytes: 100,
-        constant_processing_time_ms: constant_processing_time.as_millis().try_into().unwrap(),
-    };
-
-    // So we expect the request to fail, with `response not available error`.
-    let scenario = |server_port: u16| async move {
-        let result = make_request(server_port, br#"key_1"#).await;
-        // Check the elapsed time, allowing a margin of 50ms.
-        // TODO(#2694): Increased the margin from 10 to 50 ms as the test was starting to fail
-        // daily, but we need to investigate the regression.
-        let margin = Duration::from_millis(50);
-        assert!(
-            result.elapsed < constant_processing_time + margin,
-            "elapsed: {:?}",
-            result.elapsed
-        );
-
-        let response = result.response;
-        assert_eq!(StatusCode::PolicyTimeViolation, response.status);
-        assert_eq!(
-            std::str::from_utf8(response.body().unwrap()).unwrap(),
-            "Reason: response not available."
-        );
-    };
-
-    run_scenario_with_policy(scenario, policy).await;
-}
-
-/// Starts the server with the given policy, and runs the given test scenario.
-///
-/// A normal test scenario makes any number of requests and checks the responses. It has to be an
-/// async function, with a single `u16` input argument as the `server_port`, and returning the unit
-/// type (`()`).
-async fn run_scenario_with_policy<F, S>(test_scenario: F, policy: ServerPolicy)
-where
-    F: FnOnce(u16) -> S,
-    S: std::future::Future<Output = ()>,
-{
-    let server_port = test_utils::free_port();
-    let address = SocketAddr::from((Ipv6Addr::UNSPECIFIED, server_port));
-
-    let mut manifest_path = std::env::current_dir().unwrap();
-    manifest_path.pop();
-    manifest_path.push(MANIFEST_PATH);
-    let wasm_module_bytes =
-        test_utils::compile_rust_wasm(manifest_path.to_str().expect("Invalid target dir"), false)
-            .expect("Couldn't read Wasm module");
-
-    let logger = Logger::for_test();
-
-    let mock_static_server = Arc::new(test_utils::MockStaticServer::default());
-
-    let mock_static_server_clone = mock_static_server.clone();
-    let static_server_port = test_utils::free_port();
-    let mock_static_server_background = test_utils::background(|term| async move {
-        mock_static_server_clone
-            .serve(static_server_port, term)
-            .await
-    });
-
-    mock_static_server.set_response_body(test_utils::serialize_entries(hashmap! {
-        b"key_0".to_vec() => br#"value_0"#.to_vec(),
-        b"key_1".to_vec() => br#"value_1"#.to_vec(),
-        b"key_2".to_vec() => br#"value_2"#.to_vec(),
-    }));
-
-    let lookup_data_manager = Arc::new(LookupDataManager::new_empty(logger.clone()));
-    let lookup_data_refresher = LookupDataRefresher::new(
-        Some(LookupDataSource::Http {
-            url: format!("http://localhost:{}", static_server_port),
-            auth: LookupDataAuth::default(),
-        }),
-        lookup_data_manager.clone(),
-        logger.clone(),
-    );
-    lookup_data_refresher.refresh().await.unwrap();
-    let workload_logging_factory =
-        WorkloadLoggingFactory::new_boxed_extension_factory(logger.clone())
-            .expect("could not create WorkloadLoggingFactory");
-    let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data_manager.clone())
-        .expect("could not create LookupFactory");
-    let wasm_handler = create_wasm_handler(
-        &wasm_module_bytes,
-        vec![lookup_factory, workload_logging_factory],
-        logger.clone(),
-    )
-    .expect("could not create wasm_handler");
-
-    let server_background = test_utils::background(|term| async move {
-        create_and_start_grpc_server(&address, wasm_handler, policy.clone(), term, logger).await
-    });
-
-    // Wait for the server thread to make progress before starting the client. This is needed for a
-    // more accurate measurement of the processing time, and to avoid `connection refused` from the
-    // client in tests that run with multiple threads.
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
-    test_scenario(server_port).await;
-
-    let res = server_background.terminate_and_join().await;
-    assert!(res.is_ok());
-
-    mock_static_server_background.terminate_and_join().await;
-}
 
 #[test]
 fn parse_lookup_entries_empty() {

--- a/oak_functions/sdk/oak_functions/Cargo.toml
+++ b/oak_functions/sdk/oak_functions/Cargo.toml
@@ -16,6 +16,7 @@ serde_derive = "*"
 hashbrown = "*"
 lazy_static = "*"
 oak_functions_loader = { path = "../../loader" }
+oak_functions_wasm = { path = "../../wasm" }
 oak_functions_lookup = { path = "../../lookup" }
 oak_functions_testing_extension = { path = "../../testing" }
 oak_functions_workload_logging = { path = "../../workload_logging" }

--- a/oak_functions/sdk/oak_functions/tests/integration_test.rs
+++ b/oak_functions/sdk/oak_functions/tests/integration_test.rs
@@ -17,8 +17,9 @@
 use hashbrown::HashMap;
 use lazy_static::lazy_static;
 use oak_functions_abi::{Request, Response};
-use oak_functions_loader::{logger::Logger, server::WasmHandler};
+use oak_functions_loader::logger::Logger;
 use oak_functions_lookup::{LookupDataManager, LookupFactory};
+use oak_functions_wasm::WasmHandler;
 use oak_functions_workload_logging::WorkloadLoggingFactory;
 use std::{path::PathBuf, sync::Arc};
 

--- a/oak_functions/sdk/test_utils/Cargo.toml
+++ b/oak_functions/sdk/test_utils/Cargo.toml
@@ -8,12 +8,15 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "*"
 cargo_metadata = "*"
+duct = "*"
 log = "*"
 http = "*"
 hyper = { version = "*", features = ["client", "http1", "runtime", "server"] }
+nix = "*"
 oak_functions_abi = { path = "../../abi" }
 oak_functions_client = { path = "../../client/rust" }
 oak_remote_attestation = { path = "../../../oak_remote_attestation" }
 port_check = "*"
 prost = "*"
+tempfile = "*"
 tokio = { version = "*", features = ["sync"] }

--- a/oak_functions/wasm/src/lib.rs
+++ b/oak_functions/wasm/src/lib.rs
@@ -21,6 +21,9 @@
 extern crate alloc;
 
 #[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
 mod tests;
 
 use alloc::{boxed::Box, format, sync::Arc, vec::Vec};

--- a/oak_functions/wasm/src/tests.rs
+++ b/oak_functions/wasm/src/tests.rs
@@ -14,11 +14,10 @@
 // limitations under the License.
 //
 
+use crate::{AbiPointer, AbiPointerOffset, WasmHandler, WasmState};
 use alloc::{borrow::ToOwned, vec};
 use oak_functions_abi::{proto::OakStatus, ExtensionHandle, TestingRequest, TestingResponse};
 use oak_functions_testing_extension::{TestingFactory, TestingLogger};
-
-use crate::{AbiPointer, AbiPointerOffset, WasmHandler, WasmState};
 
 #[test]
 fn test_invoke_extension_with_invalid_handle() {
@@ -212,7 +211,8 @@ fn create_test_wasm_state() -> WasmState<TestingLogger> {
     let testing_factory = TestingFactory::new_boxed_extension_factory(logger.clone())
         .expect("Could not create TestingFactory.");
 
-    let wasm_module_bytes = test_utils::create_echo_wasm_module_bytes();
+    let wasm_module_path = test_utils::build_rust_crate_wasm("echo").unwrap();
+    let wasm_module_bytes = std::fs::read(&wasm_module_path).unwrap();
 
     let wasm_handler = WasmHandler::create(&wasm_module_bytes, vec![testing_factory], logger)
         .expect("Could not create WasmHandler.");

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -20,6 +20,7 @@ use instance::{crosvm, native, LaunchedInstance};
 use std::{
     fs,
     io::{BufRead, BufReader},
+    net::{Ipv6Addr, SocketAddr},
     os::unix::net::UnixStream,
     path::PathBuf,
 };
@@ -64,6 +65,9 @@ struct Args {
     /// Consistent response size that the runtime should apply
     #[clap(long, default_value = "1024")]
     constant_response_size: u32,
+
+    #[clap(long, default_value = "8080")]
+    port: u16,
 
     /// Path to a Wasm file to be loaded into the trusted runtime and executed by it per
     /// invocation. See the documentation for details on its ABI. Ref: <https://github.com/project-oak/oak/blob/main/docs/oak_functions_abi.md>
@@ -179,7 +183,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("no public key info returned");
 
     let server_future = server::server(
-        "127.0.0.1:8080".parse()?,
+        SocketAddr::from((Ipv6Addr::UNSPECIFIED, cli.port)),
         connector_handle,
         public_key_info
             .public_key()

--- a/oak_functions_linux_fd_bin/src/main.rs
+++ b/oak_functions_linux_fd_bin/src/main.rs
@@ -39,7 +39,7 @@ impl log::Log for Logger {
     }
 
     #[cfg(not(debug_assertions))]
-    fn log(&self, record: &log::Record) {}
+    fn log(&self, _record: &log::Record) {}
 
     fn flush(&self) {}
 }


### PR DESCRIPTION
The overall goal is to stop depending on the unified Oak Functions
loader library, so that it may be deleted.

Also remove some of the tests that rely on constant processing time,
since that's not supported in the split binary yet (https://github.com/project-oak/oak/issues/3079).

Incidentally, I made the integration tests more aligned with actually
testing meaningful integrations, and I am starting to think that they
can replace running the examples at some point in the future (so we
drive the examples from proper Rust tests, instead of doing that from xtask).

Ref https://github.com/project-oak/oak/issues/3081