### PR TITLE
Update TFLM to support REDUCE_ANY OP

### DIFF
--- a/third_party/tflite-micro/tensorflow/lite/core/api/error_reporter.h
+++ b/third_party/tflite-micro/tensorflow/lite/core/api/error_reporter.h
@@ -34,26 +34,25 @@ namespace tflite {
 /// that drives a GUI error log box.
 class ErrorReporter {
  public:
-  virtual ~ErrorReporter() {}
+  virtual ~ErrorReporter() = default;
+  /// Converts `args` to character equivalents according to `format` string,
+  /// constructs the error string and report it.
+  /// Returns number of characters written or zero on success, and negative
+  /// number on error.
   virtual int Report(const char* format, va_list args) = 0;
+
+  /// Converts arguments to character equivalents according to `format` string,
+  /// constructs the error string and report it.
+  /// Returns number of characters written or zero on success, and negative
+  /// number on error.
   int Report(const char* format, ...);
+
+  /// Equivalent to `Report` above. The additional `void*` parameter is unused.
+  /// This method is for compatibility with macros that takes `TfLiteContext`,
+  /// like TF_LITE_ENSURE and related macros.
   int ReportError(void*, const char* format, ...);
 };
 
 }  // namespace tflite
-
-// You should not make bare calls to the error reporter, instead use the
-// TF_LITE_REPORT_ERROR macro, since this allows message strings to be
-// stripped when the binary size has to be optimized. If you are looking to
-// reduce binary size, define TF_LITE_STRIP_ERROR_STRINGS when compiling and
-// every call will be stubbed out, taking no memory.
-#ifndef TF_LITE_STRIP_ERROR_STRINGS
-#define TF_LITE_REPORT_ERROR(reporter, ...)                             \
-  do {                                                                  \
-    static_cast<tflite::ErrorReporter*>(reporter)->Report(__VA_ARGS__); \
-  } while (false)
-#else  // TF_LITE_STRIP_ERROR_STRINGS
-#define TF_LITE_REPORT_ERROR(reporter, ...)
-#endif  // TF_LITE_STRIP_ERROR_STRINGS
 
 #endif  // TENSORFLOW_LITE_CORE_API_ERROR_REPORTER_H_

--- a/third_party/tflite-micro/tensorflow/lite/core/api/error_reporter_macro.h
+++ b/third_party/tflite-micro/tensorflow/lite/core/api/error_reporter_macro.h
@@ -1,0 +1,36 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_CORE_API_ERROR_REPORTER_MACRO_H_
+#define TENSORFLOW_LITE_CORE_API_ERROR_REPORTER_MACRO_H_
+
+#include "tensorflow/lite/core/api/error_reporter.h"
+
+// This Macro is intended to be used only by the code that TFLite Micro
+// shares with TFLite. In the code that is shared with TFLM you should
+// not make bare calls to the error reporter, instead use the
+// TF_LITE_REPORT_ERROR macro, since this allows message strings to be
+// stripped when the binary size has to be optimized. If you are looking to
+// reduce binary size, define TF_LITE_STRIP_ERROR_STRINGS when compiling and
+// every call will be stubbed out, taking no memory.
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+#define TF_LITE_REPORT_ERROR(reporter, ...)                             \
+  do {                                                                  \
+    static_cast<tflite::ErrorReporter*>(reporter)->Report(__VA_ARGS__); \
+  } while (false)
+#else  // TF_LITE_STRIP_ERROR_STRINGS
+#define TF_LITE_REPORT_ERROR(reporter, ...)
+#endif  // TF_LITE_STRIP_ERROR_STRINGS
+
+#endif  // TENSORFLOW_LITE_CORE_API_ERROR_REPORTER_MACRO_H_

--- a/third_party/tflite-micro/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/third_party/tflite-micro/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
+#include "tensorflow/lite/core/api/error_reporter_macro.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 

--- a/third_party/tflite-micro/tensorflow/lite/core/api/op_resolver.cc
+++ b/third_party/tflite-micro/tensorflow/lite/core/api/op_resolver.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
+#include "tensorflow/lite/core/api/error_reporter_macro.h"
 #include "tensorflow/lite/schema/schema_utils.h"
 
 namespace tflite {

--- a/third_party/tflite-micro/tensorflow/lite/kernels/internal/common.h
+++ b/third_party/tflite-micro/tensorflow/lite/kernels/internal/common.h
@@ -388,6 +388,7 @@ constexpr int LUTSize() {
                     std::is_same<T, int8_t>::value ||
                     std::is_same<T, int16_t>::value,
                 "Only LUTs with uint8, int8 or int16 inputs are supported.");
+  // As per c++11: constexpr methods cannot have more than one return statement.
   return (std::is_same<T, uint8_t>::value || std::is_same<T, int8_t>::value)
              ? 256
              : 513;

--- a/third_party/tflite-micro/tensorflow/lite/kernels/internal/reduce_common.h
+++ b/third_party/tflite-micro/tensorflow/lite/kernels/internal/reduce_common.h
@@ -1,0 +1,37 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_REDUCE_COMMON_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_REDUCE_COMMON_H_
+
+namespace tflite {
+namespace ops {
+namespace builtin {
+namespace reduce {
+
+enum ReduceType {
+  kSum,
+  kProd,
+  kMax,
+  kMin,
+  kAny,
+  kAll,
+};
+
+}  // namespace reduce
+}  // namespace builtin
+}  // namespace ops
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_REDUCE_COMMON_H_

--- a/third_party/tflite-micro/tensorflow/lite/kernels/internal/reference/strided_slice.h
+++ b/third_party/tflite-micro/tensorflow/lite/kernels/internal/reference/strided_slice.h
@@ -75,6 +75,10 @@ inline void StridedSlice(const tflite::StridedSliceParams& op_params,
       return index < end;
     }
   };
+  // With a static_cast it is not possible to initialize
+  // a variable of type 'const int *'
+  // with an rvalue of type 'const int32_t *' (aka 'const long *').
+  // reinterpret_cast is required to handle this casting.
   const int* shape = reinterpret_cast<const int*>(input_shape.DimsData());
   const int* stride = reinterpret_cast<const int*>(params_copy.strides);
   const bool inner_stride_is_1 = params_copy.strides[4] == 1;

--- a/third_party/tflite-micro/tensorflow/lite/micro/all_ops_resolver.cc
+++ b/third_party/tflite-micro/tensorflow/lite/micro/all_ops_resolver.cc
@@ -85,6 +85,7 @@ AllOpsResolver::AllOpsResolver() {
   AddPrelu();
   AddQuantize();
   AddReadVariable();
+  AddReduceAny();
   AddReduceMax();
   AddRelu();
   AddRelu6();

--- a/third_party/tflite-micro/tensorflow/lite/micro/kernels/cast.cc
+++ b/third_party/tflite-micro/tensorflow/lite/micro/kernels/cast.cc
@@ -84,6 +84,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   switch (input->type) {
     case kTfLiteBool:
+      return copyToTensor(context, input->data.b, output, num_elements);
     case kTfLiteInt8:
       return copyToTensor(context, input->data.int8, output, num_elements);
     case kTfLiteInt16:

--- a/third_party/tflite-micro/tensorflow/lite/micro/kernels/cast.cc
+++ b/third_party/tflite-micro/tensorflow/lite/micro/kernels/cast.cc
@@ -83,6 +83,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                       tflite::micro::GetTensorShape(output));
 
   switch (input->type) {
+    case kTfLiteBool:
     case kTfLiteInt8:
       return copyToTensor(context, input->data.int8, output, num_elements);
     case kTfLiteInt16:

--- a/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce.cc
+++ b/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce.cc
@@ -32,14 +32,19 @@ void* InitReduce(TfLiteContext* context, const char* buffer, size_t length) {
   return context->AllocatePersistentBuffer(context, sizeof(OpDataReduce));
 }
 
-TfLiteStatus PrepareMax(TfLiteContext* context, TfLiteNode* node) {
-  return PrepareMaxHelper(context, node,
-                          static_cast<OpDataReduce*>(node->user_data));
+TfLiteStatus PrepareMaxOrAny(TfLiteContext* context, TfLiteNode* node) {
+  return PrepareReduceHelper(context, node,
+                             static_cast<OpDataReduce*>(node->user_data));
 }
 
 TfLiteStatus PrepareMeanOrSum(TfLiteContext* context, TfLiteNode* node) {
   return PrepareMeanOrSumHelper(context, node,
                                 static_cast<OpDataReduce*>(node->user_data));
+}
+
+TfLiteStatus EvalAny(TfLiteContext* context, TfLiteNode* node) {
+  OpDataReduce* op_data = static_cast<OpDataReduce*>(node->user_data);
+  return EvalReduceHelper(context, node, op_data, ReduceType::kAny);
 }
 
 TfLiteStatus EvalMean(TfLiteContext* context, TfLiteNode* node) {
@@ -49,7 +54,7 @@ TfLiteStatus EvalMean(TfLiteContext* context, TfLiteNode* node) {
 
 TfLiteStatus EvalMax(TfLiteContext* context, TfLiteNode* node) {
   OpDataReduce* op_data = static_cast<OpDataReduce*>(node->user_data);
-  return EvalMaxHelper(context, node, op_data);
+  return EvalReduceHelper(context, node, op_data, ReduceType::kMax);
 }
 
 TfLiteStatus EvalSum(TfLiteContext* context, TfLiteNode* node) {
@@ -61,8 +66,12 @@ TfLiteRegistration Register_MEAN() {
   return tflite::micro::RegisterOp(InitReduce, PrepareMeanOrSum, EvalMean);
 }
 
+TfLiteRegistration Register_REDUCE_ANY() {
+  return tflite::micro::RegisterOp(InitReduce, PrepareMaxOrAny, EvalAny);
+}
+
 TfLiteRegistration Register_REDUCE_MAX() {
-  return tflite::micro::RegisterOp(InitReduce, PrepareMax, EvalMax);
+  return tflite::micro::RegisterOp(InitReduce, PrepareMaxOrAny, EvalMax);
 }
 
 TfLiteRegistration Register_SUM() {

--- a/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce.h
+++ b/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce.h
@@ -20,10 +20,12 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/reduce_common.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 
-namespace tflite {
+using ReduceType = tflite::ops::builtin::reduce::ReduceType;
 
+namespace tflite {
 extern const int kMaxNumberOfAxis;
 extern const int kMaxNumberOfReducedAxis;
 
@@ -39,16 +41,16 @@ struct OpDataReduce {
   int num_output_elements;
 };
 
-TfLiteStatus PrepareMaxHelper(TfLiteContext* context, TfLiteNode* node,
-                              OpDataReduce* op_data);
+TfLiteStatus PrepareReduceHelper(TfLiteContext* context, TfLiteNode* node,
+                                 OpDataReduce* op_data);
 
 TfLiteStatus PrepareMeanOrSumHelper(TfLiteContext* context, TfLiteNode* node,
                                     OpDataReduce* op_data);
 
-TfLiteStatus EvalMaxHelper(TfLiteContext* context, TfLiteNode* node,
-                           OpDataReduce* op_data);
 TfLiteStatus EvalMeanHelper(TfLiteContext* context, TfLiteNode* node,
                             OpDataReduce* op_data);
+TfLiteStatus EvalReduceHelper(TfLiteContext* context, TfLiteNode* node,
+                              OpDataReduce* op_data, ReduceType reduce_type);
 TfLiteStatus EvalSumHelper(TfLiteContext* context, TfLiteNode* node,
                            OpDataReduce* op_data);
 
@@ -56,6 +58,7 @@ void ReduceResolveAxis(const int* axis_data, int axis_count,
                        MeanParams* op_params);
 
 TfLiteRegistration Register_MEAN();
+TfLiteRegistration Register_REDUCE_ANY();
 TfLiteRegistration Register_REDUCE_MAX();
 TfLiteRegistration Register_SUM();
 

--- a/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -64,8 +64,8 @@ TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,
   return kTfLiteOk;
 }
 
-TfLiteStatus PrepareMaxHelper(TfLiteContext* context, TfLiteNode* node,
-                              OpDataReduce* op_data) {
+TfLiteStatus PrepareReduceHelper(TfLiteContext* context, TfLiteNode* node,
+                                 OpDataReduce* op_data) {
   TF_LITE_ENSURE_OK(context, PrepareSimple(context, node, &op_data->multiplier,
                                            &op_data->shift));
 
@@ -254,60 +254,6 @@ TfLiteStatus EvalMeanHelper(TfLiteContext* context, TfLiteNode* node,
   return kTfLiteOk;
 }
 
-TfLiteStatus EvalMaxHelper(TfLiteContext* context, TfLiteNode* node,
-                           OpDataReduce* op_data) {
-  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
-  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
-  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
-  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
-  TfLiteReducerParams* params =
-      static_cast<TfLiteReducerParams*>(node->builtin_data);
-
-  // Interpret an axis tensor with null dimensions as a scalar
-  int num_axis = static_cast<int>(ElementCount(*axis->dims));
-  int* temp_buffer = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->temp_buffer_idx));
-  int* resolved_axis = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->resolved_axis_idx));
-  switch (input->type) {
-    case kTfLiteFloat32:
-      TF_LITE_ENSURE(
-          context,
-          reference_ops::ReduceGeneric<float>(
-              tflite::micro::GetTensorData<float>(input), input->dims->data,
-              input->dims->size, tflite::micro::GetTensorData<float>(output),
-              output->dims->data, output->dims->size,
-              tflite::micro::GetTensorData<int>(axis), num_axis,
-              params->keep_dims, temp_buffer, resolved_axis,
-              std::numeric_limits<float>::lowest(),
-              [](const float current, const float in) -> float {
-                return (in > current) ? in : current;
-              }));
-      break;
-    case kTfLiteInt8:
-      TF_LITE_ENSURE_EQ(context, static_cast<double>(op_data->input_scale),
-                        static_cast<double>(op_data->output_scale));
-      TF_LITE_ENSURE_EQ(context, op_data->input_zp, op_data->output_zp);
-      TF_LITE_ENSURE(
-          context,
-          reference_ops::ReduceGeneric<int8_t>(
-              tflite::micro::GetTensorData<int8_t>(input), input->dims->data,
-              input->dims->size, tflite::micro::GetTensorData<int8_t>(output),
-              output->dims->data, output->dims->size,
-              tflite::micro::GetTensorData<int>(axis), num_axis,
-              params->keep_dims, temp_buffer, resolved_axis,
-              std::numeric_limits<int8_t>::lowest(),
-              [](const int8_t current, const int8_t in) -> int8_t {
-                return (in > current) ? in : current;
-              }));
-      break;
-    default:
-      MicroPrintf("Only float32 and int8 types are supported.");
-      return kTfLiteError;
-  }
-  return kTfLiteOk;
-}
-
 TfLiteStatus EvalSumHelper(TfLiteContext* context, TfLiteNode* node,
                            OpDataReduce* op_data) {
   const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
@@ -366,6 +312,119 @@ TfLiteStatus EvalSumHelper(TfLiteContext* context, TfLiteNode* node,
     } break;
     default:
       MicroPrintf("Only float32, int8, and int16 types are supported.");
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+template <typename T>
+TfLiteStatus GetReducerInitValue(ReduceType reduce_type, T& init_value) {
+  switch (reduce_type) {
+    case ReduceType::kSum:
+      init_value = T(0);
+      break;
+    case ReduceType::kProd:
+      init_value = static_cast<T>(1);
+      break;
+    case ReduceType::kMax:
+      init_value = std::numeric_limits<T>::lowest();
+      break;
+    case ReduceType::kMin:
+      init_value = std::numeric_limits<T>::max();
+      break;
+    case ReduceType::kAny:
+      init_value = false;
+      break;
+    case ReduceType::kAll:
+      init_value = true;
+      break;
+    default:
+      MicroPrintf("GetReducerInitValue: Unsupported ReduceType: %d",
+                  reduce_type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+template <typename T>
+T (*GetReducer(ReduceType reduce_type))
+(const T current, const T in) {
+  switch (reduce_type) {
+    case ReduceType::kSum:
+      return [](const T current, const T in) -> T { return in + current; };
+    case ReduceType::kProd:
+      return [](const T current, const T in) -> T { return in * current; };
+    case ReduceType::kMax:
+      return [](const T current, const T in) -> T {
+        return (in > current) ? in : current;
+      };
+    case ReduceType::kMin:
+      return [](const T current, const T in) -> T {
+        return (in < current) ? in : current;
+      };
+    case ReduceType::kAny:
+      return [](const T current, const T in) -> T { return in || current; };
+    case ReduceType::kAll:
+      return [](const T current, const T in) -> T { return in && current; };
+    default:
+      MicroPrintf("GetReducer: Unsupported ReduceType: %d", reduce_type);
+  }
+  return nullptr;
+}
+
+TfLiteStatus EvalReduceHelper(TfLiteContext* context, TfLiteNode* node,
+                              OpDataReduce* op_data, ReduceType reduce_type) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  TfLiteReducerParams* params =
+      static_cast<TfLiteReducerParams*>(node->builtin_data);
+
+  // Interpret an axis tensor with null dimensions as a scalar
+  int num_axis = static_cast<int>(ElementCount(*axis->dims));
+  int* temp_buffer = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->temp_buffer_idx));
+  int* resolved_axis = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->resolved_axis_idx));
+  switch (input->type) {
+    case kTfLiteFloat32: {
+      float init_value;
+      TF_LITE_ENSURE_EQ(context, GetReducerInitValue(reduce_type, init_value),
+                        kTfLiteOk);
+      auto reducer = GetReducer<float>(reduce_type);
+      TF_LITE_ENSURE(context, reducer != nullptr);
+      TF_LITE_ENSURE(context, reference_ops::ReduceGeneric<float>(
+                                  tflite::micro::GetTensorData<float>(input),
+                                  input->dims->data, input->dims->size,
+                                  tflite::micro::GetTensorData<float>(output),
+                                  output->dims->data, output->dims->size,
+                                  tflite::micro::GetTensorData<int>(axis),
+                                  num_axis, params->keep_dims, temp_buffer,
+                                  resolved_axis, init_value, reducer));
+      break;
+    }
+    case kTfLiteInt8: {
+      int8_t init_value;
+      TF_LITE_ENSURE_EQ(context, GetReducerInitValue(reduce_type, init_value),
+                        kTfLiteOk);
+      TF_LITE_ENSURE_EQ(context, static_cast<double>(op_data->input_scale),
+                        static_cast<double>(op_data->output_scale));
+      TF_LITE_ENSURE_EQ(context, op_data->input_zp, op_data->output_zp);
+      auto reducer = GetReducer<int8_t>(reduce_type);
+      TF_LITE_ENSURE(context, reducer != nullptr);
+      TF_LITE_ENSURE(context, reference_ops::ReduceGeneric<int8_t>(
+                                  tflite::micro::GetTensorData<int8_t>(input),
+                                  input->dims->data, input->dims->size,
+                                  tflite::micro::GetTensorData<int8_t>(output),
+                                  output->dims->data, output->dims->size,
+                                  tflite::micro::GetTensorData<int>(axis),
+                                  num_axis, params->keep_dims, temp_buffer,
+                                  resolved_axis, init_value, reducer));
+      break;
+    }
+    default:
+      MicroPrintf("Only float32 and int8 types are supported.");
       return kTfLiteError;
   }
   return kTfLiteOk;

--- a/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -347,13 +347,24 @@ TfLiteStatus GetReducerInitValue(ReduceType reduce_type, T& init_value) {
 }
 
 template <typename T>
+T (*getReducerForProd())(const T current, const T in) {
+  return [](const T current, const T in) -> T { return in * current; };
+}
+
+// Specialize for the warning: int-in-bool-context
+template <>
+bool (*getReducerForProd())(const bool current, const bool in) {
+  return [](const bool current, const bool in) -> bool { return in && current; };
+}
+
+template <typename T>
 T (*GetReducer(ReduceType reduce_type))
 (const T current, const T in) {
   switch (reduce_type) {
     case ReduceType::kSum:
       return [](const T current, const T in) -> T { return in + current; };
     case ReduceType::kProd:
-      return [](const T current, const T in) -> T { return in * current; };
+      return getReducerForProd<T>();
     case ReduceType::kMax:
       return [](const T current, const T in) -> T {
         return (in > current) ? in : current;
@@ -388,6 +399,22 @@ TfLiteStatus EvalReduceHelper(TfLiteContext* context, TfLiteNode* node,
   int* resolved_axis = static_cast<int*>(
       context->GetScratchBuffer(context, op_data->resolved_axis_idx));
   switch (input->type) {
+    case kTfLiteBool: {
+      bool init_value;
+      TF_LITE_ENSURE_EQ(context, GetReducerInitValue(reduce_type, init_value),
+                        kTfLiteOk);
+      auto reducer = GetReducer<bool>(reduce_type);
+      TF_LITE_ENSURE(context, reducer != nullptr);
+      TF_LITE_ENSURE(context, reference_ops::ReduceGeneric<bool>(
+                                  tflite::micro::GetTensorData<bool>(input),
+                                  input->dims->data, input->dims->size,
+                                  tflite::micro::GetTensorData<bool>(output),
+                                  output->dims->data, output->dims->size,
+                                  tflite::micro::GetTensorData<int>(axis),
+                                  num_axis, params->keep_dims, temp_buffer,
+                                  resolved_axis, init_value, reducer));
+      break;
+    }
     case kTfLiteFloat32: {
       float init_value;
       TF_LITE_ENSURE_EQ(context, GetReducerInitValue(reduce_type, init_value),
@@ -404,7 +431,6 @@ TfLiteStatus EvalReduceHelper(TfLiteContext* context, TfLiteNode* node,
                                   resolved_axis, init_value, reducer));
       break;
     }
-    case kTfLiteBool:
     case kTfLiteInt8: {
       int8_t init_value;
       TF_LITE_ENSURE_EQ(context, GetReducerInitValue(reduce_type, init_value),
@@ -425,7 +451,7 @@ TfLiteStatus EvalReduceHelper(TfLiteContext* context, TfLiteNode* node,
       break;
     }
     default:
-      MicroPrintf("Only float32 and int8 types are supported.");
+      MicroPrintf("Only bool, float32 and int8 types are supported.");
       return kTfLiteError;
   }
   return kTfLiteOk;

--- a/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/third_party/tflite-micro/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -404,6 +404,7 @@ TfLiteStatus EvalReduceHelper(TfLiteContext* context, TfLiteNode* node,
                                   resolved_axis, init_value, reducer));
       break;
     }
+    case kTfLiteBool:
     case kTfLiteInt8: {
       int8_t init_value;
       TF_LITE_ENSURE_EQ(context, GetReducerInitValue(reduce_type, init_value),

--- a/third_party/tflite-micro/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/third_party/tflite-micro/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -431,6 +431,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       tflite::Register_READ_VARIABLE(), ParseReadVariable);
   }
 
+  TfLiteStatus AddReduceAny() {
+    return AddBuiltin(BuiltinOperator_REDUCE_ANY, Register_REDUCE_ANY(),
+                      ParseReducer);
+  }
+
   TfLiteStatus AddReduceMax() {
     return AddBuiltin(BuiltinOperator_REDUCE_MAX, Register_REDUCE_MAX(),
                       ParseReducer);


### PR DESCRIPTION
REDUCE_ANY OP is still pending for review at TFLM github ([PR](https://github.com/tensorflow/tflite-micro/pull/1538)).

TFLM reviewers don't have time reviewing it until next week.
To support demo which requires the op, update Oak TFLM source tree first.

The OP has passed [tests](https://github.com/tensorflow/tflite-micro/blob/977c3f19786026912cd9df95f9f52b01e1c509a0/tensorflow/lite/micro/kernels/reduce_test.cc#L449-L481) that are ported from tensorflow lite.