### PR TITLE
Use sev-compatible serial port for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ dependencies = [
  "oak_simple_io",
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
+ "sev_serial",
  "strum",
  "uart_16550",
  "virtio",

--- a/oak_functions_freestanding_bin/Cargo.lock
+++ b/oak_functions_freestanding_bin/Cargo.lock
@@ -810,6 +810,7 @@ dependencies = [
  "oak_simple_io",
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
+ "sev_serial",
  "strum",
  "uart_16550",
  "virtio",
@@ -1118,6 +1119,14 @@ dependencies = [
  "strum",
  "x86_64",
  "zerocopy",
+]
+
+[[package]]
+name = "sev_serial"
+version = "0.1.0"
+dependencies = [
+ "sev_guest",
+ "x86_64",
 ]
 
 [[package]]

--- a/oak_functions_freestanding_bin/Cargo.toml
+++ b/oak_functions_freestanding_bin/Cargo.toml
@@ -13,6 +13,7 @@ members = ["."]
 default = ["vsock_channel"]
 vsock_channel = ["oak_restricted_kernel/vsock_channel"]
 simple_io_channel = ["oak_restricted_kernel/simple_io_channel"]
+serial_channel = ["oak_restricted_kernel/serial_channel"]
 
 [dependencies]
 log = "*"

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0"
 default = ["vsock_channel"]
 virtio_console_channel = ["virtio"]
 vsock_channel = ["virtio"]
-serial_channel = []
-simple_io_channel = ["oak_simple_io", "sev_guest"]
+serial_channel = ["uart_16550"]
+simple_io_channel = ["oak_simple_io"]
 
 [dependencies]
 anyhow = { version = "*", default-features = false }
@@ -30,9 +30,10 @@ oak_channel = { path = "../oak_channel" }
 oak_simple_io = { path = "../oak_simple_io", optional = true }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 rust-hypervisor-firmware-virtio = { path = "../third_party/rust-hypervisor-firmware-virtio" }
-sev_guest = { path = "../experimental/sev_guest", optional = true }
+sev_guest = { path = "../experimental/sev_guest" }
+sev_serial = { path = "../sev_serial" }
 strum = { version = "*", default-features = false, features = ["derive"] }
-uart_16550 = "*"
+uart_16550 = { version = "*", optional = true }
 virtio = { path = "../experimental/virtio", optional = true }
 x86_64 = "*"
 

--- a/oak_restricted_kernel/src/logging.rs
+++ b/oak_restricted_kernel/src/logging.rs
@@ -17,7 +17,8 @@
 use atomic_refcell::AtomicRefCell;
 use core::fmt::Write;
 use lazy_static::lazy_static;
-use uart_16550::SerialPort;
+use sev_guest::io::PortFactoryWrapper;
+use sev_serial::SerialPort;
 
 extern crate log;
 
@@ -26,10 +27,11 @@ static COM1_BASE: u16 = 0x3f8;
 
 lazy_static! {
     static ref SERIAL1: AtomicRefCell<SerialPort> = {
-        // Our contract with the loader requires the first serial port to be
+        let port_factory = PortFactoryWrapper::new_raw();
+        // Our contract with the launcher requires the first serial port to be
         // available, so assuming the loader adheres to it, this is safe.
-        let mut port = unsafe { SerialPort::new(COM1_BASE) };
-        port.init();
+        let mut port = unsafe { SerialPort::new(COM1_BASE, port_factory) };
+        port.init().expect("Couldn't initialize logging serial port.");
         AtomicRefCell::new(port)
     };
 }

--- a/oak_tensorflow_freestanding_bin/Cargo.lock
+++ b/oak_tensorflow_freestanding_bin/Cargo.lock
@@ -262,8 +262,8 @@ dependencies = [
  "oak_simple_io",
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
+ "sev_serial",
  "strum",
- "uart_16550",
  "virtio",
  "x86_64",
 ]
@@ -395,6 +395,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sev_serial"
+version = "0.1.0"
+dependencies = [
+ "sev_guest",
+ "x86_64",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,17 +521,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "uart_16550"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b074eb9300ad949edd74c529c0e8d451625af71bb948e6b65fe69f72dc1363d9"
-dependencies = [
- "bitflags",
- "rustversion",
- "x86_64",
 ]
 
 [[package]]

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -287,8 +287,8 @@ dependencies = [
  "oak_simple_io",
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
+ "sev_serial",
  "strum",
- "uart_16550",
  "virtio",
  "x86_64",
 ]
@@ -392,6 +392,14 @@ dependencies = [
  "strum",
  "x86_64",
  "zerocopy",
+]
+
+[[package]]
+name = "sev_serial"
+version = "0.1.0"
+dependencies = [
+ "sev_guest",
+ "x86_64",
 ]
 
 [[package]]
@@ -513,17 +521,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "uart_16550"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b074eb9300ad949edd74c529c0e8d451625af71bb948e6b65fe69f72dc1363d9"
-dependencies = [
- "bitflags",
- "rustversion",
- "x86_64",
 ]
 
 [[package]]


### PR DESCRIPTION
Switch to using the SEV-ES and SNP compatible serial port implementation for logging. For now we just use the direct port IO implementation. Once the HGCB is set up correctly we can start using when running on SEV-ES or SNP.