### PR TITLE
Plumb an explicit allocator through oak_simple_io crate.

### DIFF
--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -30,6 +30,7 @@
 
 #![cfg_attr(not(test), no_std)]
 #![feature(abi_x86_interrupt)]
+#![feature(allocator_api)]
 #![feature(asm_sym)]
 #![feature(naked_functions)]
 #![feature(once_cell)]
@@ -137,7 +138,10 @@ fn get_channel<A: Translator>(kernel_args: &args::Args, mapper: &A) -> Box<dyn C
         #[cfg(feature = "serial_channel")]
         ChannelType::Serial => Box::new(serial::Serial::new()),
         #[cfg(feature = "simple_io_channel")]
-        ChannelType::SimpleIo => Box::new(simpleio::SimpleIoChannel::new(mapper)),
+        ChannelType::SimpleIo => Box::new(simpleio::SimpleIoChannel::new(
+            mapper,
+            &alloc::alloc::Global,
+        )),
     }
 }
 


### PR DESCRIPTION
We need a custom allocator to ensure that the vectors are allocated in the memory area reserved for guest-host communication; we can't just rely on the system allocator in the future.

Unfortunately this means we now have to track lifetimes throughout the crate to placate the borrow checker. I'm still not _entirely_ convinced it's worth it, but at least in this crate it wasn't much hassle.