### PR TITLE
SEV enlightenment: ignore the encrypted bit when writing to memory

### DIFF
--- a/oak_functions_freestanding_bin/src/asm/boot.s
+++ b/oak_functions_freestanding_bin/src/asm/boot.s
@@ -41,7 +41,8 @@ _start:
     movq %rax, 4088(%rbx)  # rbx[511] = rax
 
     # Map the last entry of PDP to the same location as the first.
-    movabsq $0x000FFFFFFFFFF000, %rax  # rax = $const
+    # We're ignoring bit 51 (as that's commonly the encrypted bit).
+    movabsq $0x0007FFFFFFFFF000, %rax  # rax = $const
     andq (%rbx), %rax                  # rax = *rbx & rax (mask out all but the address)
     movq (%rax), %rdx                  # rdx = *rax
     movq %rdx, 4080(%rax)              # rax[510] = rdx


### PR DESCRIPTION
Literally a one-bit change that's required for our Restricted Kernel to boot under SEV.

The problem here is that the address in the page table potentially has the encrypted bit set, but we want to read from that physical address, which won't work with the encrypted bit set. Thus, let's ignore bit 51 for now.