### PR TITLE
Unify data and body in Requests/Responses

### DIFF
--- a/trusted_shuffler/server/src/http.rs
+++ b/trusted_shuffler/server/src/http.rs
@@ -109,7 +109,7 @@ impl HyperRequestWrapper {
         let minimal_headers = copy_selected_keys(parts.headers, minimal_keys);
 
         let encrypted_request = EncryptedRequest {
-            body: body.to_vec(),
+            body,
             headers: minimal_headers,
             uri,
         };

--- a/trusted_shuffler/server/src/http.rs
+++ b/trusted_shuffler/server/src/http.rs
@@ -146,7 +146,7 @@ impl HyperResponseWrapper {
         // We keep only the body, i.e., data and trailers, from the `hyper::Response`.
 
         log::info!("Response from backend: {:?}", self.0);
-        let (parts, mut body) = self.0.into_parts();
+        let (parts, mut hyper_body) = self.0.into_parts();
 
         let minimal_keys = vec![
             header::CONTENT_TYPE,
@@ -155,11 +155,11 @@ impl HyperResponseWrapper {
         ];
         let minimal_headers = copy_selected_keys(parts.headers, minimal_keys);
 
-        let data = hyper::body::to_bytes(&mut body)
+        let body = hyper::body::to_bytes(&mut hyper_body)
             .await
-            .context("Could not read data.")?;
+            .context("Could not read body.")?;
 
-        let trailers = body
+        let trailers = hyper_body
             .trailers()
             .await
             .context("Could not read trailers.")?
@@ -167,7 +167,7 @@ impl HyperResponseWrapper {
 
         let trusted_shuffler_response = PlaintextResponse {
             headers: minimal_headers,
-            data,
+            body,
             trailers,
         };
 
@@ -179,7 +179,7 @@ impl HyperResponseWrapper {
         // response.
         let (mut sender, body) = hyper::Body::channel();
         sender
-            .send_data(encrypted_response.data)
+            .send_data(encrypted_response.body)
             .await
             .context("Failed to build body from data of encrypted Trusted Shuffler response.")?;
         sender

--- a/trusted_shuffler/trusted_shuffler/src/lib.rs
+++ b/trusted_shuffler/trusted_shuffler/src/lib.rs
@@ -67,13 +67,13 @@ impl PlaintextRequest {
 #[derive(Debug, PartialEq)]
 pub struct EncryptedResponse {
     pub headers: hyper::HeaderMap,
-    pub data: hyper::body::Bytes,
+    pub body: hyper::body::Bytes,
     pub trailers: hyper::HeaderMap,
 }
 
 pub struct PlaintextResponse {
     pub headers: hyper::HeaderMap,
-    pub data: hyper::body::Bytes,
+    pub body: hyper::body::Bytes,
     pub trailers: hyper::HeaderMap,
 }
 
@@ -81,7 +81,7 @@ impl PlaintextResponse {
     fn empty() -> PlaintextResponse {
         PlaintextResponse {
             headers: hyper::HeaderMap::new(),
-            data: hyper::body::Bytes::new(),
+            body: hyper::body::Bytes::new(),
             trailers: hyper::HeaderMap::new(),
         }
     }
@@ -90,7 +90,7 @@ impl PlaintextResponse {
     fn encrypt(self) -> EncryptedResponse {
         EncryptedResponse {
             headers: self.headers,
-            data: self.data,
+            body: self.body,
             trailers: self.trailers,
         }
     }

--- a/trusted_shuffler/trusted_shuffler/src/lib.rs
+++ b/trusted_shuffler/trusted_shuffler/src/lib.rs
@@ -34,8 +34,7 @@ use tokio::{sync::oneshot, time::Duration};
 
 #[derive(Debug, PartialEq)]
 pub struct EncryptedRequest {
-    // TODO(#3282) Unify `body` and `data` from Request and Response.
-    pub body: Vec<u8>,
+    pub body: hyper::body::Bytes,
     pub headers: hyper::HeaderMap,
     pub uri: Uri,
 }
@@ -52,7 +51,7 @@ impl EncryptedRequest {
 }
 
 pub struct PlaintextRequest {
-    pub body: Vec<u8>,
+    pub body: hyper::body::Bytes,
     pub headers: hyper::HeaderMap,
     pub uri: Uri,
 }

--- a/trusted_shuffler/trusted_shuffler/src/tests.rs
+++ b/trusted_shuffler/trusted_shuffler/src/tests.rs
@@ -45,7 +45,7 @@ impl RequestHandler for TestRequestHandler {
 fn get_plaintext_response(request: &PlaintextRequest) -> PlaintextResponse {
     PlaintextResponse {
         headers: hyper::HeaderMap::new(),
-        data: hyper::body::Bytes::from(request.body.clone()),
+        body: hyper::body::Bytes::from(request.body.clone()),
         trailers: hyper::HeaderMap::new(),
     }
 }
@@ -54,7 +54,7 @@ fn get_plaintext_response(request: &PlaintextRequest) -> PlaintextResponse {
 fn get_encrypted_response(request: &EncryptedRequest) -> EncryptedResponse {
     EncryptedResponse {
         headers: hyper::HeaderMap::new(),
-        data: hyper::body::Bytes::from(request.body.clone()),
+        body: hyper::body::Bytes::from(request.body.clone()),
         trailers: hyper::HeaderMap::new(),
     }
 }
@@ -76,10 +76,10 @@ fn drop_request(request: &PlaintextRequest) -> bool {
 
 // Generates a request and a corresponding response from a string.
 fn generate_secret_request_and_expected_response(
-    data: &str,
+    body: &str,
 ) -> (EncryptedRequest, EncryptedResponse) {
     let request = EncryptedRequest {
-        body: format!("Request: {}", data).into_bytes(),
+        body: format!("Request: {}", body).into_bytes(),
         headers: hyper::HeaderMap::new(),
         uri: hyper::Uri::from_static("test.com"),
     };

--- a/trusted_shuffler/trusted_shuffler/src/tests.rs
+++ b/trusted_shuffler/trusted_shuffler/src/tests.rs
@@ -45,7 +45,7 @@ impl RequestHandler for TestRequestHandler {
 fn get_plaintext_response(request: &PlaintextRequest) -> PlaintextResponse {
     PlaintextResponse {
         headers: hyper::HeaderMap::new(),
-        body: hyper::body::Bytes::from(request.body.clone()),
+        body: request.body.clone(),
         trailers: hyper::HeaderMap::new(),
     }
 }
@@ -54,7 +54,7 @@ fn get_plaintext_response(request: &PlaintextRequest) -> PlaintextResponse {
 fn get_encrypted_response(request: &EncryptedRequest) -> EncryptedResponse {
     EncryptedResponse {
         headers: hyper::HeaderMap::new(),
-        body: hyper::body::Bytes::from(request.body.clone()),
+        body: request.body.clone(),
         trailers: hyper::HeaderMap::new(),
     }
 }

--- a/trusted_shuffler/trusted_shuffler/src/tests.rs
+++ b/trusted_shuffler/trusted_shuffler/src/tests.rs
@@ -69,9 +69,7 @@ fn generate_dropped_request() -> EncryptedRequest {
 
 // If true, then the test backend does not answer the request.
 fn drop_request(request: &PlaintextRequest) -> bool {
-    String::from_utf8(request.body.clone())
-        .unwrap()
-        .contains("Drop")
+    request.body.ends_with("Drop".as_bytes())
 }
 
 // Generates a request and a corresponding response from a string.
@@ -79,7 +77,7 @@ fn generate_secret_request_and_expected_response(
     body: &str,
 ) -> (EncryptedRequest, EncryptedResponse) {
     let request = EncryptedRequest {
-        body: format!("Request: {}", body).into_bytes(),
+        body: hyper::body::Bytes::from(format!("Request: {}", body)),
         headers: hyper::HeaderMap::new(),
         uri: hyper::Uri::from_static("test.com"),
     };


### PR DESCRIPTION
Fixes #3282 . I opted for keeping the type information because it was (a) easier, and (b) we can re-visit that when we think of serialization for the whole Request/Response, i.e., also the headers.