### PR TITLE
Make errors more consistent

### DIFF
--- a/experimental/offline_attestation/client/src/main.rs
+++ b/experimental/offline_attestation/client/src/main.rs
@@ -129,7 +129,7 @@ impl RequestHelper {
         let response_public_key_handle = self
             .private_key_handle
             .public()
-            .map_err(|error| anyhow!("Couldn't get public key: {}", error))?;
+            .map_err(|error| anyhow!("couldn't get public key: {}", error))?;
         let response_public_key = serialize_public_key(&response_public_key_handle)?;
 
         Ok(EncryptedRequest {

--- a/experimental/offline_attestation/server/src/main.rs
+++ b/experimental/offline_attestation/server/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
     let private_key_handle = Arc::new(generate_private_key()?);
     let public_key_handle = private_key_handle
         .public()
-        .map_err(|error| anyhow!("Couldn't get public key: {}", error))?;
+        .map_err(|error| anyhow!("couldn't get public key: {}", error))?;
 
     let attestation_report = generate_attestation_report(&public_key_handle)?;
 

--- a/experimental/offline_attestation/shared/src/lib.rs
+++ b/experimental/offline_attestation/shared/src/lib.rs
@@ -110,10 +110,10 @@ impl PublicKeyInfo {
 /// public key.
 pub fn encrypt(public_key_handle: &Handle, data: &[u8]) -> anyhow::Result<Vec<u8>> {
     let encryptor = tink_hybrid::new_encrypt(public_key_handle)
-        .map_err(|error| anyhow!("Couldn't create hybrid encryptor: {}", error))?;
+        .map_err(|error| anyhow!("couldn't create hybrid encryptor: {}", error))?;
     encryptor
         .encrypt(data, ENCRYPTION_CONTEXT)
-        .map_err(|error| anyhow!("Couldn't encrypt data: {}", error))
+        .map_err(|error| anyhow!("couldn't encrypt data: {}", error))
 }
 
 /// Decrypts the provides `cyphertext` using the private key.
@@ -122,17 +122,17 @@ pub fn encrypt(public_key_handle: &Handle, data: &[u8]) -> anyhow::Result<Vec<u8
 /// decryption will only succeed if the ciphertext was created using the corresponding public key.
 pub fn decrypt(private_key_handle: &Handle, ciphertext: &[u8]) -> anyhow::Result<Vec<u8>> {
     let decryptor = tink_hybrid::new_decrypt(private_key_handle)
-        .map_err(|error| anyhow!("Couldn't create hybrid decryptor: {}", error))?;
+        .map_err(|error| anyhow!("couldn't create hybrid decryptor: {}", error))?;
     decryptor
         .decrypt(ciphertext, ENCRYPTION_CONTEXT)
-        .map_err(|error| anyhow!("Couldn't decrypt ciphertext: {}", error))
+        .map_err(|error| anyhow!("couldn't decrypt ciphertext: {}", error))
 }
 
 /// Generates a new private key suitable for hybrid encryption and returns a handle to the
 /// containing keyset.
 pub fn generate_private_key() -> anyhow::Result<Handle> {
     tink_core::keyset::Handle::new(&tink_hybrid::ecies_hkdf_aes128_gcm_key_template())
-        .map_err(|error| anyhow!("Couldn't create private key: {}", error))
+        .map_err(|error| anyhow!("couldn't create private key: {}", error))
 }
 
 /// Serialises the handle's underlying keyset containing the public key to a binary representation.
@@ -143,7 +143,7 @@ pub fn serialize_public_key(public_key_handle: &Handle) -> anyhow::Result<Vec<u8
     let mut writer = tink_core::keyset::BinaryWriter::new(&mut result);
     public_key_handle
         .write_with_no_secrets(&mut writer)
-        .map_err(|error| anyhow!("Couldn't deserialise public key: {}", error))?;
+        .map_err(|error| anyhow!("couldn't deserialise public key: {}", error))?;
     Ok(result)
 }
 
@@ -152,7 +152,7 @@ pub fn serialize_public_key(public_key_handle: &Handle) -> anyhow::Result<Vec<u8
 pub fn deserialize_public_key(data: &[u8]) -> anyhow::Result<Handle> {
     let mut reader = tink_core::keyset::BinaryReader::new(data);
     Handle::read_with_no_secrets(&mut reader)
-        .map_err(|error| anyhow!("Couldn't deserialise public key: {}", error))
+        .map_err(|error| anyhow!("couldn't deserialise public key: {}", error))
 }
 
 /// Serialises the attestation report to a binary representation.

--- a/experimental/sev_guest/src/cpuid.rs
+++ b/experimental/sev_guest/src/cpuid.rs
@@ -94,10 +94,10 @@ impl CpuidPage {
     /// all zero.
     pub fn validate(&self) -> Result<(), &'static str> {
         if self.count as usize > CPUID_COUNT_MAX {
-            return Err("Invalid count");
+            return Err("invalid count");
         }
         if self._reserved.iter().any(|&value| value != 0) {
-            return Err("Nonzero value in _reserved");
+            return Err("nonzero value in _reserved");
         }
         Ok(())
     }

--- a/experimental/sev_guest/src/crypto.rs
+++ b/experimental/sev_guest/src/crypto.rs
@@ -63,7 +63,7 @@ impl GuestMessageEncryptor {
         initial_sequence_number: u64,
     ) -> Result<Self, &'static str> {
         Ok(Self {
-            cipher: Aes256Gcm::new_from_slice(key).map_err(|_| "Invalid key length")?,
+            cipher: Aes256Gcm::new_from_slice(key).map_err(|_| "invalid key length")?,
             sequence_number: initial_sequence_number,
         })
     }
@@ -94,7 +94,7 @@ impl GuestMessageEncryptor {
         let auth_tag = self
             .cipher
             .encrypt_in_place_detached(nonce, associated_data, buffer)
-            .map_err(|aes_gcm::Error| "Message encryption failed")?;
+            .map_err(|aes_gcm::Error| "message encryption failed")?;
         // Only write the payload once we are sure the encryption succeeded.
         destination.payload[0..message_size].copy_from_slice(buffer);
         destination.header.auth_tag[0..auth_tag.len()].copy_from_slice(auth_tag.as_slice());
@@ -134,7 +134,7 @@ impl GuestMessageEncryptor {
         let tag = Tag::from_slice(&source.header.auth_tag[0..size_of::<Tag>()]);
         self.cipher
             .decrypt_in_place_detached(nonce, associated_data, buffer, tag)
-            .map_err(|aes_gcm::Error| "Couldn't decrypt message")?;
+            .map_err(|aes_gcm::Error| "couldn't decrypt message")?;
         self.sequence_number += 1;
         Ok(result)
     }

--- a/experimental/sev_guest/src/ghcb.rs
+++ b/experimental/sev_guest/src/ghcb.rs
@@ -283,7 +283,7 @@ where
         let virtual_address = VirtAddr::from_ptr(ghcb.as_ref() as *const Ghcb);
         // Crashing is OK if we cannot find the physical address for the GHCB.
         let gpa = translate(virtual_address)
-            .expect("Could not translate the GHCB virtual address to a physical address.");
+            .expect("couldn't translate the GHCB virtual address to a physical address");
         Self { ghcb, gpa }
     }
 
@@ -429,7 +429,7 @@ where
             Ok(())
         } else {
             // For now we treat all non-zero return values as unrecoverable errors.
-            Err("Guest message response indicates an error.")
+            Err("guest message response indicates an error")
         }
     }
 
@@ -451,7 +451,7 @@ where
             Ok(())
         } else {
             // For now we treat all non-zero return values as unrecoverable errors.
-            Err("VMGEXIT call returned an error.")
+            Err("VMGEXIT call returned an error")
         }
     }
 }

--- a/experimental/sev_guest/src/guest.rs
+++ b/experimental/sev_guest/src/guest.rs
@@ -156,28 +156,28 @@ impl GuestMessageHeader {
         if self.get_algorithm().is_none()
             || self.auth_header.algorithm == AeadAlgorithm::Invalid as u8
         {
-            return Err("Invalid AEAD algorithm");
+            return Err("invalid AEAD algorithm");
         }
         if self.get_message_type().is_none()
             || self.auth_header.message_type == MessageType::Invalid as u8
         {
-            return Err("Invalid message type");
+            return Err("invalid message type");
         }
         if self.auth_header.header_version != CURRENT_HEADER_VERSION {
-            return Err("Invalid header version");
+            return Err("invalid header version");
         }
         if self.auth_header.message_version != CURRENT_MESSAGE_VERSION {
-            return Err("Invalid message version");
+            return Err("invalid message version");
         }
         // For now we always assume we use VMPCK_0 to encrypt all messages.
         if self.auth_header.message_vmpck != 0 {
-            return Err("Invalid message VMPCK");
+            return Err("invalid message VMPCK");
         }
         if self.auth_header.header_size != size_of::<Self>() as u16 {
-            return Err("Invalid header size");
+            return Err("invalid header size");
         }
         if self.auth_header.message_size as usize > MAX_PAYLOAD_SIZE {
-            return Err("Invalid message size");
+            return Err("invalid message size");
         }
         Ok(())
     }
@@ -311,13 +311,13 @@ impl AttestationResponse {
     /// report format are all valid.
     pub fn validate(&self) -> Result<(), &'static str> {
         if self._reserved.iter().any(|&value| value != 0) {
-            return Err("Nonzero value in _reserved");
+            return Err("nonzero value in _reserved");
         }
         if self.get_status().is_none() {
-            return Err("Invalid status");
+            return Err("invalid status");
         }
         if self.report_size != size_of::<AttestationReport>() as u32 {
-            return Err("Invalid report size");
+            return Err("invalid report size");
         }
         self.report.validate()
     }
@@ -459,25 +459,25 @@ impl AttestationReportData {
         self.reported_tcb.validate()?;
         self.committed_tcb.validate()?;
         if self._reserved_0.iter().any(|&value| value != 0) {
-            return Err("Nonzero value in _reserved_0");
+            return Err("nonzero value in _reserved_0");
         }
         if self._reserved_1 != 0 {
-            return Err("Nonzero value in _reserved_1");
+            return Err("nonzero value in _reserved_1");
         }
         if self._reserved_2 != 0 {
-            return Err("Nonzero value in _reserved_2");
+            return Err("nonzero value in _reserved_2");
         }
         if self._reserved_3.iter().any(|&value| value != 0) {
-            return Err("Nonzero value in _reserved_3");
+            return Err("nonzero value in _reserved_3");
         }
         if self.signature_algo != SigningAlgorithm::EcdsaP384Sha384 as u32 {
-            return Err("Invalid signature algorithm");
+            return Err("invalid signature algorithm");
         }
         if self.get_platform_info().is_none() {
-            return Err("Invalid platform info");
+            return Err("invalid platform info");
         }
         if self.get_author_key_en().is_none() {
-            return Err("Invalid value for author_key_en");
+            return Err("invalid value for author_key_en");
         }
         Ok(())
     }
@@ -523,10 +523,10 @@ impl GuestPolicy {
     /// Checks that the flags are valid and the reserved bytes are all zero.
     pub fn validate(&self) -> Result<(), &'static str> {
         if self._reserved != 0 {
-            return Err("Nonzero value in _reserved");
+            return Err("nonzero value in _reserved");
         }
         if self.get_flags().is_none() {
-            return Err("Invalid flags");
+            return Err("invalid flags");
         }
         Ok(())
     }
@@ -556,7 +556,7 @@ impl TcbVersion {
     /// Checks that the reserved bytes are all zero.
     pub fn validate(&self) -> Result<(), &'static str> {
         if self._reserved.iter().any(|&value| value != 0) {
-            return Err("Nonzero value in _reserved");
+            return Err("nonzero value in _reserved");
         }
         Ok(())
     }
@@ -619,7 +619,7 @@ impl EcdsaSignature {
     /// Checks that the reserved bytes are all zero.
     pub fn validate_format(&self) -> Result<(), &'static str> {
         if self._reserved.iter().any(|&value| value != 0) {
-            return Err("Nonzero value in _reserved");
+            return Err("nonzero value in _reserved");
         }
         Ok(())
     }

--- a/experimental/sev_guest/src/instructions.rs
+++ b/experimental/sev_guest/src/instructions.rs
@@ -91,7 +91,7 @@ pub fn pvalidate(
         }
     } else {
         Err(InstructionError::from_repr(result)
-            .expect("Invalid return value from PVALIDATE instruction."))
+            .expect("invalid return value from PVALIDATE instruction"))
     }
 }
 
@@ -175,7 +175,7 @@ pub fn rmpadjust(
         Ok(())
     } else {
         Err(InstructionError::from_repr(result as u32)
-            .expect("Invalid return value from RMPADJUST instruction."))
+            .expect("invalid return value from RMPADJUST instruction"))
     }
 }
 

--- a/experimental/sev_guest/src/msr.rs
+++ b/experimental/sev_guest/src/msr.rs
@@ -248,7 +248,7 @@ impl TryFrom<u64> for PreferredGhcbGpaResponse {
     fn try_from(msr_value: u64) -> Result<Self, &'static str> {
         const PREFERRED_GPA_RESPONSE_INFO: u64 = 0x011;
         if msr_value & GHCB_INFO_MASK != PREFERRED_GPA_RESPONSE_INFO {
-            return Err("Vvlue is not a valid preferred GHCP GPA response");
+            return Err("value is not a valid preferred GHCP GPA response");
         }
         let ghcb_gpa = (msr_value & GCHP_DATA_MASK) as usize;
         Ok(Self { ghcb_gpa })

--- a/experimental/sev_guest/src/msr.rs
+++ b/experimental/sev_guest/src/msr.rs
@@ -109,7 +109,7 @@ impl TryFrom<u64> for SevInfoResponse {
     fn try_from(msr_value: u64) -> Result<Self, &'static str> {
         const SEV_INFO_RESPONSE_INFO: u64 = 0x001;
         if msr_value & GHCB_INFO_MASK != SEV_INFO_RESPONSE_INFO {
-            return Err("Value is not a valid SEV information response");
+            return Err("value is not a valid SEV information response");
         }
         let max_protocol_version = (msr_value >> 48) as u16;
         let min_protocol_version = (msr_value >> 32) as u16;
@@ -179,12 +179,12 @@ impl TryFrom<u64> for CpuidResponse {
         const SEV_INFO_RESPONSE_INFO: u64 = 0x005;
         const RESERVED_MASK: u64 = 0x3FFFF000;
         if msr_value & GHCB_INFO_MASK != SEV_INFO_RESPONSE_INFO || msr_value & RESERVED_MASK != 0 {
-            return Err("Value is not a valid CPUID response");
+            return Err("value is not a valid CPUID response");
         }
         let value = (msr_value >> 32) as u32;
         const REGISTER_MASK: u64 = 0xC0000000;
         let register = CpuidRegister::from_repr(((msr_value & REGISTER_MASK) >> 30) as u8)
-            .ok_or("Invalid register")?;
+            .ok_or("invalid register")?;
         Ok(Self { value, register })
     }
 }
@@ -248,7 +248,7 @@ impl TryFrom<u64> for PreferredGhcbGpaResponse {
     fn try_from(msr_value: u64) -> Result<Self, &'static str> {
         const PREFERRED_GPA_RESPONSE_INFO: u64 = 0x011;
         if msr_value & GHCB_INFO_MASK != PREFERRED_GPA_RESPONSE_INFO {
-            return Err("Value is not a valid preferred GHCP GPA response");
+            return Err("Vvlue is not a valid preferred GHCP GPA response");
         }
         let ghcb_gpa = (msr_value & GCHP_DATA_MASK) as usize;
         Ok(Self { ghcb_gpa })
@@ -355,12 +355,12 @@ impl SnpPageStateChangeRequest {
     pub fn new(page_gpa: usize, assignment: PageAssignment) -> Result<Self, &'static str> {
         let page_gpa = page_gpa as u64;
         if page_gpa & GHCB_INFO_MASK != 0 {
-            return Err("Page must be 4KiB-aligned");
+            return Err("page must be 4KiB-aligned");
         }
         // Only 52 bits can be use for an address.
         const ADDRESS_MAX: u64 = (1 << 52) - 1;
         if page_gpa > ADDRESS_MAX {
-            return Err("Page address is too high");
+            return Err("page address is too high");
         }
         Ok(Self {
             page_gpa,
@@ -393,7 +393,7 @@ impl TryFrom<u64> for SnpPageStateChangeResponse {
         if msr_value & GHCB_INFO_MASK != SNP_PAGE_STATE_CHANGE_RESPONSE_INFO
             || msr_value & RESERVED_MASK != 0
         {
-            return Err("Value is not a valid SNP Page State Change response");
+            return Err("value is not a valid SNP Page State Change response");
         }
         let error_code = (msr_value >> 32) as u32;
         Ok(Self { error_code })
@@ -410,7 +410,7 @@ pub fn change_snp_page_state(request: SnpPageStateChangeRequest) -> Result<(), &
     let response: SnpPageStateChangeResponse = read_protocol_msr().try_into()?;
     // Ensure that the page state change was successful.
     if response.error_code != 0 {
-        return Err("Page state change failed");
+        return Err("page state change failed");
     }
     Ok(())
 }
@@ -460,10 +460,10 @@ impl TryFrom<u64> for HypervisorFeatureSupportResponse {
     fn try_from(msr_value: u64) -> Result<Self, &'static str> {
         const HYPERVISOR_FEATURE_SUPPORT_RESPONSE_INFO: u64 = 0x081;
         if msr_value & GHCB_INFO_MASK != HYPERVISOR_FEATURE_SUPPORT_RESPONSE_INFO {
-            return Err("Value is not a valid Hypervisor Feature Support response");
+            return Err("value is not a valid Hypervisor Feature Support response");
         }
         HypervisorFeatureSupportResponse::from_bits(msr_value >> 12)
-            .ok_or("Invalid Hypervisor Feature Support bitmap")
+            .ok_or("invalid Hypervisor Feature Support bitmap")
     }
 }
 

--- a/experimental/sev_guest/src/secrets.rs
+++ b/experimental/sev_guest/src/secrets.rs
@@ -93,13 +93,13 @@ impl SecretsPage {
     /// the reserved bytes are all zero.
     pub fn validate(&self) -> Result<(), &'static str> {
         if !(SECRETS_PAGE_MIN_VERSION..=SECRETS_PAGE_MAX_VERSION).contains(&self.version) {
-            return Err("Invalid version");
+            return Err("invalid version");
         }
         if self.get_imi_en().is_none() {
-            return Err("Invalid value for imi_en");
+            return Err("invalid value for imi_en");
         }
         if self._reserved != 0 {
-            return Err("Nonzero value in _reserved");
+            return Err("nonzero value in _reserved");
         }
         Ok(())
     }

--- a/experimental/virtio/src/console/mod.rs
+++ b/experimental/virtio/src/console/mod.rs
@@ -155,11 +155,11 @@ where
                 RX_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.rx_queue.inner.get_desc_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.rx_queue.inner.get_avail_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.rx_queue.inner.get_used_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
             )
             .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
             .context("couldn't configure the receive queue")?;
@@ -168,11 +168,11 @@ where
                 TX_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.tx_queue.inner.get_desc_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.tx_queue.inner.get_avail_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.tx_queue.inner.get_used_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
             )
             .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
             .context("couldn't configure the transmit queue")?;

--- a/experimental/virtio/src/console/mod.rs
+++ b/experimental/virtio/src/console/mod.rs
@@ -77,7 +77,7 @@ impl<'a, A: Allocator> Console<'a, VirtioPciTransport, A> {
         // For now we just scan the first 32 devices on PCI bus 0 to find the first one that matches
         // the vendor ID and device ID.
         let pci_device = find_device(super::PCI_VENDOR_ID, PCI_DEVICE_ID)
-            .ok_or_else(|| anyhow::anyhow!("Couldn't find a virtio console device."))?;
+            .ok_or_else(|| anyhow::anyhow!("couldn't find a virtio console device"))?;
         let transport = VirtioPciTransport::new(pci_device);
         let device = VirtioBaseDevice::new(transport);
         let mut result = Self::new(device, &translate, alloc);
@@ -148,38 +148,38 @@ where
     ) -> anyhow::Result<()> {
         self.device
             .start_init(DEVICE_ID as u32, inverse)
-            .map_err(|error| anyhow::anyhow!("Virtio error: {:?}", error))
-            .context("Couldn't initialize the PCI device.")?;
+            .map_err(|error| anyhow::anyhow!("virtio error: {:?}", error))
+            .context("couldn't initialize the PCI device")?;
         self.device
             .configure_queue(
                 RX_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.rx_queue.inner.get_desc_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.rx_queue.inner.get_avail_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.rx_queue.inner.get_used_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
             )
-            .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
-            .context("Couldn't configure the receive queue.")?;
+            .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
+            .context("couldn't configure the receive queue")?;
         self.device
             .configure_queue(
                 TX_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.tx_queue.inner.get_desc_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.tx_queue.inner.get_avail_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.tx_queue.inner.get_used_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
             )
-            .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
-            .context("Couldn't configure the transmit queue.")?;
+            .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
+            .context("couldn't configure the transmit queue")?;
         self.device
             .complete_init()
-            .map_err(|error| anyhow::anyhow!("Device activation error: {:?}", error))
-            .context("Couldn't activate the PCI device.")?;
+            .map_err(|error| anyhow::anyhow!("device activation error: {:?}", error))
+            .context("couldn't activate the PCI device")?;
 
         // Let the device know there are available buffers in the receiver queue.
         self.device.notify_queue(RX_QUEUE_ID);

--- a/experimental/virtio/src/queue/mod.rs
+++ b/experimental/virtio/src/queue/mod.rs
@@ -147,7 +147,7 @@ impl<'a, const QUEUE_SIZE: usize, const BUFFER_SIZE: usize, A: Allocator>
     fn new<VP: Translator>(flags: DescFlags, translate: VP, alloc: &'a A) -> Self {
         assert!(
             QUEUE_SIZE.is_power_of_two(),
-            "Queue size must be a power of 2."
+            "queue size must be a power of 2"
         );
 
         let mut buffer = Vec::with_capacity_in(BUFFER_SIZE * QUEUE_SIZE, alloc);

--- a/experimental/virtio/src/queue/virtq.rs
+++ b/experimental/virtio/src/queue/virtq.rs
@@ -59,11 +59,11 @@ impl Desc {
     pub fn new(flags: DescFlags, addr: PhysAddr, length: u32) -> Self {
         assert!(
             !flags.contains(DescFlags::VIRTQ_DESC_F_INDIRECT),
-            "Indirect descriptors not supported."
+            "indirect descriptors not supported"
         );
         assert!(
             !flags.contains(DescFlags::VIRTQ_DESC_F_NEXT),
-            "Chained descriptors not supported."
+            "chained descriptors not supported"
         );
         Self {
             addr,

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -101,7 +101,7 @@ impl<'a, A: Allocator> VSock<'a, VirtioPciTransport, A> {
         // For now we just scan the first 32 devices on PCI bus 0 to find the first one that matches
         // the vendor ID and device ID.
         let pci_device = find_device(super::PCI_VENDOR_ID, PCI_DEVICE_ID)
-            .ok_or_else(|| anyhow::anyhow!("Couldn't find a virtio vsock device."))?;
+            .ok_or_else(|| anyhow::anyhow!("couldn't find a virtio vsock device"))?;
         let transport = VirtioPciTransport::new(pci_device);
         let device = VirtioBaseDevice::new(transport);
         let mut result = Self::new(device, &translate, alloc);
@@ -200,8 +200,8 @@ where
     ) -> anyhow::Result<()> {
         self.device
             .start_init(DEVICE_ID as u32, inverse)
-            .map_err(|error| anyhow::anyhow!("Virtio error: {:?}", error))
-            .context("Couldn't initialize the PCI device")?;
+            .map_err(|error| anyhow::anyhow!("virtio error: {:?}", error))
+            .context("couldn't initialize the PCI device")?;
         // We have to configure the event queue before the receive queue, otherwise the event
         // queue's configuration interferes with the receiver queue. This seems to be related to
         // something specific in the Linux kernel vhost vsock implementation.
@@ -210,44 +210,44 @@ where
                 EVENT_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.event_queue.inner.get_desc_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.event_queue.inner.get_avail_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.event_queue.inner.get_used_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
             )
-            .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
-            .context("Couldn't configure the event queue")?;
+            .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
+            .context("couldn't configure the event queue")?;
         self.device
             .configure_queue(
                 RX_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.rx_queue.inner.get_desc_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.rx_queue.inner.get_avail_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.rx_queue.inner.get_used_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
             )
-            .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
-            .context("Couldn't configure the receive queue")?;
+            .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
+            .context("couldn't configure the receive queue")?;
         self.device
             .configure_queue(
                 TX_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.tx_queue.inner.get_desc_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.tx_queue.inner.get_avail_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
                 translate(self.tx_queue.inner.get_used_addr())
-                    .context("Failed to translate VirtAddr to PhysAddr")?,
+                    .context("failed to translate VirtAddr to PhysAddr")?,
             )
-            .map_err(|error| anyhow::anyhow!("Queue configuration error: {:?}", error))
-            .context("Couldn't configure the transmit queue")?;
+            .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
+            .context("couldn't configure the transmit queue")?;
         self.device
             .complete_init()
-            .map_err(|error| anyhow::anyhow!("Device activation error: {:?}", error))
-            .context("Couldn't activate the PCI device")?;
+            .map_err(|error| anyhow::anyhow!("device activation error: {:?}", error))
+            .context("couldn't activate the PCI device")?;
 
         // Read the guest CID from the PCI config. The upper 32 bits must be 0, so we only read the
         // lower 32 bits.

--- a/experimental/virtio/src/vsock/mod.rs
+++ b/experimental/virtio/src/vsock/mod.rs
@@ -210,11 +210,11 @@ where
                 EVENT_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.event_queue.inner.get_desc_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.event_queue.inner.get_avail_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.event_queue.inner.get_used_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
             )
             .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
             .context("couldn't configure the event queue")?;
@@ -223,11 +223,11 @@ where
                 RX_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.rx_queue.inner.get_desc_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.rx_queue.inner.get_avail_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.rx_queue.inner.get_used_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
             )
             .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
             .context("couldn't configure the receive queue")?;
@@ -236,11 +236,11 @@ where
                 TX_QUEUE_ID,
                 QUEUE_SIZE as u16,
                 translate(self.tx_queue.inner.get_desc_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.tx_queue.inner.get_avail_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
                 translate(self.tx_queue.inner.get_used_addr())
-                    .context("failed to translate VirtAddr to PhysAddr")?,
+                    .context("couldn't translate VirtAddr to PhysAddr")?,
             )
             .map_err(|error| anyhow::anyhow!("queue configuration error: {:?}", error))
             .context("couldn't configure the transmit queue")?;

--- a/experimental/virtio/src/vsock/packet.rs
+++ b/experimental/virtio/src/vsock/packet.rs
@@ -86,7 +86,7 @@ impl Packet {
     ) -> anyhow::Result<Self> {
         if buffer_len > super::DATA_BUFFER_SIZE {
             anyhow::bail!(
-                "Total buffer length must be less than {}",
+                "total buffer length must be less than {}",
                 super::DATA_BUFFER_SIZE
             );
         }
@@ -151,7 +151,7 @@ impl Packet {
     /// Gets the type of socket the packet is intended for.
     pub fn get_type(&self) -> anyhow::Result<VSockType> {
         VSockType::from_repr(self.read_u16(TYPE_OFFSET))
-            .ok_or_else(|| anyhow::anyhow!("Invalid socket type."))
+            .ok_or_else(|| anyhow::anyhow!("invalid socket type"))
     }
 
     /// Sets the type of socket the packet is intended for.
@@ -161,16 +161,16 @@ impl Packet {
 
     /// Gets the op that the packet represents.
     pub fn get_op(&self) -> anyhow::Result<VSockOp> {
-        VSockOp::from_repr(self.read_u16(OP_OFFSET)).ok_or_else(|| anyhow::anyhow!("Invalid op."))
+        VSockOp::from_repr(self.read_u16(OP_OFFSET)).ok_or_else(|| anyhow::anyhow!("invalid op"))
     }
 
     /// Sets the op that the packet represents.
     pub fn set_op(&mut self, op: VSockOp) -> anyhow::Result<()> {
         if self.get_len() > 0 && op != VSockOp::Rw {
-            anyhow::bail!("Non-empty payloads are only allowed with data packets.");
+            anyhow::bail!("non-empty payloads are only allowed with data packets");
         }
         if self.get_len() == 0 && op == VSockOp::Rw {
-            anyhow::bail!("Empty payloads are not allowed with the RW op.");
+            anyhow::bail!("empty payloads are not allowed with the RW op");
         }
         self.write_u16(OP_OFFSET, op as u16);
         Ok(())
@@ -221,7 +221,7 @@ impl Packet {
         assert_eq!(
             len,
             self.get_payload_len(),
-            "Actual payload length does not match the packet's configured payload length."
+            "actual payload length does not match the packet's configured payload length"
         );
         &self.buffer[HEADER_SIZE..(HEADER_SIZE + len)]
     }
@@ -237,11 +237,11 @@ impl Packet {
     /// packet's op is `VSockOp::Rw`.
     fn set_payload(&mut self, data: &[u8]) -> anyhow::Result<()> {
         if self.get_op()? != VSockOp::Rw {
-            anyhow::bail!("Non-empty payloads are only allowed with data packets.");
+            anyhow::bail!("non-empty payloads are only allowed with data packets");
         }
         let len = self.get_len();
         if len as usize != data.len() {
-            anyhow::bail!("Data length does not match the packet's configured payload length.");
+            anyhow::bail!("data length does not match the packet's configured payload length");
         }
 
         self.buffer[HEADER_SIZE..(HEADER_SIZE + len as usize)].copy_from_slice(data);

--- a/experimental/virtio/src/vsock/socket/mod.rs
+++ b/experimental/virtio/src/vsock/socket/mod.rs
@@ -83,7 +83,7 @@ where
                     break;
                 } else {
                     anyhow::bail!(
-                        "Invalid response to connection request: {}",
+                        "invalid response to connection request: {}",
                         packet.get_op()?
                     );
                 }
@@ -128,7 +128,7 @@ where
                     peer_buffer_size = packet.get_buf_alloc();
                     break;
                 } else {
-                    anyhow::bail!("Invalid connection request: {}", packet.get_op()?);
+                    anyhow::bail!("invalid connection request: {}", packet.get_op()?);
                 }
             }
         }
@@ -202,7 +202,7 @@ where
                 self.config.host_port,
                 VSockOp::Shutdown,
             )
-            .expect("Could not create control packet.");
+            .expect("couldn't create control packet");
             // Notify the host that we will not send or receive any more data packets.
             packet.set_flags(VSockFlags::all());
             self.config.vsock.write_packet(&mut packet);
@@ -230,19 +230,19 @@ where
         // For now we panic if we are disconnected.
         assert!(
             self.connection_state == ConnectionState::Connected,
-            "Stream disconnected."
+            "stream disconnected"
         );
         let data_len = data.len();
         assert!(
             data_len <= MAX_PAYLOAD_SIZE,
-            "The data is too large for a single packet. Len: {}, Max: {}",
+            "the data is too large for a single packet - len: {}, max: {}",
             data.len(),
             MAX_PAYLOAD_SIZE
         );
 
         let data_len = Wrapping(data_len as u32);
         if data_len > self.peer_buffer_size - (self.sent_bytes - self.peer_processed_bytes) {
-            anyhow::bail!("Peer's stream buffer is full.");
+            anyhow::bail!("peer's stream buffer is full");
         }
 
         self.sent_bytes += data_len;
@@ -264,7 +264,7 @@ where
         // For now we panic if we are disconnected.
         assert!(
             self.connection_state == ConnectionState::Connected,
-            "Stream disconnected."
+            "stream disconnected"
         );
         let src_port = self.config.host_port;
         let dst_port = self.config.local_port;
@@ -276,17 +276,17 @@ where
             self.peer_buffer_size = Wrapping(packet.get_buf_alloc());
             self.peer_processed_bytes = Wrapping(packet.get_fwd_cnt());
             // For now we panic if we receive an invalid op.
-            match packet.get_op().expect("Invalid packet received on stream.") {
+            match packet.get_op().expect("invalid packet received on stream") {
                 VSockOp::CreditRequest => {
                     self.send_control_packet(VSockOp::CreditUpdate)
-                        .expect("Could not create control packet.");
+                        .expect("couldn't create control packet");
                 }
                 VSockOp::CreditUpdate => {
                     // We already updated our flow-control tracking data, so do nothing.
                 }
                 VSockOp::Request | VSockOp::Response => {
                     // For now we panic if we receive an invalid op.
-                    panic!("Invalid packet received on stream.");
+                    panic!("invalid packet received on stream");
                 }
                 VSockOp::Rst => {
                     self.connection_state = ConnectionState::Disconnected;
@@ -294,7 +294,7 @@ where
                 }
                 VSockOp::Shutdown => {
                     self.send_control_packet(VSockOp::Rst)
-                        .expect("Could not create control packet.");
+                        .expect("couldn't create control packet");
                     self.connection_state = ConnectionState::Disconnected;
                     return None;
                 }
@@ -348,7 +348,7 @@ where
 
         if self.must_send_credit_update() {
             self.send_control_packet(VSockOp::CreditUpdate)
-                .map_err(|error| anyhow::anyhow!("Could not create control packet: {:?}", error))?;
+                .map_err(|error| anyhow::anyhow!("couldn't create control packet: {:?}", error))?;
         }
 
         Ok(())

--- a/experimental/vsock/echo/src/main.rs
+++ b/experimental/vsock/echo/src/main.rs
@@ -29,12 +29,12 @@ fn main() {
     let mut stream = unsafe { VsockStream::from_raw_fd(FILE_DESCRIPTOR) };
     println!(
         "Connected to the {}",
-        stream.peer_addr().expect("Couldn't get peer address")
+        stream.peer_addr().expect("couldn't get peer address")
     );
 
     let mut buffer = vec![0; BUFFER_SIZE];
     loop {
-        let read_bytes = stream.read(&mut buffer).expect("Couldn't read bytes");
+        let read_bytes = stream.read(&mut buffer).expect("couldn't read bytes");
         if read_bytes == 0 {
             break; // Stream has finished.
         }
@@ -42,10 +42,10 @@ fn main() {
 
         stream
             .write_all(&buffer[..read_bytes])
-            .expect("Couldn't write bytes");
+            .expect("couldn't write bytes");
     }
 
     stream
         .shutdown(Shutdown::Both)
-        .expect("Couldn't shutdown stream");
+        .expect("couldn't shutdown stream");
 }

--- a/experimental/web_client/build.rs
+++ b/experimental/web_client/build.rs
@@ -19,5 +19,5 @@ fn main() {
         &["oak_grpc_unary_attestation/proto/unary_server.proto"],
         &["../.."],
     )
-    .expect("Proto compilation failed");
+    .expect("proto compilation failed");
 }

--- a/experimental/web_client/src/grpc_web.rs
+++ b/experimental/web_client/src/grpc_web.rs
@@ -50,10 +50,10 @@ async fn send(uri: &str, request_bytes: bytes::Bytes) -> anyhow::Result<bytes::B
         .body(request_bytes)
         .send()
         .await
-        .map_err(|error| anyhow!("Couldn't get response {:?}", error))?
+        .map_err(|error| anyhow!("couldn't get response {:?}", error))?
         .bytes()
         .await
-        .map_err(|error| anyhow!("Couldn't get response bytes {:?}", error))?;
+        .map_err(|error| anyhow!("couldn't get response bytes {:?}", error))?;
     Ok(response)
 }
 
@@ -74,7 +74,7 @@ where
 
     // write the message
     msg.encode(&mut buf)
-        .map_err(|error| anyhow!("Couldn't encode message {:?}", error))?;
+        .map_err(|error| anyhow!("couldn't encode message {:?}", error))?;
 
     // now we know the size of encoded message and can write the
     // header
@@ -101,7 +101,7 @@ where
 
     let len = body.get_u32();
     let msg = T::decode(&mut body.split_to(len as usize))
-        .map_err(|error| anyhow!("Couldn't decode message {:?}", error))?;
+        .map_err(|error| anyhow!("couldn't decode message {:?}", error))?;
 
     Ok(msg)
 }

--- a/experimental/web_client/src/grpc_web.rs
+++ b/experimental/web_client/src/grpc_web.rs
@@ -27,13 +27,13 @@ pub async fn grpc_web_unary<A: prost::Message, B: Default + prost::Message>(
     uri: &str,
     message: A,
 ) -> anyhow::Result<B> {
-    let request_bytes = encode_body(message).context("failed to encode message")?;
+    let request_bytes = encode_body(message).context("couldn't encode message")?;
     let response_bytes = send(uri, request_bytes)
         .await
-        .context("failed to send message")?;
+        .context("couldn't send message")?;
     let reply = decode_body::<B>(response_bytes)
         .await
-        .context("failed to decode message")?;
+        .context("couldn't decode message")?;
     Ok(reply)
 }
 

--- a/experimental/web_client/src/lib.rs
+++ b/experimental/web_client/src/lib.rs
@@ -93,7 +93,7 @@ impl WebClient {
             ),
         )
         .await
-        .context("Could not create Oak Functions client")
+        .context("couldn't create Oak Functions client")
         .map_err(|error| error.to_string())?;
         let inner = Rc::new(wasm_mutex::Mutex::new(inner));
         Ok(WebClient { inner })
@@ -116,7 +116,7 @@ impl WebClient {
             let length = response
                 .length
                 .try_into()
-                .map_err(|_| "Could not fit the response length into usize")?;
+                .map_err(|_| "couldn't fit the response length into usize")?;
             let body = &response.body[0..length];
 
             // Construct a JavaScript object that contains the response status
@@ -142,11 +142,11 @@ impl WebClient {
             .await
             .message(&request)
             .await
-            .context("Error invoking Oak Functions instance")?;
+            .context("error invoking Oak Functions instance")?;
 
         Response::decode(encoded_response.as_ref())
             .map_err(anyhow::Error::msg)
-            .context("Couldn't decode response")
+            .context("couldn't decode response")
     }
 }
 

--- a/java/src/main/java/com/google/oak/functions/client/AttestationClient.java
+++ b/java/src/main/java/com/google/oak/functions/client/AttestationClient.java
@@ -189,7 +189,7 @@ public class AttestationClient {
   public void attest(ManagedChannel channel)
       throws GeneralSecurityException, IOException, InterruptedException, VerificationException {
     if (channel == null) {
-      throw new NullPointerException("Channel must not be null.");
+      throw new NullPointerException("channel must not be null");
     }
     this.channel = channel;
     stub = UnarySessionGrpc.newBlockingStub(channel);

--- a/oak_channel/src/lib.rs
+++ b/oak_channel/src/lib.rs
@@ -78,7 +78,7 @@ impl InvocationChannel {
 
     pub fn read_message<M: message::Message>(&mut self) -> anyhow::Result<M> {
         let mut encoded_message: Vec<u8> = Vec::new();
-        let mut first_frame = self.inner.read_frame().context("failed to read frame.")?;
+        let mut first_frame = self.inner.read_frame().context("failed to read frame")?;
 
         if first_frame.flags.contains(frame::Flags::START) {
             if first_frame.flags.contains(frame::Flags::END) {
@@ -107,14 +107,14 @@ impl InvocationChannel {
                 encoded_message.append(&mut first_frame.body);
             }
         } else {
-            anyhow::bail!("expected a frame with the START flag set.");
+            anyhow::bail!("expected a frame with the START flag set");
         }
 
         loop {
-            let mut frame = self.inner.read_frame().context("failed to read frame.")?;
+            let mut frame = self.inner.read_frame().context("failed to read frame")?;
 
             if frame.flags.contains(frame::Flags::START) {
-                anyhow::bail!("received two frames with the START flag set.");
+                anyhow::bail!("received two frames with the START flag set");
             } else {
                 encoded_message.append(&mut frame.body);
                 if frame.flags.contains(frame::Flags::END) {
@@ -131,7 +131,7 @@ impl InvocationChannel {
         for frame in frames.into_iter() {
             self.inner
                 .write_frame(frame)
-                .context("failed to write frame.")?
+                .context("failed to write frame")?
         }
         Ok(())
     }

--- a/oak_channel/src/lib.rs
+++ b/oak_channel/src/lib.rs
@@ -78,7 +78,7 @@ impl InvocationChannel {
 
     pub fn read_message<M: message::Message>(&mut self) -> anyhow::Result<M> {
         let mut encoded_message: Vec<u8> = Vec::new();
-        let mut first_frame = self.inner.read_frame().context("failed to read frame")?;
+        let mut first_frame = self.inner.read_frame().context("couldn't read frame")?;
 
         if first_frame.flags.contains(frame::Flags::START) {
             if first_frame.flags.contains(frame::Flags::END) {
@@ -111,7 +111,7 @@ impl InvocationChannel {
         }
 
         loop {
-            let mut frame = self.inner.read_frame().context("failed to read frame")?;
+            let mut frame = self.inner.read_frame().context("couldn't read frame")?;
 
             if frame.flags.contains(frame::Flags::START) {
                 anyhow::bail!("received two frames with the START flag set");
@@ -131,7 +131,7 @@ impl InvocationChannel {
         for frame in frames.into_iter() {
             self.inner
                 .write_frame(frame)
-                .context("failed to write frame")?
+                .context("couldn't write frame")?
         }
         Ok(())
     }

--- a/oak_channel/src/message.rs
+++ b/oak_channel/src/message.rs
@@ -55,7 +55,7 @@ impl Message for RequestMessage {
 
         let length: Length = len
             .try_into()
-            .expect("could not convert the message length usize to u32");
+            .expect("couldn't convert the message length usize to u32");
 
         message_bytes.extend_from_slice(&length.to_le_bytes());
         message_bytes.extend_from_slice(&self.invocation_id.to_le_bytes());
@@ -102,7 +102,7 @@ impl Message for ResponseMessage {
 
         let length: Length = len
             .try_into()
-            .expect("could not convert the message length usize to u32");
+            .expect("couldn't convert the message length usize to u32");
 
         message_bytes.extend_from_slice(&length.to_le_bytes());
         message_bytes.extend_from_slice(&self.invocation_id.to_le_bytes());

--- a/oak_functions/examples/benchmark/module/build.rs
+++ b/oak_functions/examples/benchmark/module/build.rs
@@ -18,7 +18,7 @@ extern crate prost_build;
 
 fn main() {
     let file_paths = ["oak_functions/proto/benchmark.proto"];
-    prost_build::compile_protos(&file_paths, &["../../../../"]).expect("Proto compilation failed");
+    prost_build::compile_protos(&file_paths, &["../../../../"]).expect("proto compilation failed");
 
     // Tell cargo to rerun this build script if the proto file has changed.
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath

--- a/oak_functions/examples/benchmark/module/src/lib.rs
+++ b/oak_functions/examples/benchmark/module/src/lib.rs
@@ -24,18 +24,18 @@ use proto::{benchmark_request::Action, BenchmarkRequest, LookupTest};
 
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn main() {
-    let request = oak_functions_sdk::read_request().expect("Couldn't read request body.");
-    let request = BenchmarkRequest::decode(&*request).expect("Couldn't decode request.");
+    let request = oak_functions_sdk::read_request().expect("couldn't read request body");
+    let request = BenchmarkRequest::decode(&*request).expect("couldn't decode request");
 
     match request.action.unwrap() {
         Action::Lookup(LookupTest { key }) => {
             let mut response = Vec::new();
             for _ in 0..request.iterations {
                 response = oak_functions_sdk::storage_get_item(&key)
-                    .expect("Couldn't look up entry")
+                    .expect("couldn't look up entry")
                     .unwrap_or_default();
             }
-            oak_functions_sdk::write_response(&response).expect("Couldn't write response body.");
+            oak_functions_sdk::write_response(&response).expect("couldn't write response body");
         }
     };
 }

--- a/oak_functions/examples/echo/module/src/lib.rs
+++ b/oak_functions/examples/echo/module/src/lib.rs
@@ -18,7 +18,7 @@
 
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn main() {
-    let request = oak_functions_sdk::read_request().expect("Couldn't read request body.");
+    let request = oak_functions_sdk::read_request().expect("couldn't read request body");
     let response = request;
-    oak_functions_sdk::write_response(&response).expect("Couldn't write response body.");
+    oak_functions_sdk::write_response(&response).expect("couldn't write response body");
 }

--- a/oak_functions/examples/key_value_lookup/module/src/lib.rs
+++ b/oak_functions/examples/key_value_lookup/module/src/lib.rs
@@ -25,9 +25,9 @@ mod tests;
 
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn main() {
-    let request = oak_functions_sdk::read_request().expect("Couldn't read request body.");
+    let request = oak_functions_sdk::read_request().expect("couldn't read request body");
     let response = oak_functions_sdk::storage_get_item(&request)
-        .expect("Couldn't look up entry")
+        .expect("couldn't look up entry")
         .unwrap_or_default();
-    oak_functions_sdk::write_response(&response).expect("Couldn't write response body.");
+    oak_functions_sdk::write_response(&response).expect("couldn't write response body");
 }

--- a/oak_functions/examples/weather_lookup/module/src/lib.rs
+++ b/oak_functions/examples/weather_lookup/module/src/lib.rs
@@ -45,24 +45,24 @@ pub extern "C" fn main() {
     let result: Result<Vec<u8>, String> = try {
         // Read the request.
         let request_body = oak_functions_sdk::read_request()
-            .map_err(|err| format!("could not read request body: {:?}", err))?;
+            .map_err(|err| format!("couldn't read request body: {:?}", err))?;
 
         // Parse the request as JSON.
         let request: Request = serde_json::from_slice(&request_body)
-            .map_err(|err| format!("could not deserialize request as JSON: {:?}", err))?;
+            .map_err(|err| format!("couldn't deserialize request as JSON: {:?}", err))?;
         log!("parsed request: {:?}\n", request);
 
         // Find the S2 cell (using the default level) that contains the current location.
         let level = location_utils::S2_DEFAULT_LEVEL;
         let location = location_from_degrees(request.latitude_degrees, request.longitude_degrees);
         let cell =
-            find_cell(&location, level).map_err(|err| format!("could not find cell: {:?}", err))?;
+            find_cell(&location, level).map_err(|err| format!("couldn't find cell: {:?}", err))?;
         log!("current location cell token: {}\n", cell.to_token());
 
         // Look up the index values for the list of weather data points in the vicinity of the cell.
         let index = oak_functions_sdk::storage_get_item(&cell_id_to_bytes(&cell))
-            .map_err(|err| format!("could not get index item: {:?}", err))?
-            .ok_or("could not find index item for cell")?;
+            .map_err(|err| format!("couldn't get index item: {:?}", err))?
+            .ok_or("couldn't find index item for cell")?;
 
         // Find the closest key by linearly scanning the nearby weather data points to find the
         // closest one.
@@ -71,7 +71,7 @@ pub extern "C" fn main() {
 
         for chunk in index.chunks(8) {
             let test = location_from_bytes(chunk)
-                .map_err(|err| format!("could not convert chunk to location: {:?}", err))?;
+                .map_err(|err| format!("couldn't convert chunk to location: {:?}", err))?;
             let distance = location.distance(&test);
             if distance < best_distance {
                 best_distance = distance;
@@ -84,13 +84,13 @@ pub extern "C" fn main() {
                 log!("nearest data point: {:?}\n", key_location);
                 let best_value =
                     oak_functions_sdk::storage_get_item(&location_to_bytes(&key_location))
-                        .map_err(|err| format!("could not get item: {:?}", err))?
-                        .ok_or("could not find item with key")?;
+                        .map_err(|err| format!("couldn't get item: {:?}", err))?
+                        .ok_or("couldn't find item with key")?;
                 log!("nearest location value: {:?}\n", best_value);
 
                 best_value
             }
-            None => b"could not find location within cutoff".to_vec(),
+            None => b"couldn't find location within cutoff".to_vec(),
         };
 
         result
@@ -99,7 +99,7 @@ pub extern "C" fn main() {
     let response = result.unwrap_or_else(|err| err.as_bytes().to_vec());
 
     // Write the response.
-    oak_functions_sdk::write_response(&response).expect("Couldn't write the response body.");
+    oak_functions_sdk::write_response(&response).expect("couldn't write the response body");
 }
 
 #[export_name = "wizer.initialize"]

--- a/oak_functions/examples/weather_lookup/module/src/tests.rs
+++ b/oak_functions/examples/weather_lookup/module/src/tests.rs
@@ -80,9 +80,14 @@ async fn test_server() {
         // A bit further from key_0.
         let response = make_request(server_port, br#"{"lat":51.4,"lng":-0.6}"#).await;
         assert_eq!(
-            r#"could not find location within cutoff"#,
-            std::str::from_utf8(&response).unwrap()
-        );
+        <<<<<<< HEAD
+                    r#"could not find location within cutoff"#,
+                    std::str::from_utf8(&response).unwrap()
+        =======
+                    r#"couldn't find location within cutoff"#,
+                    std::str::from_utf8(response.body().unwrap()).unwrap()
+        >>>>>>> e16cb33c (Make errors more consistent)
+                );
     }
     {
         // Close to key_1.
@@ -96,7 +101,7 @@ async fn test_server() {
         // Far from both keys.
         let response = make_request(server_port, br#"{"lat":-10.0,"lng":10.0}"#).await;
         assert_eq!(
-            r#"could not find index item for cell"#,
+            r#"couldn't find index item for cell"#,
             std::str::from_utf8(&response).unwrap()
         );
     }
@@ -104,7 +109,7 @@ async fn test_server() {
         // Malformed request.
         let response = make_request(server_port, b"invalid - JSON").await;
         assert_eq!(
-            "could not deserialize request as JSON: Error(\"expected value\", line: 1, column: 1)",
+            "couldn't deserialize request as JSON: Error(\"expected value\", line: 1, column: 1)",
             std::str::from_utf8(&response).unwrap()
         );
     }
@@ -128,11 +133,11 @@ fn bench_wasm_handler(bencher: &mut Bencher, warmup: bool) {
     let elapsed_limit_millis = 20;
 
     let wasm_path = oak_functions_test_utils::build_rust_crate_wasm("weather_lookup").unwrap();
-    let wasm_module_bytes = std::fs::read(&wasm_path).expect("could not read Wasm file");
+    let wasm_module_bytes = std::fs::read(&wasm_path).expect("couldn't read Wasm file");
     let wasm_module_bytes = if warmup {
         wizer::Wizer::new()
             .run(&wasm_module_bytes)
-            .expect("Couldn't initialise Wasm module via Wizer")
+            .expect("couldn't initialise Wasm module via Wizer")
     } else {
         wasm_module_bytes
     };

--- a/oak_functions/examples/weather_lookup/module/src/tests.rs
+++ b/oak_functions/examples/weather_lookup/module/src/tests.rs
@@ -80,14 +80,9 @@ async fn test_server() {
         // A bit further from key_0.
         let response = make_request(server_port, br#"{"lat":51.4,"lng":-0.6}"#).await;
         assert_eq!(
-        <<<<<<< HEAD
-                    r#"could not find location within cutoff"#,
-                    std::str::from_utf8(&response).unwrap()
-        =======
-                    r#"couldn't find location within cutoff"#,
-                    std::str::from_utf8(response.body().unwrap()).unwrap()
-        >>>>>>> e16cb33c (Make errors more consistent)
-                );
+            r#"couldn't find location within cutoff"#,
+            std::str::from_utf8(&response).unwrap()
+        );
     }
     {
         // Close to key_1.

--- a/oak_functions/load_test/src/main.rs
+++ b/oak_functions/load_test/src/main.rs
@@ -27,7 +27,7 @@ const TOTAL_REQUESTS: usize = 50;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let mut client = Client::new(URL).await.context("Could not create client")?;
+    let mut client = Client::new(URL).await.context("couldn't create client")?;
 
     let mut latencies_millis = Vec::<f64>::with_capacity(TOTAL_REQUESTS);
 
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
         let response = client
             .invoke(REQUEST)
             .await
-            .context("Could not invoke Oak Functions instance")?;
+            .context("couldn't invoke Oak Functions instance")?;
         let elapsed_millis = start.elapsed().as_millis();
         latencies_millis.push(elapsed_millis as f64);
         println!(

--- a/oak_functions/location_utils/src/lib.rs
+++ b/oak_functions/location_utils/src/lib.rs
@@ -147,7 +147,7 @@ pub fn cell_id_to_bytes(cell: &CellID) -> Vec<u8> {
 /// vector of bytes.
 pub fn cell_id_from_bytes(bytes: &[u8]) -> Result<CellID> {
     let cell_id = CellID::from_token(
-        std::str::from_utf8(bytes).context("could not parse cell id bytes to UTF8 string")?,
+        std::str::from_utf8(bytes).context("couldn't parse cell id bytes from UTF8 string")?,
     );
     Ok(cell_id)
 }

--- a/oak_functions/lookup_data_checker/src/main.rs
+++ b/oak_functions/lookup_data_checker/src/main.rs
@@ -40,7 +40,7 @@ pub fn parse_lookup_entries<B: prost::bytes::Buf>(
     while lookup_data_buffer.has_remaining() {
         let entry =
             oak_functions_abi::proto::Entry::decode_length_delimited(&mut lookup_data_buffer)
-                .context("could not decode entry")?;
+                .context("couldn't decode entry")?;
         entries.insert(entry.key, entry.value);
     }
     Ok(entries)
@@ -52,12 +52,12 @@ fn main() -> anyhow::Result<()> {
 
     // Read lookup data file.
     info!("Checking lookup data file format: {}", opt.file_path);
-    let file = File::open(opt.file_path).context("could not open file")?;
+    let file = File::open(opt.file_path).context("couldn't open file")?;
     let mut reader = BufReader::new(file);
     let mut buffer = Vec::new();
     reader.read_to_end(&mut buffer)?;
     let entries =
-        parse_lookup_entries(&mut buffer.as_ref()).context("could not parse lookup data")?;
+        parse_lookup_entries(&mut buffer.as_ref()).context("couldn't parse lookup data")?;
 
     // Parse lookup data entries.
     debug!("Parsed entries:");
@@ -66,20 +66,20 @@ fn main() -> anyhow::Result<()> {
     for entry in entries {
         if entry.0.len() == LOCATION_SIZE {
             let location = location_from_bytes(&entry.0)
-                .with_context(|| format!("could not parse location {:?}", &entry.0))?;
+                .with_context(|| format!("couldn't parse location {:?}", &entry.0))?;
             weather_locations.insert(entry.0);
 
             debug!("- {{{:?}: {:?}}} # Location", location, entry.1.to_vec());
         } else {
             let cell_id = cell_id_from_bytes(&entry.0)
-                .with_context(|| format!("could not parse cell ID {:?}", &entry.0))?;
+                .with_context(|| format!("couldn't parse cell ID {:?}", &entry.0))?;
             assert_eq!(cell_id.level(), S2_DEFAULT_LEVEL as u64);
 
             let mut locations = vec![];
             for chunk in entry.1.chunks(LOCATION_SIZE) {
                 let location = location_from_bytes(chunk).with_context(|| {
                     format!(
-                        "could not parse location {:?} corresponding to the cell ID {:?}",
+                        "couldn't parse location {:?} corresponding to the cell ID {:?}",
                         chunk, cell_id
                     )
                 })?;
@@ -96,7 +96,7 @@ fn main() -> anyhow::Result<()> {
         let extra_locations: HashSet<_> = weather_locations.difference(&cell_locations).collect();
         if !extra_locations.is_empty() {
             anyhow::bail!(format!(
-                "Locations are not presented in Cell IDs: {:?}",
+                "locations are not presented in Cell IDs: {:?}",
                 extra_locations
             ));
         }
@@ -105,7 +105,7 @@ fn main() -> anyhow::Result<()> {
             cell_locations.difference(&weather_locations).collect();
         if !extra_locations_in_cells.is_empty() {
             anyhow::bail!(format!(
-                "Locations from Cell IDs do not have individual data entries: {:?}",
+                "locations from Cell IDs do not have individual data entries: {:?}",
                 extra_locations
             ));
         }

--- a/oak_functions/lookup_data_generator/src/data.rs
+++ b/oak_functions/lookup_data_generator/src/data.rs
@@ -56,7 +56,7 @@ pub fn generate_and_serialize_random_entries<R: Rng>(
         let entry = create_random_entry(rng, key_size_bytes, value_size_bytes);
         entry
             .encode_length_delimited(&mut buf)
-            .context("could not encode entry")?;
+            .context("couldn't encode entry")?;
     }
     Ok(buf)
 }
@@ -91,7 +91,7 @@ pub fn generate_and_serialize_weather_entries<R: Rng>(rng: &mut R) -> anyhow::Re
             let entry = create_weather_entry(rng, lat, lng);
             entry
                 .encode_length_delimited(&mut buf)
-                .context("could not encode entry")?;
+                .context("couldn't encode entry")?;
         }
     }
     Ok(buf)
@@ -153,7 +153,7 @@ pub fn generate_and_serialize_sparse_weather_entries<R: Rng>(
         };
         entry
             .encode_length_delimited(&mut buf)
-            .context("could not encode entry")?;
+            .context("couldn't encode entry")?;
     }
     // Add the cell-based index entries.
     for (key, values) in cell_map.iter_all() {
@@ -163,7 +163,7 @@ pub fn generate_and_serialize_sparse_weather_entries<R: Rng>(
         };
         cell_entry
             .encode_length_delimited(&mut buf)
-            .context("could not encode cell index")?;
+            .context("couldn't encode cell index")?;
     }
     Ok(buf)
 }

--- a/oak_functions/lookup_data_generator/src/main.rs
+++ b/oak_functions/lookup_data_generator/src/main.rs
@@ -67,15 +67,15 @@ fn main() -> anyhow::Result<()> {
             value_size_bytes,
             entries,
         )
-        .context("could not generate random entries")?,
+        .context("couldn't generate random entries")?,
         Command::Weather {} => generate_and_serialize_weather_entries(&mut rng)
-            .context("could not generate weather entries")?,
+            .context("couldn't generate weather entries")?,
         Command::WeatherSparse { entries } => {
             generate_and_serialize_sparse_weather_entries(&mut rng, entries)
-                .context("could not generate sparse weather entries")?
+                .context("couldn't generate sparse weather entries")?
         }
     };
-    let mut file = File::create(opt.out_file_path).context("could not create out file")?;
-    file.write_all(&buf).context("could not write to file")?;
+    let mut file = File::create(opt.out_file_path).context("couldn't create out file")?;
+    file.write_all(&buf).context("couldn't write to file")?;
     Ok(())
 }

--- a/oak_functions/testing/src/lib.rs
+++ b/oak_functions/testing/src/lib.rs
@@ -26,12 +26,13 @@ where
     L: OakLogger,
 {
     fn invoke(&mut self, request: Vec<u8>) -> Result<Vec<u8>, OakStatus> {
-        let request = bincode::deserialize(&request).expect("Fail to deserialize testing request.");
+        let request =
+            bincode::deserialize(&request).expect("failed to deserialize testing request");
 
         let response = match request {
             TestingRequest::Echo(echo_message) => {
                 let echo_response = TestingResponse::Echo(echo_message);
-                bincode::serialize(&echo_response).expect("Fail to serialize testing request.")
+                bincode::serialize(&echo_response).expect("failed to serialize testing request")
             }
             TestingRequest::Blackhole(message) => {
                 self.logger.log_sensitive(Level::Debug, &message);

--- a/oak_functions/testing/src/lib.rs
+++ b/oak_functions/testing/src/lib.rs
@@ -26,13 +26,12 @@ where
     L: OakLogger,
 {
     fn invoke(&mut self, request: Vec<u8>) -> Result<Vec<u8>, OakStatus> {
-        let request =
-            bincode::deserialize(&request).expect("failed to deserialize testing request");
+        let request = bincode::deserialize(&request).expect("couldn't deserialize testing request");
 
         let response = match request {
             TestingRequest::Echo(echo_message) => {
                 let echo_response = TestingResponse::Echo(echo_message);
-                bincode::serialize(&echo_response).expect("failed to serialize testing request")
+                bincode::serialize(&echo_response).expect("couldn't serialize testing request")
             }
             TestingRequest::Blackhole(message) => {
                 self.logger.log_sensitive(Level::Debug, &message);

--- a/oak_functions/wasm/src/lib.rs
+++ b/oak_functions/wasm/src/lib.rs
@@ -101,13 +101,13 @@ where
             MAIN_FUNCTION_NAME,
             &wasmi::Signature::new(&[][..], None),
         )
-        .context("could not validate `main` export")?;
+        .context("couldn't validate `main` export")?;
         check_export_function_signature(
             &instance,
             ALLOC_FUNCTION_NAME,
             &wasmi::Signature::new(&[ValueType::I32][..], Some(ValueType::I32)),
         )
-        .context(" could not validate `alloc` export")?;
+        .context("couldn't validate `alloc` export")?;
 
         abi.instance = Some(instance.clone());
         // Make sure that non-empty `memory` is attached to the WasmState. Fail early if
@@ -115,10 +115,10 @@ where
         abi.memory = Some(
             instance
                 .export_by_name("memory")
-                .context("could not find Wasm `memory` export")?
+                .context("couldn't find Wasm `memory` export")?
                 .as_memory()
                 .cloned()
-                .context("could not interpret Wasm `memory` export as memory")?,
+                .context("couldn't interpret Wasm `memory` export as memory")?,
         );
 
         Ok(abi)
@@ -129,7 +129,7 @@ where
         let result = instance.invoke_export(MAIN_FUNCTION_NAME, &[], self);
         self.logger.log_sensitive(
             Level::Info,
-            &format!("Running Wasm module completed with result: {:?}", result),
+            &format!("running Wasm module completed with result: {:?}", result),
         );
     }
 
@@ -139,9 +139,7 @@ where
 
     /// Helper function to get memory.
     pub fn get_memory(&self) -> &wasmi::MemoryRef {
-        self.memory
-            .as_ref()
-            .expect("WasmState memory not attached!?")
+        self.memory.as_ref().expect("WasmState memory not attached")
     }
 
     /// Validates whether a given address range (inclusive) falls within the currently allocated
@@ -279,7 +277,7 @@ where
         response_len_ptr: AbiPointer,
     ) -> Result<(), OakStatus> {
         let handle: ExtensionHandle = ExtensionHandle::from_i32(handle).ok_or_else(|| {
-            self.log_error(&format!("Fail to convert handle {:?} from i32.", handle));
+            self.log_error(&format!("failed to convert handle {:?} from i32", handle));
             OakStatus::ErrInvalidHandle
         })?;
 
@@ -287,7 +285,7 @@ where
             .read_buffer_from_wasm_memory(request_ptr, request_len)
             .map_err(|err| {
                 self.log_error(&format!(
-                    "Handle {:?}: Unable to read input from guest memory: {:?}",
+                    "handle {:?}: unable to read input from guest memory: {:?}",
                     handle, err
                 ));
                 OakStatus::ErrInvalidArgs
@@ -297,7 +295,7 @@ where
             // Can't convince the borrow checker to use `ok_or_else` to `self.log_error`.
             Some(extension) => Ok(extension),
             None => {
-                self.log_error(&format!("Cannot find extension with handle {:?}.", handle));
+                self.log_error(&format!("cannot find extension with handle {:?}", handle));
                 Err(OakStatus::ErrInvalidHandle)
             }
         }?;
@@ -378,14 +376,14 @@ where
         // Look for the function (i.e., `field_name`) in the statically registered functions.
         let (index, expected_signature) =
             oak_functions_resolve_func(field_name).ok_or_else(|| {
-                wasmi::Error::Instantiation(format!("Export {} not found", field_name))
+                wasmi::Error::Instantiation(format!("export {} not found", field_name))
             })?;
 
         if signature == &expected_signature {
             Ok(wasmi::FuncInstance::alloc_host(expected_signature, index))
         } else {
             Err(wasmi::Error::Instantiation(format!(
-                "Export `{}` doesn't match expected signature; got: {:?}, expected: {:?}",
+                "export `{}` doesn't match expected signature; got: {:?}, expected: {:?}",
                 field_name, signature, expected_signature
             )))
         }
@@ -399,10 +397,10 @@ fn check_export_function_signature(
 ) -> anyhow::Result<()> {
     let export_function = instance
         .export_by_name(export_name)
-        .context("could not find Wasm export")?
+        .context("couldn't find Wasm export")?
         .as_func()
         .cloned()
-        .context("could not interpret Wasm export as function")?;
+        .context("couldn't interpret Wasm export as function")?;
     if export_function.signature() != expected_signature {
         anyhow::bail!(
             "invalid signature for export: {:?}, expected: {:?}",
@@ -434,7 +432,7 @@ where
         logger: L,
     ) -> anyhow::Result<Self> {
         let module = wasmi::Module::from_buffer(wasm_module_bytes)
-            .map_err(|err| anyhow::anyhow!("could not load module from buffer: {:?}", err))?;
+            .map_err(|err| anyhow::anyhow!("couldn't load module from buffer: {:?}", err))?;
 
         Ok(WasmHandler {
             module: Arc::new(module),

--- a/oak_functions/wasm/src/lib.rs
+++ b/oak_functions/wasm/src/lib.rs
@@ -93,7 +93,7 @@ where
             module,
             &wasmi::ImportsBuilder::new().with_resolver("oak_functions", &abi),
         )
-        .map_err(|err| anyhow::anyhow!("failed to instantiate Wasm module: {:?}", err))?
+        .map_err(|err| anyhow::anyhow!("couldn't instantiate Wasm module: {:?}", err))?
         .assert_no_start();
 
         check_export_function_signature(
@@ -277,7 +277,7 @@ where
         response_len_ptr: AbiPointer,
     ) -> Result<(), OakStatus> {
         let handle: ExtensionHandle = ExtensionHandle::from_i32(handle).ok_or_else(|| {
-            self.log_error(&format!("failed to convert handle {:?} from i32", handle));
+            self.log_error(&format!("couldn't convert handle {:?} from i32", handle));
             OakStatus::ErrInvalidHandle
         })?;
 

--- a/oak_functions/wasm/src/tests.rs
+++ b/oak_functions/wasm/src/tests.rs
@@ -160,7 +160,7 @@ fn test_invoke_extension() {
     // Assumes we have a Testing extension in our test wasm_state.
     let message = "Hello!".to_owned();
     let request = bincode::serialize(&TestingRequest::Echo(message.clone()))
-        .expect("Failed to serialize request.");
+        .expect("failed to serialize request");
 
     // Guess some memory addresses in linear Wasm memory to write the request to.
     let request_ptr: AbiPointer = 100;
@@ -181,7 +181,7 @@ fn test_invoke_extension() {
     assert!(result.is_ok());
 
     let expected_response =
-        bincode::serialize(&TestingResponse::Echo(message)).expect("Failed to serialize response.");
+        bincode::serialize(&TestingResponse::Echo(message)).expect("failed to serialize response");
 
     // Get response_len from response_len_ptr.
     let response_len: AbiPointerOffset = wasm_state
@@ -209,14 +209,14 @@ fn create_test_wasm_state() -> WasmState<TestingLogger> {
     let logger = TestingLogger::for_test();
 
     let testing_factory = TestingFactory::new_boxed_extension_factory(logger.clone())
-        .expect("Could not create TestingFactory.");
+        .expect("couldn't create TestingFactory");
 
     let wasm_module_path = oak_functions_test_utils::build_rust_crate_wasm("echo").unwrap();
     let wasm_module_bytes = std::fs::read(&wasm_module_path).unwrap();
 
     let wasm_handler = WasmHandler::create(&wasm_module_bytes, vec![testing_factory], logger)
-        .expect("Could not create WasmHandler.");
+        .expect("couldn't create WasmHandler");
     wasm_handler
         .init_wasm_state(b"".to_vec())
-        .expect("Could not create WasmState.")
+        .expect("couldn't create WasmState")
 }

--- a/oak_functions/wasm/src/tests.rs
+++ b/oak_functions/wasm/src/tests.rs
@@ -160,7 +160,7 @@ fn test_invoke_extension() {
     // Assumes we have a Testing extension in our test wasm_state.
     let message = "Hello!".to_owned();
     let request = bincode::serialize(&TestingRequest::Echo(message.clone()))
-        .expect("failed to serialize request");
+        .expect("couldn't serialize request");
 
     // Guess some memory addresses in linear Wasm memory to write the request to.
     let request_ptr: AbiPointer = 100;
@@ -181,7 +181,7 @@ fn test_invoke_extension() {
     assert!(result.is_ok());
 
     let expected_response =
-        bincode::serialize(&TestingResponse::Echo(message)).expect("failed to serialize response");
+        bincode::serialize(&TestingResponse::Echo(message)).expect("couldn't serialize response");
 
     // Get response_len from response_len_ptr.
     let response_len: AbiPointerOffset = wasm_state

--- a/oak_functions_abi/build.rs
+++ b/oak_functions_abi/build.rs
@@ -22,7 +22,7 @@ fn main() {
         "oak_functions/proto/lookup_data.proto",
     ];
     prost_build::compile_protos(&file_paths, &[env!("WORKSPACE_ROOT")])
-        .expect("Proto compilation failed");
+        .expect("proto compilation failed");
 
     // Tell cargo to rerun this build script if the proto file has changed.
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath

--- a/oak_functions_abi/src/lib.rs
+++ b/oak_functions_abi/src/lib.rs
@@ -188,7 +188,7 @@ impl TryFrom<&[u8]> for StorageGetItemResponse {
             return Ok(StorageGetItemResponse { value: None });
         }
         if buffer.len() < LENGTH_SIZE {
-            anyhow::bail!("Invalid buffer: buffer too small.")
+            anyhow::bail!("invalid buffer: buffer too small")
         }
 
         let mut len_buffer = [0; LENGTH_SIZE];
@@ -197,7 +197,7 @@ impl TryFrom<&[u8]> for StorageGetItemResponse {
 
         if buffer.len() != len as usize + LENGTH_SIZE {
             anyhow::bail!(
-                "Invalid buffer: expected buffer size of {}, but found {}",
+                "invalid buffer: expected buffer size of {}, but found {}",
                 len as usize + LENGTH_SIZE,
                 buffer.len()
             )

--- a/oak_functions_client/src/lib.rs
+++ b/oak_functions_client/src/lib.rs
@@ -28,7 +28,7 @@ impl Client {
     pub async fn new(uri: &str) -> anyhow::Result<Self> {
         let inner = oak_remote_attestation_noninteractive::client::OakClient::create(uri)
             .await
-            .context("Could not create Oak Functions client")?;
+            .context("couldn't create Oak Functions client")?;
         Ok(Client { inner })
     }
 
@@ -39,7 +39,7 @@ impl Client {
             .inner
             .message(request)
             .await
-            .context("Error invoking Oak Functions instance")?;
+            .context("error invoking Oak Functions instance")?;
         // TODO(#3442): Decrypt response.
         Ok(response)
     }

--- a/oak_functions_client/src/main.rs
+++ b/oak_functions_client/src/main.rs
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut client = Client::new(&opt.uri)
         .await
-        .context("Could not create Oak Functions client")?;
+        .context("couldn't create Oak Functions client")?;
 
     if opt.test_large_message {
         // The client should be a able to send a large message without
@@ -71,7 +71,7 @@ async fn main() -> anyhow::Result<()> {
         let response = client
             .invoke(&LARGE_MESSAGE)
             .await
-            .context("Error invoking Oak Functions instance");
+            .context("error invoking Oak Functions instance");
         assert!(response.is_ok());
         return Ok(());
     }
@@ -91,7 +91,7 @@ async fn main() -> anyhow::Result<()> {
         let response = client
             .invoke(request.as_bytes())
             .await
-            .context("Could not invoke Oak Functions")?;
+            .context("couldn't invoke Oak Functions")?;
 
         println!("Response: {:?}", response);
         let response_body = std::str::from_utf8(&response).unwrap();

--- a/oak_functions_client/src/rekor.rs
+++ b/oak_functions_client/src/rekor.rs
@@ -217,7 +217,7 @@ pub fn verify_rekor_signature(
         &signature_bundle.canonicalized,
         pem_encoded_public_key_bytes,
     )
-    .context("failed to verify signedEntryTimestamp of the Rekor LogEntry")
+    .context("couldn't verify signedEntryTimestamp of the Rekor LogEntry")
 }
 
 /// Verifies the signature in the `body` over the `contents_bytes`, using the public key in
@@ -258,7 +258,7 @@ pub fn verify_rekor_body(
     // Check that the public key in the body matches the given public key. This in fact checks the
     // consistency of the Rekor LogEntry, and we expect these public keys to always be the same.
     let public_key_bytes = base64::decode(body.spec.signature.public_key.content.as_bytes())
-        .expect("failed to base64-decode the public key bytes in the Rekor LogEntry body");
+        .expect("couldn't base64-decode the public key bytes in the Rekor LogEntry body");
     if compare_keys(&public_key_bytes, pem_encoded_public_key_bytes)? != Ordering::Equal {
         anyhow::bail!(
             "the given public key is different from the public key in the rekor entry: {:?} vs. {:?}",
@@ -272,7 +272,7 @@ pub fn verify_rekor_body(
         contents_bytes,
         pem_encoded_public_key_bytes,
     )
-    .context("failed to verify signature over the endorsement file")
+    .context("couldn't verify signature over the endorsement file")
 }
 
 /// Verifies the given base64-encoded signature over the given data bytes, using the given
@@ -289,7 +289,7 @@ pub fn verify_signature(
     let key = unmarshal_pem_to_p256_public_key(pem_encoded_public_key_bytes)?;
 
     key.verify(content_bytes, &signature)
-        .context("failed to verify signature")
+        .context("couldn't verify signature")
 }
 
 /// Parses a PEM-encoded x509/PKIX public key into a `p256::ecdsa::VerifyingKey`.

--- a/oak_functions_client/src/rekor.rs
+++ b/oak_functions_client/src/rekor.rs
@@ -184,14 +184,14 @@ pub fn verify_rekor_log_entry(
 
     let parsed: std::collections::HashMap<String, LogEntry> =
         serde_json::from_slice(log_entry_bytes)
-            .context("couldn't parse bytes into a LogEntry object.")?;
+            .context("couldn't parse bytes into a LogEntry object")?;
     let entry = parsed.values().next().context("no entry in the map")?;
 
     // Parse base64-encoded entry.body into an instance of Body.
     let body_bytes =
         base64::decode(entry.body.clone()).context("couldn't decode Base64 signature")?;
     let body: Body =
-        serde_json::from_slice(&body_bytes).context("couldn't parse bytes into a Body object.")?;
+        serde_json::from_slice(&body_bytes).context("couldn't parse bytes into a Body object")?;
 
     // Verify the body in the Rekor LogEntry
     verify_rekor_body(&body, endorsement_bytes, oak_public_key_bytes)?;
@@ -306,7 +306,7 @@ pub fn unmarshal_pem_to_p256_public_key(
 fn rekor_signature_bundle(log_entry_bytes: &[u8]) -> anyhow::Result<RekorSignatureBundle> {
     let parsed: std::collections::HashMap<String, LogEntry> =
         serde_json::from_slice(log_entry_bytes)
-            .context("couldn't parse bytes into a LogEntry object.")?;
+            .context("couldn't parse bytes into a LogEntry object")?;
     let entry = parsed.values().next().context("no entry in the map")?;
 
     RekorSignatureBundle::try_from(entry)

--- a/oak_functions_client/src/tests.rs
+++ b/oak_functions_client/src/tests.rs
@@ -39,12 +39,12 @@ fn test_verify_rekor_log_entry() {
     // Public key of the Rekor instance hosted by sigstore.dev. It is downloaded from https://rekor.sigstore.dev/api/v1/log/publicKey.
     let rekor_pubkey_path = "testdata/rekor_public_key.pem";
 
-    let endorsement_bytes = fs::read(endorsement_path).expect("Couldn't read endorsement file.");
-    let log_entry_bytes = fs::read(log_entry_path).expect("Couldn't read log entry file.");
+    let endorsement_bytes = fs::read(endorsement_path).expect("couldn't read endorsement file");
+    let log_entry_bytes = fs::read(log_entry_path).expect("couldn't read log entry file");
     let rekor_pem_bytes =
-        fs::read(rekor_pubkey_path).expect("Couldn't read Rekor's public key file.");
+        fs::read(rekor_pubkey_path).expect("couldn't read Rekor's public key file");
     let pubkey_pem_bytes =
-        fs::read(pubkey_path).expect("Couldn't read product team's public key file.");
+        fs::read(pubkey_path).expect("couldn't read product team's public key file");
 
     let result = verify_rekor_log_entry(
         &log_entry_bytes,
@@ -58,7 +58,7 @@ fn test_verify_rekor_log_entry() {
 #[test]
 fn test_unmarshal_pem_public_key() {
     let pubkey_path = "testdata/rekor_public_key.pem";
-    let pem_bytes = fs::read(pubkey_path).expect("Couldn't read Rekor's public key file.");
+    let pem_bytes = fs::read(pubkey_path).expect("couldn't read Rekor's public key file");
 
     let key = unmarshal_pem_to_p256_public_key(&pem_bytes);
     assert!(key.is_ok());
@@ -69,8 +69,8 @@ fn test_verify_rekor_signature() {
     let entry_path = "testdata/logentry.json";
     let pubkey_path = "testdata/rekor_public_key.pem";
 
-    let log_entry_bytes = fs::read(entry_path).expect("Couldn't read Rekor log entry.");
-    let pem_bytes = fs::read(pubkey_path).expect("Couldn't read Rekor's public key file.");
+    let log_entry_bytes = fs::read(entry_path).expect("couldn't read Rekor log entry");
+    let pem_bytes = fs::read(pubkey_path).expect("couldn't read Rekor's public key file");
 
     let result = verify_rekor_signature(&log_entry_bytes, &pem_bytes);
 

--- a/oak_functions_freestanding/src/lib.rs
+++ b/oak_functions_freestanding/src/lib.rs
@@ -92,7 +92,7 @@ impl schema::TrustedRuntime for RuntimeImplementation {
                 .map_err(|err| {
                     oak_idl::Status::new_with_message(
                         oak_idl::StatusCode::Internal,
-                        format!("could not initialize Wasm handler: {:?}", err),
+                        format!("couldn't initialize Wasm handler: {:?}", err),
                     )
                 })?;
                 let attestation_handler = Box::new(
@@ -103,7 +103,7 @@ impl schema::TrustedRuntime for RuntimeImplementation {
                     .map_err(|err| {
                         oak_idl::Status::new_with_message(
                             oak_idl::StatusCode::Internal,
-                            format!("could not create attestation handler: {:?}", err),
+                            format!("couldn't create attestation handler: {:?}", err),
                         )
                     })?,
                 );

--- a/oak_functions_freestanding/tests/integration_test.rs
+++ b/oak_functions_freestanding/tests/integration_test.rs
@@ -51,7 +51,7 @@ impl AttestationTransport for TestUserClient {
             .inner
             .handle_user_request(&request)
             .unwrap()
-            .map_err(|err| anyhow::anyhow!("could not handle user request: {:?}", err))?;
+            .map_err(|err| anyhow::anyhow!("couldn't handle user request: {:?}", err))?;
         Ok(response.body)
     }
 }

--- a/oak_functions_freestanding_bin/src/main.rs
+++ b/oak_functions_freestanding_bin/src/main.rs
@@ -40,12 +40,12 @@ fn main(channel: Box<dyn Channel>) -> ! {
     ));
     let service = oak_functions_freestanding::schema::TrustedRuntime::serve(runtime);
     oak_channel::server::start_blocking_server(channel, service)
-        .expect("Runtime encountered an unrecoverable error");
+        .expect("runtime encountered an unrecoverable error");
 }
 
 #[alloc_error_handler]
 fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
-    panic!("Error allocating memory: {:#?}", layout);
+    panic!("error allocating memory: {:#?}", layout);
 }
 
 #[panic_handler]

--- a/oak_functions_launcher/src/lookup.rs
+++ b/oak_functions_launcher/src/lookup.rs
@@ -33,7 +33,7 @@ pub fn load_lookup_data(
 ) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
     let bytes = fs::read(file_path).map_err(|error| {
         anyhow!(
-            "Couldn't read the lookup data file {}: {}",
+            "couldn't read the lookup data file {}: {}",
             file_path.display(),
             error
         )
@@ -49,7 +49,7 @@ fn parse_lookup_entries<B: prost::bytes::Buf>(
     while lookup_data_buffer.has_remaining() {
         let entry =
             oak_functions_abi::proto::Entry::decode_length_delimited(&mut lookup_data_buffer)
-                .context("could not decode entry")?;
+                .context("couldn't decode entry")?;
         entries.insert(entry.key, entry.value);
     }
     Ok(entries)

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut reader = BufReader::new(console_receiver);
 
             let mut line = String::new();
-            while reader.read_line(&mut line).expect("failed to read line") > 0 {
+            while reader.read_line(&mut line).expect("couldn't read line") > 0 {
                 log::info!("console: {:?}", line);
                 line.clear();
             }
@@ -127,15 +127,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 tokio::time::interval(std::time::Duration::from_millis(1000 * 60 * 10));
             loop {
                 let lookup_data =
-                    lookup::load_lookup_data(&cli.lookup_data).expect("failed to load lookup data");
+                    lookup::load_lookup_data(&cli.lookup_data).expect("couldn't load lookup data");
                 let encoded_lookup_data =
-                    lookup::encode_lookup_data(lookup_data).expect("failed to encode lookup data");
+                    lookup::encode_lookup_data(lookup_data).expect("couldn't encode lookup data");
 
                 if let Err(err) = runtime_client
                     .update_lookup_data(&encoded_lookup_data)
                     .await
                 {
-                    panic!("failed to send lookup data: {:?}", err)
+                    panic!("couldn't send lookup data: {:?}", err)
                 }
 
                 interval.tick().await;
@@ -162,7 +162,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .initialize(&request)
         .await
         .flatten()
-        .expect("failed to initialize the runtime");
+        .expect("couldn't initialize the runtime");
 
     let public_key_info = result.public_key_info.expect("no public key info returned");
     log::info!(

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -80,7 +80,7 @@ struct Args {
 fn path_exists(s: &str) -> Result<PathBuf, String> {
     let path = PathBuf::from(s);
     if !fs::metadata(s).map_err(|err| err.to_string())?.is_file() {
-        Err(String::from("Path does not represent a file"))
+        Err(String::from("path does not represent a file"))
     } else {
         Ok(path)
     }
@@ -144,7 +144,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let wasm_bytes = fs::read(&cli.wasm)
-        .with_context(|| format!("Couldn't read Wasm file {}", &cli.wasm.display()))
+        .with_context(|| format!("couldn't read Wasm file {}", &cli.wasm.display()))
         .unwrap();
     log::info!(
         "read Wasm file from disk {} ({} bytes)",

--- a/oak_functions_linux_fd_bin/src/main.rs
+++ b/oak_functions_linux_fd_bin/src/main.rs
@@ -64,5 +64,5 @@ fn main() -> ! {
         channel,
         oak_functions_freestanding::schema::TrustedRuntime::serve(runtime),
     )
-    .expect("Runtime encountered an unrecoverable error");
+    .expect("runtime encountered an unrecoverable error");
 }

--- a/oak_functions_linux_vsock_bin/build.rs
+++ b/oak_functions_linux_vsock_bin/build.rs
@@ -19,5 +19,5 @@ fn main() {
         &["oak_functions_linux_vsock_bin/proto/runtime.proto"],
         &[".."],
     )
-    .expect("Proto compilation failed");
+    .expect("proto compilation failed");
 }

--- a/oak_functions_linux_vsock_bin/src/channel.rs
+++ b/oak_functions_linux_vsock_bin/src/channel.rs
@@ -62,7 +62,7 @@ where
             let mut size_buffer: [u8; size_of::<u64>()] = [0; size_of::<u64>()];
             self.stream.read(&mut size_buffer).map_err(|error| {
                 anyhow!(
-                    "Couldn't read Protobuf message size from stream: {:?}",
+                    "couldn't read Protobuf message size from stream: {:?}",
                     error
                 )
             })?;
@@ -72,20 +72,20 @@ where
                 // Read Protobuf message.
                 let mut message_buffer: Vec<u8> = vec![0; size];
                 self.stream.read(&mut message_buffer).map_err(|error| {
-                    anyhow!("Couldn't read Protobuf message from stream: {:?}", error)
+                    anyhow!("couldn't read Protobuf message from stream: {:?}", error)
                 })?;
 
                 let message = Request::decode(&*message_buffer)
-                    .map_err(|error| anyhow!("Couldn't decode Protobuf message: {:?}", error))?;
+                    .map_err(|error| anyhow!("couldn't decode Protobuf message: {:?}", error))?;
                 self.read_buffer_producer.push_slice(&message.data);
             } else {
-                return Err(anyhow!("Message size is 0"));
+                return Err(anyhow!("message size is 0"));
             }
         }
 
         self.read_buffer_consumer
             .read_exact(data)
-            .map_err(|error| anyhow!("Couldn't read from buffer: {:?}", error))
+            .map_err(|error| anyhow!("couldn't read from buffer: {:?}", error))
     }
 }
 
@@ -101,23 +101,23 @@ where
         let mut message_buffer = vec![];
         message
             .encode(&mut message_buffer)
-            .map_err(|error| anyhow!("Couldn't encode proto message: {:?}", error))?;
+            .map_err(|error| anyhow!("couldn't encode proto message: {:?}", error))?;
 
         // Write Protobuf message size.
         let size_buffer: [u8; size_of::<u64>()] = (message_buffer.len() as u64).to_ne_bytes();
         self.stream
             .write_all(&size_buffer)
-            .map_err(|error| anyhow!("Couldn't write into stream: {:?}", error))?;
+            .map_err(|error| anyhow!("couldn't write into stream: {:?}", error))?;
 
         // Write Protobuf message.
         self.stream
             .write_all(&message_buffer)
-            .map_err(|error| anyhow!("Couldn't write into stream: {:?}", error))
+            .map_err(|error| anyhow!("couldn't write into stream: {:?}", error))
     }
 
     fn flush(&mut self) -> anyhow::Result<()> {
         self.stream
             .flush()
-            .map_err(|error| anyhow!("Couldn't flush stream: {:?}", error))
+            .map_err(|error| anyhow!("couldn't flush stream: {:?}", error))
     }
 }

--- a/oak_functions_linux_vsock_bin/src/main.rs
+++ b/oak_functions_linux_vsock_bin/src/main.rs
@@ -57,17 +57,17 @@ pub fn create_vsock_stream(file_descriptor: RawFd) -> anyhow::Result<VsockStream
     // Blocking is set in order to not return an error when the host hasn't written anything yet.
     stream
         .set_nonblocking(false)
-        .map_err(|error| anyhow!("Couldn't set socket into blocking mode: {}", error))?;
+        .map_err(|error| anyhow!("couldn't set socket into blocking mode: {}", error))?;
     Ok(stream)
 }
 
 fn main() -> ! {
     let opt = Opt::parse();
 
-    let stream = create_vsock_stream(opt.file_descriptor).expect("Couldn't create channel");
+    let stream = create_vsock_stream(opt.file_descriptor).expect("couldn't create channel");
     println!(
         "Connected to the {}",
-        stream.peer_addr().expect("Couldn't get peer address")
+        stream.peer_addr().expect("couldn't get peer address")
     );
 
     let channel = Box::new(Channel::new(stream));
@@ -77,5 +77,5 @@ fn main() -> ! {
         channel,
         oak_functions_freestanding::schema::TrustedRuntime::serve(runtime),
     )
-    .expect("Runtime encountered an unrecoverable error");
+    .expect("runtime encountered an unrecoverable error");
 }

--- a/oak_functions_sdk/tests/integration_test.rs
+++ b/oak_functions_sdk/tests/integration_test.rs
@@ -169,7 +169,7 @@ async fn test_echo() {
         oak_functions_testing_extension::TestingFactory::new_boxed_extension_factory(
             logger.clone(),
         )
-        .expect("failed to create testing extension factory");
+        .expect("couldn't create testing extension factory");
 
     let wasm_handler =
         WasmHandler::create(&TESTING_WASM_MODULE_BYTES, vec![testing_factory], logger)
@@ -195,7 +195,7 @@ async fn test_blackhole() {
         oak_functions_testing_extension::TestingFactory::new_boxed_extension_factory(
             logger.clone(),
         )
-        .expect("failed to create testing extension factory");
+        .expect("couldn't create testing extension factory");
 
     let wasm_handler =
         WasmHandler::create(&TESTING_WASM_MODULE_BYTES, vec![testing_factory], logger)

--- a/oak_functions_sdk/tests/integration_test.rs
+++ b/oak_functions_sdk/tests/integration_test.rs
@@ -33,7 +33,7 @@ lazy_static! {
         manifest_path.push("Cargo.toml");
 
         oak_functions_test_utils::compile_rust_wasm(manifest_path.to_str().unwrap(), false)
-            .expect("Could not read Wasm module")
+            .expect("couldn't read Wasm module")
     };
     static ref TESTING_WASM_MODULE_BYTES: Vec<u8> = {
         let mut manifest_path = PATH_TO_MODULES.clone();
@@ -41,7 +41,7 @@ lazy_static! {
         manifest_path.push("Cargo.toml");
 
         oak_functions_test_utils::compile_rust_wasm(manifest_path.to_str().unwrap(), false)
-            .expect("Could not read Wasm module")
+            .expect("couldn't read Wasm module")
     };
 }
 
@@ -50,10 +50,10 @@ async fn test_read_write() {
     let logger = oak_functions_freestanding::StandaloneLogger {};
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(HashMap::new(), logger.clone()));
     let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data_manager)
-        .expect("could not create LookupFactory");
+        .expect("couldn't create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, vec![lookup_factory], logger)
-        .expect("Could not instantiate WasmHandler.");
+        .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"ReadWrite".to_vec(),
@@ -67,10 +67,10 @@ async fn test_double_read() {
     let logger = oak_functions_freestanding::StandaloneLogger {};
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(HashMap::new(), logger.clone()));
     let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data_manager)
-        .expect("could not create LookupFactory");
+        .expect("couldn't create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, vec![lookup_factory], logger)
-        .expect("Could not instantiate WasmHandler.");
+        .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"DoubleRead".to_vec(),
@@ -84,10 +84,10 @@ async fn test_double_write() {
     let logger = oak_functions_freestanding::StandaloneLogger {};
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(HashMap::new(), logger.clone()));
     let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data_manager)
-        .expect("could not create LookupFactory");
+        .expect("couldn't create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, vec![lookup_factory], logger)
-        .expect("Could not instantiate WasmHandler.");
+        .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"DoubleWrite".to_vec(),
@@ -101,17 +101,17 @@ async fn test_write_log() {
     let logger = oak_functions_freestanding::StandaloneLogger {};
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(HashMap::new(), logger.clone()));
     let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data_manager)
-        .expect("could not create LookupFactory");
+        .expect("couldn't create LookupFactory");
     let workload_logging_factory =
         WorkloadLoggingFactory::new_boxed_extension_factory(logger.clone())
-            .expect("could not create WorkloadLoggingFactory");
+            .expect("couldn't create WorkloadLoggingFactory");
 
     let wasm_handler = WasmHandler::create(
         &LOOKUP_WASM_MODULE_BYTES,
         vec![lookup_factory, workload_logging_factory],
         logger,
     )
-    .expect("Could not instantiate WasmHandler.");
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"WriteLog".to_vec(),
@@ -128,10 +128,10 @@ async fn test_storage_get_item() {
     let logger = oak_functions_freestanding::StandaloneLogger {};
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(entries, logger.clone()));
     let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data_manager)
-        .expect("could not create LookupFactory");
+        .expect("couldn't create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, vec![lookup_factory], logger)
-        .expect("Could not instantiate WasmHandler.");
+        .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"StorageGet".to_vec(),
@@ -148,10 +148,10 @@ async fn test_storage_get_item_not_found() {
     let logger = oak_functions_freestanding::StandaloneLogger {};
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(entries, logger.clone()));
     let lookup_factory = LookupFactory::new_boxed_extension_factory(lookup_data_manager)
-        .expect("could not create LookupFactory");
+        .expect("couldn't create LookupFactory");
 
     let wasm_handler = WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, vec![lookup_factory], logger)
-        .expect("Could not instantiate WasmHandler.");
+        .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"StorageGetItemNotFound".to_vec(),
@@ -169,11 +169,11 @@ async fn test_echo() {
         oak_functions_testing_extension::TestingFactory::new_boxed_extension_factory(
             logger.clone(),
         )
-        .expect("Fail to create testing extension factory.");
+        .expect("failed to create testing extension factory");
 
     let wasm_handler =
         WasmHandler::create(&TESTING_WASM_MODULE_BYTES, vec![testing_factory], logger)
-            .expect("Could not instantiate WasmHandler.");
+            .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: message_to_echo.as_bytes().to_vec(),
@@ -195,11 +195,11 @@ async fn test_blackhole() {
         oak_functions_testing_extension::TestingFactory::new_boxed_extension_factory(
             logger.clone(),
         )
-        .expect("Fail to create testing extension factory.");
+        .expect("failed to create testing extension factory");
 
     let wasm_handler =
         WasmHandler::create(&TESTING_WASM_MODULE_BYTES, vec![testing_factory], logger)
-            .expect("Could not instantiate WasmHandler.");
+            .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: message_to_blackhole.as_bytes().to_vec(),

--- a/oak_functions_sdk/tests/lookup_module/src/lib.rs
+++ b/oak_functions_sdk/tests/lookup_module/src/lib.rs
@@ -43,12 +43,12 @@ impl TestManager<'static> {
 
     fn run_test(&self) -> anyhow::Result<()> {
         let request = oak_functions_sdk::read_request()
-            .map_err(|error| anyhow!("Couldn't read request: {:?}", error))?;
-        let test_name = String::from_utf8(request).context("Couldn't parse request")?;
+            .map_err(|error| anyhow!("couldn't read request: {:?}", error))?;
+        let test_name = String::from_utf8(request).context("couldn't parse request")?;
         let test = self
             .tests
             .get(&test_name as &str)
-            .ok_or_else(|| anyhow!("Couldn't find test: {}", &test_name))?;
+            .ok_or_else(|| anyhow!("couldn't find test: {}", &test_name))?;
         test(&test_name);
         Ok(())
     }
@@ -61,10 +61,10 @@ impl TestManager<'static> {
     /// Tests that a second call to [`oak_functions_abi::read_request`] returns the same value.
     fn test_double_read(first_request_body: &str) {
         let second_read_request =
-            oak_functions_sdk::read_request().expect("Failed to read second request.");
+            oak_functions_sdk::read_request().expect("failed to read second request");
         assert_eq!(second_read_request, first_request_body.as_bytes());
         // If assert_eq fails then run_test will return with an empty response body.
-        oak_functions_sdk::write_response(b"DoubleReadResponse").expect("Failed to write response.")
+        oak_functions_sdk::write_response(b"DoubleReadResponse").expect("failed to write response")
     }
 
     /// Tests that multiple calls to [`oak_functions_abi::write_response`] will replace the earlier
@@ -72,9 +72,9 @@ impl TestManager<'static> {
     fn test_double_write(_request: &str) {
         // First response contains a different value.
         oak_functions_sdk::write_response(b"FirstResponseInDoubleWrite")
-            .expect("Failed to write first response.");
+            .expect("failed to write first response");
         oak_functions_sdk::write_response(b"DoubleWriteResponse")
-            .expect("Failed to write second response.");
+            .expect("failed to write second response");
     }
 
     // TODO(#2417): Test logging of `write_log_message`
@@ -94,7 +94,7 @@ impl TestManager<'static> {
         let value = value.unwrap();
         assert_matches!(value, Some(_));
 
-        oak_functions_sdk::write_response(&value.unwrap()).expect("Failed to write response.");
+        oak_functions_sdk::write_response(&value.unwrap()).expect("failed to write response");
     }
 
     /// Tests `storage_get_item` when the key is not in the lookup data. The lookup data is set in
@@ -111,12 +111,12 @@ impl TestManager<'static> {
             }
             Err(_) => b"Unexpected error".to_vec(),
         };
-        oak_functions_sdk::write_response(&response_msg).expect("Failed to write response.")
+        oak_functions_sdk::write_response(&response_msg).expect("failed to write response")
     }
 }
 
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn main() {
     let test_manager = TestManager::new();
-    test_manager.run_test().expect("Couldn't run test");
+    test_manager.run_test().expect("couldn't run test");
 }

--- a/oak_functions_sdk/tests/lookup_module/src/lib.rs
+++ b/oak_functions_sdk/tests/lookup_module/src/lib.rs
@@ -61,10 +61,10 @@ impl TestManager<'static> {
     /// Tests that a second call to [`oak_functions_abi::read_request`] returns the same value.
     fn test_double_read(first_request_body: &str) {
         let second_read_request =
-            oak_functions_sdk::read_request().expect("failed to read second request");
+            oak_functions_sdk::read_request().expect("couldn't read second request");
         assert_eq!(second_read_request, first_request_body.as_bytes());
         // If assert_eq fails then run_test will return with an empty response body.
-        oak_functions_sdk::write_response(b"DoubleReadResponse").expect("failed to write response")
+        oak_functions_sdk::write_response(b"DoubleReadResponse").expect("couldn't write response")
     }
 
     /// Tests that multiple calls to [`oak_functions_abi::write_response`] will replace the earlier
@@ -72,9 +72,9 @@ impl TestManager<'static> {
     fn test_double_write(_request: &str) {
         // First response contains a different value.
         oak_functions_sdk::write_response(b"FirstResponseInDoubleWrite")
-            .expect("failed to write first response");
+            .expect("couldn't write first response");
         oak_functions_sdk::write_response(b"DoubleWriteResponse")
-            .expect("failed to write second response");
+            .expect("couldn't write second response");
     }
 
     // TODO(#2417): Test logging of `write_log_message`
@@ -94,7 +94,7 @@ impl TestManager<'static> {
         let value = value.unwrap();
         assert_matches!(value, Some(_));
 
-        oak_functions_sdk::write_response(&value.unwrap()).expect("failed to write response");
+        oak_functions_sdk::write_response(&value.unwrap()).expect("couldn't write response");
     }
 
     /// Tests `storage_get_item` when the key is not in the lookup data. The lookup data is set in
@@ -111,7 +111,7 @@ impl TestManager<'static> {
             }
             Err(_) => b"Unexpected error".to_vec(),
         };
-        oak_functions_sdk::write_response(&response_msg).expect("failed to write response")
+        oak_functions_sdk::write_response(&response_msg).expect("couldn't write response")
     }
 }
 

--- a/oak_functions_sdk/tests/testing_module/src/lib.rs
+++ b/oak_functions_sdk/tests/testing_module/src/lib.rs
@@ -21,34 +21,34 @@ use oak_functions_abi::{TestingRequest, TestingResponse};
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn main() {
     // Read the message to echo from the request.
-    let request = oak_functions_sdk::read_request().expect("failed to read request body");
-    let request = String::from_utf8(request).expect("failed to parse request");
+    let request = oak_functions_sdk::read_request().expect("couldn't read request body");
+    let request = String::from_utf8(request).expect("couldn't parse request");
 
     match request.as_str() {
         "ECHO" => {
             // Serialize a EchoRequest. Note that the message to echo is the request itself.
             let echo_request = bincode::serialize(&TestingRequest::Echo(request))
-                .expect("failed to serialize testing message");
+                .expect("couldn't serialize testing message");
             // We invoke the Testing extension with an EchoRequest.
             let serialized_echo_response =
-                oak_functions_sdk::testing(&echo_request).expect("failed to invoke testing");
+                oak_functions_sdk::testing(&echo_request).expect("couldn't invoke testing");
 
             let echo_response = bincode::deserialize(&serialized_echo_response)
-                .expect("failed to deserialize testing message");
+                .expect("couldn't deserialize testing message");
 
             let TestingResponse::Echo(response_body) = echo_response;
 
             oak_functions_sdk::write_response(response_body.as_bytes())
-                .expect("failed to write response body");
+                .expect("couldn't write response body");
         }
         "BLACKHOLE" => {
             // Keep in sync with test_blackhole in
             // `workspace/oak_functions/sdk/oak_functions/tests/integration_test.rs`.
             let blackhole_request = bincode::serialize(&TestingRequest::Blackhole(request))
-                .expect("failed to serialize testing message");
+                .expect("couldn't serialize testing message");
 
             let blackhole_response =
-                oak_functions_sdk::testing(&blackhole_request).expect("failed to invoke testing");
+                oak_functions_sdk::testing(&blackhole_request).expect("couldn't invoke testing");
             // We expect an empty response, because blackhole does not give back a result.
             assert!(blackhole_response.is_empty());
 
@@ -56,7 +56,7 @@ pub extern "C" fn main() {
             // us to distinguish from a failure in the Wasm module, where also an
             // empty response would be sent.
             oak_functions_sdk::write_response("Blackholed".as_bytes())
-                .expect("failed to write response body");
+                .expect("couldn't write response body");
         }
         _ => panic!("request not recognized"),
     }

--- a/oak_functions_sdk/tests/testing_module/src/lib.rs
+++ b/oak_functions_sdk/tests/testing_module/src/lib.rs
@@ -21,34 +21,34 @@ use oak_functions_abi::{TestingRequest, TestingResponse};
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn main() {
     // Read the message to echo from the request.
-    let request = oak_functions_sdk::read_request().expect("Fail to read request body.");
-    let request = String::from_utf8(request).expect("Fail to parse request");
+    let request = oak_functions_sdk::read_request().expect("failed to read request body");
+    let request = String::from_utf8(request).expect("failed to parse request");
 
     match request.as_str() {
         "ECHO" => {
             // Serialize a EchoRequest. Note that the message to echo is the request itself.
             let echo_request = bincode::serialize(&TestingRequest::Echo(request))
-                .expect("Fail to serialize testing message.");
+                .expect("failed to serialize testing message");
             // We invoke the Testing extension with an EchoRequest.
             let serialized_echo_response =
-                oak_functions_sdk::testing(&echo_request).expect("Fail to invoke testing.");
+                oak_functions_sdk::testing(&echo_request).expect("failed to invoke testing");
 
             let echo_response = bincode::deserialize(&serialized_echo_response)
-                .expect("Fail to deserialize testing message.");
+                .expect("failed to deserialize testing message");
 
             let TestingResponse::Echo(response_body) = echo_response;
 
             oak_functions_sdk::write_response(response_body.as_bytes())
-                .expect("Fail to write response body.");
+                .expect("failed to write response body");
         }
         "BLACKHOLE" => {
             // Keep in sync with test_blackhole in
             // `workspace/oak_functions/sdk/oak_functions/tests/integration_test.rs`.
             let blackhole_request = bincode::serialize(&TestingRequest::Blackhole(request))
-                .expect("Fail to serialize testing message.");
+                .expect("failed to serialize testing message");
 
             let blackhole_response =
-                oak_functions_sdk::testing(&blackhole_request).expect("Fail to invoke testing.");
+                oak_functions_sdk::testing(&blackhole_request).expect("failed to invoke testing");
             // We expect an empty response, because blackhole does not give back a result.
             assert!(blackhole_response.is_empty());
 
@@ -56,8 +56,8 @@ pub extern "C" fn main() {
             // us to distinguish from a failure in the Wasm module, where also an
             // empty response would be sent.
             oak_functions_sdk::write_response("Blackholed".as_bytes())
-                .expect("Fail to write response body.");
+                .expect("failed to write response body");
         }
-        _ => panic!("Request not recognized"),
+        _ => panic!("request not recognized"),
     }
 }

--- a/oak_functions_test_utils/src/lib.rs
+++ b/oak_functions_test_utils/src/lib.rs
@@ -61,14 +61,14 @@ pub fn compile_rust_wasm(manifest_path: &str, release: bool) -> anyhow::Result<V
         .args(args)
         .env_remove("RUSTFLAGS")
         .spawn()
-        .context("Couldn't spawn cargo build")?
+        .context("couldn't spawn cargo build")?
         .wait()
-        .context("Couldn't wait for cargo build to finish")?;
+        .context("couldn't wait for cargo build to finish")?;
 
     let module_path = build_wasm_module_path(&metadata);
     info!("Compiled Wasm module path: {:?}", module_path);
 
-    std::fs::read(module_path).context("Couldn't read compiled module")
+    std::fs::read(module_path).context("couldn't read compiled module")
 }
 
 /// Serializes the provided map as a contiguous buffer of length-delimited protobuf messages of type
@@ -79,20 +79,20 @@ pub fn serialize_entries(entries: HashMap<Vec<u8>, Vec<u8>>) -> Vec<u8> {
         let entry_proto = oak_functions_abi::proto::Entry { key, value };
         entry_proto
             .encode_length_delimited(&mut buf)
-            .expect("could not encode entry as length delimited");
+            .expect("couldn't encode entry as length delimited");
     }
     buf
 }
 
 pub fn write_to_temp_file(content: &[u8]) -> tempfile::NamedTempFile {
-    let mut file = tempfile::NamedTempFile::new().expect("could not create temp file");
+    let mut file = tempfile::NamedTempFile::new().expect("couldn't create temp file");
     file.write_all(content)
-        .expect("could not write content to temp file");
+        .expect("couldn't write content to temp file");
     file
 }
 
 pub fn free_port() -> u16 {
-    port_check::free_local_port().expect("could not pick free local port")
+    port_check::free_local_port().expect("couldn't pick free local port")
 }
 
 /// Wrapper around a termination signal [`oneshot::Sender`] and the [`JoinHandle`] of the associated
@@ -111,10 +111,10 @@ impl<T> Background<T> {
     pub async fn terminate_and_join(self) -> T {
         self.term_tx
             .send(())
-            .expect("could not send signal on termination channel");
+            .expect("couldn't send signal on termination channel");
         self.join_handle
             .await
-            .expect("could not wait for background task to terminate")
+            .expect("couldn' wait for background task to terminate")
     }
 }
 
@@ -148,7 +148,7 @@ fn build_rust_crate_linux(crate_name: &str) -> anyhow::Result<String> {
     )
     .dir(env!("WORKSPACE_ROOT"))
     .run()
-    .context(format!("could not compile {crate_name}"))?;
+    .context(format!("couldn't compile {crate_name}"))?;
     Ok(format!(
         "{}target/x86_64-unknown-linux-musl/release/{crate_name}",
         env!("WORKSPACE_ROOT")
@@ -168,7 +168,7 @@ pub fn build_rust_crate_wasm(crate_name: &str) -> anyhow::Result<String> {
     )
     .dir(env!("WORKSPACE_ROOT"))
     .run()
-    .context(format!("could not compile {crate_name}"))?;
+    .context(format!("couldn't compile {crate_name}"))?;
     Ok(format!(
         "{}target/wasm32-unknown-unknown/release/{crate_name}.wasm",
         env!("WORKSPACE_ROOT"),
@@ -198,7 +198,7 @@ pub fn create_and_start_oak_functions_server(
     )
     .dir(env!("WORKSPACE_ROOT"))
     .reader()
-    .context("could not run oak_functions_launcher")?;
+    .context("couldn't run oak_functions_launcher")?;
     Ok(handle)
 }
 
@@ -242,19 +242,19 @@ pub async fn make_request(port: u16, request_body: &[u8]) -> Vec<u8> {
     let uri = format!("http://localhost:{port}/");
 
     // Create client
-    let mut client = Client::new(&uri).await.expect("Could not create client");
+    let mut client = Client::new(&uri).await.expect("couldn't create client");
 
     client
         .invoke(request_body)
         .await
-        .expect("Error while awaiting response")
+        .expect("error while awaiting response")
 }
 
 // Assert that string value of the body of the given response matches the expected string.
 pub fn assert_response_body(response: Response, expected: &str) {
     let body = response.body().unwrap();
     assert_eq!(
-        std::str::from_utf8(body).expect("could not convert response body from utf8"),
+        std::str::from_utf8(body).expect("couldn't convert response body from utf8"),
         expected
     )
 }

--- a/oak_grpc_unary_attestation/src/client.rs
+++ b/oak_grpc_unary_attestation/src/client.rs
@@ -29,7 +29,7 @@ pub struct UnaryGrpcClient {
 impl UnaryGrpcClient {
     pub async fn create(uri: &str) -> anyhow::Result<Self> {
         let channel = Channel::from_shared(uri.to_string())
-            .context("Couldn't create gRPC channel")?
+            .context("couldn't create gRPC channel")?
             .connect()
             .await?;
         let inner = UnarySessionClient::new(channel);
@@ -49,7 +49,7 @@ impl AttestationTransport for UnaryGrpcClient {
                 session_id: session_id.to_vec(),
             })
             .await
-            .context("Couldn't send message")?
+            .context("couldn't send message")?
             .into_inner()
             .body;
 

--- a/oak_idl_build/src/lib.rs
+++ b/oak_idl_build/src/lib.rs
@@ -51,7 +51,7 @@ pub fn compile(protos: &[impl AsRef<Path>], includes: &[impl AsRef<Path>]) {
     config.service_generator(Box::new(ServiceGenerator {}));
     config
         .compile_protos(protos, includes)
-        .expect("could not compile protobuffer schema");
+        .expect("couldn't compile protobuffer schema");
 }
 
 struct ServiceGenerator {}
@@ -59,11 +59,11 @@ struct ServiceGenerator {}
 impl prost_build::ServiceGenerator for ServiceGenerator {
     fn generate(&mut self, service: Service, buf: &mut String) {
         *buf += "\n";
-        *buf += &generate_service(&service).expect("could not generate services");
+        *buf += &generate_service(&service).expect("couldn't generate services");
         *buf += "\n";
-        *buf += &generate_service_client(&service, false).expect("could not generate clients");
+        *buf += &generate_service_client(&service, false).expect("couldn't generate clients");
         *buf += "\n";
-        *buf += &generate_service_client(&service, true).expect("could not generate async clients");
+        *buf += &generate_service_client(&service, true).expect("couldn't generate async clients");
     }
 }
 
@@ -109,7 +109,7 @@ fn generate_service(service: &Service) -> anyhow::Result<String> {
             .iter()
             .map(generate_server_handler)
             .collect::<Result<Vec<_>, _>>()
-            .context("could not generate server handler")?
+            .context("couldn't generate server handler")?
             .into_iter()
             .flatten(),
     );
@@ -162,7 +162,7 @@ fn generate_service_client(service: &Service, asynchronous: bool) -> anyhow::Res
             .iter()
             .map(|c| generate_client_method(c, asynchronous))
             .collect::<Result<Vec<_>, _>>()
-            .context("could not generate client method")?
+            .context("couldn't generate client method")?
             .into_iter()
             .flatten(),
     );

--- a/oak_remote_attestation/src/crypto/mod.rs
+++ b/oak_remote_attestation/src/crypto/mod.rs
@@ -22,7 +22,7 @@
 // Ideally we would also have a check that enforces that at most one feature is enabled, but that
 // currently does not work because we run tests with the --all-features flag, which breaks this.
 #[cfg(not(any(feature = "ring-crypto", feature = "rust-crypto")))]
-compile_error!("Exactly one cryptographic implementation must be specified.");
+compile_error!("exactly one cryptographic implementation must be specified");
 
 // When both implementations are selected (e.g. when testing with all features) we use the `ring`
 // implementation.

--- a/oak_remote_attestation/src/crypto/rust_crypto.rs
+++ b/oak_remote_attestation/src/crypto/rust_crypto.rs
@@ -71,7 +71,7 @@ impl AeadEncryptor {
     /// Encrypts `data` using `AeadEncryptor::encryption_key`.
     pub fn encrypt(&mut self, data: &[u8]) -> anyhow::Result<EncryptedData> {
         // Generate a random nonce.
-        let nonce = Self::generate_nonce().context("Couldn't generate nonce")?;
+        let nonce = Self::generate_nonce().context("couldn't generate nonce")?;
         let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&self.encryption_key.0));
 
         let mut encrypted_data = data.to_vec();
@@ -86,7 +86,7 @@ impl AeadEncryptor {
                 EMPTY_ADITIONAL_DATA,
                 &mut encrypted_data,
             )
-            .map_err(|error| anyhow!("Couldn't encrypt data: {:?}", error))?;
+            .map_err(|error| anyhow!("couldn't encrypt data: {:?}", error))?;
 
         Ok(EncryptedData::new(nonce, encrypted_data))
     }
@@ -108,7 +108,7 @@ impl AeadEncryptor {
                 EMPTY_ADITIONAL_DATA,
                 &mut decrypted_data,
             )
-            .map_err(|error| anyhow!("Couldn't decrypt data: {:?}", error))?;
+            .map_err(|error| anyhow!("couldn't decrypt data: {:?}", error))?;
         Ok(decrypted_data.to_vec())
     }
 
@@ -153,7 +153,7 @@ impl KeyNegotiator {
     ) -> anyhow::Result<AeadEncryptor> {
         let (encryption_key, decryption_key) = self
             .derive_session_keys(peer_public_key)
-            .context("Couldn't derive session keys")?;
+            .context("couldn't derive session keys")?;
         let encryptor = AeadEncryptor::new(encryption_key, decryption_key);
         Ok(encryptor)
     }
@@ -164,7 +164,7 @@ impl KeyNegotiator {
         self,
         peer_public_key: &[u8; KEY_AGREEMENT_ALGORITHM_KEY_LENGTH],
     ) -> anyhow::Result<(EncryptionKey, DecryptionKey)> {
-        let self_public_key = self.public_key().context("Couldn't get self public key")?;
+        let self_public_key = self.public_key().context("couldn't get self public key")?;
         let parsed_public_key = PublicKey::from(*peer_public_key);
         let key_material = self.private_key.diffie_hellman(&parsed_public_key);
 
@@ -178,7 +178,7 @@ impl KeyNegotiator {
                         &self_public_key,
                         peer_public_key,
                     )
-                    .context("Couldn't derive decryption key")?,
+                    .context("couldn't derive decryption key")?,
                 );
                 let decryption_key = DecryptionKey(
                     Self::key_derivation_function(
@@ -187,7 +187,7 @@ impl KeyNegotiator {
                         &self_public_key,
                         peer_public_key,
                     )
-                    .context("Couldn't derive encryption key")?,
+                    .context("couldn't derive encryption key")?,
                 );
                 Ok((encryption_key, decryption_key))
             }
@@ -200,7 +200,7 @@ impl KeyNegotiator {
                         peer_public_key,
                         &self_public_key,
                     )
-                    .context("Couldn't derive decryption key")?,
+                    .context("couldn't derive decryption key")?,
                 );
                 let decryption_key = DecryptionKey(
                     Self::key_derivation_function(
@@ -209,7 +209,7 @@ impl KeyNegotiator {
                         peer_public_key,
                         &self_public_key,
                     )
-                    .context("Couldn't derive encryption key")?,
+                    .context("couldn't derive encryption key")?,
                 );
                 Ok((encryption_key, decryption_key))
             }
@@ -276,17 +276,17 @@ impl Signer {
             .as_bytes()
             .try_into()
             .map_err(anyhow::Error::msg)
-            .context("Incorrect public key length")
+            .context("incorrect public key length")
     }
 
     pub fn sign(&self, input: &[u8]) -> anyhow::Result<[u8; SIGNATURE_LENGTH]> {
         self.signing_key
             .try_sign(input)
-            .map_err(|error| anyhow!("Couldn't sign input: {:?}", error))?
+            .map_err(|error| anyhow!("couldn't sign input: {:?}", error))?
             .as_ref()
             .try_into()
             .map_err(anyhow::Error::msg)
-            .context("Incorrect signature length")
+            .context("incorrect signature length")
     }
 }
 
@@ -308,7 +308,7 @@ impl SignatureVerifier {
         let signature = signature[..].try_into().map_err(anyhow::Error::msg)?;
         self.verifying_key
             .verify(input, &signature)
-            .map_err(|error| anyhow!("Signature verification failed: {:?}", error))
+            .map_err(|error| anyhow!("signature verification failed: {:?}", error))
     }
 }
 
@@ -324,6 +324,6 @@ pub fn get_random<const L: usize>() -> anyhow::Result<[u8; L]> {
     let mut result: [u8; L] = [Default::default(); L];
     OsRng
         .try_fill_bytes(&mut result[..])
-        .map_err(|error| anyhow!("Couldn't create random value: {:?}", error))?;
+        .map_err(|error| anyhow!("couldn't create random value: {:?}", error))?;
     Ok(result)
 }

--- a/oak_remote_attestation/src/message.rs
+++ b/oak_remote_attestation/src/message.rs
@@ -180,14 +180,14 @@ impl Deserializable for ClientHello {
     fn deserialize(input: &[u8]) -> anyhow::Result<Self> {
         if input.len() != ClientHello::len() {
             bail!(
-                "Invalid client hello message length: expected {}, found {}",
+                "invalid client hello message length: expected {}, found {}",
                 ClientHello::len(),
                 input.len(),
             );
         }
         let mut input = input;
         if input.get_u8() != CLIENT_HELLO_HEADER {
-            bail!("Invalid client hello message header");
+            bail!("invalid client hello message header");
         }
         let mut random = [0u8; REPLAY_PROTECTION_ARRAY_LENGTH];
         input.copy_to_slice(&mut random);
@@ -250,21 +250,21 @@ impl Deserializable for ServerIdentity {
     fn deserialize(input: &[u8]) -> anyhow::Result<Self> {
         if input.len() < ServerIdentity::min_len() {
             bail!(
-                "Server identity message too short: expected at least {} bytes, found {}",
+                "server identity message too short: expected at least {} bytes, found {}",
                 ServerIdentity::min_len(),
                 input.len(),
             );
         }
         if input.len() > MAXIMUM_MESSAGE_SIZE {
             bail!(
-                "Maximum handshake message size of {} exceeded, found {}",
+                "maximum handshake message size of {} exceeded, found {}",
                 MAXIMUM_MESSAGE_SIZE,
                 input.len(),
             );
         }
         let mut input = input;
         if input.get_u8() != SERVER_IDENTITY_HEADER {
-            bail!("Invalid server identity message header");
+            bail!("invalid server identity message header");
         }
 
         let version = input.get_u8();
@@ -280,7 +280,7 @@ impl Deserializable for ServerIdentity {
 
         if input.has_remaining() {
             bail!(
-                "Invalid server identity message: {} unused bytes detected",
+                "invalid server identity message: {} unused bytes detected",
                 input.remaining()
             );
         }
@@ -344,21 +344,21 @@ impl Deserializable for ClientIdentity {
     fn deserialize(input: &[u8]) -> anyhow::Result<Self> {
         if input.len() < ClientIdentity::min_len() {
             bail!(
-                "Client identity message too short: expected at least {} bytes, found {}",
+                "client identity message too short: expected at least {} bytes, found {}",
                 ClientIdentity::min_len(),
                 input.len(),
             );
         }
         if input.len() > MAXIMUM_MESSAGE_SIZE {
             bail!(
-                "Maximum handshake message size of {} exceeded, found {}",
+                "maximum handshake message size of {} exceeded, found {}",
                 MAXIMUM_MESSAGE_SIZE,
                 input.len(),
             );
         }
         let mut input = input;
         if input.get_u8() != CLIENT_IDENTITY_HEADER {
-            bail!("Invalid client identity message header");
+            bail!("invalid client identity message header");
         }
 
         let mut ephemeral_public_key = [0u8; KEY_AGREEMENT_ALGORITHM_KEY_LENGTH];
@@ -371,7 +371,7 @@ impl Deserializable for ClientIdentity {
 
         if input.has_remaining() {
             bail!(
-                "Invalid client identity message: {} unused bytes detected",
+                "invalid client identity message: {} unused bytes detected",
                 input.remaining()
             );
         }
@@ -409,14 +409,14 @@ impl Deserializable for EncryptedData {
     fn deserialize(input: &[u8]) -> anyhow::Result<Self> {
         if input.len() < EncryptedData::min_len() {
             bail!(
-                "Encrypted data message too short: expected at least {} bytes, found {}",
+                "encrypted data message too short: expected at least {} bytes, found {}",
                 EncryptedData::min_len(),
                 input.len(),
             );
         }
         let mut input = input;
         if input.get_u8() != ENCRYPTED_DATA_HEADER {
-            bail!("Invalid encrypted data message header");
+            bail!("invalid encrypted data message header");
         }
 
         let mut nonce = [0u8; NONCE_LENGTH];
@@ -425,7 +425,7 @@ impl Deserializable for EncryptedData {
 
         if input.has_remaining() {
             bail!(
-                "Invalid encrypted data message: {} unused bytes detected",
+                "invalid encrypted data message: {} unused bytes detected",
                 input.remaining()
             );
         }
@@ -438,30 +438,30 @@ impl Deserializable for EncryptedData {
 /// [`MessageWrapper`].
 pub fn deserialize_message(input: &[u8]) -> anyhow::Result<MessageWrapper> {
     if input.is_empty() {
-        return Err(anyhow!("Empty input"));
+        return Err(anyhow!("empty input"));
     }
     match input[0] {
         CLIENT_HELLO_HEADER => {
             let message: ClientHello = Deserializable::deserialize(input)
-                .context("Couldn't deserialize client hello message")?;
+                .context("couldn't deserialize client hello message")?;
             Ok(MessageWrapper::ClientHello(message))
         }
         SERVER_IDENTITY_HEADER => {
             let message: ServerIdentity = Deserializable::deserialize(input)
-                .context("Couldn't deserialize server identity message")?;
+                .context("couldn't deserialize server identity message")?;
             Ok(MessageWrapper::ServerIdentity(message))
         }
         CLIENT_IDENTITY_HEADER => {
             let message: ClientIdentity = Deserializable::deserialize(input)
-                .context("Couldn't deserialize client identity message")?;
+                .context("couldn't deserialize client identity message")?;
             Ok(MessageWrapper::ClientIdentity(message))
         }
         ENCRYPTED_DATA_HEADER => {
             let message: EncryptedData = Deserializable::deserialize(input)
-                .context("Couldn't deserialize encrypted data message")?;
+                .context("couldn't deserialize encrypted data message")?;
             Ok(MessageWrapper::EncryptedData(message))
         }
-        header => Err(anyhow!("Unknown message header: {:#02x}", header)),
+        header => Err(anyhow!("unknown message header: {:#02x}", header)),
     }
 }
 
@@ -474,7 +474,7 @@ fn get_vec(source: &mut &[u8]) -> anyhow::Result<Vec<u8>> {
     let length = source.get_u64_le();
     if length > source.remaining() as u64 {
         bail!(
-            "Invalid vector serialization: required length is {} but only {} bytes provided",
+            "nvalid vector serialization: required length is {} but only {} bytes provided",
             length,
             source.remaining()
         )

--- a/oak_remote_attestation/src/message.rs
+++ b/oak_remote_attestation/src/message.rs
@@ -474,7 +474,7 @@ fn get_vec(source: &mut &[u8]) -> anyhow::Result<Vec<u8>> {
     let length = source.get_u64_le();
     if length > source.remaining() as u64 {
         bail!(
-            "nvalid vector serialization: required length is {} but only {} bytes provided",
+            "invalid vector serialization: required length is {} but only {} bytes provided",
             length,
             source.remaining()
         )

--- a/oak_remote_attestation/src/tests/crypto.rs
+++ b/oak_remote_attestation/src/tests/crypto.rs
@@ -113,19 +113,19 @@ fn test_encrypt(data: Vec<u8>) -> bool {
 
     let encrypted_data = server_encryptor
         .encrypt(&data)
-        .expect("Couldn't encrypt data");
+        .expect("couldn't encrypt data");
     let decrypted_data = client_encryptor
         .decrypt(&encrypted_data)
-        .expect("Couldn't decrypt data");
+        .expect("couldn't decrypt data");
     data == decrypted_data
 }
 
 #[test]
 fn test_create_key_negotiator() {
     let server_key_negotiator = KeyNegotiator::create(KeyNegotiatorType::Server)
-        .expect("Couldn't create server key negotiator");
+        .expect("couldn't create server key negotiator");
     let client_key_negotiator = KeyNegotiator::create(KeyNegotiatorType::Client)
-        .expect("Couldn't create client key negotiator");
+        .expect("couldn't create client key negotiator");
 
     let server_ephemeral_public_key = server_key_negotiator.public_key();
     assert!(server_ephemeral_public_key.is_ok());
@@ -184,10 +184,10 @@ fn test_create_encryptor() {
 
     let mut server_encryptor = server_key_negotiator
         .create_encryptor(&client_ephemeral_public_key)
-        .expect("Couldn't create server encryptor");
+        .expect("couldn't create server encryptor");
     let mut client_encryptor = client_key_negotiator
         .create_encryptor(&server_ephemeral_public_key)
-        .expect("Couldn't create client encryptor");
+        .expect("couldn't create client encryptor");
 
     let encrypted_server_data = server_encryptor.encrypt(&DATA).unwrap();
     let decrypted_server_data = client_encryptor.decrypt(&encrypted_server_data).unwrap();
@@ -200,7 +200,7 @@ fn test_create_encryptor() {
 
 #[test]
 fn test_create_signer() {
-    let signer = Signer::create().expect("Couldn't create signer");
+    let signer = Signer::create().expect("couldn't create signer");
     let result = signer.public_key();
     assert!(result.is_ok());
 }
@@ -216,11 +216,11 @@ fn test_verify() {
 
 #[quickcheck]
 fn test_sign(data: Vec<u8>) -> bool {
-    let signer = Signer::create().expect("Couldn't create signer");
+    let signer = Signer::create().expect("couldn't create signer");
     let public_key = signer
         .public_key()
-        .expect("Couldn't get signing public key");
-    let signature = signer.sign(&data).expect("Couldn't sign data");
+        .expect("couldn't get signing public key");
+    let signature = signer.sign(&data).expect("couldn't sign data");
 
     let verifier = SignatureVerifier::new(&public_key).unwrap();
     let result = verifier.verify(&data, &signature);

--- a/oak_remote_attestation/src/tests/handshaker.rs
+++ b/oak_remote_attestation/src/tests/handshaker.rs
@@ -72,7 +72,7 @@ fn create_handshakers() -> (
 
     let server_handshaker = ServerHandshaker::new(
         bidirectional_attestation,
-        Arc::new(Signer::create().expect("Couldn't create signer")),
+        Arc::new(Signer::create().expect("couldn't create signer")),
     )
     .unwrap();
 
@@ -85,46 +85,46 @@ fn test_handshake() {
 
     let client_hello = client_handshaker
         .create_client_hello()
-        .expect("Couldn't create client hello message");
+        .expect("couldn't create client hello message");
 
     let server_identity = server_handshaker
         .next_step(&client_hello)
-        .expect("Couldn't process client hello message")
-        .expect("Empty server identity message");
+        .expect("couldn't process client hello message")
+        .expect("empty server identity message");
 
     let client_identity = client_handshaker
         .next_step(&server_identity)
-        .expect("Couldn't process server identity message")
-        .expect("Empty client identity message");
+        .expect("couldn't process server identity message")
+        .expect("empty client identity message");
     assert!(client_handshaker.is_completed());
 
     let result = server_handshaker
         .next_step(&client_identity)
-        .expect("Couldn't process client identity message");
+        .expect("couldn't process client identity message");
     assert_matches!(result, None);
     assert!(server_handshaker.is_completed());
 
     let mut client_encryptor = client_handshaker
         .get_encryptor()
-        .expect("Couldn't get client encryptor");
+        .expect("couldn't get client encryptor");
     let mut server_encryptor = server_handshaker
         .get_encryptor()
-        .expect("Couldn't get server encryptor");
+        .expect("couldn't get server encryptor");
 
     let encrypted_client_data = client_encryptor
         .encrypt(&DATA)
-        .expect("Couldn't encrypt client data");
+        .expect("couldn't encrypt client data");
     let decrypted_client_data = server_encryptor
         .decrypt(&encrypted_client_data)
-        .expect("Couldn't decrypt client data");
+        .expect("couldn't decrypt client data");
     assert_eq!(decrypted_client_data, DATA);
 
     let encrypted_server_data = server_encryptor
         .encrypt(&DATA)
-        .expect("Couldn't encrypt server data");
+        .expect("couldn't encrypt server data");
     let decrypted_server_data = client_encryptor
         .decrypt(&encrypted_server_data)
-        .expect("Couldn't decrypt server data");
+        .expect("couldn't decrypt server data");
     assert_eq!(decrypted_server_data, DATA);
 }
 

--- a/oak_remote_attestation/src/tests/message.rs
+++ b/oak_remote_attestation/src/tests/message.rs
@@ -54,7 +54,7 @@ where
         Ok(result)
     } else {
         Err(anyhow!(
-            "Maximum input length exceeded, maximum {}, found {}",
+            "maximum input length exceeded, maximum {}, found {}",
             L,
             input.len()
         ))
@@ -64,9 +64,9 @@ where
 fn test_serialize_template<M: Serializable + Deserializable + PartialEq>(
     message: &M,
 ) -> anyhow::Result<bool> {
-    let serialized_message = message.serialize().context("Couldn't serialize message")?;
+    let serialized_message = message.serialize().context("couldn't serialize message")?;
     let deserialized_message =
-        M::deserialize(&serialized_message).context("Couldn't deserialize message")?;
+        M::deserialize(&serialized_message).context("couldn't deserialize message")?;
     Ok(*message == deserialized_message)
 }
 

--- a/oak_remote_attestation_amd/src/lib.rs
+++ b/oak_remote_attestation_amd/src/lib.rs
@@ -55,7 +55,7 @@ impl AttestationVerifier for PlaceholderAmdAttestationVerifier {
     ) -> anyhow::Result<()> {
         let attestation_report = PlaceholderAmdReport::from_string(
             core::str::from_utf8(attestation)
-                .map_err(|_err| anyhow::anyhow!("could not parse remote attestation report"))?,
+                .map_err(|_err| anyhow::anyhow!("couldn't parse remote attestation report"))?,
         )?;
         let actual_attested_data = attestation_report.data;
         if actual_attested_data == expected_attested_data {
@@ -108,12 +108,12 @@ impl PlaceholderAmdReport {
     // TODO(#2842): Use raw report instead of JSON.
     pub fn from_string(input: &str) -> anyhow::Result<Self> {
         serde_json::from_str(input)
-            .map_err(|_err| anyhow::anyhow!("Couldn't deserialize attestation report"))
+            .map_err(|_err| anyhow::anyhow!("couldn't deserialize attestation report"))
     }
 
     // TODO(#2842): Use raw report instead of JSON.
     pub fn to_string(&self) -> anyhow::Result<String> {
         serde_json::to_string(&self)
-            .map_err(|_err| anyhow::anyhow!("Couldn't serialize attestation report"))
+            .map_err(|_err| anyhow::anyhow!("couldn't serialize attestation report"))
     }
 }

--- a/oak_remote_attestation_noninteractive/src/client.rs
+++ b/oak_remote_attestation_noninteractive/src/client.rs
@@ -37,7 +37,7 @@ pub struct OakClient {
 impl OakClient {
     pub async fn create(uri: &str) -> anyhow::Result<Self> {
         let channel = Channel::from_shared(uri.to_string())
-            .context("Couldn't create gRPC channel")?
+            .context("couldn't create gRPC channel")?
             .connect()
             .await?;
         let inner = StreamingSessionClient::new(channel);
@@ -58,7 +58,7 @@ impl OakClient {
                 request: Some(request_wrapper::Request::InvokeRequest(invoke_request)),
             }]))
             .await
-            .context("could not send message")?
+            .context("couldn't send message")?
             .into_inner();
         // Read the next (and only) message from the response stream.
         let response_wrapper = response_stream

--- a/oak_remote_attestation_sessions/src/lib.rs
+++ b/oak_remote_attestation_sessions/src/lib.rs
@@ -88,7 +88,7 @@ impl<G: AttestationGenerator + Clone, V: AttestationVerifier> SessionTracker<G, 
                     false => Ok(SessionState::HandshakeInProgress(handshaker)),
                     true => match handshaker.get_encryptor() {
                         Ok(encryptor) => Ok(SessionState::EncryptedMessageExchange(encryptor)),
-                        Err(error) => Err(error.context("Couldn't get encryptor")),
+                        Err(error) => Err(error.context("couldn't get encryptor")),
                     },
                 }
             }

--- a/oak_remote_attestation_sessions_client/src/lib.rs
+++ b/oak_remote_attestation_sessions_client/src/lib.rs
@@ -47,29 +47,29 @@ impl<T: AttestationTransport> GenericAttestationClient<T> {
         let mut handshaker = ClientHandshaker::new(attestation_behavior)?;
         let client_hello = handshaker
             .create_client_hello()
-            .context("Couldn't create client hello message")?;
+            .context("couldn't create client hello message")?;
 
         let mut response = client
             .message(session_id, client_hello)
             .await
-            .context("Couldn't message client hello message")?;
+            .context("couldn't message client hello message")?;
 
         while !handshaker.is_completed() {
             let request = handshaker
                 .next_step(&response)
-                .context("Couldn't process handshake message")?;
+                .context("couldn't process handshake message")?;
 
             if let Some(request) = request {
                 response = client
                     .message(session_id, request)
                     .await
-                    .context("Couldn't message client hello message")?;
+                    .context("couldn't message client hello message")?;
             }
         }
 
         let encryptor = handshaker
             .get_encryptor()
-            .context("Couldn't get encryptor")?;
+            .context("couldn't get encryptor")?;
 
         Ok(Self {
             session_id,
@@ -83,13 +83,13 @@ impl<T: AttestationTransport> GenericAttestationClient<T> {
         let encrypted_request = self
             .encryptor
             .encrypt(request_as_plaintext_bytes)
-            .context("Couldn't encrypt request")?;
+            .context("couldn't encrypt request")?;
 
         let encrypted_response = self
             .client
             .message(self.session_id, encrypted_request)
             .await
-            .context("Couldn't message encrypted data request")?;
+            .context("couldn't message encrypted data request")?;
 
         // The runtime responds with an encrypted response that contains an
         // encoded proto containing the plaintext response and status code.
@@ -97,7 +97,7 @@ impl<T: AttestationTransport> GenericAttestationClient<T> {
         let encoded_response = self
             .encryptor
             .decrypt(&encrypted_response)
-            .context("Couldn't decrypt response")?;
+            .context("couldn't decrypt response")?;
 
         Ok(encoded_response)
     }

--- a/oak_restricted_kernel/src/args.rs
+++ b/oak_restricted_kernel/src/args.rs
@@ -52,11 +52,11 @@ impl Args {
 pub fn init_args(args: &CStr) -> core::result::Result<Args, &str> {
     let args = args
         .to_str()
-        .map_err(|core::str::Utf8Error { .. }| "Kernel arguments are not valid UTF-8")?;
+        .map_err(|core::str::Utf8Error { .. }| "kernel arguments are not valid UTF-8")?;
     // Safety: this is called once early in the initialization process from a single thread, so
     // there will not be any concurrent writes.
     unsafe { ARGS.try_push_str(args) }
-        .map_err(|arrayvec::CapacityError { .. }| "Kernel arguments too long")?;
+        .map_err(|arrayvec::CapacityError { .. }| "kernel arguments too long")?;
     // Safety: we've just populated ARGS, successfully, in the line just above.
     Ok(Args {
         args: LazyCell::new(|| split_args(unsafe { ARGS.as_str() })),

--- a/oak_restricted_kernel/src/attestation.rs
+++ b/oak_restricted_kernel/src/attestation.rs
@@ -38,14 +38,14 @@ pub fn get_attestation(report_data: [u8; REPORT_DATA_SIZE]) -> anyhow::Result<At
     let mut guard = GUEST_MESSAGE_ENCRYPTOR.lock();
     let encryptor = guard
         .as_mut()
-        .ok_or_else(|| anyhow::anyhow!("Guest message encryptor is not initialized."))?;
+        .ok_or_else(|| anyhow::anyhow!("guest message encryptor is not initialized"))?;
 
     let mut report_request = AttestationRequest::new();
     report_request.report_data = report_data;
 
     let alloc = GUEST_HOST_HEAP
         .get()
-        .ok_or_else(|| anyhow::anyhow!("Guest-host heap is not initialized."))?;
+        .ok_or_else(|| anyhow::anyhow!("guest-host heap is not initialized"))?;
 
     let mut request_message = Box::new_in(GuestMessage::new(), alloc);
     encryptor
@@ -55,17 +55,17 @@ pub fn get_attestation(report_data: [u8; REPORT_DATA_SIZE]) -> anyhow::Result<At
 
     let translator = ADDRESS_TRANSLATOR
         .get()
-        .ok_or_else(|| anyhow::anyhow!("Address translator is not initialized."))?;
+        .ok_or_else(|| anyhow::anyhow!("address translator is not initialized"))?;
     let request_address = translator
         .translate_virtual(VirtAddr::from_ptr(
             request_message.as_ref() as *const GuestMessage
         ))
-        .ok_or_else(|| anyhow::anyhow!("Couldn't translate request address."))?;
+        .ok_or_else(|| anyhow::anyhow!("couldn't translate request address"))?;
     let response_address = translator
         .translate_virtual(VirtAddr::from_ptr(
             response_message.as_ref() as *const GuestMessage
         ))
-        .ok_or_else(|| anyhow::anyhow!("Couldn't translate response address."))?;
+        .ok_or_else(|| anyhow::anyhow!("couldn't translate response address"))?;
 
     GHCB_PROTOCOL
         .lock()
@@ -80,7 +80,7 @@ pub fn get_attestation(report_data: [u8; REPORT_DATA_SIZE]) -> anyhow::Result<At
         .validate()
         .map_err(anyhow::Error::msg)?;
     if attestation_response.status != ReportStatus::Success as u32 {
-        anyhow::bail!("Report request failed due to invalid parameters.");
+        anyhow::bail!("report request failed due to invalid parameters");
     }
     Ok(attestation_response.report)
 }

--- a/oak_restricted_kernel/src/ghcb.rs
+++ b/oak_restricted_kernel/src/ghcb.rs
@@ -83,7 +83,7 @@ pub fn reshare_ghcb<M: Mapper<Size4KiB>>(mapper: &mut M) {
                 | PageTableFlags::NO_EXECUTE,
         ) {
             Ok(mapper_flush) => mapper_flush.flush(),
-            Err(error) => panic!("Couldn't update page table flags for GHCB: {:?}", error),
+            Err(error) => panic!("couldn't update page table flags for GHCB: {:?}", error),
         };
     }
 }
@@ -101,21 +101,21 @@ fn init_ghcb_early(snp_enabled: bool) -> GhcbProtocol<'static, Ghcb> {
         let ghcb_frame = PhysFrame::<Size2MiB>::from_start_address(
             mapper
                 .translate_virtual(ghcb_page.start_address())
-                .expect("Couldn't find the physical address for the GHCB"),
+                .expect("couldn't find the physical address for the GHCB"),
         )
-        .expect("The GHCB physical address is not correctly aligned");
+        .expect("the GHCB physical address is not correctly aligned");
 
         // Since we don't have the GHCB set up already we need to use the MSR protocol to mark every
         // individual 4KiB area in the 2MiB page as shared in the RMP. It is OK to crash if we
         // cannot share the GHCB with the hypervisor.
         change_snp_state_for_frame(&ghcb_frame, PageAssignment::Shared)
-            .expect("Could not change SNP state for frame.");
+            .expect("couldn't change SNP state for frame");
 
         let ghcb_location_request =
             RegisterGhcbGpaRequest::new(ghcb_frame.start_address().as_u64() as usize)
-                .expect("Invalid address for GHCB location");
+                .expect("invalid address for GHCB location");
         register_ghcb_location(ghcb_location_request)
-            .expect("Couldn't register the GHCB address with the hypervisor");
+            .expect("couldn't register the GHCB address with the hypervisor");
     }
 
     // Safety: we only remove the encrypted bit as the initial pages created by the stage 0 firmware
@@ -126,7 +126,7 @@ fn init_ghcb_early(snp_enabled: bool) -> GhcbProtocol<'static, Ghcb> {
             PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
         ) {
             Ok(mapper_flush) => mapper_flush.flush(),
-            Err(error) => panic!("Couldn't update page table flags for GHCB: {:?}", error),
+            Err(error) => panic!("couldn't update page table flags for GHCB: {:?}", error),
         };
     }
 
@@ -160,6 +160,5 @@ fn get_ghcb_page() -> Page<Size2MiB> {
     // address and don't dereference it.
     let ghcb_pointer = unsafe { &GHCB_WRAPPER as *const GhcbAlignmentWrapper };
     let ghcb_address = VirtAddr::from_ptr(ghcb_pointer);
-    Page::<Size2MiB>::from_start_address(ghcb_address)
-        .expect("Invalid start address for GHCB page.")
+    Page::<Size2MiB>::from_start_address(ghcb_address).expect("invalid start address for GHCB page")
 }

--- a/oak_restricted_kernel/src/interface.rs
+++ b/oak_restricted_kernel/src/interface.rs
@@ -55,7 +55,7 @@ pub extern "C" fn heap_alloc(size: usize) -> *mut c_void {
     // This should never panic since we checked that the size is non-zero and calculated a valid
     // alignment.
     let layout = Layout::from_size_align(size, calculate_alignment(size))
-        .expect("Invalid alignment calculated.");
+        .expect("invalid alignment calculated");
 
     // We use the global allocator directly (rather than using e.g. `Vec<u8>`) so that we have the
     // required control over the alignment of the allocated memory.
@@ -95,7 +95,7 @@ pub extern "C" fn heap_free(ptr: *mut c_void) {
         .lock()
         .borrow_mut()
         .remove(&key)
-        .expect("Invalid memory region pointer. It was either already freed or not allocated.");
+        .expect("invalid memory region pointer: it was either already freed or not allocated");
 
     // Safety: we have validated that we previously allocated the memory, found the layout that was
     // used to allocate it, and it was not yet freed.

--- a/oak_restricted_kernel/src/interrupts.rs
+++ b/oak_restricted_kernel/src/interrupts.rs
@@ -142,7 +142,7 @@ mutable_interrupt_handler_with_error_code!(
                     shutdown::shutdown();
                 }
                 let leaf = stack_frame.rax as u32;
-                get_cpuid_for_vc_exception(leaf, stack_frame).expect("Error reading CPUID");
+                get_cpuid_for_vc_exception(leaf, stack_frame).expect("error reading CPUID");
                 // CPUID instruction is 2 bytes long, so we advance the instruction pointer by 2.
                 stack_frame.rip += 2u64;
             }

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -130,7 +130,7 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
             // when SEV-SNP is active. Panicking is OK at this point, because these pages are
             // required to support the full features and we don't want to run without them.
             init_snp_pages(
-                snp_pages.expect("Missing SNP CPUID and secrets pages."),
+                snp_pages.expect("missing SNP CPUID and secrets pages"),
                 &mapper,
             );
             snp::init_guest_message_encryptor();
@@ -155,7 +155,7 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
         // TODO(#3414): Use the GHCB protocol when it is available.
         for frame in guest_host_frames {
             change_snp_state_for_frame(&frame, PageAssignment::Shared)
-                .expect("Could not change SNP state for frame.");
+                .expect("couldn't change SNP state for frame");
         }
     }
 
@@ -166,11 +166,11 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
         .set(unsafe { memory::init_guest_host_heap(guest_host_pages, &mut mapper) }.unwrap())
         .is_err()
     {
-        panic!("Could not initialize the guest-host heap.");
+        panic!("couldn't initialize the guest-host heap");
     }
 
     if ADDRESS_TRANSLATOR.set(mapper).is_err() {
-        panic!("Could not initialize the address translator.");
+        panic!("couldn't initialize the address translator");
     }
     let mapper = ADDRESS_TRANSLATOR.get().unwrap();
 
@@ -190,9 +190,9 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
         // For now we just generate a sample attestation report and log the value.
         // TODO(#2842): Use attestation report in attestation behaviour.
         let report =
-            attestation::get_attestation([42; 64]).expect("Couldn't generate attestation report.");
+            attestation::get_attestation([42; 64]).expect("couldn't generate attestation report");
         info!("Attestation: {:?}", report);
-        report.validate().expect("Attestation report is invalid");
+        report.validate().expect("attestation report is invalid");
     }
 
     get_channel(

--- a/oak_restricted_kernel/src/logging.rs
+++ b/oak_restricted_kernel/src/logging.rs
@@ -41,7 +41,7 @@ lazy_static! {
         // Our contract with the launcher requires the first serial port to be
         // available, so assuming the loader adheres to it, this is safe.
         let mut port = unsafe { SerialPort::new(COM1_BASE, port_factory) };
-        port.init().expect("Couldn't initialize logging serial port.");
+        port.init().expect("couldn't initialize logging serial port");
         AtomicRefCell::new(port)
     };
 }

--- a/oak_restricted_kernel/src/mm/bitmap_frame_allocator.rs
+++ b/oak_restricted_kernel/src/mm/bitmap_frame_allocator.rs
@@ -189,15 +189,15 @@ impl<S: PageSize, const N: usize> FrameDeallocator<S> for BitmapAllocator<S, N> 
     unsafe fn deallocate_frame(&mut self, frame: PhysFrame<S>) {
         if let Some(frame_idx) = self.frame_idx(frame) {
             if !self.valid[frame_idx] {
-                panic!("Frame {:?} is not valid in this allocator", frame);
+                panic!("frame {:?} is not valid in this allocator", frame);
             }
             if !self.allocated[frame_idx] {
-                panic!("Frame {:?} was not allocated in this allocator", frame);
+                panic!("frame {:?} was not allocated in this allocator", frame);
             }
             self.allocated.set(frame_idx, false);
         } else {
             panic!(
-                "Can't deallocate frame that's outside our range; our range: {:?}, frame: {:?}",
+                "can't deallocate frame that's outside our range; our range: {:?}, frame: {:?}",
                 self.range, frame
             );
         }

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -272,7 +272,7 @@ pub fn init_paging<A: FrameAllocator<Size4KiB>>(
     // This reference will no longer be valid after we reload the page tables!
     let pml4_frame = frame_allocator
         .allocate_frame()
-        .ok_or("Could not allocate a frame for PML4")?;
+        .ok_or("couldn't allocate a frame for PML4")?;
     let pml4 = unsafe { &mut *(pml4_frame.start_address().as_u64() as *mut PageTable) };
     pml4.zero();
 

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -306,12 +306,12 @@ pub fn init_paging<A: FrameAllocator<Size4KiB>>(
             &mut page_table,
             frame_allocator,
         )
-        .map_err(|_| "failed to set up paging for physical memory")?;
+        .map_err(|_| "couldn't set up paging for physical memory")?;
 
         // Mapping for the kernel itself in the upper -2G of memory, based on the mappings (and
         // permissions) in the program header.
         page_tables::create_kernel_map(program_headers, &mut page_table, frame_allocator)
-            .map_err(|_| "failed to set up paging for the kernel")?;
+            .map_err(|_| "couldn't set up paging for the kernel")?;
     }
 
     // Safety: the new page tables keep the identity mapping at -2GB intact, so it's safe to load

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -306,12 +306,12 @@ pub fn init_paging<A: FrameAllocator<Size4KiB>>(
             &mut page_table,
             frame_allocator,
         )
-        .map_err(|_| "Failed to set up paging for physical memory")?;
+        .map_err(|_| "failed to set up paging for physical memory")?;
 
         // Mapping for the kernel itself in the upper -2G of memory, based on the mappings (and
         // permissions) in the program header.
         page_tables::create_kernel_map(program_headers, &mut page_table, frame_allocator)
-            .map_err(|_| "Failed to set up paging for the kernel")?;
+            .map_err(|_| "failed to set up paging for the kernel")?;
     }
 
     // Safety: the new page tables keep the identity mapping at -2GB intact, so it's safe to load

--- a/oak_restricted_kernel/src/snp.rs
+++ b/oak_restricted_kernel/src/snp.rs
@@ -77,7 +77,7 @@ pub fn get_snp_page_addresses(info: &BootParams) -> SnpPageAddresses {
     }
 
     if setup_data_ptr.is_null() {
-        panic!("Couldn't find setup data of type CCBlob.");
+        panic!("couldn't find setup data of type CCBlob");
     }
 
     // Safety: we have checked that the pointer is not null and at least points to memory within the
@@ -117,35 +117,35 @@ pub fn init_snp_pages<T: Translator>(snp_pages: SnpPageAddresses, mapper: &T) {
 
     let cpuid_page_address = mapper
         .translate_physical(snp_pages.cpuid_page_address)
-        .expect("Couldn't find a valid virtual address for the CPUID page.");
+        .expect("couldn't find a valid virtual address for the CPUID page");
     // Safety: we have checked that the pointer is in the expected valid memory range, not null, and
     // 4KiB page-aligned.
     let cpuid_slice: &[u8] =
         unsafe { from_raw_parts(cpuid_page_address.as_ptr(), Size4KiB::SIZE as usize) };
     CPUID_PAGE
-        .set(CpuidPage::read_from(cpuid_slice).expect("CPUID page byte slice was invalid."))
-        .expect("Couldn't set CPUID page.");
+        .set(CpuidPage::read_from(cpuid_slice).expect("CPUID page byte slice was invalid"))
+        .expect("couldn't set CPUID page");
     CPUID_PAGE
         .get()
         .unwrap()
         .validate()
-        .expect("Invalid CPUID page.");
+        .expect("invalid CPUID page");
 
     let secrets_page_address = mapper
         .translate_physical(snp_pages.secrets_page_address)
-        .expect("Couldn't find a valid virtual address for the secrets page.");
+        .expect("couldn't find a valid virtual address for the secrets page");
     // Safety: we have checked that the pointer is in the expected valid memory range, not null, and
     // 4KiB page-aligned.
     let secrets_slice: &[u8] =
         unsafe { from_raw_parts(secrets_page_address.as_ptr(), Size4KiB::SIZE as usize) };
     SECRETS_PAGE
-        .set(SecretsPage::read_from(secrets_slice).expect("Secrets page byte slice was invalid."))
-        .expect("Couldn't set secrets page.");
+        .set(SecretsPage::read_from(secrets_slice).expect("secrets page byte slice was invalid"))
+        .expect("couldn't set secrets page");
     SECRETS_PAGE
         .get()
         .unwrap()
         .validate()
-        .expect("Invalid secrets page.");
+        .expect("invalid secrets page");
 }
 
 /// Initializes the guest message encryptor.
@@ -155,26 +155,26 @@ pub fn init_guest_message_encryptor() {
     // For now we always use VMPCK_0 from the secrets page as the key.
     let key = &SECRETS_PAGE
         .get()
-        .expect("Secrets page is not initialized.")
+        .expect("secrets page is not initialized")
         .vmpck_0[..];
-    GUEST_MESSAGE_ENCRYPTOR.lock().replace(
-        GuestMessageEncryptor::new(key).expect("Couldn't create guest message encryptor."),
-    );
+    GUEST_MESSAGE_ENCRYPTOR
+        .lock()
+        .replace(GuestMessageEncryptor::new(key).expect("couldn't create guest message encryptor"));
 }
 
 /// Panics if the physical address is not the start of a 4KiB page, null, or not below the maximum
 /// expected address.
 fn assert_page_in_valid_range(page: PhysAddr) {
-    assert!(!page.is_null(), "Address is null");
+    assert!(!page.is_null(), "address is null");
     assert_eq!(
         page.align_down(Size4KiB::SIZE),
         page,
-        "Address {:#018x} is not the start of a 4KiB page.",
+        "address {:#018x} is not the start of a 4KiB page",
         page
     );
     assert!(
         page < MAX_ADDRESS,
-        "Address {:#018x} is not below the expected maximum address {:#018x}",
+        "address {:#018x} is not below the expected maximum address {:#018x}",
         page,
         MAX_ADDRESS
     );
@@ -182,11 +182,11 @@ fn assert_page_in_valid_range(page: PhysAddr) {
 
 /// Panics if the pointer is null or points to an address that falls outside the expected range.
 fn assert_pointer_in_valid_range<T>(pointer: *const T) {
-    assert!(!pointer.is_null(), "Pointer is null");
+    assert!(!pointer.is_null(), "pointer is null");
     let address = VirtAddr::from_ptr(pointer);
     assert!(
         address.as_u64() < MAX_ADDRESS.as_u64(),
-        "Pointer {:#018x} is not below the expected maximum address {:#018x}",
+        "pointer {:#018x} is not below the expected maximum address {:#018x}",
         address,
         MAX_ADDRESS
     );

--- a/oak_restricted_kernel/src/virtio.rs
+++ b/oak_restricted_kernel/src/virtio.rs
@@ -60,7 +60,7 @@ pub fn get_console_channel<'a, X: Translator, A: Allocator>(
         |paddr: PhysAddr| translator.translate_physical(paddr),
         alloc,
     )
-    .expect("Couldn't configure PCI virtio console device.");
+    .expect("couldn't configure PCI virtio console device");
     info!("Console device status: {}", console.get_status());
     Channel { inner: console }
 }
@@ -75,10 +75,10 @@ pub fn get_vsock_channel<'a, X: Translator, A: Allocator>(
         |paddr: PhysAddr| translator.translate_physical(paddr),
         alloc,
     )
-    .expect("Couldn't configure PCI virtio vsock device.");
+    .expect("couldn't configure PCI virtio vsock device");
     info!("Socket device status: {}", vsock.get_status());
     let listener = virtio::vsock::socket::SocketListener::new(vsock, VSOCK_PORT);
     Channel {
-        inner: listener.accept().expect("Couldn't accept connection."),
+        inner: listener.accept().expect("couldn't accept connection"),
     }
 }

--- a/oak_simple_io/src/lib.rs
+++ b/oak_simple_io/src/lib.rs
@@ -85,14 +85,14 @@ impl<'a, A: Allocator> SimpleIo<'a, A> {
         write_address(
             &io_port_factory,
             translate(VirtAddr::from_ptr(output_buffer.as_ptr()))
-                .ok_or("failed to translate VirtAddr to PhysAddr")?,
+                .ok_or("couldn't translate VirtAddr to PhysAddr")?,
             output.buffer_msb_port,
             output.buffer_lsb_port,
         )?;
         write_address(
             &io_port_factory,
             translate(VirtAddr::from_ptr(input_buffer.as_ptr()))
-                .ok_or("failed to translate VirtAddr to PhysAddr")?,
+                .ok_or("couldn't translate VirtAddr to PhysAddr")?,
             input.buffer_msb_port,
             input.buffer_lsb_port,
         )?;

--- a/oak_simple_io/src/lib.rs
+++ b/oak_simple_io/src/lib.rs
@@ -85,14 +85,14 @@ impl<'a, A: Allocator> SimpleIo<'a, A> {
         write_address(
             &io_port_factory,
             translate(VirtAddr::from_ptr(output_buffer.as_ptr()))
-                .ok_or("Failed to translate VirtAddr to PhysAddr")?,
+                .ok_or("failed to translate VirtAddr to PhysAddr")?,
             output.buffer_msb_port,
             output.buffer_lsb_port,
         )?;
         write_address(
             &io_port_factory,
             translate(VirtAddr::from_ptr(input_buffer.as_ptr()))
-                .ok_or("Failed to translate VirtAddr to PhysAddr")?,
+                .ok_or("failed to translate VirtAddr to PhysAddr")?,
             input.buffer_msb_port,
             input.buffer_lsb_port,
         )?;
@@ -136,7 +136,7 @@ impl<'a, A: Allocator> SimpleIo<'a, A> {
         // implementation. This is probably not recoverable, so panic.
         assert!(
             length <= INPUT_BUFFER_LENGTH,
-            "Invalid simple IO input message length."
+            "invalid simple IO input message length."
         );
         let mut result = VecDeque::with_capacity(length);
         result.extend(&self.input_buffer[..length]);

--- a/oak_tensorflow_freestanding_bin/src/main.rs
+++ b/oak_tensorflow_freestanding_bin/src/main.rs
@@ -37,12 +37,12 @@ fn start_server(channel: Box<dyn Channel>) -> ! {
     let service_impl = oak_tensorflow_service::TensorflowServiceImpl::new();
     let server = oak_tensorflow_service::schema::TensorflowService::serve(service_impl);
     oak_channel::server::start_blocking_server(channel, server)
-        .expect("Server encountered an unrecoverable error")
+        .expect("server encountered an unrecoverable error")
 }
 
 #[alloc_error_handler]
 fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
-    panic!("Error allocating memory: {:#?}", layout);
+    panic!("error allocating memory: {:#?}", layout);
 }
 
 #[panic_handler]

--- a/oak_tensorflow_service/build.rs
+++ b/oak_tensorflow_service/build.rs
@@ -49,7 +49,7 @@ fn build_tflite() {
     // WORKSPACE_ROOT is set in .cargo/config.toml.
     // Rerun `build.rs` next time if TensorFlow Lite library sources have been changed.
     let path_pattern = format!("{}/{}", env!("WORKSPACE_ROOT"), TFLITE_SOURCES_PATTERN);
-    for entry in glob(&path_pattern).expect("Failed to read tflite source pattern") {
+    for entry in glob(&path_pattern).expect("failed to read tflite source pattern") {
         match entry {
             Ok(path) => rerun_if_changed(&path),
             Err(e) => println!("{:?}", e),
@@ -61,9 +61,9 @@ fn build_tflite() {
         .arg("build")
         .arg(build_target)
         .status()
-        .expect("Failed to run bazel build");
+        .expect("failed to run bazel build");
     if !status.success() {
-        panic!("Failed to run bazel build: exit status is {}", status);
+        panic!("failed to run bazel build: exit status is {}", status);
     }
 
     // Add TensorFlow Lite build directory to the library search path.

--- a/oak_tensorflow_service/build.rs
+++ b/oak_tensorflow_service/build.rs
@@ -49,7 +49,7 @@ fn build_tflite() {
     // WORKSPACE_ROOT is set in .cargo/config.toml.
     // Rerun `build.rs` next time if TensorFlow Lite library sources have been changed.
     let path_pattern = format!("{}/{}", env!("WORKSPACE_ROOT"), TFLITE_SOURCES_PATTERN);
-    for entry in glob(&path_pattern).expect("failed to read tflite source pattern") {
+    for entry in glob(&path_pattern).expect("couldn't read tflite source pattern") {
         match entry {
             Ok(path) => rerun_if_changed(&path),
             Err(e) => println!("{:?}", e),
@@ -61,9 +61,9 @@ fn build_tflite() {
         .arg("build")
         .arg(build_target)
         .status()
-        .expect("failed to run bazel build");
+        .expect("couldn't run bazel build");
     if !status.success() {
-        panic!("failed to run bazel build: exit status is {}", status);
+        panic!("couldn't run bazel build: exit status is {}", status);
     }
 
     // Add TensorFlow Lite build directory to the library search path.

--- a/oak_tensorflow_service/src/tflite.rs
+++ b/oak_tensorflow_service/src/tflite.rs
@@ -120,7 +120,7 @@ impl TfliteModel {
         log!(Level::Info, "Running TFLite inference");
         let output_buffer_len = self
             .output_buffer_len
-            .context("Running inference on a non-initialized TensorFlow model")?;
+            .context("running inference on a non-initialized TensorFlow model")?;
 
         let input_bytes_len = input_bytes.len();
         let mut output_buffer = vec![0; output_buffer_len];
@@ -140,7 +140,7 @@ impl TfliteModel {
             // Panicing since if the output bytes length is bigger than the output buffer length,
             // then there is a potential for memory corruption and we can't rely on any of the Rust
             // memory safety assumptions.
-            panic!("Output bytes length is bigger than the output buffer length");
+            panic!("output bytes length is bigger than the output buffer length");
         }
     }
 }

--- a/rfcs/01391_async_sdk.md
+++ b/rfcs/01391_async_sdk.md
@@ -72,7 +72,7 @@ async fn handler(requests: GrpcInvocations<HelloWorld>) {
                 }
                 // ...
             }
-    }).await.expect("Error handling request");
+    }).await.expect("error handling request");
 }
 ```
 

--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -154,7 +154,7 @@ impl FwCfg {
         if let Some(file) = entry {
             self.read_file(file, object.as_bytes_mut())
         } else {
-            Err("Could not find requested file")
+            Err("couldn't find requested file")
         }
     }
 

--- a/stage0/src/logging.rs
+++ b/stage0/src/logging.rs
@@ -52,7 +52,7 @@ pub fn init_logging(port_factory: PortFactoryWrapper) {
     // available, so assuming the loader adheres to it, this is safe.
     let mut port = unsafe { SerialPort::new(SERIAL_BASE, port_factory) };
     port.init()
-        .expect("Couldn't initialize logging serial port.");
+        .expect("couldn't initialize logging serial port");
     {
         let mut lock = SERIAL_PORT.lock();
         *lock.deref_mut() = Some(port);

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -81,7 +81,7 @@ pub fn init_ghcb(snp: bool, encrypted: u64) -> &'static Spinlock<GhcbProtocol<'s
         })))
         .is_err()
     {
-        panic!("failed to initialize GHCB wrapper");
+        panic!("couldn't initialize GHCB wrapper");
     }
     GHCB_WRAPPER.get().unwrap()
 }

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -63,13 +63,13 @@ pub fn init_ghcb(snp: bool, encrypted: u64) -> &'static Spinlock<GhcbProtocol<'s
     // SNP requires extra handling beyond just removing the encrypted bit.
     if snp {
         let request = SnpPageStateChangeRequest::new(ghcb_addr as usize, PageAssignment::Shared)
-            .expect("Invalid address for GHCB location");
-        change_snp_page_state(request).expect("Could not change SNP state for GHCB");
+            .expect("invalid address for GHCB location");
+        change_snp_page_state(request).expect("couldn't change SNP state for GHCB");
 
         let ghcb_location_request = RegisterGhcbGpaRequest::new(ghcb_addr as usize)
-            .expect("Invalid address for GHCB location");
+            .expect("invalid address for GHCB location");
         register_ghcb_location(ghcb_location_request)
-            .expect("Couldn't register the GHCB address with the hypervisor");
+            .expect("couldn't register the GHCB address with the hypervisor");
     }
 
     let ghcb = unsafe { GHCB.write(Ghcb::new()) };
@@ -81,7 +81,7 @@ pub fn init_ghcb(snp: bool, encrypted: u64) -> &'static Spinlock<GhcbProtocol<'s
         })))
         .is_err()
     {
-        panic!("Failed to initialize GHCB wrapper");
+        panic!("failed to initialize GHCB wrapper");
     }
     GHCB_WRAPPER.get().unwrap()
 }
@@ -91,8 +91,8 @@ pub fn deinit_ghcb(snp: bool, encrypted: u64) {
 
     if snp {
         let request = SnpPageStateChangeRequest::new(ghcb_addr as usize, PageAssignment::Private)
-            .expect("Invalid address for GHCB location");
-        change_snp_page_state(request).expect("Could not change SNP state for GHCB");
+            .expect("invalid address for GHCB location");
+        change_snp_page_state(request).expect("couldn't change SNP state for GHCB");
     }
 
     let pd = get_pd(encrypted);
@@ -172,7 +172,7 @@ pub fn validate_memory(zero_page: &BootParams, encrypted: u64) {
                 })
                 .find(|result| result.is_err())
             {
-                panic!("Unexpected error: {:?}", err);
+                panic!("unexpected error: {:?}", err);
             }
 
             page_table.zero();

--- a/testing/oak_echo_bin/src/main.rs
+++ b/testing/oak_echo_bin/src/main.rs
@@ -40,12 +40,12 @@ fn start_echo_server(channel: Box<dyn Channel>) -> ! {
     let service = oak_echo_service::EchoServiceImpl::default();
     let server = service.serve();
     oak_channel::server::start_blocking_server(channel, server)
-        .expect("Runtime encountered an unrecoverable error");
+        .expect("runtime encountered an unrecoverable error");
 }
 
 #[alloc_error_handler]
 fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
-    panic!("Error allocating memory: {:#?}", layout);
+    panic!("error allocating memory: {:#?}", layout);
 }
 
 #[panic_handler]

--- a/testing/oak_echo_raw_bin/src/main.rs
+++ b/testing/oak_echo_raw_bin/src/main.rs
@@ -41,16 +41,16 @@ fn start_echo_server(mut channel: Box<dyn Channel>) -> ! {
     loop {
         let bytes = {
             let mut bytes: Vec<u8> = vec![0; MESSAGE_SIZE];
-            channel.read(&mut bytes).expect("Couldn't read bytes");
+            channel.read(&mut bytes).expect("couldn't read bytes");
             bytes
         };
-        channel.write(&bytes).expect("Couldn't write bytes");
+        channel.write(&bytes).expect("couldn't write bytes");
     }
 }
 
 #[alloc_error_handler]
 fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
-    panic!("Error allocating memory: {:#?}", layout);
+    panic!("error allocating memory: {:#?}", layout);
 }
 
 #[panic_handler]

--- a/testing/sev_snp_hello_world_kernel/src/ghcb.rs
+++ b/testing/sev_snp_hello_world_kernel/src/ghcb.rs
@@ -62,9 +62,9 @@ fn share_ghcb_with_hypervisor(ghcb: &Ghcb, snp_enabled: bool) {
         mark_2mib_page_shared_in_rmp(ghcb_physical_address);
         let ghcb_location_request =
             RegisterGhcbGpaRequest::new(ghcb_physical_address.as_u64() as usize)
-                .expect("Invalid address for GHCB location");
+                .expect("invalid address for GHCB location");
         register_ghcb_location(ghcb_location_request)
-            .expect("Couldn't register the GHCB address with the hypervisor");
+            .expect("couldn't register the GHCB address with the hypervisor");
     }
     // Mark the page as not encrypted in the page tables.
     set_encrypted_bit_for_page(&ghcb_address, false);
@@ -150,7 +150,7 @@ fn mark_2mib_page_shared_in_rmp(physical_address: PhysAddr) {
             (raw_address + i * Size4KiB::SIZE) as usize,
             PageAssignment::Shared,
         )
-        .expect("Invalid page address");
-        change_snp_page_state(request).expect("Couldn't change page state");
+        .expect("invalid page address");
+        change_snp_page_state(request).expect("couldn't change page state");
     }
 }

--- a/testing/sev_snp_hello_world_kernel/src/serial.rs
+++ b/testing/sev_snp_hello_world_kernel/src/serial.rs
@@ -47,7 +47,7 @@ lazy_static! {
             PortFactoryWrapper::new_raw()
         };
         let mut port = unsafe { SerialPort::new(COM1_BASE, factory) };
-        port.init().expect("Couldn't initialize serial port");
+        port.init().expect("couldn't initialize serial port");
         Spinlock::new(port)
     };
 }

--- a/trusted_shuffler/backend/src/main.rs
+++ b/trusted_shuffler/backend/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
     let address = opt
         .listen_address
         .parse()
-        .context("Couldn't parse address")?;
+        .context("couldn't parse address")?;
 
     if opt.use_grpc {
         start_grpc_backend(address).await
@@ -77,7 +77,7 @@ async fn start_http_backend(address: SocketAddr) -> anyhow::Result<()> {
 
     tokio::select!(
         result = server => {
-            result.context("Couldn't run server")?;
+            result.context("couldn't run server")?;
         },
         () = tokio::signal::ctrl_c().map(|r| r.unwrap()) => {
             info!("Stopping the backend server");
@@ -127,7 +127,7 @@ async fn start_grpc_backend(address: SocketAddr) -> anyhow::Result<()> {
 
     tokio::select!(
         result = server => {
-            result.context("Couldn't run server")?;
+            result.context("couldn't run server")?;
         },
         () = tokio::signal::ctrl_c().map(|r| r.unwrap()) => {
             info!("Stopping the backend server");

--- a/trusted_shuffler/client/src/main.rs
+++ b/trusted_shuffler/client/src/main.rs
@@ -87,12 +87,12 @@ async fn main() -> anyhow::Result<()> {
                 let url = format!("{}/request", server_url);
                 send_http_request(&url, Method::POST, request.as_bytes()).await
             }
-            .context("Couldn't receive response");
+            .context("couldn't receive response");
             let response_received = start_time.elapsed();
 
             // Parse and check the response.
             let parsed_response =
-                String::from_utf8(response.unwrap()).context("Couldn't decode response body");
+                String::from_utf8(response.unwrap()).context("couldn't decode response body");
             log::info!(
                 "Client Response {} at {:?}",
                 prime_to_send,

--- a/trusted_shuffler/common/src/lib.rs
+++ b/trusted_shuffler/common/src/lib.rs
@@ -26,9 +26,9 @@ pub async fn send_with_request(request: Request<Body>) -> anyhow::Result<Respons
     let response = client
         .request(request)
         .await
-        .context("Couldn't send request")?;
+        .context("couldn't send request")?;
     if response.status() != http::StatusCode::OK {
-        return Err(anyhow!("Non-OK status: {:?}", response.status()));
+        return Err(anyhow!("non-OK status: {:?}", response.status()));
     }
 
     Ok(response)
@@ -39,13 +39,13 @@ pub async fn send_http_request(uri: &str, method: Method, body: &[u8]) -> anyhow
         .method(method)
         .uri(uri)
         .body(Body::from(body.to_vec()))
-        .context("Couldn't create request")?;
+        .context("couldn't create request")?;
 
     let response = send_with_request(request).await?;
 
     let response_body = hyper::body::to_bytes(response.into_body())
         .await
-        .context("Couldn't read response body")?
+        .context("couldn't read response body")?
         .to_vec();
     Ok(response_body)
 }

--- a/trusted_shuffler/server/src/http.rs
+++ b/trusted_shuffler/server/src/http.rs
@@ -43,7 +43,7 @@ impl RequestHandler for HttpRequestHandler {
         // The following does not work, because &self would need 'static life time.
         // let parts = request.uri().into_parts();
         // parts.authority = Some(Authority::from_static(&self.backend_url));
-        // let new_uri = Uri::from_parts(parts).expect("Failed to create new URI");
+        // let new_uri = Uri::from_parts(parts).expect("couldn't create new URI");
         let path = request.uri().path();
         // And extend the URL to the backend.
         let new_uri = format!("{}{}", self.backend_url, path)
@@ -92,7 +92,7 @@ impl HyperRequestWrapper {
         let (parts, body) = self.0.into_parts();
         let body = hyper::body::to_bytes(body)
             .await
-            .context("failed to read request body")?;
+            .context("couldn't read request body")?;
         log::debug!("Body {:?}", body);
 
         let uri = parts.uri.clone();
@@ -125,7 +125,7 @@ impl HyperRequestWrapper {
             .method(Method::POST)
             .version(http::Version::HTTP_2)
             .body(body)
-            .context("failed to convert a plaintext Trusted Shuffler request to a hyper request")?;
+            .context("couldn't convert a plaintext Trusted Shuffler request to a hyper request")?;
 
         let headers = hyper_request.headers_mut();
 
@@ -179,18 +179,18 @@ impl HyperResponseWrapper {
         sender
             .send_data(encrypted_response.body)
             .await
-            .context("failed to build body from data of encrypted Trusted Shuffler response")?;
+            .context("couldn't build body from data of encrypted Trusted Shuffler response")?;
         sender
             .send_trailers(encrypted_response.trailers)
             .await
             .context(
-                "failed to build build body from trailers of encrypted Trusted Shuffler response",
+                "couldn't build build body from trailers of encrypted Trusted Shuffler response",
             )?;
 
         let mut hyper_response = Response::builder()
             .version(http::Version::HTTP_2)
             .body(body)
-            .context("failed to convert encrypted Trusted Shuffler response to hyper response")?;
+            .context("couldn't convert encrypted Trusted Shuffler response to hyper response")?;
 
         let headers = hyper_response.headers_mut();
 

--- a/trusted_shuffler/server/src/http.rs
+++ b/trusted_shuffler/server/src/http.rs
@@ -48,7 +48,7 @@ impl RequestHandler for HttpRequestHandler {
         // And extend the URL to the backend.
         let new_uri = format!("{}{}", self.backend_url, path)
             .parse::<Uri>()
-            .map_err(|error| anyhow!("Couldn't parse URI for backend: {:?}", error))?;
+            .map_err(|error| anyhow!("couldn't parse URI for backend: {:?}", error))?;
         let uri = request.uri_mut();
         *uri = new_uri;
 
@@ -59,7 +59,7 @@ impl RequestHandler for HttpRequestHandler {
         let scheme = request
             .uri()
             .scheme()
-            .context("Could not get scheme from backend_url.")?;
+            .context("couldn't get scheme from backend_url")?;
 
         let response = if scheme == &http::uri::Scheme::HTTPS {
             Client::builder()
@@ -75,7 +75,7 @@ impl RequestHandler for HttpRequestHandler {
 
         match response.await {
             Err(error) => Err(anyhow!(
-                "Couldn't receive response from the backend: {:?}",
+                "couldn't receive response from the backend: {:?}",
                 error
             )),
             Ok(response) => Ok(HyperResponseWrapper(response).strip().await?),
@@ -92,7 +92,7 @@ impl HyperRequestWrapper {
         let (parts, body) = self.0.into_parts();
         let body = hyper::body::to_bytes(body)
             .await
-            .context("Failed to read request body.")?;
+            .context("failed to read request body")?;
         log::debug!("Body {:?}", body);
 
         let uri = parts.uri.clone();
@@ -125,9 +125,7 @@ impl HyperRequestWrapper {
             .method(Method::POST)
             .version(http::Version::HTTP_2)
             .body(body)
-            .context(
-                "Failed to convert a plaintext Trusted Shuffler request to a hyper request.",
-            )?;
+            .context("failed to convert a plaintext Trusted Shuffler request to a hyper request")?;
 
         let headers = hyper_request.headers_mut();
 
@@ -157,12 +155,12 @@ impl HyperResponseWrapper {
 
         let body = hyper::body::to_bytes(&mut hyper_body)
             .await
-            .context("Could not read body.")?;
+            .context("couldn't read body")?;
 
         let trailers = hyper_body
             .trailers()
             .await
-            .context("Could not read trailers.")?
+            .context("couldn't read trailers")?
             .unwrap_or_default();
 
         let trusted_shuffler_response = PlaintextResponse {
@@ -181,18 +179,18 @@ impl HyperResponseWrapper {
         sender
             .send_data(encrypted_response.body)
             .await
-            .context("Failed to build body from data of encrypted Trusted Shuffler response.")?;
+            .context("failed to build body from data of encrypted Trusted Shuffler response")?;
         sender
             .send_trailers(encrypted_response.trailers)
             .await
             .context(
-                "Failed to build build body from trailers of encrypted Trusted Shuffler response.",
+                "failed to build build body from trailers of encrypted Trusted Shuffler response",
             )?;
 
         let mut hyper_response = Response::builder()
             .version(http::Version::HTTP_2)
             .body(body)
-            .context("Failed to convert encrypted Trusted Shuffler response to hyper response.")?;
+            .context("failed to convert encrypted Trusted Shuffler response to hyper response")?;
 
         let headers = hyper_response.headers_mut();
 

--- a/trusted_shuffler/server/src/main.rs
+++ b/trusted_shuffler/server/src/main.rs
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
     let listen_address = opt
         .listen_address
         .parse()
-        .context("Couldn't parse address")?;
+        .context("couldn't parse address")?;
     let timeout = opt.timeout_ms.map(Duration::from_millis);
 
     info!(
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
     ));
     tokio::select!(
         result = server => {
-            result.context("Couldn't run server")?;
+            result.context("couldn't run server")?;
         },
         () = tokio::signal::ctrl_c().map(|r| r.unwrap()) => {
             info!("Stopping the Trusted Shuffler server");

--- a/trusted_shuffler/trusted_shuffler/src/lib.rs
+++ b/trusted_shuffler/trusted_shuffler/src/lib.rs
@@ -165,7 +165,7 @@ impl TrustedShuffler {
             let mut requests_to_shuffle = self
                 .requests_to_shuffle
                 .lock()
-                .map_err(|error| anyhow!("Couldn't lock current messages mutex: {:?}", error))?;
+                .map_err(|error| anyhow!("couldn't lock current messages mutex: {:?}", error))?;
 
             let request = RequestMessage {
                 index: requests_to_shuffle.len(),
@@ -192,7 +192,7 @@ impl TrustedShuffler {
             }
         }
 
-        response_receiver.await.context("Couldn't receive response")
+        response_receiver.await.context("couldn't receive response")
     }
 
     // Lexicographically sorts requests and sends them to the backend using the
@@ -239,7 +239,7 @@ impl TrustedShuffler {
             .await
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .context("Couldn't send responses")?;
+            .context("couldn't send responses")?;
 
         Self::shuffle_responses(responses)
     }
@@ -259,7 +259,7 @@ impl TrustedShuffler {
                  }| {
                     response_sender
                         .send(data)
-                        .map_err(|_data| anyhow!("Couldn't send response"))
+                        .map_err(|_data| anyhow!("couldn't send response"))
                 },
             )
             .collect::<Result<Vec<_>, _>>()

--- a/xtask/src/check_build_licenses.rs
+++ b/xtask/src/check_build_licenses.rs
@@ -34,7 +34,7 @@ impl Runnable for CheckBuildLicenses {
     }
 
     fn run(self: Box<Self>, _opt: &Opt) -> Box<dyn Running> {
-        let file_content = std::fs::read_to_string(&self.path).expect("could not read file");
+        let file_content = std::fs::read_to_string(&self.path).expect("couldn't read file");
         let result_value = if file_content.contains("licenses = [\"notice\"]") {
             StatusResultValue::Ok
         } else {

--- a/xtask/src/check_todo.rs
+++ b/xtask/src/check_todo.rs
@@ -20,7 +20,7 @@ use regex::Regex;
 
 static PATTERN: Lazy<Regex> =
     // Break up "TO" and "DO" to avoid false positives on this code.
-    Lazy::new(|| Regex::new(&format!(r"{}DO\(#\d+\)", "TO")).expect("Could not parse regex"));
+    Lazy::new(|| Regex::new(&format!(r"{}DO\(#\d+\)", "TO")).expect("couldn't parse regex"));
 
 /// A [`Runnable`] command that checks for the existence of todos in the codebase with no associated
 /// GitHub issue number.
@@ -45,7 +45,7 @@ impl Runnable for CheckTodo {
     }
 
     fn run(self: Box<Self>, _opt: &Opt) -> Box<dyn Running> {
-        let file_content = std::fs::read_to_string(&self.path).expect("could not read file");
+        let file_content = std::fs::read_to_string(&self.path).expect("couldn't read file");
         let invalid_todo_words = file_content
             .split_whitespace()
             .filter(|word| CheckTodo::is_invalid_todo(word))

--- a/xtask/src/diffs.rs
+++ b/xtask/src/diffs.rs
@@ -67,7 +67,7 @@ pub fn modified_files(scope: &Scope) -> ModifiedContent {
             let output = Command::new("git")
                 .args(spread!["diff".to_owned(), "--name-only".to_owned(), args,])
                 .output()
-                .expect("could not get modified files");
+                .expect("couldn't get modified files");
 
             if output.status.success() {
                 let vec = output.stdout;
@@ -75,14 +75,14 @@ pub fn modified_files(scope: &Scope) -> ModifiedContent {
                 // Extract the file names from the git output
                 Some(
                     String::from_utf8(vec)
-                        .expect("could not convert to string")
+                        .expect("couldn't convert to string")
                         .split('\n')
                         .map(|s| format!("./{}", s))
                         .collect(),
                 )
             } else {
                 eprintln!(
-                    "WARN: git diff failed with error ({}), running the command for the entire code base.",
+                    "WARN: git diff failed with error ({}), running the command for the entire code base",
                     output.status
                 );
                 None
@@ -189,7 +189,7 @@ fn imported_proto_files(proto_file_path: String) -> Vec<String> {
 
         // Scan the lines in the file line by line to find all the imports.
         for line in lines {
-            let line = line.expect("could not read line");
+            let line = line.expect("couldn't read line");
             if let Some(imported) = re.captures(&line).map(|c| c[1].to_string()) {
                 imported_protos.push(imported);
             }
@@ -292,7 +292,7 @@ fn get_local_dependencies(toml_path: &Path) -> Vec<String> {
     let cargo_manifest: CargoManifest =
         toml::from_str(&read_file(toml_path)).unwrap_or_else(|err| {
             panic!(
-                "could not parse crate manifest file {:?}: {}",
+                "couldn't parse crate manifest file {:?}: {}",
                 toml_path, err
             )
         });

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -208,7 +208,7 @@ pub fn run_oak_functions_examples(opt: &RunOakExamplesOpt, scope: &Scope) -> Ste
     let examples: Vec<OakExample> = example_toml_files(scope)
         .map(|path| {
             toml::from_str(&read_file(&path)).unwrap_or_else(|err| {
-                panic!("could not parse example manifest file {:?}: {}", path, err)
+                panic!("couldn't parse example manifest file {:?}: {}", path, err)
             })
         })
         .filter(|example: &OakExample| example.has_oak_functions_application())
@@ -315,12 +315,12 @@ pub fn build_oak_functions_example(opt: &RunOakExamplesOpt, scope: &Scope) -> St
     let example: OakExample = example_toml_files(scope)
         .map(|path| {
             toml::from_str(&read_file(&path)).unwrap_or_else(|err| {
-                panic!("could not parse example manifest file {:?}: {}", path, err)
+                panic!("couldn't parse example manifest file {:?}: {}", path, err)
             })
         })
         .find(|example: &OakExample| &example.name == example_name)
         .filter(|example| example.has_oak_functions_application())
-        .expect("could not find the specified functions example, try with `--scope=all`");
+        .expect("couldn't find the specified functions example, try with `--scope=all`");
 
     // Build steps for building clients
     let build_client = Step::Multiple {

--- a/xtask/src/files.rs
+++ b/xtask/src/files.rs
@@ -21,10 +21,10 @@ use std::{
 };
 
 pub fn read_file(path: &Path) -> String {
-    let mut file = std::fs::File::open(path).expect("could not open file");
+    let mut file = std::fs::File::open(path).expect("couldn't open file");
     let mut contents = String::new();
     file.read_to_string(&mut contents)
-        .expect("could not read file contents");
+        .expect("couldn't read file contents");
     contents
 }
 
@@ -40,7 +40,7 @@ pub fn source_files() -> impl Iterator<Item = PathBuf> {
 
 pub fn file_contains(path: &Path, pattern: &str) -> bool {
     if path.is_file() {
-        let mut file = std::fs::File::open(path).expect("could not open file");
+        let mut file = std::fs::File::open(path).expect("couldn't open file");
         let mut contents = String::new();
         // Content may be non-UTF-8, in which case we just return false.
         if file.read_to_string(&mut contents).is_ok() {
@@ -166,7 +166,7 @@ pub fn is_typescript_file(path: &Path) -> bool {
 
 pub fn is_shell_script(path: &Path) -> bool {
     if path.is_file() {
-        let mut file = std::fs::File::open(path).expect("could not open file");
+        let mut file = std::fs::File::open(path).expect("couldn't open file");
         let mut contents = String::new();
         match file.read_to_string(&mut contents) {
             Ok(_size) => contents.starts_with("#!"),

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -139,7 +139,7 @@ impl std::str::FromStr for Scope {
                 Some(groups) => {
                     let commits_count = groups
                         .get(1)
-                        .ok_or(format!("failed to parse commits {}", scope))?
+                        .ok_or(format!("couldn't parse commits {}", scope))?
                         .as_str()
                         .to_string();
                     let count = commits_count
@@ -147,7 +147,7 @@ impl std::str::FromStr for Scope {
                         .map_err(|err| format!("couldn't parse to u8 {:?}", err))?;
                     Ok(Self::Commits(count))
                 }
-                None => Err(format!("failed to parse scope {}", scope)),
+                None => Err(format!("couldn't parse scope {}", scope)),
             },
         }
     }
@@ -191,7 +191,7 @@ impl std::str::FromStr for ServerVariant {
         match variant {
             "base" => Ok(ServerVariant::Base),
             _ => Err(format!(
-                "Failed to parse functions server variant {}",
+                "couldn't parse functions server variant {}",
                 variant
             )),
         }

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -139,15 +139,15 @@ impl std::str::FromStr for Scope {
                 Some(groups) => {
                     let commits_count = groups
                         .get(1)
-                        .ok_or(format!("Failed to parse commits {}", scope))?
+                        .ok_or(format!("failed to parse commits {}", scope))?
                         .as_str()
                         .to_string();
                     let count = commits_count
                         .parse::<u8>()
-                        .map_err(|err| format!("Could not parse to u8 {:?}", err))?;
+                        .map_err(|err| format!("couldn't parse to u8 {:?}", err))?;
                     Ok(Self::Commits(count))
                 }
-                None => Err(format!("Failed to parse scope {}", scope)),
+                None => Err(format!("failed to parse scope {}", scope)),
             },
         }
     }
@@ -658,7 +658,7 @@ pub async fn run_step(context: &Context, step: Step, mut run_status: Status) -> 
                 let mut buf = Vec::new();
                 io.read_to_end(&mut buf)
                     .await
-                    .expect("could not read from future");
+                    .expect("couldn't read from future");
                 buf
             }
 
@@ -673,10 +673,10 @@ pub async fn run_step(context: &Context, step: Step, mut run_status: Status) -> 
 
             let stdout = background_stdout_future
                 .await
-                .expect("could not read stdout");
+                .expect("couldn't read stdout");
             let stderr = background_stderr_future
                 .await
-                .expect("could not read stderr");
+                .expect("couldn't read stderr");
 
             let logs = format_logs(&stdout, &stderr);
 
@@ -809,12 +809,12 @@ impl Runnable for Cmd {
                 .stdout(stdout)
                 .stderr(stderr)
                 .spawn()
-                .unwrap_or_else(|err| panic!("could not spawn command: {:?}: {}", cmd, err));
+                .unwrap_or_else(|err| panic!("couldn't spawn command: {:?}: {}", cmd, err));
 
             if let Some(pid) = child.id() {
                 crate::PROCESSES
                     .lock()
-                    .expect("could not acquire processes lock")
+                    .expect("couldn't acquire processes lock")
                     .push(pid as i32);
             }
 
@@ -832,8 +832,8 @@ pub fn process_gone(raw_pid: i32) -> bool {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()
-        .unwrap_or_else(|err| panic!("could not spawn command: {:?}: {}", cmd, err));
-    let output = child.wait().expect("could not get exit status");
+        .unwrap_or_else(|err| panic!("couldn't spawn command: {:?}: {}", cmd, err));
+    let output = child.wait().expect("couldn't get exit status");
     // ps -p has success exit code if the pid exists.
     !output.success()
 }
@@ -883,7 +883,7 @@ impl Running for RunningCmd {
             .child
             .wait_with_output()
             .await
-            .expect("could not get exit status");
+            .expect("couldn't get exit status");
         let logs = format_logs(&output.stdout, &output.stderr);
         if output.status.success() {
             SingleStatusResult {
@@ -904,13 +904,13 @@ fn format_logs(stdout: &[u8], stderr: &[u8]) -> String {
     if !stdout.is_empty() {
         logs += &format!(
             "════╡ stdout ╞════\n{}",
-            std::str::from_utf8(stdout).expect("could not parse stdout as UTF8")
+            std::str::from_utf8(stdout).expect("couldn't parse stdout as UTF8")
         );
     }
     if !stderr.is_empty() {
         logs += &format!(
             "════╡ stderr ╞════\n{}",
-            std::str::from_utf8(stderr).expect("could not parse stderr as UTF8")
+            std::str::from_utf8(stderr).expect("couldn't parse stderr as UTF8")
         );
     }
     logs

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(async {
         tokio::signal::ctrl_c()
             .await
-            .expect("could not wait for signal");
+            .expect("couldn't wait for signal");
         cleanup();
         std::process::exit(-1);
     });
@@ -152,7 +152,7 @@ fn cleanup() {
     );
     for pid in PROCESSES
         .lock()
-        .expect("could not acquire processes lock")
+        .expect("couldn't acquire processes lock")
         .iter()
     {
         // We intentionally don't print anything here as it may obscure more interesting
@@ -209,7 +209,7 @@ pub fn run_fuzz_targets_in_crate(path: &Path, opt: &RunCargoFuzz) -> Step {
     fuzz_path.pop();
 
     let cargo_manifest: CargoManifest = toml::from_str(&read_file(path))
-        .unwrap_or_else(|err| panic!("could not parse cargo manifest file {:?}: {}", path, err));
+        .unwrap_or_else(|err| panic!("couldn't parse cargo manifest file {:?}: {}", path, err));
 
     Step::Multiple {
         name: "run cargo-fuzz".to_owned(),
@@ -297,9 +297,9 @@ fn run_completion(completion: &Completion) -> Step {
 fn run_ci() -> Step {
     // parse cmds for ./scripts/xtask from ci.yaml to keep them in sync
     let path_to_ci_yaml = ".github/workflows/ci.yaml";
-    let file = std::fs::File::open(path_to_ci_yaml).expect("could not open file");
+    let file = std::fs::File::open(path_to_ci_yaml).expect("couldn't open file");
     let contents: serde_yaml::Value =
-        serde_yaml::from_reader(file).expect("could not read file contents");
+        serde_yaml::from_reader(file).expect("couldn't read file contents");
     let mut ci_cmds = contents["jobs"]["xtask"]["strategy"]["matrix"]["cmd"]
         .as_sequence()
         .unwrap()


### PR DESCRIPTION
Error messages and additional information throughout the codebase have been somewhat inconsistent. This PR tries to make it a bit more consistent, mostly around the following:

- Don't capitalize the first letter of an error message
- Don't end error messages with a `.`
- Use consistent forms of words (mostly `couldn't` over `could not` and `failed to`)
