### PR TITLE
Add support for CPUID to the GHCB protocol

### DIFF
--- a/experimental/sev_guest/src/cpuid.rs
+++ b/experimental/sev_guest/src/cpuid.rs
@@ -30,15 +30,38 @@ pub const CPUID_PAGE_SIZE: usize = 4096;
 #[repr(C)]
 #[derive(Debug, FromBytes)]
 pub struct CpuidFunction {
-    /// The input value of the EAX register when CPUID was called. This represents the CPUID leaf.
-    pub eax_in: u32,
-    /// The input value of the ECX register when CPUID was called. This represents the CPUID
-    /// sub-leaf.
-    pub ecx_in: u32,
-    /// The value of the XCR0 extended control register when CPUID was called.
-    pub xcr0_in: u64,
-    /// The value of the IA32_XSS model-specific register when CPUID was called.
-    pub xss_in: u64,
+    /// The input values when CPUID was invoked.
+    input: CpuidInput,
+    /// The resulting register values when CPUID was invoked.
+    output: CpuidOutput,
+    _reserved: u64,
+}
+
+static_assertions::assert_eq_size!(CpuidFunction, [u8; 48]);
+
+/// The required input valus for invoking CPUID.
+#[repr(C)]
+#[derive(Debug, FromBytes)]
+pub struct CpuidInput {
+    /// The input value of the EAX register, which represents the CPUID leaf.
+    pub eax: u32,
+    /// The input value of the ECX register, which represents the CPUID sub-leaf.
+    pub ecx: u32,
+    /// The input value of the XCR0 extended control register.
+    ///
+    /// Only required when a request for CPUID 0000_000D is made. Must be zero otherwise.
+    pub xcr0: u64,
+    /// The value of the IA32_XSS model-specific register.
+    ///
+    /// Only required when a request for CPUID 0000_000D is made and the guest supports the XSS
+    /// MSR. Must be zero otherwise.
+    pub xss: u64,
+}
+
+/// The resulting register values after invoking CPUID.
+#[repr(C)]
+#[derive(Debug, FromBytes)]
+pub struct CpuidOutput {
     /// The EAX register output from calling CPUID.
     pub eax: u32,
     /// The EBX register output from calling CPUID.
@@ -47,7 +70,6 @@ pub struct CpuidFunction {
     pub ecx: u32,
     /// The EDX register output from calling CPUID.
     pub edx: u32,
-    _reserved: u64,
 }
 
 /// Representation of the CPUID page.

--- a/experimental/sev_guest/src/cpuid.rs
+++ b/experimental/sev_guest/src/cpuid.rs
@@ -49,11 +49,11 @@ pub struct CpuidInput {
     pub ecx: u32,
     /// The input value of the XCR0 extended control register.
     ///
-    /// Only required when a request for CPUID 0000_000D is made. Must be zero otherwise.
+    /// Only required when a request for CPUID 0x0000_000D is made. Must be zero otherwise.
     pub xcr0: u64,
     /// The value of the IA32_XSS model-specific register.
     ///
-    /// Only required when a request for CPUID 0000_000D is made and the guest supports the XSS
+    /// Only required when a request for CPUID 0x0000_000D is made and the guest supports the XSS
     /// MSR. Must be zero otherwise.
     pub xss: u64,
 }

--- a/oak_restricted_kernel/src/ghcb.rs
+++ b/oak_restricted_kernel/src/ghcb.rs
@@ -33,6 +33,7 @@ use x86_64::{
     registers::control::Cr3,
     structures::paging::{
         mapper::PageTableFrameMapping, MappedPageTable, Page, PageSize, PhysFrame, Size2MiB,
+        Size4KiB,
     },
 };
 


### PR DESCRIPTION
The GHCB protocol provides a richer and more efficient mechanism for calling CPUID under AMD SEV-ES than the MSR protocol, including support for sub-leafs.

With AMD SEV-SNP the CPUID page can be used to get the information, but with SEV-ES there is no CPUID page.