### PR TITLE
Add DMA support to the QEMU FW_CFG device

### DIFF
--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
 name = "oak_stage0"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "goblin",
  "log",
  "oak_core",

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 members = ["."]
 
 [dependencies]
+bitflags = "*"
 goblin = { version = "*", default-features = false, features = ["elf64"] }
 log = "*"
 oak_core = { path = "../oak_core", default-features = false }

--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -237,8 +237,6 @@ impl FwCfg {
         let mut initrd_addr: u32 = 0;
         self.write_selector(FwCfgItems::InitrdAddr as u16)?;
         self.read(&mut initrd_addr)?;
-        // Since we use an identity mapping in the Stage0 firmware, we can interpret the physical
-        // address directly as a virtual address.
         Ok(PhysAddr::new(initrd_addr as u64))
     }
 

--- a/stage0/src/initramfs.rs
+++ b/stage0/src/initramfs.rs
@@ -16,6 +16,7 @@
 
 use crate::fw_cfg::FwCfg;
 use core::slice;
+use x86_64::VirtAddr;
 
 /// Tries to load an initial RAM disk from the QEMU FW_CFG device.
 ///
@@ -33,6 +34,9 @@ pub fn try_load_initial_ram_disk(fw_cfg: &mut FwCfg) -> Option<&[u8]> {
     let address = fw_cfg
         .read_initrd_address()
         .expect("couldn't read initial RAM disk address");
+
+    // We use an identity mapping for memory.
+    let address = VirtAddr::new(address.as_u64());
 
     log::debug!("Initial RAM disk size {}", size);
     log::debug!("Initial RAM disk address {:#018x}", address.as_u64());


### PR DESCRIPTION
This allows us to load the initial RAM disk via DMA rather than 1 byte at a time.

Fixes #3631