### PR TITLE
Fix logic for tracking changes to protobuf

### DIFF
--- a/oak_functions_client/build.rs
+++ b/oak_functions_client/build.rs
@@ -18,8 +18,8 @@ use oak_utils::{generate_grpc_code, CodegenOptions, ExternPath};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        env!("WORKSPACE_ROOT"),
-        &["oak_grpc_unary_attestation/proto/unary_server.proto"],
+        &format!("{}oak_grpc_unary_attestation/proto", env!("WORKSPACE_ROOT")),
+        &["unary_server.proto"],
         CodegenOptions {
             build_client: true,
             build_server: false,

--- a/oak_functions_launcher/build.rs
+++ b/oak_functions_launcher/build.rs
@@ -20,8 +20,8 @@ const RUNTIME_INTERFACE_SCHEMA: &str = "../oak_functions_freestanding/schema.fbs
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../",
-        &["oak_grpc_unary_attestation/proto/unary_server.proto"],
+        &format!("{}oak_grpc_unary_attestation/proto", env!("WORKSPACE_ROOT")),
+        &["unary_server.proto"],
         CodegenOptions {
             build_client: false,
             build_server: true,

--- a/oak_utils/src/lib.rs
+++ b/oak_utils/src/lib.rs
@@ -59,12 +59,6 @@ pub fn generate_grpc_code(
         .map(|file_path| proto_path.join(file_path))
         .collect();
 
-    // Tell cargo to rerun this build script if the proto file has changed.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
-    for file_path in file_paths.iter() {
-        println!("cargo:rerun-if-changed={}", file_path.display());
-    }
-
     // Generate the normal (non-Oak) server and client code for the gRPC service,
     // along with the Rust types corresponding to the message definitions.
     let mut config = tonic_build::configure()


### PR DESCRIPTION
Currently we pass the entire workspace as the root path for protos compiled by tonic, but this causes tonic itself to emit change tracking logic that covers the entire directory (recursively).

Instead, limit the include path to the proto directory only.

Also, do not emit additional change tracking in our own code, since tonic already does that.

Fix #3392