### PR TITLE
Change all other enclave binaries to be standalone as well.

### DIFF
--- a/buildconfigs/oak_echo_enclave.toml
+++ b/buildconfigs/oak_echo_enclave.toml
@@ -4,8 +4,6 @@ command = [
   "--chdir=testing/oak_echo_enclave",
   "cargo",
   "build",
-  "--no-default-features",
-  "--features=simple_io_channel",
   "--release"
 ]
 output_path = "./testing/oak_echo_enclave/target/x86_64-unknown-none/release/oak_echo_enclave"

--- a/buildconfigs/oak_echo_raw_enclave.toml
+++ b/buildconfigs/oak_echo_raw_enclave.toml
@@ -4,8 +4,6 @@ command = [
   "--chdir=testing/oak_echo_raw_enclave",
   "cargo",
   "build",
-  "--no-default-features",
-  "--features=simple_io_channel",
   "--release"
 ]
 output_path = "./testing/oak_echo_raw_enclave/target/x86_64-unknown-none/release/oak_echo_raw_enclave"

--- a/buildconfigs/oak_tensorflow_enclave.toml
+++ b/buildconfigs/oak_tensorflow_enclave.toml
@@ -4,8 +4,6 @@ command = [
   "--chdir=oak_tensorflow_enclave",
   "cargo",
   "build",
-  "--no-default-features",
-  "--features=simple_io_channel",
   "--release"
 ]
 output_path = "./oak_tensorflow_enclave/target/x86_64-unknown-none/release/oak_tensorflow_enclave"

--- a/oak_enclave_runtime_support/src/libm.rs
+++ b/oak_enclave_runtime_support/src/libm.rs
@@ -25,3 +25,75 @@ pub extern "C" fn fmodf(a: f32, b: f32) -> f32 {
 pub extern "C" fn fmod(a: f64, b: f64) -> f64 {
     libm::fmod(a, b)
 }
+
+// These functions are required by oak_tensorflow_enclave.
+
+#[no_mangle]
+pub extern "C" fn sqrtf(x: f32) -> f32 {
+    libm::sqrtf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn logf(x: f32) -> f32 {
+    libm::logf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cosf(x: f32) -> f32 {
+    libm::cosf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sinf(x: f32) -> f32 {
+    libm::sinf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp(x: f64) -> f64 {
+    libm::exp(x)
+}
+
+#[no_mangle]
+pub extern "C" fn roundf(x: f32) -> f32 {
+    libm::roundf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expf(x: f32) -> f32 {
+    libm::expf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expm1f(x: f32) -> f32 {
+    libm::expm1f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn round(x: f64) -> f64 {
+    libm::round(x)
+}
+
+#[no_mangle]
+pub extern "C" fn fminf(x: f32, y: f32) -> f32 {
+    libm::fminf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fmaxf(x: f32, y: f32) -> f32 {
+    libm::fmaxf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn tanhf(x: f32) -> f32 {
+    libm::tanhf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn powf(x: f32, y: f32) -> f32 {
+    libm::powf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn ceilf(x: f32) -> f32 {
+    libm::ceilf(x)
+}

--- a/oak_tensorflow_enclave/.cargo/config.toml
+++ b/oak_tensorflow_enclave/.cargo/config.toml
@@ -2,4 +2,4 @@
 target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
-rustflags = "-C relocation-model=static -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,-soft-float"
+rustflags = "-C relocation-model=static -C code-model=small -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,-soft-float"

--- a/oak_tensorflow_enclave/Cargo.lock
+++ b/oak_tensorflow_enclave/Cargo.lock
@@ -3,52 +3,6 @@
 version = 3
 
 [[package]]
-name = "acpi"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
-dependencies = [
- "bit_field",
- "log",
- "rsdp",
-]
-
-[[package]]
-name = "aead"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,27 +14,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aml"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c264f2e933012ef2dd324cdac38f4c6c142473c1d1a1357ba16321e7d892975f"
-dependencies = [
- "bit_field",
- "byteorder",
- "log",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
@@ -94,46 +31,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b5e5f48b927f04e952dedc932f31995a65a0bf65ec971c74436e51bf6e970d"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -146,50 +53,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cipher"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -213,22 +76,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "generic-array"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,27 +84,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
-
-[[package]]
-name = "goblin"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
-dependencies = [
- "log",
- "plain",
- "scroll",
 ]
 
 [[package]]
@@ -283,15 +109,6 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -392,52 +209,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_core"
+name = "oak_enclave_runtime_support"
 version = "0.1.0"
 dependencies = [
- "lock_api",
- "spinning_top",
-]
-
-[[package]]
-name = "oak_linux_boot_params"
-version = "0.1.0"
-dependencies = [
- "bitflags",
- "static_assertions",
- "strum",
- "zerocopy",
-]
-
-[[package]]
-name = "oak_restricted_kernel"
-version = "0.1.0"
-dependencies = [
- "acpi",
- "aml",
- "anyhow",
- "arrayvec",
- "atomic_refcell",
- "bitflags",
- "bitvec",
- "goblin",
  "libm",
  "linked_list_allocator",
  "log",
- "oak_channel",
- "oak_core",
- "oak_linux_boot_params",
+ "oak_restricted_kernel_api",
  "oak_restricted_kernel_interface",
- "oak_sev_guest",
- "oak_simple_io",
- "oak_virtio",
- "rust-hypervisor-firmware-virtio",
- "sev_serial",
  "spinning_top",
- "static_assertions",
- "strum",
- "x86_64",
- "zerocopy",
 ]
 
 [[package]]
@@ -460,38 +240,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_sev_guest"
-version = "0.1.0"
-dependencies = [
- "aes-gcm",
- "bitflags",
- "lock_api",
- "snafu",
- "spinning_top",
- "static_assertions",
- "strum",
- "x86_64",
- "zerocopy",
-]
-
-[[package]]
-name = "oak_simple_io"
-version = "0.1.0"
-dependencies = [
- "bitflags",
- "oak_sev_guest",
- "x86_64",
-]
-
-[[package]]
 name = "oak_tensorflow_enclave"
 version = "0.1.0"
 dependencies = [
  "log",
  "micro_rpc",
  "oak_channel",
- "oak_linux_boot_params",
- "oak_restricted_kernel",
+ "oak_enclave_runtime_support",
  "oak_restricted_kernel_api",
  "oak_tensorflow_service",
  "static_assertions",
@@ -512,28 +267,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_virtio"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bitflags",
- "log",
- "rust-hypervisor-firmware-virtio",
- "strum",
- "x86_64",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "petgraph"
@@ -543,24 +280,6 @@ checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
-]
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "polyval"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
 ]
 
 [[package]]
@@ -635,12 +354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,25 +387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsdp"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "rust-hypervisor-firmware-virtio"
-version = "0.1.0"
-dependencies = [
- "atomic_refcell",
- "bitflags",
- "log",
- "x86_64",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,56 +397,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sev_serial"
-version = "0.1.0"
-dependencies = [
- "oak_sev_guest",
- "x86_64",
-]
-
-[[package]]
-name = "snafu"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd726aec4ebad65756394ff89a9b9598793d4e30121cd71690244c1e497b3aee"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712529e9b0b014eabaa345b38e06032767e3dc393e8b017e853b1d7247094e74"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "spinning_top"
@@ -792,12 +436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
 name = "syn"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,12 +445,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -829,38 +461,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "volatile"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ca98349dda8a60ae74e04fd90c7fb4d6a4fbe01e6d3be095478aa0b76f6c0c"
 
 [[package]]
 name = "wasi"
@@ -900,45 +510,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
-dependencies = [
- "tap",
-]
-
-[[package]]
-name = "x86_64"
-version = "0.14.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
-dependencies = [
- "bit_field",
- "bitflags",
- "rustversion",
- "volatile",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/oak_tensorflow_enclave/Cargo.toml
+++ b/oak_tensorflow_enclave/Cargo.toml
@@ -9,19 +9,13 @@ license = "Apache-2.0"
 resolver = "2"
 members = ["."]
 
-[features]
-default = ["vsock_channel"]
-vsock_channel = ["oak_restricted_kernel/vsock_channel"]
-simple_io_channel = ["oak_restricted_kernel/simple_io_channel"]
-
 [dependencies]
 oak_tensorflow_service = { path = "../oak_tensorflow_service" }
 log = "*"
 oak_channel = { path = "../oak_channel" }
-oak_restricted_kernel = { path = "../oak_restricted_kernel", default-features = false }
+oak_enclave_runtime_support = { path = "../oak_enclave_runtime_support" }
 oak_restricted_kernel_api = { path = "../oak_restricted_kernel_api" }
 micro_rpc = { path = "../micro_rpc" }
-oak_linux_boot_params = { path = "../linux_boot_params" }
 static_assertions = "*"
 
 [[bin]]

--- a/oak_tensorflow_enclave/build.rs
+++ b/oak_tensorflow_enclave/build.rs
@@ -15,12 +15,5 @@
 //
 
 fn main() {
-    println!(
-        "cargo:rerun-if-changed={}/oak_restricted_kernel/layout.ld",
-        env!("WORKSPACE_ROOT")
-    );
-    println!(
-        "cargo:rustc-link-arg=--script={}/oak_restricted_kernel/layout.ld",
-        env!("WORKSPACE_ROOT")
-    );
+    println!("cargo:rustc-link-arg=-zmax-page-size=0x200000");
 }

--- a/testing/oak_echo_enclave/.cargo/config.toml
+++ b/testing/oak_echo_enclave/.cargo/config.toml
@@ -2,4 +2,4 @@
 target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
-rustflags = "-C relocation-model=static -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,-soft-float"
+rustflags = "-C relocation-model=static -C code-model=small -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,-soft-float"

--- a/testing/oak_echo_enclave/Cargo.lock
+++ b/testing/oak_echo_enclave/Cargo.lock
@@ -3,52 +3,6 @@
 version = 3
 
 [[package]]
-name = "acpi"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
-dependencies = [
- "bit_field",
- "log",
- "rsdp",
-]
-
-[[package]]
-name = "aead"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,27 +14,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aml"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c264f2e933012ef2dd324cdac38f4c6c142473c1d1a1357ba16321e7d892975f"
-dependencies = [
- "bit_field",
- "byteorder",
- "log",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
@@ -94,46 +31,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b5e5f48b927f04e952dedc932f31995a65a0bf65ec971c74436e51bf6e970d"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -146,50 +53,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cipher"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -213,22 +76,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "generic-array"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,27 +84,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
-
-[[package]]
-name = "goblin"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
-dependencies = [
- "log",
- "plain",
- "scroll",
 ]
 
 [[package]]
@@ -283,15 +109,6 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -392,14 +209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_core"
-version = "0.1.0"
-dependencies = [
- "lock_api",
- "spinning_top",
-]
-
-[[package]]
 name = "oak_echo_enclave"
 version = "0.1.0"
 dependencies = [
@@ -407,8 +216,7 @@ dependencies = [
  "micro_rpc",
  "oak_channel",
  "oak_echo_service",
- "oak_linux_boot_params",
- "oak_restricted_kernel",
+ "oak_enclave_runtime_support",
  "oak_restricted_kernel_api",
  "static_assertions",
 ]
@@ -425,44 +233,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_linux_boot_params"
+name = "oak_enclave_runtime_support"
 version = "0.1.0"
 dependencies = [
- "bitflags",
- "static_assertions",
- "strum",
- "zerocopy",
-]
-
-[[package]]
-name = "oak_restricted_kernel"
-version = "0.1.0"
-dependencies = [
- "acpi",
- "aml",
- "anyhow",
- "arrayvec",
- "atomic_refcell",
- "bitflags",
- "bitvec",
- "goblin",
  "libm",
  "linked_list_allocator",
  "log",
- "oak_channel",
- "oak_core",
- "oak_linux_boot_params",
+ "oak_restricted_kernel_api",
  "oak_restricted_kernel_interface",
- "oak_sev_guest",
- "oak_simple_io",
- "oak_virtio",
- "rust-hypervisor-firmware-virtio",
- "sev_serial",
  "spinning_top",
- "static_assertions",
- "strum",
- "x86_64",
- "zerocopy",
 ]
 
 [[package]]
@@ -485,52 +264,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_sev_guest"
-version = "0.1.0"
-dependencies = [
- "aes-gcm",
- "bitflags",
- "lock_api",
- "snafu",
- "spinning_top",
- "static_assertions",
- "strum",
- "x86_64",
- "zerocopy",
-]
-
-[[package]]
-name = "oak_simple_io"
-version = "0.1.0"
-dependencies = [
- "bitflags",
- "oak_sev_guest",
- "x86_64",
-]
-
-[[package]]
-name = "oak_virtio"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bitflags",
- "log",
- "rust-hypervisor-firmware-virtio",
- "strum",
- "x86_64",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "petgraph"
@@ -540,24 +277,6 @@ checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
-]
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "polyval"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
 ]
 
 [[package]]
@@ -632,12 +351,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,25 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsdp"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "rust-hypervisor-firmware-virtio"
-version = "0.1.0"
-dependencies = [
- "atomic_refcell",
- "bitflags",
- "log",
- "x86_64",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,56 +394,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sev_serial"
-version = "0.1.0"
-dependencies = [
- "oak_sev_guest",
- "x86_64",
-]
-
-[[package]]
-name = "snafu"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd726aec4ebad65756394ff89a9b9598793d4e30121cd71690244c1e497b3aee"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712529e9b0b014eabaa345b38e06032767e3dc393e8b017e853b1d7247094e74"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "spinning_top"
@@ -789,12 +433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
 name = "syn"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,12 +442,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -826,38 +458,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "volatile"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ca98349dda8a60ae74e04fd90c7fb4d6a4fbe01e6d3be095478aa0b76f6c0c"
 
 [[package]]
 name = "wasi"
@@ -897,45 +507,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
-dependencies = [
- "tap",
-]
-
-[[package]]
-name = "x86_64"
-version = "0.14.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
-dependencies = [
- "bit_field",
- "bitflags",
- "rustversion",
- "volatile",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/testing/oak_echo_enclave/Cargo.toml
+++ b/testing/oak_echo_enclave/Cargo.toml
@@ -9,19 +9,13 @@ license = "Apache-2.0"
 resolver = "2"
 members = ["."]
 
-[features]
-default = ["vsock_channel"]
-vsock_channel = ["oak_restricted_kernel/vsock_channel"]
-simple_io_channel = ["oak_restricted_kernel/simple_io_channel"]
-
 [dependencies]
 oak_echo_service = { path = "../oak_echo_service" }
+oak_enclave_runtime_support = { path = "../../oak_enclave_runtime_support" }
 log = "*"
 oak_channel = { path = "../../oak_channel" }
-oak_restricted_kernel = { path = "../../oak_restricted_kernel", default-features = false }
 oak_restricted_kernel_api = { path = "../../oak_restricted_kernel_api" }
 micro_rpc = { path = "../../micro_rpc" }
-oak_linux_boot_params = { path = "../../linux_boot_params" }
 static_assertions = "*"
 
 [[bin]]

--- a/testing/oak_echo_enclave/build.rs
+++ b/testing/oak_echo_enclave/build.rs
@@ -15,12 +15,5 @@
 //
 
 fn main() {
-    println!(
-        "cargo:rerun-if-changed={}/oak_restricted_kernel/layout.ld",
-        env!("WORKSPACE_ROOT")
-    );
-    println!(
-        "cargo:rustc-link-arg=--script={}/oak_restricted_kernel/layout.ld",
-        env!("WORKSPACE_ROOT")
-    );
+    println!("cargo:rustc-link-arg=-zmax-page-size=0x200000");
 }

--- a/testing/oak_echo_enclave/src/main.rs
+++ b/testing/oak_echo_enclave/src/main.rs
@@ -23,12 +23,19 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::panic::PanicInfo;
 use log::info;
-use oak_linux_boot_params::BootParams;
-use oak_restricted_kernel_api::FileDescriptorChannel;
+use oak_restricted_kernel_api::{FileDescriptorChannel, StderrLogger};
+
+static LOGGER: StderrLogger = StderrLogger {};
 
 #[no_mangle]
-pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
-    oak_restricted_kernel::start_kernel(rsi);
+fn _start() -> ! {
+    log::set_logger(&LOGGER).unwrap();
+    log::set_max_level(log::LevelFilter::Debug);
+    oak_enclave_runtime_support::init();
+    main();
+}
+
+fn main() -> ! {
     info!("In main!");
     start_echo_server()
 }
@@ -49,5 +56,6 @@ fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
-    oak_restricted_kernel::panic(info);
+    log::error!("PANIC: {}", info);
+    oak_restricted_kernel_api::syscall::exit(-1);
 }

--- a/testing/oak_echo_raw_enclave/.cargo/config.toml
+++ b/testing/oak_echo_raw_enclave/.cargo/config.toml
@@ -2,4 +2,4 @@
 target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
-rustflags = "-C relocation-model=static -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,-soft-float"
+rustflags = "-C relocation-model=static -C code-model=small -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,-soft-float"

--- a/testing/oak_echo_raw_enclave/Cargo.lock
+++ b/testing/oak_echo_raw_enclave/Cargo.lock
@@ -3,73 +3,10 @@
 version = 3
 
 [[package]]
-name = "acpi"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
-dependencies = [
- "bit_field",
- "log",
- "rsdp",
-]
-
-[[package]]
-name = "aead"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
-name = "aml"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c264f2e933012ef2dd324cdac38f4c6c142473c1d1a1357ba16321e7d892975f"
-dependencies = [
- "bit_field",
- "byteorder",
- "log",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
@@ -83,46 +20,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b5e5f48b927f04e952dedc932f31995a65a0bf65ec971c74436e51bf6e970d"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -135,50 +42,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cipher"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -202,43 +65,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "generic-array"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
-
-[[package]]
-name = "goblin"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,15 +84,6 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -367,65 +184,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_core"
-version = "0.1.0"
-dependencies = [
- "lock_api",
- "spinning_top",
-]
-
-[[package]]
 name = "oak_echo_raw_enclave"
 version = "0.1.0"
 dependencies = [
  "log",
  "micro_rpc",
  "oak_channel",
- "oak_linux_boot_params",
- "oak_restricted_kernel",
+ "oak_enclave_runtime_support",
  "oak_restricted_kernel_api",
  "static_assertions",
 ]
 
 [[package]]
-name = "oak_linux_boot_params"
+name = "oak_enclave_runtime_support"
 version = "0.1.0"
 dependencies = [
- "bitflags",
- "static_assertions",
- "strum",
- "zerocopy",
-]
-
-[[package]]
-name = "oak_restricted_kernel"
-version = "0.1.0"
-dependencies = [
- "acpi",
- "aml",
- "anyhow",
- "arrayvec",
- "atomic_refcell",
- "bitflags",
- "bitvec",
- "goblin",
  "libm",
  "linked_list_allocator",
  "log",
- "oak_channel",
- "oak_core",
- "oak_linux_boot_params",
+ "oak_restricted_kernel_api",
  "oak_restricted_kernel_interface",
- "oak_sev_guest",
- "oak_simple_io",
- "oak_virtio",
- "rust-hypervisor-firmware-virtio",
- "sev_serial",
  "spinning_top",
- "static_assertions",
- "strum",
- "x86_64",
- "zerocopy",
 ]
 
 [[package]]
@@ -448,52 +227,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_sev_guest"
-version = "0.1.0"
-dependencies = [
- "aes-gcm",
- "bitflags",
- "lock_api",
- "snafu",
- "spinning_top",
- "static_assertions",
- "strum",
- "x86_64",
- "zerocopy",
-]
-
-[[package]]
-name = "oak_simple_io"
-version = "0.1.0"
-dependencies = [
- "bitflags",
- "oak_sev_guest",
- "x86_64",
-]
-
-[[package]]
-name = "oak_virtio"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bitflags",
- "log",
- "rust-hypervisor-firmware-virtio",
- "strum",
- "x86_64",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "petgraph"
@@ -503,24 +240,6 @@ checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
-]
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "polyval"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
 ]
 
 [[package]]
@@ -595,12 +314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,25 +347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsdp"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "rust-hypervisor-firmware-virtio"
-version = "0.1.0"
-dependencies = [
- "atomic_refcell",
- "bitflags",
- "log",
- "x86_64",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,56 +357,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sev_serial"
-version = "0.1.0"
-dependencies = [
- "oak_sev_guest",
- "x86_64",
-]
-
-[[package]]
-name = "snafu"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd726aec4ebad65756394ff89a9b9598793d4e30121cd71690244c1e497b3aee"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712529e9b0b014eabaa345b38e06032767e3dc393e8b017e853b1d7247094e74"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "spinning_top"
@@ -752,12 +396,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
 name = "syn"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,12 +405,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -789,38 +421,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
-
-[[package]]
-name = "universal-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "volatile"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ca98349dda8a60ae74e04fd90c7fb4d6a4fbe01e6d3be095478aa0b76f6c0c"
 
 [[package]]
 name = "which"
@@ -854,45 +458,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
-dependencies = [
- "tap",
-]
-
-[[package]]
-name = "x86_64"
-version = "0.14.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
-dependencies = [
- "bit_field",
- "bitflags",
- "rustversion",
- "volatile",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/testing/oak_echo_raw_enclave/Cargo.toml
+++ b/testing/oak_echo_raw_enclave/Cargo.toml
@@ -9,18 +9,12 @@ license = "Apache-2.0"
 resolver = "2"
 members = ["."]
 
-[features]
-default = ["vsock_channel"]
-vsock_channel = ["oak_restricted_kernel/vsock_channel"]
-simple_io_channel = ["oak_restricted_kernel/simple_io_channel"]
-
 [dependencies]
 log = "*"
 oak_channel = { path = "../../oak_channel" }
-oak_restricted_kernel = { path = "../../oak_restricted_kernel", default-features = false }
+oak_enclave_runtime_support = { path = "../../oak_enclave_runtime_support" }
 oak_restricted_kernel_api = { path = "../../oak_restricted_kernel_api" }
 micro_rpc = { path = "../../micro_rpc" }
-oak_linux_boot_params = { path = "../../linux_boot_params" }
 static_assertions = "*"
 
 [[bin]]

--- a/testing/oak_echo_raw_enclave/build.rs
+++ b/testing/oak_echo_raw_enclave/build.rs
@@ -15,12 +15,5 @@
 //
 
 fn main() {
-    println!(
-        "cargo:rerun-if-changed={}/oak_restricted_kernel/layout.ld",
-        env!("WORKSPACE_ROOT")
-    );
-    println!(
-        "cargo:rustc-link-arg=--script={}/oak_restricted_kernel/layout.ld",
-        env!("WORKSPACE_ROOT")
-    );
+    println!("cargo:rustc-link-arg=-zmax-page-size=0x200000");
 }

--- a/testing/oak_echo_raw_enclave/src/main.rs
+++ b/testing/oak_echo_raw_enclave/src/main.rs
@@ -24,14 +24,21 @@ use alloc::{vec, vec::Vec};
 use core::panic::PanicInfo;
 use log::info;
 use oak_channel::{Read, Write};
-use oak_linux_boot_params::BootParams;
-use oak_restricted_kernel_api::FileDescriptorChannel;
+use oak_restricted_kernel_api::{FileDescriptorChannel, StderrLogger};
 
 const MESSAGE_SIZE: usize = 1;
 
+static LOGGER: StderrLogger = StderrLogger {};
+
 #[no_mangle]
-pub extern "C" fn rust64_start(_rdi: u64, rsi: &BootParams) -> ! {
-    oak_restricted_kernel::start_kernel(rsi);
+fn _start() -> ! {
+    log::set_logger(&LOGGER).unwrap();
+    log::set_max_level(log::LevelFilter::Debug);
+    oak_enclave_runtime_support::init();
+    main();
+}
+
+fn main() -> ! {
     info!("In main!");
     start_echo_server()
 }
@@ -57,5 +64,6 @@ fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
-    oak_restricted_kernel::panic(info);
+    log::error!("PANIC: {}", info);
+    oak_restricted_kernel_api::syscall::exit(-1);
 }


### PR DESCRIPTION
Now that we have Ring 3 and have applications as separate binaries, it's time to bring everyone else along for the ride as well.

I still need to fix Google-internal systems to work with these, though, so unfortunately for a short while you won't be able to just copy them into Google and run them on SEV-SNP.