### PR TITLE
Enlighten fw_cfg to support AMD SEV-SNP

### DIFF
--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -39,8 +39,8 @@ pub struct DmaBuffer {
 
 static_assertions::assert_eq_size!(DmaBuffer, [u8; Size4KiB::SIZE as usize]);
 
-impl DmaBuffer {
-    pub const fn new() -> Self {
+impl Default for DmaBuffer {
+    fn default() -> Self {
         DmaBuffer {
             data: [0u8; Size4KiB::SIZE as usize],
         }


### PR DESCRIPTION
The memory-encryption part is currently untested as we cannot run Linux workloads with initial RAM disks on AMD SEV-SNP yet using the stage 0 firmware.

Fixes #3636