### PR TITLE
Implement a synchronized no_std OnceCell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,6 +2590,7 @@ name = "oak_functions_utils"
 version = "0.1.0"
 dependencies = [
  "lock_api",
+ "spinning_top",
 ]
 
 [[package]]

--- a/oak_functions_freestanding_bin/Cargo.lock
+++ b/oak_functions_freestanding_bin/Cargo.lock
@@ -657,6 +657,7 @@ name = "oak_functions_utils"
 version = "0.1.0"
 dependencies = [
  "lock_api",
+ "spinning_top",
 ]
 
 [[package]]

--- a/oak_functions_utils/Cargo.toml
+++ b/oak_functions_utils/Cargo.toml
@@ -6,3 +6,4 @@ license = "Apache-2.0"
 
 [dependencies]
 lock_api = { version = "*", features = ["arc_lock"] }
+spinning_top = "*"

--- a/oak_functions_utils/src/sync.rs
+++ b/oak_functions_utils/src/sync.rs
@@ -15,10 +15,70 @@
 //
 
 use core::{
+    cell::UnsafeCell,
     hint::spin_loop,
+    mem::MaybeUninit,
     sync::atomic::{AtomicBool, Ordering},
 };
 use lock_api::{GuardSend, RawMutex};
+use spinning_top::RawSpinlock;
+
+/// A synchronised implementation of a cell that can be initialized only once.
+///
+/// This achieves the same goal as `std::sync::OnceLock`, but uses a spinlock to be compatible with
+/// `no_std`.
+pub struct OnceCell<T> {
+    initialized: AtomicBool,
+    lock: RawSpinlock,
+    value: UnsafeCell<MaybeUninit<T>>,
+}
+
+impl<T> OnceCell<T> {
+    pub const fn new() -> Self {
+        Self {
+            initialized: AtomicBool::new(false),
+            lock: RawSpinlock::INIT,
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+
+    pub fn get(&self) -> Option<&T> {
+        if !self.initialized.load(Ordering::Acquire) {
+            return None;
+        }
+        // Safety: there are no mutable references to the inner value if `initialized` is set to
+        // `true`, and the value has been initialized, so it is safe to create a new shared
+        // reference and assume it is initialized.
+        Some(unsafe { (*self.value.get()).assume_init_ref() })
+    }
+
+    pub fn set(&self, value: T) -> Result<(), T> {
+        let mut result = Ok(());
+        // Do an initial check to see whether the value has been initialized.
+        if !self.initialized.load(Ordering::Acquire) {
+            // Lock to make sure we have exclusive access.
+            self.lock.lock();
+            // Double check that someone else didn't initialize while we were waiting to get the
+            // lock. Relaxed ordering is sufficient since the lock acts as a memory barrier and also
+            // ensures no concurrent access to the code that stores the value.
+            if !self.initialized.load(Ordering::Relaxed) {
+                // Safety: the combination of the lock and the fact that `initialized` is `false`
+                // ensures that we have exclusive access to the inner value, so taking a mutable
+                // reference to it is safe.
+                unsafe { &mut *self.value.get() }.write(value);
+                self.initialized.store(true, Ordering::Release);
+            } else {
+                result = Err(value);
+            }
+            // Safety: we acquired the lock in the same context, so unlocking here is safe.
+            unsafe { self.lock.unlock() };
+        } else {
+            result = Err(value);
+        }
+
+        result
+    }
+}
 
 pub struct SpinLock(AtomicBool);
 
@@ -55,3 +115,30 @@ unsafe impl RawMutex for SpinLock {
 
 pub type Mutex<T> = lock_api::Mutex<SpinLock, T>;
 pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, SpinLock, T>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_once_cell_get_uninitialized() {
+        let cell = OnceCell::<u64>::new();
+        assert!(cell.get().is_none());
+    }
+
+    #[test]
+    fn test_once_cell_set_and_get() {
+        let cell = OnceCell::<u64>::new();
+        assert!(cell.get().is_none());
+        assert!(cell.set(4).is_ok());
+        assert_eq!(cell.get(), Some(&4));
+    }
+
+    #[test]
+    fn test_once_cell_set_twice() {
+        let cell = OnceCell::<u64>::new();
+        assert!(cell.set(4).is_ok());
+        assert_eq!(cell.set(5), Err(5));
+        assert_eq!(cell.get(), Some(&4));
+    }
+}


### PR DESCRIPTION
This PR provides an implementation of a synchronised OnceCell. We want this so that we can move away from using `lazy_static!` and have better control over the initialisation of static variables throughout.

See #3403 for more information.

The `oak_functions_utils` crate also contains a spinlock implementation, but this OnceCell implementation uses the spinlock from the `spinning_top` crate. We rely on the `spinning_top` crate for some other dependencies (such as the linked-list allocator), and having two equivalent but different spinlock implementations is not needed. I will remove our spinlock implementation and rename the crate in a follow-up PR.