### PR TITLE
Don't use `CPUID` to detect whether SEV is enabled in stage0

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -238,7 +238,12 @@ SECTIONS {
         QUAD(0) /* 10 - #TS */
         QUAD(0) /* 11 - #NP */
         QUAD(0) /* 12 - #SS */
-        QUAD(0) /* 13 - #GP */
+        QUAD(   /* 13 - #GP */
+            (gp_handler & 0xFFFF0000) << 32 | /* target offset [31:16] */
+            DESCRIPTOR_PRESENT |
+            DESCRIPTOR_INTERRUPT_GATE |
+            cs32 << 16 |                      /* code segment selector */
+            gp_handler & 0xFFFF)              /* target offset [15:0] */
         QUAD(0) /* 14 - #PF */
         QUAD(0) /* 15 - reserved */
         QUAD(0) /* 16 - #MF */
@@ -254,12 +259,7 @@ SECTIONS {
         QUAD(0) /* 26 - reserved */
         QUAD(0) /* 27 - reserved */
         QUAD(0) /* 28 - #HV */
-        QUAD(   /* 29 - #VC */
-            (vc_handler & 0xFFFF0000) << 32 | /* target offset [31:16] */
-            DESCRIPTOR_PRESENT |
-            DESCRIPTOR_INTERRUPT_GATE |
-            cs32 << 16 |                      /* code segment selector */
-            vc_handler & 0xFFFF)              /* target offset [15:0] */
+        QUAD(0) /* 29 - #VC */
         QUAD(0) /* 30 - #SX */
         QUAD(0) /* 31 - reserved */
     } > bios


### PR DESCRIPTION
This implements the fake `RDMSR` handler we have in Restricted Kernel, in 32-bit bootstrap code in stage0.

We need to know whether SEV is enabled so that we'd know whether we have to toggle the encrypted bit in the page tables. Previously, we first called `CPUID` to figure out whether SEV is supported at all, before calling `RDMSR` to figure out whether SEV is enabled.

However... as we're not particularly thorough here (we don't check whether the CPUID page is supported at all, for example) it looks like some Intel CPUs gave us garbage in return which we interpreted as SEV support being there, which then caused stage0 to crash with a `#GP` when trying to read the MSR.

However, we can just shortcut the whole process and trap the `#GP` that happens when we try to read the MSR and it doesn't exist, instead of first checking CPUID. This makes the code simpler to reason about and more reliable.