### PR TITLE
Support multi tensors in generic model runner

### DIFF
--- a/cc/tflite_micro/include/tflite_micro.h
+++ b/cc/tflite_micro/include/tflite_micro.h
@@ -35,8 +35,8 @@ int tflite_run(
     const uint8_t* input_bytes_ptr, size_t input_bytes_len,
     uint8_t* output_bytes_ptr, size_t* output_bytes_len_ptr);
 
-const TfLiteTensor* tflite_get_input_tensor();
-const TfLiteTensor* tflite_get_output_tensor();
+const TfLiteTensor* tflite_get_input_tensor(int id);
+const TfLiteTensor* tflite_get_output_tensor(int id);
 
 // Use weak reference to build both freestanding binaries that
 // can run on Oak server and local PC where Oak server does

--- a/testing/tflite_micro/hello_world/main.cc
+++ b/testing/tflite_micro/hello_world/main.cc
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
       float x = position * kXrange;
 
       // Quantize the input from floating-point to integer
-      auto input_tensor = tflite_get_input_tensor();
+      auto input_tensor = tflite_get_input_tensor(0);
       int8_t x_quantized =
           x / input_tensor->params.scale + input_tensor->params.zero_point;
 
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
       }
 
       // Dequantize the output from integer to floating-point
-      auto output_tensor = tflite_get_output_tensor();
+      auto output_tensor = tflite_get_output_tensor(0);
       float y =
           (output - output_tensor->params.zero_point)
           * output_tensor->params.scale;


### PR DESCRIPTION
Generic model runner is extended to support multiple input/output tensors that demo model requires.
Demo model has: 1 input tensor and 3 output tensors.
input tensor[0]: int * 10
output tensor[0]: float * 3
output tensor[1]: float * 105
output tensor[2]: float * 4522

As we only accept one single input buffer and one single output buffer,
input buffer will be split properly into input tensors per tensor size and
output tensors will be consolidated and cancatenated to output buffer in order.

Next step: I'll create a testing freestanding binary for demo model to validate flowing data through all layers w/o crashes.
I'll be off for rest of the week but could still check and work intermittently.