### PR TITLE
Add support for `MAP_FIXED` to `mmap` syscall

### DIFF
--- a/oak_restricted_kernel/src/mm/encrypted_mapper.rs
+++ b/oak_restricted_kernel/src/mm/encrypted_mapper.rs
@@ -133,6 +133,28 @@ impl<'a> EncryptedPageTable<MappedPageTable<'a, PhysOffset>> {
         }
     }
 
+    /// Checks wheter all the pages in the range are unallocated.
+    ///
+    /// Even though the pages may be of arbitrary size, we check all 4KiB-aligned addresses in the
+    /// range, as the mappings may be done with a smaller page size.
+    ///
+    /// If we find an address with a valid mapping, we return the page which contains a valid
+    /// mapping.
+    pub fn is_unallocated<S: PageSize>(&self, range: PageRange<S>) -> Result<(), Page<S>> {
+        if let Some(item) = Page::<Size4KiB>::range(
+            Page::containing_address(range.start.start_address()),
+            Page::containing_address(range.end.start_address()),
+        )
+        .find(|page| self.translate_virtual(page.start_address()).is_some())
+        {
+            // We found a page that had a valid mapping in that range, bail out.
+            Err(Page::<S>::containing_address(item.start_address()))
+        } else {
+            // No valid mappings found, the whole range is unmapped!
+            Ok(())
+        }
+    }
+
     /// Finds a range of unallocated pages of the requested size.
     ///
     /// Args:
@@ -158,20 +180,11 @@ impl<'a> EncryptedPageTable<MappedPageTable<'a, PhysOffset>> {
         while start < limit {
             let range = Page::range(start, start + count as u64);
 
-            // We need to make sure all 4K pages inside that range are unmapped, as we _may_ have
-            // some 4K mappings.
-            if let Some(item) = Page::<Size4KiB>::range(
-                Page::containing_address(range.start.start_address()),
-                Page::containing_address(range.end.start_address()),
-            )
-            .find(|page| self.translate_virtual(page.start_address()).is_some())
-            {
-                // We found a page that had a valid mapping in that range. Let's move our search
-                // window to the page just past the page that had a valid address.
-                start = Page::<S>::containing_address(item.start_address()) + 1;
-            } else {
-                // No valid mappings found, the whole range is unmapped!
-                return Some(range);
+            // If it turns out something in that range was allocated, we move forward to the page
+            // after that and try again.
+            match self.is_unallocated(range) {
+                Ok(()) => return Some(range),
+                Err(page) => start = page + 1,
             }
         }
 

--- a/oak_restricted_kernel_interface/src/syscalls.rs
+++ b/oak_restricted_kernel_interface/src/syscalls.rs
@@ -52,7 +52,8 @@ pub enum Syscall {
     ///   - arg0 (*const c_void): hint for start address for the new mapping, may be nullptr
     ///   - arg1 (c_size_t): size of the new mapping
     ///   - arg2 (c_int): protection on mapping (PROT_EXEC, PROT_READ, PROT_WRITE, PROT_NONE)
-    ///   - arg3 (c_int): flags. The only combination we support is MAP_PRIVATE | MAP_ANONYMOUS.
+    ///   - arg3 (c_int): flags. We require MAP_PRIVATE and MAP_ANONYMOUS to be set, and
+    ///     additionally support MAP_FIXED.
     ///   - arg4 (c_int): file descriptor. Ignored, as we only support anonymous mappings. Should
     ///     be set to -1 by caller.
     ///   - arg5 (c_int): offset. Ignored, as we only support anonymous mappings. Should be set to
@@ -62,7 +63,8 @@ pub enum Syscall {
     ///     chunk of memory. Thus, size should be kept as a multiple of 2 MiB.
     ///   - related to previous, the allocation address will always be 2 MiB-aligned (rounded
     ///     upward from hint).
-    ///   - We do not support MAP_FIXED.
+    ///   - MAP_FIXED requires address to be 2 MiB-aligned, and will return an error if it'd touch
+    ///     any existing mappings.
     ///   - We do not support PROT_NONE; PROT_READ is always implied.
     Mmap = 9,
 
@@ -102,6 +104,9 @@ bitflags! {
     pub struct MmapFlags: i32 {
         /// Private copy-on-write mapping.
         const MAP_PRIVATE = 0x02;
+
+        /// Don't interpret addr as a hint, but require mapping at given address.
+        const MAP_FIXED = 0x10;
 
         /// The mapping is not backed by any file; contents are initialized to zero.
         const MAP_ANONYMOUS = 0x20;


### PR DESCRIPTION
The main use case for this will be setting up the user space, where we will want mappings to land on certain fixed addresses and not just the next available one.