### PR TITLE
Use consistent naming

### DIFF
--- a/oak_functions_freestanding/proto/oak_functions.proto
+++ b/oak_functions_freestanding/proto/oak_functions.proto
@@ -18,25 +18,21 @@ syntax = "proto3";
 
 package oak.functions;
 
-service TrustedRuntime {
+service OakFunctions {
+  // Initializes the service and remote attestation keys.
   // method_id: 0
-  rpc HandleUserRequest(UserRequest) returns (UserRequestResponse);
+  rpc Initialize(InitializeRequest) returns (InitializeResponse);
+
+  // Handles an invocation coming from a client.
   // method_id: 1
-  rpc Initialize(Initialization) returns (InitializeResponse);
+  rpc Invoke(InvokeRequest) returns (InvokeResponse);
+
   // Replaces the existing lookup data with the new value.
   // method_id: 2
   rpc UpdateLookupData(LookupData) returns (Empty);
 }
 
-message UserRequest {
-  bytes body = 1;
-}
-
-message UserRequestResponse {
-  bytes body = 1;
-}
-
-message Initialization {
+message InitializeRequest {
   bytes wasm_module = 1;
   uint32 constant_response_size = 2;
 }
@@ -48,6 +44,14 @@ message InitializeResponse {
 message PublicKeyInfo {
   bytes public_key = 1;
   bytes attestation = 2;
+}
+
+message InvokeRequest {
+  bytes body = 1;
+}
+
+message InvokeResponse {
+  bytes body = 1;
 }
 
 message LookupDataEntry {

--- a/oak_functions_freestanding/src/lib.rs
+++ b/oak_functions_freestanding/src/lib.rs
@@ -43,13 +43,13 @@ enum InitializationState {
     Initialized(Box<dyn AttestationHandler>),
 }
 
-pub struct RuntimeImplementation {
+pub struct OakFunctionsService {
     attestation_generator: Arc<dyn AttestationGenerator>,
     initialization_state: InitializationState,
     lookup_data_manager: Arc<LookupDataManager<logger::StandaloneLogger>>,
 }
 
-impl RuntimeImplementation {
+impl OakFunctionsService {
     pub fn new(attestation_generator: Arc<dyn AttestationGenerator>) -> Self {
         Self {
             attestation_generator,
@@ -71,10 +71,10 @@ impl<L: oak_logger::OakLogger> Handler for WasmHandler<L> {
     }
 }
 
-impl schema::TrustedRuntime for RuntimeImplementation {
+impl schema::OakFunctions for OakFunctionsService {
     fn initialize(
         &mut self,
-        initialization: &schema::Initialization,
+        initialization: &schema::InitializeRequest,
     ) -> Result<schema::InitializeResponse, oak_idl::Status> {
         match &mut self.initialization_state {
             InitializationState::Initialized(_attestation_handler) => {
@@ -119,10 +119,10 @@ impl schema::TrustedRuntime for RuntimeImplementation {
         }
     }
 
-    fn handle_user_request(
+    fn invoke(
         &mut self,
-        request_message: &schema::UserRequest,
-    ) -> Result<schema::UserRequestResponse, oak_idl::Status> {
+        request_message: &schema::InvokeRequest,
+    ) -> Result<schema::InvokeResponse, oak_idl::Status> {
         match &mut self.initialization_state {
             InitializationState::Uninitialized => Err(oak_idl::Status::new_with_message(
                 oak_idl::StatusCode::FailedPrecondition,
@@ -138,7 +138,7 @@ impl schema::TrustedRuntime for RuntimeImplementation {
                                 format!("{:?}", err),
                             )
                         })?;
-                Ok(schema::UserRequestResponse { body: response })
+                Ok(schema::InvokeResponse { body: response })
             }
         }
     }

--- a/oak_functions_freestanding_bin/src/main.rs
+++ b/oak_functions_freestanding_bin/src/main.rs
@@ -35,12 +35,12 @@ pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
 
 fn main(channel: Box<dyn Channel>) -> ! {
     info!("In main!");
-    let runtime = oak_functions_freestanding::RuntimeImplementation::new(Arc::new(
+    let service = oak_functions_freestanding::OakFunctionsService::new(Arc::new(
         PlaceholderAmdAttestationGenerator,
     ));
-    let service = oak_functions_freestanding::schema::TrustedRuntime::serve(runtime);
-    oak_channel::server::start_blocking_server(channel, service)
-        .expect("runtime encountered an unrecoverable error");
+    let server = oak_functions_freestanding::schema::OakFunctions::serve(service);
+    oak_channel::server::start_blocking_server(channel, server)
+        .expect("server encountered an unrecoverable error");
 }
 
 #[alloc_error_handler]

--- a/oak_functions_launcher/README.md
+++ b/oak_functions_launcher/README.md
@@ -17,7 +17,7 @@ The Oak Functions binary may be loaded in crosvm via
     --lookup-data=oak_functions_launcher/mock_lookup_data \
     crosvm \
     --vmm-binary=/usr/local/cargo/bin/crosvm \
-    --app-binary=oak_functions_freestanding_bin/target/x86_64-unknown-none/debug/oak_functions_freestanding_bin
+    --enclave-binary=oak_functions_freestanding_bin/target/x86_64-unknown-none/debug/oak_functions_freestanding_bin
 ```
 
 See also the See the task integration at `xtask/src/vm.rs`. Additional
@@ -31,5 +31,5 @@ cargo build --package=oak_functions_linux_fd_bin \
     --wasm=oak_functions_launcher/key_value_lookup.wasm \
     --lookup-data=oak_functions_launcher/mock_lookup_data \
     native \
-    --app-binary=target/debug/oak_functions_linux_fd_bin
+    --enclave-binary=target/debug/oak_functions_linux_fd_bin
 ```

--- a/oak_functions_launcher/src/instance/crosvm.rs
+++ b/oak_functions_launcher/src/instance/crosvm.rs
@@ -43,9 +43,9 @@ pub struct Params {
     #[arg(long, value_parser = path_exists)]
     pub vmm_binary: PathBuf,
 
-    /// Path to the binary to load into the VM.
+    /// Path to the enclave binary to load into the VM.
     #[arg(long, value_parser = path_exists)]
-    pub app_binary: PathBuf,
+    pub enclave_binary: PathBuf,
 
     /// Port to use for debugging with gdb
     #[arg(long = "gdb")]
@@ -87,7 +87,7 @@ impl Instance {
             cmd.args(["--gdb", format!("{}", gdb_port).as_str()]);
         }
 
-        cmd.arg(params.app_binary);
+        cmd.arg(params.enclave_binary);
 
         info!("Executing: {:?}", cmd);
 

--- a/oak_functions_launcher/src/instance/mod.rs
+++ b/oak_functions_launcher/src/instance/mod.rs
@@ -20,18 +20,18 @@ pub mod native;
 use anyhow::Result;
 use async_trait::async_trait;
 
-/// Defines the interface of a launched runtime instance. Standardizes the interface of different
-/// implementations, e.g. a VM in which the runtime is running or the runtime running directly as a
+/// Defines the interface of a launched guest instance. Standardizes the interface of different
+/// implementations, e.g. a VM in which the guest is running or the guest running directly as a
 /// unix binary.
 #[async_trait]
 pub trait LaunchedInstance {
-    /// Wait for the runtime instance process to finish.
+    /// Wait for the guest instance process to finish.
     async fn wait(&mut self) -> Result<std::process::ExitStatus>;
 
-    /// Kill the runtime instance.
+    /// Kill the guest instance.
     async fn kill(self: Box<Self>) -> Result<std::process::ExitStatus>;
 
-    /// Creates a channel to communicate with the runtime instance.
+    /// Creates a channel to communicate with the guest instance.
     ///
     /// Since different VMMs might use different comms channels, we leave it up to the VMM to create
     /// the channel rather than passing it in as part of the parameters.

--- a/oak_functions_launcher/src/instance/native.rs
+++ b/oak_functions_launcher/src/instance/native.rs
@@ -26,15 +26,15 @@ use std::{
     path::PathBuf,
 };
 
-/// Parameters used for launching the runtime as a native binary
+/// Parameters used for launching the enclave as a native binary
 #[derive(Parser, Clone, Debug, PartialEq)]
 pub struct Params {
-    /// Path to the runtime binary
+    /// Path to the enclave binary.
     #[arg(long, value_parser = path_exists)]
-    pub app_binary: PathBuf,
+    pub enclave_binary: PathBuf,
 }
 
-/// An instance of the runtime running directly as a linux binary
+/// An instance of the enclave running directly as a linux binary
 pub struct Instance {
     comms_host: UnixStream,
     instance: tokio::process::Child,
@@ -44,7 +44,7 @@ impl Instance {
     pub fn start(params: Params) -> Result<Self> {
         let (comms_guest, comms_host) = UnixStream::pair()?;
 
-        let mut cmd = tokio::process::Command::new(params.app_binary);
+        let mut cmd = tokio::process::Command::new(params.enclave_binary);
 
         // Print any logs & errors
         cmd.stdout(std::process::Stdio::inherit());

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -52,14 +52,14 @@ impl oak_remote_attestation_noninteractive::proto::streaming_session_server::Str
         let Some(request_wrapper::Request::InvokeRequest(invoke_request)) = request.request else {
             return Err(tonic::Status::invalid_argument("request wrapper must have invoke_request field set"));
         };
-        let encoded_request = schema::UserRequest {
+        let encoded_request = schema::InvokeRequest {
             body: invoke_request.encrypted_body,
         };
 
-        let mut client = schema::TrustedRuntimeAsyncClient::new(self.connector_handle.clone());
+        let mut client = schema::OakFunctionsAsyncClient::new(self.connector_handle.clone());
 
         let response = client
-            .handle_user_request(&encoded_request)
+            .invoke(&encoded_request)
             .await
             .flatten()
             .map_err(|err| {

--- a/oak_functions_linux_fd_bin/src/main.rs
+++ b/oak_functions_linux_fd_bin/src/main.rs
@@ -57,12 +57,12 @@ fn main() -> ! {
     // enforce this. This should be safe however, since we only call this once.
     let socket = unsafe { std::os::unix::net::UnixStream::from_raw_fd(opt.comms_fd) };
     let channel = Box::new(socket);
-    let runtime = oak_functions_freestanding::RuntimeImplementation::new(Arc::new(
+    let service = oak_functions_freestanding::OakFunctionsService::new(Arc::new(
         PlaceholderAmdAttestationGenerator,
     ));
     oak_channel::server::start_blocking_server(
         channel,
-        oak_functions_freestanding::schema::TrustedRuntime::serve(runtime),
+        oak_functions_freestanding::schema::OakFunctions::serve(service),
     )
-    .expect("runtime encountered an unrecoverable error");
+    .expect("server encountered an unrecoverable error");
 }

--- a/oak_functions_linux_vsock_bin/src/main.rs
+++ b/oak_functions_linux_vsock_bin/src/main.rs
@@ -71,11 +71,11 @@ fn main() -> ! {
     );
 
     let channel = Box::new(Channel::new(stream));
-    let runtime =
-        oak_functions_freestanding::RuntimeImplementation::new(Arc::new(EmptyAttestationGenerator));
+    let service =
+        oak_functions_freestanding::OakFunctionsService::new(Arc::new(EmptyAttestationGenerator));
     oak_channel::server::start_blocking_server(
         channel,
-        oak_functions_freestanding::schema::TrustedRuntime::serve(runtime),
+        oak_functions_freestanding::schema::OakFunctions::serve(service),
     )
-    .expect("runtime encountered an unrecoverable error");
+    .expect("server encountered an unrecoverable error");
 }

--- a/oak_functions_test_utils/src/lib.rs
+++ b/oak_functions_test_utils/src/lib.rs
@@ -194,7 +194,7 @@ pub fn create_and_start_oak_functions_server(
         format!("--port={server_port}"),
         format!("--lookup-data={lookup_data_path}"),
         "native",
-        format!("--app-binary={oak_functions_linux_fd_bin_path}"),
+        format!("--enclave-binary={oak_functions_linux_fd_bin_path}"),
     )
     .dir(env!("WORKSPACE_ROOT"))
     .reader()

--- a/oak_tensorflow_freestanding_bin/src/main.rs
+++ b/oak_tensorflow_freestanding_bin/src/main.rs
@@ -34,8 +34,8 @@ pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
 }
 
 fn start_server(channel: Box<dyn Channel>) -> ! {
-    let service_impl = oak_tensorflow_service::TensorflowServiceImpl::new();
-    let server = oak_tensorflow_service::schema::TensorflowService::serve(service_impl);
+    let service = oak_tensorflow_service::TensorflowService::new();
+    let server = oak_tensorflow_service::schema::Tensorflow::serve(service);
     oak_channel::server::start_blocking_server(channel, server)
         .expect("server encountered an unrecoverable error")
 }

--- a/oak_tensorflow_service/proto/oak_tensorflow.proto
+++ b/oak_tensorflow_service/proto/oak_tensorflow.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package oak.tensorflow;
 
-service TensorflowService {
+service Tensorflow {
   // method_id: 0
   rpc Initialize(InitializeRequest) returns (InitializeResponse);
   // method_id: 1

--- a/oak_tensorflow_service/src/lib.rs
+++ b/oak_tensorflow_service/src/lib.rs
@@ -27,11 +27,11 @@ pub mod schema {
 mod tflite;
 
 #[derive(Default)]
-pub struct TensorflowServiceImpl {
+pub struct TensorflowService {
     tflite_model: tflite::TfliteModel,
 }
 
-impl TensorflowServiceImpl {
+impl TensorflowService {
     pub fn new() -> Self {
         Self {
             tflite_model: tflite::TfliteModel::new(),
@@ -39,7 +39,7 @@ impl TensorflowServiceImpl {
     }
 }
 
-impl schema::TensorflowService for TensorflowServiceImpl {
+impl schema::Tensorflow for TensorflowService {
     fn initialize(
         &mut self,
         initialization: &schema::InitializeRequest,

--- a/testing/oak_echo_bin/src/main.rs
+++ b/testing/oak_echo_bin/src/main.rs
@@ -24,7 +24,7 @@ use alloc::boxed::Box;
 use core::panic::PanicInfo;
 use log::info;
 use oak_channel::Channel;
-use oak_echo_service::EchoService;
+use oak_echo_service::proto::Echo;
 use oak_linux_boot_params::BootParams;
 
 #[no_mangle]
@@ -37,10 +37,10 @@ pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
 // Starts an echo server that uses the Oak communication channel:
 // https://github.com/project-oak/oak/blob/main/oak_channel/SPEC.md
 fn start_echo_server(channel: Box<dyn Channel>) -> ! {
-    let service = oak_echo_service::EchoServiceImpl::default();
+    let service = oak_echo_service::EchoService::default();
     let server = service.serve();
     oak_channel::server::start_blocking_server(channel, server)
-        .expect("runtime encountered an unrecoverable error");
+        .expect("server encountered an unrecoverable error");
 }
 
 #[alloc_error_handler]

--- a/testing/oak_echo_service/build.rs
+++ b/testing/oak_echo_service/build.rs
@@ -15,5 +15,5 @@
 //
 
 fn main() {
-    oak_idl_build::compile(&["proto/oak_echo_service.proto"], &["."]);
+    oak_idl_build::compile(&["proto/oak_echo.proto"], &["."]);
 }

--- a/testing/oak_echo_service/proto/oak_echo.proto
+++ b/testing/oak_echo_service/proto/oak_echo.proto
@@ -26,7 +26,7 @@ message EchoResponse {
   bytes body = 1;
 }
 
-service EchoService {
+service Echo {
   // method_id: 1988
   rpc Echo(EchoRequest) returns (EchoResponse);
 }

--- a/testing/oak_echo_service/src/lib.rs
+++ b/testing/oak_echo_service/src/lib.rs
@@ -27,12 +27,10 @@ pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/oak.echo.rs"));
 }
 
-pub use proto::EchoService;
-
 #[derive(Default)]
-pub struct EchoServiceImpl {}
+pub struct EchoService;
 
-impl proto::EchoService for EchoServiceImpl {
+impl proto::Echo for EchoService {
     fn echo(
         &mut self,
         request: &proto::EchoRequest,

--- a/testing/oak_echo_service/tests/integration_test.rs
+++ b/testing/oak_echo_service/tests/integration_test.rs
@@ -21,16 +21,16 @@
 extern crate alloc;
 
 use oak_echo_service::{
-    proto::{EchoRequest, EchoService, EchoServiceClient},
-    EchoServiceImpl,
+    proto::{Echo, EchoClient, EchoRequest},
+    EchoService,
 };
 
 const TEST_DATA: &[u8] = b"test_data";
 
 #[test]
 fn it_should_handle_echo_requests() {
-    let service = EchoServiceImpl::default();
-    let mut client = EchoServiceClient::new(service.serve());
+    let service = EchoService::default();
+    let mut client = EchoClient::new(service.serve());
 
     let request = EchoRequest {
         body: TEST_DATA.to_vec(),

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -469,10 +469,9 @@ fn run_oak_functions_server(server: &Server) -> Box<dyn Runnable> {
                 server.constant_response_size_bytes
             ),
             format!("--lookup-data={}", server.lookup_data),
-            // Run the "trusted" runtime binary as a native Linux process, connecting over a file
-            // descriptor.
+            // Run the enclave binary as a native Linux process, connecting over a file descriptor.
             "native".to_string(),
-            "--app-binary=target/x86_64-unknown-linux-musl/release/oak_functions_linux_fd_bin"
+            "--enclave-binary=target/x86_64-unknown-linux-musl/release/oak_functions_linux_fd_bin"
                 .to_string(),
         ],
     )


### PR DESCRIPTION
In particular enclave, service, server and corresponding definitions.

Also request and response messages.