### PR TITLE
Initialize the GHCB in the restricted kernel

### DIFF
--- a/experimental/sev_guest/src/ghcb.rs
+++ b/experimental/sev_guest/src/ghcb.rs
@@ -131,7 +131,7 @@ pub struct Ghcb {
 
 impl Default for Ghcb {
     fn default() -> Self {
-        Self::new_zeroed()
+        Self::new()
     }
 }
 
@@ -191,6 +191,37 @@ bitflags! {
 }
 
 impl Ghcb {
+    pub const fn new() -> Self {
+        Ghcb {
+            _reserved_0: [0; 203],
+            cpl: 0,
+            _reserved_1: [0; 116],
+            xss: 0,
+            _reserved_2: [0; 24],
+            dr7: 0,
+            _reserved_3: [0; 144],
+            rax: 0,
+            _reserved_4: [0; 264],
+            rbx: 0,
+            rcx: 0,
+            rdx: 0,
+            _reserved_5: [0; 112],
+            sw_exit_code: 0,
+            sw_exit_info_1: 0,
+            sw_exit_info_2: 0,
+            sw_scratch: 0,
+            _reserved_6: [0; 56],
+            xcr0: 0,
+            valid_bitmap: ValidBitmap::empty(),
+            x87_state_gpa: 0,
+            _reserved_7: [0; 1016],
+            shared_buffer: [0; 2032],
+            _reserved_8: [0; 10],
+            protocol_version: 0,
+            ghcb_usage: 0,
+        }
+    }
+
     /// Zeroes the entire GHCB.
     pub fn reset(&mut self) {
         reset_slice(&mut self._reserved_0[..]);

--- a/oak_functions_freestanding_bin/Cargo.lock
+++ b/oak_functions_freestanding_bin/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
  "sev_serial",
+ "static_assertions",
  "strum",
  "uart_16550",
  "virtio",

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-c_interface = ["hashbrown", "libc", "spinning_top", "static_assertions"]
+c_interface = ["hashbrown", "libc", "spinning_top"]
 default = ["vsock_channel"]
 virtio_console_channel = ["virtio"]
 vsock_channel = ["virtio"]
@@ -37,7 +37,7 @@ rust-hypervisor-firmware-virtio = { path = "../third_party/rust-hypervisor-firmw
 sev_guest = { path = "../experimental/sev_guest" }
 sev_serial = { path = "../sev_serial" }
 spinning_top = { version = "*", optional = true }
-static_assertions = { version = "*", optional = true }
+static_assertions = { version = "*" }
 strum = { version = "*", default-features = false, features = ["derive"] }
 uart_16550 = { version = "*", optional = true }
 virtio = { path = "../experimental/virtio", optional = true }

--- a/oak_restricted_kernel/src/ghcb.rs
+++ b/oak_restricted_kernel/src/ghcb.rs
@@ -1,0 +1,184 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::mm::{ENCRYPTED_BIT_POSITION, KERNEL_OFFSET};
+use sev_guest::{
+    ghcb::{Ghcb, GhcbProtocol},
+    msr::{
+        change_snp_page_state, register_ghcb_location, PageAssignment, RegisterGhcbGpaRequest,
+        SnpPageStateChangeRequest,
+    },
+    Translator,
+};
+use x86_64::{
+    addr::{PhysAddr, VirtAddr},
+    align_down,
+    instructions::tlb::flush_all,
+    registers::control::Cr3,
+    structures::paging::{
+        page_table::{PageTable, PageTableFlags},
+        PageSize, Size2MiB, Size4KiB,
+    },
+};
+
+/// The mask for the encrypted bit
+const ENCRYPTED_BIT: u64 = 1 << ENCRYPTED_BIT_POSITION;
+
+/// A wrapper to ensure that the GHCB is alone in alone in a 2MiB page.
+///
+/// We use 2MiB pages during early boot, so we must make sure there are no other kernel data
+/// structures located in the page so that we can safely share the page with the hypervisor without
+/// leaking other data.
+#[derive(Debug)]
+#[repr(C, align(2097152))]
+struct GhcbAlignmentWrapper {
+    ghcb: Ghcb,
+}
+
+static_assertions::assert_eq_size!(GhcbAlignmentWrapper, [u8; Size2MiB::SIZE as usize]);
+
+static mut GHCB_WRAPPER: GhcbAlignmentWrapper = GhcbAlignmentWrapper { ghcb: Ghcb::new() };
+
+/// Initializes the GHCB and shares it with the hypervisor during early boot.
+pub fn init_ghcb_early(snp_enabled: bool) -> GhcbProtocol<'static, Ghcb> {
+    // Safety: This is called only during early boot, so there is only a single execution context.
+    let ghcb = unsafe { &mut GHCB_WRAPPER.ghcb };
+    let translate = |vaddr: VirtAddr| {
+        let address = vaddr.as_u64();
+        // We assume a fixed offset mapping for kernel pages.
+        if address < KERNEL_OFFSET {
+            None
+        } else {
+            Some(PhysAddr::new(address - KERNEL_OFFSET))
+        }
+    };
+    share_ghcb_with_hypervisor(ghcb, snp_enabled, translate);
+    ghcb.reset();
+
+    GhcbProtocol::new(ghcb, translate)
+}
+
+/// Marks the page containing the GHCB data structure to be shared with the hypervisor.
+fn share_ghcb_with_hypervisor<VP: Translator>(ghcb: &Ghcb, snp_enabled: bool, translate: VP) {
+    let ghcb_address = VirtAddr::new(ghcb as *const Ghcb as usize as u64);
+    // On SEV-SNP we need to additionally update the RMP and register the GHCB location with the
+    // hypervisor. We assume an identity mapping between virtual and physical addresses for now.
+    if snp_enabled {
+        // It is OK to crash if we cannot find a valid physica address for the GHCB.
+        let ghcb_physical_address = translate(ghcb_address).unwrap();
+        mark_2mib_page_shared_in_rmp(ghcb_physical_address);
+        let ghcb_location_request =
+            RegisterGhcbGpaRequest::new(ghcb_physical_address.as_u64() as usize)
+                .expect("Invalid address for GHCB location");
+        register_ghcb_location(ghcb_location_request)
+            .expect("Couldn't register the GHCB address with the hypervisor");
+    }
+    // Mark the page as not encrypted in the page tables.
+    set_encrypted_bit_for_page(&ghcb_address, false);
+}
+
+/// Sets the encrypted bit for the page that contains the address.
+///
+/// Since this is called during early boot, before the frame allocator of page mapper is initialised
+/// we have to manually traverse the existing page tables. We use only 2MiB huge pages during early
+/// boot.
+fn set_encrypted_bit_for_page(address: &VirtAddr, encrypted: bool) {
+    // Find the level 4 page table that is currently in use.
+    let (l4_frame, _) = Cr3::read();
+    // Safety: this is safe because we use the address of the current page table as configured in
+    // the CR3 register.
+    let l4_table = unsafe { get_mut_page_table_ref(physical_to_virtual(l4_frame.start_address())) };
+    let l4_entry = &l4_table[address.p4_index()];
+    // Make sure the entry pointing to the L3 page table is present.
+    assert!(l4_entry.flags().contains(PageTableFlags::PRESENT));
+    let l3_table_address = l4_entry.addr();
+    assert!(l3_table_address.as_u64() > 0);
+    // Safety: this is safe because we checked that the page table entry is marked as present and
+    // the physical address is non-zero.
+    let l3_table = unsafe { get_mut_page_table_ref(physical_to_virtual(l3_table_address)) };
+
+    let l3_entry = &l3_table[address.p3_index()];
+    // Make sure the entry pointing to the L2 page table is present.
+    assert!(l3_entry.flags().contains(PageTableFlags::PRESENT));
+    // Make sure it is not marked as a 1GiB huge page, so it points to an L2 page table.
+    assert!(!l3_entry.flags().contains(PageTableFlags::HUGE_PAGE));
+    let l2_table_address = l3_entry.addr();
+    assert!(l2_table_address.as_u64() > 0);
+    // Safety: this is safe because we checked that the page table entry is marked as present, not a
+    // 1GiB huge page and the physical address is non-zero.
+    let l2_table = unsafe { get_mut_page_table_ref(physical_to_virtual(l2_table_address)) };
+
+    let page_entry = &mut l2_table[address.p2_index()];
+    let flags = page_entry.flags();
+    let page_frame_address = page_entry.addr();
+    // Make sure the entry for the L2 page table is present.
+    assert!(flags.contains(PageTableFlags::PRESENT));
+    // Make sure it is marked as a 2MiB huge page.
+    assert!(flags.contains(PageTableFlags::HUGE_PAGE));
+
+    let page_frame_address = PhysAddr::new(if encrypted {
+        page_frame_address.as_u64() | ENCRYPTED_BIT
+    } else {
+        page_frame_address.as_u64() & !ENCRYPTED_BIT
+    });
+
+    page_entry.set_addr(page_frame_address, flags);
+
+    // Flush the entire TLB to make sure the old value of the encrypted bit is not cached.
+    flush_all();
+}
+
+/// Converts a physical address to a virtual address.
+///
+/// This must only be used during early boot when the page tables are still located in an identity
+/// mapped region.
+///
+/// # Safety
+///
+/// This function requires that the page tables are in an identity mapped region of memory, which is
+/// only the case during early boot before the kernel's memory initialisation.
+unsafe fn physical_to_virtual(physical: PhysAddr) -> VirtAddr {
+    let normalized = physical.as_u64() & !ENCRYPTED_BIT;
+    VirtAddr::new(normalized)
+}
+
+/// Gets a mutable reference to a page table that starts at the given address.
+///
+/// # Safety
+///
+/// The caller must provide a valid address for the start of a valid page table.
+unsafe fn get_mut_page_table_ref<'a>(start_address: VirtAddr) -> &'a mut PageTable {
+    &mut *(start_address.as_u64() as usize as *mut PageTable)
+}
+
+/// Marks a 2MiB page as shared in the SEV-SNP reverse-map table (RMP).
+///
+/// Panics if the physical address is not the start of a 2MiB page or if the page sharing request
+/// fails.
+fn mark_2mib_page_shared_in_rmp(physical_address: PhysAddr) {
+    let raw_address = physical_address.as_u64();
+    assert_eq!(align_down(raw_address, Size2MiB::SIZE), raw_address);
+    // Since we don't have the GHCB set up already we need to use the MSR protocol to mark every
+    // individual 4KiB area in the 2MiB page as shared.
+    for i in 0..512 {
+        let request = SnpPageStateChangeRequest::new(
+            (raw_address + i * Size4KiB::SIZE) as usize,
+            PageAssignment::Shared,
+        )
+        .expect("Invalid page address");
+        change_snp_page_state(request).expect("Couldn't change page state");
+    }
+}

--- a/oak_restricted_kernel/src/ghcb.rs
+++ b/oak_restricted_kernel/src/ghcb.rs
@@ -108,7 +108,7 @@ fn set_encrypted_bit_for_page(address: &VirtAddr, encrypted: bool) {
     assert!(l3_table_address.as_u64() > 0);
     assert!(l3_table_address.as_u64() < Size1GiB::SIZE);
     // Safety: this is safe because we checked that the page table entry is marked as present and
-    // the physical address is non-zero and falls withing the first 1GB identity mapper region.
+    // the physical address is non-zero and falls withing the first 1GB identity-mapped region.
     let l3_table = unsafe { get_mut_page_table_ref(physical_to_virtual(l3_table_address)) };
 
     let l3_entry = &l3_table[address.p3_index()];
@@ -121,7 +121,7 @@ fn set_encrypted_bit_for_page(address: &VirtAddr, encrypted: bool) {
     assert!(l3_table_address.as_u64() < Size1GiB::SIZE);
     // Safety: this is safe because we checked that the page table entry is marked as present, not a
     // 1GiB huge page and the physical address is non-zero and falls withing the first 1GB identity
-    // mapper region.
+    // mapped-region.
     let l2_table = unsafe { get_mut_page_table_ref(physical_to_virtual(l2_table_address)) };
 
     let page_entry = &mut l2_table[address.p2_index()];

--- a/oak_restricted_kernel/src/ghcb.rs
+++ b/oak_restricted_kernel/src/ghcb.rs
@@ -37,7 +37,7 @@ use x86_64::{
 /// The mask for the encrypted bit
 const ENCRYPTED_BIT: u64 = 1 << ENCRYPTED_BIT_POSITION;
 
-/// A wrapper to ensure that the GHCB is alone in alone in a 2MiB page.
+/// A wrapper to ensure that the GHCB is alone in a 2MiB page.
 ///
 /// We use 2MiB pages during early boot, so we must make sure there are no other kernel data
 /// structures located in the page so that we can safely share the page with the hypervisor without
@@ -75,9 +75,9 @@ pub fn init_ghcb_early(snp_enabled: bool) -> GhcbProtocol<'static, Ghcb> {
 fn share_ghcb_with_hypervisor<VP: Translator>(ghcb: &Ghcb, snp_enabled: bool, translate: VP) {
     let ghcb_address = VirtAddr::new(ghcb as *const Ghcb as usize as u64);
     // On SEV-SNP we need to additionally update the RMP and register the GHCB location with the
-    // hypervisor. We assume an identity mapping between virtual and physical addresses for now.
+    // hypervisor.
     if snp_enabled {
-        // It is OK to crash if we cannot find a valid physica address for the GHCB.
+        // It is OK to crash if we cannot find a valid physical address for the GHCB.
         let ghcb_physical_address = translate(ghcb_address).unwrap();
         mark_2mib_page_shared_in_rmp(ghcb_physical_address);
         let ghcb_location_request =
@@ -92,7 +92,7 @@ fn share_ghcb_with_hypervisor<VP: Translator>(ghcb: &Ghcb, snp_enabled: bool, tr
 
 /// Sets the encrypted bit for the page that contains the address.
 ///
-/// Since this is called during early boot, before the frame allocator of page mapper is initialised
+/// Since this is called during early boot, before the frame allocator or page mapper is initialised
 /// we have to manually traverse the existing page tables. We use only 2MiB huge pages during early
 /// boot.
 fn set_encrypted_bit_for_page(address: &VirtAddr, encrypted: bool) {

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -76,13 +76,13 @@ static mut GUEST_HOST_HEAP: OnceCell<LockedHeap> = OnceCell::new();
 /// Main entry point for the kernel, to be called from bootloader.
 pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     avx::enable_avx();
+    descriptors::init_gdt();
+    interrupts::init_idt();
     let sev_status = get_sev_status().unwrap_or(SevStatus::empty());
     if sev_status.contains(SevStatus::SEV_ES_ENABLED) {
         let _ = ghcb::init_ghcb_early(sev_status.contains(SevStatus::SNP_ACTIVE));
     }
     logging::init_logging();
-    descriptors::init_gdt();
-    interrupts::init_idt();
 
     // We need to be done with the boot info struct before intializing memory. For example, the
     // multiboot protocol explicitly states data can be placed anywhere in memory; therefore, it's

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -34,12 +34,15 @@ use x86_64::{
 };
 
 mod bitmap_frame_allocator;
-mod encrypted_mapper;
+pub mod encrypted_mapper;
 pub mod frame_allocator;
 pub mod page_tables;
 
 /// The start of kernel memory.
 pub const KERNEL_OFFSET: u64 = 0xFFFF_FFFF_8000_0000;
+
+/// The offset used for the direct mapping of all physical memory.
+const DIRECT_MAPPING_OFFSET: VirtAddr = VirtAddr::new_truncate(0xFFFF_8800_0000_0000);
 
 /// For now we use a fixed position for the encrypted bit. For now we assume that we will be running
 /// on AMD Arcadia-Milan CPUs, which use bit 51.
@@ -160,8 +163,6 @@ pub trait Mapper<S: PageSize> {
         flags: PageTableFlags,
     ) -> Result<MapperFlush<S>, FlagUpdateError>;
 }
-
-const DIRECT_MAPPING_OFFSET: VirtAddr = VirtAddr::new_truncate(0xFFFF_8800_0000_0000);
 
 pub fn init<const N: usize>(
     memory_map: &[BootE820Entry],

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -38,6 +38,13 @@ mod encrypted_mapper;
 pub mod frame_allocator;
 pub mod page_tables;
 
+/// The start of kernel memory.
+pub const KERNEL_OFFSET: u64 = 0xFFFF_FFFF_8000_0000;
+
+/// For now we use a fixed position for the encrypted bit. For now we assume that we will be running
+/// on AMD Arcadia-Milan CPUs, which use bit 51.
+pub const ENCRYPTED_BIT_POSITION: u8 = 51;
+
 // TODO(#3394): Move to a shared crate.
 pub trait Translator {
     /// Translates the given virtual address to the physical address that it maps to.
@@ -273,7 +280,7 @@ pub fn init_paging<A: FrameAllocator<Size4KiB>>(
         .unwrap_or(SevStatus::empty())
         .contains(SevStatus::SEV_ENABLED)
     {
-        MemoryEncryption::Encrypted(51)
+        MemoryEncryption::Encrypted(ENCRYPTED_BIT_POSITION)
     } else {
         MemoryEncryption::NoEncryption
     };

--- a/oak_restricted_kernel/src/mm/page_tables.rs
+++ b/oak_restricted_kernel/src/mm/page_tables.rs
@@ -24,7 +24,7 @@ use x86_64::{
     PhysAddr, VirtAddr,
 };
 
-use super::{Mapper, PageTableFlags};
+use super::{Mapper, PageTableFlags, KERNEL_OFFSET};
 
 /// Map a region of physical memory to a virtual address using 2 MiB pages.
 ///
@@ -90,7 +90,7 @@ pub unsafe fn create_kernel_map<
 ) -> Result<(), MapToError<Size4KiB>> {
     program_headers
         .iter()
-        .filter(|phdr| phdr.p_type == PT_LOAD && phdr.p_vaddr >= 0xFFFF_FFFF_8000_0000)
+        .filter(|phdr| phdr.p_type == PT_LOAD && phdr.p_vaddr >= KERNEL_OFFSET)
         .map(|phdr| {
             (
                 PhysFrame::<Size4KiB>::range(

--- a/oak_tensorflow_freestanding_bin/Cargo.lock
+++ b/oak_tensorflow_freestanding_bin/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
  "sev_serial",
+ "static_assertions",
  "strum",
  "virtio",
  "x86_64",

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
  "sev_serial",
+ "static_assertions",
  "strum",
  "virtio",
  "x86_64",


### PR DESCRIPTION
This PR only adds the code to initialise the GHCB in the Restricted Kernel and share it with the hypervisor. The code for actually using the GHCB will be added in a follow-up PR.