### PR TITLE
Try validating memory with 2 MiB pages

### DIFF
--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -27,21 +27,30 @@ use oak_sev_guest::{
 };
 use spinning_top::Spinlock;
 use x86_64::{
-    align_down, align_up,
     instructions::tlb,
     registers::control::Cr3,
-    structures::paging::{PageSize, PageTable, PageTableFlags, PhysFrame, Size2MiB, Size4KiB},
+    structures::paging::{
+        frame::PhysFrameRange, page::AddressNotAligned, Page, PageSize, PageTable, PageTableFlags,
+        PhysFrame, Size1GiB, Size2MiB, Size4KiB,
+    },
     PhysAddr, VirtAddr,
 };
 
 static GHCB_WRAPPER: OnceCell<Spinlock<GhcbProtocol<'static, Ghcb>>> = OnceCell::new();
 
-fn get_pd(encrypted: u64) -> &'static mut PageTable {
+struct PageTables {
+    pub pdpt: &'static mut PageTable,
+    pub pd: &'static mut PageTable,
+}
+
+/// Returns references to the currently active PDPT and PD.
+fn get_page_tables(encrypted: u64) -> PageTables {
     let (pml4_frame, _) = Cr3::read();
     let pml4 =
         unsafe { &*((pml4_frame.start_address().as_u64() & !encrypted) as *const PageTable) };
-    let pdpt = unsafe { &*((pml4[0].addr().as_u64() & !encrypted) as *const PageTable) };
-    unsafe { &mut *((pdpt[0].addr().as_u64() & !encrypted) as *mut PageTable) }
+    let pdpt = unsafe { &mut *((pml4[0].addr().as_u64() & !encrypted) as *mut PageTable) };
+    let pd = unsafe { &mut *((pdpt[0].addr().as_u64() & !encrypted) as *mut PageTable) };
+    PageTables { pdpt, pd }
 }
 
 pub fn init_ghcb(
@@ -52,7 +61,7 @@ pub fn init_ghcb(
     let ghcb_addr = ghcb as *const _ as u64;
 
     // Remove the ENCRYPTED bit from the entry that maps the GHCB.
-    let pd = get_pd(encrypted);
+    let PageTables { pdpt: _, pd } = get_page_tables(encrypted);
     let pt = unsafe { &mut *((pd[0].addr().as_u64() & !encrypted) as *mut PageTable) };
     let idx = (ghcb_addr / Size4KiB::SIZE) as usize;
     pt[idx].set_addr(
@@ -94,7 +103,7 @@ pub fn deinit_ghcb(snp: bool, encrypted: u64) {
         change_snp_page_state(request).expect("couldn't change SNP state for GHCB");
     }
 
-    let pd = get_pd(encrypted);
+    let PageTables { pdpt: _, pd } = get_page_tables(encrypted);
     let pt = unsafe { &mut *((pd[0].addr().as_u64() & !encrypted) as *mut PageTable) };
     let idx = (ghcb_addr / Size4KiB::SIZE) as usize;
     pt[idx].set_addr(
@@ -104,18 +113,235 @@ pub fn deinit_ghcb(snp: bool, encrypted: u64) {
     tlb::flush_all();
 }
 
+// Page tables come in three sizes: for 1 GiB, 2 MiB and 4 KiB pages. However, `PVALIDATE` can only
+// be invoked on 2 MiB and 4 KiB pages.
+// This trait translates between the page sizes defined in the x86_64 crate (`Size4KiB`, `Size2MiB`)
+// and the sizes defined in `oak_sev_guest` crate (`Page4KiB`, `Page2MiB`). There is no mapping for
+// `Size1GiB` as pages of that size can't be used for valitation.
+pub trait ValidatablePageSize {
+    const SEV_PAGE_SIZE: SevPageSize;
+}
+
+impl ValidatablePageSize for Size4KiB {
+    const SEV_PAGE_SIZE: SevPageSize = SevPageSize::Page4KiB;
+}
+
+impl ValidatablePageSize for Size2MiB {
+    const SEV_PAGE_SIZE: SevPageSize = SevPageSize::Page2MiB;
+}
+
+trait Validate<S: PageSize> {
+    fn pvalidate(&self) -> Result<(), InstructionError>;
+}
+
+impl<S: PageSize + ValidatablePageSize> Validate<S> for Page<S> {
+    fn pvalidate(&self) -> Result<(), InstructionError> {
+        pvalidate(
+            self.start_address().as_u64() as usize,
+            S::SEV_PAGE_SIZE,
+            Validation::Validated,
+        )
+    }
+}
+
+/// Container for a page of virtual memory, and the page table that controls the mappings for that
+/// page.
+struct MappedPage<S: PageSize> {
+    pub page: Page<S>,
+    pub page_table: PageTable,
+}
+
+impl<S: PageSize> MappedPage<S> {
+    pub fn new(vaddr: VirtAddr) -> Result<Self, AddressNotAligned> {
+        let mapped_page = Self {
+            page: Page::from_start_address(vaddr)?,
+            page_table: PageTable::new(),
+        };
+        Ok(mapped_page)
+    }
+}
+
+fn pvalidate_range<S: PageSize + ValidatablePageSize, T: PageSize, F>(
+    range: &PhysFrameRange<S>,
+    memory: &mut MappedPage<T>,
+    encrypted: u64,
+    flags: PageTableFlags,
+    mut f: F,
+) -> Result<(), InstructionError>
+where
+    F: FnMut(PhysAddr, InstructionError) -> Result<(), InstructionError>,
+{
+    // Create a copy as we'll be consuming the range as we call `next()`, below.
+    let mut range = *range;
+
+    // A page table consists of 512 entries; let's figure out what the pages would be.
+    let start = Page::from_start_address(memory.page.start_address()).unwrap();
+    let pages = Page::<S>::range(start, start + 512);
+
+    // We have 512 entries to play with, but the frame range can contain many more entries than
+    // that. Thus, we need to iterate over the range in chunks of 512; the easiest way to do it is
+    // to iterate (mutably) over the page directory itself, and for each entry, fetch the next
+    // entry in the range. If we've covered everything, `range.next()` will return `None`, and
+    // the count will be zero once we've covered everything.
+    memory.page_table.zero();
+    while memory
+        .page_table
+        .iter_mut()
+        .filter_map(|entry| range.next().map(|frame| (entry, frame)))
+        .map(|(entry, frame)| {
+            entry.set_addr(
+                frame.start_address() + encrypted,
+                PageTableFlags::PRESENT | flags,
+            )
+        })
+        .count()
+        > 0
+    {
+        // We now know we've filled in at least one entry of the page table, and thus have something
+        // to validate.
+        tlb::flush_all();
+
+        if let Some((_, err)) = memory
+            .page_table
+            .iter()
+            .zip(pages)
+            .filter(|(entry, _)| !entry.is_unused())
+            .map(|(entry, page)| (entry, page.pvalidate()))
+            .map(|(entry, result)| (entry, result.or_else(|err| f(entry.addr(), err))))
+            .find(|(_, result)| result.is_err())
+        {
+            return err;
+        }
+
+        // Clear out the page table, ready for the next iteration.
+        memory.page_table.zero();
+    }
+
+    Ok(())
+}
+
+trait Validatable4KiB {
+    /// Validate a region of memory using 4 KiB pages.
+    ///
+    /// Args:
+    ///   pt: pointer to the page table we can mutate to map 4 KiB pages to memory
+    ///   encrypted: value of the encrypted bit in the page table
+    fn pvalidate(
+        &self,
+        pt: &mut MappedPage<Size2MiB>,
+        encrypted: u64,
+    ) -> Result<(), InstructionError>;
+}
+
+impl Validatable4KiB for PhysFrameRange<Size4KiB> {
+    fn pvalidate(
+        &self,
+        pt: &mut MappedPage<Size2MiB>,
+        encrypted: u64,
+    ) -> Result<(), InstructionError> {
+        pvalidate_range(
+            self,
+            pt,
+            encrypted,
+            PageTableFlags::empty(),
+            |addr, err| match err {
+                InstructionError::ValidationStatusNotUpdated => {
+                    let addr = addr.as_u64() & !encrypted;
+
+                    // Failing validation for addresses < 1 MiB is fine, as that memory was
+                    // validated in bootstrap assembly.
+                    if addr < 0x100000 {
+                        return Ok(());
+                    }
+
+                    log::warn!("validation status not updated for address {:#018x}", addr);
+                    Ok(())
+                }
+                other => Err(other),
+            },
+        )
+    }
+}
+
+trait Validatable2MiB {
+    /// Validate a region of memory using 2 MiB pages, falling back to 4 KiB if necessary.
+    ///
+    /// Args:
+    ///   pd: pointer to the page directory we can mutate to map 2 MiB pages to memory
+    ///   pt: pointer to the page table we can mutate to map 4 KiB pages to memory
+    ///   encrypted: value of the encrypted bit in the page table
+    fn pvalidate(
+        &self,
+        pd: &mut MappedPage<Size1GiB>,
+        pt: &mut MappedPage<Size2MiB>,
+        encrypted: u64,
+    ) -> Result<(), InstructionError>;
+}
+
+impl Validatable2MiB for PhysFrameRange<Size2MiB> {
+    fn pvalidate(
+        &self,
+        pd: &mut MappedPage<Size1GiB>,
+        pt: &mut MappedPage<Size2MiB>,
+        encrypted: u64,
+    ) -> Result<(), InstructionError> {
+        pvalidate_range(
+            self,
+            pd,
+            encrypted,
+            PageTableFlags::HUGE_PAGE,
+            |addr, err| match err {
+                InstructionError::FailSizeMismatch => {
+                    // 2MiB is no go, fail back to 4KiB pages.
+                    // This will not panic as every address that is 2 MiB-aligned is by definition
+                    // also 4 KiB-aligned.
+                    let start = PhysFrame::<Size4KiB>::from_start_address(PhysAddr::new(
+                        addr.as_u64() & !encrypted,
+                    ))
+                    .unwrap();
+                    let range = PhysFrame::range(start, start + 512);
+                    range.pvalidate(pt, encrypted)
+                }
+                other => {
+                    log::error!(
+                        "validation failure for address {:#018x}: {:?}",
+                        addr.as_u64() & !encrypted,
+                        other
+                    );
+                    Err(other)
+                }
+            },
+        )
+    }
+}
+
 /// Calls `PVALIDATE` on all memory ranges specified in the E820 table with type `RAM`.
 pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
-    let mut page_table = PageTable::new();
+    log::info!("starting SEV-SNP memory validation");
 
+    let PageTables { pdpt, pd } = get_page_tables(encrypted);
+
+    // Page directory, for validation with 2 MiB pages.
+    let mut validation_pd = MappedPage::new(VirtAddr::new(Size1GiB::SIZE)).unwrap();
+    // For virtual address space, we currently shouldn't have anything at the second gigabyte, so we
+    // can map the page to virtual address [1 GiB..2 GiB).
+    if pdpt[1].flags().contains(PageTableFlags::PRESENT) {
+        panic!("PDPT[1] is in use");
+    }
+    pdpt[1].set_addr(
+        PhysAddr::new(&validation_pd.page_table as *const _ as u64 | encrypted),
+        PageTableFlags::PRESENT,
+    );
+
+    // Page table, for validation with 4 KiB pages.
+    let mut validation_pt = MappedPage::new(VirtAddr::new(Size2MiB::SIZE)).unwrap();
     // Find a location for our (temporary) page table. The initial page tables map [0..2MiB), so it
     // should be safe to put our temporary mappings at [2..4MiB).
-    let pd = get_pd(encrypted);
     if pd[1].flags().contains(PageTableFlags::PRESENT) {
         panic!("PD[1] is in use");
     }
     pd[1].set_addr(
-        PhysAddr::new(&page_table as *const _ as u64 | encrypted),
+        PhysAddr::new(&validation_pt.page_table as *const _ as u64 | encrypted),
         PageTableFlags::PRESENT,
     );
 
@@ -124,59 +350,30 @@ pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
             continue;
         }
 
-        let mut range = PhysFrame::<Size4KiB>::range(
-            PhysFrame::from_start_address(PhysAddr::new(align_up(
-                entry.addr() as u64,
-                Size4KiB::SIZE,
-            )))
-            .unwrap(),
-            PhysFrame::from_start_address(PhysAddr::new(align_down(
-                (entry.addr() + entry.size()) as u64,
-                Size4KiB::SIZE,
-            )))
-            .unwrap(),
-        );
+        let start_address = PhysAddr::new(entry.addr() as u64);
+        let limit_address = PhysAddr::new((entry.addr() + entry.size()) as u64);
 
-        // Our temporary page table will only fit 512 4K frames at a time, so iterate in chunks of
-        // 512 (with the last one being smaller if needed)
-        while page_table
-            .iter_mut()
-            .map(|pte| {
-                if let Some(frame) = range.next() {
-                    pte.set_addr(frame.start_address() + encrypted, PageTableFlags::PRESENT);
-                    1
-                } else {
-                    0
-                }
-            })
-            .sum::<u64>()
-            > 0
-        {
-            tlb::flush_all();
-
-            if let Some(err) = page_table
-                .iter()
-                .enumerate()
-                .filter(|(_, entry)| !entry.is_unused())
-                .map(|(n, _)| {
-                    pvalidate(
-                        Size2MiB::SIZE as usize + (n * Size4KiB::SIZE as usize),
-                        SevPageSize::Page4KiB,
-                        Validation::Validated,
-                    )
-                })
-                .map(|result| match result {
-                    Err(InstructionError::ValidationStatusNotUpdated) => Ok(()),
-                    other => other,
-                })
-                .find(|result| result.is_err())
-            {
-                panic!("unexpected error: {:?}", err);
-            }
-
-            page_table.zero();
+        // If the memory boundaries align with 2 MiB, start with that.
+        if start_address.is_aligned(Size2MiB::SIZE) && limit_address.is_aligned(Size2MiB::SIZE) {
+            // These unwraps can't fail as we've made sure that the addresses are 2 MiB-aligned.
+            let range = PhysFrame::<Size2MiB>::range(
+                PhysFrame::from_start_address(start_address).unwrap(),
+                PhysFrame::from_start_address(limit_address).unwrap(),
+            );
+            range.pvalidate(&mut validation_pd, &mut validation_pt, encrypted)
+        } else {
+            // No such luck, fail over to 4K pages.
+            // The unwraps can't fail as we make sure that the addresses are 4 KiB-aligned.
+            let range = PhysFrame::<Size4KiB>::range(
+                PhysFrame::from_start_address(start_address.align_up(Size4KiB::SIZE)).unwrap(),
+                PhysFrame::from_start_address(limit_address.align_down(Size4KiB::SIZE)).unwrap(),
+            );
+            range.pvalidate(&mut validation_pt, encrypted)
         }
+        .expect("failed to validate memory");
     }
     pd[1].set_unused();
+    pdpt[1].set_unused();
     tlb::flush_all();
+    log::info!("SEV-SNP memory validation complete.");
 }


### PR DESCRIPTION
One of the most important things we have to do in stage0 when running under SEV-SNP is to run `PVALIDATE` on all of the physical memory to ensure it's marked as guest-private.

Right now we just blindly iterate over all the memory using 4 KiB pages. However, this means that if the host side was using 2 MiB pages, the host needs to create a 4 KiB page table on the host side as well -- incurring a significant overhead, especially if we give a large amount of memory to the guest (consider 8 GiB of memory: using 2 MiB pages, it takes 8 page tables, or 32 KiB, to cover the whole range; with 4 KiB pages, it takes 4096 page tables, or 16 MiB).

Thus, let's first try `PVALIDATE` using 2 MiB pages in hopes that it aligns with what the host is using. If we get `FailSizeMismatch`, which means that the _host_ was using 4 KiB pages for that memory, then we fall back to validating using 4 KiB pages as well.

Note that this code is still playing it fast and loose with any errors: we fully expect some memory regions to fail (e.g. the first 1 MiB that we `PVALIDATE` in the bootstrap assembly code, and the regions where we get data copied in by the host), but whereas thus far we've been just ignoring the errors, we'll now at least log them.