### PR TITLE
Enable LTO on Oak Functions binary

### DIFF
--- a/oak_functions_freestanding_bin/Cargo.toml
+++ b/oak_functions_freestanding_bin/Cargo.toml
@@ -36,3 +36,6 @@ static_assertions = "*"
 name = "oak_functions_freestanding_bin"
 test = false
 bench = false
+
+[profile.release]
+lto = true


### PR DESCRIPTION
For some yet unknown reason, the binary only works on SNP with this option or, or with some other random changes to the code. This is not a perfect solution, and will likely break again in the future, but at least it unblocks syncing previous changes to google3.