### PR TITLE
Extend the PublicKeyInfo proto definition with additional evidence info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,9 +2389,12 @@ name = "oak_remote_attestation_noninteractive"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "futures",
  "futures-util",
  "oak_grpc_utils",
  "prost 0.11.2",
+ "tokio",
  "tonic",
 ]
 

--- a/oak_remote_attestation_noninteractive/Cargo.toml
+++ b/oak_remote_attestation_noninteractive/Cargo.toml
@@ -13,15 +13,8 @@ tonic = "*"
 [dev-dependencies]
 async-trait = "*"
 futures = "*"
+tokio = { version = "*", features = ["rt-multi-thread", "net"] }
 tonic = "*"
-tokio = { version = "*", features = [
-  "rt-multi-thread",
-  "macros",
-  "net",
-  "process",
- # "signal",
- # "sync",
-] }
 
 [build-dependencies]
 oak_grpc_utils = { path = "../oak_grpc_utils" }

--- a/oak_remote_attestation_noninteractive/Cargo.toml
+++ b/oak_remote_attestation_noninteractive/Cargo.toml
@@ -10,5 +10,18 @@ futures-util = "*"
 prost = "*"
 tonic = "*"
 
+[dev-dependencies]
+async-trait = "*"
+futures = "*"
+tonic = "*"
+tokio = { version = "*", features = [
+  "rt-multi-thread",
+  "macros",
+  "net",
+  "process",
+ # "signal",
+ # "sync",
+] }
+
 [build-dependencies]
 oak_grpc_utils = { path = "../oak_grpc_utils" }

--- a/oak_remote_attestation_noninteractive/proto/v1/messages.proto
+++ b/oak_remote_attestation_noninteractive/proto/v1/messages.proto
@@ -21,19 +21,38 @@ package oak.session.noninteractive.v1;
 option java_multiple_files = true;
 option java_package = "oak.session.noninteractive.v1";
 
-message PublicKeyInfo {
-  // The serialized enclave public key.
+// AttestationEvidence contains the information that the untrusted launcher provides to the client
+// in response to its request for the enclave's public key(s). The name is chosen to match the RATS
+// terminology (see https://datatracker.ietf.org/wg/rats/about/).
+message AttestationEvidence {
+  // The serialized public key part of the enclave encryption key.
   // TODO(#3442): Specify key format.
-  bytes enclave_public_key = 1;
+  bytes encryption_public_key = 1;
+
+  // The serialized public key part of the enclave signing key. This field is optional, and can be
+  // left empty if the protocol does not require it, e.g., if no application data is present.
+  // TODO(#3442): Specify key format.
+  bytes signing_public_key = 2;
+
   // The serialized attestation report binding the public key.
-  bytes attestation = 2;
-  // The serialized AMD-SEV-SNP certificate.
-  bytes tee_certificate = 3;
-  // The serialized binary attestation evidence.
-  bytes binary_attestation = 4;
-  // The serialized server configuration. The details of the configuration is application-specific.
-  // This field is optional and can be left empty.
-  bytes server_config = 5;
+  bytes attestation = 3;
+
+  // The serialized TEE certificate(s). The details of the format and how the certificate(s) are
+  // encoded into this byte array are implementation-specific. In case of AMD-SEV-SNP, as described
+  // in https://www.amd.com/system/files/TechDocs/57230.pdf, there are three different certificates
+  // packaged in two different files.
+  bytes tee_certificates = 4;
+
+  // The binary attestation evidence.
+  BinaryAttestation binary_attestation = 5;
+
+  // The optional application-specific data.
+  optional ApplicationData application_data = 6;
+
+  // The signature over the application_data, signed by the enclave using its signing key. This
+  // field is optional, and must be left empty if application_data is not provided.
+  // TODO(#3442): Specify the signing details, or link to a specification.
+  bytes signed_application_data = 7;
 }
 
 message BinaryAttestation {
@@ -43,11 +62,20 @@ message BinaryAttestation {
   bytes rekor_log_entry = 2;
 }
 
+message ApplicationData {
+  // The cryptographic digest of the application, of the form "<algorithm>:<value>".
+  bytes digest = 1;
+
+  // The serialized application configuration. The format of the configuration is
+  // application-specific. This field is optional and can be empty.
+  bytes config = 2;
+}
+
 message GetPublicKeyRequest {}
 
 message GetPublicKeyResponse {
-  // The enclave public key.
-  PublicKeyInfo public_key_info = 1;
+  // The AttestationEvidence containing the enclave's signing and encryption public keys.
+  AttestationEvidence public_key_info = 1;
 }
 
 message InvokeRequest {

--- a/oak_remote_attestation_noninteractive/proto/v1/messages.proto
+++ b/oak_remote_attestation_noninteractive/proto/v1/messages.proto
@@ -23,7 +23,7 @@ option java_package = "oak.session.noninteractive.v1";
 
 // AttestationEvidence contains the information that the untrusted launcher provides to the client
 // in response to its request for the enclave's public key(s). The name is chosen to match the RATS
-// terminology (see https://datatracker.ietf.org/wg/rats/about/).
+// terminology (see https://datatracker.ietf.org/doc/draft-ietf-rats-eat/).
 message AttestationEvidence {
   // The serialized public key part of the enclave encryption key.
   // TODO(#3442): Specify key format.
@@ -74,8 +74,8 @@ message ApplicationData {
 message GetPublicKeyRequest {}
 
 message GetPublicKeyResponse {
-  // The AttestationEvidence containing the enclave's signing and encryption public keys.
-  AttestationEvidence public_key_info = 1;
+  // The enclave's signing and encryption public keys and attestation evidence about them.
+  AttestationEvidence attestation_evidence = 1;
 }
 
 message InvokeRequest {

--- a/oak_remote_attestation_noninteractive/proto/v1/messages.proto
+++ b/oak_remote_attestation_noninteractive/proto/v1/messages.proto
@@ -24,10 +24,23 @@ option java_package = "oak.session.noninteractive.v1";
 message PublicKeyInfo {
   // The serialized enclave public key.
   // TODO(#3442): Specify key format.
-  bytes public_key = 1;
+  bytes enclave_public_key = 1;
   // The serialized attestation report binding the public key.
   bytes attestation = 2;
-  // TODO(#3442): Add evidence (endorsements and inclusion proofs) for the attested binary.
+  // The serialized AMD-SEV-SNP certificate.
+  bytes tee_certificate = 3;
+  // The serialized binary attestation evidence.
+  bytes binary_attestation = 4;
+  // The serialized server configuration. The details of the configuration is application-specific.
+  // This field is optional and can be left empty.
+  bytes server_config = 5;
+}
+
+message BinaryAttestation {
+  // The serialized binary endorsement statement from the transparent release process.
+  bytes endorsement_statement = 1;
+  // The serialized Rekor LogEntry as proof of the inclusion of the endorsement statement in Rekor.
+  bytes rekor_log_entry = 2;
 }
 
 message GetPublicKeyRequest {}

--- a/oak_remote_attestation_noninteractive/proto/v1/messages.proto
+++ b/oak_remote_attestation_noninteractive/proto/v1/messages.proto
@@ -23,7 +23,7 @@ option java_package = "oak.session.noninteractive.v1";
 
 // AttestationEvidence contains the information that the untrusted launcher provides to the client
 // in response to its request for the enclave's public key(s). The name is chosen to match the RATS
-// terminology (see https://datatracker.ietf.org/doc/draft-ietf-rats-eat/).
+// terminology (see https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence).
 message AttestationEvidence {
   // The serialized public key part of the enclave encryption key.
   // TODO(#3442): Specify key format.

--- a/oak_remote_attestation_noninteractive/proto/v1/service_streaming.proto
+++ b/oak_remote_attestation_noninteractive/proto/v1/service_streaming.proto
@@ -46,7 +46,7 @@ service StreamingSession {
   // messages exchanged by client and server, giving it a minimal amount of structure and type
   // safety.
   //
-  // The expected message seqeuence starts with the client sending a `GetPublicKeyRequest` message
+  // The expected message sequence starts with the client sending a `GetPublicKeyRequest` message
   // in order to fetch the public key of the enclave. This method may be handled by the untrusted
   // launcher or by the enclave, depending on the server implementation.
   //

--- a/oak_remote_attestation_noninteractive/tests/integration_test.rs
+++ b/oak_remote_attestation_noninteractive/tests/integration_test.rs
@@ -1,0 +1,123 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::Context;
+use futures::{Stream, StreamExt};
+use oak_remote_attestation_noninteractive::proto::{
+    request_wrapper, response_wrapper,
+    streaming_session_client::StreamingSessionClient,
+    streaming_session_server::{StreamingSession, StreamingSessionServer},
+    AttestationEvidence, GetPublicKeyRequest, GetPublicKeyResponse, RequestWrapper,
+    ResponseWrapper,
+};
+use std::pin::Pin;
+use tonic::{
+    transport::{Channel, Server},
+    Request, Response, Status, Streaming,
+};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_get_public_key() {
+    let port = 54321;
+
+    let handle = tokio::spawn(async move {
+        let _ = start_server(port).await;
+    });
+
+    let result = run_client(port).await;
+    assert!(result.is_ok());
+
+    handle.abort();
+}
+
+async fn start_server(port: u16) -> Result<(), tonic::transport::Error> {
+    let address = format!("[::1]:{port}").parse().unwrap();
+    let server = Server::builder()
+        .add_service(StreamingSessionServer::new(TestEvidenceProviderServer {}))
+        .serve(address);
+
+    server.await
+}
+
+async fn run_client(port: u16) -> anyhow::Result<()> {
+    // TODO(#3641): Replace with a call to the OakClient, once it supports sending
+    // GetPublicKeyRequest.
+    let channel = Channel::from_shared(format!("http://[::1]:{port}"))
+        .context("couldn't create gRPC channel")?
+        .connect()
+        .await?;
+    let mut inner = StreamingSessionClient::new(channel);
+
+    let mut response_stream = inner
+        .stream(futures_util::stream::iter(vec![RequestWrapper {
+            request: Some(request_wrapper::Request::GetPublicKeyRequest(
+                GetPublicKeyRequest {},
+            )),
+        }]))
+        .await
+        .context("couldn't send message")?
+        .into_inner();
+
+    // Read the next (and only) message from the response stream.
+    let response_wrapper = response_stream
+        .message()
+        .await
+        .context("gRPC server error when invoking method")?
+        .context("received empty response stream")?;
+
+    let Some(response_wrapper::Response::GetPublicKeyResponse(_)) = response_wrapper.response  else {
+        return Err(anyhow::anyhow!("response_wrapper does not have a valid invoke_response message"))
+    };
+
+    Ok(())
+}
+
+pub struct TestEvidenceProviderServer {}
+
+#[tonic::async_trait]
+impl StreamingSession for TestEvidenceProviderServer {
+    type StreamStream = Pin<Box<dyn Stream<Item = Result<ResponseWrapper, Status>> + Send>>;
+
+    async fn stream(
+        &self,
+        request: Request<Streaming<RequestWrapper>>,
+    ) -> Result<Response<Self::StreamStream>, tonic::Status> {
+        let mut request_stream = request.into_inner();
+        let request = request_stream
+            .next()
+            .await
+            .ok_or_else(|| tonic::Status::invalid_argument("empty request stream"))?
+            .map_err(|err| {
+                tonic::Status::internal(format!("error reading message from request stream: {err}"))
+            })?;
+
+        let Some(request_wrapper::Request::GetPublicKeyRequest(_)) = request.request else {
+            return Err(tonic::Status::invalid_argument("request wrapper must have get_public_key_request field set"));
+        };
+
+        // TODO(#3641): Respond with a more interesting AttestationEvidence.
+        let attestation_evidence = Some(AttestationEvidence::default());
+        Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
+            ResponseWrapper {
+                response: Some(response_wrapper::Response::GetPublicKeyResponse(
+                    GetPublicKeyResponse {
+                        attestation_evidence,
+                    },
+                )),
+            },
+        )]))))
+    }
+}


### PR DESCRIPTION
Fixes #3656

@project-oak/core Putting this out early for discussion. 

1. What do you think about the naming?
2. Any important points that could be included in the documentation at this stage?
3. Is there any other piece of information that should be included in `PublicKeyInfo`?