### PR TITLE
PVALIDATE page when unsharing

### DIFF
--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -115,6 +115,12 @@ pub fn unshare_page(page: Page<Size4KiB>, snp: bool, encrypted: u64) {
         let request = SnpPageStateChangeRequest::new(page_start as usize, PageAssignment::Private)
             .expect("invalid address for page location");
         change_snp_page_state(request).expect("couldn't change SNP state for page");
+        pvalidate(
+            page_start as usize,
+            SevPageSize::Page4KiB,
+            Validation::Validated,
+        )
+        .unwrap();
     }
 
     let PageTables { pdpt: _, pd } = get_page_tables(encrypted);


### PR DESCRIPTION
After changing the page state in the RMP to guest-private we need to PVALIDATE it again to make it usable. The current pages we are unsharing don't really matter, since they fall in a range that will not be used by the kernel, but in future this function might be used on pages that will be reused.