### PR TITLE
Remove codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# Default reviewer, using auto-assignment: https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment
-* @project-oak/core


### PR DESCRIPTION
We will manually assign reviewers going forward. It is still possible to manually assign the team as reviewer if desired, in which case a reviewer will be auto selected according to the previous logic.