### PR TITLE
Rebuild Oak TensorFlow if third-party has been updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,12 +1547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "goblin"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,7 +2796,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "glob",
  "hashbrown",
  "log",
  "oak_idl",

--- a/cc/tflite_micro/tflite_micro.cc
+++ b/cc/tflite_micro/tflite_micro.cc
@@ -107,8 +107,8 @@ int tflite_run(const uint8_t* input_bytes_ptr, size_t input_bytes_len, uint8_t* 
   }
 
   if (input_bytes_len != input_size) {
-    MicroPrintf("incorrect input length: expected %d bytes but got %d bytes",
-                input_size, input_bytes_len);
+    MicroPrintf("incorrect input length: expected %d bytes but got %d bytes", input_size,
+                input_bytes_len);
     return -1;
   }
 

--- a/cc/tflite_micro/tflite_micro.cc
+++ b/cc/tflite_micro/tflite_micro.cc
@@ -107,8 +107,8 @@ int tflite_run(const uint8_t* input_bytes_ptr, size_t input_bytes_len, uint8_t* 
   }
 
   if (input_bytes_len != input_size) {
-    MicroPrintf("incorrect input length: expected %d bytes but got %d bytes\n", input_size,
-                input_bytes_len);
+    MicroPrintf("incorrect input length: expected %d bytes but got %d bytes",
+                input_size, input_bytes_len);
     return -1;
   }
 
@@ -121,7 +121,7 @@ int tflite_run(const uint8_t* input_bytes_ptr, size_t input_bytes_len, uint8_t* 
   // Run inference, and report any error
   TfLiteStatus invoke_status = interpreter->Invoke();
   if (invoke_status != kTfLiteOk) {
-    MicroPrintf("couldn't run Invoke(), err: %d\n", invoke_status);
+    MicroPrintf("couldn't run Invoke(), err: %d", invoke_status);
     return -1;
   }
 

--- a/oak_tensorflow_freestanding_bin/Cargo.lock
+++ b/oak_tensorflow_freestanding_bin/Cargo.lock
@@ -228,12 +228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "goblin"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,7 +446,6 @@ name = "oak_tensorflow_service"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "glob",
  "hashbrown",
  "log",
  "oak_idl",

--- a/oak_tensorflow_service/Cargo.toml
+++ b/oak_tensorflow_service/Cargo.toml
@@ -13,7 +13,6 @@ oak_idl = { path = "../oak_idl" }
 prost = { version = "*", default-features = false, features = ["prost-derive"] }
 
 [build-dependencies]
-glob = "*"
 oak_idl_build = { path = "../oak_idl_build" }
 
 [dev-dependencies]

--- a/oak_tensorflow_service/build.rs
+++ b/oak_tensorflow_service/build.rs
@@ -64,9 +64,9 @@ fn build_bazel_target(target_dir: &str, target: &str) -> PathBuf {
     }
     let dependency_paths = from_utf8(&output.stdout)
         .expect("couldn't parse bazel query output")
-        .split("\n")
+        .split('\n')
         .into_iter()
-        .map(|build_target| build_target_to_path(build_target))
+        .map(build_target_to_path)
         .collect::<Vec<_>>();
 
     // Rerun `build.rs` next time one of the dependencies has been updated.
@@ -96,7 +96,7 @@ fn build_target_to_path(target: &str) -> PathBuf {
         .into_iter()
         .last()
         .expect("couldn't remove bazel build target prefix")
-        .replace(":", "");
+        .replace(':', "/");
     return [env!("WORKSPACE_ROOT"), &file_path].iter().collect();
 }
 

--- a/third_party/tflite-micro/tensorflow/lite/micro/micro_log.cc
+++ b/third_party/tflite-micro/tensorflow/lite/micro/micro_log.cc
@@ -33,7 +33,6 @@ void Log(const char* format, va_list args) {
   char log_buffer[kMaxLogLen];
   MicroVsnprintf(log_buffer, kMaxLogLen, format, args);
   DebugLog(log_buffer);
-  DebugLog("\r\n");
 #endif
 }
 


### PR DESCRIPTION
This PR makes `oak_tensorflow_service` rebuild the `tflite_micro` if third-party dependencies have been updated