### PR TITLE
Allow for multiple file descriptors in read/write/sync

### DIFF
--- a/oak_restricted_kernel/src/syscall/channel.rs
+++ b/oak_restricted_kernel/src/syscall/channel.rs
@@ -14,22 +14,13 @@
 // limitations under the License.
 //
 
-use core::ffi::{c_int, c_size_t, c_ssize_t, c_void};
-
-use alloc::{boxed::Box, slice};
+use super::fd::FileDescriptor;
+use alloc::boxed::Box;
 use oak_channel::Channel;
-use oak_core::sync::OnceCell;
-use oak_restricted_kernel_interface::Errno;
-use spinning_top::Spinlock;
-
-trait FileDescriptor {
-    fn read(&mut self, buf: &mut [u8]) -> Result<isize, Errno>;
-    fn write(&mut self, buf: &[u8]) -> Result<isize, Errno>;
-    fn sync(&mut self) -> Result<(), Errno>;
-}
+use oak_restricted_kernel_interface::{Errno, OAK_CHANNEL_FD};
 
 #[repr(transparent)]
-struct ChannelDescriptor {
+pub struct ChannelDescriptor {
     channel: Box<dyn Channel>,
 }
 
@@ -58,48 +49,9 @@ impl FileDescriptor for ChannelDescriptor {
     }
 }
 
-static CHANNEL_DESCRIPTOR: OnceCell<Spinlock<ChannelDescriptor>> = OnceCell::new();
-
-pub fn init(channel: Box<dyn Channel>) {
-    CHANNEL_DESCRIPTOR
-        .set(Spinlock::new(ChannelDescriptor::new(channel)))
-        .map_err(|_| ())
-        .expect("communication channel was already initialised");
-}
-
-pub fn syscall_read(_fd: c_int, buf: *mut c_void, count: c_size_t) -> c_ssize_t {
-    // We should validate that the pointer and count are valid, as these come from userspace and
-    // therefore are not to be trusted, but right now everything is in kernel space so there is
-    // nothing to check.
-    let data = unsafe { slice::from_raw_parts_mut(buf as *mut u8, count) };
-
-    let mut channel = CHANNEL_DESCRIPTOR
-        .get()
-        .expect("syscall interface not ready yet")
-        .lock();
-    channel.read(data).unwrap_or_else(|err| err as isize)
-}
-
-pub fn syscall_write(_fd: c_int, buf: *const c_void, count: c_size_t) -> c_ssize_t {
-    // We should validate that the pointer and count are valid, as these come from userspace and
-    // therefore are not to be trusted, but right now everything is in kernel space so there is
-    // nothing to check.
-    let data = unsafe { slice::from_raw_parts(buf as *mut u8, count) };
-
-    let mut channel = CHANNEL_DESCRIPTOR
-        .get()
-        .expect("syscall interface not ready yet")
-        .lock();
-    channel.write(data).unwrap_or_else(|err| err as isize)
-}
-
-pub fn syscall_fsync(_fd: c_int) -> c_ssize_t {
-    let mut channel = CHANNEL_DESCRIPTOR
-        .get()
-        .expect("syscall interface not ready yet")
-        .lock();
-    channel
-        .sync()
-        .map(|()| 0)
-        .unwrap_or_else(|err| err as isize)
+/// Registers a handler for the Oak communication channel file descriptor (`OAK_CHANNEL_FD`)
+pub fn register(channel: Box<dyn Channel>) {
+    super::fd::register(OAK_CHANNEL_FD, Box::new(ChannelDescriptor::new(channel)))
+        .map_err(|_| ()) // throw away the box we get back
+        .expect("communication channel was already registered");
 }

--- a/oak_restricted_kernel/src/syscall/fd.rs
+++ b/oak_restricted_kernel/src/syscall/fd.rs
@@ -1,0 +1,98 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use alloc::{
+    boxed::Box,
+    collections::{btree_map::Entry, BTreeMap},
+    slice,
+};
+use core::ffi::{c_int, c_size_t, c_ssize_t, c_void};
+use oak_restricted_kernel_interface::Errno;
+use spinning_top::Spinlock;
+
+pub trait FileDescriptor: Send {
+    fn read(&mut self, buf: &mut [u8]) -> Result<isize, Errno>;
+    fn write(&mut self, buf: &[u8]) -> Result<isize, Errno>;
+    fn sync(&mut self) -> Result<(), Errno>;
+}
+
+type Fd = c_int;
+
+static FILE_DESCRIPTORS: Spinlock<BTreeMap<Fd, Box<dyn FileDescriptor>>> =
+    Spinlock::new(BTreeMap::new());
+
+/// Register a file descriptor.
+///
+/// This is kind of similar to what the "open" syscall would do, except that we don't expose this to
+/// the user space and we don't allocate file descriptors.
+///
+/// Returns the FileDescriptor object back as an error if the fd is already in use.
+pub fn register(
+    fd: Fd,
+    descriptor: Box<dyn FileDescriptor>,
+) -> Result<(), Box<dyn FileDescriptor>> {
+    let mut descriptors = FILE_DESCRIPTORS.lock();
+
+    if let Entry::Vacant(e) = descriptors.entry(fd) {
+        e.insert(descriptor);
+        Ok(())
+    } else {
+        Err(descriptor)
+    }
+}
+
+/// Unregisters a file descriptor.
+///
+/// If the fd was registered, returns the FileDescriptor object backing it; if the fd was
+/// unregistered, returns None.
+#[allow(dead_code)]
+pub fn unregister(fd: Fd) -> Option<Box<dyn FileDescriptor>> {
+    FILE_DESCRIPTORS.lock().remove(&fd)
+}
+
+pub fn syscall_read(fd: c_int, buf: *mut c_void, count: c_size_t) -> c_ssize_t {
+    // We should validate that the pointer and count are valid, as these come from userspace and
+    // therefore are not to be trusted, but right now everything is in kernel space so there is
+    // nothing to check.
+    let data = unsafe { slice::from_raw_parts_mut(buf as *mut u8, count) };
+
+    FILE_DESCRIPTORS
+        .lock()
+        .get_mut(&fd)
+        .map(|channel| channel.read(data).unwrap_or_else(|err| err as isize))
+        .unwrap_or(Errno::EBADF as isize)
+}
+
+pub fn syscall_write(fd: c_int, buf: *const c_void, count: c_size_t) -> c_ssize_t {
+    // We should validate that the pointer and count are valid, as these come from userspace and
+    // therefore are not to be trusted, but right now everything is in kernel space so there is
+    // nothing to check.
+    let data = unsafe { slice::from_raw_parts(buf as *mut u8, count) };
+
+    FILE_DESCRIPTORS
+        .lock()
+        .get_mut(&fd)
+        .map(|channel| channel.write(data).unwrap_or_else(|err| err as isize))
+        .unwrap_or(Errno::EBADF as isize)
+}
+
+pub fn syscall_fsync(fd: c_int) -> c_ssize_t {
+    FILE_DESCRIPTORS
+        .lock()
+        .get_mut(&fd)
+        .map(|channel| channel.sync().map_or_else(|err| err as isize, |()| 0))
+        .unwrap_or(Errno::EBADF as isize)
+}

--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -15,7 +15,10 @@
 //
 
 mod channel;
+mod fd;
+mod stdio;
 
+use self::fd::{syscall_fsync, syscall_read, syscall_write};
 use alloc::boxed::Box;
 use core::{arch::asm, ffi::c_void};
 use oak_channel::Channel;
@@ -28,10 +31,9 @@ use x86_64::{
     VirtAddr,
 };
 
-use self::channel::{syscall_fsync, syscall_read, syscall_write};
-
 pub fn enable_syscalls(channel: Box<dyn Channel>) {
-    channel::init(channel);
+    channel::register(channel);
+    stdio::register();
 
     LStar::write(VirtAddr::new(syscall_entrypoint as *const fn() as u64));
     unsafe {

--- a/oak_restricted_kernel/src/syscall/stdio.rs
+++ b/oak_restricted_kernel/src/syscall/stdio.rs
@@ -1,0 +1,58 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::logging::SERIAL1;
+
+use super::fd::FileDescriptor;
+use alloc::boxed::Box;
+use core::cmp::min;
+use oak_restricted_kernel_interface::Errno;
+
+#[derive(Default)]
+struct Stderr {}
+
+impl FileDescriptor for Stderr {
+    fn read(&mut self, _buf: &mut [u8]) -> Result<isize, oak_restricted_kernel_interface::Errno> {
+        Err(Errno::EINVAL)
+    }
+
+    fn write(&mut self, buf: &[u8]) -> Result<isize, oak_restricted_kernel_interface::Errno> {
+        // buf may be up to usize, but we need to return the number of bytes as isize. Let's follow
+        // the Linux example of only writing up to isize::MAX bytes.
+        let buf = &buf[..min(buf.len(), isize::MAX as usize)];
+        let mut lock = SERIAL1.lock();
+        let port = lock.as_mut().unwrap();
+        for &byte in buf {
+            // We don't log the error, as (a) we're holding the mutex on the serial port so logging
+            // wouldn't work, and (b) it's the write to the serial port that failed, and our
+            // logs would go over the exact same serial port so writing the log would likely fail as
+            // well.
+            port.send(byte).map_err(|_| Errno::EIO)?;
+        }
+        Ok(buf.len() as isize)
+    }
+
+    fn sync(&mut self) -> Result<(), oak_restricted_kernel_interface::Errno> {
+        Ok(())
+    }
+}
+
+/// Registers a file descriptor for stderr (2)
+pub fn register() {
+    super::fd::register(2, Box::<Stderr>::default())
+        .map_err(|_| ()) // throw away the box
+        .expect("stderr already registered");
+}

--- a/oak_restricted_kernel_interface/src/syscalls.rs
+++ b/oak_restricted_kernel_interface/src/syscalls.rs
@@ -29,8 +29,7 @@ pub enum Syscall {
     /// Read from a file descriptor.
     ///
     /// Arguments:
-    ///   - arg0 (c_ssize_t): file descriptor number. Ignored by the kernel as we don't support
-    ///     multiple file descriptors.
+    ///   - arg0 (c_ssize_t): file descriptor number
     ///   - arg1 (*mut c_void): pointer to the buffer to be filled
     ///   - arg2 (c_size_t): size of the buffer
     /// Returns:
@@ -40,8 +39,7 @@ pub enum Syscall {
     /// Write to a file descriptor.
     ///
     /// Arguments:
-    ///   - arg0 (c_ssize_t): file descriptor number. Ignored by the kernel as we don't support
-    ///     multiple file descriptors.
+    ///   - arg0 (c_ssize_t): file descriptor number
     ///   - arg1 (*const c_void): pointer to the buffer containing data to be written
     ///   - arg2 (c_size_t): size of the buffer
     /// Returns:


### PR DESCRIPTION
Here we shuffle the code around a little bit (extracting the generic file descriptor code to a separate file), make it possible to have multiple file descriptors and register a handler for FD 2 (stdout) that just dumps data to the serial port.

The goal is that anything our future user space code writes to stdout (logging) would end up with the kernel logs.

Longer-term, as we've discussed previously, we probably want to treat the logs coming from user space differently than the kernel logs as they can potentially contain data we shouldn't leak. But for now, let's just proxy everything.