### PR TITLE
Make the guest-host heap and mapper public

### DIFF
--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -81,7 +81,7 @@ use x86_64::{
 /// The allocator for allocating space in the memory area that is shared with the hypervisor.
 pub static GUEST_HOST_HEAP: OnceCell<LockedHeap> = OnceCell::new();
 
-/// Translator that can convert between physical and virtuall address.
+/// Translator that can convert between physical and virtual addresses.
 pub static ADDRESS_TRANSLATOR: OnceCell<EncryptedPageTable<MappedPageTable<'static, PhysOffset>>> =
     OnceCell::new();
 


### PR DESCRIPTION
This is needed to support the remote attestation requests.

We must be able to create pages in the shared heap for the remote attestation requests and also be able to translate the virtual addresses to physical addresses when notifying the hypervisor of their location.

This PR also uses the synchronised OnceCell for the guest-host heap to avoid the spread of unsafe blocks everywhere it is used.

Using these as part of a remote attestation request will be done in a future PR.