### PR TITLE
Load the application binary separately

### DIFF
--- a/oak_functions_launcher/src/instance/virtualized.rs
+++ b/oak_functions_launcher/src/instance/virtualized.rs
@@ -15,12 +15,14 @@
 //
 
 use crate::{instance::LaunchedInstance, path_exists};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use clap::Parser;
 use command_fds::tokio::CommandFdAsyncExt;
 use log::info;
+use oak_channel::{Channel, Write};
 use std::{
+    fs,
     net::Shutdown,
     os::unix::{io::AsRawFd, net::UnixStream},
     path::PathBuf,
@@ -38,6 +40,10 @@ pub struct Params {
     #[arg(long, value_parser = path_exists)]
     pub enclave_binary: PathBuf,
 
+    /// Path to the Oak Functions application binary to be loaded into the enclave.
+    #[arg(long, value_parser = path_exists)]
+    pub app_binary: PathBuf,
+
     /// Path to the BIOS image to use.
     #[arg(long, value_parser = path_exists)]
     pub bios_binary: PathBuf,
@@ -45,6 +51,17 @@ pub struct Params {
     /// Port to use for debugging with gdb
     #[arg(long = "gdb")]
     pub gdb: Option<u16>,
+}
+
+/// Writes a chunk to a channel, and expects an acknowledgement containing the length of the chunk.
+fn write_chunk(channel: &mut dyn Channel, chunk: &[u8]) -> Result<()> {
+    channel.write(chunk)?;
+    let mut ack: [u8; 4] = Default::default();
+    channel.read(&mut ack)?;
+    if u32::from_be_bytes(ack) as usize != chunk.len() {
+        anyhow::bail!("ack wasnt of correct length");
+    }
+    Ok(())
 }
 
 pub struct Instance {
@@ -55,8 +72,20 @@ pub struct Instance {
 
 impl Instance {
     pub fn start(params: Params, console: UnixStream) -> Result<Self> {
+        let app_bytes = fs::read(&params.app_binary).with_context(|| {
+            format!(
+                "couldn't read application binary {}",
+                &params.app_binary.display()
+            )
+        })?;
+        log::info!(
+            "read application binary from disk {} ({} bytes)",
+            &params.app_binary.display(),
+            app_bytes.len()
+        );
+
         let mut cmd = tokio::process::Command::new(params.vmm_binary);
-        let (comms_guest, comms_host) = UnixStream::pair()?;
+        let (comms_guest, mut comms_host) = UnixStream::pair()?;
 
         cmd.stderr(Stdio::inherit());
         cmd.stdin(Stdio::null());
@@ -114,8 +143,22 @@ impl Instance {
 
         info!("Executing: {:?}", cmd);
 
+        let instance = cmd.spawn()?;
+
+        // Loading the application binary needs to happen before we start using microrpc over the
+        // channel.
+        comms_host
+            .write(&(app_bytes.len() as u32).to_be_bytes())
+            .expect("failed to send application binary length to enclave");
+
+        let mut chunks = app_bytes.array_chunks::<4096>();
+        for chunk in chunks.by_ref() {
+            write_chunk(&mut comms_host, chunk)?;
+        }
+        write_chunk(&mut comms_host, chunks.remainder())?;
+
         Ok(Self {
-            instance: cmd.spawn()?,
+            instance,
             console,
             comms: comms_host,
         })

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -16,6 +16,7 @@
 
 #![feature(never_type)]
 #![feature(result_flattening)]
+#![feature(array_chunks)]
 
 use anyhow::Context;
 use clap::Parser;

--- a/oak_restricted_kernel/layout.ld
+++ b/oak_restricted_kernel/layout.ld
@@ -88,21 +88,6 @@ SECTIONS {
     } : bss
     stack_start = .;
 
-    /* This section is empty when we link the binary together, but later we'll embed the user-space
-     * binary here. This needs to be the last item, as we don't know the size of it when we're linking
-     * the program.
-     */
-    .payload : ALIGN(2M) {
-        payload_start = .;
-        /* The ELF64 header is 64 bytes long, so let's ensure that even if we forget to include the payload
-         * binary there's at least a header's worth of data to load in here.
-         * As the four-byte magic would need to be 0x7F 'E' 'L' 'F', filling this section with 64*0xFF means
-         * we'll get an runtime error when attempting to parse this section.
-         */
-        FILL(0xFF)
-        . += 64;
-    } : payload
-
     /DISCARD/ : {
         *(.eh_frame*)
     }


### PR DESCRIPTION
As we've discussed before, we want to load the application (e.g. Oak Functions itself) separately from the rest of the kernel. In order to achieve this, we hijack the communication channel before we hand it to user code, and transmit the ELF file to the kernel using a really trivial chunked protocol.

(We need the chunks, as sending 20 MB file into the enclave in 4K chunks takes <5 seconds, whereas just dumping the whole 20MB file into the channel at one takes several minutes).

I will admit that this is a bit hacky. In the future, we want to be able to talk to multiple processes inside the VM, so we'll need some kind of multiplexing over the channel. The multiplexing will be useful for other things as well, as we do want to have some kind of "control channel" in the future: say, to get metrics that we want to expose to monitoring. Once we have that, we can implement a more proper protocol (micro_rpc based, as always) to talk to the moral equivalent of an `init` process, and delegate loading and executing the ELF file to that.

However, at this point we really don't have the facility to handle multiple recipients or processes in the kernel, so this is the most straightforward way to get this done, for now.

Also, I'll follow up with a separate PR to rename things. `oak_enclave_shim` is a misnomer now as it's the only "enclave binary", and `oak_*_enclave` crates don't make much sense either any longer as they're not the enclave binaries. (Suggestions welcome, I was thinking of `oak_*_app` or going to something like `oak_*_rk_bin`, to mirror the `_linux_bin` names).