### PR TITLE
Implement IDL based on protobuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_protobuf_idl_build"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "prost 0.9.0",
+ "prost-build 0.9.0",
+]
+
+[[package]]
+name = "oak_protobuf_idl_tests"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "maplit",
+ "oak_idl",
+ "oak_protobuf_idl_build",
+ "prost 0.9.0",
+ "tokio",
+]
+
+[[package]]
 name = "oak_remote_attestation"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ members = [
   "oak_idl_gen_services",
   "oak_idl_gen_structs",
   "oak_idl_tests",
+  "oak_protobuf_idl_build",
+  "oak_protobuf_idl_tests",
   "oak_remote_attestation",
   "oak_remote_attestation_amd",
   "oak_remote_attestation_sessions",

--- a/oak_protobuf_idl_build/Cargo.toml
+++ b/oak_protobuf_idl_build/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "oak_protobuf_idl_build"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "*"
+prost = "*"
+prost-build = "*"

--- a/oak_protobuf_idl_build/src/lib.rs
+++ b/oak_protobuf_idl_build/src/lib.rs
@@ -1,0 +1,267 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#![feature(iter_intersperse)]
+
+//! This crate allows compiling protobuf services to Rust in `build.rs` scripts.
+
+use anyhow::Context;
+use prost_build::{Method, Service};
+
+/// Compile Rust server code from the services in the provided protobuf file.
+///
+/// Each method in a service definition must have exactly one comment line of the form `//
+/// method_id: 42`, which is used to generate a stable identifier for that method, which is part of
+/// the serialization protocol used for invocation.
+///
+/// For a service called `TestName`, `compile` generates the following objects:
+///
+/// - a struct named `TestNameServer`, which implements the `oak_idl::InvocationHandler` trait,
+///   dispatching each request to the appropriate method on the underlying service implementation.
+/// - a trait named `TestName`, with a method for each method defined in the protobuf service, and
+///   an additional default method named `serve` which returns an instance of `TestNameServer`; the
+///   developer of a service would usually define a concrete struct and manually implement this
+///   trait for it,
+/// - a struct named `TestNameClient`, exposing a method for each method defined in the protobuf
+///   service. This may be used to directly invoke the underlying handler in order to indirectly
+///   invoke methods on the corresponding `Server` object on the other side of the handler.
+/// - a struct named `TestNameAsyncClient`, similar to `TestNameClient` but with async support.
+pub fn compile(filename: &str) {
+    println!("cargo:rerun-if-changed={}", filename);
+    let mut config = prost_build::Config::new();
+    config.service_generator(Box::new(ServiceGenerator {}));
+    config
+        .compile_protos(&[filename], &["."])
+        .expect("could not compile protobuffer schema");
+}
+
+struct ServiceGenerator {}
+
+impl prost_build::ServiceGenerator for ServiceGenerator {
+    fn generate(&mut self, service: Service, buf: &mut String) {
+        *buf += "\n";
+        *buf += &generate_service(&service).expect("could not generate services");
+        *buf += "\n";
+        *buf += &generate_service_client(&service, false).expect("could not generate clients");
+        *buf += "\n";
+        *buf += &generate_service_client(&service, true).expect("could not generate async clients");
+    }
+}
+
+/// Generate the Rust objects from the input [`Service`] instance, corresponding to a `service`
+/// entry.
+fn generate_service(service: &Service) -> anyhow::Result<String> {
+    let mut lines = Vec::new();
+    lines.extend(vec![
+        format!("pub struct {}<S> {{", server_name(service)),
+        format!("    service: S"),
+        format!("}}"),
+        format!(""),
+        format!(
+            "impl <S: {}> ::oak_idl::Handler for {}<S> {{",
+            service_name(service),
+            server_name(service)
+        ),
+        format!("    fn invoke(&mut self, request: ::oak_idl::Request) -> Result<::prost::alloc::vec::Vec<u8>, ::oak_idl::Status> {{"),
+        format!("        match request.method_id {{"),
+    ]);
+    lines.extend(
+        service
+            .methods
+            .iter()
+            .map(generate_server_handler)
+            .collect::<Result<Vec<_>, _>>()
+            .context("could not generate server handler")?
+            .into_iter()
+            .flatten(),
+    );
+    lines.extend(vec![
+        format!(
+            "            _ => Err(::oak_idl::Status::new(::oak_idl::StatusCode::Unimplemented))"
+        ),
+        format!("        }}"),
+        format!("    }}"),
+        format!("}}"),
+        format!(""),
+        format!("pub trait {}: Sized {{", service_name(service)),
+    ]);
+    lines.extend(service.methods.iter().flat_map(generate_service_method));
+    lines.extend(vec![
+        format!("    fn serve(self) -> {}<Self> {{", server_name(service)),
+        format!("        {} {{ service : self }}", server_name(service)),
+        format!("    }}"),
+        format!("}}"),
+        format!(""),
+    ]);
+    Ok(lines.into_iter().intersperse("\n".to_string()).collect())
+}
+
+/// Generate the service client Rust objects from the input [`Service`] instance, corresponding to
+/// an `rpc` entry.
+fn generate_service_client(service: &Service, asynchronous: bool) -> anyhow::Result<String> {
+    let client_name = client_name(service, asynchronous);
+    let handler_trait = if asynchronous {
+        "::oak_idl::AsyncHandler"
+    } else {
+        "::oak_idl::Handler"
+    };
+    let mut lines = Vec::new();
+    lines.extend(vec![
+        format!("pub struct {}<T: {}> {{", client_name, handler_trait),
+        format!("    handler: T"),
+        format!("}}"),
+        format!(""),
+        format!("impl <T: {}>{}<T> {{", handler_trait, client_name),
+        format!("    pub fn new(handler: T) -> Self {{"),
+        format!("        Self {{"),
+        format!("            handler"),
+        format!("        }}"),
+        format!("    }}"),
+    ]);
+    lines.extend(
+        service
+            .methods
+            .iter()
+            .map(|c| generate_client_method(c, asynchronous))
+            .collect::<Result<Vec<_>, _>>()
+            .context("could not generate client method")?
+            .into_iter()
+            .flatten(),
+    );
+    lines.extend(vec![format!("}}"), format!("")]);
+    Ok(lines.into_iter().intersperse("\n".to_string()).collect())
+}
+
+fn generate_client_method(method: &Method, asynchronous: bool) -> anyhow::Result<Vec<String>> {
+    // For each method on the schema, generate a client method with the same name, accepting a
+    // buffer containing the serialized request as input. Unfortunately it does not seem easy to
+    // make this more type safe than this; ideally it would take a reference to a message of the
+    // correct type.
+    //
+    // The return value is wrapped in an `oak_idl::Message` since it is owned by the implementation
+    // of this method and needs to be passed to the caller; building a buffer within the generated
+    // method and returning an object that points to it would not work because of the mismatch in
+    // lifetimes. In principle it should be possible though if the caller passes in the buffer to
+    // fill in, which would remain owned by the caller, but that seems more complicated and for not
+    // much benefit.
+    Ok(vec![
+            format!(
+                "    pub {}fn {}(&mut self, request: &{}) -> Result<{}, ::oak_idl::Status> {{",
+                if asynchronous {"async "} else {""},
+                method_name(method),
+                request_type(method),
+                response_type(method)
+            ),
+            format!("        use ::prost::Message;"),
+            format!("        let request_body = request.encode_to_vec();"),
+            format!("        let request = ::oak_idl::Request {{"),
+            format!("            method_id: {},", method_id(method)?),
+            format!("            body: request_body,"),
+            format!("        }};"),
+            format!("        let response_body = self.handler.invoke(request){}?;", if asynchronous {".await"} else {""}),
+            format!("        {}::decode(response_body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!(\"Client failed to deserialize the response: {{:?}}\", err)))", response_type(method)),
+            format!("    }}"),
+        ])
+}
+
+fn generate_server_handler(method: &Method) -> anyhow::Result<Vec<String>> {
+    // This handler appears inside a `match` block in the server implementation. Its purpose is to
+    // parse the incoming request buffer as an object of the correct type, and dispatch a reference
+    // to that object to the underlying service implementation, provided by the developer, which
+    // deals with type safe generated objects instead of raw buffers.
+    Ok(vec![
+        format!("            {} => {{", method_id(method)?),
+        format!("                use ::prost::Message;"),
+        format!(
+            "                let request = {}::decode(request.body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!(\"Service failed to deserialize the request: {{:?}}\", err)))?;",
+            request_type(method),
+        ),
+        format!(
+            "                let response = self.service.{}(&request)?;",
+            method_name(method),
+        ),
+        format!("                let response_body = response.encode_to_vec();"),
+        format!("                Ok(response_body)"),
+        format!("            }}",),
+    ])
+}
+
+fn generate_service_method(method: &Method) -> Vec<String> {
+    vec![format!(
+        "    fn {}(&mut self, request: &{}) -> Result<{}, ::oak_idl::Status>;",
+        method_name(method),
+        request_type(method),
+        response_type(method)
+    )]
+}
+
+/// Returns the value of the `method_id` commend on the method.
+fn method_id(method: &Method) -> anyhow::Result<u32> {
+    let method_ids = method
+        .comments
+        .leading
+        .iter()
+        .filter_map(|line| line.strip_prefix(" method_id: "))
+        .collect::<Vec<_>>();
+    if method_ids.is_empty() {
+        anyhow::bail!("no method_id comment on method {}", method.proto_name,)
+    } else if method_ids.len() > 1 {
+        anyhow::bail!(
+            "multiple method_id comments on method {}",
+            method.proto_name
+        )
+    } else {
+        Ok(method_ids[0].parse()?)
+    }
+}
+
+/// The type name of the generated Rust client struct.
+fn client_name(service: &Service, asynchronous: bool) -> String {
+    format!(
+        "{}{}",
+        service.name,
+        if asynchronous {
+            "AsyncClient"
+        } else {
+            "Client"
+        }
+    )
+}
+
+/// The type name of the generated Rust server struct.
+fn server_name(service: &Service) -> String {
+    format!("{}Server", service.name)
+}
+
+/// The type name of the generated Rust service struct.
+fn service_name(service: &Service) -> String {
+    service.name.to_string()
+}
+
+/// The method name of the generated Rust client method.
+fn method_name(method: &Method) -> String {
+    method.name.to_string()
+}
+
+/// The type name of the generated Rust request struct.
+fn request_type(method: &Method) -> String {
+    method.input_type.to_string()
+}
+
+/// The type name of the generated Rust response struct.
+fn response_type(method: &Method) -> String {
+    method.output_type.to_string()
+}

--- a/oak_protobuf_idl_tests/Cargo.toml
+++ b/oak_protobuf_idl_tests/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "oak_protobuf_idl_tests"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+
+[dev-dependencies]
+async-trait = "*"
+maplit = "*"
+oak_idl = { path = "../oak_idl", features = ["async-clients"] }
+prost = "*"
+tokio = { version = "*", features = ["macros", "rt-multi-thread"] }
+
+[build-dependencies]
+oak_protobuf_idl_build = { path = "../oak_protobuf_idl_build" }

--- a/oak_protobuf_idl_tests/build.rs
+++ b/oak_protobuf_idl_tests/build.rs
@@ -1,0 +1,22 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+const SCHEMA: &str = "test_schema.proto";
+
+fn main() {
+    println!("cargo:rerun-if-changed={}", SCHEMA);
+    oak_protobuf_idl_build::compile(SCHEMA);
+}

--- a/oak_protobuf_idl_tests/build.rs
+++ b/oak_protobuf_idl_tests/build.rs
@@ -17,6 +17,5 @@
 const SCHEMA: &str = "test_schema.proto";
 
 fn main() {
-    println!("cargo:rerun-if-changed={}", SCHEMA);
     oak_protobuf_idl_build::compile(SCHEMA);
 }

--- a/oak_protobuf_idl_tests/oak.protobuf_idl.tests.rs.txt
+++ b/oak_protobuf_idl_tests/oak.protobuf_idl.tests.rs.txt
@@ -1,0 +1,116 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LookupDataRequest {
+    #[prost(bytes="vec", tag="1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LookupDataResponse {
+    #[prost(bytes="vec", tag="1")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LogRequest {
+    #[prost(string, tag="1")]
+    pub entry: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LogResponse {
+}
+
+pub struct TestServiceServer<S> {
+    service: S
+}
+
+impl <S: TestService> ::oak_idl::Handler for TestServiceServer<S> {
+    fn invoke(&mut self, request: ::oak_idl::Request) -> Result<::prost::alloc::vec::Vec<u8>, ::oak_idl::Status> {
+        match request.method_id {
+            15 => {
+                use ::prost::Message;
+                let request = LookupDataRequest::decode(request.body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Service failed to deserialize the request: {:?}", err)))?;
+                let response = self.service.lookup_data(&request)?;
+                let response_body = response.encode_to_vec();
+                Ok(response_body)
+            }
+            16 => {
+                use ::prost::Message;
+                let request = LogRequest::decode(request.body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Service failed to deserialize the request: {:?}", err)))?;
+                let response = self.service.log(&request)?;
+                let response_body = response.encode_to_vec();
+                Ok(response_body)
+            }
+            _ => Err(::oak_idl::Status::new(::oak_idl::StatusCode::Unimplemented))
+        }
+    }
+}
+
+pub trait TestService: Sized {
+    fn lookup_data(&mut self, request: &LookupDataRequest) -> Result<LookupDataResponse, ::oak_idl::Status>;
+    fn log(&mut self, request: &LogRequest) -> Result<LogResponse, ::oak_idl::Status>;
+    fn serve(self) -> TestServiceServer<Self> {
+        TestServiceServer { service : self }
+    }
+}
+
+pub struct TestServiceClient<T: ::oak_idl::Handler> {
+    handler: T
+}
+
+impl <T: ::oak_idl::Handler>TestServiceClient<T> {
+    pub fn new(handler: T) -> Self {
+        Self {
+            handler
+        }
+    }
+    pub fn lookup_data(&mut self, request: &LookupDataRequest) -> Result<LookupDataResponse, ::oak_idl::Status> {
+        use ::prost::Message;
+        let request_body = request.encode_to_vec();
+        let request = ::oak_idl::Request {
+            method_id: 15,
+            body: request_body,
+        };
+        let response_body = self.handler.invoke(request)?;
+        LookupDataResponse::decode(response_body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+    }
+    pub fn log(&mut self, request: &LogRequest) -> Result<LogResponse, ::oak_idl::Status> {
+        use ::prost::Message;
+        let request_body = request.encode_to_vec();
+        let request = ::oak_idl::Request {
+            method_id: 16,
+            body: request_body,
+        };
+        let response_body = self.handler.invoke(request)?;
+        LogResponse::decode(response_body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+    }
+}
+
+pub struct TestServiceAsyncClient<T: ::oak_idl::AsyncHandler> {
+    handler: T
+}
+
+impl <T: ::oak_idl::AsyncHandler>TestServiceAsyncClient<T> {
+    pub fn new(handler: T) -> Self {
+        Self {
+            handler
+        }
+    }
+    pub async fn lookup_data(&mut self, request: &LookupDataRequest) -> Result<LookupDataResponse, ::oak_idl::Status> {
+        use ::prost::Message;
+        let request_body = request.encode_to_vec();
+        let request = ::oak_idl::Request {
+            method_id: 15,
+            body: request_body,
+        };
+        let response_body = self.handler.invoke(request).await?;
+        LookupDataResponse::decode(response_body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+    }
+    pub async fn log(&mut self, request: &LogRequest) -> Result<LogResponse, ::oak_idl::Status> {
+        use ::prost::Message;
+        let request_body = request.encode_to_vec();
+        let request = ::oak_idl::Request {
+            method_id: 16,
+            body: request_body,
+        };
+        let response_body = self.handler.invoke(request).await?;
+        LogResponse::decode(response_body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+    }
+}

--- a/oak_protobuf_idl_tests/oak.protobuf_idl.tests.rs.txt
+++ b/oak_protobuf_idl_tests/oak.protobuf_idl.tests.rs.txt
@@ -26,14 +26,16 @@ impl <S: TestService> ::oak_idl::Handler for TestServiceServer<S> {
         match request.method_id {
             15 => {
                 use ::prost::Message;
-                let request = LookupDataRequest::decode(request.body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Service failed to deserialize the request: {:?}", err)))?;
+                let request = LookupDataRequest::decode(request.body.as_ref())
+                    .map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Service failed to deserialize the request: {:?}", err)))?;
                 let response = self.service.lookup_data(&request)?;
                 let response_body = response.encode_to_vec();
                 Ok(response_body)
             }
             16 => {
                 use ::prost::Message;
-                let request = LogRequest::decode(request.body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Service failed to deserialize the request: {:?}", err)))?;
+                let request = LogRequest::decode(request.body.as_ref())
+                    .map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Service failed to deserialize the request: {:?}", err)))?;
                 let response = self.service.log(&request)?;
                 let response_body = response.encode_to_vec();
                 Ok(response_body)
@@ -69,7 +71,8 @@ impl <T: ::oak_idl::Handler>TestServiceClient<T> {
             body: request_body,
         };
         let response_body = self.handler.invoke(request)?;
-        LookupDataResponse::decode(response_body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+        LookupDataResponse::decode(response_body.as_ref())
+            .map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
     }
     pub fn log(&mut self, request: &LogRequest) -> Result<LogResponse, ::oak_idl::Status> {
         use ::prost::Message;
@@ -79,7 +82,8 @@ impl <T: ::oak_idl::Handler>TestServiceClient<T> {
             body: request_body,
         };
         let response_body = self.handler.invoke(request)?;
-        LogResponse::decode(response_body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+        LogResponse::decode(response_body.as_ref())
+            .map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
     }
 }
 
@@ -101,7 +105,8 @@ impl <T: ::oak_idl::AsyncHandler>TestServiceAsyncClient<T> {
             body: request_body,
         };
         let response_body = self.handler.invoke(request).await?;
-        LookupDataResponse::decode(response_body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+        LookupDataResponse::decode(response_body.as_ref())
+            .map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
     }
     pub async fn log(&mut self, request: &LogRequest) -> Result<LogResponse, ::oak_idl::Status> {
         use ::prost::Message;
@@ -111,6 +116,7 @@ impl <T: ::oak_idl::AsyncHandler>TestServiceAsyncClient<T> {
             body: request_body,
         };
         let response_body = self.handler.invoke(request).await?;
-        LogResponse::decode(response_body.as_ref()).map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
+        LogResponse::decode(response_body.as_ref())
+            .map_err(|err| ::oak_idl::Status::new_with_message(::oak_idl::StatusCode::Internal, format!("Client failed to deserialize the response: {:?}", err)))
     }
 }

--- a/oak_protobuf_idl_tests/test_schema.proto
+++ b/oak_protobuf_idl_tests/test_schema.proto
@@ -1,0 +1,38 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.protobuf_idl.tests;
+
+message LookupDataRequest {
+  bytes key = 1;
+}
+message LookupDataResponse {
+  bytes value = 1;
+}
+
+message LogRequest {
+  string entry = 1;
+}
+message LogResponse {}
+
+service TestService {
+  // method_id: 15
+  rpc LookupData(LookupDataRequest) returns (LookupDataResponse);
+  // method_id: 16
+  rpc Log(LogRequest) returns (LogResponse);
+}

--- a/oak_protobuf_idl_tests/tests/generate.rs
+++ b/oak_protobuf_idl_tests/tests/generate.rs
@@ -1,0 +1,38 @@
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+const OUTPUTS: [&str; 1] = ["oak.protobuf_idl.tests.rs"];
+
+#[test]
+fn generate() {
+    // This test simply copies the output created by the `build.rs` script back into the source
+    // tree, so that it can be tracked in Git. We use the `.txt` extension so that other tools do
+    // not attempt to format or lint it or warn about missing license header.
+    //
+    // This allows to see the current output of the generator, and see how changes in the generator
+    // affect the output file.
+    //
+    // This test does not actually compare the current output to the expected one, it always
+    // overwrite the current one whenever it is run. The actual comparison is performed by the
+    // developer (who should notice that the generated file has changed), and also in CI (thanks to
+    // the git_check_diff step).
+    for output in OUTPUTS.into_iter() {
+        std::fs::copy(
+            format!("{}/{}", env!("OUT_DIR"), output),
+            format!("{}.txt", output),
+        )
+        .unwrap();
+    }
+}

--- a/oak_protobuf_idl_tests/tests/test_schema.rs
+++ b/oak_protobuf_idl_tests/tests/test_schema.rs
@@ -1,0 +1,124 @@
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! This crate contains tests for the `oak_idl_gen_structs` and `oak_idl_gen_services` crates. It
+//! needs to be separate from them in order to be able to invoke them at build time.
+
+extern crate alloc;
+
+use oak_idl::Handler;
+
+mod test_schema {
+    #![allow(dead_code)]
+    include!(concat!(env!("OUT_DIR"), "/oak.protobuf_idl.tests.rs"));
+}
+
+struct TestServiceImpl;
+
+/// An implementation of the [`test_schema::TestService`] service trait for testing.
+impl test_schema::TestService for TestServiceImpl {
+    fn lookup_data(
+        &mut self,
+        request: &test_schema::LookupDataRequest,
+    ) -> Result<test_schema::LookupDataResponse, oak_idl::Status> {
+        let h = maplit::hashmap! {
+            vec![14, 12] => vec![19, 88]
+        };
+        h.get(&request.key)
+            .map(|v| test_schema::LookupDataResponse { value: v.clone() })
+            .ok_or_else(|| oak_idl::Status::new(oak_idl::StatusCode::NotFound))
+    }
+
+    fn log(
+        &mut self,
+        request: &test_schema::LogRequest,
+    ) -> Result<test_schema::LogResponse, oak_idl::Status> {
+        eprintln!("log: {}", request.entry);
+        Ok(test_schema::LogResponse {})
+    }
+}
+
+#[test]
+fn test_lookup_data() {
+    let service = TestServiceImpl;
+    use test_schema::TestService;
+    let handler = service.serve();
+    let mut client = test_schema::TestServiceClient::new(handler);
+    {
+        let request = test_schema::LookupDataRequest { key: vec![14, 12] };
+        let response = client.lookup_data(&request);
+        assert_eq!(
+            Ok(test_schema::LookupDataResponse {
+                value: vec![19, 88]
+            }),
+            response
+        );
+    }
+    {
+        let request = test_schema::LookupDataRequest { key: vec![10, 00] };
+        let response = client.lookup_data(&request);
+        assert_eq!(
+            Err(oak_idl::Status::new(oak_idl::StatusCode::NotFound)),
+            response
+        );
+    }
+}
+
+/// Simple async wrapper around the synchronous server.
+/// Used to test async clients that expect an async handler.
+pub struct AsyncTestServiceServer<S: test_schema::TestService> {
+    inner: test_schema::TestServiceServer<S>,
+}
+
+#[async_trait::async_trait]
+impl<S: test_schema::TestService + std::marker::Send + std::marker::Sync> oak_idl::AsyncHandler
+    for AsyncTestServiceServer<S>
+{
+    async fn invoke(
+        &mut self,
+        request: oak_idl::Request,
+    ) -> Result<alloc::vec::Vec<u8>, oak_idl::Status> {
+        self.inner.invoke(request)
+    }
+}
+
+#[tokio::test]
+async fn test_async_lookup_data() {
+    let service = TestServiceImpl;
+    use test_schema::TestService;
+    let service_impl = service.serve();
+    let async_handler = AsyncTestServiceServer {
+        inner: service_impl,
+    };
+    let mut client = test_schema::TestServiceAsyncClient::new(async_handler);
+    {
+        let request = test_schema::LookupDataRequest { key: vec![14, 12] };
+        let response = client.lookup_data(&request).await;
+        assert_eq!(
+            Ok(test_schema::LookupDataResponse {
+                value: vec![19, 88]
+            }),
+            response
+        );
+    }
+    {
+        let request = test_schema::LookupDataRequest { key: vec![10, 00] };
+        let response = client.lookup_data(&request).await;
+        assert_eq!(
+            Err(oak_idl::Status::new(oak_idl::StatusCode::NotFound)),
+            response
+        );
+    }
+}


### PR DESCRIPTION
Currently as a stand-alone crate, but in the future it may replace (and be renamed into) `oak_idl`.

Currently not used anywhere, just in its own tests.

The structure of the code generator is identical to the existing one from
https://github.com/project-oak/oak/blob/e75740a22c5c3db3d25031cd8b660b50aa60eda2/oak_idl_gen_services/src/lib.rs , which I copy-pasted and modified in order to be driven from prost instead of flatc.

The easiest way of reviewing this PR is probably to look at the generated file, which is also checked in for convenience and to catch regression or changes in the generator.

Ref #3385