### PR TITLE
SEV-ES: enable `RDRAND` in Oak Functions build

### DIFF
--- a/oak_functions_freestanding_bin/.cargo/config.toml
+++ b/oak_functions_freestanding_bin/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
 runner = "./runner"
-rustflags = "-C relocation-model=static -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,-soft-float"
+rustflags = "-C relocation-model=static -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,+rdrand,-soft-float"
 
 [unstable]
 build-std = ["core", "alloc"]


### PR DESCRIPTION
Given that our `#VC` handler is still buggy, any calls to `CPUID` fail right now. Case in point, the Rust getrandom crate will try to use `CPUID` to figure out if it can use `RDRAND`, which means we can't run under SEV-ES right now.

However... we can just force-enable the `RDRAND` instruction in the build target, optimizing away the `CPUID` check in getrandom. With this change we can run under SEV-ES!