### PR TITLE
Really send a 2MiB test message

### DIFF
--- a/oak_functions/lookup/src/lib.rs
+++ b/oak_functions/lookup/src/lib.rs
@@ -61,7 +61,11 @@ impl<L: OakLogger> OakApiNativeExtension for LookupData<L> {
     fn invoke(&mut self, request: Vec<u8>) -> Result<Vec<u8>, OakStatus> {
         // The request is the key to lookup.
         let key = request;
-        self.log_debug(&format!("storage_get_item(): key: {}", format_bytes(&key)));
+        let key_to_log = key.clone().into_iter().take(512).collect::<Vec<_>>();
+        self.log_debug(&format!(
+            "storage_get_item(): key: {}",
+            format_bytes(&key_to_log)
+        ));
         let value = self.get(&key);
 
         // Log found value.

--- a/oak_functions_client/src/main.rs
+++ b/oak_functions_client/src/main.rs
@@ -23,7 +23,7 @@ use oak_functions_abi::Request;
 use oak_functions_client::Client;
 use regex::Regex;
 
-const TWO_MIB: usize = (2 * 1024) ^ 2;
+const TWO_MIB: usize = 2 * 1024 * 1024;
 const LARGE_MESSAGE: [u8; TWO_MIB] = [0; TWO_MIB];
 
 #[derive(Parser, Clone)]


### PR DESCRIPTION
The large test key we sent in was not really 2MiB, but only 2050 bytes.

Logging such a large key is very slow, so I also updated the debug logging code for the key to match the way the value is logged: only log the first 512 bytes.