### PR TITLE
Build std for stage0

### DIFF
--- a/stage0/.cargo/config.toml
+++ b/stage0/.cargo/config.toml
@@ -3,3 +3,8 @@ target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
 rustflags = "-C relocation-model=static -C code-model=large"
+
+[unstable]
+# We need to build std / core because of the code model. This may be removed if / when it's possible to build stage0 without it in the future.
+build-std = ["core"]
+build-std-features = ["compiler-builtins-mem"]


### PR DESCRIPTION
There was a race between the following commits:
- dd3be6ab3e9c47844869ff5807aca0ee1d8c360a
- c7207686ecda0c6474714a34ea1d8c4c2e2766c8

Which introduced a bug that causes Kokoro to fail.