### PR TITLE
Include VMSA page in the attestation measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,6 +4134,7 @@ dependencies = [
  "env_logger 0.8.4",
  "hex",
  "log",
+ "oak_sev_guest",
  "sha2 0.9.9",
  "static_assertions",
  "strum",

--- a/oak_sev_guest/src/vmsa.rs
+++ b/oak_sev_guest/src/vmsa.rs
@@ -35,6 +35,15 @@ pub struct VmsaPage {
 
 static_assertions::assert_eq_size!(VmsaPage, [u8; VMSA_PAGE_SIZE]);
 
+impl VmsaPage {
+    pub fn new(vmsa: Vmsa) -> Self {
+        Self {
+            vmsa,
+            _reserved: [0u8; VMSA_PAGE_SIZE - VMSA_SIZE],
+        }
+    }
+}
+
 impl Default for VmsaPage {
     fn default() -> Self {
         // We cannot derive Default because Default is only implemented for fixed-size arrays up to

--- a/snp_measurement/Cargo.toml
+++ b/snp_measurement/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "*"
 clap = { version = "*", features = ["derive"] }
 env_logger = "*"
 hex = "*"
+oak_sev_guest = { path = "../oak_sev_guest" }
 log = "*"
 sha2 = "*"
 static_assertions = "*"

--- a/snp_measurement/src/main.rs
+++ b/snp_measurement/src/main.rs
@@ -16,8 +16,12 @@
 
 mod page;
 mod stage0;
+mod vmsa;
 
-use crate::stage0::load_stage0;
+use crate::{
+    stage0::load_stage0,
+    vmsa::{get_boot_vmsa, VMSA_ADDRESS},
+};
 use clap::Parser;
 use page::PageInfo;
 use std::path::PathBuf;
@@ -52,7 +56,10 @@ fn main() -> anyhow::Result<()> {
     // Add the legacy boot shadow of the Stage 0 firmware ROM image.
     page_info.update_from_data(stage0.legacy_shadow_bytes(), stage0.legacy_start_address);
 
-    // TODO(#3486): Also include enclave binary, SNP-specific pages and the VMSA in the measurement.
+    // TODO(#3486): Also include the enclave binary and SNP-specific pages.
+
+    // For now we assume there will only be one vCPU in the VM.
+    page_info.update_from_vmsa(&get_boot_vmsa(), VMSA_ADDRESS);
 
     println!(
         "Attestation Measurement: {}",

--- a/snp_measurement/src/page.rs
+++ b/snp_measurement/src/page.rs
@@ -93,6 +93,7 @@ impl PageInfo {
         self.page_type = PageType::Vmsa;
         self.gpa = start_address.as_u64();
         self.set_contents_from_page_bytes(vmsa.as_bytes());
+        self.update_current_digest();
     }
 
     /// Sets the `contents` field based to the SHA-384 digest of the byte contents of a 4KiB memory

--- a/snp_measurement/src/page.rs
+++ b/snp_measurement/src/page.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+use oak_sev_guest::vmsa::VmsaPage;
 use sha2::{Digest, Sha384};
 use strum::FromRepr;
 use x86_64::{
@@ -80,16 +81,28 @@ impl PageInfo {
         self.page_type = PageType::Normal;
         let mut address = start_address;
         for chunk in data.chunks(Size4KiB::SIZE as usize) {
-            let mut content_hasher = Sha384::new();
-            content_hasher.update(chunk);
-            let content_hash = content_hasher.finalize();
-            self.contents[..].copy_from_slice(&content_hash);
-
             self.gpa = address.as_u64();
             address += Size4KiB::SIZE;
-
+            self.set_contents_from_page_bytes(chunk);
             self.update_current_digest();
         }
+    }
+
+    /// Updates the current measurement digest from a VMSA page.
+    pub fn update_from_vmsa(&mut self, vmsa: &VmsaPage, start_address: PhysAddr) {
+        self.page_type = PageType::Vmsa;
+        self.gpa = start_address.as_u64();
+        self.set_contents_from_page_bytes(vmsa.as_bytes());
+    }
+
+    /// Sets the `contents` field based to the SHA-384 digest of the byte contents of a 4KiB memory
+    /// page.
+    fn set_contents_from_page_bytes(&mut self, page_bytes: &[u8]) {
+        assert_eq!(page_bytes.len() as u64, Size4KiB::SIZE);
+        let mut contents_hasher = Sha384::new();
+        contents_hasher.update(page_bytes);
+        let contents_digest = contents_hasher.finalize();
+        self.contents[..].copy_from_slice(&contents_digest);
     }
 
     /// Calculates the SHA-384 digest of the struct's memory and updates `digest_cur` to the new

--- a/snp_measurement/src/vmsa.rs
+++ b/snp_measurement/src/vmsa.rs
@@ -16,7 +16,10 @@
 
 use log::trace;
 use oak_sev_guest::vmsa::{calculate_rdx_from_fms, Vmsa, VmsaPage};
-use x86_64::PhysAddr;
+use x86_64::{
+    structures::paging::{PageSize, Size4KiB},
+    PhysAddr,
+};
 
 /// The CPU family of the vCPU we expect to be running on.
 const CPU_FAMILY: u8 = 6;
@@ -35,7 +38,7 @@ const CPU_STEPPING: u8 = 0;
 /// For AMD "Milan" CPUs the maximum supported physical memory bit-width is 48 when SEV-SNP is
 /// enabled.
 #[allow(unused)]
-pub const VMSA_ADDRESS: PhysAddr = PhysAddr::new(0xFFFF_FFFF_F000);
+pub const VMSA_ADDRESS: PhysAddr = PhysAddr::new((1 << 48) - Size4KiB::SIZE);
 
 /// Gets the initial VMSA for the vCPU that is used to boot the VM.
 pub fn get_boot_vmsa() -> VmsaPage {

--- a/snp_measurement/src/vmsa.rs
+++ b/snp_measurement/src/vmsa.rs
@@ -1,0 +1,49 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use log::trace;
+use oak_sev_guest::vmsa::{calculate_rdx_from_fms, Vmsa, VmsaPage};
+use x86_64::PhysAddr;
+
+/// The CPU family of the vCPU we expect to be running on.
+const CPU_FAMILY: u8 = 6;
+
+/// The CPU model of the vCPU we expect to be running on.
+const CPU_MODEL: u8 = 0;
+
+/// The stepping of the vCPU we expect to be running on.
+const CPU_STEPPING: u8 = 0;
+
+/// The guest-physical address of the VMSA page.
+///
+/// The current implementation uses the same fixed address for all VMSA pages. It is calculated as
+/// the start-address of the last 4KiB page that can be addressed within the allowed physical bits.
+///
+/// For AMD "Milan" CPUs the maximum supported physical memory bit-width is 48 when SEV-SNP is
+/// enabled.
+#[allow(unused)]
+pub const VMSA_ADDRESS: PhysAddr = PhysAddr::new(0xFFFF_FFFF_F000);
+
+/// Gets the initial VMSA for the vCPU that is used to boot the VM.
+pub fn get_boot_vmsa() -> VmsaPage {
+    let result = VmsaPage::new(Vmsa::new_vcpu_boot(calculate_rdx_from_fms(
+        CPU_FAMILY,
+        CPU_MODEL,
+        CPU_STEPPING,
+    )));
+    trace!("Boot VMSA: {:?}", result);
+    result
+}


### PR DESCRIPTION
The initial state of the VM state save area for the boot vCPU must be included in the attestation measurement calculation.

See #3486 for more details.