### PR TITLE
Allocate only the necessary memory to the kernel heap

### DIFF
--- a/oak_restricted_kernel/src/attestation.rs
+++ b/oak_restricted_kernel/src/attestation.rs
@@ -15,8 +15,7 @@
 //
 
 use crate::{
-    ghcb::GHCB_PROTOCOL, mm::Translator, snp::GUEST_MESSAGE_ENCRYPTOR, ADDRESS_TRANSLATOR,
-    GUEST_HOST_HEAP,
+    ghcb::GHCB_PROTOCOL, mm::Translator, snp::GUEST_MESSAGE_ENCRYPTOR, GUEST_HOST_HEAP, PAGE_TABLES,
 };
 use alloc::boxed::Box;
 pub use oak_sev_guest::guest::{
@@ -53,9 +52,10 @@ pub fn get_attestation(report_data: [u8; REPORT_DATA_SIZE]) -> anyhow::Result<At
         .map_err(anyhow::Error::msg)?;
     let response_message = Box::new_in(GuestMessage::new(), alloc);
 
-    let translator = ADDRESS_TRANSLATOR
+    let translator = PAGE_TABLES
         .get()
-        .ok_or_else(|| anyhow::anyhow!("address translator is not initialized"))?;
+        .ok_or_else(|| anyhow::anyhow!("address translator is not initialized"))?
+        .lock();
     let request_address = translator
         .translate_virtual(VirtAddr::from_ptr(
             request_message.as_ref() as *const GuestMessage

--- a/oak_restricted_kernel/src/memory.rs
+++ b/oak_restricted_kernel/src/memory.rs
@@ -14,32 +14,175 @@
 // limitations under the License.
 //
 
-use crate::mm::{Mapper, PageTableFlags};
-use core::result::Result;
-use linked_list_allocator::LockedHeap;
+use crate::{
+    mm::{Mapper, PageTableFlags},
+    FRAME_ALLOCATOR, PAGE_TABLES,
+};
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+    result::Result,
+};
+use linked_list_allocator::{Heap, LockedHeap};
 use log::info;
-use x86_64::structures::paging::{mapper::FlagUpdateError, page::PageRange, PageSize};
+use spinning_top::Spinlock;
+use x86_64::{
+    structures::paging::{
+        mapper::FlagUpdateError, page::PageRange, FrameAllocator, Page, PageSize, PhysFrame,
+        Size2MiB,
+    },
+    VirtAddr,
+};
 
 #[cfg(not(test))]
 #[global_allocator]
-static ALLOCATOR: LockedHeap = LockedHeap::empty();
+static ALLOCATOR: LockedGrowableHeap = LockedGrowableHeap::empty();
 
 #[cfg(test)]
-static ALLOCATOR: LockedHeap = LockedHeap::empty();
+static ALLOCATOR: LockedGrowableHeap = LockedGrowableHeap::empty();
+
+/// Heap allocator that requests more physical memory as required.
+struct GrowableHeap {
+    /// Underlying heap allocator implementation.
+    heap: Heap,
+
+    /// Base virtual address for the heap.
+    base: Page<Size2MiB>,
+
+    /// Non-nclusive limit of the heap: the last page of the heap.
+    ///
+    /// The heap will use [base, cursor) addresses in the virtual memory.
+    cursor: Page<Size2MiB>,
+}
+
+impl GrowableHeap {
+    pub const fn empty() -> Self {
+        // Safety: zero is definitely aligned with a 2 MiB boundary.
+        Self {
+            heap: Heap::empty(),
+            base: unsafe { Page::from_start_address_unchecked(VirtAddr::zero()) },
+            cursor: unsafe { Page::from_start_address_unchecked(VirtAddr::zero()) },
+        }
+    }
+
+    /// Extends the current pool of memory by one 2 MiB page.
+    fn extend(&mut self) -> Result<(), &'static str> {
+        // We might want to do something more clever here, such as exponentially increasing the
+        // number of frames we allocate. For now, let's just keep extending by one frame.
+        let mut frame_allocator = FRAME_ALLOCATOR.get().unwrap().lock();
+        let frame: PhysFrame<Size2MiB> = frame_allocator
+            .allocate_frame()
+            .ok_or("failed to allocate memory for kernel heap")?;
+
+        let mut mapper = PAGE_TABLES.get().unwrap().lock();
+
+        // Safety: if the page is already mapped, then we'll get an error and thus we won't
+        // overwrite any existing mappings, Otherwise, creating a new mapping is safe as
+        // the memory is currently unused and thus there should be no references to that memory.
+        unsafe {
+            mapper
+                .map_to_with_table_flags(
+                    self.cursor,
+                    frame,
+                    PageTableFlags::PRESENT
+                        | PageTableFlags::WRITABLE
+                        | PageTableFlags::GLOBAL
+                        | PageTableFlags::NO_EXECUTE
+                        | PageTableFlags::HUGE_PAGE
+                        | PageTableFlags::ENCRYPTED,
+                    PageTableFlags::PRESENT
+                        | PageTableFlags::GLOBAL
+                        | PageTableFlags::WRITABLE
+                        | PageTableFlags::NO_EXECUTE
+                        | PageTableFlags::ENCRYPTED,
+                    frame_allocator.deref_mut(),
+                )
+                .map_err(|_| "unable to create page mapping for kernel heap")?
+                .flush();
+        }
+        self.cursor += 1;
+
+        log::debug!(
+            "Extending kernel heap to [{:#018x}..{:#018x}).",
+            self.base.start_address().as_u64(),
+            self.cursor.start_address().as_u64()
+        );
+        Ok(())
+    }
+
+    pub unsafe fn init(&mut self, base: Page<Size2MiB>) {
+        self.base = base;
+        self.cursor = base;
+
+        // Get the first 2 MiB of memory for the heap.
+        self.extend().unwrap();
+
+        self.heap
+            .init(base.start_address().as_mut_ptr(), Size2MiB::SIZE as usize);
+    }
+
+    pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<NonNull<u8>, ()> {
+        // Try allocating the data structure; if the allocation fails, grow the heap and try again
+        // until we succeed (or until we can't extend ourselves any further)
+        loop {
+            match self.heap.allocate_first_fit(layout) {
+                Ok(ptr) => return Ok(ptr),
+                Err(()) => {
+                    self.extend().map_err(|err| log::error!("{}", err))?;
+                    // Safety: this is safe as we've just mapped a fresh 2 MiB page for the heap.
+                    unsafe { self.heap.extend(Size2MiB::SIZE as usize) };
+                }
+            }
+        }
+    }
+
+    pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) {
+        self.heap.deallocate(ptr, layout)
+    }
+}
+
+struct LockedGrowableHeap(Spinlock<GrowableHeap>);
+
+impl LockedGrowableHeap {
+    pub const fn empty() -> Self {
+        Self(Spinlock::new(GrowableHeap::empty()))
+    }
+}
+
+impl Deref for LockedGrowableHeap {
+    type Target = Spinlock<GrowableHeap>;
+
+    fn deref(&self) -> &Spinlock<GrowableHeap> {
+        &self.0
+    }
+}
+
+unsafe impl GlobalAlloc for LockedGrowableHeap {
+    unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
+        self.0
+            .lock()
+            .allocate_first_fit(layout)
+            .ok()
+            .map_or(core::ptr::null_mut(), |allocation| allocation.as_ptr())
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
+        self.0
+            .lock()
+            .deallocate(NonNull::new_unchecked(ptr), layout)
+    }
+}
 
 /// Initializes the global allocator from the largest contiguous slice of available memory.
 ///
 /// Pointers to addresses in the memory area (or references to data contained within the slice) must
 /// be considered invalid after calling this function, as the allocator may overwrite the data at
 /// any point.
-pub fn init_kernel_heap<S: PageSize>(range: PageRange<S>) -> Result<(), &'static str> {
-    let start = range.start.start_address().as_u64() as usize;
-    let limit = range.end.start_address().as_u64() as usize;
-
-    info!("Using [{:#018x}..{:#018x}) for kernel heap.", start, limit);
+pub fn init_kernel_heap(base: Page<Size2MiB>) -> Result<(), &'static str> {
     // This is safe as we know the memory is available based on the e820 map.
     unsafe {
-        ALLOCATOR.lock().init(start as *mut u8, limit - start);
+        ALLOCATOR.lock().init(base);
     }
     Ok(())
 }

--- a/oak_restricted_kernel/src/virtio.rs
+++ b/oak_restricted_kernel/src/virtio.rs
@@ -51,13 +51,14 @@ where
 }
 
 #[cfg(feature = "vsock_channel")]
-pub fn get_vsock_channel<'a, X: Translator, A: Allocator>(
-    translator: &X,
-    alloc: &'a A,
-) -> Channel<oak_virtio::vsock::socket::Socket<'a, VirtioPciTransport, A>> {
+pub fn get_vsock_channel<A: Allocator>(
+    alloc: &A,
+) -> Channel<oak_virtio::vsock::socket::Socket<'_, VirtioPciTransport, A>> {
+    use crate::PAGE_TABLES;
+
     let vsock = oak_virtio::vsock::VSock::find_and_configure_device(
-        |vaddr: VirtAddr| translator.translate_virtual(vaddr),
-        |paddr: PhysAddr| translator.translate_physical(paddr),
+        |vaddr: VirtAddr| PAGE_TABLES.get().unwrap().lock().translate_virtual(vaddr),
+        |paddr: PhysAddr| PAGE_TABLES.get().unwrap().lock().translate_physical(paddr),
         alloc,
     )
     .expect("couldn't configure PCI virtio vsock device");


### PR DESCRIPTION
Right now we pretty much dump all of the physical memory into the kernel heap and call it a day.

Obviously this won't do in the future: we expect the vast majority of memory to be used by the user space, not the kernel.

Here we create a wrapper around some existing heap allocator (so that we could replace the `linked_list_allocator` with something more clever in the future) that uses at minimum 2 MiB of memory (one page), and asks for more physical memory only if necessary.

The address chosen for the heap -- `0xFFFF_C900_0000_0000` -- is arbitrarly chosen to be the same as the Linux vmalloc area (as I understand it, Linux kmalloc() will return memory from the directly mapped region, and vmalloc() will return memory from the vmalloc area, setting up page tables as necessary -- thus, it seems a good fit.)