### PR TITLE
Remove the flaky `test_erroneous_read` test.

### DIFF
--- a/oak_restricted_kernel_api/src/syscall.rs
+++ b/oak_restricted_kernel_api/src/syscall.rs
@@ -142,17 +142,6 @@ mod tests {
     }
 
     #[test]
-    fn test_erroneus_read() {
-        let fd = {
-            let (reader, _) = os_pipe::pipe().unwrap();
-            reader.as_raw_fd()
-        };
-
-        let mut rx = [0u8; 4];
-        assert!(read(fd, &mut rx).is_err());
-    }
-
-    #[test]
     fn test_erroneus_write() {
         let fd = {
             let (_, writer) = os_pipe::pipe().unwrap();


### PR DESCRIPTION
For whatever reason, when we execute this on Github Actions (which presumably are linux), we'll still be able to read even though there's nobody writing to the socket.