### PR TITLE
Ensure the initial RAM disk address is suitable

### DIFF
--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -253,6 +253,22 @@ impl FwCfg {
         Ok(buf.len())
     }
 
+    /// Reads the size of the kernel.
+    pub fn read_kernel_size(&mut self) -> Result<u32, &'static str> {
+        let mut kernel_size: u32 = 0;
+        self.write_selector(FwCfgItems::KernelSize as u16)?;
+        self.read(&mut kernel_size)?;
+        Ok(kernel_size)
+    }
+
+    /// Reads the address for the intended start of the kernel.
+    pub fn read_kernel_address(&mut self) -> Result<PhysAddr, &'static str> {
+        let mut kernel_addr: u32 = 0;
+        self.write_selector(FwCfgItems::KernelAddr as u16)?;
+        self.read(&mut kernel_addr)?;
+        Ok(PhysAddr::new(kernel_addr as u64))
+    }
+
     /// Reads contents of a file; returns the number of bytes actually read.
     ///
     /// The buffer `buf` will be filled to capacity if the file is larger;

--- a/stage0/src/initramfs.rs
+++ b/stage0/src/initramfs.rs
@@ -16,38 +16,135 @@
 
 use crate::fw_cfg::FwCfg;
 use core::slice;
-use x86_64::VirtAddr;
+use oak_linux_boot_params::{BootE820Entry, E820EntryType};
+use x86_64::{
+    structures::paging::{PageSize, Size2MiB, Size4KiB},
+    PhysAddr, VirtAddr,
+};
 
 /// Tries to load an initial RAM disk from the QEMU FW_CFG device.
 ///
-/// If it finds a RAM disk it returns the address where it is loaded and the size. If not it
-/// returns `None`.
-pub fn try_load_initial_ram_disk(fw_cfg: &mut FwCfg) -> Option<&[u8]> {
+/// If it finds a RAM disk it returns the byte slice where it is loaded. If not it returns `None`.
+pub fn try_load_initial_ram_disk(
+    fw_cfg: &mut FwCfg,
+    e820_table: &[BootE820Entry],
+) -> Option<&'static [u8]> {
     let size = fw_cfg
         .read_initrd_size()
-        .expect("couldn't read initial RAM disk size");
+        .expect("couldn't read initial RAM disk size") as usize;
     if size == 0 {
         log::debug!("No initial RAM disk");
         return None;
     }
 
-    let address = fw_cfg
+    let mut initrd_address = fw_cfg
         .read_initrd_address()
         .expect("couldn't read initial RAM disk address");
 
-    // We use an identity mapping for memory.
-    let address = VirtAddr::new(address.as_u64());
-
     log::debug!("Initial RAM disk size {}", size);
-    log::debug!("Initial RAM disk address {:#018x}", address.as_u64());
+    log::debug!("Initial RAM disk address {:#018x}", initrd_address.as_u64());
 
-    // TODO(#3628): Check that the suggested address is valid and sensible.
-    // Safety: for now we trust that the hypervisor suggests a valid address and to load the RAM
-    // disk, but will add checks to ensure it falls in valid mapped memory and won't overwrite
-    // existing structures. We only write to the slice and don't assume anything about its layout.
-    let buf = unsafe { slice::from_raw_parts_mut::<u8>(address.as_mut_ptr(), size as usize) };
+    let kernel_address = fw_cfg
+        .read_kernel_address()
+        .expect("couldn't read kernel address");
+    let kernel_size = fw_cfg
+        .read_kernel_size()
+        .expect("couldn't read kernel address") as u64;
+
+    log::debug!("Kernel size {}", kernel_size);
+    log::debug!("Kernel start address {:#018x}", kernel_address.as_u64());
+
+    if let Err(error) = check_initrd_address(
+        initrd_address,
+        initrd_address + (size as u64),
+        kernel_address,
+        kernel_address + kernel_size,
+        e820_table,
+    ) {
+        log::warn!("Unsuitable initial RAM disk address: {}", error);
+        initrd_address = find_suitable_initrd_address(size, e820_table)
+            .expect("couldn't a find suitable initial RAM disk address");
+        log::debug!(
+            "Suggested new initial RAM disk address: {:#018x}",
+            initrd_address.as_u64()
+        );
+    }
+
+    // If it is still not a suitable address, just panic.
+    check_initrd_address(
+        initrd_address,
+        initrd_address + size as u64,
+        kernel_address,
+        kernel_address + kernel_size,
+        e820_table,
+    )
+    .expect("couldn't find a suitable initial RAM disk address");
+
+    // We use an identity mapping for memory.
+    let address = VirtAddr::new(initrd_address.as_u64());
+
+    // Safety: We already checked that the slice falls within the mapped virtual memory, is backed
+    // by physical memory, does not overlap with the kernel, and does not overlap with the first
+    // 2MiB where our important data structures live. It can also not overlap with the firmware ROM
+    // image, since that is above the 1GiB upper limit we support. We only write to the slice and
+    // don't assume anything about its layout or alignment.
+    let buf = unsafe { slice::from_raw_parts_mut::<u8>(address.as_mut_ptr(), size) };
     fw_cfg
         .read_initrd_data(buf)
         .expect("couldn't read initial RAM disk content");
     Some(buf)
+}
+
+fn check_initrd_address(
+    initrd_start: PhysAddr,
+    initrd_end: PhysAddr,
+    kernel_start: PhysAddr,
+    kernel_end: PhysAddr,
+    e820_table: &[BootE820Entry],
+) -> Result<(), &'static str> {
+    if initrd_start.as_u64() < Size2MiB::SIZE {
+        return Err("address falls in the first 2MiB");
+    }
+    if initrd_start < kernel_end && initrd_end > kernel_start {
+        return Err("initial RAM disk overlaps with the kernel");
+    }
+    if initrd_end.as_u64() > crate::TOP_OF_VIRTUAL_MEMORY {
+        return Err("initial RAM disk ends above the mapped virtual memory");
+    }
+    if !e820_table.iter().any(|entry| {
+        entry.entry_type() == Some(E820EntryType::RAM)
+            && entry.addr() as u64 <= initrd_start.as_u64()
+            && (entry.addr() + entry.size()) as u64 >= initrd_end.as_u64()
+    }) {
+        return Err("initial RAM disk is not backed by physical memory");
+    }
+
+    Ok(())
+}
+
+fn find_suitable_initrd_address(
+    initrd_size: usize,
+    e820_table: &[BootE820Entry],
+) -> Result<PhysAddr, &'static str> {
+    let padded_size = (initrd_size as u64)
+        .checked_next_multiple_of(Size4KiB::SIZE)
+        .unwrap();
+    // We use the end of the highest section of RAM that is big enough and falls below 1GiB.
+    e820_table
+        .iter()
+        .filter_map(|entry| {
+            if entry.entry_type() != Some(E820EntryType::RAM) {
+                return None;
+            }
+            let start = entry.addr() as u64;
+            let end = crate::TOP_OF_VIRTUAL_MEMORY.min(start + entry.size() as u64);
+            if padded_size.checked_add(start).unwrap() > end {
+                return None;
+            }
+
+            // Align the start address down in case the end was not aligned.
+            Some(PhysAddr::new(end.checked_sub(padded_size).unwrap()).align_down(Size4KiB::SIZE))
+        })
+        .max_by(PhysAddr::cmp)
+        .ok_or("no suitable memory available for the initial RAM disk")
 }

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -17,6 +17,7 @@
 #![no_std]
 #![no_main]
 #![feature(cstr_from_bytes_until_nul)]
+#![feature(int_roundings)]
 
 use core::{
     alloc::Layout,
@@ -39,7 +40,7 @@ use x86_64::{
         idt::InterruptDescriptorTable,
         paging::{
             page_table::{PageTable, PageTableFlags},
-            PageSize, PhysFrame, Size2MiB,
+            PageSize, PhysFrame, Size1GiB, Size2MiB,
         },
     },
     PhysAddr, VirtAddr,
@@ -62,6 +63,12 @@ static SEV_SECRETS: MaybeUninit<oak_sev_guest::secrets::SecretsPage> = MaybeUnin
 #[link_section = ".boot"]
 #[no_mangle]
 static SEV_CPUID: MaybeUninit<oak_sev_guest::cpuid::CpuidPage> = MaybeUninit::uninit();
+
+/// The default entry point for the kernel if one wasn't supplied via the QEMU fw_cfg device.
+const DEFAULT_KERNEL_ENTRY: u64 = 0x200000;
+
+/// We create an identity map for the first 1GiB of memory.
+const TOP_OF_VIRTUAL_MEMORY: u64 = Size1GiB::SIZE;
 
 extern "C" {
     #[link_name = "pd_addr"]
@@ -291,11 +298,23 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
         }
     }
 
-    // Attempt to parse 64 bytes at 0x200000 (2MiB) as an ELF header. If it works, extract the entry
-    // point address from there; if there is no valid ELF header at that address, assume it's code,
-    // and jump there directly.
+    // For the Linux boot protocol we use the start address as the entry point. The kernel entry
+    // point provided by the fw_cfg device actually points to the entry point for the PVH boot
+    // protocol. We use an identity mapping.
+    let mut entry = VirtAddr::new(
+        fwcfg
+            .read_kernel_address()
+            .expect("failed to read kernel start addres from fw_cfg")
+            .as_u64(),
+    );
+    if entry.is_null() {
+        entry = VirtAddr::new(DEFAULT_KERNEL_ENTRY);
+    }
+
+    // Attempt to parse 64 bytes at the suggested entry point as an ELF header. If it works, extract
+    // the entry point address from there; if there is no valid ELF header at that address, assume
+    // it's code, and jump there directly.
     // Safety: this assumes the kernel is loaded at the given address.
-    let mut entry = VirtAddr::new(0x200000);
     let header = header::header64::Header::from_bytes(unsafe {
         &*(entry.as_u64() as *const [u8; header::header64::SIZEOF_EHDR])
     });
@@ -314,7 +333,8 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
 
     zero_page.set_acpi_rsdp_addr(acpi::build_acpi_tables(&mut fwcfg).unwrap());
 
-    if let Some(ram_disk) = initramfs::try_load_initial_ram_disk(&mut fwcfg) {
+    if let Some(ram_disk) = initramfs::try_load_initial_ram_disk(&mut fwcfg, zero_page.e820_table())
+    {
         zero_page.set_initial_ram_disk(ram_disk);
     }
 


### PR DESCRIPTION
Checks whether the suggested initial RAM disk address is suitable, and if not tries to find a more suitable one.

Fixes #3628