### PR TITLE
Reduce the size of stage0 binary

### DIFF
--- a/stage0/.cargo/config.toml
+++ b/stage0/.cargo/config.toml
@@ -5,5 +5,5 @@ target = "x86_64-unknown-none"
 rustflags = "-C relocation-model=static -C code-model=large"
 
 [unstable]
-build-std = ["core", "alloc"]
+build-std = ["core"]
 build-std-features = ["compiler-builtins-mem"]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -15,6 +15,16 @@ oak_linux_boot_params = { path = "../linux_boot_params" }
 sev_guest = { path = "../experimental/sev_guest" }
 x86_64 = "*"
 
+[profile.dev]
+opt-level = "z"
+panic = "abort"
+
+[profile.release]
+opt-level = "z"
+debug = true
+lto = true
+panic = "abort"
+
 [[bin]]
 name = "oak_stage0"
 test = false

--- a/stage0/build.rs
+++ b/stage0/build.rs
@@ -14,7 +14,15 @@
 // limitations under the License.
 //
 
+use std::env;
+
 fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rustc-link-arg=--script=layout.ld");
+
+    if env::var("PROFILE").unwrap() == "release" {
+        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=64K");
+    } else {
+        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=256K");
+    }
 }

--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -15,7 +15,7 @@
 */
 
 HIDDEN(TOP = 4096M);
-HIDDEN(BIOS_SIZE = 512K);
+/* We assume BIOS_SIZE will be provided externally. */
 
 MEMORY {
     ram_low : ORIGIN = 0, LENGTH = 1M
@@ -152,7 +152,7 @@ SECTIONS {
         *(.data .data.*)
     } > bios
 
-    .bss :  {
+    .bss (NOLOAD) : {
         bss_start = .;
         *(.bss .bss.*)
         bss_size = . - bss_start;


### PR DESCRIPTION
There are three major things in here:
  * Enabling `opt-level = "z"` reduces the code by ~50K
  * enabling LTO (which prunes a lot of dead code) reduces code size ~10x (!!!) -- from 70K to 7K.
 
This means we can fit the debug build into 256K instead of 512K, and in theory the release build would fit into 48K (!!!).

There are other things we can do to trim the size down further; for example, we could move the stack to low memory and we have 12K worth of page table structures in the BIOS data area. We could construct them during runtime in low memory with far less code than that -- but, to be blunt, I'm amazed at how much just enabling LTO for release builds saved us.

My main goal was to shave it down enough so that the release build could fit into 128K, and that goal is met, so I've left the rest of the yak unshaven.