### PR TITLE
Move server creation method

### DIFF
--- a/micro_rpc_build/src/lib.rs
+++ b/micro_rpc_build/src/lib.rs
@@ -93,6 +93,9 @@ fn generate_service(service: &Service) -> anyhow::Result<String> {
         format!("}}"),
         format!(""),
         format!("impl <S: {service_name}> {server_name}<S> {{"),
+        format!("    pub fn new(service: S) -> Self {{"),
+        format!("        Self {{ service }}"),
+        format!("    }}"),
         // invoke_inner returns either a successful response body, or an error represented as Status.
         format!("    fn invoke_inner(&mut self, request_bytes: &[u8]) -> Result<::prost::alloc::vec::Vec<u8>, ::micro_rpc::Status> {{"),
         format!("        let request = ::micro_rpc::Request::decode(request_bytes).map_err(|err| {{"),
@@ -124,13 +127,7 @@ fn generate_service(service: &Service) -> anyhow::Result<String> {
         format!("pub trait {service_name}: Sized {{"),
     ]);
     lines.extend(service.methods.iter().flat_map(generate_service_method));
-    lines.extend(vec![
-        format!("    fn serve(self) -> {server_name}<Self> {{"),
-        format!("        {server_name} {{ service : self }}"),
-        format!("    }}"),
-        format!("}}"),
-        format!(""),
-    ]);
+    lines.extend(vec![format!("}}"), format!("")]);
     Ok(lines.into_iter().intersperse("\n".to_string()).collect())
 }
 

--- a/micro_rpc_tests/out/micro_rpc.tests.rs.txt
+++ b/micro_rpc_tests/out/micro_rpc.tests.rs.txt
@@ -32,6 +32,9 @@ impl<S: TestService> ::micro_rpc::Transport for TestServiceServer<S> {
     }
 }
 impl<S: TestService> TestServiceServer<S> {
+    pub fn new(service: S) -> Self {
+        Self { service }
+    }
     fn invoke_inner(
         &mut self,
         request_bytes: &[u8],
@@ -84,9 +87,6 @@ pub trait TestService: Sized {
         request: &LookupDataRequest,
     ) -> Result<LookupDataResponse, ::micro_rpc::Status>;
     fn log(&mut self, request: &LogRequest) -> Result<LogResponse, ::micro_rpc::Status>;
-    fn serve(self) -> TestServiceServer<Self> {
-        TestServiceServer { service: self }
-    }
 }
 pub struct TestServiceClient<T: ::micro_rpc::Transport> {
     transport: T,

--- a/micro_rpc_tests/tests/test_schema.rs
+++ b/micro_rpc_tests/tests/test_schema.rs
@@ -78,8 +78,7 @@ fn test_failing_transport() {
 #[test]
 fn test_lookup_data() {
     let service = TestServiceImpl;
-    use test_schema::TestService;
-    let transport = service.serve();
+    let transport = test_schema::TestServiceServer::new(service);
     let mut client = test_schema::TestServiceClient::new(transport);
     {
         let request = test_schema::LookupDataRequest { key: vec![14, 12] };
@@ -122,8 +121,7 @@ impl<S: test_schema::TestService + std::marker::Send + std::marker::Sync> micro_
 #[tokio::test]
 async fn test_async_lookup_data() {
     let service = TestServiceImpl;
-    use test_schema::TestService;
-    let service_impl = service.serve();
+    let service_impl = test_schema::TestServiceServer::new(service);
     let async_transport = AsyncTestServiceServer {
         inner: service_impl,
     };

--- a/oak_functions_freestanding/tests/integration_test.rs
+++ b/oak_functions_freestanding/tests/integration_test.rs
@@ -21,7 +21,7 @@ extern crate alloc;
 
 use core::assert_matches::assert_matches;
 use oak_functions_freestanding::{
-    schema::{self, OakFunctions},
+    schema::{self, OakFunctionsServer},
     OakFunctionsService,
 };
 use oak_remote_attestation_amd::PlaceholderAmdAttestationGenerator;
@@ -34,7 +34,7 @@ const LOOKUP_TEST_VALUE: &[u8] = b"test_value";
 #[test]
 fn it_should_not_handle_user_requests_before_initialization() {
     let service = OakFunctionsService::new(Arc::new(PlaceholderAmdAttestationGenerator));
-    let mut client = schema::OakFunctionsClient::new(OakFunctions::serve(service));
+    let mut client = schema::OakFunctionsClient::new(OakFunctionsServer::new(service));
 
     let request = schema::InvokeRequest {
         body: vec![1, 2, 3],
@@ -53,7 +53,7 @@ fn it_should_not_handle_user_requests_before_initialization() {
 #[test]
 fn it_should_handle_user_requests_after_initialization() {
     let service = OakFunctionsService::new(Arc::new(PlaceholderAmdAttestationGenerator));
-    let mut client = schema::OakFunctionsClient::new(OakFunctions::serve(service));
+    let mut client = schema::OakFunctionsClient::new(OakFunctionsServer::new(service));
 
     let wasm_path = oak_functions_test_utils::build_rust_crate_wasm("echo").unwrap();
     let wasm_bytes = std::fs::read(wasm_path).unwrap();
@@ -75,7 +75,7 @@ fn it_should_handle_user_requests_after_initialization() {
 #[test]
 fn it_should_only_initialize_once() {
     let service = OakFunctionsService::new(Arc::new(PlaceholderAmdAttestationGenerator));
-    let mut client = schema::OakFunctionsClient::new(OakFunctions::serve(service));
+    let mut client = schema::OakFunctionsClient::new(OakFunctionsServer::new(service));
 
     let wasm_path = oak_functions_test_utils::build_rust_crate_wasm("echo").unwrap();
     let wasm_bytes = std::fs::read(wasm_path).unwrap();
@@ -99,7 +99,7 @@ fn it_should_only_initialize_once() {
 #[tokio::test]
 async fn it_should_support_lookup_data() {
     let service = OakFunctionsService::new(Arc::new(PlaceholderAmdAttestationGenerator));
-    let mut client = schema::OakFunctionsClient::new(OakFunctions::serve(service));
+    let mut client = schema::OakFunctionsClient::new(OakFunctionsServer::new(service));
 
     let wasm_path = oak_functions_test_utils::build_rust_crate_wasm("key_value_lookup").unwrap();
     let wasm_bytes = std::fs::read(wasm_path).unwrap();

--- a/oak_functions_freestanding_bin/src/main.rs
+++ b/oak_functions_freestanding_bin/src/main.rs
@@ -38,7 +38,7 @@ fn main(channel: Box<dyn Channel>) -> ! {
     let service = oak_functions_freestanding::OakFunctionsService::new(Arc::new(
         PlaceholderAmdAttestationGenerator,
     ));
-    let server = oak_functions_freestanding::schema::OakFunctions::serve(service);
+    let server = oak_functions_freestanding::schema::OakFunctionsServer::new(service);
     oak_channel::server::start_blocking_server(channel, server)
         .expect("server encountered an unrecoverable error");
 }

--- a/oak_functions_linux_fd_bin/src/main.rs
+++ b/oak_functions_linux_fd_bin/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> ! {
     ));
     oak_channel::server::start_blocking_server(
         channel,
-        oak_functions_freestanding::schema::OakFunctions::serve(service),
+        oak_functions_freestanding::schema::OakFunctionsServer::new(service),
     )
     .expect("server encountered an unrecoverable error");
 }

--- a/oak_functions_linux_vsock_bin/src/main.rs
+++ b/oak_functions_linux_vsock_bin/src/main.rs
@@ -75,7 +75,7 @@ fn main() -> ! {
         oak_functions_freestanding::OakFunctionsService::new(Arc::new(EmptyAttestationGenerator));
     oak_channel::server::start_blocking_server(
         channel,
-        oak_functions_freestanding::schema::OakFunctions::serve(service),
+        oak_functions_freestanding::schema::OakFunctionsServer::new(service),
     )
     .expect("server encountered an unrecoverable error");
 }

--- a/oak_tensorflow_freestanding_bin/src/main.rs
+++ b/oak_tensorflow_freestanding_bin/src/main.rs
@@ -35,7 +35,7 @@ pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
 
 fn start_server(channel: Box<dyn Channel>) -> ! {
     let service = oak_tensorflow_service::TensorflowService::new();
-    let server = oak_tensorflow_service::schema::Tensorflow::serve(service);
+    let server = oak_tensorflow_service::schema::TensorflowServer::new(service);
     oak_channel::server::start_blocking_server(channel, server)
         .expect("server encountered an unrecoverable error")
 }

--- a/testing/oak_echo_bin/src/main.rs
+++ b/testing/oak_echo_bin/src/main.rs
@@ -24,7 +24,6 @@ use alloc::boxed::Box;
 use core::panic::PanicInfo;
 use log::info;
 use oak_channel::Channel;
-use oak_echo_service::proto::Echo;
 use oak_linux_boot_params::BootParams;
 
 #[no_mangle]
@@ -38,7 +37,7 @@ pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
 // https://github.com/project-oak/oak/blob/main/oak_channel/SPEC.md
 fn start_echo_server(channel: Box<dyn Channel>) -> ! {
     let service = oak_echo_service::EchoService::default();
-    let server = service.serve();
+    let server = oak_echo_service::proto::EchoServer::new(service);
     oak_channel::server::start_blocking_server(channel, server)
         .expect("server encountered an unrecoverable error");
 }

--- a/testing/oak_echo_service/tests/integration_test.rs
+++ b/testing/oak_echo_service/tests/integration_test.rs
@@ -21,7 +21,7 @@
 extern crate alloc;
 
 use oak_echo_service::{
-    proto::{Echo, EchoClient, EchoRequest},
+    proto::{EchoClient, EchoRequest, EchoServer},
     EchoService,
 };
 
@@ -30,7 +30,7 @@ const TEST_DATA: &[u8] = b"test_data";
 #[test]
 fn it_should_handle_echo_requests() {
     let service = EchoService::default();
-    let mut client = EchoClient::new(service.serve());
+    let mut client = EchoClient::new(EchoServer::new(service));
 
     let request = EchoRequest {
         body: TEST_DATA.to_vec(),


### PR DESCRIPTION
The previous method was added to the list of methods on the trait, but that risks conflicting with a real method with the same name.