### PR TITLE
Fix provenance workflow

### DIFF
--- a/.github/actions/reproducibility_index/action.yml
+++ b/.github/actions/reproducibility_index/action.yml
@@ -69,7 +69,7 @@ runs:
 
     # Also post a reply on the PR thread with the contents of the index, after merge.
     - name: Post Reproducibility Index (post-merge only)
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v6
       if: github.event_name == 'push'
       with:
         github-token: ${{inputs.GITHUB_TOKEN}}

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -160,8 +160,16 @@ jobs:
       compile-generator: true
 
   dsse-upload:
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
     needs: [provenance]
+    runs-on: ubuntu-20.04
+
+    permissions:
+      # Allow the job to update the repo with the latest provenances and index.
+      contents: write
+      # Allow the job to add a comment to the PR.
+      pull-requests: write
+
     steps:
       - name: Download DSSE document
         uses: actions/download-artifact@v3
@@ -189,6 +197,40 @@ jobs:
       # TODO(#3339): publish as a comment
       - name: Print SHA256 hash
         run: sha256sum oak_functions_freestanding_bin.intoto.jsonl
+
+    # Also post a reply on the PR thread with the sha256sum of the DSSE artifact.
+    - name: Post SHA256 Hash of the DSSE Artifact (post-merge only)
+      uses: actions/github-script@0.9.0
+      # if: github.event_name == 'push'
+      with:
+        github-token: ${{inputs.GITHUB_TOKEN}}
+        script: |
+          const execa = require('execa')
+          const { stdout } = await execa('sha256sum', ['oak_functions_freestanding_bin.intoto.jsonl'])
+          const opts = await github.repos.listPullRequestsAssociatedWithCommit({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            commit_sha: context.sha
+          });
+          // See:
+          // - https://octokit.github.io/rest.js/v17#previews
+          // - https://developer.github.com/v3/repos/commits/#list-pull-requests-associated-with-commit
+          opts.mediaType = {
+              previews: ['groot']
+          };
+
+          const issues = await github.paginate(opts);
+
+          await github.issues.createComment({
+            issue_number: issues[0].number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `SHA256 hash of the signed provenance uploaded to Ent as a DSSE document:
+
+          \`\`\`
+          ${stdout}
+          \`\`\`
+          `});
 
       - name: Upload to Ent
         run: |

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -159,8 +159,10 @@ jobs:
       # Build the generator from source.
       compile-generator: true
 
+  # This job uploads the signed provenance from the previous step to Ent, and
+  # publishes a comment about it on the PR.
   dsse-upload:
-    # if: github.event_name == 'push'
+    if: github.event_name == 'push'
     needs: [provenance]
     runs-on: ubuntu-20.04
 
@@ -174,7 +176,7 @@ jobs:
       - name: Download DSSE document
         uses: actions/download-artifact@v3
         with:
-          name: 'oak_functions_freestanding_bin.intoto.jsonl'
+          name: oak_functions_freestanding_bin.intoto.jsonl
 
       # See https://github.com/google/ent
       - name: Download Ent CLI
@@ -194,44 +196,40 @@ jobs:
           api_key = '${{ secrets.ENT_API_KEY }}'
           EOF
 
-      # TODO(#3339): publish as a comment
-      - name: Print SHA256 hash
-        run: sha256sum oak_functions_freestanding_bin.intoto.jsonl
-
-    # Also post a reply on the PR thread with the sha256sum of the DSSE artifact.
-    - name: Post SHA256 Hash of the DSSE Artifact (post-merge only)
-      uses: actions/github-script@0.9.0
-      # if: github.event_name == 'push'
-      with:
-        github-token: ${{inputs.GITHUB_TOKEN}}
-        script: |
-          const execa = require('execa')
-          const { stdout } = await execa('sha256sum', ['oak_functions_freestanding_bin.intoto.jsonl'])
-          const opts = await github.repos.listPullRequestsAssociatedWithCommit({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            commit_sha: context.sha
-          });
-          // See:
-          // - https://octokit.github.io/rest.js/v17#previews
-          // - https://developer.github.com/v3/repos/commits/#list-pull-requests-associated-with-commit
-          opts.mediaType = {
-              previews: ['groot']
-          };
-
-          const issues = await github.paginate(opts);
-
-          await github.issues.createComment({
-            issue_number: issues[0].number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `SHA256 hash of the signed provenance uploaded to Ent as a DSSE document:
-
-          \`\`\`
-          ${stdout}
-          \`\`\`
-          `});
-
       - name: Upload to Ent
         run: |
-          ent put oak_functions_freestanding_bin.intoto.jsonl
+          ent put oak_functions_freestanding_bin.intoto.jsonl | tee ./digest
+
+      # Also post a reply on the PR thread with the sha256sum of the DSSE artifact.
+      - name: Post SHA256 digest of the DSSE Artifact (post-merge only)
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{inputs.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs').promises;
+            const digest_line = await fs.readFile('./digest');
+
+            const opts = await github.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha
+            });
+            // See:
+            // - https://octokit.github.io/rest.js/v17#previews
+            // - https://developer.github.com/v3/repos/commits/#list-pull-requests-associated-with-commit
+            opts.mediaType = {
+                previews: ['groot']
+            };
+
+            const issues = await github.paginate(opts);
+
+            await github.issues.createComment({
+              issue_number: issues[0].number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `SHA256 hash of the signed provenance uploaded to Ent as a DSSE document:
+
+            \`\`\`
+            ${digest_line}
+            \`\`\`
+            `});

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -138,7 +138,7 @@ jobs:
           cd $(dirname ${{ env.OAK_FUNCTIONS_FREESTANDING_BIN_PATH }})
           # sha256sum generates sha256 hash for the target binary.
           # base64 --wrap=0 disables line wrapping, and encodes to base64 and outputs on a single line.
-          echo "::set-output name=hashes::$(sha256sum $(basename ${{ env.OAK_FUNCTIONS_FREESTANDING_BIN_PATH }}) | base64 --wrap=0)"
+          echo "hashes=$(sha256sum $(basename ${{ env.OAK_FUNCTIONS_FREESTANDING_BIN_PATH }}) | base64 --wrap=0)" >> $GITHUB_OUTPUT
 
   # This job calls the generic workflow to generate provenance.
   # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md


### PR DESCRIPTION
- Fixes the currently failing workflow job. 
- Fixes the set-output issue in GitHub workflow
- Adds a workflow step for publishing the output of uploading DSSE to Ent as a comment on the PR. 