### PR TITLE
Return output buffer length from TFLite initialization

### DIFF
--- a/cc/tflite_micro/tflite_micro.cc
+++ b/cc/tflite_micro/tflite_micro.cc
@@ -23,16 +23,16 @@
 void tflite_log_debug(const char* message) { oak_log_debug(message, strlen(message)); }
 
 // TODO(#3297): Implement TensorFlow Lite initialization logic.
-int tflite_init(const uint8_t* model_bytes, size_t model_bytes_len,
-                const uint8_t* tensor_arena_bytes, size_t tensor_arena_bytes_len,
-                size_t* output_buffer_len) {
+int tflite_init(const uint8_t* model_bytes_ptr, size_t model_bytes_len,
+                const uint8_t* tensor_arena_bytes_ptr, size_t tensor_arena_bytes_len,
+                size_t* output_buffer_len_ptr) {
   tflite_log_debug("Initializing TensorFlow Lite");
   return 0;
 }
 
 // TODO(#3297): Implement TensorFlow Lite inference logic.
-int tflite_run(const uint8_t* input_bytes, size_t input_bytes_len, uint8_t* output_bytes,
-               size_t* output_bytes_len) {
+int tflite_run(const uint8_t* input_bytes_ptr, size_t input_bytes_len, uint8_t* output_bytes_ptr,
+               size_t* output_bytes_len_ptr) {
   tflite_log_debug("Running TensorFlow Lite inference");
   return 0;
 }

--- a/cc/tflite_micro/tflite_micro.cc
+++ b/cc/tflite_micro/tflite_micro.cc
@@ -24,7 +24,8 @@ void tflite_log_debug(const char* message) { oak_log_debug(message, strlen(messa
 
 // TODO(#3297): Implement TensorFlow Lite initialization logic.
 int tflite_init(const uint8_t* model_bytes, size_t model_bytes_len,
-                const uint8_t* tensor_arena_bytes, size_t tensor_arena_bytes_len) {
+                const uint8_t* tensor_arena_bytes, size_t tensor_arena_bytes_len,
+                size_t* output_buffer_len) {
   tflite_log_debug("Initializing TensorFlow Lite");
   return 0;
 }

--- a/cc/tflite_micro/tflite_micro.h
+++ b/cc/tflite_micro/tflite_micro.h
@@ -30,7 +30,8 @@ extern "C" {
 #endif
 
 int tflite_init(const uint8_t* model_bytes, size_t model_bytes_len,
-                const uint8_t* tensor_arena_bytes, size_t tensor_arena_bytes_len);
+                const uint8_t* tensor_arena_bytes, size_t tensor_arena_bytes_len,
+                size_t* output_buffer_len);
 
 int tflite_run(const uint8_t* input_bytes, size_t input_bytes_len, uint8_t* output_bytes,
                size_t* output_bytes_len);

--- a/cc/tflite_micro/tflite_micro.h
+++ b/cc/tflite_micro/tflite_micro.h
@@ -29,14 +29,14 @@ void tflite_log_debug(const char* message);
 extern "C" {
 #endif
 
-int tflite_init(const uint8_t* model_bytes, size_t model_bytes_len,
-                const uint8_t* tensor_arena_bytes, size_t tensor_arena_bytes_len,
-                size_t* output_buffer_len);
+int tflite_init(const uint8_t* model_bytes_ptr, size_t model_bytes_len,
+                const uint8_t* tensor_arena_bytes_ptr, size_t tensor_arena_bytes_len,
+                size_t* output_buffer_len_ptr);
 
-int tflite_run(const uint8_t* input_bytes, size_t input_bytes_len, uint8_t* output_bytes,
-               size_t* output_bytes_len);
+int tflite_run(const uint8_t* input_bytes_ptr, size_t input_bytes_len, uint8_t* output_bytes_ptr,
+               size_t* output_bytes_len_ptr);
 
-void oak_log_debug(const char* message, size_t message_len);
+void oak_log_debug(const char* message_ptr, size_t message_len);
 
 #ifdef __cplusplus
 }

--- a/oak_tensorflow_service/src/lib.rs
+++ b/oak_tensorflow_service/src/lib.rs
@@ -34,17 +34,15 @@ pub mod schema {
 }
 mod tflite;
 
-use alloc::sync::Arc;
-
 #[derive(Default)]
 pub struct TensorflowServiceImpl {
-    tflite_model: Arc<tflite::TfliteModel>,
+    tflite_model: tflite::TfliteModel,
 }
 
 impl TensorflowServiceImpl {
     pub fn new() -> Self {
         Self {
-            tflite_model: Arc::new(tflite::TfliteModel::new()),
+            tflite_model: tflite::TfliteModel::new(),
         }
     }
 }

--- a/oak_tensorflow_service/src/tflite.rs
+++ b/oak_tensorflow_service/src/tflite.rs
@@ -15,7 +15,7 @@
 //
 
 use alloc::{vec, vec::Vec};
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use log::{log, Level};
 
 // TODO(#3297): Don't use null terminated and use `string_view` instead.
@@ -43,20 +43,24 @@ extern "C" {
     ///
     /// Memory area that will be used by the TFLM memory manager is defined by `tensor_arena_bytes`:
     /// <https://github.com/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/docs/memory_management.md>
+    ///
+    /// This function returns a buffer size value in the `output_buffer_len`. This buffer should be
+    /// allocated before calling `tflite_run` to store inference results.
     fn tflite_init(
         model_bytes: *const u8,
-        model_bytes_len: u64,
+        model_bytes_len: usize,
         tensor_arena_bytes: *const u8,
-        tensor_arena_bytes_len: u64,
+        tensor_arena_bytes_len: usize,
+        output_buffer_len: *mut usize,
     ) -> i32;
 
     /// Performs inference on `input_bytes` and pass inference result to `output_bytes` and returns
     /// an error code.
     fn tflite_run(
         input_bytes: *const u8,
-        input_bytes_len: u64,
+        input_bytes_len: usize,
         output_bytes: *mut u8,
-        output_bytes_len: *mut u64,
+        output_bytes_len: *mut usize,
     ) -> i32;
 }
 
@@ -66,51 +70,55 @@ const TENSOR_ARENA_SIZE: usize = 1024;
 #[derive(Default)]
 pub struct TfliteModel {
     tensor_arena: Vec<u8>,
+    output_buffer_len: Option<usize>,
 }
 
 impl TfliteModel {
     pub fn new() -> Self {
         let tensor_arena = vec![0; TENSOR_ARENA_SIZE];
-        Self { tensor_arena }
+        Self {
+            tensor_arena,
+            output_buffer_len: None,
+        }
     }
 
-    pub fn initialize(&self, model_bytes: &[u8]) -> anyhow::Result<()> {
-        let model_bytes_len = model_bytes
-            .len()
-            .try_into()
-            .map_err(|error| anyhow!("Failed to convert usize to u64: {}", error))?;
-        let tensor_arena_len = self
-            .tensor_arena
-            .len()
-            .try_into()
-            .map_err(|error| anyhow!("Failed to convert usize to u64: {}", error))?;
+    pub fn initialize(&mut self, model_bytes: &[u8]) -> anyhow::Result<()> {
+        let model_bytes_len = model_bytes.len();
+        let tensor_arena_len = self.tensor_arena.len();
+        let mut output_buffer_len = 0usize;
         let _ = unsafe {
             tflite_init(
                 model_bytes.as_ptr(),
                 model_bytes_len,
                 self.tensor_arena.as_ptr(),
                 tensor_arena_len,
+                &mut output_buffer_len,
             )
         };
+        self.output_buffer_len = Some(output_buffer_len);
         Ok(())
     }
 
-    pub fn run(&self, input_bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
-        let input_bytes_len = input_bytes
-            .len()
-            .try_into()
-            .map_err(|error| anyhow!("Failed to convert usize to u64: {}", error))?;
-        // TODO(#3297): Allocate enough bytes for the TensorFlow Lite model.
-        let mut output_bytes = vec![0; input_bytes.len()];
-        let mut output_bytes_len = 0u64;
+    pub fn run(&mut self, input_bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
+        let buffer_len = self
+            .output_buffer_len
+            .context("Running inference on a non-initialized TensorFlow model")?;
+
+        let input_bytes_len = input_bytes.len();
+        let mut output_bytes = vec![0; buffer_len];
+        let mut output_bytes_len = 0usize;
         let _ = unsafe {
             tflite_run(
                 input_bytes.as_ptr(),
                 input_bytes_len,
                 output_bytes.as_mut_ptr(),
-                &mut output_bytes_len as *mut u64,
+                &mut output_bytes_len,
             )
         };
-        Ok(output_bytes)
+        if output_bytes_len <= buffer_len {
+            Ok(output_bytes[..output_bytes_len].to_vec())
+        } else {
+            Err(anyhow!("Response size is larger than the allocated buffer"))
+        }
     }
 }


### PR DESCRIPTION
This PR makes TFLite initialization function return an output buffer length, so that this buffer could be allocated in Rust before calling TFLite inference.