### PR TITLE
Get inference output bytes from TensorFlow Lite

### DIFF
--- a/cc/tflite_micro/tflite_micro.cc
+++ b/cc/tflite_micro/tflite_micro.cc
@@ -26,7 +26,7 @@ int tflite_init(const uint8_t* model_bytes, size_t model_bytes_len,
 }
 
 // TODO(#3297): Implement TensorFlow Lite inference logic.
-int tflite_run(const uint8_t* input_bytes, size_t input_bytes_len, uint8_t* output_bytes,
+int tflite_run(const uint8_t* input_bytes, size_t input_bytes_len, uint8_t** output_bytes,
                size_t* output_bytes_len) {
   return 0;
 }

--- a/cc/tflite_micro/tflite_micro.h
+++ b/cc/tflite_micro/tflite_micro.h
@@ -27,7 +27,7 @@ extern "C" {
 int tflite_init(const uint8_t* model_bytes, size_t model_bytes_len,
                 const uint8_t* tensor_arena_bytes, size_t tensor_arena_bytes_len);
 
-int tflite_run(const uint8_t* input_bytes, size_t input_bytes_len, uint8_t* output_bytes,
+int tflite_run(const uint8_t* input_bytes, size_t input_bytes_len, uint8_t** output_bytes,
                size_t* output_bytes_len);
 
 #ifdef __cplusplus

--- a/oak_tensorflow_service/src/tflite.rs
+++ b/oak_tensorflow_service/src/tflite.rs
@@ -61,11 +61,10 @@ impl TfliteModel {
             .len()
             .try_into()
             .map_err(|error| anyhow!("Failed to convert model bytes length to u64: {}", error))?;
-        let tensor_arena_len = self
-            .tensor_arena
-            .len()
-            .try_into()
-            .map_err(|error| anyhow!("Failed to convert tensor arena length to u64: {}", error))?;
+        let tensor_arena_len =
+            self.tensor_arena.len().try_into().map_err(|error| {
+                anyhow!("Failed to convert tensor arena length to u64: {}", error)
+            })?;
         let _ = unsafe {
             tflite_init(
                 model_bytes.as_ptr(),
@@ -100,9 +99,8 @@ impl TfliteModel {
             .try_into()
             .map_err(|error| anyhow!("Failed to get output bytes length from bytes: {}", error))?;
 
-        let output_bytes = unsafe {
-            alloc::slice::from_raw_parts(*output_bytes_ptr, output_bytes_len)
-        };
+        let output_bytes =
+            unsafe { alloc::slice::from_raw_parts(*output_bytes_ptr, output_bytes_len) };
         Ok(output_bytes.to_vec())
     }
 }


### PR DESCRIPTION
This PR makes TensorFlow Lite C++ code return a pointer to the buffer containing the inference output bytes.