### PR TITLE
Refactor the provenance workflow to make parameterization easier

### DIFF
--- a/.github/actions/reproducibility_index/action.yml
+++ b/.github/actions/reproducibility_index/action.yml
@@ -3,7 +3,9 @@ description: 'Updates the reproducibility index for the given path.'
 inputs:
   base64_digest:
     required: true
-    description: 'Base64-encoded digest of the strings.'
+    description:
+      'Base64-encoded string containing the name and sha256 digest of a file to
+      include in the reproducibility index.'
   GITHUB_TOKEN:
     description:
       'The GitHub token of the GitHub repository. Must be provided for push

--- a/.github/actions/reproducibility_index/action.yml
+++ b/.github/actions/reproducibility_index/action.yml
@@ -1,9 +1,9 @@
 name: Build Reproducibility Index
 description: 'Updates the reproducibility index for the given path.'
 inputs:
-  OAK_FUNCTIONS_FREESTANDING_BIN_PATH:
+  base64_digest:
     required: true
-    description: 'Path to the oak_functions_freestanding_bin binary.'
+    description: 'Base64-encoded digest of the strings.'
   GITHUB_TOKEN:
     description:
       'The GitHub token of the GitHub repository. Must be provided for push

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -20,7 +20,8 @@ jobs:
     uses: ./.github/workflows/reusable_provenance.yaml
     with:
       build-config-path: './buildconfigs/oak_functions_freestanding_bin.toml'
-    secrets: inherit
+    secrets:
+      ENT_API_KEY: ${{ secrets.ENT_API_KEY }}
 
   # TODO(#3428): To make it work with the matrix strategy, we most likely need
   # the reusable workflow to write its output to some file that we can then

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -86,6 +86,7 @@ jobs:
 
       # Also post a reply on the PR thread with the sha256sum of the DSSE artifact.
       - name: Post SHA256 digest of the DSSE Artifact (post-merge only)
+        if: github.event_name == 'push'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -1,4 +1,4 @@
-name: Build Provenance
+name: Build All Provenances
 
 # See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run
 concurrency:
@@ -13,11 +13,22 @@ on:
 
 jobs:
   build_binary:
-    outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: ./.github/workflows/reusable_provenance.yaml
+    with:
+      build-config-path: './buildconfigs/oak_functions_freestanding_bin.toml'
+    secrets: inherit
+
+  # TODO(#3428): To make it work with the matrix strategy, we most likely need
+  # the reusable workflow to write its output to some file that we can then
+  # load here, extract all the digests and merge them to files that can be
+  # written as comments on the PR.
+  publish_comments:
     runs-on: ubuntu-20.04
-    env:
-      OAK_FUNCTIONS_FREESTANDING_BIN_PATH: './oak_functions_freestanding_bin/target/x86_64-unknown-none/release/oak_functions_freestanding_bin'
+    needs: [build_binary]
 
     permissions:
       # Allow the job to update the repo with the latest provenance info and index.
@@ -26,72 +37,13 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Mount main branch
-        uses: actions/checkout@v3
-
-      - name: Git setup
-        run: |
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
-
-      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
-      - name: free disk space
-        run: |
-          df --human-readable
-          sudo swapoff --all
-          sudo rm --force /swapfile
-          sudo apt clean
-          docker rmi $(docker image ls --all --quiet)
-          df --human-readable
-
-      - name: Docker pull
-        timeout-minutes: 10
-        run: |
-          ./scripts/docker_pull
-          df --human-readable
-
-      - name: Build the crosvm freestanding binary
-        run: |
-          ./scripts/build_binary -c buildconfigs/oak_functions_freestanding_bin.toml
-
-      # Download the Ent CLI and configure a remote with write access using a private API key, if
-      # available (GitHub secrets are not available on forks, see
-      # https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow).
-      # If this step is run from a fork, the API key will be empty, and Ent will work in read-only
-      # mode.
-      # See https://github.com/google/ent
-      - name: Download Ent CLI
-        if: steps.cache-ent.outputs.cache-hit != 'true'
-        env:
-          ENT_URL: https://ent-server-62sa4xcfia-ew.a.run.app
-          ENT_DIGEST: sha256:944a34854a2bf9c5d32f3bffa93885ee1c7ef8ab0f4fcc30898a981050ae4233
-        run: |
-          curl --fail ${ENT_URL}/raw/${ENT_DIGEST} > /usr/local/bin/ent
-          chmod +x /usr/local/bin/ent
-          ent
-          cat <<EOF > ~/.config/ent.toml
-          [[remotes]]
-          name = 'ent-store'
-          url = '${ENT_URL}'
-          write = true
-          api_key = '${{ secrets.ENT_API_KEY }}'
-          EOF
-
-      # Upload artifacts to Ent, where they will be retained and publicly accessible by their hash.
-      # This only applies to `push` events, since it needs access to a valid Ent API key (which is
-      # not available on forks / PRs).
-      - name: Upload to Ent
-        if: github.event_name == 'push'
-        run: |
-          ent put ${{ env.OAK_FUNCTIONS_FREESTANDING_BIN_PATH }}
-
       # Build reproducibility index on `push` events.
       - name: Build reproducibility index
         if: github.event_name == 'push'
         uses: ./.github/actions/reproducibility_index
         with:
           OAK_FUNCTIONS_FREESTANDING_BIN_PATH:
-            ${{ env.OAK_FUNCTIONS_FREESTANDING_BIN_PATH }}
+            ${{ needs.build_binary.outputs.artifact_digest }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Build reproducibility index on non-`push` events. This is similar to the previous step,
@@ -101,81 +53,13 @@ jobs:
         uses: ./.github/actions/reproducibility_index
         with:
           OAK_FUNCTIONS_FREESTANDING_BIN_PATH:
-            ${{ env.OAK_FUNCTIONS_FREESTANDING_BIN_PATH }}
+            ${{ needs.build_binary.outputs.artifact_digest }}
 
-      # Generate the input to the generate_provenance job.
-      # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md
-      - name: Generate oak_functions_freestanding_bin hash
-        id: hash
+      # TODO(#3428): For the parameterized workflow we cannot use the output
+      # from the previous workflow, but must read the digests from an uploaded artifact.
+      - name: Write digest to file
         run: |
-          # first cd to the directory containing the target binary. This allows us calling sha256
-          # on the target binary instead of having to provide the full path. This is fine for this
-          # experimental version, but has to be cleaned-up once we switch completely to SLSA
-          # provenance generation.
-          cd $(dirname ${{ env.OAK_FUNCTIONS_FREESTANDING_BIN_PATH }})
-          # sha256sum generates sha256 hash for the target binary.
-          # base64 --wrap=0 disables line wrapping, and encodes to base64 and outputs on a single line.
-          echo "hashes=$(sha256sum $(basename ${{ env.OAK_FUNCTIONS_FREESTANDING_BIN_PATH }}) | base64 --wrap=0)" >> $GITHUB_OUTPUT
-
-  # This job calls the generic SLSA workflow to generate provenance.
-  # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md
-  generate_provenance:
-    if: github.event_name == 'push'
-    needs: [build_binary]
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
-    with:
-      base64-subjects: '${{ needs.build_binary.outputs.hashes }}'
-      # Set a custom name for the provenance attestation.
-      attestation-name: 'oak_functions_freestanding_bin.intoto.jsonl'
-      # Upload the provenance.
-      upload-assets: true
-      # Build the generator from source.
-      compile-generator: true
-
-  # This job uploads the signed provenance from the previous step to Ent, and
-  # publishes a comment about it on the PR.
-  upload_provenance:
-    if: github.event_name == 'push'
-    needs: [generate_provenance]
-    runs-on: ubuntu-20.04
-
-    permissions:
-      # Allow the job to update the repo with the latest provenances and index.
-      contents: write
-      # Allow the job to add a comment to the PR.
-      pull-requests: write
-
-    steps:
-      - name: Download the DSSE document
-        uses: actions/download-artifact@v3
-        with:
-          name: oak_functions_freestanding_bin.intoto.jsonl
-
-      # See https://github.com/google/ent
-      - name: Download Ent CLI
-        if: steps.cache-ent.outputs.cache-hit != 'true'
-        env:
-          ENT_URL: https://ent-server-62sa4xcfia-ew.a.run.app
-          ENT_DIGEST: sha256:944a34854a2bf9c5d32f3bffa93885ee1c7ef8ab0f4fcc30898a981050ae4233
-        run: |
-          curl --fail ${ENT_URL}/raw/${ENT_DIGEST} > /usr/local/bin/ent
-          chmod +x /usr/local/bin/ent
-          ent
-          cat <<EOF > ~/.config/ent.toml
-          [[remotes]]
-          name = 'ent-store'
-          url = '${ENT_URL}'
-          write = true
-          api_key = '${{ secrets.ENT_API_KEY }}'
-          EOF
-
-      - name: Upload to Ent
-        run: |
-          ent put oak_functions_freestanding_bin.intoto.jsonl | tee ./digest
+          echo ${{ needs.build_binary.outputs.provenance_digest }} | tee -a ./digest
 
       # Also post a reply on the PR thread with the sha256sum of the DSSE artifact.
       - name: Post SHA256 digest of the DSSE Artifact (post-merge only)

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -38,6 +38,9 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Mount main branch
+        uses: actions/checkout@v3
+
       # Build reproducibility index on `push` events.
       - name: Build reproducibility index
         if: github.event_name == 'push'

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -41,6 +41,25 @@ jobs:
       - name: Mount main branch
         uses: actions/checkout@v3
 
+      - name: Git setup
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
+      - name: free disk space
+        run: |
+          df --human-readable
+          sudo swapoff --all
+          sudo rm --force /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          df --human-readable
+      - name: Docker pull
+        timeout-minutes: 10
+        run: |
+          ./scripts/docker_pull
+          df --human-readable
+
       # Build reproducibility index on `push` events.
       - name: Build reproducibility index
         if: github.event_name == 'push'

--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -1,0 +1,183 @@
+# Builds an artifact from the input build config, and uploads it to Ent. Then generates the SLSA provenance for it and uploads that to Ent too.
+# Returns (1) the name and digest of the generated artifact as a based64-encoded string, and (2) the digest of the provenance.
+name: Build Provenance
+
+on:
+  workflow_call:
+    inputs:
+      build-config-path:
+        required: true
+        type: string
+    # Map the workflow outputs to job outputs
+    outputs:
+      artifact_digest:
+        description:
+          'Base64-encoded digest of the artifact, including its name.'
+        value: ${{ jobs.build_binary.outputs.hashes }}
+      provenance_digest:
+        description: 'SHA256 digest of the provenance.'
+        value: ${{ jobs.upload_provenance.outputs.provenance_digest }}
+    # usage: secrets: inherit
+    secrets:
+      ENT_API_KEY:
+        required: true
+
+jobs:
+  build_binary:
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+      filename: ${{ steps.filename.outputs.filename }}
+    runs-on: ubuntu-20.04
+
+    permissions:
+      # Allow the job to update the repo with the latest provenance info and index.
+      contents: write
+      # Allow the job to add a comment to the PR.
+      pull-requests: write
+
+    steps:
+      - name: Mount main branch
+        uses: actions/checkout@v3
+
+      - name: Git setup
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
+      - name: free disk space
+        run: |
+          df --human-readable
+          sudo swapoff --all
+          sudo rm --force /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls --all --quiet)
+          df --human-readable
+
+      - name: Docker pull
+        timeout-minutes: 10
+        run: |
+          ./scripts/docker_pull
+          df --human-readable
+
+      - name: Get artifact path
+        id: artifact_path
+        run: |
+          echo "artifact_path=$(tail -1 ${{ inputs.build-config-path }} | grep -oP 'output_path = \K(.*)')" >> $GITHUB_OUTPUT
+
+      - name: Get artifact filename
+        id: filename
+        run: |
+          echo "filename=$(basename ${{ steps.artifact_path.outputs.artifact_path }})" >> $GITHUB_OUTPUT
+
+      - name: Build the artifact
+        run: |
+          ./scripts/build_binary -c ${{ inputs.build-config-path }}
+
+      # Download the Ent CLI and configure a remote with write access using a private API key, if
+      # available (GitHub secrets are not available on forks, see
+      # https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow).
+      # If this step is run from a fork, the API key will be empty, and Ent will work in read-only
+      # mode.
+      # See https://github.com/google/ent
+      - name: Download Ent CLI
+        if: steps.cache-ent.outputs.cache-hit != 'true'
+        env:
+          ENT_URL: https://ent-server-62sa4xcfia-ew.a.run.app
+          ENT_DIGEST: sha256:944a34854a2bf9c5d32f3bffa93885ee1c7ef8ab0f4fcc30898a981050ae4233
+        run: |
+          curl --fail ${ENT_URL}/raw/${ENT_DIGEST} > /usr/local/bin/ent
+          chmod +x /usr/local/bin/ent
+          ent
+          cat <<EOF > ~/.config/ent.toml
+          [[remotes]]
+          name = 'ent-store'
+          url = '${ENT_URL}'
+          write = true
+          api_key = '${{ secrets.ENT_API_KEY }}'
+          EOF
+
+      # Upload artifacts to Ent, where they will be retained and publicly accessible by their hash.
+      # This only applies to `push` events, since it needs access to a valid Ent API key (which is
+      # not available on forks / PRs).
+      - name: Upload to Ent
+        if: github.event_name == 'push'
+        run: |
+          ent put ${{ steps.artifact_path.outputs.artifact_path }}
+
+      # Generate the input to the generate_provenance job.
+      # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md
+      - name: Generate artifact's base64-encoded hash
+        id: hash
+        run: |
+          # first cd to the directory containing the target binary. This allows us calling sha256
+          # on the target binary instead of having to provide the full path. This is fine for this
+          # experimental version, but has to be cleaned-up once we switch completely to SLSA
+          # provenance generation.
+          cd $(dirname ${{ steps.artifact_path.outputs.artifact_path }})
+          # sha256sum generates sha256 hash for the target binary.
+          # base64 --wrap=0 disables line wrapping, and encodes to base64 and outputs on a single line.
+          echo "hashes=$(sha256sum $(basename ${{ steps.artifact_path.outputs.artifact_path }}) | base64 --wrap=0)" >> $GITHUB_OUTPUT
+
+  # This job calls the generic SLSA workflow to generate provenance.
+  # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md
+  generate_provenance:
+    if: github.event_name == 'push'
+    needs: [build_binary]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
+    with:
+      base64-subjects: '${{ needs.build_binary.outputs.hashes }}'
+      # Set a custom name for the provenance attestation.
+      attestation-name: '${{ needs.filename.outputs.filename }}.intoto.jsonl'
+      # Upload the provenance.
+      upload-assets: true
+      # Build the generator from source.
+      compile-generator: true
+
+  # This job uploads the signed provenance from the previous step to Ent, and
+  # publishes a comment about it on the PR.
+  upload_provenance:
+    if: github.event_name == 'push'
+    needs: [generate_provenance]
+    outputs:
+      provenance_digest: ${{ steps.ent_upload.outputs.provenance_digest }}
+    runs-on: ubuntu-20.04
+
+    permissions:
+      # Allow the job to update the repo with the latest provenances and index.
+      contents: write
+      # Allow the job to add a comment to the PR.
+      pull-requests: write
+
+    steps:
+      - name: Download the DSSE document
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.filename.outputs.filename }}.intoto.jsonl
+
+      # See https://github.com/google/ent
+      - name: Download Ent CLI
+        if: steps.cache-ent.outputs.cache-hit != 'true'
+        env:
+          ENT_URL: https://ent-server-62sa4xcfia-ew.a.run.app
+          ENT_DIGEST: sha256:944a34854a2bf9c5d32f3bffa93885ee1c7ef8ab0f4fcc30898a981050ae4233
+        run: |
+          curl --fail ${ENT_URL}/raw/${ENT_DIGEST} > /usr/local/bin/ent
+          chmod +x /usr/local/bin/ent
+          ent
+          cat <<EOF > ~/.config/ent.toml
+          [[remotes]]
+          name = 'ent-store'
+          url = '${ENT_URL}'
+          write = true
+          api_key = '${{ secrets.ENT_API_KEY }}'
+          EOF
+
+      - name: Upload to Ent
+        id: ent_upload
+        run: |
+          echo "provenance_digest=$(ent put ${{ needs.filename.outputs.filename }}.intoto.jsonl)" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -29,12 +29,6 @@ jobs:
       filename: ${{ steps.filename.outputs.filename }}
     runs-on: ubuntu-20.04
 
-    permissions:
-      # Allow the job to update the repo with the latest provenance info and index.
-      contents: write
-      # Allow the job to add a comment to the PR.
-      pull-requests: write
-
     steps:
       - name: Mount main branch
         uses: actions/checkout@v3
@@ -146,12 +140,6 @@ jobs:
     outputs:
       provenance_digest: ${{ steps.ent_upload.outputs.provenance_digest }}
     runs-on: ubuntu-20.04
-
-    permissions:
-      # Allow the job to update the repo with the latest provenances and index.
-      contents: write
-      # Allow the job to add a comment to the PR.
-      pull-requests: write
 
     steps:
       - name: Download the DSSE document

--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -12,8 +12,9 @@ on:
     outputs:
       artifact_digest:
         description:
-          'Base64-encoded digest of the artifact, including its name.'
-        value: ${{ jobs.build_binary.outputs.hashes }}
+          'Base64-encoded string containing the sha256 digest and name of the
+          artifact.'
+        value: ${{ jobs.build_binary.outputs.digest }}
       provenance_digest:
         description: 'SHA256 digest of the provenance.'
         value: ${{ jobs.upload_provenance.outputs.provenance_digest }}
@@ -25,7 +26,7 @@ on:
 jobs:
   build_binary:
     outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
+      digest: ${{ steps.hash.outputs.digest }}
       filename: ${{ steps.filename.outputs.filename }}
     runs-on: ubuntu-20.04
 
@@ -111,7 +112,7 @@ jobs:
           cd $(dirname ${{ steps.artifact_path.outputs.artifact_path }})
           # sha256sum generates sha256 hash for the target binary.
           # base64 --wrap=0 disables line wrapping, and encodes to base64 and outputs on a single line.
-          echo "hashes=$(sha256sum $(basename ${{ steps.artifact_path.outputs.artifact_path }}) | base64 --wrap=0)" >> $GITHUB_OUTPUT
+          echo "digest=$(sha256sum $(basename ${{ steps.artifact_path.outputs.artifact_path }}) | base64 --wrap=0)" >> $GITHUB_OUTPUT
 
   # This job calls the generic SLSA workflow to generate provenance.
   # See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md
@@ -124,7 +125,7 @@ jobs:
       contents: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
     with:
-      base64-subjects: '${{ needs.build_binary.outputs.hashes }}'
+      base64-subjects: '${{ needs.build_binary.outputs.digest }}'
       # Set a custom name for the provenance attestation.
       attestation-name: '${{ needs.filename.outputs.filename }}.intoto.jsonl'
       # Upload the provenance.

--- a/scripts/build_reproducibility_index
+++ b/scripts/build_reproducibility_index
@@ -16,6 +16,11 @@ readonly REPRODUCIBLE_ARTIFACTS=( "$@" )
 # Index file containing hashes of the reproducible artifacts, alongside their file names.
 readonly REPRODUCIBILITY_INDEX='./reproducibility_index'
 
-# Generate the index file by computing the hashes of the artifacts.
-# The index file must be checked in, and
-sha256sum "${REPRODUCIBLE_ARTIFACTS[@]}" | tee "${REPRODUCIBILITY_INDEX}"
+# Wipe out everything in the reproducibility index.
+echo "" | tee "${REPRODUCIBILITY_INDEX}"
+
+# Regenerate the index file by appending to it decoded base64 digests of the artifacts.
+for encoded in "${REPRODUCIBLE_ARTIFACTS[@]}"
+do
+    echo "${encoded}" | base64 -d | tee -a "${REPRODUCIBILITY_INDEX}"
+done


### PR DESCRIPTION
Ref #3428.
Prerequisite for #3473.

Refactors the provenances workflow, moving most of the steps to a reusable workflow, to make parameterization with a matrix easier.

Some steps only run on push... this might still fail after merge. 