### PR TITLE
Ignore twoway deprecation notice

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,7 @@ unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = [
+  "RUSTSEC-2021-0146",
   # TODO(#3377): Remove when updated.
   "RUSTSEC-2022-0061",
   "RUSTSEC-2022-0075",


### PR DESCRIPTION
Let's try this again and hope the checks actually run this time around.