### PR TITLE
Move BSS to low memory and put the allocator in there

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -69,6 +69,12 @@ SECTIONS {
         . = ALIGN(4K);
     } > ram_low
 
+    .bss (NOLOAD) : {
+        bss_start = .;
+        *(.bss .bss.*)
+        bss_size = . - bss_start;
+    } > ram_low
+
     /* Put the stack just below the EBDA, at the end of 512K. */
     .stack (0x80000 - 32K) (NOLOAD) : {
         . += 32K;
@@ -133,12 +139,6 @@ SECTIONS {
 
     .data : {
         *(.data .data.*)
-    } > bios
-
-    .bss (NOLOAD) : {
-        bss_start = .;
-        *(.bss .bss.*)
-        bss_size = . - bss_start;
     } > bios
 
     /* Everything below this line interacts with 16-bit code, so should be kept as close to the end of the file as


### PR DESCRIPTION
For context, `.bss` is the section in the compiled binary where zero-initialized static variables are placed. The memory gets zeroed out in `boot.s` , just before we jump to Rust. (For static variables that _have_ an initial value, they end up in `.data`.)

Shuffling these around has the following benefits:
  - Moving BSS to low memory means that the BIOS image can be smaller.
  - Increased compatibility as we won't try to write to BIOS memory region (as that sometimes is indeed read-only)
  - Moving the `BOOT_ALLOC` to the BSS allows us to simplify the code and get rid of one `unsafe` block.