### PR TITLE
Fix public key malleability in offline attestation

### DIFF
--- a/experimental/offline_attestation/README.md
+++ b/experimental/offline_attestation/README.md
@@ -80,7 +80,8 @@ data appropriately and not leak the private key from the enclave.
 Once the client has the server's public key it encrypts the request. The client
 also generates its own asymmetric key-pair and includes the public key in the
 request. This provides a mechansim for the server to encrypt the response back
-to the client.
+to the client. The public key is bound to the encrypted payload as context info
+to prevent tampering.
 
 When the client receives the encrypted response from the server it decrypts it
 using is private key and processes the cleartext content.

--- a/experimental/offline_attestation/server/src/main.rs
+++ b/experimental/offline_attestation/server/src/main.rs
@@ -22,7 +22,7 @@ use clap::Parser;
 use log::{debug, info};
 use offline_attestation_shared::{
     decrypt, encrypt, generate_private_key, AttestationReport, EncryptedRequest, EncryptedResponse,
-    Handle, PublicKeyInfo,
+    Handle, PublicKeyInfo, RESPONSE_CONTEXT_INFO,
 };
 use std::{
     net::{Ipv6Addr, SocketAddr},
@@ -117,11 +117,19 @@ fn handle(encrypted_request: EncryptedRequest, private_key_handle: Arc<Handle>) 
         );
 
         // Decrypt the ciphertext.
-        let clear_text = decrypt(private_key_handle.as_ref(), &encrypted_request.ciphertext)?;
+        let clear_text = decrypt(
+            private_key_handle.as_ref(),
+            &encrypted_request.ciphertext,
+            &encrypted_request.response_public_key,
+        )?;
         info!("Received cleartext: {:?}", clear_text);
         // For now we just echo it back, so encrypt the same clear text with the client's public
         // key.
-        let ciphertext = encrypt(&encrypted_request.get_public_key_handle()?, &clear_text)?;
+        let ciphertext = encrypt(
+            &encrypted_request.get_public_key_handle()?,
+            &clear_text,
+            RESPONSE_CONTEXT_INFO,
+        )?;
         let response = EncryptedResponse { ciphertext };
 
         debug!(


### PR DESCRIPTION
The public key provided by the client was not covered by any cryptographic authentication, which meant that someone in the middle could replace it with a different pulbic key and intercept the response.

This change binds the public key to the encrypted payload as context info, which means that the payload cannot be decrypted if the public key is modified.