### PR TITLE
Advance RIP in CPUID VC handler

### DIFF
--- a/experimental/sev_guest/src/interrupts.rs
+++ b/experimental/sev_guest/src/interrupts.rs
@@ -60,6 +60,7 @@ use x86_64::VirtAddr;
 /// It will point to the backed-up values of registers on the stack. This makes it possible to
 /// modify the register values that will be restored when the outer handler returns.
 #[repr(C)]
+#[derive(Debug)]
 pub struct MutableInterruptStackFrame {
     /// The backed-up value of the RAX register.
     pub rax: u64,

--- a/oak_restricted_kernel/src/interrupts.rs
+++ b/oak_restricted_kernel/src/interrupts.rs
@@ -144,7 +144,7 @@ mutable_interrupt_handler_with_error_code!(
                 let leaf = stack_frame.rax as u32;
                 get_cpuid_for_vc_exception(leaf, stack_frame).expect("Error reading CPUID");
                 // CPUID instruction is 2 bytes long, so we advance the instruction pointer by 2.
-                stack_frame.rip = VirtAddr::new(stack_frame.rip.as_u64() + 2);
+                stack_frame.rip += 2u64;
             }
             _ => {
                 error!("KERNEL PANIC: UNHANDLED #VC EXCEPTION");

--- a/oak_restricted_kernel/src/interrupts.rs
+++ b/oak_restricted_kernel/src/interrupts.rs
@@ -143,6 +143,8 @@ mutable_interrupt_handler_with_error_code!(
                 }
                 let leaf = stack_frame.rax as u32;
                 get_cpuid_for_vc_exception(leaf, stack_frame).expect("Error reading CPUID");
+                // CPUID instruction is 2 bytes long, so we advance the instruction pointer by 2.
+                stack_frame.rip = VirtAddr::new(stack_frame.rip.as_u64() + 2);
             }
             _ => {
                 error!("KERNEL PANIC: UNHANDLED #VC EXCEPTION");


### PR DESCRIPTION
I forgot to advance the instruction pointer past the CPUID instruction in the #VC exception handler, which meant that it kept on executing it after returning from the handler. This fixes the problem.