### PR TITLE
Make Stage0 load the Linux initial RAM disk

### DIFF
--- a/oak_hello_world_linux_init/src/init.rs
+++ b/oak_hello_world_linux_init/src/init.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The Project Oak Authors
+// Copyright 2023 The Project Oak Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/oak_hello_world_linux_init/src/main.rs
+++ b/oak_hello_world_linux_init/src/main.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The Project Oak Authors
+// Copyright 2023 The Project Oak Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/stage0/src/initramfs.rs
+++ b/stage0/src/initramfs.rs
@@ -1,0 +1,55 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::fw_cfg::FwCfg;
+use core::slice;
+use x86_64::VirtAddr;
+
+pub struct RamDiskInfo {
+    pub address: VirtAddr,
+    pub size: u32,
+}
+
+/// Tries to load an initial RAM disk from the QEMU FW_CFG device.
+///
+/// If it finds a RAM disk it returns the address where it is loaded and the size. If not it
+/// returns `None`.
+pub fn try_load_initial_ram_disk(fw_cfg: &mut FwCfg) -> Option<RamDiskInfo> {
+    let size = fw_cfg
+        .read_initrd_size()
+        .expect("couldn't read initial RAM disk size");
+    if size == 0 {
+        log::debug!("No initial RAM disk");
+        return None;
+    }
+
+    let address = fw_cfg
+        .read_initrd_address()
+        .expect("couldn't read initial RAM disk address");
+
+    log::debug!("Initial RAM disk size {}", size);
+    log::debug!("Initial RAM disk address {:#018x}", address.as_u64());
+
+    // TODO(#3628): Check that the suggested address is valid and sensible.
+    // Safety: for now we trust that the hypervisor suggests a valid address and to load the RAM
+    // disk, but will add checks to ensure it falls in valid mapped memory and won't overwrite
+    // existing structures. We only write to the slice and don't assume anything about its layout.
+    let buf = unsafe { slice::from_raw_parts_mut::<u8>(address.as_mut_ptr(), size as usize) };
+    fw_cfg
+        .read_initrd_data(buf)
+        .expect("couldn't read initial RAM disk content");
+    Some(RamDiskInfo { size, address })
+}

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -49,6 +49,7 @@ mod acpi;
 mod asm;
 mod cmos;
 mod fw_cfg;
+mod initramfs;
 mod logging;
 mod sev;
 mod zero_page;
@@ -312,6 +313,10 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
     }
 
     zero_page.set_acpi_rsdp_addr(acpi::build_acpi_tables(&mut fwcfg).unwrap());
+
+    if let Some(ram_disk) = initramfs::try_load_initial_ram_disk(&mut fwcfg) {
+        zero_page.set_initial_ram_disk(&ram_disk);
+    }
 
     log::info!("jumping to kernel at {:#018x}", entry.as_u64());
 

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{cmos::Cmos, fw_cfg::FwCfg};
+use crate::{cmos::Cmos, fw_cfg::FwCfg, initramfs::RamDiskInfo};
 use core::{ffi::CStr, mem::size_of};
 use oak_linux_boot_params::{BootE820Entry, BootParams, E820EntryType};
 use oak_sev_guest::io::PortFactoryWrapper;
@@ -115,6 +115,12 @@ impl ZeroPage {
         // Put our header as the first element in the linked list.
         setup_data.header.next = self.inner.hdr.setup_data;
         self.inner.hdr.setup_data = &setup_data.header as *const oak_linux_boot_params::SetupData;
+    }
+
+    /// Sets the address and size of the initial RAM disk.
+    pub fn set_initial_ram_disk(&mut self, ram_disk: &RamDiskInfo) {
+        self.inner.hdr.ramdisk_image = ram_disk.address.as_u64() as u32;
+        self.inner.hdr.ramdisk_size = ram_disk.size;
     }
 }
 


### PR DESCRIPTION
This adds support to the Stage 0 firmware to load the initial RAM disk if it is available and set the address and size in the Linux boot paramters. With this change we are now able to boot the Linux kernel with an initial RAM disk using the Stage 0 firmware.