### PR TITLE
Use separate heap for guest-host communication memory.

### DIFF
--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -26,7 +26,7 @@ goblin = { version = "*", default-features = false, features = [
 ] }
 hashbrown = { version = "*", optional = true }
 lazy_static = { version = "*", features = ["spin_no_std"] }
-linked_list_allocator = { version = "*" }
+linked_list_allocator = { version = "*", features = ["alloc_ref"] }
 log = "*"
 libc = { version = "*", optional = true }
 libm = "*"

--- a/oak_restricted_kernel/src/mm/frame_allocator.rs
+++ b/oak_restricted_kernel/src/mm/frame_allocator.rs
@@ -53,6 +53,14 @@ impl<const N: usize> PhysicalMemoryAllocator<N> {
     pub fn largest_available(&mut self) -> Option<PhysFrameRange<Size2MiB>> {
         self.large_frames.largest_available()
     }
+
+    /// Allocate `num` contiguous 2 MiB pages.
+    ///
+    /// Returns the frame range if a contiguous range of sufficient size was available; the memory
+    /// is marked as allocated before returning.
+    pub fn allocate_contiguous(&mut self, num: usize) -> Option<PhysFrameRange<Size2MiB>> {
+        self.large_frames.allocate_contiguous(num)
+    }
 }
 
 unsafe impl<const N: usize> FrameAllocator<Size2MiB> for PhysicalMemoryAllocator<N> {


### PR DESCRIPTION
We allocate 4 MB (two contiguous pages) for guest-host communication, set up a separate heap allocator managing that space, and then finally connect the dots by passing that allocator to the comms channels, instead of using the global allocator.

Note that the guest-host heap is still "global", hence we store it in a `static`.