### PR TITLE
Initialize the SNP CPUID and secrets pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
  "linked_list_allocator",
  "log",
  "oak_channel",
+ "oak_core",
  "oak_linux_boot_params",
  "oak_simple_io",
  "rust-hypervisor-firmware-virtio",
@@ -2796,6 +2797,7 @@ dependencies = [
  "uart_16550",
  "virtio",
  "x86_64",
+ "zerocopy",
 ]
 
 [[package]]

--- a/oak_core/src/sync.rs
+++ b/oak_core/src/sync.rs
@@ -71,6 +71,12 @@ impl<T> OnceCell<T> {
     }
 }
 
+// Safety: It is safe to share references across threads since the inner value will only be set
+// while an exclusive lock is held and only once. Until it is set there can be no shared references
+// to it, and once it is set, and there are potential shared references to it, it will never be
+// modified again.
+unsafe impl<T> Sync for OnceCell<T> where T: Send + Sync {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/oak_functions_freestanding_bin/Cargo.lock
+++ b/oak_functions_freestanding_bin/Cargo.lock
@@ -585,6 +585,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_core"
+version = "0.1.0"
+dependencies = [
+ "lock_api",
+ "spinning_top",
+]
+
+[[package]]
 name = "oak_functions_abi"
 version = "0.1.0"
 dependencies = [
@@ -760,6 +768,7 @@ dependencies = [
  "linked_list_allocator",
  "log",
  "oak_channel",
+ "oak_core",
  "oak_linux_boot_params",
  "oak_simple_io",
  "rust-hypervisor-firmware-virtio",
@@ -771,6 +780,7 @@ dependencies = [
  "uart_16550",
  "virtio",
  "x86_64",
+ "zerocopy",
 ]
 
 [[package]]

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -31,6 +31,7 @@ log = "*"
 libc = { version = "*", optional = true }
 libm = "*"
 oak_channel = { path = "../oak_channel" }
+oak_core = { path = "../oak_core" }
 oak_simple_io = { path = "../oak_simple_io", optional = true }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 rust-hypervisor-firmware-virtio = { path = "../third_party/rust-hypervisor-firmware-virtio" }
@@ -42,6 +43,7 @@ strum = { version = "*", default-features = false, features = ["derive"] }
 uart_16550 = { version = "*", optional = true }
 virtio = { path = "../experimental/virtio", optional = true }
 x86_64 = "*"
+zerocopy = "*"
 
 [dev-dependencies]
 assertables = "*"

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -97,9 +97,9 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     let protocol = info.protocol();
     info!("Boot protocol:  {}", protocol);
     let snp_pages = if sev_status.contains(SevStatus::SNP_ACTIVE) {
-        // We have get the physical addresses of the CPUID pages now while the identity mapping is
-        // still in place, but we can only initialize the instances after the new page mappings
-        // have been set up.
+        // We have to get the physical addresses of the CPUID pages now while the identity mapping
+        // is still in place, but we can only initialize the instances after the new page
+        // mappings have been set up.
         Some(get_snp_page_addresses(info))
     } else {
         None

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -53,12 +53,16 @@ mod serial;
 pub mod shutdown;
 #[cfg(feature = "simple_io_channel")]
 mod simpleio;
+mod snp;
 #[cfg(any(feature = "virtio_console_channel", feature = "vsock_channel"))]
 mod virtio;
 
 extern crate alloc;
 
-use crate::mm::Translator;
+use crate::{
+    mm::Translator,
+    snp::{init_snp_pages, try_get_snp_page_addresses},
+};
 use alloc::{alloc::Allocator, boxed::Box};
 use core::{cell::OnceCell, marker::Sync, panic::PanicInfo, str::FromStr};
 use linked_list_allocator::LockedHeap;
@@ -92,6 +96,14 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
 
     let protocol = info.protocol();
     info!("Boot protocol:  {}", protocol);
+    let snp_pages = if sev_status.contains(SevStatus::SNP_ACTIVE) {
+        // We have get the physical addresses of the CPUID pages now while the identity mapping is
+        // still in place, but we can only initialize the instances after the new page mappings
+        // have been set up.
+        Some(try_get_snp_page_addresses(info).expect("Could not find valid SEV-SNP pages."))
+    } else {
+        None
+    };
 
     // Safety: in the linker script we specify that the ELF header should be placed at 0x200000.
     let program_headers = unsafe { elf::get_phdrs(VirtAddr::new(0x20_0000)) };
@@ -101,9 +113,19 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
 
     let mut mapper = mm::init_paging(&mut frame_allocator, program_headers).unwrap();
 
-    // Now that the page tables have been updated, we have to re-share the GHCB with the hypervisor.
     if sev_status.contains(SevStatus::SEV_ES_ENABLED) {
+        // Now that the page tables have been updated, we have to re-share the GHCB with the
+        // hypervisor.
         ghcb::reshare_ghcb(&mut mapper);
+        if sev_status.contains(SevStatus::SNP_ACTIVE) {
+            // We must also initialise the CPUID and secrets pages when SEV-SNP is active. Panicking
+            // is OK at this point, because these pages are required to support the full features
+            // and we don't want to run without them.
+            init_snp_pages(
+                snp_pages.expect("Missing SNP CPUID and secrets pages."),
+                &mapper,
+            );
+        }
     }
 
     // Allocate a section for guest-host communication (without the `ENCRYPTED` bit set)

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -61,7 +61,7 @@ extern crate alloc;
 
 use crate::{
     mm::Translator,
-    snp::{init_snp_pages, try_get_snp_page_addresses},
+    snp::{get_snp_page_addresses, init_snp_pages},
 };
 use alloc::{alloc::Allocator, boxed::Box};
 use core::{cell::OnceCell, marker::Sync, panic::PanicInfo, str::FromStr};
@@ -100,7 +100,7 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
         // We have get the physical addresses of the CPUID pages now while the identity mapping is
         // still in place, but we can only initialize the instances after the new page mappings
         // have been set up.
-        Some(try_get_snp_page_addresses(info).expect("Could not find valid SEV-SNP pages."))
+        Some(get_snp_page_addresses(info))
     } else {
         None
     };

--- a/oak_restricted_kernel/src/snp.rs
+++ b/oak_restricted_kernel/src/snp.rs
@@ -47,9 +47,9 @@ pub struct SnpPageAddresses {
 /// Tries to extract the guest-physical addresses of the SEV-SNP secrets page and CPUID page.
 ///
 /// This function must only be used while the identity mapping is still in place, since the pointers
-/// in the boot paramter page was constructed by the Stage 0 firmware with an identity mapping.
+/// in the boot parameter page was constructed by the Stage 0 firmware with an identity mapping.
 ///
-/// This function will panic if the boot paramter page is not valid.
+/// This function will panic if the boot parameter page is not valid.
 pub fn get_snp_page_addresses(info: &BootParams) -> SnpPageAddresses {
     // Check that the address of the boot parameter page looks OK.
     let base_address = VirtAddr::from_ptr(info as *const BootParams);
@@ -134,7 +134,7 @@ pub fn init_snp_pages<T: Translator>(snp_pages: SnpPageAddresses, mapper: &T) {
         .expect("Couldn't set secrets page.");
 }
 
-/// Panics is the physical address is not the start of a 4KiB page, null, or not below the maximum
+/// Panics if the physical address is not the start of a 4KiB page, null, or not below the maximum
 /// expected address.
 fn assert_page_in_valid_range(page: PhysAddr) {
     assert!(!page.is_null(), "Address is null");

--- a/oak_restricted_kernel/src/snp.rs
+++ b/oak_restricted_kernel/src/snp.rs
@@ -1,0 +1,175 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::mm::Translator;
+use anyhow::Context;
+use core::slice::from_raw_parts;
+use oak_core::sync::OnceCell;
+use oak_linux_boot_params::{BootParams, CCBlobSevInfo, CCSetupData, SetupDataType};
+use sev_guest::{cpuid::CpuidPage, secrets::SecretsPage};
+use x86_64::{
+    structures::paging::{PageSize, Size2MiB, Size4KiB},
+    PhysAddr, VirtAddr,
+};
+use zerocopy::FromBytes;
+
+/// The exclusive upper limit of the address range where we expect the SNP-specific pages to reside.
+///
+/// We expect the boot paramteres and the CPUID and secrets pages to all be placed in the first 1MiB
+/// of physical memory by the Stage 0 Firmware, so we can use this range to help with validation.
+const MAX_ADDRESS: PhysAddr = PhysAddr::new_truncate(Size2MiB::SIZE / 2);
+
+/// The SEV-SNP secrets page.
+pub static SECRETS_PAGE: OnceCell<SecretsPage> = OnceCell::new();
+
+/// The SEV-SNP CPUID page.
+pub static CPUID_PAGE: OnceCell<CpuidPage> = OnceCell::new();
+
+/// Wrapper for the guest-physical addresses of the secrets page and the CPUID page.
+pub struct SnpPageAddresses {
+    pub secrets_page_address: PhysAddr,
+    pub cpuid_page_address: PhysAddr,
+}
+
+/// Tries to extract the guest-physical addresses of the SEV-SNP secrets page and CPUID page.
+///
+/// This function must only be used while the identity mapping is still in place, since the pointers
+/// in the boot paramter page was constructed by the Stage 0 firmware with an identity mapping.
+pub fn try_get_snp_page_addresses(info: &BootParams) -> anyhow::Result<SnpPageAddresses> {
+    let base_address = VirtAddr::from_ptr(info as *const BootParams);
+    // We assume an identity mapping from virtual to physical address.
+    let phys = PhysAddr::new(base_address.as_u64());
+    // Check that the physical address is page-aligned and in the expected range below 1MiB.
+    check_page_under_max_address(phys).context("Invalid boot parameter page")?;
+    // The setup data is stored in a null-terminated linked list, so we step through the list until
+    // we find and entry with the right type or reach the end.
+    let mut setup_data_ptr = info.hdr.setup_data;
+    while !setup_data_ptr.is_null() {
+        check_pointer_in_4kib_page(setup_data_ptr, base_address)?;
+        // Safety: we have checked that the pointer is not null and at least points to memory
+        // within the boot paramter page.
+        let setup_data = unsafe { &*setup_data_ptr };
+        let type_ = setup_data.type_;
+        if type_ == SetupDataType::CCBlob {
+            break;
+        }
+        setup_data_ptr = setup_data.next;
+    }
+
+    if setup_data_ptr.is_null() {
+        anyhow::bail!("Couldn't find setup data of type CCBlob.");
+    }
+
+    // Safety: we have checked that the pointer is not null, at least points to memory within the
+    // boot paramter page and has the appropriate value for the type field set.
+    let cc_blob_address =
+        unsafe { &*(setup_data_ptr as *const CCSetupData) }.cc_blob_address as *const CCBlobSevInfo;
+
+    check_pointer_in_4kib_page(cc_blob_address, base_address)?;
+    // Safety: we have checked that the pointer is not null and at least points to memory within the
+    // boot paramter page. We also validate the magic number as an additional check.
+    let cc_blob = unsafe { &*cc_blob_address };
+    let magic = cc_blob.magic;
+    if magic != oak_linux_boot_params::CC_BLOB_SEV_INFO_MAGIC {
+        anyhow::bail!("CCBlobSevInfo data structure has invalid magic: {}", magic);
+    }
+
+    let cpuid_page_address = PhysAddr::try_new(cc_blob.cpuid_phys as u64)
+        .map_err(|_| anyhow::anyhow!("Invalid CPUID page physical address."))?;
+    let secrets_page_address = PhysAddr::try_new(cc_blob.secrets_phys as u64)
+        .map_err(|_| anyhow::anyhow!("Invalid secrets page physical address."))?;
+    Ok(SnpPageAddresses {
+        secrets_page_address,
+        cpuid_page_address,
+    })
+}
+
+/// Iinitializes the references to the SEV-SNP CPUID and secrets pages.
+///
+/// This function will panic if it is called more than once or if page addresses outside of the
+/// expected range are supplied.
+///
+/// Panicking throughout this functions is OK, because if any of these values are invalid it means
+/// the environment was not set up correctly and we don't know how to recover from that.
+pub fn init_snp_pages<T: Translator>(snp_pages: SnpPageAddresses, mapper: &T) {
+    // First make sure the addresses look OK: they are not null, point to the start of a 4KiB page,
+    // and within the expected area.
+    if snp_pages.cpuid_page_address.is_null() {
+        panic!("CPUID page address is null.")
+    }
+    check_page_under_max_address(snp_pages.cpuid_page_address)
+        .expect("Invalid CPUID page address.");
+    if snp_pages.secrets_page_address.is_null() {
+        panic!("Secrets page address is null.")
+    }
+    check_page_under_max_address(snp_pages.secrets_page_address)
+        .expect("Invalid secrets page address.");
+
+    let cpuid_page_address = mapper
+        .translate_physical(snp_pages.cpuid_page_address)
+        .expect("Couldn't find a valid virtual address for the CPUID page.");
+    // Safety: we have checked that the pointer is in the expected valid memory range, not null, and
+    // 4KiB page-aligned.
+    let cpuid_slice: &[u8] =
+        unsafe { from_raw_parts(cpuid_page_address.as_ptr(), Size4KiB::SIZE as usize) };
+    CPUID_PAGE
+        .set(CpuidPage::read_from(cpuid_slice).expect("CPUID page byte slice was invalid."))
+        .expect("Couldn't set CPUID page.");
+
+    let secrets_page_address = mapper
+        .translate_physical(snp_pages.secrets_page_address)
+        .expect("Couldn't find a valid virtual address for the secrets page.");
+    // Safety: we have checked that the pointer is in the expected valid memory range, not null, and
+    // 4KiB page-aligned.
+    let secrets_slice: &[u8] =
+        unsafe { from_raw_parts(secrets_page_address.as_ptr(), Size4KiB::SIZE as usize) };
+    SECRETS_PAGE
+        .set(SecretsPage::read_from(secrets_slice).expect("Secrets page byte slice was invalid."))
+        .expect("Couldn't set secrets page.");
+}
+
+/// Checks that the physical address is the start of a 4KiB page that is below the maximum expected
+/// address.
+fn check_page_under_max_address(page: PhysAddr) -> anyhow::Result<()> {
+    if page.align_down(Size4KiB::SIZE) != page {
+        anyhow::bail!(
+            "The address {:#018x} is not the start of a 4KiB page.",
+            page
+        );
+    }
+    if page >= MAX_ADDRESS {
+        anyhow::bail!(
+            "Address {:#018x} is not below the expected maximum address {:#018x}",
+            page,
+            MAX_ADDRESS
+        )
+    }
+    Ok(())
+}
+
+/// Checks that the pointer points to an address that falls in the 4KiB page starting at
+/// `page_start`.
+fn check_pointer_in_4kib_page<T>(pointer: *const T, page_start: VirtAddr) -> anyhow::Result<()> {
+    let address = VirtAddr::from_ptr(pointer);
+    if address < page_start || address >= page_start + Size4KiB::SIZE {
+        anyhow::bail!(
+            "Pointer {:#018x} is not in the 4KiB page starting at {:#018x}",
+            address,
+            page_start
+        )
+    }
+    Ok(())
+}

--- a/oak_tensorflow_freestanding_bin/Cargo.lock
+++ b/oak_tensorflow_freestanding_bin/Cargo.lock
@@ -260,6 +260,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_core"
+version = "0.1.0"
+dependencies = [
+ "lock_api",
+ "spinning_top",
+]
+
+[[package]]
 name = "oak_idl"
 version = "0.1.0"
 dependencies = [
@@ -300,6 +308,7 @@ dependencies = [
  "linked_list_allocator",
  "log",
  "oak_channel",
+ "oak_core",
  "oak_linux_boot_params",
  "oak_simple_io",
  "rust-hypervisor-firmware-virtio",
@@ -310,6 +319,7 @@ dependencies = [
  "strum",
  "virtio",
  "x86_64",
+ "zerocopy",
 ]
 
 [[package]]

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -254,6 +254,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_core"
+version = "0.1.0"
+dependencies = [
+ "lock_api",
+ "spinning_top",
+]
+
+[[package]]
 name = "oak_echo_bin"
 version = "0.1.0"
 dependencies = [
@@ -318,6 +326,7 @@ dependencies = [
  "linked_list_allocator",
  "log",
  "oak_channel",
+ "oak_core",
  "oak_linux_boot_params",
  "oak_simple_io",
  "rust-hypervisor-firmware-virtio",
@@ -328,6 +337,7 @@ dependencies = [
  "strum",
  "virtio",
  "x86_64",
+ "zerocopy",
 ]
 
 [[package]]

--- a/testing/oak_echo_raw_bin/Cargo.lock
+++ b/testing/oak_echo_raw_bin/Cargo.lock
@@ -229,6 +229,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_core"
+version = "0.1.0"
+dependencies = [
+ "lock_api",
+ "spinning_top",
+]
+
+[[package]]
 name = "oak_echo_raw_bin"
 version = "0.1.0"
 dependencies = [
@@ -281,6 +289,7 @@ dependencies = [
  "linked_list_allocator",
  "log",
  "oak_channel",
+ "oak_core",
  "oak_linux_boot_params",
  "oak_simple_io",
  "rust-hypervisor-firmware-virtio",
@@ -291,6 +300,7 @@ dependencies = [
  "strum",
  "virtio",
  "x86_64",
+ "zerocopy",
 ]
 
 [[package]]


### PR DESCRIPTION
When SEV-SNP is enabled the Stage 0 firmware provides the addresses of the SNP-specific pages (CPUID and secrets pages) as part of the boot parameters.

This PR reads the locations of the pages from the boot paramters and initialises static instances. Using the information from these pages will be done in follow-up PRs.