### PR TITLE
Remove fprintf from TFLM debug logging

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -200,6 +200,7 @@ http_archive(
     name = "com_github_tensorflow_tflite_micro",
     patches = [
         # Replaces debug logging function with an empty stub.
+        # TODO(#3297): Replace TFLM logging with Restricted Kernel logging.
         "//third_party/tflite-micro:remove-debug-logging.patch",
     ],
     sha256 = "922425b778d5c9336b69f7f68b5f76ae7e6834e026d981179259993d1de5476d",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -198,6 +198,10 @@ http_archive(
 # TensorFlow Lite for Microcontrollers.
 http_archive(
     name = "com_github_tensorflow_tflite_micro",
+    patches = [
+        # Replaces debug logging function with an empty stub.
+        "//third_party/tflite-micro:remove-debug-logging.patch",
+    ],
     sha256 = "922425b778d5c9336b69f7f68b5f76ae7e6834e026d981179259993d1de5476d",
     strip_prefix = "tflite-micro-3648cf9003d0e2d5658b1add916000ce09a4b427",
     urls = [

--- a/third_party/tflite-micro/remove-debug-logging.patch
+++ b/third_party/tflite-micro/remove-debug-logging.patch
@@ -1,8 +1,16 @@
 diff --git tensorflow/lite/micro/debug_log.cc tensorflow/lite/micro/debug_log.cc
-index 46ca253..d34dc21 100644
+index 46ca253..3c9b047 100644
 --- tensorflow/lite/micro/debug_log.cc
 +++ tensorflow/lite/micro/debug_log.cc
-@@ -45,6 +45,5 @@ extern "C" void DebugLog(const char* s) {
+@@ -37,7 +37,6 @@ limitations under the License.
+ #include "tensorflow/lite/micro/debug_log.h"
+ 
+ #ifndef TF_LITE_STRIP_ERROR_STRINGS
+-#include <cstdio>
+ #endif
+ 
+ extern "C" void DebugLog(const char* s) {
+@@ -45,6 +44,5 @@ extern "C" void DebugLog(const char* s) {
    // Reusing TF_LITE_STRIP_ERROR_STRINGS to disable DebugLog completely to get
    // maximum reduction in binary size. This is because we have DebugLog calls
    // via TF_LITE_CHECK that are not stubbed out by TF_LITE_REPORT_ERROR.

--- a/third_party/tflite-micro/remove-debug-logging.patch
+++ b/third_party/tflite-micro/remove-debug-logging.patch
@@ -1,0 +1,12 @@
+diff --git tensorflow/lite/micro/debug_log.cc tensorflow/lite/micro/debug_log.cc
+index 46ca253..d34dc21 100644
+--- tensorflow/lite/micro/debug_log.cc
++++ tensorflow/lite/micro/debug_log.cc
+@@ -45,6 +45,5 @@ extern "C" void DebugLog(const char* s) {
+   // Reusing TF_LITE_STRIP_ERROR_STRINGS to disable DebugLog completely to get
+   // maximum reduction in binary size. This is because we have DebugLog calls
+   // via TF_LITE_CHECK that are not stubbed out by TF_LITE_REPORT_ERROR.
+-  fprintf(stderr, "%s", s);
+ #endif
+ }
+


### PR DESCRIPTION
This PR adds a patch to TFLM that removes the use of `fprintf`.

Ref https://github.com/project-oak/oak/issues/3297