### PR TITLE
Switch from inclusive ranges to exclusive ranges.

### DIFF
--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -43,10 +43,10 @@ pub fn init<const N: usize>(
     program_headers: &[ProgramHeader],
 ) -> frame_allocator::PhysicalMemoryAllocator<N> {
     // This assumes all memory is in the lower end of the address space.
-    let mut alloc = frame_allocator::PhysicalMemoryAllocator::new(PhysFrame::range_inclusive(
+    let mut alloc = frame_allocator::PhysicalMemoryAllocator::new(PhysFrame::range(
         PhysFrame::from_start_address(PhysAddr::new(0x0)).unwrap(),
         // N u64-s * 64 frames per u64 * 2 MiB per frame
-        PhysFrame::from_start_address(PhysAddr::new((N as u64 * 64 - 1) * Size2MiB::SIZE)).unwrap(),
+        PhysFrame::from_start_address(PhysAddr::new(N as u64 * 64 * Size2MiB::SIZE)).unwrap(),
     ));
 
     /* Step 1: mark all RAM as available (event though it may contain data!) */
@@ -73,9 +73,9 @@ pub fn init<const N: usize>(
         .map(|(start, limit)| {
             // Safety: align_down/align_up guarantees we're aligned to 2 MiB boundaries,
             // and we know there's _something_ in the memory range.
-            PhysFrame::range_inclusive(
+            PhysFrame::range(
                 PhysFrame::from_start_address(start).unwrap(),
-                PhysFrame::from_start_address(limit).unwrap() - 1,
+                PhysFrame::from_start_address(limit).unwrap(),
             )
         })
         .for_each(|range| alloc.mark_valid(range, true));
@@ -84,9 +84,9 @@ pub fn init<const N: usize>(
 
     // First, leave out the first 2 MiB as there be dragons (and bootloader data structures)
     alloc.mark_valid(
-        PhysFrame::range_inclusive(
+        PhysFrame::range(
             PhysFrame::from_start_address(PhysAddr::new(0x0)).unwrap(),
-            PhysFrame::from_start_address(PhysAddr::new(0x0)).unwrap(),
+            PhysFrame::from_start_address(PhysAddr::new(Size2MiB::SIZE)).unwrap(),
         ),
         false,
     );
@@ -97,7 +97,7 @@ pub fn init<const N: usize>(
         .filter(|phdr| phdr.p_type == PT_LOAD)
         .map(|phdr| {
             // Align the physical addresses to 2 MiB boundaries, making them larger if necessary.
-            PhysFrame::range_inclusive(
+            PhysFrame::range(
                 PhysFrame::from_start_address(PhysAddr::new(align_down(
                     phdr.p_paddr,
                     Size2MiB::SIZE,
@@ -112,9 +112,9 @@ pub fn init<const N: usize>(
         })
         .for_each(|range| {
             info!(
-                "marking [{:#018x}..{:#018x}] as reserved",
+                "marking [{:#018x}..{:#018x}) as reserved",
                 range.start.start_address().as_u64(),
-                range.end.start_address().as_u64() + range.end.size() - 1
+                range.end.start_address().as_u64()
             );
             alloc.mark_valid(range, false)
         });


### PR DESCRIPTION
Ranges are hard.

We're using a mix of inclusive ranges ([start...end], both ends included in range) and exclusive ranges ([start..limit), where the limit is not inside the range).

It's a mess and we should consolidate on one particular range style, and I think it makes sense to use exclusive ranges -- while we still need to do range arithmetic here and there, there's less of it when using exclusive ranges.

I've left the tests largely untouched on purpose: there's some clean-up to do there as well, but for now, I wanted the tests to pass with no (or at least minimal) changes.