### PR TITLE
Remove unused tf_inference and metrics references

### DIFF
--- a/docs/oak_functions_abi.md
+++ b/docs/oak_functions_abi.md
@@ -128,29 +128,6 @@ The following
 [`ExtensionHandles`](https://github.com/project-oak/oak/blob/main/oak_functions/proto/abi.proto)
 are currently supported:
 
-- `TfHandle`: The Oak Functions runtime runs the TensorFlow model specified in
-  the Oak Functions runtime configuration on the given input vector. The
-  extesion returns an error if either the input vector was malformed or the
-  decoding of the resulting inference failed. This is experimental, and only
-  available with the unsafe version of the Oak Functions runtime.
-- `MetricsHandle`: The Oak Functions WebAssembly module reports the metric value
-  `value` for a sum-based metric bucket identified by a `label` from the
-  `ReportMetricsRequest`. The Oak Functions runtime attempts to interpret the
-  bytes in the label buffer as a UTF-8 encoded string. If the decoding is
-  successful, the string is used as a label to identify the bucket. If the bytes
-  are not a valid UTF-8 string or the string does not match the label of a
-  configured bucket the metric value will be ignored.
-
-  If differentially-private metrics are enabled in the configuration the
-  aggregated bucket totals per label will be logged in batches after the
-  required amount of noise has been added. Only buckets that are explicitly
-  allowed in the configuration will be tracked and included in the results.
-
-  If metrics are reported for the same bucket multiple times in a single request
-  only the last reported value will be used for that request. If values are not
-  reported for some buckets during a request it will be treated as if values of
-  0 were reported for those buckets.
-
 - `LookupHandle`: The Oak Functions runtime retrieves a single (optional) item
   for the given key from the lookup data in-memory store of the Oak Functions
   runtime. If no item with the given key is found, it returns `None`.

--- a/oak_functions/README.md
+++ b/oak_functions/README.md
@@ -3,7 +3,7 @@
 The objective of Oak Functions is to design and implement a general-purpose
 computing platform that allows developing stateless applications in a privacy
 preserving way. Oak Functions leverages TEEs and remote attestation, Wasm
-sandboxing, and allows exposing metrics in a Differentially Private way.
+sandboxing.
 
 At its core, Oak Functions consists of a **trusted runtime** compiled into a
 server binary ([`oak_functions_loader`](loader/)) that, for each incoming client
@@ -76,7 +76,3 @@ compared to Oak, but those use cases are the most commonly occurring ones. One
 apparent restriction is the use of a read-only in-memory storage. With a
 distributed runtime, however, it should be possible to use Oak Functions for
 applications that require a larger storage.
-
-We have an experimental support for ML-inference using TensorFlow models in Oak
-Functions. The benefit of this, compared to running ML-inference on-device, is
-that the model will remain protected and secure.

--- a/oak_functions/proto/abi.proto
+++ b/oak_functions/proto/abi.proto
@@ -30,8 +30,6 @@ enum ExtensionHandle {
   TESTING_HANDLE = 1;
   LOOKUP_HANDLE = 2;
   LOGGING_HANDLE = 3;
-  METRICS_HANDLE = 4;
-  TF_HANDLE = 5;
 }
 
 // Status values exchanged as i32 values across the Node Wasm interface.
@@ -47,13 +45,6 @@ enum OakStatus {
   ERR_INVALID_HANDLE = 4;
   // Error when serializing the request or deserializing the response fails in the Wasm module.
   ERR_SERIALIZING = 5;
-}
-
-// The inference from a TensorFlow model, containing an inference vector of floats, and a shape
-// vector specifying the dimensions of the inference vector.
-message Inference {
-  repeated uint64 shape = 1;
-  repeated float inference_vec = 2;
 }
 
 // The client can check the configuration report for the configuration of the Oak Functions runtime.
@@ -86,12 +77,4 @@ message ServerPolicy {
   // sends a response to the client containing an error message indicating the failure. The size
   // of this response is equal to the size specified by the previous parameter.
   uint32 constant_processing_time_ms = 2;
-}
-
-// Configuration for differentially private metrics.
-message PrivateMetricsConfig {
-  // The privacy budget.
-  double epsilon = 1;
-  // The number of requests that will be aggregated into each batch.
-  uint32 batch_size = 2;
 }

--- a/oak_functions/wasm/src/tests.rs
+++ b/oak_functions/wasm/src/tests.rs
@@ -32,9 +32,9 @@ fn test_invoke_extension_with_invalid_handle() {
 #[test]
 fn test_find_extension_not_available() {
     let mut wasm_state = create_test_wasm_state();
-    // Assumes we have no TF extension in our test wasm_state. The remaining arguments don't
-    // matter, hence they are 0.
-    let extension = wasm_state.invoke_extension(ExtensionHandle::TfHandle as i32, 0, 0, 0, 0);
+    // Assumes we have no extension with a handle value of 5 in our test wasm_state. The remaining
+    // arguments don't matter, hence they are 0.
+    let extension = wasm_state.invoke_extension(5, 0, 0, 0, 0);
     assert!(extension.is_err());
     assert_eq!(OakStatus::ErrInvalidHandle, extension.unwrap_err())
 }

--- a/oak_functions_abi/src/lib.rs
+++ b/oak_functions_abi/src/lib.rs
@@ -209,36 +209,6 @@ impl TryFrom<&[u8]> for StorageGetItemResponse {
     }
 }
 
-/// Holds the `label` and the `value` to report a metric.
-#[derive(Serialize, Deserialize)]
-pub struct ReportMetricRequest {
-    pub label: String,
-    pub value: i64,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum ReportMetricError {
-    ProxyAlreadyConsumed,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct ReportMetricResponse {
-    pub result: Result<(), ReportMetricError>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum TfModelInferError {
-    // Error when running the TensorFlow model, due to bad input tensor.
-    BadTensorFlowModelInput,
-    // Error when decoding the inference bytes.
-    ErrorDecodingInference,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct TfModelInferResponse {
-    pub result: Result<Vec<u8>, TfModelInferError>,
-}
-
 #[derive(Serialize, Deserialize)]
 pub enum TestingRequest {
     Echo(String),


### PR DESCRIPTION
The TF Infrerence and Differentially Private metrics code has been removed, but there were still a few references to it in the code base.