### PR TITLE
Add test with >2 GiB of Lookup Data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,6 +2106,7 @@ dependencies = [
  "micro_rpc_build",
  "oak_channel",
  "oak_functions_abi",
+ "oak_functions_test_utils",
  "oak_remote_attestation_noninteractive",
  "prost 0.11.2",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,7 @@ dependencies = [
  "oak_functions_test_utils",
  "oak_remote_attestation_noninteractive",
  "prost 0.11.2",
+ "rand 0.4.6",
  "serde",
  "tokio",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,6 +2100,7 @@ dependencies = [
  "env_logger 0.10.0",
  "futures",
  "hashbrown 0.13.1",
+ "lazy_static",
  "log",
  "micro_rpc",
  "micro_rpc_build",

--- a/oak_functions_launcher/Cargo.toml
+++ b/oak_functions_launcher/Cargo.toml
@@ -40,3 +40,4 @@ micro_rpc_build = { path = "../micro_rpc_build" }
 
 [dev-dependencies]
 lazy_static = "*"
+oak_functions_test_utils = { path = "../oak_functions_test_utils" }

--- a/oak_functions_launcher/Cargo.toml
+++ b/oak_functions_launcher/Cargo.toml
@@ -37,3 +37,6 @@ hashbrown = "*"
 
 [build-dependencies]
 micro_rpc_build = { path = "../micro_rpc_build" }
+
+[dev-dependencies]
+lazy_static = "*"

--- a/oak_functions_launcher/Cargo.toml
+++ b/oak_functions_launcher/Cargo.toml
@@ -41,3 +41,4 @@ micro_rpc_build = { path = "../micro_rpc_build" }
 [dev-dependencies]
 lazy_static = "*"
 oak_functions_test_utils = { path = "../oak_functions_test_utils" }
+rand = "*"

--- a/oak_functions_launcher/src/instance/native.rs
+++ b/oak_functions_launcher/src/instance/native.rs
@@ -28,7 +28,6 @@ use std::{
 
 use std::fs;
 
-// TODO(mschett): Remove this duplicated path_exists.
 fn path_exists(s: &str) -> Result<PathBuf, String> {
     let path = PathBuf::from(s);
     if !fs::metadata(s).map_err(|err| err.to_string())?.is_file() {

--- a/oak_functions_launcher/src/instance/native.rs
+++ b/oak_functions_launcher/src/instance/native.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{instance::LaunchedInstance, path_exists};
+use crate::instance::LaunchedInstance;
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::Parser;
@@ -25,6 +25,18 @@ use std::{
     os::unix::{io::AsRawFd, net::UnixStream},
     path::PathBuf,
 };
+
+use std::fs;
+
+// TODO(mschett): Remove this duplicated path_exists.
+fn path_exists(s: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(s);
+    if !fs::metadata(s).map_err(|err| err.to_string())?.is_file() {
+        Err(String::from("path does not represent a file"))
+    } else {
+        Ok(path)
+    }
+}
 
 /// Parameters used for launching the enclave as a native binary
 #[derive(Parser, Clone, Debug, PartialEq)]

--- a/oak_functions_launcher/src/instance/virtualized.rs
+++ b/oak_functions_launcher/src/instance/virtualized.rs
@@ -29,7 +29,6 @@ use std::{
     process::Stdio,
 };
 
-// TODO(mschett): Remove this duplicated path_exists.
 fn path_exists(s: &str) -> Result<PathBuf, String> {
     let path = PathBuf::from(s);
     if !fs::metadata(s).map_err(|err| err.to_string())?.is_file() {

--- a/oak_functions_launcher/src/instance/virtualized.rs
+++ b/oak_functions_launcher/src/instance/virtualized.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use crate::{instance::LaunchedInstance, path_exists};
+use crate::instance::LaunchedInstance;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use clap::Parser;
@@ -28,6 +28,16 @@ use std::{
     path::PathBuf,
     process::Stdio,
 };
+
+// TODO(mschett): Remove this duplicated path_exists.
+fn path_exists(s: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(s);
+    if !fs::metadata(s).map_err(|err| err.to_string())?.is_file() {
+        Err(String::from("path does not represent a file"))
+    } else {
+        Ok(path)
+    }
+}
 
 const PAGE_SIZE: usize = 4096;
 

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -1,0 +1,165 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#![feature(never_type)]
+#![feature(result_flattening)]
+#![feature(array_chunks)]
+
+use crate::channel::ConnectorHandle;
+use anyhow::Context;
+use instance::{native, virtualized, LaunchedInstance};
+use std::{
+    fs,
+    io::{BufRead, BufReader},
+    os::unix::net::UnixStream,
+    path::PathBuf,
+};
+
+use crate::schema::InitializeResponse;
+
+pub mod schema {
+    #![allow(dead_code)]
+    use prost::Message;
+    include!(concat!(env!("OUT_DIR"), "/oak.functions.rs"));
+}
+
+mod channel;
+mod instance;
+mod lookup;
+pub mod server;
+
+#[derive(clap::Subcommand, Clone, Debug, PartialEq)]
+pub enum Mode {
+    /// Launch a virtual enclave binary
+    Virtual(virtualized::Params),
+    /// Launch an enclave binary directly as a child process
+    Native(native::Params),
+}
+
+pub async fn create(
+    mode: Mode,
+    lookup_data_path: PathBuf,
+    wasm_path: PathBuf,
+    constant_response_size: u32,
+) -> Result<
+    (
+        Box<dyn LaunchedInstance>,
+        ConnectorHandle,
+        InitializeResponse,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    let (launched_instance, connector_handle) = launch_instance(mode).await?;
+    setup_lookup_data(connector_handle.clone(), lookup_data_path).await;
+    let result = setup_wasm(connector_handle.clone(), &wasm_path, constant_response_size).await?;
+    Ok((launched_instance, connector_handle, result))
+}
+
+async fn launch_instance(
+    mode: Mode,
+) -> Result<(Box<dyn LaunchedInstance>, ConnectorHandle), Box<dyn std::error::Error>> {
+    // Provide a way for the launched instance to send logs
+    let logs_console: UnixStream = {
+        // Create two linked consoles. Technically both can read/write, but we'll
+        // use them as a one way channel.
+        let (console_writer, console_receiver) = UnixStream::pair()?;
+
+        // Log everything sent by the writer.
+        tokio::spawn(async {
+            let mut reader = BufReader::new(console_receiver);
+
+            let mut line = String::new();
+            while reader.read_line(&mut line).expect("couldn't read line") > 0 {
+                log::info!("console: {:?}", line);
+                line.clear();
+            }
+        });
+
+        console_writer
+    };
+
+    let launched_instance: Box<dyn LaunchedInstance> = match mode {
+        Mode::Virtual(params) => Box::new(virtualized::Instance::start(params, logs_console)?),
+        Mode::Native(params) => Box::new(native::Instance::start(params)?),
+    };
+    let comms = launched_instance.create_comms_channel().await?;
+    let connector_handle = channel::Connector::spawn(comms);
+
+    Ok((launched_instance, connector_handle))
+}
+
+// Initially loads lookup data and spawns task to periodically refresh lookup data.
+async fn setup_lookup_data(connector_handle: ConnectorHandle, lookup_data_path: PathBuf) {
+    let mut client = schema::OakFunctionsAsyncClient::new(connector_handle);
+
+    // Block for [invariant that lookup data is fully loaded](https://github.com/project-oak/oak/tree/main/oak_functions/lookup/README.md#invariant-fully-loaded-lookup-data)
+    let lookup_data =
+        lookup::load_lookup_data(&lookup_data_path).expect("couldn't load lookup data");
+    let encoded_lookup_data =
+        lookup::encode_lookup_data(lookup_data).expect("couldn't encode lookup data");
+
+    if let Err(err) = client.update_lookup_data(&encoded_lookup_data).await {
+        panic!("couldn't send lookup data: {:?}", err)
+    }
+
+    // Spawn task to periodically refresh lookup data.
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(1000 * 60 * 10));
+        loop {
+            // Wait before updating because we just loaded the lookup data.
+            interval.tick().await;
+
+            let lookup_data =
+                lookup::load_lookup_data(&lookup_data_path).expect("couldn't load lookup data");
+            let encoded_lookup_data =
+                lookup::encode_lookup_data(lookup_data).expect("couldn't encode lookup data");
+
+            if let Err(err) = client.update_lookup_data(&encoded_lookup_data).await {
+                panic!("couldn't send lookup data: {:?}", err)
+            }
+        }
+    });
+}
+
+// Loads wasm bytes.
+async fn setup_wasm(
+    connector_handle: ConnectorHandle,
+    wasm: &PathBuf,
+    constant_response_size: u32,
+) -> Result<InitializeResponse, Box<dyn std::error::Error>> {
+    let wasm_bytes = fs::read(&wasm)
+        .with_context(|| format!("couldn't read Wasm file {}", wasm.display()))
+        .unwrap();
+    log::info!(
+        "read Wasm file from disk {} ({} bytes)",
+        &wasm.display(),
+        wasm_bytes.len()
+    );
+
+    let request = schema::InitializeRequest {
+        wasm_module: wasm_bytes,
+        constant_response_size: constant_response_size,
+    };
+
+    let mut client = schema::OakFunctionsAsyncClient::new(connector_handle);
+    let result = client
+        .initialize(&request)
+        .await
+        .flatten()
+        .expect("couldn't initialize the service");
+
+    return Ok(result);
+}

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -37,7 +37,7 @@ pub mod schema {
 }
 
 mod channel;
-mod instance;
+pub mod instance;
 mod lookup;
 pub mod server;
 

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -141,7 +141,7 @@ async fn setup_wasm(
     wasm: &PathBuf,
     constant_response_size: u32,
 ) -> Result<InitializeResponse, Box<dyn std::error::Error>> {
-    let wasm_bytes = fs::read(&wasm)
+    let wasm_bytes = fs::read(wasm)
         .with_context(|| format!("couldn't read Wasm file {}", wasm.display()))
         .unwrap();
     log::info!(
@@ -152,7 +152,7 @@ async fn setup_wasm(
 
     let request = schema::InitializeRequest {
         wasm_module: wasm_bytes,
-        constant_response_size: constant_response_size,
+        constant_response_size,
     };
 
     let mut client = schema::OakFunctionsAsyncClient::new(connector_handle);
@@ -162,5 +162,5 @@ async fn setup_wasm(
         .flatten()
         .expect("couldn't initialize the service");
 
-    return Ok(initialize_response);
+    Ok(initialize_response)
 }

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -64,8 +64,9 @@ pub async fn create(
 > {
     let (launched_instance, connector_handle) = launch_instance(mode).await?;
     setup_lookup_data(connector_handle.clone(), lookup_data_path).await;
-    let result = setup_wasm(connector_handle.clone(), &wasm_path, constant_response_size).await?;
-    Ok((launched_instance, connector_handle, result))
+    let intialization_response =
+        setup_wasm(connector_handle.clone(), &wasm_path, constant_response_size).await?;
+    Ok((launched_instance, connector_handle, intialization_response))
 }
 
 async fn launch_instance(
@@ -155,11 +156,11 @@ async fn setup_wasm(
     };
 
     let mut client = schema::OakFunctionsAsyncClient::new(connector_handle);
-    let result = client
+    let initialize_response = client
         .initialize(&request)
         .await
         .flatten()
         .expect("couldn't initialize the service");
 
-    return Ok(result);
+    return Ok(initialize_response);
 }

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -88,9 +88,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         public_key_info.public_key.len()
     );
 
-    let server_future = oak_functions_launcher::server::server(
+    let server_future = oak_functions_launcher::server::new(
         SocketAddr::from((Ipv6Addr::UNSPECIFIED, cli.port)),
-        connector_handle.clone(),
+        connector_handle,
         public_key_info.public_key,
         public_key_info.attestation,
     );

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -18,20 +18,13 @@
 #![feature(result_flattening)]
 #![feature(array_chunks)]
 
-use anyhow::Context;
-use channel::ConnectorHandle;
 use clap::Parser;
-use instance::{native, virtualized, LaunchedInstance};
 use std::{
     fs,
-    io::{BufRead, BufReader},
     net::{Ipv6Addr, SocketAddr},
-    os::unix::net::UnixStream,
     path::PathBuf,
 };
 use tokio::signal;
-
-use crate::schema::InitializeResponse;
 
 pub mod schema {
     #![allow(dead_code)]
@@ -39,24 +32,11 @@ pub mod schema {
     include!(concat!(env!("OUT_DIR"), "/oak.functions.rs"));
 }
 
-mod channel;
-mod instance;
-mod lookup;
-mod server;
-
-#[derive(clap::Subcommand, Clone, Debug, PartialEq)]
-pub enum Mode {
-    /// Launch a virtual enclave binary
-    Virtual(virtualized::Params),
-    /// Launch an enclave binary directly as a child process
-    Native(native::Params),
-}
-
 #[derive(Parser, Debug)]
 struct Args {
     /// Execution mode.
     #[command(subcommand)]
-    mode: Mode,
+    mode: oak_functions_launcher::Mode,
 
     /// Consistent response size that the enclave should apply
     #[arg(long, default_value = "1024")]
@@ -94,7 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Args::parse();
     env_logger::init();
 
-    let (mut launched_instance, connector_handle, result) = create(
+    let (mut launched_instance, connector_handle, result) = oak_functions_launcher::create(
         cli.mode,
         cli.lookup_data,
         cli.wasm,
@@ -108,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         public_key_info.public_key.len()
     );
 
-    let server_future = server::server(
+    let server_future = oak_functions_launcher::server::server(
         SocketAddr::from((Ipv6Addr::UNSPECIFIED, cli.port)),
         connector_handle.clone(),
         public_key_info.public_key,
@@ -129,119 +109,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
-}
-
-pub async fn create(
-    mode: Mode,
-    lookup_data_path: PathBuf,
-    wasm_path: PathBuf,
-    constant_response_size: u32,
-) -> Result<
-    (
-        Box<dyn LaunchedInstance>,
-        ConnectorHandle,
-        InitializeResponse,
-    ),
-    Box<dyn std::error::Error>,
-> {
-    let (launched_instance, connector_handle) = launch_instance(mode).await?;
-    setup_lookup_data(connector_handle.clone(), lookup_data_path).await;
-    let result = setup_wasm(connector_handle.clone(), &wasm_path, constant_response_size).await?;
-    Ok((launched_instance, connector_handle, result))
-}
-
-async fn launch_instance(
-    mode: Mode,
-) -> Result<(Box<dyn LaunchedInstance>, ConnectorHandle), Box<dyn std::error::Error>> {
-    // Provide a way for the launched instance to send logs
-    let logs_console: UnixStream = {
-        // Create two linked consoles. Technically both can read/write, but we'll
-        // use them as a one way channel.
-        let (console_writer, console_receiver) = UnixStream::pair()?;
-
-        // Log everything sent by the writer.
-        tokio::spawn(async {
-            let mut reader = BufReader::new(console_receiver);
-
-            let mut line = String::new();
-            while reader.read_line(&mut line).expect("couldn't read line") > 0 {
-                log::info!("console: {:?}", line);
-                line.clear();
-            }
-        });
-
-        console_writer
-    };
-
-    let launched_instance: Box<dyn LaunchedInstance> = match mode {
-        Mode::Virtual(params) => Box::new(virtualized::Instance::start(params, logs_console)?),
-        Mode::Native(params) => Box::new(native::Instance::start(params)?),
-    };
-    let comms = launched_instance.create_comms_channel().await?;
-    let connector_handle = channel::Connector::spawn(comms);
-
-    Ok((launched_instance, connector_handle))
-}
-
-// Initially loads lookup data and spawns task to periodically refresh lookup data.
-async fn setup_lookup_data(connector_handle: ConnectorHandle, lookup_data_path: PathBuf) {
-    let mut client = schema::OakFunctionsAsyncClient::new(connector_handle);
-
-    // Block for [invariant that lookup data is fully loaded](https://github.com/project-oak/oak/tree/main/oak_functions/lookup/README.md#invariant-fully-loaded-lookup-data)
-    let lookup_data =
-        lookup::load_lookup_data(&lookup_data_path).expect("couldn't load lookup data");
-    let encoded_lookup_data =
-        lookup::encode_lookup_data(lookup_data).expect("couldn't encode lookup data");
-
-    if let Err(err) = client.update_lookup_data(&encoded_lookup_data).await {
-        panic!("couldn't send lookup data: {:?}", err)
-    }
-
-    // Spawn task to periodically refresh lookup data.
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_millis(1000 * 60 * 10));
-        loop {
-            // Wait before updating because we just loaded the lookup data.
-            interval.tick().await;
-
-            let lookup_data =
-                lookup::load_lookup_data(&lookup_data_path).expect("couldn't load lookup data");
-            let encoded_lookup_data =
-                lookup::encode_lookup_data(lookup_data).expect("couldn't encode lookup data");
-
-            if let Err(err) = client.update_lookup_data(&encoded_lookup_data).await {
-                panic!("couldn't send lookup data: {:?}", err)
-            }
-        }
-    });
-}
-
-// Loads wasm bytes.
-async fn setup_wasm(
-    connector_handle: ConnectorHandle,
-    wasm: &PathBuf,
-    constant_response_size: u32,
-) -> Result<InitializeResponse, Box<dyn std::error::Error>> {
-    let wasm_bytes = fs::read(&wasm)
-        .with_context(|| format!("couldn't read Wasm file {}", wasm.display()))
-        .unwrap();
-    log::info!(
-        "read Wasm file from disk {} ({} bytes)",
-        &wasm.display(),
-        wasm_bytes.len()
-    );
-
-    let request = schema::InitializeRequest {
-        wasm_module: wasm_bytes,
-        constant_response_size: constant_response_size,
-    };
-
-    let mut client = schema::OakFunctionsAsyncClient::new(connector_handle);
-    let result = client
-        .initialize(&request)
-        .await
-        .flatten()
-        .expect("couldn't initialize the service");
-
-    return Ok(result);
 }

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -74,15 +74,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Args::parse();
     env_logger::init();
 
-    let (mut launched_instance, connector_handle, result) = oak_functions_launcher::create(
-        cli.mode,
-        cli.lookup_data,
-        cli.wasm,
-        cli.constant_response_size,
-    )
-    .await?;
+    let (mut launched_instance, connector_handle, initialize_response) =
+        oak_functions_launcher::create(
+            cli.mode,
+            cli.lookup_data,
+            cli.wasm,
+            cli.constant_response_size,
+        )
+        .await?;
 
-    let public_key_info = result.public_key_info.expect("no public key info returned");
+    let public_key_info = initialize_response
+        .public_key_info
+        .expect("no public key info returned");
     log::info!(
         "obtained public key ({} bytes)",
         public_key_info.public_key.len()

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -76,7 +76,7 @@ impl oak_remote_attestation_noninteractive::proto::streaming_session_server::Str
     }
 }
 
-pub fn server(
+pub fn new(
     addr: SocketAddr,
     connector_handle: ConnectorHandle,
     signing_public_key: Vec<u8>,

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -21,7 +21,6 @@ use oak_functions_launcher::{
     schema::{self, InvokeRequest},
     Mode,
 };
-use oak_functions_test_utils;
 use rand::Rng;
 use std::path::PathBuf;
 
@@ -65,7 +64,7 @@ async fn test_launcher_looks_up_key() {
 
     let mut client = schema::OakFunctionsAsyncClient::new(connector_handle);
     let body = b"test_key".to_vec();
-    let invoke_request = InvokeRequest { body: body };
+    let invoke_request = InvokeRequest { body };
 
     let response = client
         .invoke(&invoke_request)

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -35,16 +35,19 @@ lazy_static! {
          [env!("WORKSPACE_ROOT"),"oak_functions_launcher", "mock_lookup_data"].iter().collect()
     };
 
+    static ref ENCLAVE_BINARY_PATH: PathBuf = {
+        let oak_functions_linux_fd_bin_path =
+    oak_functions_test_utils::build_rust_crate_linux("oak_functions_linux_fd_bin")
+        .expect("Failed to build oak_functions_linux_fd_bin");
+        PathBuf::from(oak_functions_linux_fd_bin_path)
+    };
+
 }
 
 #[tokio::test]
 async fn test_launcher_looks_up_key() {
-    let oak_functions_linux_fd_bin_path =
-        oak_functions_test_utils::build_rust_crate_linux("oak_functions_linux_fd_bin")
-            .expect("Failed to build oak_functions_linux_fd_bin");
-
     let params = oak_functions_launcher::instance::native::Params {
-        enclave_binary: PathBuf::from(oak_functions_linux_fd_bin_path),
+        enclave_binary: ENCLAVE_BINARY_PATH.to_path_buf(),
     };
 
     let (launched_instance, connector_handle, _) = oak_functions_launcher::create(
@@ -59,7 +62,6 @@ async fn test_launcher_looks_up_key() {
     let mut client = schema::OakFunctionsAsyncClient::new(connector_handle);
     let body = b"test_key".to_vec();
     let invoke_request = InvokeRequest { body: body };
-
 
     let response = client
         .invoke(&invoke_request)

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -1,0 +1,64 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the Oak Functions Launcher.
+
+use std::path::PathBuf;
+
+use lazy_static::lazy_static;
+use micro_rpc::AsyncTransport;
+use oak_functions_launcher::Mode;
+
+lazy_static! {
+    static ref WASM_PATH: PathBuf = {
+        // WORKSPACE_ROOT is set in .cargo/config.toml.
+         [env!("WORKSPACE_ROOT"),"oak_functions_launcher", "key_value_lookup.wasm"].iter().collect()
+    };
+
+    static ref LOOKUP_DATA_PATH: PathBuf = {
+        // WORKSPACE_ROOT is set in .cargo/config.toml.
+         [env!("WORKSPACE_ROOT"),"oak_functions_launcher", "mock_lookup_data"].iter().collect()
+    };
+
+    // TODO(mschett): make sure the binary is there, probably by building it.
+    static ref ENCLAVE_BINARY_PATH : PathBuf = {
+        [env!("WORKSPACE_ROOT"), "target",  "debug", "oak_functions_linux_fd_bin"].iter().collect()
+    };
+}
+
+#[tokio::test]
+async fn test_launcher_looks_up_key() {
+    let params = oak_functions_launcher::instance::native::Params {
+        enclave_binary: ENCLAVE_BINARY_PATH.to_path_buf(),
+    };
+
+    let (launched_instance, mut connector_handle, _) = oak_functions_launcher::create(
+        Mode::Native(params),
+        LOOKUP_DATA_PATH.to_path_buf(),
+        WASM_PATH.to_path_buf(),
+        // TODO(mschett): make sure the response fits in the constant response size.
+        1024,
+    )
+    .await
+    .expect("Fail to create launcher");
+
+    // TODO(mschett): Find easiest way to send "test_key".
+    // Send lookup request.
+    let _ = connector_handle.invoke(&[42u8]).await;
+
+    // TODO(mschett): Check lookup response "test_value".
+
+    let _ = launched_instance.kill().await;
+}

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -79,7 +79,7 @@ async fn test_launcher_looks_up_key() {
 }
 
 #[tokio::test]
-
+#[ignore]
 async fn test_load_large_lookup_data() {
     let params = oak_functions_launcher::instance::native::Params {
         enclave_binary: ENCLAVE_BINARY_PATH.to_path_buf(),

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use lazy_static::lazy_static;
 use micro_rpc::AsyncTransport;
 use oak_functions_launcher::Mode;
+use oak_functions_test_utils;
 
 lazy_static! {
     static ref WASM_PATH: PathBuf = {
@@ -32,16 +33,16 @@ lazy_static! {
          [env!("WORKSPACE_ROOT"),"oak_functions_launcher", "mock_lookup_data"].iter().collect()
     };
 
-    // TODO(mschett): make sure the binary is there, probably by building it.
-    static ref ENCLAVE_BINARY_PATH : PathBuf = {
-        [env!("WORKSPACE_ROOT"), "target",  "debug", "oak_functions_linux_fd_bin"].iter().collect()
-    };
 }
 
 #[tokio::test]
 async fn test_launcher_looks_up_key() {
+    let oak_functions_linux_fd_bin_path =
+        oak_functions_test_utils::build_rust_crate_linux("oak_functions_linux_fd_bin")
+            .expect("Failed to build oak_functions_linux_fd_bin.");
+
     let params = oak_functions_launcher::instance::native::Params {
-        enclave_binary: ENCLAVE_BINARY_PATH.to_path_buf(),
+        enclave_binary: PathBuf::from(oak_functions_linux_fd_bin_path),
     };
 
     let (launched_instance, mut connector_handle, _) = oak_functions_launcher::create(

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -39,7 +39,7 @@ lazy_static! {
 async fn test_launcher_looks_up_key() {
     let oak_functions_linux_fd_bin_path =
         oak_functions_test_utils::build_rust_crate_linux("oak_functions_linux_fd_bin")
-            .expect("Failed to build oak_functions_linux_fd_bin.");
+            .expect("Failed to build oak_functions_linux_fd_bin");
 
     let params = oak_functions_launcher::instance::native::Params {
         enclave_binary: PathBuf::from(oak_functions_linux_fd_bin_path),
@@ -49,17 +49,22 @@ async fn test_launcher_looks_up_key() {
         Mode::Native(params),
         LOOKUP_DATA_PATH.to_path_buf(),
         WASM_PATH.to_path_buf(),
-        // TODO(mschett): make sure the response fits in the constant response size.
         1024,
     )
     .await
     .expect("Fail to create launcher");
 
-    // TODO(mschett): Find easiest way to send "test_key".
-    // Send lookup request.
-    let _ = connector_handle.invoke(&[42u8]).await;
+    // TODO(mschett): Find easiest way to send "test_key" as invocation of lookup data and unwrap
+    // "test_value".
+    let response = connector_handle
+        .invoke(&[42u8])
+        .await
+        .expect("Failed to receive response.");
 
-    // TODO(mschett): Check lookup response "test_value".
+    assert_eq!(b"test_value".to_vec(), response);
 
-    let _ = launched_instance.kill().await;
+    launched_instance
+        .kill()
+        .await
+        .expect("Failed to stop launcher");
 }

--- a/oak_functions_test_utils/src/lib.rs
+++ b/oak_functions_test_utils/src/lib.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-//! Test utilities to help with unit testing of Oak-Functions SDK code.
+//! Test utilities to help with unit testing of Oak Functions code.
 
 use anyhow::Context;
 use log::info;
@@ -138,7 +138,7 @@ where
 /// Builds the crate identified by the given package name (as per the `name` attribute in a
 /// Cargo.toml file included in the root cargo workspace) as a Linux binary, and returns the path of
 /// the resulting binary.
-fn build_rust_crate_linux(crate_name: &str) -> anyhow::Result<String> {
+pub fn build_rust_crate_linux(crate_name: &str) -> anyhow::Result<String> {
     duct::cmd!(
         "cargo",
         "build",


### PR DESCRIPTION
- Refactor to allow integration tests
- Add integration test with single lookup.
- Add integration test with lookup in 2 GiB of lookup data.

Fixes #3660.