### PR TITLE
Mark the location where we'll write the zero page as unmeasured

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -311,7 +311,7 @@ SECTIONS {
      * Unfortunately it doesn't look like `SIZEOF()` works here, so we have to keep track of the data
      * structure size by hand to ensure that it ends at the correct location in memory.
      */
-    .guid_tables TOP - 0x20 - (16 + 3*12 + 2*22 + 18) : {
+    .guid_tables TOP - 0x20 - (16 + 4*12 + 2*22 + 18) : {
         /* SEV metadata. This data structure is not part of the GUIDed tables, but it makes sense to have
          * them together at the end of the file, thus we put them in the .guid_tables section along with
          * the GUIDed tables themselves. The data structure is defined in the EDK2 source:
@@ -333,6 +333,10 @@ SECTIONS {
         /* Unmeasured page location */
         LONG(ADDR(.boot.ghcb))
         LONG(SIZEOF(.boot.ghcb))
+        LONG(SEV_SECTION_UNMEASURED)
+        /* Zero page location */
+        LONG(ADDR(.boot.zero_page))
+        LONG(SIZEOF(.boot.zero_page))
         LONG(SEV_SECTION_UNMEASURED)
         /* Secrets page location */
         LONG(ADDR(.boot.secrets))


### PR DESCRIPTION
As we're no longer relying on the VMM to provide us with a zero page, we need to ensure that the memory location is validated when we run under SEV-SNP before we write to it.

However, we're in a bit of a chicken and egg scenario here: we need the zero page to know where the physical memory is in order to validate all of the memory, and we need the memory for the zero page to be valid before we write to it.

Thus, add the zero page location to the SEV metadata as an unmeasured page, which means the VMM will do the state change for us before we boot.