### PR TITLE
SEV enlightenment: create an allocator for unencrypted memory

### DIFF
--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -63,7 +63,7 @@ use oak_channel::Channel;
 use oak_linux_boot_params::BootParams;
 use strum::{EnumIter, EnumString, IntoEnumIterator};
 use x86_64::{
-    structures::paging::{Page, Size2MiB},
+    structures::paging::{FrameAllocator, Page, PhysFrame, Size2MiB},
     VirtAddr,
 };
 
@@ -91,11 +91,21 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     // Physical frame allocator: support up to 128 GiB of memory, for now.
     let mut frame_allocator = mm::init::<1024>(info.e820_table(), program_headers);
 
-    let mapper = mm::init_paging(&mut frame_allocator, program_headers).unwrap();
+    let mut mapper = mm::init_paging(&mut frame_allocator, program_headers).unwrap();
+
+    // Allocate a section for guest-host communication (without the `ENCRYPTED` bit set)
+    let guest_host_frame: PhysFrame<Size2MiB> = frame_allocator.allocate_frame().unwrap();
+    let guest_host_page = mapper.translate_physical_frame(guest_host_frame).unwrap();
+    let _guest_host_heap = unsafe {
+        memory::init_guest_host_heap(
+            Page::range(guest_host_page, guest_host_page + 1),
+            &mut mapper,
+        )
+    };
 
     // If we don't find memory for heap, it's ok to panic.
     let heap_phys_frames = frame_allocator.largest_available().unwrap();
-    memory::init_allocator::<Size2MiB>(Page::range(
+    memory::init_kernel_heap::<Size2MiB>(Page::range(
         mapper
             .translate_physical_frame(heap_phys_frames.start)
             .unwrap(),

--- a/oak_restricted_kernel/src/memory.rs
+++ b/oak_restricted_kernel/src/memory.rs
@@ -14,10 +14,11 @@
 // limitations under the License.
 //
 
+use crate::mm::{Mapper, PageTableFlags};
 use core::result::Result;
 use linked_list_allocator::LockedHeap;
 use log::info;
-use x86_64::structures::paging::{page::PageRange, PageSize};
+use x86_64::structures::paging::{mapper::FlagUpdateError, page::PageRange, PageSize};
 
 #[cfg(not(test))]
 #[global_allocator]
@@ -31,14 +32,48 @@ static ALLOCATOR: LockedHeap = LockedHeap::empty();
 /// Pointers to addresses in the memory area (or references to data contained within the slice) must
 /// be considered invalid after calling this function, as the allocator may overwrite the data at
 /// any point.
-pub fn init_allocator<S: PageSize>(range: PageRange<S>) -> Result<(), &'static str> {
+pub fn init_kernel_heap<S: PageSize>(range: PageRange<S>) -> Result<(), &'static str> {
     let start = range.start.start_address().as_u64() as usize;
     let limit = range.end.start_address().as_u64() as usize;
 
-    info!("Using [{:#016x}..{:#016x}) for heap.", start, limit);
+    info!("Using [{:#018x}..{:#018x}) for kernel heap.", start, limit);
     // This is safe as we know the memory is available based on the e820 map.
     unsafe {
         ALLOCATOR.lock().init(start as *mut u8, limit - start);
     }
     Ok(())
+}
+
+/// Initializes an allocator for guest-host communication on unencrypted memory.
+///
+/// # Safety
+///
+/// The caller has to guarantee that the page range is valid and not in use, as we will change page
+/// table flags for pages in that range.
+pub unsafe fn init_guest_host_heap<S: PageSize, M: Mapper<S>>(
+    pages: PageRange<S>,
+    mapper: &mut M,
+) -> Result<LockedHeap, FlagUpdateError> {
+    for page in pages {
+        mapper
+            .update_flags(
+                page,
+                PageTableFlags::PRESENT
+                    | PageTableFlags::WRITABLE
+                    | PageTableFlags::GLOBAL
+                    | PageTableFlags::NO_EXECUTE,
+            )?
+            .flush();
+    }
+
+    info!(
+        "Marking [{:#018x}..{:#018x}) for guest-host communication.",
+        pages.start.start_address().as_u64(),
+        pages.end.start_address().as_u64()
+    );
+
+    Ok(LockedHeap::new(
+        pages.start.start_address().as_mut_ptr(),
+        pages.count() * S::SIZE as usize,
+    ))
 }

--- a/oak_restricted_kernel/src/mm/page_tables.rs
+++ b/oak_restricted_kernel/src/mm/page_tables.rs
@@ -24,7 +24,7 @@ use x86_64::{
     PhysAddr, VirtAddr,
 };
 
-use super::encrypted_mapper::{Mapper, PageTableFlags};
+use super::{Mapper, PageTableFlags};
 
 /// Map a region of physical memory to a virtual address using 2 MiB pages.
 ///


### PR DESCRIPTION
This adds a facility to change page table flags (by default, all memory is marked as `ENCRYPTED`) and then uses it to set up a 2M page for use with guest-host communication.

I've also shuffled some data structures around in the hope of keeping `encrypted_mapper` private.

The allocator is not used for anything (yet) -- that'll be in follow-up PRs. This PR just lays out the infrastructure.