### PR TITLE
Move the stage0 stack to low memory, out of BIOS ROM area

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -69,8 +69,6 @@ SECTIONS {
     } > ram_low
     ASSERT(SIZEOF(.boot.zero_page) == 4K, "Zero page has to be exactly one page in size")
 
-    boot_stack_pointer = 0x8000;
-
     .boot.ghcb ALIGN(4K) (NOLOAD) : {
         KEEP(*(.boot.ghcb))
     } > ram_low
@@ -79,6 +77,12 @@ SECTIONS {
     .boot ALIGN(4K) (NOLOAD) : {
         KEEP(*(.boot))
         . = ALIGN(4K);
+    } > ram_low
+
+    /* Put the stack just below the EBDA, at the end of 512K. */
+    .stack (0x80000 - 32K) (NOLOAD) : {
+        . += 32K;
+        stack_start = .;
     } > ram_low
 
     /* EBDA - Extended BIOS Data Area; 128K of memory between [512K, 640K). The RSDP must be within
@@ -145,11 +149,6 @@ SECTIONS {
         bss_start = .;
         *(.bss .bss.*)
         bss_size = . - bss_start;
-    } > bios
-
-    .stack ALIGN(4K) (NOLOAD) : {
-        . += 32K;
-        stack_start = .;
     } > bios
 
     /* Everything below this line interacts with 16-bit code, so should be kept as close to the end of the file as
@@ -295,8 +294,11 @@ SECTIONS {
          * Thankfully none of these clashed with existing data structures that we're setting up.
          */
         /* Unmeasured page location */
-        LONG(ADDR(.boot.ghcb))
-        LONG(SIZEOF(.boot.ghcb))
+        /* We mark the stack as unmeasured, as we need to support interrupts before we even know whether
+         * we're running under some form of SEV, and interrupts require a functioning stack.
+         */
+        LONG(ADDR(.stack))
+        LONG(SIZEOF(.stack))
         LONG(SEV_SECTION_UNMEASURED)
         /* Zero page location */
         LONG(ADDR(.boot.zero_page))

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -63,7 +63,7 @@ extern "C" {
     #[link_name = "pt_addr"]
     static BIOS_PT: c_void;
 
-    #[link_name = "boot_stack_pointer"]
+    #[link_name = "stack_start"]
     static BOOT_STACK_POINTER: c_void;
 }
 


### PR DESCRIPTION
Right now we have the stack somewhere just below the 4 GiB boundary, where the BIOS ROMs are mapped.

This has two unfortunate side effects:
  - Sometimes (like the QEMU q35 machine) the BIOS ROM areas are _really_ read-only. This means having the stack there wouldn't work.
  - Having the stack in there means that 32 KiB of the total 128 KiB image size are just zeroes for the stack. Moving it down will (a) allow us to shave 32K off the BIOS image size, if we want to, and (b) let us increase the stack size, if necessary, without bloating the BIOS image size.

I've also removed the special "boot_stack_pointer"; once we jump to the kernel, we might as well recycle our existing stack as we're not going to use it any longer.