### PR TITLE
Ignore security advisories due to ancient libraries

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,9 @@ yanked = "deny"
 notice = "deny"
 ignore = [
   # TODO(#3377): Remove when updated.
-  "RUSTSEC-2022-0061"
+  "RUSTSEC-2022-0061",
+  "RUSTSEC-2022-0075",
+  "RUSTSEC-2022-0076",
 ]
 
 [bans]


### PR DESCRIPTION
I tried looking at the dependency mess, but at this point I'd rather stick pins under my fingernails than deal with that mess.

The root cause of some ancient deps seems to be `ed25519_dalek`, which hasn't been updated in years.