### PR TITLE
Instantiate a channel in the payload, not the kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,6 @@ dependencies = [
  "oak_channel",
  "oak_core",
  "oak_linux_boot_params",
- "oak_restricted_kernel_api",
  "oak_restricted_kernel_interface",
  "oak_sev_guest",
  "oak_simple_io",

--- a/oak_functions_enclave/Cargo.lock
+++ b/oak_functions_enclave/Cargo.lock
@@ -643,6 +643,7 @@ dependencies = [
  "oak_remote_attestation",
  "oak_remote_attestation_amd",
  "oak_restricted_kernel",
+ "oak_restricted_kernel_api",
  "static_assertions",
 ]
 
@@ -772,7 +773,6 @@ dependencies = [
  "oak_channel",
  "oak_core",
  "oak_linux_boot_params",
- "oak_restricted_kernel_api",
  "oak_restricted_kernel_interface",
  "oak_sev_guest",
  "oak_simple_io",

--- a/oak_functions_enclave/Cargo.toml
+++ b/oak_functions_enclave/Cargo.toml
@@ -20,6 +20,7 @@ serial_channel = ["oak_restricted_kernel/serial_channel"]
 log = "*"
 oak_channel = { path = "../oak_channel" }
 oak_restricted_kernel = { path = "../oak_restricted_kernel", default-features = false }
+oak_restricted_kernel_api = { path = "../oak_restricted_kernel_api" }
 oak_functions_service = { path = "../oak_functions_service", default-features = false }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 oak_remote_attestation = { path = "../oak_remote_attestation", default-features = false, features = [

--- a/oak_functions_enclave/src/main.rs
+++ b/oak_functions_enclave/src/main.rs
@@ -23,23 +23,23 @@ extern crate alloc;
 use alloc::{boxed::Box, sync::Arc};
 use core::panic::PanicInfo;
 use log::info;
-use oak_channel::Channel;
 use oak_linux_boot_params::BootParams;
 use oak_remote_attestation_amd::PlaceholderAmdAttestationGenerator;
+use oak_restricted_kernel_api::FileDescriptorChannel;
 
 #[no_mangle]
 pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
-    let channel = oak_restricted_kernel::start_kernel(rsi);
-    main(channel)
+    oak_restricted_kernel::start_kernel(rsi);
+    main()
 }
 
-fn main(channel: Box<dyn Channel>) -> ! {
+fn main() -> ! {
     info!("In main!");
     let service = oak_functions_service::OakFunctionsService::new(Arc::new(
         PlaceholderAmdAttestationGenerator,
     ));
     let server = oak_functions_service::schema::OakFunctionsServer::new(service);
-    oak_channel::server::start_blocking_server(channel, server)
+    oak_channel::server::start_blocking_server(Box::<FileDescriptorChannel>::default(), server)
         .expect("server encountered an unrecoverable error");
 }
 

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -35,7 +35,6 @@ oak_channel = { path = "../oak_channel" }
 oak_core = { path = "../oak_core" }
 oak_simple_io = { path = "../oak_simple_io", optional = true }
 oak_linux_boot_params = { path = "../linux_boot_params" }
-oak_restricted_kernel_api = { path = "../oak_restricted_kernel_api" }
 oak_restricted_kernel_interface = { path = "../oak_restricted_kernel_interface" }
 rust-hypervisor-firmware-virtio = { path = "../third_party/rust-hypervisor-firmware-virtio" }
 oak_sev_guest = { path = "../oak_sev_guest" }

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -78,7 +78,6 @@ use mm::encrypted_mapper::{EncryptedPageTable, PhysOffset};
 use oak_channel::Channel;
 use oak_core::sync::OnceCell;
 use oak_linux_boot_params::BootParams;
-use oak_restricted_kernel_api::FileDescriptorChannel;
 use oak_sev_guest::msr::{change_snp_state_for_frame, get_sev_status, PageAssignment, SevStatus};
 use strum::{EnumIter, EnumString, IntoEnumIterator};
 use x86_64::{
@@ -94,7 +93,7 @@ pub static ADDRESS_TRANSLATOR: OnceCell<EncryptedPageTable<MappedPageTable<'stat
     OnceCell::new();
 
 /// Main entry point for the kernel, to be called from bootloader.
-pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
+pub fn start_kernel(info: &BootParams) {
     avx::enable_avx();
     descriptors::init_gdt();
     interrupts::init_idt();
@@ -239,8 +238,6 @@ pub fn start_kernel(info: &BootParams) -> Box<dyn Channel> {
     );
 
     syscall::enable_syscalls(channel);
-
-    Box::<FileDescriptorChannel>::default()
 }
 
 #[derive(EnumIter, EnumString)]

--- a/oak_tensorflow_enclave/Cargo.lock
+++ b/oak_tensorflow_enclave/Cargo.lock
@@ -427,7 +427,6 @@ dependencies = [
  "oak_channel",
  "oak_core",
  "oak_linux_boot_params",
- "oak_restricted_kernel_api",
  "oak_restricted_kernel_interface",
  "oak_sev_guest",
  "oak_simple_io",
@@ -491,6 +490,7 @@ dependencies = [
  "oak_channel",
  "oak_linux_boot_params",
  "oak_restricted_kernel",
+ "oak_restricted_kernel_api",
  "oak_tensorflow_service",
  "static_assertions",
 ]

--- a/oak_tensorflow_enclave/Cargo.toml
+++ b/oak_tensorflow_enclave/Cargo.toml
@@ -19,6 +19,7 @@ oak_tensorflow_service = { path = "../oak_tensorflow_service" }
 log = "*"
 oak_channel = { path = "../oak_channel" }
 oak_restricted_kernel = { path = "../oak_restricted_kernel", default-features = false }
+oak_restricted_kernel_api = { path = "../oak_restricted_kernel_api" }
 micro_rpc = { path = "../micro_rpc" }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 static_assertions = "*"

--- a/oak_tensorflow_enclave/src/main.rs
+++ b/oak_tensorflow_enclave/src/main.rs
@@ -23,20 +23,20 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::panic::PanicInfo;
 use log::info;
-use oak_channel::Channel;
 use oak_linux_boot_params::BootParams;
+use oak_restricted_kernel_api::FileDescriptorChannel;
 
 #[no_mangle]
 pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
-    let channel = oak_restricted_kernel::start_kernel(rsi);
+    oak_restricted_kernel::start_kernel(rsi);
     info!("In main!");
-    start_server(channel)
+    start_server()
 }
 
-fn start_server(channel: Box<dyn Channel>) -> ! {
+fn start_server() -> ! {
     let service = oak_tensorflow_service::TensorflowService::new();
     let server = oak_tensorflow_service::schema::TensorflowServer::new(service);
-    oak_channel::server::start_blocking_server(channel, server)
+    oak_channel::server::start_blocking_server(Box::<FileDescriptorChannel>::default(), server)
         .expect("server encountered an unrecoverable error")
 }
 

--- a/testing/oak_echo_enclave/Cargo.lock
+++ b/testing/oak_echo_enclave/Cargo.lock
@@ -409,6 +409,7 @@ dependencies = [
  "oak_echo_service",
  "oak_linux_boot_params",
  "oak_restricted_kernel",
+ "oak_restricted_kernel_api",
  "static_assertions",
 ]
 
@@ -451,7 +452,6 @@ dependencies = [
  "oak_channel",
  "oak_core",
  "oak_linux_boot_params",
- "oak_restricted_kernel_api",
  "oak_restricted_kernel_interface",
  "oak_sev_guest",
  "oak_simple_io",

--- a/testing/oak_echo_enclave/Cargo.toml
+++ b/testing/oak_echo_enclave/Cargo.toml
@@ -19,6 +19,7 @@ oak_echo_service = { path = "../oak_echo_service" }
 log = "*"
 oak_channel = { path = "../../oak_channel" }
 oak_restricted_kernel = { path = "../../oak_restricted_kernel", default-features = false }
+oak_restricted_kernel_api = { path = "../../oak_restricted_kernel_api" }
 micro_rpc = { path = "../../micro_rpc" }
 oak_linux_boot_params = { path = "../../linux_boot_params" }
 static_assertions = "*"

--- a/testing/oak_echo_enclave/src/main.rs
+++ b/testing/oak_echo_enclave/src/main.rs
@@ -23,22 +23,22 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::panic::PanicInfo;
 use log::info;
-use oak_channel::Channel;
 use oak_linux_boot_params::BootParams;
+use oak_restricted_kernel_api::FileDescriptorChannel;
 
 #[no_mangle]
 pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
-    let channel = oak_restricted_kernel::start_kernel(rsi);
+    oak_restricted_kernel::start_kernel(rsi);
     info!("In main!");
-    start_echo_server(channel)
+    start_echo_server()
 }
 
 // Starts an echo server that uses the Oak communication channel:
 // https://github.com/project-oak/oak/blob/main/oak_channel/SPEC.md
-fn start_echo_server(channel: Box<dyn Channel>) -> ! {
+fn start_echo_server() -> ! {
     let service = oak_echo_service::EchoService::default();
     let server = oak_echo_service::proto::EchoServer::new(service);
-    oak_channel::server::start_blocking_server(channel, server)
+    oak_channel::server::start_blocking_server(Box::<FileDescriptorChannel>::default(), server)
         .expect("server encountered an unrecoverable error");
 }
 

--- a/testing/oak_echo_raw_enclave/Cargo.lock
+++ b/testing/oak_echo_raw_enclave/Cargo.lock
@@ -383,6 +383,7 @@ dependencies = [
  "oak_channel",
  "oak_linux_boot_params",
  "oak_restricted_kernel",
+ "oak_restricted_kernel_api",
  "static_assertions",
 ]
 
@@ -414,7 +415,6 @@ dependencies = [
  "oak_channel",
  "oak_core",
  "oak_linux_boot_params",
- "oak_restricted_kernel_api",
  "oak_restricted_kernel_interface",
  "oak_sev_guest",
  "oak_simple_io",

--- a/testing/oak_echo_raw_enclave/Cargo.toml
+++ b/testing/oak_echo_raw_enclave/Cargo.toml
@@ -18,6 +18,7 @@ simple_io_channel = ["oak_restricted_kernel/simple_io_channel"]
 log = "*"
 oak_channel = { path = "../../oak_channel" }
 oak_restricted_kernel = { path = "../../oak_restricted_kernel", default-features = false }
+oak_restricted_kernel_api = { path = "../../oak_restricted_kernel_api" }
 micro_rpc = { path = "../../micro_rpc" }
 oak_linux_boot_params = { path = "../../linux_boot_params" }
 static_assertions = "*"

--- a/testing/oak_echo_raw_enclave/src/main.rs
+++ b/testing/oak_echo_raw_enclave/src/main.rs
@@ -20,24 +20,26 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::{vec, vec::Vec};
 use core::panic::PanicInfo;
 use log::info;
-use oak_channel::Channel;
+use oak_channel::{Read, Write};
 use oak_linux_boot_params::BootParams;
+use oak_restricted_kernel_api::FileDescriptorChannel;
 
 const MESSAGE_SIZE: usize = 1;
 
 #[no_mangle]
 pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
-    let channel = oak_restricted_kernel::start_kernel(rsi);
+    oak_restricted_kernel::start_kernel(rsi);
     info!("In main!");
-    start_echo_server(channel)
+    start_echo_server()
 }
 
 // Starts an echo server that reads single bytes from the channel and writes
 // them back.
-fn start_echo_server(mut channel: Box<dyn Channel>) -> ! {
+fn start_echo_server() -> ! {
+    let mut channel = FileDescriptorChannel::default();
     loop {
         let bytes = {
             let mut bytes: Vec<u8> = vec![0; MESSAGE_SIZE];


### PR DESCRIPTION
The actual implementation if the channel (virtio-vsock, virtio-console, serial, simpleio) is now hidden in the kernel. The payload code should just use the newly-introduced syscall interface to communicate with the kernel.

Thus, we can move the actual channel instantiation to the payload crates and out of the kernel. I think we might be able to do some more clean-up here (like replacing the Box<dyn Channel> with a generic argument and getting rid of the box altogether), but that can wait for a future PR.