### PR TITLE
Use the GHCB for drivers in the Restricted Kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,7 +2736,7 @@ dependencies = [
  "async-trait",
  "oak_idl",
  "oak_protobuf_idl_build",
- "prost 0.9.0",
+ "prost 0.11.0",
 ]
 
 [[package]]

--- a/oak_functions_freestanding_bin/Cargo.lock
+++ b/oak_functions_freestanding_bin/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
  "sev_serial",
+ "spinning_top",
  "static_assertions",
  "strum",
  "uart_16550",

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-c_interface = ["hashbrown", "libc", "spinning_top"]
+c_interface = ["hashbrown", "libc"]
 default = ["vsock_channel"]
 virtio_console_channel = ["virtio"]
 vsock_channel = ["virtio"]
@@ -36,7 +36,7 @@ oak_linux_boot_params = { path = "../linux_boot_params" }
 rust-hypervisor-firmware-virtio = { path = "../third_party/rust-hypervisor-firmware-virtio" }
 sev_guest = { path = "../experimental/sev_guest" }
 sev_serial = { path = "../sev_serial" }
-spinning_top = { version = "*", optional = true }
+spinning_top = { version = "*" }
 static_assertions = { version = "*" }
 strum = { version = "*", default-features = false, features = ["derive"] }
 uart_16550 = { version = "*", optional = true }

--- a/oak_restricted_kernel/src/ghcb.rs
+++ b/oak_restricted_kernel/src/ghcb.rs
@@ -70,7 +70,7 @@ lazy_static! {
 /// Shares the page containing the GHCB with the hypervisor again.
 ///
 /// This should be called as soon as the kernel memory has been initialised, as that would have
-/// cause the page to be marked as encrypted.
+/// caused the page to be marked as encrypted.
 pub fn reshare_ghcb<M: Mapper<Size2MiB>>(mapper: &mut M) {
     // Safety: we only use the reference to calculate the address and never dereference it.
     let ghcb_address =

--- a/oak_restricted_kernel/src/ghcb.rs
+++ b/oak_restricted_kernel/src/ghcb.rs
@@ -74,8 +74,7 @@ lazy_static! {
 /// caused the page to be marked as encrypted.
 pub fn reshare_ghcb<M: Mapper<Size2MiB>>(mapper: &mut M) {
     // Safety: we only use the reference to calculate the address and never dereference it.
-    let ghcb_address =
-        unsafe { VirtAddr::new(&GHCB_WRAPPER as *const GhcbAlignmentWrapper as usize as u64) };
+    let ghcb_address = unsafe { VirtAddr::from_ptr(&GHCB_WRAPPER as *const GhcbAlignmentWrapper) };
     // Safety: we only change the encrypted flag, all other flags for the GHCB pages are as they
     // were set during the kernel memory initialisation.
     unsafe {

--- a/oak_restricted_kernel/src/ghcb.rs
+++ b/oak_restricted_kernel/src/ghcb.rs
@@ -76,23 +76,23 @@ pub fn reshare_ghcb<M: Mapper<Size2MiB>>(mapper: &mut M) {
     let ghcb_address =
         unsafe { VirtAddr::new(&GHCB_WRAPPER as *const GhcbAlignmentWrapper as usize as u64) };
     // Panicking is OK if we cannot find a valid 2MiB page starting with the GHCB wrapper, or cannot
-    // update the page table flags for it..
+    // update the page table flags for it.
     let page = Page::<Size2MiB>::from_start_address(ghcb_address)
         .expect("Invalid start address for GHCB page.");
 
     // Safety: we dont change the address of the page or any of the existing flags, except for
     // removing the encrypted flag.
     unsafe {
-        mapper
-            .update_flags(
-                page,
-                OakPageTableFlags::PRESENT
-                    | OakPageTableFlags::WRITABLE
-                    | OakPageTableFlags::GLOBAL
-                    | OakPageTableFlags::NO_EXECUTE,
-            )
-            .expect("Couldn't update page table flags for GHCB.")
-            .flush();
+        match mapper.update_flags(
+            page,
+            OakPageTableFlags::PRESENT
+                | OakPageTableFlags::WRITABLE
+                | OakPageTableFlags::GLOBAL
+                | OakPageTableFlags::NO_EXECUTE,
+        ) {
+            Ok(mapper_flush) => mapper_flush.flush(),
+            Err(error) => panic!("Couldn't update page table flags for GHCB: {:?}", error),
+        };
     }
 }
 

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -101,7 +101,9 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     let mut mapper = mm::init_paging(&mut frame_allocator, program_headers).unwrap();
 
     // Now that the page tables have been updated, we have to re-share the GHCB with the hypervisor.
-    ghcb::reshare_ghcb(&mut mapper);
+    if sev_status.contains(SevStatus::SEV_ES_ENABLED) {
+        ghcb::reshare_ghcb(&mut mapper);
+    }
 
     // Allocate a section for guest-host communication (without the `ENCRYPTED` bit set)
     // We'll allocate 2*2MiB, as virtio needs more than 2 MiB for its data structures.

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -100,6 +100,9 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
 
     let mut mapper = mm::init_paging(&mut frame_allocator, program_headers).unwrap();
 
+    // Now that the page tables have been updated, we have to re-share the GHCB with the hypervisor.
+    ghcb::reshare_ghcb(&mut mapper);
+
     // Allocate a section for guest-host communication (without the `ENCRYPTED` bit set)
     // We'll allocate 2*2MiB, as virtio needs more than 2 MiB for its data structures.
     let guest_host_frames = frame_allocator.allocate_contiguous(2).unwrap();

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -79,9 +79,6 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     descriptors::init_gdt();
     interrupts::init_idt();
     let sev_status = get_sev_status().unwrap_or(SevStatus::empty());
-    if sev_status.contains(SevStatus::SEV_ES_ENABLED) {
-        let _ = ghcb::init_ghcb_early(sev_status.contains(SevStatus::SNP_ACTIVE));
-    }
     logging::init_logging();
 
     // We need to be done with the boot info struct before intializing memory. For example, the
@@ -135,7 +132,7 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     ))
     .unwrap();
 
-    get_channel(&kernel_args, &mapper, guest_host_heap)
+    get_channel(&kernel_args, &mapper, guest_host_heap, sev_status)
 }
 
 #[derive(EnumIter, EnumString)]
@@ -156,6 +153,7 @@ fn get_channel<'a, X: Translator, A: Allocator + Sync>(
     kernel_args: &args::Args,
     mapper: &X,
     alloc: &'a A,
+    sev_status: SevStatus,
 ) -> Box<dyn Channel + 'a> {
     // If we weren't told which channel to use, arbitrarily pick the first one in the `ChannelType`
     // enum. Depending on features that are enabled, this means that the enum acts as kind of a
@@ -173,7 +171,9 @@ fn get_channel<'a, X: Translator, A: Allocator + Sync>(
         #[cfg(feature = "serial_channel")]
         ChannelType::Serial => Box::new(serial::Serial::new()),
         #[cfg(feature = "simple_io_channel")]
-        ChannelType::SimpleIo => Box::new(simpleio::SimpleIoChannel::new(mapper, alloc)),
+        ChannelType::SimpleIo => {
+            Box::new(simpleio::SimpleIoChannel::new(mapper, alloc, sev_status))
+        }
     }
 }
 

--- a/oak_tensorflow_freestanding_bin/Cargo.lock
+++ b/oak_tensorflow_freestanding_bin/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
  "sev_serial",
+ "spinning_top",
  "static_assertions",
  "strum",
  "virtio",

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
  "sev_serial",
+ "spinning_top",
  "static_assertions",
  "strum",
  "virtio",

--- a/testing/oak_echo_raw_bin/Cargo.lock
+++ b/testing/oak_echo_raw_bin/Cargo.lock
@@ -202,6 +202,8 @@ dependencies = [
  "rust-hypervisor-firmware-virtio",
  "sev_guest",
  "sev_serial",
+ "spinning_top",
+ "static_assertions",
  "strum",
  "virtio",
  "x86_64",


### PR DESCRIPTION
We can now use the GHCB for serial port logging and the simple IO device to support running under SEV-ES and SEV-SNP.

The virtio drivers are not yet compatible as they require additional work to support the MMIO GHCB protocol. That will be added in future.