### PR TITLE
Set ACPI RSDP location and kernel command line in zero_page

### DIFF
--- a/stage0/src/acpi.rs
+++ b/stage0/src/acpi.rs
@@ -384,7 +384,10 @@ impl RomfileCommand {
     }
 }
 
-pub fn build_acpi_tables(fwcfg: &mut FwCfg) -> Result<(), &'static str> {
+/// Populates the ACPI tables per linking instructions in `etc/table-loader`.
+///
+/// Returns the address of the RSDP table.
+pub fn build_acpi_tables(fwcfg: &mut FwCfg) -> Result<u64, &'static str> {
     let mut commands: [RomfileCommand; 32] = Default::default();
 
     let file = fwcfg
@@ -415,5 +418,5 @@ pub fn build_acpi_tables(fwcfg: &mut FwCfg) -> Result<(), &'static str> {
         command.invoke(fwcfg)?;
     }
 
-    Ok(())
+    Ok(unsafe { RSDP.as_ptr() } as u64)
 }


### PR DESCRIPTION
Some low-level changes for the future Linux kernel compatibility:

 - set the ACPI RSDP location in the zero page structures. The Linux kernel won't search EBDA for RSDP, it expects the value in the zero page to point to the correct location.
 - if there's a kernel command line available in fw_cfg, load that into memory and pass it to the kernel as well.