### PR TITLE
Parse ACPI tables, if present, in Restricted Kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "acpi"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
+dependencies = [
+ "bit_field",
+ "log",
+ "rsdp",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +156,17 @@ name = "ambient-authority"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
+
+[[package]]
+name = "aml"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c264f2e933012ef2dd324cdac38f4c6c142473c1d1a1357ba16321e7d892975f"
+dependencies = [
+ "bit_field",
+ "byteorder",
+ "log",
+]
 
 [[package]]
 name = "android_system_properties"
@@ -2755,6 +2777,8 @@ dependencies = [
 name = "oak_restricted_kernel"
 version = "0.1.0"
 dependencies = [
+ "acpi",
+ "aml",
  "anyhow",
  "arrayvec",
  "assertables",
@@ -3685,6 +3709,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e68dd9c1d8f7bb0c664e1556b1521809bc6fa62d92bb3b813adf8611caa0eb"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rsdp"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/oak_functions_freestanding_bin/Cargo.lock
+++ b/oak_functions_freestanding_bin/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "acpi"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
+dependencies = [
+ "bit_field",
+ "log",
+ "rsdp",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +57,17 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
+]
+
+[[package]]
+name = "aml"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c264f2e933012ef2dd324cdac38f4c6c142473c1d1a1357ba16321e7d892975f"
+dependencies = [
+ "bit_field",
+ "byteorder",
+ "log",
 ]
 
 [[package]]
@@ -739,6 +761,8 @@ dependencies = [
 name = "oak_restricted_kernel"
 version = "0.1.0"
 dependencies = [
+ "acpi",
+ "aml",
  "anyhow",
  "arrayvec",
  "atomic_refcell",
@@ -987,6 +1011,15 @@ dependencies = [
  "crypto-bigint",
  "hmac 0.11.0",
  "zeroize",
+]
+
+[[package]]
+name = "rsdp"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -14,6 +14,8 @@ serial_channel = ["uart_16550"]
 simple_io_channel = ["oak_simple_io"]
 
 [dependencies]
+acpi = "*"
+aml = "*"
 anyhow = { version = "*", default-features = false }
 arrayvec = { version = "*", default-features = false }
 atomic_refcell = "*"

--- a/oak_restricted_kernel/src/acpi.rs
+++ b/oak_restricted_kernel/src/acpi.rs
@@ -1,0 +1,373 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use acpi::{AcpiHandler, AcpiTables, AmlTable, PhysicalMapping};
+use alloc::{boxed::Box, string::String};
+use aml::{
+    resource::{resource_descriptor_list, MemoryRangeDescriptor, Resource},
+    value::Args,
+    AmlContext, AmlError, AmlName, AmlValue, LevelType,
+};
+use anyhow::{anyhow, bail, Result};
+use core::ptr::NonNull;
+use oak_linux_boot_params::BootParams;
+use x86_64::PhysAddr;
+
+use crate::{mm::Translator, ADDRESS_TRANSLATOR};
+
+/// Table of well-known ACPI devices (or, rather, well-known to us)
+const ACPI_GED: &str = "ACPI0013";
+const VIRTIO_MMIO: &str = "LNRO0005";
+const SERIAL_PORT: &str = "PNP0501";
+const PCI_BUS: &str = "PNP0A03";
+const PCIE_BUS: &str = "PNP0A08";
+const POWER_BUTTON: &str = "PNP0C0C";
+const QEMU_FW_CFG_DEVICE_ID: &str = "QEMU0002";
+
+fn description(hid: &str) -> &str {
+    match hid {
+        ACPI_GED => "ACPI Generic Event Device",
+        VIRTIO_MMIO => "Memory-mapped virtio device bus",
+        SERIAL_PORT => "16550A-compatible COM Serial Port",
+        PCI_BUS => "PCI bus",
+        PCIE_BUS => "PCI Express bus",
+        POWER_BUTTON => "Power Button Device",
+        QEMU_FW_CFG_DEVICE_ID => "QEMU fw_cfg Device",
+        _ => "(unknown device)",
+    }
+}
+
+#[derive(Copy, Clone)]
+struct Handler {}
+impl AcpiHandler for Handler {
+    unsafe fn map_physical_region<T>(
+        &self,
+        physical_address: usize,
+        size: usize,
+    ) -> PhysicalMapping<Self, T> {
+        PhysicalMapping::new(
+            physical_address,
+            NonNull::new(
+                ADDRESS_TRANSLATOR
+                    .get()
+                    .unwrap()
+                    .translate_physical(PhysAddr::new(physical_address as u64))
+                    .unwrap()
+                    .as_mut_ptr(),
+            )
+            .unwrap(),
+            size,
+            size,
+            *self,
+        )
+    }
+
+    fn unmap_physical_region<T>(_region: &acpi::PhysicalMapping<Self, T>) {
+        // Nothing to do here.
+    }
+}
+
+impl aml::Handler for Handler {
+    fn read_u8(&self, _address: usize) -> u8 {
+        unimplemented!()
+    }
+
+    fn read_u16(&self, _address: usize) -> u16 {
+        unimplemented!()
+    }
+
+    fn read_u32(&self, _address: usize) -> u32 {
+        unimplemented!()
+    }
+
+    fn read_u64(&self, _address: usize) -> u64 {
+        unimplemented!()
+    }
+
+    fn write_u8(&mut self, _address: usize, _value: u8) {
+        unimplemented!()
+    }
+
+    fn write_u16(&mut self, _address: usize, _value: u16) {
+        unimplemented!()
+    }
+
+    fn write_u32(&mut self, _address: usize, _value: u32) {
+        unimplemented!()
+    }
+
+    fn write_u64(&mut self, _address: usize, _value: u64) {
+        unimplemented!()
+    }
+
+    fn read_io_u8(&self, _port: u16) -> u8 {
+        unimplemented!()
+    }
+
+    fn read_io_u16(&self, _port: u16) -> u16 {
+        unimplemented!()
+    }
+
+    fn read_io_u32(&self, _port: u16) -> u32 {
+        unimplemented!()
+    }
+
+    fn write_io_u8(&self, _port: u16, _value: u8) {
+        unimplemented!()
+    }
+
+    fn write_io_u16(&self, _port: u16, _value: u16) {
+        unimplemented!()
+    }
+
+    fn write_io_u32(&self, _port: u16, _value: u32) {
+        unimplemented!()
+    }
+
+    fn read_pci_u8(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16) -> u8 {
+        unimplemented!()
+    }
+
+    fn read_pci_u16(
+        &self,
+        _segment: u16,
+        _bus: u8,
+        _device: u8,
+        _function: u8,
+        _offset: u16,
+    ) -> u16 {
+        unimplemented!()
+    }
+
+    fn read_pci_u32(
+        &self,
+        _segment: u16,
+        _bus: u8,
+        _device: u8,
+        _function: u8,
+        _offset: u16,
+    ) -> u32 {
+        unimplemented!()
+    }
+
+    fn write_pci_u8(
+        &self,
+        _segment: u16,
+        _bus: u8,
+        _device: u8,
+        _function: u8,
+        _offset: u16,
+        _value: u8,
+    ) {
+        unimplemented!()
+    }
+
+    fn write_pci_u16(
+        &self,
+        _segment: u16,
+        _bus: u8,
+        _device: u8,
+        _function: u8,
+        _offset: u16,
+        _value: u16,
+    ) {
+        unimplemented!()
+    }
+
+    fn write_pci_u32(
+        &self,
+        _segment: u16,
+        _bus: u8,
+        _device: u8,
+        _function: u8,
+        _offset: u16,
+        _value: u32,
+    ) {
+        unimplemented!()
+    }
+}
+
+trait TableContents<'a> {
+    fn contents(&self) -> &'a [u8];
+}
+impl<'a> TableContents<'a> for AmlTable {
+    fn contents(&self) -> &'a [u8] {
+        let virt_addr = ADDRESS_TRANSLATOR
+            .get()
+            .unwrap()
+            .translate_physical(PhysAddr::new(self.address as u64))
+            .unwrap();
+        // Safety: this address was specified in the ACPI tables by the firmware, so if the tables
+        // are correct, this is safe.
+        unsafe { core::slice::from_raw_parts(virt_addr.as_ptr(), self.length as usize) }
+    }
+}
+
+/// Translates an EISA ID (a compressed 32-bit identifier) to its string representation.
+///
+/// For the full specification, see the Plug and Play BIOS Specification (the latest of which seems
+/// to be v1.0a from 1994), but in short:
+/// The EISA ID is a 32-bit identifier that encodes a 8-character ASCII string as follows:
+/// 0b0_AAAAA_BBBBB_CCCCC_1111_2222_3333_4444
+///   - The 31th bit is always 0.
+///   - Bits 30..26, 25..21, 20..16 (five bits each) encode the compressed three-letter manufacturer
+///     ID; the compression algorithm is the lowest 5 bits of (character - 0x40).
+///   - Bits 15..12, 11..8, 7..4, 3..0 (four bits each) encode a hexadecimal digit.
+///
+/// As to what the IDs map to, as the specfication says, look for "Device Identifier Reference Table
+/// & Device Type Code Table" on the PlugPlay forum on CompuServe.
+fn name_from_eisa_id(eisa_id: u64) -> Result<String, AmlError> {
+    let eisa_id: u32 = u32::from_be(eisa_id.try_into().map_err(|_| AmlError::InvalidNameSeg)?);
+    let mut str = String::with_capacity(7);
+
+    for x in [26, 21, 16].iter() {
+        str.push(
+            char::from_u32(0x40 + ((eisa_id & (0b11111u32 << x)) >> x))
+                .ok_or(AmlError::InvalidNameSeg)?,
+        );
+    }
+    for x in [12, 8, 4, 0].iter() {
+        str.push(
+            char::from_digit((eisa_id & (0b1111u32 << x)) >> x, 0xF)
+                .ok_or(AmlError::InvalidNameSeg)?
+                .to_ascii_uppercase(),
+        );
+    }
+
+    Ok(str)
+}
+pub struct Acpi {
+    tables: AcpiTables<Handler>,
+    aml: AmlContext,
+}
+
+impl Acpi {
+    pub fn new(params: &BootParams) -> Result<Self> {
+        let mut acpi = Self {
+            tables: find_acpi_tables(params)?,
+            aml: AmlContext::new(Box::new(Handler {}), aml::DebugVerbosity::None),
+        };
+
+        // Parse the DSDT and all SSDTs.
+        if let Some(ref dsdt) = acpi.tables.dsdt {
+            acpi.aml
+                .parse_table(dsdt.contents())
+                .map_err(|err| anyhow!("failed to parse ACPI DSDT: {:?}", err))?;
+        } else {
+            bail!("no DSDT found in ACPI tables");
+        }
+
+        for ssdt in &acpi.tables.ssdts {
+            acpi.aml.parse_table(ssdt.contents()).map_err(|err| {
+                anyhow!(
+                    "failed to parse ACPI SSDT at address {}: {:?}",
+                    ssdt.address,
+                    err
+                )
+            })?;
+        }
+
+        acpi.aml
+            .initialize_objects()
+            .map_err(|err| anyhow!("failed to initialize ACPI AML objects: {:?}", err))?;
+
+        Ok(acpi)
+    }
+
+    pub fn devices(&mut self) -> Result<()> {
+        self.aml
+            .namespace
+            .clone()
+            .traverse(|name, level| match level.typ {
+                LevelType::Device => {
+                    let hid = self
+                        .aml
+                        .invoke_method(&AmlName::from_str("_HID")?.resolve(name)?, Args::default());
+
+                    if let Ok(hid) = hid {
+                        // If the name is an integer, it's a compressed EISA identifier (yes,
+                        // really)
+                        let hid = match hid {
+                            AmlValue::String(s) => Ok(s),
+                            AmlValue::Integer(i) => name_from_eisa_id(i),
+                            _ => Err(AmlError::InvalidNameSeg),
+                        }?;
+                        log::info!(
+                            "ACPI device: {} {:7} {}",
+                            name,
+                            hid,
+                            description(hid.as_str())
+                        );
+                    } else {
+                        log::info!("ACPI device: {} (no HID)", name);
+                    }
+
+                    let crs = self
+                        .aml
+                        .invoke_method(&AmlName::from_str("_CRS")?.resolve(name)?, Args::default());
+
+                    if let Ok(crs) = crs {
+                        let resources = resource_descriptor_list(&crs)?;
+                        for resource in resources {
+                            match resource {
+                                Resource::Irq(irq) => log::info!("  IRQ: {}", irq.irq),
+                                Resource::AddressSpace(address) => {
+                                    log::info!("  Address space: {:?}", address)
+                                }
+                                Resource::MemoryRange(MemoryRangeDescriptor::FixedLocation {
+                                    is_writable: _,
+                                    base_address,
+                                    range_length,
+                                }) => log::info!(
+                                    "  Memory range: [{:#018x}..{:#018x})",
+                                    base_address,
+                                    base_address + range_length
+                                ),
+                                Resource::IOPort(port) => log::info!("  IO port: {:?}", port),
+                                Resource::Dma(dma) => log::info!("  DMA: {:?}", dma),
+                            }
+                        }
+                    }
+
+                    Ok(true)
+                }
+                LevelType::Scope => Ok(true),
+                _ => Ok(false),
+            })
+            .map_err(|err| anyhow!("failed to walk ACPI tables: {:?}", err))
+    }
+}
+
+fn find_acpi_tables(params: &BootParams) -> Result<AcpiTables<Handler>> {
+    let acpi_rsdp_addr = params.acpi_rsdp_addr;
+    if acpi_rsdp_addr > 0 {
+        // Safety: we trust the boot params to be correct.
+        return unsafe { AcpiTables::from_rsdp(Handler {}, params.acpi_rsdp_addr as usize) }
+            .map_err(|err| {
+                anyhow!(
+                    "failed to load ACPI tables from address {:#x} specified in boot params: {:?}",
+                    acpi_rsdp_addr,
+                    err
+                )
+            });
+    }
+
+    // Safety: the EBDA area will be mapped and valid, so this is memory-safe, but we're still
+    // searching 1 KiB of memory for the signature that may not be there or match some random
+    // garbage.
+    unsafe { AcpiTables::search_for_rsdp_bios(Handler {}) }
+        .map_err(|err| anyhow!("failed to load ACPI tables from EBDA: {:?}", err))
+}

--- a/oak_tensorflow_freestanding_bin/Cargo.lock
+++ b/oak_tensorflow_freestanding_bin/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "acpi"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
+dependencies = [
+ "bit_field",
+ "log",
+ "rsdp",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +57,17 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
+]
+
+[[package]]
+name = "aml"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c264f2e933012ef2dd324cdac38f4c6c142473c1d1a1357ba16321e7d892975f"
+dependencies = [
+ "bit_field",
+ "byteorder",
+ "log",
 ]
 
 [[package]]
@@ -394,6 +416,8 @@ dependencies = [
 name = "oak_restricted_kernel"
 version = "0.1.0"
 dependencies = [
+ "acpi",
+ "aml",
  "anyhow",
  "arrayvec",
  "atomic_refcell",
@@ -628,6 +652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rsdp"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/testing/oak_echo_bin/Cargo.lock
+++ b/testing/oak_echo_bin/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "acpi"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
+dependencies = [
+ "bit_field",
+ "log",
+ "rsdp",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +57,17 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
+]
+
+[[package]]
+name = "aml"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c264f2e933012ef2dd324cdac38f4c6c142473c1d1a1357ba16321e7d892975f"
+dependencies = [
+ "bit_field",
+ "byteorder",
+ "log",
 ]
 
 [[package]]
@@ -418,6 +440,8 @@ dependencies = [
 name = "oak_restricted_kernel"
 version = "0.1.0"
 dependencies = [
+ "acpi",
+ "aml",
  "anyhow",
  "arrayvec",
  "atomic_refcell",
@@ -627,6 +651,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rsdp"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/testing/oak_echo_raw_bin/Cargo.lock
+++ b/testing/oak_echo_raw_bin/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "acpi"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
+dependencies = [
+ "bit_field",
+ "log",
+ "rsdp",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,6 +46,17 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+]
+
+[[package]]
+name = "aml"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c264f2e933012ef2dd324cdac38f4c6c142473c1d1a1357ba16321e7d892975f"
+dependencies = [
+ "bit_field",
+ "byteorder",
+ "log",
 ]
 
 [[package]]
@@ -381,6 +403,8 @@ dependencies = [
 name = "oak_restricted_kernel"
 version = "0.1.0"
 dependencies = [
+ "acpi",
+ "aml",
  "anyhow",
  "arrayvec",
  "atomic_refcell",
@@ -590,6 +614,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rsdp"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
+dependencies = [
+ "log",
 ]
 
 [[package]]


### PR DESCRIPTION
We don't do anything useful with these tables (yet), but at least we can (mostly) parse them!

For some reason some fields in the ACPI tables are not marked as public in the `aml` crate; in particular, we can't peek into `IoPortDescriptor` or `AddressSpaceDescriptor` structs. I'll need to find out what's going on there, if this is on principle, ongoing work or just an oversight.

Some examples:
  - running on crosvm:
```
INFO: ACPI device: \_SB_.PC00 PNP0A08 PCI Express bus
INFO:   Address space: AddressSpaceDescriptor { resource_type: BusNumberRange, is_maximum_address_fixed: true, is_minimum_address_fixed: true, decode_type: Additive, granularity: 0, address_range: (0, 63), translation_offset: 0, length: 64 }
INFO:   IO port: IOPortDescriptor { decodes_full_address: true, memory_range: (3320, 3320), base_alignment: 1, range_length: 8 }
INFO:   Address space: AddressSpaceDescriptor { resource_type: MemoryRange, is_maximum_address_fixed: true, is_minimum_address_fixed: true, decode_type: Additive, granularity: 0, address_range: (3489660928, 4160749567), translation_offset: 0, length: 671088640 }
INFO:   Address space: AddressSpaceDescriptor { resource_type: MemoryRange, is_maximum_address_fixed: true, is_minimum_address_fixed: true, decode_type: Additive, granularity: 0, address_range: (4429185024, 70368744177663), translation_offset: 0, length: 70364314992640 }
INFO: ACPI device: \_SB_.PC00.PC01 (no HID)
INFO: ACPI device: \_SB_.PC00.PE08 (no HID)
INFO: ACPI device: \_SB_.PC00.PE10 (no HID)
```
  - running on QEMU (`-machine microvm`, with MMIO virtio devices):
```
INFO: ACPI device: \_SB_.COM1 PNP0501 16550A-compatible COM Serial Port
INFO:   IO port: IOPortDescriptor { decodes_full_address: true, memory_range: (1016, 1016), base_alignment: 0, range_length: 8 }
INFO:   IRQ: 16
INFO: ACPI device: \_SB_.FWCF QEMU0002 QEMU fw_cfg Device
INFO:   IO port: IOPortDescriptor { decodes_full_address: true, memory_range: (1296, 1296), base_alignment: 1, range_length: 12 }
INFO: ACPI device: \_SB_.GED_ ACPI0013 ACPI Generic Event Device
INFO:   IRQ: 9
INFO: ACPI device: \_SB_.PWRB PNP0C0C Power Button Device
INFO: ACPI device: \_SB_.VR23 LNRO0005 Memory-mapped virtio device bus
INFO:   Memory range: [0x00000000feb02e00..0x00000000feb03000)
INFO:   IRQ: 47
```
  - running on QEMU (`-machine microvm,pcie=on`):
```
ERROR: Failed to parse AML stream. Err = UnexpectedByte(8)
WARN: Failed to load ACPI tables: Failed to parse ACPI DSDT: UnexpectedByte(8)
```

The latter looks like a bug in the AML crate. I'll need to follow up about that as well.