### PR TITLE
Add a failing fuzz target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
           - run-oak-functions-examples --application-variant=rust
           - run-trusted-shuffler
           - run-trusted-shuffler-grpc
-          - run-cargo-fuzz -- -max_total_time=2
+          - run-cargo-fuzz --target-name=apply_policy -- -max_total_time=2
           - completion
           - run-cargo-clippy
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
           - run-oak-functions-examples --application-variant=rust
           - run-trusted-shuffler
           - run-trusted-shuffler-grpc
+          # TODO(#3503): Remove `--target-name=apply_policy` to run all targets.
           - run-cargo-fuzz --target-name=apply_policy -- -max_total_time=2
           - completion
           - run-cargo-clippy

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -15,14 +15,14 @@ jobs:
         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
         with:
           oss-fuzz-project-name: 'oak'
-          dry-run: false
+          dry-run: true
           language: rust
       - name: Run Fuzzers
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
         with:
           oss-fuzz-project-name: 'oak'
           fuzz-seconds: 600
-          dry-run: false
+          dry-run: true
       - name: Upload Crash
         uses: actions/upload-artifact@v1
         if: failure() && steps.build.outcome == 'success'

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -15,6 +15,7 @@ jobs:
         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
         with:
           oss-fuzz-project-name: 'oak'
+          # TODO(#3503): Change to false.
           dry-run: true
           language: rust
       - name: Run Fuzzers
@@ -22,6 +23,7 @@ jobs:
         with:
           oss-fuzz-project-name: 'oak'
           fuzz-seconds: 600
+          # TODO(#3503): Change to false.
           dry-run: true
       - name: Upload Crash
         uses: actions/upload-artifact@v1

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -39,6 +39,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
 name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +147,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -199,9 +220,20 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
+ "hex",
  "libfuzzer-sys",
  "oak_functions_abi",
+ "oak_remote_attestation",
  "prost-build",
+]
+
+[[package]]
+name = "oak_remote_attestation"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "ring",
 ]
 
 [[package]]
@@ -327,6 +359,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +398,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
@@ -416,6 +469,76 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+
+[[package]]
+name = "web-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,8 +11,12 @@ cargo-fuzz = true
 [dependencies]
 anyhow = "*"
 arbitrary = { version = "1", features = ["derive"] }
+hex = "*"
 libfuzzer-sys = "*"
 oak_functions_abi = { path = "../oak_functions_abi" }
+oak_remote_attestation = { path = "../oak_remote_attestation", features = [
+  "ring-crypto"
+] }
 
 [build-dependencies]
 prost-build = "*"
@@ -25,5 +29,11 @@ members = ["."]
 [[bin]]
 name = "apply_policy"
 path = "fuzz_targets/apply_policy.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "failing"
+path = "fuzz_targets/failing.rs"
 test = false
 doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,9 +11,11 @@ cargo-fuzz = true
 [dependencies]
 anyhow = "*"
 arbitrary = { version = "1", features = ["derive"] }
+# TODO(#3503): Required for the failing target. Remove.
 hex = "*"
 libfuzzer-sys = "*"
 oak_functions_abi = { path = "../oak_functions_abi" }
+# TODO(#3503): Required for the failing target. Remove.
 oak_remote_attestation = { path = "../oak_remote_attestation", features = [
   "ring-crypto"
 ] }
@@ -32,6 +34,7 @@ path = "fuzz_targets/apply_policy.rs"
 test = false
 doc = false
 
+# TODO(#3503): Remove.
 [[bin]]
 name = "failing"
 path = "fuzz_targets/failing.rs"

--- a/fuzz/fuzz_targets/failing.rs
+++ b/fuzz/fuzz_targets/failing.rs
@@ -1,0 +1,30 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This is an intentionally failing fuzz target for testing.
+
+#![no_main]
+#![feature(async_closure)]
+
+use libfuzzer_sys::fuzz_target;
+use oak_remote_attestation::crypto::get_sha256;
+
+// A fake fuzz target that computes the SHA256 digest of the input, and checks that it does not
+// start with `000` zeros. This fuzz target is intentionally designed to fail.
+fuzz_target!(|data: &[u8]| {
+    let digest_bytes = get_sha256(data);
+    let digest_hex = hex::encode(digest_bytes);
+    assert!(!digest_hex.starts_with("000"));
+});

--- a/fuzz/fuzz_targets/failing.rs
+++ b/fuzz/fuzz_targets/failing.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(#3503): This target is temporary. Remove the file once we have enough data.
 //! This is an intentionally failing fuzz target for testing.
 
 #![no_main]


### PR DESCRIPTION
- Adds a temporary failing fuzz target, to generate data.
- Tweaks fuzz-related CI steps to avoid CI failures. 