### PR TITLE
Run payload code in Ring 3, not kernel (Ring 0).

### DIFF
--- a/oak_restricted_kernel/src/payload.rs
+++ b/oak_restricted_kernel/src/payload.rs
@@ -83,13 +83,13 @@ pub unsafe fn run_payload(payload: *const u8) -> ! {
     )
     .expect("failed to allocate memory for user stack");
 
-    // Jump to user code; instead of raw jump (or call, as the case is here) in the future we'll
-    // need to enter Ring 3 properly.
+    // Enter Ring 3 and jump to user code.
     asm! {
-        "mov {1}, %rsp",
-        "call *{0}",
-        in(reg) header.e_entry,
-        in(reg) rsp.as_u64(),
-        options(noreturn, att_syntax)
+        "mov rsp, {}", // user stack
+        "sysretq",
+        in(reg) rsp.as_u64() - 8, // maintain stack alignment
+        in("rcx") header.e_entry, // initial RIP
+        in("r11") 0x202, // initial RFLAGS
+        options(noreturn)
     }
 }

--- a/oak_restricted_kernel/src/syscall/mmap.rs
+++ b/oak_restricted_kernel/src/syscall/mmap.rs
@@ -117,7 +117,10 @@ pub fn mmap(
                     page,
                     frame.ok_or(Errno::ENOMEM)?,
                     pt_flags,
-                    PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::ENCRYPTED,
+                    PageTableFlags::PRESENT
+                        | PageTableFlags::WRITABLE
+                        | PageTableFlags::ENCRYPTED
+                        | PageTableFlags::USER_ACCESSIBLE,
                     FRAME_ALLOCATOR.get().unwrap().lock().deref_mut(),
                 )
                 .map_err(|err| {

--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -42,6 +42,7 @@ use x86_64::{
 ///
 /// Do not change the order of the fields here, as this is accessed from assembly!
 #[repr(C)]
+#[derive(Debug)]
 struct GsData {
     /// Kernel stack pointer (what to set in RSP after saving user RSP).
     kernel_sp: VirtAddr,
@@ -235,11 +236,8 @@ extern "C" fn syscall_entrypoint() {
             "mov r11, gs:[0x18]", // restore user RFLAGS
             "swapgs", // restore user GS
 
-            // We can't use SYSRET as that'll force us to Ring 3!
-            // However, we've restored all the registers, and the return value is in RAX, and we
-            // are allowed to trash RCX. Thus... let's just jump back.
-            // Note that this does *not* restore flags properly.
-            "jmp rcx",
+            // Back to user code in Ring 3.
+            "sysretq",
             HANDLER = sym syscall_handler,
             options(noreturn)
         }


### PR DESCRIPTION
After all the work to break up the stacks and everything else, we can finally run things in Ring 3!

(Note that interrupts are still broken, that'll be fixed in #3620 once I figure out what's broken.)