### PR TITLE
Refactor ACPI code to include a simple `AcpiDevice` wrapper

### DIFF
--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -206,7 +206,7 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     // Init ACPI, if available.
     match acpi::Acpi::new(info) {
         Err(ref err) => log::warn!("Failed to load ACPI tables: {}", err),
-        Ok(ref mut acpi) => acpi.devices().unwrap(),
+        Ok(ref mut acpi) => acpi.print_devices().unwrap(),
     };
 
     if sev_snp_enabled {


### PR DESCRIPTION
We'll soon need to search the ACPI device tree for the virtio device: this sets up the infrastructure so that we can do that.