### PR TITLE
Use CMOS to populate E820 table if one is not available from QEMU

### DIFF
--- a/linux_boot_params/src/lib.rs
+++ b/linux_boot_params/src/lib.rs
@@ -469,6 +469,13 @@ pub struct BootE820Entry {
 }
 
 impl BootE820Entry {
+    pub fn new(addr: usize, size: usize, type_: E820EntryType) -> Self {
+        Self {
+            addr,
+            size,
+            type_: type_ as u32,
+        }
+    }
     pub fn entry_type(&self) -> Option<E820EntryType> {
         E820EntryType::from_repr(self.type_)
     }

--- a/stage0/src/cmos.rs
+++ b/stage0/src/cmos.rs
@@ -1,0 +1,86 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use oak_sev_guest::io::{IoPortFactory, PortFactoryWrapper, PortReader, PortWrapper, PortWriter};
+
+const CMOS_INDEX_PORT: u16 = 0x0070;
+const CMOS_DATA_PORT: u16 = 0x0071;
+
+// QEMU-specific CMOS config fields.
+const CMOS_MEM_EXTMEM_LOW: u8 = 0x30;
+const CMOS_MEM_EXTMEM_HIGH: u8 = 0x31;
+const CMOS_MEM_EXTMEM2_LOW: u8 = 0x34;
+const CMOS_MEM_EXTMEM2_HIGH: u8 = 0x35;
+const CMOS_MEM_HIGHMEM_LOW: u8 = 0x5b;
+const CMOS_MEM_HIGHMEM_MID: u8 = 0x5c;
+const CMOS_MEM_HIGHMEM_HIGH: u8 = 0x5d;
+
+const NMI_DISABLE_BIT: u8 = 0x80;
+
+pub struct Cmos {
+    index_port: PortWrapper<u8>,
+    data_port: PortWrapper<u8>,
+}
+
+impl Cmos {
+    /// Creates a new CMOS reader wrapper.
+    ///
+    /// # Safety
+    ///
+    /// It's up to the caller to guarantee that there will be no other readers/writers to the CMOS
+    /// ports (0x70, 0x71) and that CMOS is actually available on those ports, otherwise the
+    /// behaviour is undefined.
+    pub unsafe fn new(port_factory: PortFactoryWrapper) -> Self {
+        Self {
+            index_port: port_factory.new_writer(CMOS_INDEX_PORT),
+            data_port: port_factory.new_reader(CMOS_DATA_PORT),
+        }
+    }
+
+    /// Returns the low RAM size (memory under the 4 GiB mark)
+    pub fn low_ram_size(&mut self) -> Result<u32, &'static str> {
+        let mut rs: u32 = (self.read(CMOS_MEM_EXTMEM2_LOW)? as u32) << 16;
+        rs |= (self.read(CMOS_MEM_EXTMEM2_HIGH)? as u32) << 24;
+
+        if rs > 0 {
+            rs += 16 * 1024 * 1024; // 16 MiB
+        } else {
+            rs = (self.read(CMOS_MEM_EXTMEM_LOW)? as u32) << 10;
+            rs |= (self.read(CMOS_MEM_EXTMEM_HIGH)? as u32) << 18;
+            rs += 1024 * 1024; // 1 MiB
+        }
+
+        Ok(rs)
+    }
+
+    /// Returns the high RAM size (memory over the 4 GiB mark)
+    pub fn high_ram_size(&mut self) -> Result<u64, &'static str> {
+        let mut high: u64 = (self.read(CMOS_MEM_HIGHMEM_LOW)? as u64) << 16;
+        high |= (self.read(CMOS_MEM_HIGHMEM_MID)? as u64) << 24;
+        high |= (self.read(CMOS_MEM_HIGHMEM_HIGH)? as u64) << 32;
+
+        Ok(high)
+    }
+
+    fn read(&mut self, index: u8) -> Result<u8, &'static str> {
+        // Safety: we've asked the caller to guarantee that these ports are exclusively available
+        // when calling new(), so accessing them is safe.
+        unsafe {
+            self.index_port.try_write(index | NMI_DISABLE_BIT)?;
+            self.data_port.try_read()
+        }
+    }
+}

--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -28,6 +28,7 @@ const SIGNATURE: &[u8] = b"QEMU";
 enum FwCfgItems {
     Signature = 0x0000,
     FileDir = 0x0019,
+    E820ReservationTable = 0x8003,
 }
 
 /// an individual file entry, 64 bytes total
@@ -174,6 +175,16 @@ impl FwCfg {
         } else {
             Err("couldn't find requested file")
         }
+    }
+
+    /// Reads the size of the E820 reservation table.
+    ///
+    /// This table predates the file interface and thus has its own selector.
+    pub fn read_e820_reservation_table_size(&mut self) -> Result<u32, &'static str> {
+        let mut reservation_count: u32 = 0;
+        self.write_selector(FwCfgItems::E820ReservationTable as u16)?;
+        self.read(&mut reservation_count)?;
+        Ok(reservation_count)
     }
 
     /// Reads contents of a file; returns the number of bytes actrually read.

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -14,17 +14,21 @@
 // limitations under the License.
 //
 
-use crate::fw_cfg::FwCfg;
+use crate::{cmos::Cmos, fw_cfg::FwCfg};
 use core::{
     ffi::CStr,
     mem::{size_of, MaybeUninit},
 };
-use oak_linux_boot_params::{BootE820Entry, BootParams};
+use oak_linux_boot_params::{BootE820Entry, BootParams, E820EntryType};
+use oak_sev_guest::io::PortFactoryWrapper;
 
 #[link_section = ".boot.zero_page"]
 static mut BOOT_ZERO_PAGE: MaybeUninit<BootParams> = MaybeUninit::uninit();
 
-pub fn init_zero_page(fw_cfg: &mut FwCfg) -> &'static mut BootParams {
+pub fn init_zero_page(
+    fw_cfg: &mut FwCfg,
+    port_factory: PortFactoryWrapper,
+) -> &'static mut BootParams {
     let mut zero_page = unsafe { BOOT_ZERO_PAGE.write(core::mem::zeroed()) };
 
     // Magic constants.
@@ -34,7 +38,7 @@ pub fn init_zero_page(fw_cfg: &mut FwCfg) -> &'static mut BootParams {
     zero_page.hdr.header = 0x53726448; // Magic "HdrS" string
     zero_page.hdr.kernel_alignment = 0x1000000; // Magic number from crosvm source.
 
-    // Load the E820 table from fw_cfg.
+    // Try to load the E820 table from fw_cfg.
     // Safety: BootE820Entry has the same structure as what qemu uses, and we're limiting
     // ourselves to up to 128 entries.
     let len_bytes = unsafe {
@@ -42,10 +46,26 @@ pub fn init_zero_page(fw_cfg: &mut FwCfg) -> &'static mut BootParams {
             CStr::from_bytes_with_nul(b"etc/e820\0").unwrap(),
             &mut zero_page.e820_table,
         )
-    }
-    .unwrap();
-    zero_page.e820_entries = (len_bytes / size_of::<BootE820Entry>()) as u8;
-    zero_page.e820_table[..(zero_page.e820_entries as usize)].sort_unstable_by_key(|x| x.addr());
+    };
+
+    match len_bytes {
+        Ok(len_bytes) => {
+            zero_page.e820_entries = (len_bytes / size_of::<BootE820Entry>()) as u8;
+            zero_page.e820_table[..(zero_page.e820_entries as usize)]
+                .sort_unstable_by_key(|x| x.addr());
+        }
+        Err(err) => {
+            log::warn!("Failed to read 'etc/e820': {}, failing back to CMOS", err);
+
+            // We don't support the early reservation entries, so panic if there are any.
+            if fw_cfg.read_e820_reservation_table_size().unwrap_or(0) > 0 {
+                panic!("QEMU_E820_RESERVATION_TABLE was not empty!");
+            }
+
+            build_e820_from_nvram(zero_page, port_factory).expect("failed to read from CMOS");
+        }
+    };
+
     for entry in zero_page.e820_table() {
         log::debug!(
             "early E820 entry: [{:#018x}-{:#018x}), len {}, type {}",
@@ -57,6 +77,47 @@ pub fn init_zero_page(fw_cfg: &mut FwCfg) -> &'static mut BootParams {
     }
 
     zero_page
+}
+
+/// Builds an E820 table by reading the low and high memory amount from CMOS.
+///
+/// The code is largely based on what SeaBIOS is doing (see `qemu_preinit()` and `qemu_cfg_e820()`
+/// in <https://github.com/qemu/seabios/blob/b0d61ecef66eb05bd7a4eb7ada88ec5dab06dfee/src/fw/paravirt.c>),
+/// but <https://wiki.osdev.org/Detecting_Memory_%28x86%29> is also a good read on the topic.
+fn build_e820_from_nvram(
+    zero_page: &mut BootParams,
+    port_factory: PortFactoryWrapper,
+) -> Result<(), &'static str> {
+    // Safety: (a) fw_cfg is available, so we're running under QEMU(ish) and (b) there was no
+    // pre-built E820 table in fw_cfg; thus, we can reasonably expect CMOS to available, as that's
+    // what SeaBIOS would use in that situation to build the E820 table.
+    let mut cmos = unsafe { Cmos::new(port_factory) };
+    let mut rs = cmos.low_ram_size()?;
+    let high = cmos.high_ram_size()?;
+
+    // Time to put all that we know together.
+    // First, we'll leave the top 256K just below the 4G mark reserved for the BIOS itself.
+    // Second, leave the last 4 pages of low memory as reserved just below the BIOS area as
+    // reserved; according to SeaBIOS, KVM stores some data structures there.
+    // Thus, the maximum memory we can have under 4G is 0x1_0000_0000 - (44 * 0x1000) = 0xFFFB_C000.
+    if rs > 0xFFFB_C000 {
+        rs = 0xFFFB_C000;
+    };
+    zero_page.e820_entries = 2;
+    zero_page.e820_table[0] = BootE820Entry::new(0, rs as usize, E820EntryType::RAM);
+    zero_page.e820_table[1] = BootE820Entry::new(
+        0xFFFB_C000,
+        0x1_0000_0000 - 0xFFFB_C000,
+        E820EntryType::RESERVED,
+    );
+
+    if high > 0 {
+        zero_page.e820_entries += 1;
+        zero_page.e820_table[2] =
+            BootE820Entry::new(0x1_0000_0000, high as usize, E820EntryType::RAM);
+    }
+
+    Ok(())
 }
 
 /// Returns a mutable reference to the zero page, which we assume is initialized.


### PR DESCRIPTION
Sometimes the E820 table is not available in the `fw_cfg` interface, and we have to resort to more arcane methods of determining what memory is available to us.

This code is largely inspired by what SeaBIOS is doing under QEMU in the exact same scenario.