### PR TITLE
Add initial attestation measurement calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,8 +1250,11 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
+ "atty",
+ "humantime",
  "log",
  "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -4120,6 +4123,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "snp_measurement"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "env_logger 0.8.4",
+ "hex",
+ "log",
+ "sha2 0.9.9",
+ "static_assertions",
+ "strum",
+ "x86_64",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
   "oak_tensorflow_service",
   "oak_virtio",
   "sev_serial",
+  "snp_measurement",
   "testing/oak_echo_service",
   "trusted_shuffler/backend",
   "trusted_shuffler/client",

--- a/snp_measurement/Cargo.toml
+++ b/snp_measurement/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "snp_measurement"
+version = "0.1.0"
+authors = ["Conrad Grobler <grobler@google.com>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "*"
+clap = { version = "*", features = ["derive"] }
+env_logger = "*"
+hex = "*"
+log = "*"
+sha2 = "*"
+static_assertions = "*"
+strum = { version = "*", default-features = false, features = ["derive"] }
+x86_64 = "*"
+zerocopy = "*"

--- a/snp_measurement/src/main.rs
+++ b/snp_measurement/src/main.rs
@@ -1,0 +1,61 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+mod page;
+mod stage0;
+
+use clap::Parser;
+use page::PageInfo;
+use stage0::FIRMWARE_TOP;
+use std::path::PathBuf;
+
+use crate::stage0::load_stage0;
+
+/// The default workspace-relative path to the Stage 0 firmware ROM image.
+const DEFAULT_STAGE0_ROM: &str = "stage0/target/x86_64-unknown-none/release/stage0.bin";
+
+#[derive(Parser, Clone)]
+#[command(about = "Oak SEV-SNP Measurement Calculator")]
+struct Cli {
+    #[arg(long, help = "The location of the Stage 0 firmware ROM image")]
+    stage0_rom: Option<PathBuf>,
+}
+
+impl Cli {
+    fn stage0_path(&self) -> PathBuf {
+        self.stage0_rom
+            .clone()
+            .unwrap_or_else(|| format!("{}/{}", env!("WORKSPACE_ROOT"), DEFAULT_STAGE0_ROM).into())
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let cli = Cli::parse();
+
+    let stage0_bytes = load_stage0(cli.stage0_path())?;
+
+    let mut page_info = PageInfo::new();
+    page_info.update_from_data(&stage0_bytes, FIRMWARE_TOP - stage0_bytes.len());
+
+    // TODO(#3486): Also include enclave binary, SNP-specific pages and the VMSA in the measurement.
+
+    println!(
+        "Attestation Measurement: {}",
+        hex::encode(page_info.digest_cur)
+    );
+    Ok(())
+}

--- a/snp_measurement/src/page.rs
+++ b/snp_measurement/src/page.rs
@@ -1,0 +1,142 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use sha2::{Digest, Sha384};
+use strum::FromRepr;
+use x86_64::{
+    structures::paging::{PageSize, Size4KiB},
+    PhysAddr,
+};
+use zerocopy::AsBytes;
+
+/// The size of the PageInfo struct.
+const PAGE_INFO_SIZE: usize = 112;
+
+/// Implementation of the Page Info structure used for extending the measurement in each step.
+///
+/// See table 67 in <https://www.amd.com/system/files/TechDocs/56860.pdf>.
+#[repr(C)]
+#[derive(Debug, AsBytes)]
+pub struct PageInfo {
+    /// The current measurement up to this point.
+    pub digest_cur: [u8; 48],
+    /// The SHA-384 digest of the contents to be measured for normal and VMSA pages, or all zeros
+    /// for all other page types.
+    pub contents: [u8; 48],
+    /// The length of this struct in bytes.
+    _length: u16,
+    /// The type of page being measured.
+    pub page_type: PageType,
+    /// Whether the page is part of an initial migration image. For now we treat this as reserved
+    /// and zero.
+    _imi_page: ImiPage,
+    /// Reserved. Must be 0.
+    _reserved: u8,
+    /// The permissions for VMPL1. For now we treat this as reserved and zero.
+    _vmpl1_perms: u8,
+    /// The permissions for VMPL2. For now we treat this as reserved and zero.
+    _vmpl2_perms: u8,
+    /// The permissions for VMPL3. For now we treat this as reserved and zero.
+    _vmpl3_perms: u8,
+    /// The guest-physical address of the page being measured.
+    pub gpa: u64,
+}
+
+static_assertions::assert_eq_size!(PageInfo, [u8; PAGE_INFO_SIZE]);
+
+impl PageInfo {
+    pub const fn new() -> Self {
+        Self {
+            digest_cur: [0; 48],
+            contents: [0; 48],
+            _length: PAGE_INFO_SIZE as u16,
+            page_type: PageType::Invalid,
+            _imi_page: ImiPage::No,
+            _reserved: 0,
+            _vmpl1_perms: 0,
+            _vmpl2_perms: 0,
+            _vmpl3_perms: 0,
+            gpa: 0,
+        }
+    }
+
+    /// Updates the current measurement digest from a byte slice representing normal data pages.
+    ///
+    /// The current digest is updated separately for each 4KiB page.
+    pub fn update_from_data(&mut self, data: &[u8], start_address: PhysAddr) {
+        self.page_type = PageType::Normal;
+        let mut address = start_address;
+        for chunk in data.chunks(Size4KiB::SIZE as usize) {
+            let mut content_hasher = Sha384::new();
+            content_hasher.update(chunk);
+            let content_hash = content_hasher.finalize();
+            self.contents[..].copy_from_slice(&content_hash);
+
+            self.gpa = address.as_u64();
+            address += Size4KiB::SIZE;
+
+            self.update_current_digest();
+        }
+    }
+
+    /// Calculates the SHA-384 digest of the struct's memory and updates `digest_cur` to the new
+    /// value.
+    fn update_current_digest(&mut self) {
+        let mut digest_hasher = Sha384::new();
+        digest_hasher.update(self.as_bytes());
+        let current_digest = digest_hasher.finalize();
+        self.digest_cur[..].copy_from_slice(&current_digest);
+    }
+}
+
+impl Default for PageInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Whether the page is part of an initial migration image (IMI).
+///
+/// For now we assume we won't have any IMI pages.
+#[derive(Debug, FromRepr, AsBytes)]
+#[repr(u8)]
+enum ImiPage {
+    /// The page is not an IMI page.
+    No = 0,
+}
+
+/// The type of page being measured.
+///
+/// See table 65 in <https://www.amd.com/system/files/TechDocs/56860.pdf>.
+#[derive(Debug, FromRepr, AsBytes)]
+#[repr(u8)]
+#[allow(unused)]
+pub enum PageType {
+    /// Reserved value.
+    Invalid = 0,
+    /// The page is a normal page.
+    Normal = 1,
+    /// The page contains a VM state save area (VMSA) for a vCPU.
+    Vmsa = 2,
+    /// A page filled with zeros.
+    Zero = 3,
+    /// A page that is encrypted but not measured.
+    Unmeasured = 4,
+    /// The SEV-SNP secrets page.
+    Secrets = 5,
+    /// The SEV-SNP CPUID page.
+    Cpuid = 6,
+}

--- a/snp_measurement/src/stage0.rs
+++ b/snp_measurement/src/stage0.rs
@@ -23,17 +23,67 @@ use x86_64::PhysAddr;
 /// The address of the first byte after the end of the firmware image.
 ///
 /// The firmware image gets loaded just below the 4GiB boundary.
-pub const FIRMWARE_TOP: PhysAddr = PhysAddr::new(0x1_0000_0000);
+const FIRMWARE_TOP: PhysAddr = PhysAddr::new(0x1_0000_0000);
 
-/// Loads the Stage0 firmware ROM image from the supplied path.
-pub fn load_stage0(stage0_rom_path: PathBuf) -> anyhow::Result<Vec<u8>> {
+/// The address of the first byte after the end of the legacy boot shadow firmware image.
+///
+/// To support legacy booting the last 128KiB of the firmware gets shadowed just below the end of
+/// 20-bit memory.
+const LEGACY_TOP: PhysAddr = PhysAddr::new(0x10_0000);
+
+/// The maximum size of the shadow firmware for legacy boot.
+const LEGACY_MAX_SIZE: usize = 128 * 1024;
+
+/// The contents of the Stage 0 firmware ROM image and its associated metadata.
+pub struct Stage0Info {
+    /// The bytes of the State 0 firmware ROM image.
+    bytes: Vec<u8>,
+    /// The start address of the firmware ROM in guest memory.
+    pub start_address: PhysAddr,
+    /// The start address of the legacy boot shadow of the firmware ROM in guest memory.
+    pub legacy_start_address: PhysAddr,
+    /// The offset into the firmware ROM image from where the legacy boot shadow starts.
+    legacy_offset: usize,
+}
+
+impl Stage0Info {
+    /// Gets the bytes of the entire ROM image.
+    pub fn rom_bytes(&self) -> &[u8] {
+        &self.bytes[..]
+    }
+
+    /// Gets the bytes of the legacy boot shadow of the ROM image.
+    pub fn legacy_shadow_bytes(&self) -> &[u8] {
+        &self.bytes[self.legacy_offset..]
+    }
+
+    fn new(bytes: Vec<u8>) -> Self {
+        let size = bytes.len();
+        let start_address = FIRMWARE_TOP - size;
+        let legacy_size = size.min(LEGACY_MAX_SIZE);
+        let legacy_start_address = LEGACY_TOP - legacy_size;
+        let legacy_offset = size - legacy_size;
+        Self {
+            bytes,
+            start_address,
+            legacy_start_address,
+            legacy_offset,
+        }
+    }
+}
+
+/// Loads the Stage 0 firmware ROM image from the supplied path.
+pub fn load_stage0(stage0_rom_path: PathBuf) -> anyhow::Result<Stage0Info> {
     let stage0_bytes =
         std::fs::read(&stage0_rom_path).context("couldn't load stage0 firmware ROM image")?;
     debug!("Stage0 size: {}", stage0_bytes.len());
 
     let mut stage0_hasher = Sha256::new();
     stage0_hasher.update(&stage0_bytes);
-    let stage0_cecksum = stage0_hasher.finalize();
-    info!("Stage0 SHA256 hash: {}", hex::encode(stage0_cecksum));
-    Ok(stage0_bytes)
+    let stage0_sha256_digest = stage0_hasher.finalize();
+    info!(
+        "Stage0 digest: sha256:{}",
+        hex::encode(stage0_sha256_digest)
+    );
+    Ok(Stage0Info::new(stage0_bytes))
 }

--- a/snp_measurement/src/stage0.rs
+++ b/snp_measurement/src/stage0.rs
@@ -1,0 +1,39 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::Context;
+use log::{debug, info};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use x86_64::PhysAddr;
+
+/// The address of the first byte after the end of the firmware image.
+///
+/// The firmware image gets loaded just below the 4GiB boundary.
+pub const FIRMWARE_TOP: PhysAddr = PhysAddr::new(0x1_0000_0000);
+
+/// Loads the Stage0 firmware ROM image from the supplied path.
+pub fn load_stage0(stage0_rom_path: PathBuf) -> anyhow::Result<Vec<u8>> {
+    let stage0_bytes =
+        std::fs::read(&stage0_rom_path).context("couldn't load stage0 firmware ROM image")?;
+    debug!("Stage0 size: {}", stage0_bytes.len());
+
+    let mut stage0_hasher = Sha256::new();
+    stage0_hasher.update(&stage0_bytes);
+    let stage0_cecksum = stage0_hasher.finalize();
+    info!("Stage0 SHA256 hash: {}", hex::encode(stage0_cecksum));
+    Ok(stage0_bytes)
+}


### PR DESCRIPTION
This is the first step towards calculating the expected measurement in the attestation report from the Stage 0 firmware image and the enclave binary.

See #3486 for more details.