### PR TITLE
Generalize Java attestation client

### DIFF
--- a/java/src/main/java/com/google/oak/functions/client/BUILD
+++ b/java/src/main/java/com/google/oak/functions/client/BUILD
@@ -41,7 +41,6 @@ java_library(
     name = "client_noninteractive",
     srcs = ["AttestationClientNoninteractive.java"],
     deps = [
-        "//oak_remote_attestation_noninteractive/proto:oak_session_noninteractive_v1_java_grpc",
         "//oak_remote_attestation_noninteractive/proto:oak_session_noninteractive_v1_java_proto",
         "@com_google_protobuf//:protobuf_javalite",
         "@io_grpc_grpc_java//api",

--- a/java/src/main/java/com/google/oak/functions/weather_lookup_client/BUILD
+++ b/java/src/main/java/com/google/oak/functions/weather_lookup_client/BUILD
@@ -27,6 +27,7 @@ java_binary(
     deps = [
         "//java/src/main/java/com/google/oak/functions/client",
         "//java/src/main/java/com/google/oak/functions/client:client_noninteractive",
+        "//oak_remote_attestation_noninteractive/proto:oak_session_noninteractive_v1_java_grpc",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@io_grpc_grpc_java//api",

--- a/java/src/main/java/com/google/oak/functions/weather_lookup_client/Main.java
+++ b/java/src/main/java/com/google/oak/functions/weather_lookup_client/Main.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import oak.session.noninteractive.v1.StreamingSessionGrpc;
 
 public class Main {
   private static Logger logger = Logger.getLogger(Main.class.getName());
@@ -43,12 +44,12 @@ public class Main {
     builder = AttestationClient.addApiKey(builder, EMPTY_API_KEY);
     ManagedChannel channel = builder.build();
 
-    // Attest a gRPC channel.
-    AttestationClientNoninteractive client = new AttestationClientNoninteractive(channel);
+    // Create gRPC client stub.
+    StreamingSessionGrpc.StreamingSessionStub client = StreamingSessionGrpc.newStub(channel);
 
     // Test request coordinates are defined in `oak_functions/lookup_data_generator/src/data.rs`.
     byte[] requestBody = "{\"lat\":0,\"lng\":0}".getBytes(UTF_8);
-    byte[] response = client.send(requestBody);
+    byte[] response = AttestationClientNoninteractive.invoke(client::stream, requestBody);
     String decodedResponse = new String(response, StandardCharsets.UTF_8);
 
     if (decodedResponse.matches(EXPECTED_RESPONSE_PATTERN)) {


### PR DESCRIPTION
Now it does not depend on the gRPC method definition, only on an abstraction over it that works with any streaming method with the appropriate request and response types.

Ref #3442