### PR TITLE
Build newlib with bazel

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:56c100e3674788e7b84774084d1d5cc1c49da828e04f26bc23fb1711d33e1851",
+  "image": "sha256:4e64310a2b3210c26cc0b55e148d6f2ad4a25cbe716bba057448fce919f2842d",
   "extensions": [
     "13xforever.language-x86-64-assembly",
     "bazelbuild.vscode-bazel",

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN apt-get --yes update \
   qemu-system-x86 \
   shellcheck \
   software-properties-common \
+  texinfo \
   vim \
   xml2 \
   # `unzip` and `zlib1g-dev` are needed for Bazel.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -217,3 +217,16 @@ grpc_deps()
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
+
+http_archive(
+    name = "rules_foreign_cc",
+    sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+    strip_prefix = "rules_foreign_cc-0.9.0",
+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
+)
+
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
+# This sets up some common toolchains for building targets. For more details, please see
+# https://bazelbuild.github.io/rules_foreign_cc/0.9.0/flatten.html#rules_foreign_cc_dependencies
+rules_foreign_cc_dependencies()

--- a/scripts/common
+++ b/scripts/common
@@ -20,7 +20,7 @@ readonly DOCKER_IMAGE_NAME='europe-west2-docker.pkg.dev/oak-ci/oak-development/o
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:56c100e3674788e7b84774084d1d5cc1c49da828e04f26bc23fb1711d33e1851'
+readonly DOCKER_IMAGE_ID='sha256:4e64310a2b3210c26cc0b55e148d6f2ad4a25cbe716bba057448fce919f2842d'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
 readonly DOCKER_IMAGE_REPO_DIGEST='europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development@sha256:d650c48659f23688099591e6924219658807eab585a7c8756aa83c568318145e'

--- a/third_party/newlib/BUILD
+++ b/third_party/newlib/BUILD
@@ -1,0 +1,29 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+filegroup(
+    name = "newlib_srcs",
+    srcs = glob(["newlib-4.3.0/**"]),
+)
+
+configure_make(
+    name = "newlib",
+    configure_options = [
+        "--target=x86_64-unknown-oak",
+        "--disable-multilib",
+    ],
+    # We don't have a separate toolchain for `x86_64-unknown-oak`, so redirect tools to the standard
+    # `x86_64-linux-gnu` ones.
+    env = {
+        "AR_FOR_TARGET": "x86_64-linux-gnu-ar",
+        "CC_FOR_TARGET": "x86_64-linux-gnu-gcc",
+        "RANLIB_FOR_TARGET": "x86_64-linux-gnu-ranlib",
+    },
+    lib_source = ":newlib_srcs",
+    out_include_dir = "x86_64-unknown-oak/include",
+    out_lib_dir = "x86_64-unknown-oak/lib",
+    out_static_libs = [
+        "libm.a",
+        "libc.a",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/newlib/newlib-4.3.0/config.sub
+++ b/third_party/newlib/newlib-4.3.0/config.sub
@@ -1725,7 +1725,7 @@ case $os in
 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
-	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx*)
+	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | oak*)
 		;;
 	# This one is extra strict with allowed versions
 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)


### PR DESCRIPTION
This is not a full port to Oak Restricted Kernel by any means, but it's enough to get newlib to compile for `x86_64-unknown-oak`.

What's missing beyond the fact that it compiles: essentially everything. There's no crt0, there's no syscall wrappers. This is a broken implementation, but the keyword here is that _it compiles_. Next step would be to write a small test enclave application and patch the holes in the libc as we find them.

As we also don't have a cross-compiler for our target, I've done some environment shenanigans to compile things with the regular Linux compiler. It should work, as we're following the same ABI when it comes to function calls and both are targeting x86_64. The "correct" way would be to set up cross-compilers, but that'd be a significant effort in itself that's probably not worth it at this stage.

But... it compiles, and we get a `libc.a` and `libm.a` out of it!