### PR TITLE
Clean up GHCB sharing code

### DIFF
--- a/oak_restricted_kernel/src/mm/encrypted_mapper.rs
+++ b/oak_restricted_kernel/src/mm/encrypted_mapper.rs
@@ -59,6 +59,12 @@ pub struct PhysOffset {
     encryption: MemoryEncryption,
 }
 
+impl PhysOffset {
+    pub fn new(offset: VirtAddr, encryption: MemoryEncryption) -> Self {
+        PhysOffset { offset, encryption }
+    }
+}
+
 unsafe impl PageTableFrameMapping for PhysOffset {
     fn frame_to_pointer(&self, frame: PhysFrame) -> *mut PageTable {
         let virt = self.offset


### PR DESCRIPTION
The GHCB sharing code duplicated code around address translation and page table management that was already written elsewhere in the restricted kernel. This PR removes the duplication and simplifies the implementation.