### PR TITLE
Stop assuming identity mapping for GHCB

### DIFF
--- a/experimental/sev_guest/src/lib.rs
+++ b/experimental/sev_guest/src/lib.rs
@@ -19,6 +19,8 @@
 
 #![no_std]
 
+use x86_64::{PhysAddr, VirtAddr};
+
 pub mod cpuid;
 pub mod ghcb;
 pub mod instructions;
@@ -26,3 +28,8 @@ pub mod interrupts;
 pub mod io;
 pub mod msr;
 pub mod secrets;
+
+// TODO(#3394): Move to a shared crate.
+/// Memory address translation functions.
+pub trait Translator: Fn(VirtAddr) -> Option<PhysAddr> {}
+impl<X: Fn(VirtAddr) -> Option<PhysAddr>> Translator for X {}

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -38,6 +38,7 @@ mod encrypted_mapper;
 pub mod frame_allocator;
 pub mod page_tables;
 
+// TODO(#3394): Move to a shared crate.
 pub trait Translator {
     /// Translates the given virtual address to the physical address that it maps to.
     ///

--- a/oak_simple_io/src/lib.rs
+++ b/oak_simple_io/src/lib.rs
@@ -54,6 +54,7 @@ pub const OUTPUT_BUFFER_LENGTH: usize = 4096;
 /// The length of the buffer that will be used for input messages.
 pub const INPUT_BUFFER_LENGTH: usize = 4096;
 
+// TODO(#3394): Move to a shared crate.
 /// Memory address translation function.
 pub trait Translator: Fn(VirtAddr) -> Option<PhysAddr> {}
 impl<X: Fn(VirtAddr) -> Option<PhysAddr>> Translator for X {}

--- a/testing/sev_snp_hello_world_kernel/src/ghcb.rs
+++ b/testing/sev_snp_hello_world_kernel/src/ghcb.rs
@@ -48,7 +48,8 @@ pub fn init_ghcb(snp_enabled: bool) -> GhcbProtocol<'static, Ghcb> {
     let ghcb: &mut Ghcb = unsafe { GHCB.assume_init_mut() };
     share_ghcb_with_hypervisor(ghcb, snp_enabled);
     ghcb.reset();
-    GhcbProtocol::new(ghcb)
+    // We are using an identity mapping between virtual and physical addresses.
+    GhcbProtocol::new(ghcb, |vaddr: VirtAddr| Some(PhysAddr::new(vaddr.as_u64())))
 }
 
 /// Marks the page containing the GHCB data structure to be shared with the hypervisor.

--- a/third_party/rust-hypervisor-firmware-virtio/src/lib.rs
+++ b/third_party/rust-hypervisor-firmware-virtio/src/lib.rs
@@ -15,5 +15,6 @@ pub mod mem;
 pub mod pci;
 pub mod virtio;
 
+// TODO(#3394): Move to a shared crate.
 pub trait InverseTranslator: Fn(PhysAddr) -> Option<VirtAddr> {}
 impl<X: Fn(PhysAddr) -> Option<VirtAddr>> InverseTranslator for X {}


### PR DESCRIPTION
So far we have assumed an identity mapping between virtual and physical addresses of the GHCB. That works for the "hello world" test kernel, but will not work for the restricted kernel which is relocated to high memory.