### PR TITLE
Turn off LTO on `oak_functions_freestanding_bin`

### DIFF
--- a/oak_functions_freestanding_bin/Cargo.toml
+++ b/oak_functions_freestanding_bin/Cargo.toml
@@ -36,6 +36,3 @@ static_assertions = "*"
 name = "oak_functions_freestanding_bin"
 test = false
 bench = false
-
-[profile.release]
-lto = true


### PR DESCRIPTION
@tiziano88 added this in #3435 as it seemed to help with weird errors we were seeing while running under SEV-SNP; however, it looks like @conradgrobler fixed the real underlying problem in #3441.

Thus, let's disable LTO, again. This is not to say we shouldn't enable LTO or LTO is bad; in fact, we probably should enable it, and will likely do so in the future. For now, I want to reduce the number of baseline changes until we're certain we caught the bug.