### PR TITLE
Clean up the Kokoro presubmit a bit.

### DIFF
--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -1,20 +1,14 @@
 #!/usr/bin/env bash
 
-# Kokoro requires us to manually load the kernel modules required for vsock
-# Ref: https://g3doc.corp.google.com/security/bedebox/g3doc/requirements.md?cl=head#vhostvhost-vsock-kernel-module-vs-vmware
-sudo rmmod vmw_vsock_virtio_transport_common
-sudo rmmod vmw_vsock_vmci_transport
-sudo rmmod vsock
-sudo modprobe vhost_vsock
-
 # On Kokoro instances /dev/kvm, /dev/vhost-vsock and /dev/vsock are owned by root:root.
 # Set the permissions so that these are owned by the `kvm` group as our scripts expect it to be.
 readonly KVM_GID="$(getent group kvm | cut -d: -f3)"
 sudo chown "$USER:$KVM_GID" /dev/kvm
-sudo chown "$USER:$KVM_GID" /dev/vhost-vsock
-sudo chown "$USER:$KVM_GID" /dev/vsock
+
+sudo /etc/init.d/docker stop
+sudo mv /var/lib/docker /tmpfs/
+sudo ln -s /tmpfs/docker /var/lib/docker
+sudo /etc/init.d/docker start
 
 ./scripts/docker_pull
-
-./scripts/docker_run ./scripts/xtask build-oak-functions-server-variants
 ./scripts/docker_run ./scripts/xtask run-launcher-test


### PR DESCRIPTION
a) we don't need vsock right now;
b) the launcher is built as a part of `run-launcher-test` anyway, so there's no need to build it separately.