### PR TITLE
Cleanup the run-cargo-fuzz command

### DIFF
--- a/.xtask_bash_completion
+++ b/.xtask_bash_completion
@@ -655,16 +655,12 @@ _xtask() {
             return 0
             ;;
         xtask__run__cargo__fuzz)
-            opts="-h --crate-name --target-name --help [ARGS]..."
+            opts="-h --target-name --help [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --crate-name)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-name)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/docs/development.md
+++ b/docs/development.md
@@ -321,11 +321,11 @@ Response: "{\"temperature_degrees_celsius\":29}"
 
 We currently have fuzz testing enabled for Oak Functions on
 [OSS-Fuzz](https://github.com/google/oss-fuzz/tree/master/projects/oak). In
-addition, `xtask` has a command for running fuzz targets `run-fuzz-targets`.
-This command runs `cargo-fuzz` with the `-O` option for optimization, and
-supports all `libFuzzer` options. These options must be provided as the last
-argument. For instance, the following command runs all fuzz targets with a 2
-seconds timeout for each target.
+addition, `xtask` has a command for running fuzz targets `run-cargo-fuzz`. This
+command runs `cargo-fuzz` with the `-O` option for optimization, and supports
+all `libFuzzer` options. These options must be provided as the last argument.
+For instance, the following command runs all fuzz targets with a 2 seconds
+timeout for each target.
 
 ```bash
 xtask run-cargo-fuzz -- -max_total_time=2
@@ -337,12 +337,10 @@ The following lists all the `libFuzzer` options:
 xtask --logs run-cargo-fuzz -- -help=1
 ```
 
-Moreover, `crate-name` alone or together with `target-name` could be specified
-to run all targets for a specific crate, or to run a specific target,
-respectively.
+Moreover, `target-name` could be specified to run a specific target.
 
 ```bash
-xtask --logs run-cargo-fuzz --crate-name=loader --target-name=wasm_invoke -- -max_total_time=20
+xtask --logs run-cargo-fuzz --target-name=apply_policy -- -max_total_time=20
 ```
 
 ## Build and Release

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -245,13 +245,7 @@ pub struct RunTestsOpt {
 pub struct RunCargoFuzz {
     #[arg(
         long,
-        help = "name of a specific crate with fuzz-target. If not specified, runs all fuzz targets for all crates."
-    )]
-    pub crate_name: Option<String>,
-    #[arg(
-        long,
-        help = "name of a specific fuzz-target. If not specified, runs all fuzz targets.",
-        requires("crate_name")
+        help = "name of a specific fuzz-target. If not specified, runs all fuzz targets."
     )]
     pub target_name: Option<String>,
     /// Additional `libFuzzer` arguments passed through to the binary

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -204,17 +204,15 @@ pub fn run_cargo_fuzz(opt: &RunCargoFuzz) -> Step {
 }
 
 pub fn run_fuzz_targets_in_crate(path: &Path, opt: &RunCargoFuzz) -> Step {
-    // `cargo-fuzz` can only run in the crate that contains the `fuzz` crate. So we need to use
-    // `Cmd::new_in_dir` to execute the command inside the crate's directory. Pop one component
-    // (i.e., `./Cargo.toml`) to get to the crate path.
-    let mut crate_path = path.to_path_buf();
-    crate_path.pop();
+    // Pop one component to get to the `fuzz` crate.
+    let mut fuzz_path = path.to_path_buf();
+    fuzz_path.pop();
 
     let cargo_manifest: CargoManifest = toml::from_str(&read_file(path))
         .unwrap_or_else(|err| panic!("could not parse cargo manifest file {:?}: {}", path, err));
 
     Step::Multiple {
-        name: format!("fuzzing {:?}", &crate_path.file_name().unwrap()),
+        name: "run cargo-fuzz".to_owned(),
         steps: cargo_manifest
             .bin
             .iter()
@@ -233,7 +231,7 @@ pub fn run_fuzz_targets_in_crate(path: &Path, opt: &RunCargoFuzz) -> Step {
                         "--".to_string(),
                         ...opt.args
                     ],
-                    &crate_path,
+                    &fuzz_path,
                 ),
             })
             .collect(),


### PR DESCRIPTION
#3271 has moved fuzz targets to a top-level `fuzz` crate. As a result the `crate-name` option passed to the `run-cargo-fuzz` command is no longer needed. This PR removes it.   