### PR TITLE
Use an allocator for boot data structures in stage0

### DIFF
--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-traits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2d54853319fd101b8dd81de382bcbf3e03410a64d8928bbee85a3e7dcde483"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +230,7 @@ dependencies = [
  "oak_sev_guest",
  "sev_serial",
  "spinning_top",
+ "static-alloc",
  "static_assertions",
  "strum",
  "x86_64",
@@ -327,6 +334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "static-alloc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570b7e840addf99f80c5b26abba410e21537002316fc82f2747fd87c171e9d7e"
+dependencies = [
+ "alloc-traits",
 ]
 
 [[package]]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -17,6 +17,7 @@ oak_linux_boot_params = { path = "../linux_boot_params" }
 oak_sev_guest = { path = "../oak_sev_guest" }
 sev_serial = { path = "../sev_serial" }
 spinning_top = "*"
+static-alloc = "*"
 static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
 x86_64 = "*"

--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -65,18 +65,6 @@ SECTIONS {
      * 
      * These sections have to be marked NOLOAD, otherwise you risk ending up with a 4GB BIOS image.
      */
-    .boot.gdt 0x1500 (NOLOAD) : {
-        *(.boot.gdt)
-    } > ram_low
-
-    /* The GDT provided by crosvm has 4 entries, which means that the (empty) IDT can go
-     * immediately after that to address 0x1520. The Rust x86_64::GlobalDescriptorTable has 8
-     * entries instead of 4, and the x86_64::InterruptDescriptorTable takes a full 4K of memory, so
-     * let's move it to the next page.
-     */
-    .boot.idt 0x2000 (NOLOAD) : {
-        *(.boot.idt)
-    } > ram_low
     
     .boot.zero_page 0x7000 (NOLOAD) : {
         *(.boot.zero_page)
@@ -84,18 +72,6 @@ SECTIONS {
     ASSERT(SIZEOF(.boot.zero_page) == 4K, "Zero page has to be exactly one page in size")
 
     boot_stack_pointer = 0x8000;
-
-    .boot.pml4 0x9000 (NOLOAD) : {
-        *(.boot.pml4)
-    } > ram_low
-
-    .boot.pdpt 0xA000 (NOLOAD) : {
-        *(.boot.pdpt)
-    } > ram_low
-
-    .boot.pd 0xB000 (NOLOAD) : {
-        *(.boot.pd)
-    } > ram_low
 
     .boot.secrets 0xD000 (NOLOAD) : {
         KEEP(*(.boot.secrets))


### PR DESCRIPTION
Thus far, we've had a lot of tricky code to ensure that the boot data structures end up at well-known addresses (where the addresses were mostly derived from crosvm).

Truth is, it doesn't really matter where in memory those data structures are and we were just making things much more difficult for us.

By using a simple bump allocator -- as we're never going to deallocate anything anyway -- we can make the code much more simpler, more understandable, and safe.