### PR TITLE
Rename check-format to lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
         cmd:
           # format tries to format all the source files, and relies on the git diff step to determine whether anything was missed.
           - format
-          # check-format checks for additional issues (e.g. missing license headers) that format does not enforce.
-          - check-format
+          # lint checks for additional issues (e.g. missing license headers) that format does not enforce.
+          - lint
           - run-cargo-deny
           - run-cargo-udeps
           - build-oak-functions-server-variants

--- a/scripts/git_check_diff
+++ b/scripts/git_check_diff
@@ -5,7 +5,9 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 source "$SCRIPTS_DIR/common"
 
 # Check that any generated files match those that are checked in.
-if [[ $(git status --short) ]]; then
-    # One or more files are either modified or newly generated, exit with an error code
+if [[ $(git status --porcelain) ]]; then
+    # One or more files are either modified or newly generated; print the full git diff and exit with an error code
+    git status
+    git diff
     exit 1
 fi

--- a/xtask/src/internal.rs
+++ b/xtask/src/internal.rs
@@ -60,7 +60,7 @@ pub enum Command {
     BuildOakFunctionsExample(RunOakExamplesOpt),
     BuildOakFunctionsServerVariants(BuildServerOpt),
     Format,
-    CheckFormat,
+    Lint,
     RunTests,
     RunCargoClippy,
     RunCargoTests(RunTestsOpt),


### PR DESCRIPTION
We rely on format and git-diff to identify non formatted files, but we still need some additional checks, which at this point are mostly about linting rather than formatting