### PR TITLE
Add PortFactory and a serial log to stage0

### DIFF
--- a/oak_core/Cargo.toml
+++ b/oak_core/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = ["alloc"]
+alloc = ["dep:lock_api"]
+
 [dependencies]
-lock_api = { version = "*", features = ["arc_lock"] }
+lock_api = { version = "*", features = ["arc_lock"], optional = true }
 spinning_top = "*"

--- a/oak_core/src/lib.rs
+++ b/oak_core/src/lib.rs
@@ -15,6 +15,7 @@
 //
 #![no_std]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 pub mod sync;

--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -173,6 +173,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "oak_core"
+version = "0.1.0"
+dependencies = [
+ "spinning_top",
+]
+
+[[package]]
 name = "oak_linux_boot_params"
 version = "0.1.0"
 dependencies = [
@@ -186,8 +202,12 @@ name = "oak_stage0"
 version = "0.1.0"
 dependencies = [
  "goblin",
+ "log",
+ "oak_core",
  "oak_linux_boot_params",
  "sev_guest",
+ "sev_serial",
+ "spinning_top",
  "x86_64",
 ]
 
@@ -264,6 +284,14 @@ dependencies = [
  "strum",
  "x86_64",
  "zerocopy",
+]
+
+[[package]]
+name = "sev_serial"
+version = "0.1.0"
+dependencies = [
+ "sev_guest",
+ "x86_64",
 ]
 
 [[package]]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -11,8 +11,12 @@ members = ["."]
 
 [dependencies]
 goblin = { version = "*", default-features = false, features = ["elf64"] }
+log = "*"
+oak_core = { path = "../oak_core", default-features = false }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 sev_guest = { path = "../experimental/sev_guest" }
+sev_serial = { path = "../sev_serial" }
+spinning_top = "*"
 x86_64 = "*"
 
 [profile.dev]

--- a/stage0/build.rs
+++ b/stage0/build.rs
@@ -21,7 +21,7 @@ fn main() {
     println!("cargo:rustc-link-arg=--script=layout.ld");
 
     if env::var("PROFILE").unwrap() == "release" {
-        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=64K");
+        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=128K");
     } else {
         println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=256K");
     }

--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -174,7 +174,7 @@ SECTIONS {
     } > bios
 
     .stack ALIGN(4K) (NOLOAD) : {
-        . += 16K;
+        . += 32K;
         stack_start = .;
     } > bios
 

--- a/stage0/src/logging.rs
+++ b/stage0/src/logging.rs
@@ -1,0 +1,62 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use core::{fmt::Write, ops::DerefMut};
+use sev_guest::io::PortFactoryWrapper;
+use sev_serial::SerialPort;
+use spinning_top::Spinlock;
+
+extern crate log;
+
+// Base I/O port for the first serial port in the system (colloquially known as COM1)
+static SERIAL_BASE: u16 = 0x3f8;
+static SERIAL_PORT: Spinlock<Option<SerialPort>> = Spinlock::new(None);
+
+struct Logger {}
+
+impl log::Log for Logger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        let mut lock = SERIAL_PORT.lock();
+        // Don't log anything if the port is not initialized yet.
+        if let Some(port) = lock.deref_mut() {
+            writeln!(port, "stage0 {}: {}", record.level(), record.args()).unwrap();
+        }
+    }
+
+    fn flush(&self) {
+        // No-op, as we can't flush the serial port.
+    }
+}
+
+static LOGGER: Logger = Logger {};
+
+pub fn init_logging(port_factory: PortFactoryWrapper) {
+    // Our contract with the launcher requires the first serial port to be
+    // available, so assuming the loader adheres to it, this is safe.
+    let mut port = unsafe { SerialPort::new(SERIAL_BASE, port_factory) };
+    port.init()
+        .expect("Couldn't initialize logging serial port.");
+    {
+        let mut lock = SERIAL_PORT.lock();
+        *lock.deref_mut() = Some(port);
+    }
+    log::set_logger(&LOGGER).unwrap();
+    log::set_max_level(log::LevelFilter::Debug);
+}


### PR DESCRIPTION
This sets up a PortFactory that we can use to get access to the raw I/O ports in the system, which we will need for communicating via the serial port and in the future to use the QEMU fw_cfg API.

As the first step, this PR exercises the PortFactory functionality to enable basic logging in stage0.

However, unfortunately formatting is really expensive for the stack. I blew the 16K stack with hilarious results as usual; bumping it to 32K gives it enough headroom. Unfortunately this means the BIOS image won't fit in 64K any longer, and I had to bump the size to 128K.

In the future we should move the stack to the low 1M of memory as well, as it doesn't really need to be in the BIOS image area.