### PR TITLE
Create a `#GP` handler that emulates `rdmsr` in Restricted Kernel.

### DIFF
--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -30,6 +30,8 @@
 
 #![cfg_attr(not(test), no_std)]
 #![feature(abi_x86_interrupt)]
+#![feature(asm_sym)]
+#![feature(naked_functions)]
 #![feature(once_cell)]
 
 mod args;


### PR DESCRIPTION
This is similar to #3323 where we introduced a similar handler in the hello world kernel, but a bit more clever.

As we can't change register values when using the `x86-interrupt` calling convention, the naked interrupt handler checks if we're dealing with a `rdmsr`. If yes, it emulates `rdmsr` by setting RAX and RDX to zero, skipping the `rdmsr`, and continuing execution.

If, however, the `#GP` as triggered by something else than `rdmsr`, we make sure to _not_ overwrite RAX and pass the control on to the interrupt handler written in Rust, so that it could do whatever it pleases.

All of this is necessary so that we could read the SEV_STATUS MSR on machines that may not support SEV, such as Github Actions or Kokoro, without crashing.