### PR TITLE
Add enclave binary to attestation measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,6 +4132,7 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger 0.8.4",
+ "goblin",
  "hex",
  "log",
  "oak_sev_guest",

--- a/snp_measurement/Cargo.toml
+++ b/snp_measurement/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 anyhow = "*"
 clap = { version = "*", features = ["derive"] }
 env_logger = "*"
+goblin = "*"
 hex = "*"
 oak_sev_guest = { path = "../oak_sev_guest" }
 log = "*"

--- a/snp_measurement/src/elf.rs
+++ b/snp_measurement/src/elf.rs
@@ -1,0 +1,57 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::Context;
+use goblin::elf::{program_header::PT_LOAD, Elf};
+use log::{debug, info};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use x86_64::PhysAddr;
+
+/// A memory segment extracted from an ELF file.
+pub struct MemorySegment {
+    /// The guest-physical start address of the segment.
+    pub start_address: PhysAddr,
+    /// The data specified for the segment in the ELF file.
+    pub data: Vec<u8>,
+}
+
+/// Loads an ELF file and extracts the non-zero loadable memory segments.
+pub fn load_elf_segments(elf_path: PathBuf) -> anyhow::Result<Vec<MemorySegment>> {
+    let elf_bytes = load_elf_file(elf_path)?;
+    let elf = Elf::parse(&elf_bytes).context("invalid ELF file")?;
+    // For now we assume each segment's start address will be 4KiB aligned, so we do not pad the
+    // start. This assumption is validated when the segments are measured.
+    Ok(elf
+        .program_headers
+        .iter()
+        .filter(|header| header.p_type == PT_LOAD && header.p_filesz > 0)
+        .map(|header| MemorySegment {
+            start_address: PhysAddr::new(header.p_paddr),
+            data: elf_bytes[header.file_range()].to_vec(),
+        })
+        .collect())
+}
+
+fn load_elf_file(elf_path: PathBuf) -> anyhow::Result<Vec<u8>> {
+    let elf_bytes = std::fs::read(&elf_path).context("couldn't load ELF file")?;
+    debug!("ELF file size: {}", elf_bytes.len());
+    let mut elf_hasher = Sha256::new();
+    elf_hasher.update(&elf_bytes);
+    let elf_sha256_digest = elf_hasher.finalize();
+    info!("ELF file digest: sha256:{}", hex::encode(elf_sha256_digest));
+    Ok(elf_bytes)
+}


### PR DESCRIPTION
The contents of the enclave binary is the final part that is needed to calculate the predicted attestation measurement.

Fixes #3486

Note: The result does not yet match the actual measurements we get, as the boot paramters (zero page) is not yet marked as unmeasured so the measurement depends on the memory layout of the VM. This will be addressed in a follow-up PR.