### PR TITLE
Use the QEMU fw_cfg device to read the memory layout in stage0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,6 +2708,7 @@ dependencies = [
  "bitflags",
  "static_assertions",
  "strum",
+ "zerocopy",
 ]
 
 [[package]]

--- a/linux_boot_params/Cargo.toml
+++ b/linux_boot_params/Cargo.toml
@@ -9,3 +9,4 @@ license = "Apache-2.0"
 bitflags = "*"
 static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
+zerocopy = "*"

--- a/linux_boot_params/src/lib.rs
+++ b/linux_boot_params/src/lib.rs
@@ -19,6 +19,7 @@
 use bitflags::bitflags;
 use core::ffi::{c_char, CStr};
 use strum::{Display, FromRepr};
+use zerocopy::{AsBytes, FromBytes};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Display, FromRepr)]
 #[repr(u32)]
@@ -460,16 +461,16 @@ pub struct SetupHeader {
 static_assertions::assert_eq_size!(SetupHeader, [u8; 123usize]);
 
 #[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, FromBytes, AsBytes)]
 pub struct BootE820Entry {
     addr: usize,
     size: usize,
-    type_: E820EntryType,
+    type_: u32,
 }
 
 impl BootE820Entry {
-    pub fn entry_type(&self) -> E820EntryType {
-        self.type_
+    pub fn entry_type(&self) -> Option<E820EntryType> {
+        E820EntryType::from_repr(self.type_)
     }
 
     pub fn addr(&self) -> usize {

--- a/oak_functions_freestanding_bin/Cargo.lock
+++ b/oak_functions_freestanding_bin/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "bitflags",
  "static_assertions",
  "strum",
+ "zerocopy",
 ]
 
 [[package]]

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -184,10 +184,10 @@ pub fn init<const N: usize>(
                 e.addr(),
                 e.addr() + e.size(),
                 e.size(),
-                e.entry_type()
+                e.entry_type().unwrap()
             );
         })
-        .filter(|e| e.entry_type() == E820EntryType::RAM)
+        .filter(|e| e.entry_type() == Some(E820EntryType::RAM))
         .map(|e| {
             // Clip both ends, if necessary, to make sure that we are aligned with 2 MiB pages.
             (

--- a/oak_tensorflow_freestanding_bin/Cargo.lock
+++ b/oak_tensorflow_freestanding_bin/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "bitflags",
  "static_assertions",
  "strum",
+ "zerocopy",
 ]
 
 [[package]]

--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "bitflags",
  "static_assertions",
  "strum",
+ "zerocopy",
 ]
 
 [[package]]
@@ -208,7 +209,9 @@ dependencies = [
  "sev_guest",
  "sev_serial",
  "spinning_top",
+ "static_assertions",
  "x86_64",
+ "zerocopy",
 ]
 
 [[package]]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -17,7 +17,9 @@ oak_linux_boot_params = { path = "../linux_boot_params" }
 sev_guest = { path = "../experimental/sev_guest" }
 sev_serial = { path = "../sev_serial" }
 spinning_top = "*"
+static_assertions = "*"
 x86_64 = "*"
+zerocopy = "*"
 
 [profile.dev]
 opt-level = "z"

--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -1,0 +1,189 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use core::{cmp::min, ffi::CStr};
+use sev_guest::io::{IoPortFactory, PortFactoryWrapper, PortReader, PortWrapper, PortWriter};
+use zerocopy::{AsBytes, FromBytes};
+
+// See https://www.qemu.org/docs/master/specs/fw_cfg.html for documentation about the various data structures and constants.
+const FWCFG_PORT_SELECTOR: u16 = 0x510;
+const FWCFG_PORT_DATA: u16 = 0x511;
+
+const SIGNATURE: &[u8] = b"QEMU";
+
+#[repr(u16)]
+enum FwCfgItems {
+    Signature = 0x0000,
+    FileDir = 0x0019,
+}
+
+/// an individual file entry, 64 bytes total
+#[repr(C)]
+#[derive(Debug, AsBytes, FromBytes)]
+pub struct DirEntry {
+    /// size of referenced fw_cfg item, big-endian
+    size: u32,
+    /// selector key of fw_cfg item, big-endian
+    select: u16,
+    _reserved: u16,
+    /// fw_cfg item name, NUL-terminated ascii
+    name: [u8; 56],
+}
+static_assertions::assert_eq_size!(DirEntry, [u8; 64usize]);
+
+impl Default for DirEntry {
+    fn default() -> Self {
+        Self {
+            size: 0,
+            select: 0,
+            _reserved: 0,
+            name: [0; 56],
+        }
+    }
+}
+
+impl DirEntry {
+    pub fn name(&self) -> &CStr {
+        CStr::from_bytes_until_nul(&self.name).unwrap()
+    }
+
+    pub fn size(&self) -> usize {
+        u32::from_be(self.size) as usize
+    }
+
+    pub fn selector(&self) -> u16 {
+        u16::from_be(self.select)
+    }
+}
+
+pub struct FwCfg {
+    selector: PortWrapper<u16>,
+    data: PortWrapper<u8>,
+}
+
+impl FwCfg {
+    /// # Safety
+    ///
+    /// While we do probe for the existence of the QEMU fw_cfg device, reading or writing to I/O
+    /// ports that are not in use is inherently undefined behaviour. What's worse, if there happens
+    /// to be some other device using those I/O ports, the results are completely unknowable.
+    ///
+    /// The caller has to guarantee that at least doing the probe will not cause any adverse
+    /// effects.
+    pub unsafe fn new(port_factory: PortFactoryWrapper) -> Result<Self, &'static str> {
+        let mut fwcfg = Self {
+            selector: port_factory.new_writer(FWCFG_PORT_SELECTOR),
+            data: port_factory.new_reader(FWCFG_PORT_DATA),
+        };
+
+        // Make sure the fw_cfg device is available. If the device is not available, writing and
+        // reading to I/O ports is undefined behaviour.
+        fwcfg.write_selector(FwCfgItems::Signature as u16)?;
+        let mut signature = [0u8; SIGNATURE.len()];
+        fwcfg.read(&mut signature)?;
+
+        if signature == SIGNATURE {
+            Ok(fwcfg)
+        } else {
+            Err("QEMU fw_cfg device not available")
+        }
+    }
+
+    /// Returns an iterator over the files in the fw_cfg system.
+    ///
+    /// # Safety
+    ///
+    /// You should consume the iterator fully before calling any other methods of this struct, or at
+    /// the very least don't use the iterator after calling some other function.
+    /// (This means that, for example, you shouldn't try to read the files while iterating over the
+    /// directory contents.)
+    /// If you call any other methods, the iterator will be in an undefined state and unsafe to read
+    /// from.
+    pub unsafe fn dir(&mut self) -> impl Iterator<Item = DirEntry> + '_ {
+        self.write_selector(FwCfgItems::FileDir as u16).unwrap();
+
+        // We don't represent FwCfgFiles as a struct, as you can't do that in safe Rust. Therefore,
+        // read fields individually.
+        let count = {
+            let mut buf = [0u8; 4];
+            self.read(&mut buf).unwrap();
+            u32::from_be_bytes(buf)
+        };
+
+        (0..count).map(|_| {
+            let mut file = DirEntry::default();
+            self.read(&mut file).unwrap();
+            file
+        })
+    }
+
+    /// Reads the contents of a file to a predetermined struct.
+    /// Returns the number of bytes read.
+    ///
+    /// # Safety
+    ///
+    /// While we will never write beyond the memory allocated to `object`, it is up to the caller to
+    /// ensure that the type of `object` is a faithful representation of the contents of the file;
+    /// otherwise, `object` may be left in an invalid state.
+    pub unsafe fn read_file_by_name<T: AsBytes + FromBytes>(
+        &mut self,
+        name: &CStr,
+        object: &mut T,
+    ) -> Result<usize, &'static str> {
+        let mut entry: Option<DirEntry> = None;
+        for file in self.dir() {
+            if file.name() != name {
+                continue;
+            };
+            entry = Some(file);
+            break;
+        }
+        if let Some(file) = entry {
+            self.read_file(file, object.as_bytes_mut())
+        } else {
+            Err("Could not find requested file")
+        }
+    }
+
+    /// Reads contents of a file; returns the number of bytes acrually read.
+    ///
+    /// The buffer `buf` will be filled to capacity if the file is larger;
+    /// if it is shorter, the trailing bytes will not be touched.
+    pub fn read_file(&mut self, file: DirEntry, buf: &mut [u8]) -> Result<usize, &'static str> {
+        self.write_selector(file.selector())?;
+        let len = min(buf.len(), file.size());
+        self.read_buf(&mut buf[..len])?;
+        Ok(len)
+    }
+
+    fn write_selector(&mut self, selector: u16) -> Result<(), &'static str> {
+        // Safety: we make sure the device is available when initializing FwCfg.
+        unsafe { self.selector.try_write(selector) }
+    }
+
+    fn read<T: AsBytes + FromBytes>(&mut self, object: &mut T) -> Result<(), &'static str> {
+        self.read_buf(object.as_bytes_mut())
+    }
+
+    fn read_buf(&mut self, buf: &mut [u8]) -> Result<(), &'static str> {
+        for i in buf {
+            // Safety: We make sure that the device is available in `new()`, so reading from the
+            // port is safe.
+            *i = unsafe { self.data.try_read() }?;
+        }
+        Ok(())
+    }
+}

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -121,7 +121,7 @@ pub fn validate_memory(zero_page: &BootParams, encrypted: u64) {
     );
 
     for entry in zero_page.e820_table() {
-        if entry.entry_type() != E820EntryType::RAM {
+        if entry.entry_type() != Some(E820EntryType::RAM) {
             continue;
         }
 

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -1,0 +1,69 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::fw_cfg::FwCfg;
+use core::{
+    ffi::CStr,
+    mem::{size_of, MaybeUninit},
+};
+use oak_linux_boot_params::{BootE820Entry, BootParams};
+
+#[link_section = ".boot.zero_page"]
+static mut BOOT_ZERO_PAGE: MaybeUninit<BootParams> = MaybeUninit::uninit();
+
+pub fn init_zero_page(fw_cfg: &mut FwCfg) -> &'static mut BootParams {
+    let mut zero_page = unsafe { BOOT_ZERO_PAGE.write(core::mem::zeroed()) };
+
+    // Magic constants.
+    // See https://www.kernel.org/doc/html/latest/x86/boot.html#the-real-mode-kernel-header for more details.
+    zero_page.hdr.type_of_loader = 0xFF; // loader type undefined
+    zero_page.hdr.boot_flag = 0xAA55; // magic number
+    zero_page.hdr.header = 0x53726448; // Magic "HdrS" string
+    zero_page.hdr.kernel_alignment = 0x1000000; // Magic number from crosvm source.
+
+    // Load the E820 table from fw_cfg.
+    // Safety: BootE820Entry has the same structure as what qemu uses, and we're limiting
+    // ourselves to up to 128 entries.
+    let len_bytes = unsafe {
+        fw_cfg.read_file_by_name(
+            CStr::from_bytes_with_nul(b"etc/e820\0").unwrap(),
+            &mut zero_page.e820_table,
+        )
+    }
+    .unwrap();
+    zero_page.e820_entries = (len_bytes / size_of::<BootE820Entry>()) as u8;
+
+    for entry in zero_page.e820_table() {
+        log::debug!(
+            "early E820 entry: start {:#018x}, len {}, type {}",
+            entry.addr(),
+            entry.size(),
+            entry.entry_type().unwrap()
+        );
+    }
+
+    zero_page
+}
+
+/// Returns a mutable reference to the zero page, which we assume is initialized.
+///
+/// # Safety
+///
+/// This assumes the VMM has set up the zero page for us. Calling this function without the memory
+/// set up correctly is undefined behaviour.
+pub unsafe fn get_zero_page() -> &'static mut BootParams {
+    BOOT_ZERO_PAGE.assume_init_mut()
+}

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "bitflags",
  "static_assertions",
  "strum",
+ "zerocopy",
 ]
 
 [[package]]

--- a/testing/oak_echo_raw_bin/Cargo.lock
+++ b/testing/oak_echo_raw_bin/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "bitflags",
  "static_assertions",
  "strum",
+ "zerocopy",
 ]
 
 [[package]]

--- a/testing/sev_snp_hello_world_kernel/Cargo.lock
+++ b/testing/sev_snp_hello_world_kernel/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "bitflags",
  "static_assertions",
  "strum",
+ "zerocopy",
 ]
 
 [[package]]
@@ -209,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -276,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
+checksum = "a152ba99b054b22972ee794cf04e5ef572da1229e33b65f3c57abbff0525a454"
 dependencies = [
  "doc-comment",
  "snafu-derive",
@@ -286,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
+checksum = "d5e79cdebbabaebb06a9bdbaedc7f159b410461f63611d4d0e3fb0fab8fed850"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -347,25 +348,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -376,15 +365,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "universal-hash"
@@ -432,11 +415,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
 dependencies = [
  "proc-macro2",
+ "quote",
  "syn",
- "synstructure",
 ]


### PR DESCRIPTION
For now, neither of the VMMs we use exposes the QEMU `fw_cfg` device, but longer term we do want to switch to using it (which will mean that we'll got from crosvm back to QEMU).

Thus, the only thing this PR really does is just debug log the E820 entries. We likely need to do some post-processing here as well, because (a) the entries are not sorted and (b) I believe SeaBIOS does something extra in its code, like marking ACPI memory ranges as reserved, which we should duplicate as well.

As an example, here's the output when I run stage0 with `qemu` and give it 32 MB of memory:
```
stage0 INFO: starting...
stage0 DEBUG: early E820 entry: start 0x00000000feffc000, len 16384, type RESERVED
stage0 DEBUG: early E820 entry: start 0x0000000000000000, len 33554432, type RAM
```

and here's what it looks like when I give it 8 GB of memory:
```
stage0 INFO: starting...
stage0 DEBUG: early E820 entry: start 0x00000000feffc000, len 16384, type RESERVED
stage0 DEBUG: early E820 entry: start 0x0000000000000000, len 3221225472, type RAM
stage0 DEBUG: early E820 entry: start 0x0000000100000000, len 5368709120, type RAM
```