### PR TITLE
Remove the fixed location for GHCB in stage0

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -69,11 +69,6 @@ SECTIONS {
         . = ALIGN(4K);
     } > ram_low
 
-    .boot.ghcb ALIGN(4K) (NOLOAD) : {
-        KEEP(*(.boot.ghcb))
-    } > ram_low
-    ASSERT(SIZEOF(.boot.ghcb) == 4K, "GHCB has to be exactly one page in size")
-
     /* Put the stack just below the EBDA, at the end of 512K. */
     .stack (0x80000 - 32K) (NOLOAD) : {
         . += 32K;


### PR DESCRIPTION
This is the last data structure which has a magic location pre-allocated in the linker script: the GHCB, or guest-host communcation block, that's used under SEV-ES and SEV-SNP to communicate with the hypervisor.

While I do think this code is _a bit_ cleaner than previously, it's still a mess and not particularly Rust-y. This is the minimum I was able to do without starting heavy refactoring of our existing GHCB APIs, so better take the easy win here and come back later for more clean-ups.