### PR TITLE
Add an `exit` syscall to cause a crash.

### DIFF
--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -17,11 +17,13 @@
 mod channel;
 mod fd;
 mod mmap;
+mod process;
 mod stdio;
 
 use self::{
     fd::{syscall_fsync, syscall_read, syscall_write},
     mmap::syscall_mmap,
+    process::syscall_exit,
 };
 use alloc::boxed::Box;
 use core::{arch::asm, ffi::c_void};
@@ -62,6 +64,7 @@ extern "sysv64" fn syscall_handler(
     match Syscall::from_repr(syscall) {
         Some(Syscall::Read) => syscall_read(arg1 as i32, arg2 as *mut c_void, arg3),
         Some(Syscall::Write) => syscall_write(arg1 as i32, arg2 as *const c_void, arg3),
+        Some(Syscall::Exit) => syscall_exit(arg1 as i32),
         Some(Syscall::Mmap) => {
             syscall_mmap(arg1 as *const c_void, arg2, arg3, arg4, arg5 as i32, arg6)
         }

--- a/oak_restricted_kernel/src/syscall/process.rs
+++ b/oak_restricted_kernel/src/syscall/process.rs
@@ -1,0 +1,19 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub fn syscall_exit(status: i32) -> isize {
+    panic!("User code terminated with status code: {}", status);
+}

--- a/oak_restricted_kernel_api/src/syscall.rs
+++ b/oak_restricted_kernel_api/src/syscall.rs
@@ -110,6 +110,16 @@ pub fn mmap(
     }
 }
 
+#[no_mangle]
+pub extern "C" fn sys_exit(status: c_int) {
+    unsafe { syscall!(Syscall::Exit, status) };
+}
+
+pub fn exit(status: i32) -> ! {
+    sys_exit(status);
+    unreachable!();
+}
+
 // Note that these tests are not being executed against Restricted Kernel, but rather the Linux
 // kernel of the machine cargo is running on!
 #[cfg(test)]

--- a/oak_restricted_kernel_interface/src/syscalls.rs
+++ b/oak_restricted_kernel_interface/src/syscalls.rs
@@ -66,6 +66,14 @@ pub enum Syscall {
     ///   - We do not support PROT_NONE; PROT_READ is always implied.
     Mmap = 9,
 
+    /// Terminates he calling process.
+    /// Arguments:
+    ///   - arg0 (c_int): error code
+    /// Oak Restricted Kernel considerations:
+    ///   We don't expect the user process to terminate, so this triggers a kernel panic, no matter
+    ///   the error code.
+    Exit = 60,
+
     /// Flush a file descriptor.
     /// Arguments:
     ///   - arg0 (c_ssize_t): file descriptor number. Ignored by the kernel as we don't support


### PR DESCRIPTION
We need a way how the user space code can notify the kernel of a potentially abnormal termination: for example, when the code panics in an unrecoverable way.

As we'll eventually move into the process management business anyway, the most obvious way how to do it would be via an `exit` syscall that lets you report a termination status to the kernel.

However, as we _don't_ have proper process management yet, we don't expect the user code ever to call this unless something has gone horribly wrong -- therefore, we can just cause a kernel panic if the user code terminates.