### PR TITLE
Add a 4K page table for the lowest 2M of memory in stage0

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -132,13 +132,23 @@ SECTIONS {
     pdpt_addr = ADDR(.rodata.pdpt);
 
     .rodata.pd ALIGN(4K) : {
-        QUAD(0 | PAGE_PRESENT | PAGE_WRITABLE | PAGE_SIZE) /* 0 .. 2 MiB */
+        QUAD(ADDR(.rodata.pt) | PAGE_PRESENT | PAGE_WRITABLE) /* 0 .. 2 MiB */
         FILL(0x00)
         . += 510 * 8;
         QUAD((TOP - 2M) | PAGE_PRESENT | PAGE_WRITABLE | PAGE_SIZE) /* (4GiB - 2MiB) .. 4 GiB */
     } > bios
 
     pd_addr = ADDR(.rodata.pd);
+
+    .rodata.pt ALIGN(4K) : {
+        /* This will be filled in the bootstrap assembly code. We do this as having 512 lines
+         * here would be unwieldy.
+         */
+        FILL(0x00)
+        . += 4K;
+    } > bios
+
+    pt_addr = ADDR(.rodata.pt);
 
     .rodata : {
         KEEP(*(.rodata .rodata.*))

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -35,7 +35,7 @@ pub fn validate_memory(zero_page: &BootParams, encrypted: u64) {
         unsafe { &*((pml4_frame.start_address().as_u64() & !encrypted) as *const PageTable) };
     let pdpt = unsafe { &*((pml4[0].addr().as_u64() & !encrypted) as *const PageTable) };
     let pd = unsafe { &mut *((pdpt[0].addr().as_u64() & !encrypted) as *mut PageTable) };
-    if !pd[1].is_unused() {
+    if pd[1].flags().contains(PageTableFlags::PRESENT) {
         panic!("PD[1] is in use");
     }
     pd[1].set_addr(


### PR DESCRIPTION
Thus far we've relied on three levels of page tables (PML4, PDPT, PD) leaving the leaf covering [0, 2MiB) in the PD to be a 2M hugepage.

However, we want to designate one 4K page in there as the GHCB for early logging under SEV-SNP, which requires us to change flags for just that 4K page, and not the whole 2M page.

Therefore, let's break the 2M page into 512 4K pages, and introduce a fourth-level page table (PT) for that memory area.

Instead of copy-pasting something in the linker script 512 times, I've written a small loop in assembly to set up the page table.

As we can't rely on hard-coded entries, setting the encrypted bit is both simpler and more complicated: I thought it'd be easiest just to blanket set the encrypted bit in all 512 entries of all four page tables, even if the entries are unused. As those entries don't have the `PRESENT` bit set, the CPU ignores those entries.