### PR TITLE
Set up an early GHCB page in stage0.

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -107,6 +107,11 @@ SECTIONS {
     } > ram_low
     ASSERT(SIZEOF(.boot.cpuid) == 4K, "CPUID section has to be exactly one page in size")
 
+    .boot.ghcb ALIGN(4K) (NOLOAD) : {
+        KEEP(*(.boot.ghcb))
+    } > ram_low
+    ASSERT(SIZEOF(.boot.ghcb) == 4K, "GHCB has to be exactly one page in size")
+
     .boot ALIGN(4K) (NOLOAD) : {
         KEEP(*(.boot))
         . = ALIGN(4K);
@@ -316,8 +321,8 @@ SECTIONS {
          * Thankfully none of these clashed with existing data structures that we're setting up.
          */
         /* Unmeasured page location */
-        LONG(ADDR(.boot))
-        LONG(SIZEOF(.boot))
+        LONG(ADDR(.boot.ghcb))
+        LONG(SIZEOF(.boot.ghcb))
         LONG(SEV_SECTION_UNMEASURED)
         /* Secrets page location */
         LONG(ADDR(.boot.secrets))


### PR DESCRIPTION
We need a GHCB page to use the IOIO protocol under SEV-ES/SNP for two reasons:
  - We want to do some early logging, which means we need to access the serial port.
  - We need to set up the E820 tables, for which we need to use the QEMU `fw_cfg` interface, which again implies using IO ports.

Both of these will be tackled separately in future PRs; this just sets up a GHCB page for us to use in the future.

In particular, we'd like the comms to be initialized as early as possible. Earlier than the point we run `PVALIDATE` on physical memory; partly because we need to query `fw_cfg` to figure out what the physical memory is at all. Thus, we ask the GHCB location to be pre-validated in the SEV metadata blob.

