### PR TITLE
Create a separate stack for interrupts and double faults.

### DIFF
--- a/oak_restricted_kernel/src/descriptors.rs
+++ b/oak_restricted_kernel/src/descriptors.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use oak_core::sync::OnceCell;
+use spinning_top::Spinlock;
 use x86_64::{
     instructions::tables::load_tss,
     registers::{model_specific::Star, segmentation::*},
@@ -22,10 +22,12 @@ use x86_64::{
         gdt::{Descriptor, GlobalDescriptorTable},
         tss::TaskStateSegment,
     },
+    VirtAddr,
 };
 
 struct Descriptors {
     gdt: GlobalDescriptorTable,
+    tss: TaskStateSegment,
     kernel_cs_selector: SegmentSelector,
     kernel_ds_selector: SegmentSelector,
     user_cs_selector: SegmentSelector,
@@ -33,34 +35,29 @@ struct Descriptors {
     tss_selector: SegmentSelector,
 }
 
-static TSS: TaskStateSegment = TaskStateSegment::new();
-static DESCRIPTORS: OnceCell<Descriptors> = OnceCell::new();
+const DOUBLE_FAULT_STACK_INDEX: u16 = 1;
 
-/// Initializes the Global Descriptor Table.
-///
-/// This function will panic if the GDT is already initialized.
-pub fn init_gdt() {
-    let mut descriptors = Descriptors {
-        gdt: GlobalDescriptorTable::new(),
-        kernel_cs_selector: SegmentSelector::NULL,
-        kernel_ds_selector: SegmentSelector::NULL,
-        user_cs_selector: SegmentSelector::NULL,
-        user_ds_selector: SegmentSelector::NULL,
-        tss_selector: SegmentSelector::NULL,
-    };
+static DESCRIPTORS: Spinlock<Descriptors> = Spinlock::new(Descriptors {
+    gdt: GlobalDescriptorTable::new(),
+    tss: TaskStateSegment::new(),
+    kernel_cs_selector: SegmentSelector::NULL,
+    kernel_ds_selector: SegmentSelector::NULL,
+    user_cs_selector: SegmentSelector::NULL,
+    user_ds_selector: SegmentSelector::NULL,
+    tss_selector: SegmentSelector::NULL,
+});
+
+/// Does basic initialization of the GDT for the kernel itself.
+pub fn init_gdt_early() {
+    let mut descriptors = DESCRIPTORS.lock();
     descriptors.kernel_cs_selector = descriptors.gdt.add_entry(Descriptor::kernel_code_segment());
     descriptors.kernel_ds_selector = descriptors.gdt.add_entry(Descriptor::kernel_data_segment());
-    descriptors.user_ds_selector = descriptors.gdt.add_entry(Descriptor::user_data_segment());
-    descriptors.user_cs_selector = descriptors.gdt.add_entry(Descriptor::user_code_segment());
-    descriptors.tss_selector = descriptors.gdt.add_entry(Descriptor::tss_segment(&TSS));
 
-    // Make sure the GDT was not previously initialized.
-    if DESCRIPTORS.set(descriptors).is_err() {
-        panic!("gdt is already initialized");
+    // Safety: descriptors are 'static, so this is safe to load, but unfortunately the fact isn't
+    // visible through the MutexGuard.
+    unsafe {
+        descriptors.gdt.load_unsafe();
     }
-
-    let descriptors = DESCRIPTORS.get().unwrap();
-    descriptors.gdt.load();
 
     // Safety: it's safe to load these segments as we've initialized the GDT just above.
     unsafe {
@@ -70,6 +67,30 @@ pub fn init_gdt() {
         FS::set_reg(descriptors.kernel_ds_selector);
         GS::set_reg(descriptors.kernel_ds_selector);
         SS::set_reg(descriptors.kernel_ds_selector);
+    }
+}
+
+/// Adds descriptors required for Ring 3 to the GDT.
+pub fn init_gdt(double_fault_stack: VirtAddr, privileged_interrupt_stack: VirtAddr) -> u16 {
+    let mut descriptors = DESCRIPTORS.lock();
+
+    // If an interrupt triggers a switch to Ring 0, the CPU will switch to the privileged stack.
+    descriptors.tss.privilege_stack_table[0] = privileged_interrupt_stack;
+    // If we double fault (which means something is _really_ wrong), the CPU will switch to this
+    // stack.
+    descriptors.tss.interrupt_stack_table[DOUBLE_FAULT_STACK_INDEX as usize] = double_fault_stack;
+
+    descriptors.user_ds_selector = descriptors.gdt.add_entry(Descriptor::user_data_segment());
+    descriptors.user_cs_selector = descriptors.gdt.add_entry(Descriptor::user_code_segment());
+    // Safety: we know that descriptors are 'static as they are stored in the static variable, but
+    // unfortunately that fact is not visible through the MutexGuard.
+    // Thus, we need to rely on `transmute()` to extend the lifetime and use `load_unsafe()` to
+    // actually load the GDT.
+    let tss_descriptor =
+        Descriptor::tss_segment(unsafe { core::intrinsics::transmute(&descriptors.tss) });
+    descriptors.tss_selector = descriptors.gdt.add_entry(tss_descriptor);
+    unsafe {
+        descriptors.gdt.load_unsafe();
         load_tss(descriptors.tss_selector);
     }
 
@@ -81,4 +102,6 @@ pub fn init_gdt() {
         descriptors.kernel_ds_selector, // Stack segment for SYSCALL
     )
     .expect("failed to set IA32_STAR MSR");
+
+    DOUBLE_FAULT_STACK_INDEX
 }


### PR DESCRIPTION
This should be the last bit that's needed before we can try entering Ring 3 properly.

We allocate two stacks here:
a) one that is used when an interrupt triggers change from Ring 3 to Ring 0 (referenced by `tss.privilege_stack_table`)
b) one that is used if things go horribly wrong and we get a double fault (referenced by `tss.interrupt_stack_table` and `opts.set_stack_index`)

The idea behind giving the double fault handler its own stack is that if we do ever get a double fault, things must have gone spectacularly bad and we can't trust any other stack to be in a reasonable state. It's a best practice followed by many kernels.

While in there, I also simplified the code drastically by getting rid of a bunch of OnceCells and replacing them with bog-standard Spinlocks.