### PR TITLE
Write bytes in LE order, not BE order when loading the application.

### DIFF
--- a/oak_functions_launcher/src/instance/virtualized.rs
+++ b/oak_functions_launcher/src/instance/virtualized.rs
@@ -60,7 +60,7 @@ fn write_chunk(channel: &mut dyn Channel, chunk: &[u8]) -> Result<()> {
     channel.write(chunk)?;
     let mut ack: [u8; 4] = Default::default();
     channel.read(&mut ack)?;
-    if u32::from_be_bytes(ack) as usize != chunk.len() {
+    if u32::from_le_bytes(ack) as usize != chunk.len() {
         anyhow::bail!("ack wasn't of correct length");
     }
     Ok(())
@@ -150,7 +150,7 @@ impl Instance {
         // Loading the application binary needs to happen before we start using microrpc over the
         // channel.
         comms_host
-            .write(&(app_bytes.len() as u32).to_be_bytes())
+            .write(&(app_bytes.len() as u32).to_le_bytes())
             .expect("failed to send application binary length to enclave");
 
         // The kernel expects data to be transmitted in chunks of one page.

--- a/oak_restricted_kernel/src/payload.rs
+++ b/oak_restricted_kernel/src/payload.rs
@@ -34,7 +34,7 @@ fn read_chunk<C: Channel + ?Sized>(channel: &mut C, chunk: &mut [u8]) -> Result<
         .try_into()
         .map_err(|_| anyhow::anyhow!("chunk too big"))?;
     channel.read(chunk)?;
-    channel.write(&len.to_be_bytes())
+    channel.write(&len.to_le_bytes())
 }
 
 /// Reads a payload blob, one page at a time, from the given channel.
@@ -42,7 +42,7 @@ pub fn read_payload<C: Channel + ?Sized>(channel: &mut C) -> Result<Vec<u8>> {
     let payload_len = {
         let mut buf: [u8; 4] = Default::default();
         channel.read(&mut buf)?;
-        u32::from_be_bytes(buf)
+        u32::from_le_bytes(buf)
     };
     let mut payload = vec![0; payload_len as usize];
     let mut chunks_mut = payload.array_chunks_mut::<{ Size4KiB::SIZE as usize }>();


### PR DESCRIPTION
Little-endian is the native byte order for x86-64, and this is also the one used by our regular communication protocol.

I don't know why I blanked out and used big-endian format here at all; this should always have been little-endian.