### PR TITLE
Create an allocator for a pool of virtual memory

### DIFF
--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -37,6 +37,7 @@ mod bitmap_frame_allocator;
 pub mod encrypted_mapper;
 pub mod frame_allocator;
 pub mod page_tables;
+pub mod virtual_address_allocator;
 
 /// The start of kernel memory.
 pub const KERNEL_OFFSET: u64 = 0xFFFF_FFFF_8000_0000;

--- a/oak_restricted_kernel/src/mm/virtual_address_allocator.rs
+++ b/oak_restricted_kernel/src/mm/virtual_address_allocator.rs
@@ -1,0 +1,49 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use x86_64::structures::paging::{page::PageRange, Page, PageSize};
+
+/// Extremely simple virtual memory address allocator using the bump algorithm.
+///
+/// The main goal for this allocator is to provide pages for things like the kernel heap and kernel
+/// stack(s). As these data structures should live for the entire lifetime of the kernel, we don't
+/// implement deallocation.
+///
+/// This allocator only hands out pages; mapping the pages to frames, as necessary, is for the
+/// caller.
+pub struct VirtualAddressAllocator<S: PageSize> {
+    range: PageRange<S>,
+    cursor: Page<S>,
+}
+
+impl<S: PageSize> VirtualAddressAllocator<S> {
+    pub const fn new(range: PageRange<S>) -> Self {
+        Self {
+            range,
+            cursor: range.start,
+        }
+    }
+
+    pub fn allocate(&mut self, count: u64) -> Option<PageRange<S>> {
+        if self.cursor + count >= self.range.end {
+            None
+        } else {
+            let cur = self.cursor;
+            self.cursor += count;
+            Some(Page::range(cur, self.cursor))
+        }
+    }
+}


### PR DESCRIPTION
Instead of allocating all of `[0xFFFF_C900_0000_0000...0xFFFF_E900_0000_0000)` for the kernel heap, let's use this range of virtual memory for other long-lived data structures that need a place in the virtual memory, as well. After all, we don't really expect the kernel heap to ever grow particularly large.

The motivating example is that we're going to need a separate stack for syscalls. We could just allocate a frame, and use the directly-mapped region for the stack; however, this runs the risk that if we ever blow the stack, we start writing to memory that's not ours.

With this allocator, the algorithm can be: ask for two pages of virtual memory and one frame of physical memory; leave the first page unmapped as a guard page, and map the second page to the physical frame; use that physical frame as stack.

Plus, we're likely need per-CPU data structures with fixed addresses as well in the future, hence having a separate virtual memory range for structures like this is nice to have.