### PR TITLE
Sort E820 entries by address in stage0.

### DIFF
--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -45,11 +45,12 @@ pub fn init_zero_page(fw_cfg: &mut FwCfg) -> &'static mut BootParams {
     }
     .unwrap();
     zero_page.e820_entries = (len_bytes / size_of::<BootE820Entry>()) as u8;
-
+    zero_page.e820_table[..(zero_page.e820_entries as usize)].sort_unstable_by_key(|x| x.addr());
     for entry in zero_page.e820_table() {
         log::debug!(
-            "early E820 entry: start {:#018x}, len {}, type {}",
+            "early E820 entry: [{:#018x}-{:#018x}), len {}, type {}",
             entry.addr(),
+            entry.addr() + entry.size(),
             entry.size(),
             entry.entry_type().unwrap()
         );


### PR DESCRIPTION
Looking over the SeaBIOS code we might just get lucky by not having to mark any other additional memory ranges as reserved (what SeaBIOS does is that it marks the memory ranges it itself uses as RESERVED, but we don't need stage0 to stick around after we've jumped to the kernel.)

However, all BIOSes I've seen thus far sort the E820 map before handing it over to the kernel. So let's do the same.

Ideally, we'd have a proper interval map implementation in there that'd let us detect overlaps etc, but this will do for now.