### PR TITLE
Some minor fixes to mmap and interrupt handling

### DIFF
--- a/oak_enclave_runtime_support/src/heap.rs
+++ b/oak_enclave_runtime_support/src/heap.rs
@@ -88,7 +88,7 @@ impl GrowableHeap {
         .map_err(|_| "failed to acquire memory")?;
 
         // Move the cursor to the next unallocated page.
-        self.cursor = Some(mem.as_ptr() as usize + Self::PAGE_SIZE);
+        self.cursor = Some(mem.as_ptr() as usize + (pages * Self::PAGE_SIZE));
         self.base.get_or_insert(mem.as_ptr() as usize);
 
         Ok(())

--- a/oak_tensorflow_service/src/tflite.rs
+++ b/oak_tensorflow_service/src/tflite.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+use core::ffi::c_void;
+
 use alloc::{vec, vec::Vec};
 use anyhow::{anyhow, Context};
 use log::{log, Level};
@@ -96,7 +98,9 @@ impl TfliteModel {
         // Allocate memory. Both Oak Restricted Kernel and Linux have similar enough `mmap()`
         // semantics for this to work.
         let mem = mmap(
-            None, // we don't care where the allocation lands
+            // We don't particularly care where the allocation lands, but let's place it at the 64
+            // GiB mark to ensure we won't reasonably have the heap running into it.
+            Some(0x10_0000_0000 as *const c_void),
             TENSOR_ARENA_SIZE,
             MmapProtection::PROT_READ | MmapProtection::PROT_WRITE,
             MmapFlags::MAP_ANONYMOUS | MmapFlags::MAP_PRIVATE,


### PR DESCRIPTION
This fixes a couple of things I ran into while getting things up and running on our internal VMM:

 - When increasing the application heap size I didn't take the number of pages into account correctly when moving the cursor forward.
 - Just to be on the safe side, if we're asked to load data to an address that's not aligned with 2 MiB pages and need to align the address down, take the extra padding we need to have into account when allocating memory.
 - Keep interrupts disabled when we jump to Ring 3, as we don't handle them properly yet. Case in point, I think we need to disable the PIC (external interrupt controller) that QEMU microvm doesn't expose, but I think our internal VMM has.
 - For Tensorflow, make sure that the heap can grow a reasonable bit before we hit the chunk of memory we don't manage.