### PR TITLE
Always expect `fw_cfg` to be available

### DIFF
--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -119,13 +119,3 @@ fn build_e820_from_nvram(
 
     Ok(())
 }
-
-/// Returns a mutable reference to the zero page, which we assume is initialized.
-///
-/// # Safety
-///
-/// This assumes the VMM has set up the zero page for us. Calling this function without the memory
-/// set up correctly is undefined behaviour.
-pub unsafe fn get_zero_page() -> &'static mut BootParams {
-    BOOT_ZERO_PAGE.assume_init_mut()
-}


### PR DESCRIPTION
Time to do some clean-ups :)

In the past with some VMMs we expected the zero page to be constructed for us. That is no longer the case: for all VMMs, we expect `fw_cfg` to be available, so that we could construct the zero page ourselves inside the VM.

Thus, panic if we don't have `fw_cfg` available.