### PR TITLE
Support well known Empty type in micro RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,6 +2254,7 @@ dependencies = [
  "micro_rpc",
  "micro_rpc_build",
  "prost 0.11.2",
+ "prost-types 0.11.2",
  "tokio",
 ]
 

--- a/micro_rpc_build/src/lib.rs
+++ b/micro_rpc_build/src/lib.rs
@@ -194,7 +194,9 @@ fn generate_server_handler(method: &Method) -> anyhow::Result<Vec<String>> {
     let method_name = method_name(method);
     Ok(vec![
         format!("            {method_id} => {{"),
-        format!("                let request = {request_type}::decode(request.body.as_ref()).map_err(|err| {{"),
+        // We need the angle brackets around the type in order to make sure it works with Rust well 
+        // known types, e.g. when `google.protobuf.Empty` is replaced by `()`.
+        format!("                let request = <{request_type}>::decode(request.body.as_ref()).map_err(|err| {{"),
         format!("                    ::micro_rpc::Status::new_with_message("),
         format!("                        ::micro_rpc::StatusCode::Internal,"),
         format!("                        ::micro_rpc::format!(\"Service failed to deserialize the request: {{:?}}\", err)"),

--- a/micro_rpc_tests/Cargo.toml
+++ b/micro_rpc_tests/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "*"
 maplit = "*"
 micro_rpc = { path = "../micro_rpc" }
 prost = "*"
+prost-types = "*"
 tokio = { version = "*", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]

--- a/micro_rpc_tests/out/micro_rpc.tests.rs.txt
+++ b/micro_rpc_tests/out/micro_rpc.tests.rs.txt
@@ -50,7 +50,7 @@ impl<S: TestService> TestServiceServer<S> {
             })?;
         match request.method_id {
             15 => {
-                let request = LookupDataRequest::decode(request.body.as_ref())
+                let request = <LookupDataRequest>::decode(request.body.as_ref())
                     .map_err(|err| {
                         ::micro_rpc::Status::new_with_message(
                             ::micro_rpc::StatusCode::Internal,
@@ -64,7 +64,7 @@ impl<S: TestService> TestServiceServer<S> {
                 Ok(response_body)
             }
             16 => {
-                let request = LogRequest::decode(request.body.as_ref())
+                let request = <LogRequest>::decode(request.body.as_ref())
                     .map_err(|err| {
                         ::micro_rpc::Status::new_with_message(
                             ::micro_rpc::StatusCode::Internal,
@@ -74,6 +74,62 @@ impl<S: TestService> TestServiceServer<S> {
                         )
                     })?;
                 let response = self.service.log(&request)?;
+                let response_body = response.encode_to_vec();
+                Ok(response_body)
+            }
+            17 => {
+                let request = <()>::decode(request.body.as_ref())
+                    .map_err(|err| {
+                        ::micro_rpc::Status::new_with_message(
+                            ::micro_rpc::StatusCode::Internal,
+                            ::micro_rpc::format!(
+                                "Service failed to deserialize the request: {:?}", err
+                            ),
+                        )
+                    })?;
+                let response = self.service.empty(&request)?;
+                let response_body = response.encode_to_vec();
+                Ok(response_body)
+            }
+            18 => {
+                let request = <::prost_types::Duration>::decode(request.body.as_ref())
+                    .map_err(|err| {
+                        ::micro_rpc::Status::new_with_message(
+                            ::micro_rpc::StatusCode::Internal,
+                            ::micro_rpc::format!(
+                                "Service failed to deserialize the request: {:?}", err
+                            ),
+                        )
+                    })?;
+                let response = self.service.duration(&request)?;
+                let response_body = response.encode_to_vec();
+                Ok(response_body)
+            }
+            19 => {
+                let request = <::prost_types::Timestamp>::decode(request.body.as_ref())
+                    .map_err(|err| {
+                        ::micro_rpc::Status::new_with_message(
+                            ::micro_rpc::StatusCode::Internal,
+                            ::micro_rpc::format!(
+                                "Service failed to deserialize the request: {:?}", err
+                            ),
+                        )
+                    })?;
+                let response = self.service.timestamp(&request)?;
+                let response_body = response.encode_to_vec();
+                Ok(response_body)
+            }
+            20 => {
+                let request = <::prost_types::Any>::decode(request.body.as_ref())
+                    .map_err(|err| {
+                        ::micro_rpc::Status::new_with_message(
+                            ::micro_rpc::StatusCode::Internal,
+                            ::micro_rpc::format!(
+                                "Service failed to deserialize the request: {:?}", err
+                            ),
+                        )
+                    })?;
+                let response = self.service.any(&request)?;
                 let response_body = response.encode_to_vec();
                 Ok(response_body)
             }
@@ -87,6 +143,19 @@ pub trait TestService: Sized {
         request: &LookupDataRequest,
     ) -> Result<LookupDataResponse, ::micro_rpc::Status>;
     fn log(&mut self, request: &LogRequest) -> Result<LogResponse, ::micro_rpc::Status>;
+    fn empty(&mut self, request: &()) -> Result<(), ::micro_rpc::Status>;
+    fn duration(
+        &mut self,
+        request: &::prost_types::Duration,
+    ) -> Result<::prost_types::Duration, ::micro_rpc::Status>;
+    fn timestamp(
+        &mut self,
+        request: &::prost_types::Timestamp,
+    ) -> Result<::prost_types::Timestamp, ::micro_rpc::Status>;
+    fn any(
+        &mut self,
+        request: &::prost_types::Any,
+    ) -> Result<::prost_types::Any, ::micro_rpc::Status>;
 }
 pub struct TestServiceClient<T: ::micro_rpc::Transport> {
     transport: T,
@@ -107,6 +176,30 @@ impl<T: ::micro_rpc::Transport> TestServiceClient<T> {
     ) -> Result<Result<LogResponse, ::micro_rpc::Status>, T::Error> {
         ::micro_rpc::client_invoke(&mut self.transport, 16, request)
     }
+    pub fn empty(
+        &mut self,
+        request: &(),
+    ) -> Result<Result<(), ::micro_rpc::Status>, T::Error> {
+        ::micro_rpc::client_invoke(&mut self.transport, 17, request)
+    }
+    pub fn duration(
+        &mut self,
+        request: &::prost_types::Duration,
+    ) -> Result<Result<::prost_types::Duration, ::micro_rpc::Status>, T::Error> {
+        ::micro_rpc::client_invoke(&mut self.transport, 18, request)
+    }
+    pub fn timestamp(
+        &mut self,
+        request: &::prost_types::Timestamp,
+    ) -> Result<Result<::prost_types::Timestamp, ::micro_rpc::Status>, T::Error> {
+        ::micro_rpc::client_invoke(&mut self.transport, 19, request)
+    }
+    pub fn any(
+        &mut self,
+        request: &::prost_types::Any,
+    ) -> Result<Result<::prost_types::Any, ::micro_rpc::Status>, T::Error> {
+        ::micro_rpc::client_invoke(&mut self.transport, 20, request)
+    }
 }
 pub struct TestServiceAsyncClient<T: ::micro_rpc::AsyncTransport> {
     transport: T,
@@ -126,5 +219,29 @@ impl<T: ::micro_rpc::AsyncTransport> TestServiceAsyncClient<T> {
         request: &LogRequest,
     ) -> Result<Result<LogResponse, ::micro_rpc::Status>, T::Error> {
         ::micro_rpc::async_client_invoke(&mut self.transport, 16, request).await
+    }
+    pub async fn empty(
+        &mut self,
+        request: &(),
+    ) -> Result<Result<(), ::micro_rpc::Status>, T::Error> {
+        ::micro_rpc::async_client_invoke(&mut self.transport, 17, request).await
+    }
+    pub async fn duration(
+        &mut self,
+        request: &::prost_types::Duration,
+    ) -> Result<Result<::prost_types::Duration, ::micro_rpc::Status>, T::Error> {
+        ::micro_rpc::async_client_invoke(&mut self.transport, 18, request).await
+    }
+    pub async fn timestamp(
+        &mut self,
+        request: &::prost_types::Timestamp,
+    ) -> Result<Result<::prost_types::Timestamp, ::micro_rpc::Status>, T::Error> {
+        ::micro_rpc::async_client_invoke(&mut self.transport, 19, request).await
+    }
+    pub async fn any(
+        &mut self,
+        request: &::prost_types::Any,
+    ) -> Result<Result<::prost_types::Any, ::micro_rpc::Status>, T::Error> {
+        ::micro_rpc::async_client_invoke(&mut self.transport, 20, request).await
     }
 }

--- a/micro_rpc_tests/proto/test_schema.proto
+++ b/micro_rpc_tests/proto/test_schema.proto
@@ -18,6 +18,11 @@ syntax = "proto3";
 
 package micro_rpc.tests;
 
+import "google/protobuf/empty.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
+
 message LookupDataRequest {
   bytes key = 1;
 }
@@ -35,4 +40,12 @@ service TestService {
   rpc LookupData(LookupDataRequest) returns (LookupDataResponse);
   // method_id: 16
   rpc Log(LogRequest) returns (LogResponse);
+  // method_id: 17
+  rpc Empty(google.protobuf.Empty) returns (google.protobuf.Empty);
+  // method_id: 18
+  rpc Duration(google.protobuf.Duration) returns (google.protobuf.Duration);
+  // method_id: 19
+  rpc Timestamp(google.protobuf.Timestamp) returns (google.protobuf.Timestamp);
+  // method_id: 20
+  rpc Any(google.protobuf.Any) returns (google.protobuf.Any);
 }

--- a/micro_rpc_tests/tests/test_schema.rs
+++ b/micro_rpc_tests/tests/test_schema.rs
@@ -24,7 +24,7 @@ extern crate alloc;
 use micro_rpc::Transport;
 
 mod test_schema {
-    #![allow(dead_code)]
+    #![allow(dead_code, clippy::let_unit_value)]
     use prost::Message;
     include!(concat!(env!("OUT_DIR"), "/micro_rpc.tests.rs"));
 }
@@ -64,6 +64,28 @@ impl test_schema::TestService for TestServiceImpl {
     ) -> Result<test_schema::LogResponse, micro_rpc::Status> {
         eprintln!("log: {}", request.entry);
         Ok(test_schema::LogResponse {})
+    }
+
+    fn empty(&mut self, _request: &()) -> Result<(), ::micro_rpc::Status> {
+        Ok(())
+    }
+    fn duration(
+        &mut self,
+        _request: &::prost_types::Duration,
+    ) -> Result<::prost_types::Duration, ::micro_rpc::Status> {
+        Ok(std::time::Duration::from_millis(123).try_into().unwrap())
+    }
+    fn timestamp(
+        &mut self,
+        _request: &::prost_types::Timestamp,
+    ) -> Result<::prost_types::Timestamp, ::micro_rpc::Status> {
+        Ok(std::time::SystemTime::UNIX_EPOCH.try_into().unwrap())
+    }
+    fn any(
+        &mut self,
+        _request: &::prost_types::Any,
+    ) -> Result<::prost_types::Any, ::micro_rpc::Status> {
+        Ok(prost_types::Any::default())
     }
 }
 


### PR DESCRIPTION
Previously the generator was producing incorrect code because the `()` type was not correctly delimited.