### PR TITLE
SEV enligthenment: implement encryption-aware page mapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,6 +2674,7 @@ dependencies = [
  "arrayvec",
  "assertables",
  "atomic_refcell",
+ "bitflags",
  "bitvec",
  "goblin",
  "lazy_static",

--- a/oak_functions_freestanding_bin/Cargo.lock
+++ b/oak_functions_freestanding_bin/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "atomic_refcell",
+ "bitflags",
  "bitvec",
  "goblin",
  "lazy_static",

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -16,6 +16,7 @@ simple_io_channel = ["oak_simple_io"]
 anyhow = { version = "*", default-features = false }
 arrayvec = { version = "*", default-features = false }
 atomic_refcell = "*"
+bitflags = "*"
 bitvec = { version = "*", default-features = false }
 goblin = { version = "*", default-features = false, features = [
   "elf32",

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -53,6 +53,7 @@ mod virtio;
 
 extern crate alloc;
 
+use crate::mm::Translator;
 use alloc::boxed::Box;
 use core::{panic::PanicInfo, str::FromStr};
 use log::{error, info};
@@ -63,8 +64,6 @@ use x86_64::{
     structures::paging::{Page, Size2MiB},
     VirtAddr,
 };
-
-use crate::mm::Translate;
 
 /// Main entry point for the kernel, to be called from bootloader.
 pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
@@ -95,8 +94,12 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     // If we don't find memory for heap, it's ok to panic.
     let heap_phys_frames = frame_allocator.largest_available().unwrap();
     memory::init_allocator::<Size2MiB>(Page::range(
-        mapper.translate_frame(heap_phys_frames.start).unwrap(),
-        mapper.translate_frame(heap_phys_frames.end + 1).unwrap(),
+        mapper
+            .translate_physical_frame(heap_phys_frames.start)
+            .unwrap(),
+        mapper
+            .translate_physical_frame(heap_phys_frames.end + 1)
+            .unwrap(),
     ))
     .unwrap();
 
@@ -117,7 +120,7 @@ enum ChannelType {
 }
 
 /// Create a channel for communicating with the Untrusted Launcher.
-fn get_channel<A: Translate>(kernel_args: &args::Args, mapper: &A) -> Box<dyn Channel> {
+fn get_channel<A: Translator>(kernel_args: &args::Args, mapper: &A) -> Box<dyn Channel> {
     // If we weren't told which channel to use, arbitrarily pick the first one in the `ChannelType`
     // enum. Depending on features that are enabled, this means that the enum acts as kind of a
     // reverse priority list for defaults.

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -64,7 +64,7 @@ use x86_64::{
     VirtAddr,
 };
 
-use crate::mm::page_tables::DirectMap;
+use crate::mm::Translate;
 
 /// Main entry point for the kernel, to be called from bootloader.
 pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
@@ -117,7 +117,7 @@ enum ChannelType {
 }
 
 /// Create a channel for communicating with the Untrusted Launcher.
-fn get_channel(kernel_args: &args::Args, mapper: &DirectMap) -> Box<dyn Channel> {
+fn get_channel<A: Translate>(kernel_args: &args::Args, mapper: &A) -> Box<dyn Channel> {
     // If we weren't told which channel to use, arbitrarily pick the first one in the `ChannelType`
     // enum. Depending on features that are enabled, this means that the enum acts as kind of a
     // reverse priority list for defaults.

--- a/oak_restricted_kernel/src/mm/encrypted_mapper.rs
+++ b/oak_restricted_kernel/src/mm/encrypted_mapper.rs
@@ -1,0 +1,253 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use core::marker::PhantomData;
+use x86_64::{
+    structures::paging::{
+        mapper::{MapToError, MapperFlush, PageTableFrameMapping},
+        FrameAllocator, MappedPageTable, Mapper as BaseMapper, Page, PageSize, PageTable,
+        PageTableFlags as BasePageTableFlags, PhysFrame, Size4KiB, Translate as BaseTranslate,
+    },
+    PhysAddr, VirtAddr,
+};
+
+use super::Translate;
+
+#[derive(Clone, Copy)]
+pub enum MemoryEncryption {
+    /// Memory encryption is not supported. If `ENCRYPTED` page flag is set, it is ignored.
+    NoEncryption,
+
+    /// Memory encryption uses bit `C` in the page tables.
+    ///
+    /// The location of the C-bit is machine-dependent; it is reported by CPUID function 8000_001F
+    /// in EBX[5:0].
+    /// See AMD64 Architecture Programmer's Manual, Volume 2, Section 15.34.1 and
+    /// AMD64 Architecture Programmer's Manual, Volume 3, Section E.4.17 for more details.
+    Encrypted(u8),
+}
+
+impl MemoryEncryption {
+    pub fn bit(&self) -> u64 {
+        match self {
+            MemoryEncryption::NoEncryption => 0,
+            MemoryEncryption::Encrypted(c) => 1u64 << c,
+        }
+    }
+}
+
+bitflags::bitflags! {
+    /// Possible flags for a page table entry.
+    ///
+    /// See <x86_64::structures::paging::PageTableFlags> for more details.
+    pub struct PageTableFlags: u64 {
+        const PRESENT = 1;
+        const WRITABLE = 1 << 1;
+        const USER_ACCESSIBLE = 1 << 2;
+        const WRITE_THROUGH = 1 << 3;
+        const NO_CACHE = 1 << 4;
+        const ACCESSED = 1<< 5;
+        const DIRTY = 1 << 6;
+        const HUGE_PAGE = 1 << 7;
+        const GLOBAL = 1 << 8;
+        /// Marks the page as encrypted. Ignored under <NoEncryption>.
+        ///
+        /// The bit value is hardcoded to be 51 here, but that's because it's not possible to
+        /// represent `ENCRYPTED = 1 << C` in Rust right now. The actual bit set may not be 51.
+        const ENCRYPTED = 1 << 51;
+        const NO_EXECUTE = 1 << 63;
+    }
+}
+
+impl From<PageTableFlags> for BasePageTableFlags {
+    fn from(value: PageTableFlags) -> Self {
+        let mut flags = BasePageTableFlags::empty();
+        if value.contains(PageTableFlags::PRESENT) {
+            flags |= BasePageTableFlags::PRESENT
+        }
+        if value.contains(PageTableFlags::WRITABLE) {
+            flags |= BasePageTableFlags::WRITABLE
+        }
+        if value.contains(PageTableFlags::USER_ACCESSIBLE) {
+            flags |= BasePageTableFlags::USER_ACCESSIBLE
+        }
+        if value.contains(PageTableFlags::WRITE_THROUGH) {
+            flags |= BasePageTableFlags::WRITE_THROUGH
+        }
+        if value.contains(PageTableFlags::NO_CACHE) {
+            flags |= BasePageTableFlags::NO_CACHE
+        }
+        if value.contains(PageTableFlags::ACCESSED) {
+            flags |= BasePageTableFlags::ACCESSED
+        }
+        if value.contains(PageTableFlags::DIRTY) {
+            flags |= BasePageTableFlags::DIRTY
+        }
+        if value.contains(PageTableFlags::HUGE_PAGE) {
+            flags |= BasePageTableFlags::HUGE_PAGE
+        }
+        if value.contains(PageTableFlags::GLOBAL) {
+            flags |= BasePageTableFlags::GLOBAL
+        }
+        // There is no equivalent of ENCRYPTED in BasePageTableFlags.
+        if value.contains(PageTableFlags::NO_EXECUTE) {
+            flags |= BasePageTableFlags::NO_EXECUTE
+        }
+        flags
+    }
+}
+
+/// Helper for mapper that assumes all memory is mapped to a given fixed offset.
+///
+/// See <x86_64::structures::paging::mapper::PageTableFrameMapping> for more details.
+struct PhysOffset {
+    offset: VirtAddr,
+    encryption: MemoryEncryption,
+}
+
+unsafe impl PageTableFrameMapping for PhysOffset {
+    fn frame_to_pointer(&self, frame: PhysFrame) -> *mut PageTable {
+        let virt = self.offset
+            + match self.encryption {
+                // Mapping without encryption: just do the calculation using the offset.
+                MemoryEncryption::NoEncryption => frame.start_address().as_u64(),
+                // Mapping under encryption: strip off the encrypted bit before adding the offset.
+                MemoryEncryption::Encrypted(c) => frame.start_address().as_u64() & !(1 << c),
+            };
+        virt.as_mut_ptr()
+    }
+}
+
+/// Wrapper around `FrameAllocator` that sets the encrypted bit on the allocated frame, if needed.
+///
+/// This is only meant to be used inside `EncryptedPageTable` to lie to `MappedPageTable` about the
+/// physical addresses.
+struct EncryptedFrameAllocator<'a, S: PageSize, A: FrameAllocator<S>> {
+    inner: &'a mut A,
+    encryption: MemoryEncryption,
+    phantom: PhantomData<S>,
+}
+
+impl<'a, S: PageSize, A: FrameAllocator<S>> EncryptedFrameAllocator<'a, S, A> {
+    fn new(inner: &'a mut A, encryption: MemoryEncryption) -> Self {
+        Self {
+            inner,
+            encryption,
+            phantom: PhantomData,
+        }
+    }
+}
+
+unsafe impl<'a, S: PageSize, A: FrameAllocator<S>> FrameAllocator<S>
+    for EncryptedFrameAllocator<'a, S, A>
+{
+    fn allocate_frame(&mut self) -> Option<PhysFrame<S>> {
+        match self.encryption {
+            // Frame allocator with no memory encryption: just delegate to the inner allocator.
+            MemoryEncryption::NoEncryption => self.inner.allocate_frame(),
+            // Frame allocator with memory encryption: tack on the encrypted bit.
+            MemoryEncryption::Encrypted(c) => {
+                let start_address = self.inner.allocate_frame()?.start_address() + (1u64 << c);
+                Some(PhysFrame::from_start_address(start_address).unwrap())
+            }
+        }
+    }
+}
+
+/// Page mapper for pages of type <S>
+///
+/// This is equivalent to <x86_64::structures::paging::mapper::Mapper>, but knows about memory
+/// encryption.
+pub trait Mapper<S: PageSize> {
+    unsafe fn map_to_with_table_flags<A>(
+        &mut self,
+        page: Page<S>,
+        frame: PhysFrame<S>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        frame_allocator: &mut A,
+    ) -> Result<MapperFlush<S>, MapToError<S>>
+    where
+        A: FrameAllocator<Size4KiB>;
+}
+
+pub struct EncryptedPageTable<'a> {
+    encryption: MemoryEncryption,
+    offset: VirtAddr,
+    inner: MappedPageTable<'a, PhysOffset>,
+}
+
+impl<'a> EncryptedPageTable<'a> {
+    pub fn new(pml4: &'a mut PageTable, offset: VirtAddr, encryption: MemoryEncryption) -> Self {
+        Self {
+            encryption,
+            offset,
+            inner: unsafe { MappedPageTable::new(pml4, PhysOffset { offset, encryption }) },
+        }
+    }
+}
+
+impl<'a, S: PageSize> Mapper<S> for EncryptedPageTable<'a>
+where
+    MappedPageTable<'a, PhysOffset>: x86_64::structures::paging::Mapper<S>,
+{
+    unsafe fn map_to_with_table_flags<A>(
+        &mut self,
+        page: Page<S>,
+        frame: PhysFrame<S>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        frame_allocator: &mut A,
+    ) -> Result<MapperFlush<S>, MapToError<S>>
+    where
+        A: FrameAllocator<Size4KiB>,
+    {
+        // Set the encrypted bit in the physical frame, if needed.
+        let frame = match self.encryption {
+            MemoryEncryption::Encrypted(c) if flags.contains(PageTableFlags::ENCRYPTED) => {
+                PhysFrame::from_start_address(frame.start_address() + (1u64 << c)).unwrap()
+            }
+            _ => frame,
+        };
+
+        self.inner.map_to_with_table_flags(
+            page,
+            frame,
+            flags.into(),
+            parent_table_flags.into(),
+            &mut EncryptedFrameAllocator::new(frame_allocator, self.encryption),
+        )
+    }
+}
+
+impl<'a> Translate for EncryptedPageTable<'a> {
+    fn translate(&self, addr: VirtAddr) -> Option<PhysAddr> {
+        match self.encryption {
+            MemoryEncryption::Encrypted(c) => Some(PhysAddr::new(
+                self.inner.translate_addr(addr)?.as_u64() & !(1u64 << c),
+            )),
+            MemoryEncryption::NoEncryption => self.inner.translate_addr(addr),
+        }
+    }
+
+    fn translate_addr(&self, addr: PhysAddr) -> Option<VirtAddr> {
+        Some(self.offset + addr.as_u64())
+    }
+
+    fn translate_frame<S: PageSize>(&self, frame: PhysFrame<S>) -> Option<Page<S>> {
+        Page::from_start_address(self.translate_addr(frame.start_address())?).ok()
+    }
+}

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -25,17 +25,34 @@ use x86_64::{
         model_specific::{Efer, EferFlags},
     },
     structures::paging::{
-        FrameAllocator, OffsetPageTable, PageSize, PageTable, PageTableFlags, PhysFrame, Size2MiB,
-        Size4KiB,
+        FrameAllocator, OffsetPageTable, Page, PageSize, PageTable, PageTableFlags, PhysFrame,
+        Size2MiB, Size4KiB,
     },
     PhysAddr, VirtAddr,
 };
 
-use self::page_tables::DirectMap;
+use self::encrypted_mapper::{EncryptedPageTable, MemoryEncryption};
 
 mod bitmap_frame_allocator;
+mod encrypted_mapper;
 pub mod frame_allocator;
 pub mod page_tables;
+
+pub trait Translate {
+    /// Translates the given virtual address to the physical address that it maps to.
+    ///
+    /// Returns `None` if there is no valid mapping for the given address.
+    fn translate(&self, addr: VirtAddr) -> Option<PhysAddr>;
+
+    /// Translate a physical address to a virtual address.
+    ///
+    /// Note that a physical address may be mapped multiple times. This function will always return
+    /// the address from the directly mapped region, ignoring ohter mappings if they exist.
+    fn translate_addr(&self, addr: PhysAddr) -> Option<VirtAddr>;
+
+    /// Translate a physical frame to virtual page, using the directly mapped region.
+    fn translate_frame<S: PageSize>(&self, frame: PhysFrame<S>) -> Option<Page<S>>;
+}
 
 const DIRECT_MAPPING_OFFSET: VirtAddr = VirtAddr::new_truncate(0xFFFF_8800_0000_0000);
 
@@ -141,7 +158,7 @@ pub fn init<const N: usize>(
 pub fn init_paging<A: FrameAllocator<Size4KiB> + ?Sized>(
     frame_allocator: &mut A,
     program_headers: &[ProgramHeader],
-) -> Result<DirectMap<'static>, &'static str> {
+) -> Result<EncryptedPageTable<'static>, &'static str> {
     // Safety: this expects the frame allocator to be initialized and the memory region it's handing
     // memory out of to be identity mapped. This is true for the lower 2 GiB after we boot.
     // This reference will no longer be valid after we reload the page tables!
@@ -155,11 +172,15 @@ pub fn init_paging<A: FrameAllocator<Size4KiB> + ?Sized>(
     // GiB of memory.
     let mut page_table = unsafe { OffsetPageTable::new(pml4, VirtAddr::new(0)) };
 
-    // Should we set the C-bit (encrypted memory for SEV)?
-    let encrypted = get_sev_status()
+    // Should we set the C-bit (encrypted memory for SEV)? For now, let's assume it's bit 51.
+    let encrypted = if get_sev_status()
         .unwrap_or(SevStatus::empty())
         .contains(SevStatus::SEV_ENABLED)
-        .then_some(1 << 51);
+    {
+        MemoryEncryption::Encrypted(51)
+    } else {
+        MemoryEncryption::NoEncryption
+    };
 
     // Safety: these operations are safe as they're not done on active page tables.
     unsafe {
@@ -207,7 +228,9 @@ pub fn init_paging<A: FrameAllocator<Size4KiB> + ?Sized>(
     let pml4 =
         unsafe { &mut *(DIRECT_MAPPING_OFFSET + pml4_frame.start_address().as_u64()).as_mut_ptr() };
 
-    Ok(DirectMap(unsafe {
-        OffsetPageTable::new(pml4, DIRECT_MAPPING_OFFSET)
-    }))
+    Ok(EncryptedPageTable::new(
+        pml4,
+        DIRECT_MAPPING_OFFSET,
+        encrypted,
+    ))
 }

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -25,13 +25,13 @@ use x86_64::{
         model_specific::{Efer, EferFlags},
     },
     structures::paging::{
-        FrameAllocator, OffsetPageTable, Page, PageSize, PageTable, PageTableFlags, PhysFrame,
-        Size2MiB, Size4KiB,
+        FrameAllocator, MappedPageTable, OffsetPageTable, Page, PageSize, PageTable,
+        PageTableFlags, PhysFrame, Size2MiB, Size4KiB,
     },
     PhysAddr, VirtAddr,
 };
 
-use self::encrypted_mapper::{EncryptedPageTable, MemoryEncryption};
+use self::encrypted_mapper::{EncryptedPageTable, MemoryEncryption, PhysOffset};
 
 mod bitmap_frame_allocator;
 mod encrypted_mapper;
@@ -158,7 +158,7 @@ pub fn init<const N: usize>(
 pub fn init_paging<A: FrameAllocator<Size4KiB> + ?Sized>(
     frame_allocator: &mut A,
     program_headers: &[ProgramHeader],
-) -> Result<EncryptedPageTable<'static>, &'static str> {
+) -> Result<EncryptedPageTable<MappedPageTable<'static, PhysOffset>>, &'static str> {
     // Safety: this expects the frame allocator to be initialized and the memory region it's handing
     // memory out of to be identity mapped. This is true for the lower 2 GiB after we boot.
     // This reference will no longer be valid after we reload the page tables!

--- a/oak_restricted_kernel/src/mm/page_tables.rs
+++ b/oak_restricted_kernel/src/mm/page_tables.rs
@@ -18,41 +18,13 @@ use goblin::elf64::program_header::{ProgramHeader, PF_W, PF_X, PT_LOAD};
 use x86_64::{
     align_down, align_up,
     structures::paging::{
-        frame::PhysFrameRange, mapper::MapToError, FrameAllocator, Mapper, OffsetPageTable, Page,
-        PageSize, PageTableFlags, PhysFrame, Size2MiB, Size4KiB, Translate,
+        frame::PhysFrameRange, mapper::MapToError, FrameAllocator, Mapper, Page, PageSize,
+        PageTableFlags, PhysFrame, Size2MiB, Size4KiB,
     },
     PhysAddr, VirtAddr,
 };
 
-/// Virtual to physical (and inverse) mapping.
-///
-/// The kernel will map all of the physical memory somewhere in the virtual memory, at some offset.
-/// This struct provides translation functions from virtual to physical addresses, and vice versa,
-/// in the mapped region.
-pub struct DirectMap<'a>(pub(crate) OffsetPageTable<'a>);
-
-impl<'a> DirectMap<'a> {
-    /// Translate a physical address to a virtual address.
-    ///
-    /// Note that a physical address may be mapped multiple times. This function will always return
-    /// the address from the directly mapped region, ignoring ohter mappings if they exist.
-    #[allow(dead_code)]
-    pub fn translate_addr(&self, addr: PhysAddr) -> Option<VirtAddr> {
-        Some(self.0.phys_offset() + addr.as_u64())
-    }
-
-    /// Translate a physical frame to virtual page, using the directly mapped region.
-    #[allow(dead_code)]
-    pub fn translate_frame<S: PageSize>(&self, frame: PhysFrame<S>) -> Option<Page<S>> {
-        Page::from_start_address(self.translate_addr(frame.start_address())?).ok()
-    }
-}
-
-impl<'a> Translate for DirectMap<'a> {
-    fn translate(&self, addr: VirtAddr) -> x86_64::structures::paging::mapper::TranslateResult {
-        self.0.translate(addr)
-    }
-}
+use super::encrypted_mapper::MemoryEncryption;
 
 /// Map a region of physical memory to a virtual address using 2 MiB pages.
 ///
@@ -64,13 +36,13 @@ pub unsafe fn create_offset_map<S: PageSize, A: FrameAllocator<Size4KiB> + ?Size
     range: PhysFrameRange<S>,
     offset: VirtAddr,
     flags: PageTableFlags,
-    encrypted: Option<u64>,
+    encrypted: MemoryEncryption,
     mapper: &mut M,
     frame_allocator: &mut A,
 ) -> Result<(), MapToError<S>> {
     for (i, frame) in range.enumerate() {
         let frame = PhysFrame::from_start_address(PhysAddr::new(
-            frame.start_address().as_u64() | encrypted.unwrap_or_default(),
+            frame.start_address().as_u64() | encrypted.bit(),
         ))
         .unwrap();
 
@@ -115,7 +87,7 @@ pub unsafe fn create_kernel_map<
     M: Mapper<Size2MiB> + Mapper<Size4KiB>,
 >(
     program_headers: &[ProgramHeader],
-    encrypted: Option<u64>,
+    encrypted: MemoryEncryption,
     mapper: &mut M,
     frame_allocator: &mut A,
 ) -> Result<(), MapToError<Size4KiB>> {

--- a/oak_restricted_kernel/src/simpleio.rs
+++ b/oak_restricted_kernel/src/simpleio.rs
@@ -14,12 +14,11 @@
 // limitations under the License.
 //
 
+use crate::mm::Translator;
 use alloc::collections::VecDeque;
 use oak_simple_io::SimpleIo;
 use sev_guest::io::PortFactoryWrapper;
 use x86_64::VirtAddr;
-
-use crate::mm::Translate;
 
 /// A communications channel using a simple IO device.
 pub struct SimpleIoChannel {
@@ -32,11 +31,12 @@ pub struct SimpleIoChannel {
 }
 
 impl SimpleIoChannel {
-    pub fn new<A: Translate>(mapper: &A) -> Self {
+    pub fn new<A: Translator>(translator: &A) -> Self {
         let io_port_factory = PortFactoryWrapper::new_raw();
-        let device =
-            SimpleIo::new_with_defaults(io_port_factory, |vaddr: VirtAddr| mapper.translate(vaddr))
-                .expect("couldn't create IO device");
+        let device = SimpleIo::new_with_defaults(io_port_factory, |vaddr: VirtAddr| {
+            translator.translate_virtual(vaddr)
+        })
+        .expect("couldn't create IO device");
         let pending_data = None;
         Self {
             device,

--- a/oak_restricted_kernel/src/virtio.rs
+++ b/oak_restricted_kernel/src/virtio.rs
@@ -14,12 +14,11 @@
 // limitations under the License.
 //
 
+use crate::mm::Translator;
 use log::info;
 use oak_channel::{Read, Write};
 use rust_hypervisor_firmware_virtio::pci::VirtioPciTransport;
 use x86_64::{PhysAddr, VirtAddr};
-
-use crate::mm::Translate;
 
 // The virtio vsock port on which to listen.
 #[cfg(feature = "vsock_channel")]
@@ -51,12 +50,12 @@ where
 }
 
 #[cfg(feature = "virtio_console_channel")]
-pub fn get_console_channel<A: Translate>(
-    mapper: &A,
+pub fn get_console_channel<A: Translator>(
+    translator: &A,
 ) -> Channel<virtio::console::Console<VirtioPciTransport>> {
     let console = virtio::console::Console::find_and_configure_device(
-        |vaddr: VirtAddr| mapper.translate(vaddr),
-        |paddr: PhysAddr| mapper.translate_addr(paddr),
+        |vaddr: VirtAddr| translator.translate_virtual(vaddr),
+        |paddr: PhysAddr| translator.translate_physical(paddr),
     )
     .expect("Couldn't configure PCI virtio console device.");
     info!("Console device status: {}", console.get_status());
@@ -64,12 +63,12 @@ pub fn get_console_channel<A: Translate>(
 }
 
 #[cfg(feature = "vsock_channel")]
-pub fn get_vsock_channel<A: Translate>(
-    mapper: &A,
+pub fn get_vsock_channel<A: Translator>(
+    translator: &A,
 ) -> Channel<virtio::vsock::socket::Socket<VirtioPciTransport>> {
     let vsock = virtio::vsock::VSock::find_and_configure_device(
-        |vaddr: VirtAddr| mapper.translate(vaddr),
-        |paddr: PhysAddr| mapper.translate_addr(paddr),
+        |vaddr: VirtAddr| translator.translate_virtual(vaddr),
+        |paddr: PhysAddr| translator.translate_physical(paddr),
     )
     .expect("Couldn't configure PCI virtio vsock device.");
     info!("Socket device status: {}", vsock.get_status());

--- a/oak_tensorflow_freestanding_bin/Cargo.lock
+++ b/oak_tensorflow_freestanding_bin/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "atomic_refcell",
+ "bitflags",
  "bitvec",
  "goblin",
  "lazy_static",

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "atomic_refcell",
+ "bitflags",
  "bitvec",
  "goblin",
  "lazy_static",


### PR DESCRIPTION
Building page maps is complex enough, and this PR does its best to delegate things to the `x86_64` crate but I still needed to re-implement several bits of it.

The mapper created here still doesn't know how to add or remove the `ENCRYPTED` bit for now; that'll be addressed separately.

I also tried really hard to hoist the encryption status into the type system, but let's just say it got real unwieldy real quick.

The key here is that we want to lie to the mapper from `x86_64` crate: first, we create a `FrameAllocator` that asks the real frame allocator for a frame and sets the encrypted bit in there, if necessary. That encryption-aware FrameAllocator is passed to the `x86_64` OffsetMapper, which is completely oblivious to the fact that something weird is going on with the physical frames.
Conversely, the `OffsetMapper` itself is wrapped in an encryption-aware Mapper, that adds and/or strips the encrypted bit from the physical frame as required.

And the tests are a sight to behold...