### PR TITLE
Plumb an explicit allocator through the virtio crate.

### DIFF
--- a/experimental/virtio/src/console/tests.rs
+++ b/experimental/virtio/src/console/tests.rs
@@ -19,19 +19,19 @@ use crate::test::{
     identity_map, inverse_identity_map, new_legacy_transport, new_transport_small_queue,
     new_valid_transport, DeviceStatus, VIRTIO_F_VERSION_1,
 };
-use alloc::{vec, vec::Vec};
+use alloc::{alloc::Global, vec, vec::Vec};
 
 #[test]
 fn test_legacy_device_not_supported() {
     let device = VirtioBaseDevice::new(new_legacy_transport());
-    let mut console = Console::new(device, identity_map);
+    let mut console = Console::new(device, identity_map, &Global);
     assert!(console.init(identity_map, inverse_identity_map).is_err());
 }
 
 #[test]
 fn test_max_queue_size_too_small() {
     let device = VirtioBaseDevice::new(new_transport_small_queue());
-    let mut console = Console::new(device, identity_map);
+    let mut console = Console::new(device, identity_map, &Global);
     assert!(console.init(identity_map, inverse_identity_map).is_err());
 }
 
@@ -40,7 +40,7 @@ fn test_device_init() {
     let transport = new_valid_transport();
     let config = transport.config.clone();
     let device = VirtioBaseDevice::new(transport);
-    let mut console = Console::new(device, identity_map);
+    let mut console = Console::new(device, identity_map, &Global);
     let result = console.init(identity_map, inverse_identity_map);
     assert!(result.is_ok());
 
@@ -70,7 +70,7 @@ fn test_read_bytes() {
     let data = vec![2, 4, 6];
     let transport = new_valid_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut console = Console::new(device, identity_map);
+    let mut console = Console::new(device, identity_map, &Global);
     console.init(identity_map, inverse_identity_map).unwrap();
     transport.device_write_to_queue::<QUEUE_SIZE>(0, &data[..]);
     let bytes = console.read_bytes().unwrap();
@@ -83,7 +83,7 @@ fn test_write_bytes() {
     let data = vec![7; 5];
     let transport = new_valid_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut console = Console::new(device, identity_map);
+    let mut console = Console::new(device, identity_map, &Global);
     console.init(identity_map, inverse_identity_map).unwrap();
     let len = console.write_bytes(&data[..]).unwrap();
     assert_eq!(len, 5);
@@ -100,7 +100,7 @@ fn test_read_exact() {
     let mut second = vec![0; 3];
     let transport = new_valid_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut console = Console::new(device, identity_map);
+    let mut console = Console::new(device, identity_map, &Global);
     console.init(identity_map, inverse_identity_map).unwrap();
     transport.device_write_to_queue::<QUEUE_SIZE>(0, &data[..]);
     assert!(console.read(&mut first).is_ok());
@@ -116,7 +116,7 @@ fn test_write_all() {
     let data = vec![13; 5000];
     let transport = new_valid_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut console = Console::new(device, identity_map);
+    let mut console = Console::new(device, identity_map, &Global);
     console.init(identity_map, inverse_identity_map).unwrap();
     assert!(console.write(&data[..]).is_ok());
     let first = transport

--- a/experimental/virtio/src/lib.rs
+++ b/experimental/virtio/src/lib.rs
@@ -20,6 +20,7 @@
 //! guest-physical addresses are the same.
 
 #![no_std]
+#![feature(allocator_api)]
 #![feature(let_chains)]
 
 use x86_64::{PhysAddr, VirtAddr};

--- a/experimental/virtio/src/queue/tests.rs
+++ b/experimental/virtio/src/queue/tests.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+use alloc::{alloc::Global, vec};
+
 use crate::test::identity_map;
 
 use super::*;
@@ -23,7 +25,8 @@ const BUFFER_SIZE: usize = 4;
 
 #[test]
 fn test_read_empty_queue() {
-    let mut queue = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
+    let mut queue =
+        DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE, Global>::new(identity_map, &Global);
     let data = queue.read_next_used_buffer();
     assert!(data.is_none());
     assert_eq!(queue.inner.last_used_idx.0, 0);
@@ -35,13 +38,14 @@ fn test_read_empty_queue() {
 #[should_panic]
 fn test_invalid_queue_size() {
     // `QUEUE_SIZE` must be a power of 2.
-    let _ = Queue::<3, BUFFER_SIZE>::new(DescFlags::empty(), identity_map);
+    let _ = Queue::<3, BUFFER_SIZE, Global>::new(DescFlags::empty(), identity_map, &Global);
 }
 
 #[test]
 fn test_read_once() {
     let data = vec![0, 1, 2];
-    let mut queue = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
+    let mut queue =
+        DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE, Global>::new(identity_map, &Global);
 
     let result = device_write(queue.inner.virt_queue.as_mut(), &data);
     assert_eq!(Some(3), result);
@@ -59,7 +63,8 @@ fn test_read_once() {
 #[test]
 fn test_write_once() {
     let data = vec![0, 1, 2];
-    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
+    let mut queue =
+        DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE, Global>::new(identity_map, &Global);
 
     let result = queue.write_buffer(&data);
     assert_eq!(Some(3), result);
@@ -73,7 +78,8 @@ fn test_write_once() {
 #[test]
 fn test_wrapping_idx() {
     let data = vec![0, 1, 2];
-    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
+    let mut queue =
+        DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE, Global>::new(identity_map, &Global);
 
     // Move the indices along to the max value.
     queue.inner.virt_queue.avail.idx = Wrapping(u16::MAX);
@@ -92,7 +98,8 @@ fn test_wrapping_idx() {
 #[test]
 fn test_write_too_long() {
     let data = vec![0, 1, 2, 3, 4];
-    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
+    let mut queue =
+        DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE, Global>::new(identity_map, &Global);
 
     let result = queue.write_buffer(&data);
     assert_eq!(Some(4), result);
@@ -100,7 +107,8 @@ fn test_write_too_long() {
 
 #[test]
 fn test_device_queue_exhaustion() {
-    let mut queue = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
+    let mut queue =
+        DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE, Global>::new(identity_map, &Global);
     let data = Some(vec![0]);
     // We can write 4 times.
     let result = device_write(queue.inner.virt_queue.as_mut(), data.as_ref().unwrap());
@@ -131,7 +139,8 @@ fn test_device_queue_exhaustion() {
 
 #[test]
 fn test_driver_queue_exhaustion() {
-    let mut queue = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
+    let mut queue =
+        DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE, Global>::new(identity_map, &Global);
     let data = Some(vec![0]);
     // We should be able to write 4 times.
     let result = queue.write_buffer(data.as_ref().unwrap());
@@ -165,8 +174,10 @@ fn test_many_echos() {
     let data_1 = Some(vec![0]);
     let data_2 = Some(vec![1, 2, 3]);
     let data_3 = Some(vec![4, 5]);
-    let mut tx = DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
-    let mut rx = DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE>::new(identity_map);
+    let mut tx =
+        DriverWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE, Global>::new(identity_map, &Global);
+    let mut rx =
+        DeviceWriteOnlyQueue::<QUEUE_SIZE, BUFFER_SIZE, Global>::new(identity_map, &Global);
     for _ in 0..100 {
         // Run batches of 3 echos or different data lengths repeatedly.
         tx.write_buffer(data_1.as_ref().unwrap()).unwrap();

--- a/experimental/virtio/src/vsock/tests.rs
+++ b/experimental/virtio/src/vsock/tests.rs
@@ -19,21 +19,21 @@ use crate::test::{
     identity_map, inverse_identity_map, new_legacy_transport, new_transport_small_queue,
     new_valid_transport, DeviceStatus, TestingTransport, VIRTIO_F_VERSION_1,
 };
-use alloc::vec;
+use alloc::{alloc::Global, vec};
 
 const GUEST_CID: u64 = 3;
 
 #[test]
 fn test_legacy_device_not_supported() {
     let device = VirtioBaseDevice::new(new_legacy_transport());
-    let mut vsock = VSock::new(device, identity_map);
+    let mut vsock = VSock::new(device, identity_map, &Global);
     assert!(vsock.init(identity_map, inverse_identity_map).is_err());
 }
 
 #[test]
 fn test_max_queue_size_too_small() {
     let device = VirtioBaseDevice::new(new_transport_small_queue());
-    let mut vsock = VSock::new(device, identity_map);
+    let mut vsock = VSock::new(device, identity_map, &Global);
     assert!(vsock.init(identity_map, inverse_identity_map).is_err());
 }
 
@@ -42,7 +42,7 @@ fn test_device_init() {
     let transport = new_configured_transport();
     let config = transport.config.clone();
     let device = VirtioBaseDevice::new(transport);
-    let mut vsock = VSock::new(device, identity_map);
+    let mut vsock = VSock::new(device, identity_map, &Global);
     let result = vsock.init(identity_map, inverse_identity_map);
     assert!(result.is_ok());
 
@@ -76,7 +76,7 @@ fn test_read_packet() {
     packet.set_src_cid(HOST_CID);
     let transport = new_configured_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut vsock = VSock::new(device, identity_map);
+    let mut vsock = VSock::new(device, identity_map, &Global);
     vsock.init(identity_map, inverse_identity_map).unwrap();
     transport.device_write_to_queue::<QUEUE_SIZE>(0, packet.as_slice());
     let result = vsock.read_packet().unwrap();
@@ -89,7 +89,7 @@ fn test_write_packet() {
     let mut packet = Packet::new_data(&data[..], 1, 2).unwrap();
     let transport = new_configured_transport();
     let device = VirtioBaseDevice::new(transport.clone());
-    let mut vsock = VSock::new(device, identity_map);
+    let mut vsock = VSock::new(device, identity_map, &Global);
     vsock.init(identity_map, inverse_identity_map).unwrap();
     vsock.write_packet(&mut packet);
     let bytes = transport

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -134,9 +134,13 @@ fn get_channel<A: Translator>(kernel_args: &args::Args, mapper: &A) -> Box<dyn C
 
     match chan_type {
         #[cfg(feature = "virtio_console_channel")]
-        ChannelType::VirtioConsole => Box::new(virtio::get_console_channel(mapper)),
+        ChannelType::VirtioConsole => {
+            Box::new(virtio::get_console_channel(mapper, &alloc::alloc::Global))
+        }
         #[cfg(feature = "vsock_channel")]
-        ChannelType::VirtioVsock => Box::new(virtio::get_vsock_channel(mapper)),
+        ChannelType::VirtioVsock => {
+            Box::new(virtio::get_vsock_channel(mapper, &alloc::alloc::Global))
+        }
         #[cfg(feature = "serial_channel")]
         ChannelType::Serial => Box::new(serial::Serial::new()),
         #[cfg(feature = "simple_io_channel")]


### PR DESCRIPTION
We need a custom allocator to ensure that the vectors are allocated in the memory area reserved for guest-host communication; we can't just rely on the system allocator in the future.

Unfortunately this means we now have to track lifetimes throughout the crate to placate the borrow checker. I'm still not entirely convinced it's worth it, but at least in this crate it wasn't much hassle.

This PR mirrors #3360 for the simple_io crate.