### PR TITLE
Create a C(++)-based oak_echo_raw binary

### DIFF
--- a/cc/oak_echo_raw_enclave_app/BUILD
+++ b/cc/oak_echo_raw_enclave_app/BUILD
@@ -1,0 +1,34 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package(
+    licenses = ["notice"],
+)
+
+cc_binary(
+    name = "oak_echo_raw_enclave_app",
+    srcs = ["main.cc"],
+    copts = [
+        "-nostdlib",
+        "-ffreestanding",
+    ],
+    features = ["fully_static_link"],
+    linkopts = [
+        "-nostdlib",
+        "-zmax-page-size=0x200000",
+    ],
+    deps = ["//third_party/newlib"],
+)

--- a/cc/oak_echo_raw_enclave_app/main.cc
+++ b/cc/oak_echo_raw_enclave_app/main.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+constexpr int CHANNEL_FD = 10;
+
+int main(int argc, char* argv[]) {
+  char buf;
+
+  fprintf(stderr, "In main!\n");
+
+  while (true) {
+    if (read(CHANNEL_FD, &buf, sizeof(buf)) != 1) {
+      return -1;
+    }
+
+    if (write(CHANNEL_FD, &buf, sizeof(buf)) != 1) {
+      return -1;
+    }
+  }
+
+  return 0;
+}

--- a/third_party/newlib/BUILD
+++ b/third_party/newlib/BUILD
@@ -24,6 +24,7 @@ configure_make(
     out_static_libs = [
         "libm.a",
         "libc.a",
+        "liboak.a",
     ],
     visibility = ["//visibility:public"],
 )

--- a/third_party/newlib/newlib-4.3.0/libgloss/Makefile.am
+++ b/third_party/newlib/newlib-4.3.0/libgloss/Makefile.am
@@ -99,3 +99,6 @@ endif
 if CONFIG_WINCE
 include wince/Makefile.inc
 endif
+if CONFIG_OAK
+include oak/Makefile.inc
+endif

--- a/third_party/newlib/newlib-4.3.0/libgloss/Makefile.in
+++ b/third_party/newlib/newlib-4.3.0/libgloss/Makefile.in
@@ -190,6 +190,7 @@ check_PROGRAMS = $(am__EXEEXT_2) $(am__EXEEXT_3)
 @CONFIG_RISCV_TRUE@	riscv/libsemihost.a
 @CONFIG_WINCE_TRUE@am__append_36 = $(gdbdir)
 @CONFIG_WINCE_TRUE@am__append_37 = wince/stub.exe
+@CONFIG_OAK_TRUE@am__append_38 = oak/liboak.a
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/../config/depstand.m4 \
@@ -450,6 +451,11 @@ nios2_libnios2_a_LIBADD =
 @CONFIG_NIOS2_TRUE@	nios2/nios2_libnios2_a-kill.$(OBJEXT) \
 @CONFIG_NIOS2_TRUE@	nios2/nios2_libnios2_a-sbrk.$(OBJEXT)
 nios2_libnios2_a_OBJECTS = $(am_nios2_libnios2_a_OBJECTS)
+oak_liboak_a_AR = $(AR) $(ARFLAGS)
+oak_liboak_a_LIBADD =
+@CONFIG_OAK_TRUE@am_oak_liboak_a_OBJECTS = oak/syscalls.$(OBJEXT) \
+@CONFIG_OAK_TRUE@	oak/crt0.$(OBJEXT)
+oak_liboak_a_OBJECTS = $(am_oak_liboak_a_OBJECTS)
 riscv_libgloss_a_AR = $(AR) $(ARFLAGS)
 riscv_libgloss_a_LIBADD =
 @CONFIG_RISCV_TRUE@am_riscv_libgloss_a_OBJECTS = riscv/riscv_libgloss_a-sys_access.$(OBJEXT) \
@@ -573,9 +579,9 @@ SOURCES = $(aarch64_librdimon_a_SOURCES) $(arc_libnsim_a_SOURCES) \
 	$(csky_libsemi_a_SOURCES) $(d30v_libsim_a_SOURCES) \
 	$(iq2000_libeval_a_SOURCES) $(libnosys_libnosys_a_SOURCES) \
 	$(libobjs_a_SOURCES) $(lm32_libgloss_a_SOURCES) \
-	$(nios2_libnios2_a_SOURCES) $(riscv_libgloss_a_SOURCES) \
-	$(riscv_libsemihost_a_SOURCES) bfin/sim-test.c iq2000/test.c \
-	$(wince_stub_exe_SOURCES)
+	$(nios2_libnios2_a_SOURCES) $(oak_liboak_a_SOURCES) \
+	$(riscv_libgloss_a_SOURCES) $(riscv_libsemihost_a_SOURCES) \
+	bfin/sim-test.c iq2000/test.c $(wince_stub_exe_SOURCES)
 AM_V_DVIPS = $(am__v_DVIPS_@AM_V@)
 am__v_DVIPS_ = $(am__v_DVIPS_@AM_DEFAULT_V@)
 am__v_DVIPS_0 = @echo "  DVIPS   " $@;
@@ -802,7 +808,8 @@ multilibtool_DATA = $(am__append_3) $(am__append_6) $(am__append_7) \
 multilibtool_LIBRARIES = $(am__append_2) $(am__append_5) \
 	$(am__append_9) $(am__append_11) $(am__append_20) \
 	$(am__append_21) $(am__append_24) $(am__append_28) \
-	$(am__append_30) $(am__append_33) $(am__append_35)
+	$(am__append_30) $(am__append_33) $(am__append_35) \
+	$(am__append_38)
 includetooldir = $(tooldir)/include
 includetool_DATA = $(am__append_16)
 includesystooldir = $(tooldir)/include/sys
@@ -1092,6 +1099,10 @@ TEXINFO_TEX = ../texinfo/texinfo.tex
 @CONFIG_WINCE_TRUE@wince_stub_exe_SOURCES = wince-stub.c
 @CONFIG_WINCE_TRUE@wince_stub_exe_CPPFLAGS = $(AM_CPPFLAGS) -I$(gdbdir)
 @CONFIG_WINCE_TRUE@wince_stub_exe_LDADD = -lwinsock $(WINCE_STUB_LIBS)
+@CONFIG_OAK_TRUE@oak_liboak_a_SOURCES = \
+@CONFIG_OAK_TRUE@    oak/syscalls.c \
+@CONFIG_OAK_TRUE@    oak/crt0.S
+
 all: config.h
 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
 
@@ -1099,7 +1110,7 @@ all: config.h
 .SUFFIXES: .S .c .dvi .o .obj .ps
 am--refresh: Makefile
 	@:
-$(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am $(top_srcdir)/../multilib.am $(srcdir)/doc/Makefile.inc $(srcdir)/aarch64/Makefile.inc $(srcdir)/aarch64/cpu-init/Makefile.inc $(srcdir)/arc/Makefile.inc $(srcdir)/arm/Makefile.inc $(srcdir)/arm/cpu-init/Makefile.inc $(srcdir)/bfin/Makefile.inc $(srcdir)/csky/Makefile.inc $(srcdir)/d30v/Makefile.inc $(srcdir)/iq2000/Makefile.inc $(srcdir)/libnosys/Makefile.inc $(srcdir)/lm32/Makefile.inc $(srcdir)/nios2/Makefile.inc $(srcdir)/riscv/Makefile.inc $(srcdir)/wince/Makefile.inc $(am__configure_deps)
+$(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am $(top_srcdir)/../multilib.am $(srcdir)/doc/Makefile.inc $(srcdir)/aarch64/Makefile.inc $(srcdir)/aarch64/cpu-init/Makefile.inc $(srcdir)/arc/Makefile.inc $(srcdir)/arm/Makefile.inc $(srcdir)/arm/cpu-init/Makefile.inc $(srcdir)/bfin/Makefile.inc $(srcdir)/csky/Makefile.inc $(srcdir)/d30v/Makefile.inc $(srcdir)/iq2000/Makefile.inc $(srcdir)/libnosys/Makefile.inc $(srcdir)/lm32/Makefile.inc $(srcdir)/nios2/Makefile.inc $(srcdir)/riscv/Makefile.inc $(srcdir)/wince/Makefile.inc $(srcdir)/oak/Makefile.inc $(am__configure_deps)
 	@for dep in $?; do \
 	  case '$(am__configure_deps)' in \
 	    *$$dep*) \
@@ -1121,7 +1132,7 @@ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	    echo ' cd $(top_builddir) && $(SHELL) ./config.status $@ $(am__depfiles_maybe)'; \
 	    cd $(top_builddir) && $(SHELL) ./config.status $@ $(am__depfiles_maybe);; \
 	esac;
-$(top_srcdir)/../multilib.am $(srcdir)/doc/Makefile.inc $(srcdir)/aarch64/Makefile.inc $(srcdir)/aarch64/cpu-init/Makefile.inc $(srcdir)/arc/Makefile.inc $(srcdir)/arm/Makefile.inc $(srcdir)/arm/cpu-init/Makefile.inc $(srcdir)/bfin/Makefile.inc $(srcdir)/csky/Makefile.inc $(srcdir)/d30v/Makefile.inc $(srcdir)/iq2000/Makefile.inc $(srcdir)/libnosys/Makefile.inc $(srcdir)/lm32/Makefile.inc $(srcdir)/nios2/Makefile.inc $(srcdir)/riscv/Makefile.inc $(srcdir)/wince/Makefile.inc $(am__empty):
+$(top_srcdir)/../multilib.am $(srcdir)/doc/Makefile.inc $(srcdir)/aarch64/Makefile.inc $(srcdir)/aarch64/cpu-init/Makefile.inc $(srcdir)/arc/Makefile.inc $(srcdir)/arm/Makefile.inc $(srcdir)/arm/cpu-init/Makefile.inc $(srcdir)/bfin/Makefile.inc $(srcdir)/csky/Makefile.inc $(srcdir)/d30v/Makefile.inc $(srcdir)/iq2000/Makefile.inc $(srcdir)/libnosys/Makefile.inc $(srcdir)/lm32/Makefile.inc $(srcdir)/nios2/Makefile.inc $(srcdir)/riscv/Makefile.inc $(srcdir)/wince/Makefile.inc $(srcdir)/oak/Makefile.inc $(am__empty):
 
 $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
 	$(SHELL) ./config.status --recheck
@@ -1645,6 +1656,20 @@ nios2/libnios2.a: $(nios2_libnios2_a_OBJECTS) $(nios2_libnios2_a_DEPENDENCIES) $
 	$(AM_V_at)-rm -f nios2/libnios2.a
 	$(AM_V_AR)$(nios2_libnios2_a_AR) nios2/libnios2.a $(nios2_libnios2_a_OBJECTS) $(nios2_libnios2_a_LIBADD)
 	$(AM_V_at)$(RANLIB) nios2/libnios2.a
+oak/$(am__dirstamp):
+	@$(MKDIR_P) oak
+	@: > oak/$(am__dirstamp)
+oak/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) oak/$(DEPDIR)
+	@: > oak/$(DEPDIR)/$(am__dirstamp)
+oak/syscalls.$(OBJEXT): oak/$(am__dirstamp) \
+	oak/$(DEPDIR)/$(am__dirstamp)
+oak/crt0.$(OBJEXT): oak/$(am__dirstamp) oak/$(DEPDIR)/$(am__dirstamp)
+
+oak/liboak.a: $(oak_liboak_a_OBJECTS) $(oak_liboak_a_DEPENDENCIES) $(EXTRA_oak_liboak_a_DEPENDENCIES) oak/$(am__dirstamp)
+	$(AM_V_at)-rm -f oak/liboak.a
+	$(AM_V_AR)$(oak_liboak_a_AR) oak/liboak.a $(oak_liboak_a_OBJECTS) $(oak_liboak_a_LIBADD)
+	$(AM_V_at)$(RANLIB) oak/liboak.a
 riscv/$(am__dirstamp):
 	@$(MKDIR_P) riscv
 	@: > riscv/$(am__dirstamp)
@@ -1854,6 +1879,7 @@ mostlyclean-compile:
 	-rm -f libnosys/*.$(OBJEXT)
 	-rm -f lm32/*.$(OBJEXT)
 	-rm -f nios2/*.$(OBJEXT)
+	-rm -f oak/*.$(OBJEXT)
 	-rm -f riscv/*.$(OBJEXT)
 
 distclean-compile:
@@ -1996,6 +2022,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@nios2/$(DEPDIR)/nios2_libnios2_a-io-write.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@nios2/$(DEPDIR)/nios2_libnios2_a-kill.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@nios2/$(DEPDIR)/nios2_libnios2_a-sbrk.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@oak/$(DEPDIR)/crt0.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@oak/$(DEPDIR)/syscalls.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libgloss_a-sys_access.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libgloss_a-sys_chdir.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libgloss_a-sys_chmod.Po@am__quote@
@@ -4224,6 +4252,8 @@ distclean-generic:
 	-rm -f lm32/$(am__dirstamp)
 	-rm -f nios2/$(DEPDIR)/$(am__dirstamp)
 	-rm -f nios2/$(am__dirstamp)
+	-rm -f oak/$(DEPDIR)/$(am__dirstamp)
+	-rm -f oak/$(am__dirstamp)
 	-rm -f riscv/$(DEPDIR)/$(am__dirstamp)
 	-rm -f riscv/$(am__dirstamp)
 	-rm -f wince/$(am__dirstamp)
@@ -4239,7 +4269,7 @@ clean-am: clean-aminfo clean-binPROGRAMS clean-checkPROGRAMS \
 
 distclean: distclean-recursive
 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
-	-rm -rf ./$(DEPDIR) aarch64/$(DEPDIR) arc/$(DEPDIR) arm/$(DEPDIR) bfin/$(DEPDIR) csky/$(DEPDIR) d30v/$(DEPDIR) iq2000/$(DEPDIR) libnosys/$(DEPDIR) lm32/$(DEPDIR) nios2/$(DEPDIR) riscv/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) aarch64/$(DEPDIR) arc/$(DEPDIR) arm/$(DEPDIR) bfin/$(DEPDIR) csky/$(DEPDIR) d30v/$(DEPDIR) iq2000/$(DEPDIR) libnosys/$(DEPDIR) lm32/$(DEPDIR) nios2/$(DEPDIR) oak/$(DEPDIR) riscv/$(DEPDIR)
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-hdr distclean-local distclean-tags
@@ -4382,7 +4412,7 @@ installcheck-am:
 maintainer-clean: maintainer-clean-recursive
 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
 	-rm -rf $(top_srcdir)/autom4te.cache
-	-rm -rf ./$(DEPDIR) aarch64/$(DEPDIR) arc/$(DEPDIR) arm/$(DEPDIR) bfin/$(DEPDIR) csky/$(DEPDIR) d30v/$(DEPDIR) iq2000/$(DEPDIR) libnosys/$(DEPDIR) lm32/$(DEPDIR) nios2/$(DEPDIR) riscv/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) aarch64/$(DEPDIR) arc/$(DEPDIR) arm/$(DEPDIR) bfin/$(DEPDIR) csky/$(DEPDIR) d30v/$(DEPDIR) iq2000/$(DEPDIR) libnosys/$(DEPDIR) lm32/$(DEPDIR) nios2/$(DEPDIR) oak/$(DEPDIR) riscv/$(DEPDIR)
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-aminfo \
 	maintainer-clean-generic maintainer-clean-local

--- a/third_party/newlib/newlib-4.3.0/libgloss/configure
+++ b/third_party/newlib/newlib-4.3.0/libgloss/configure
@@ -630,6 +630,8 @@ CPPFLAGS
 LDFLAGS
 CFLAGS
 CC
+CONFIG_OAK_FALSE
+CONFIG_OAK_TRUE
 CONFIG_WINCE_FALSE
 CONFIG_WINCE_TRUE
 CONFIG_RISCV_FALSE
@@ -2980,6 +2982,10 @@ case "${target}" in
   nios2-*-*)
 	config_nios2=true
 	;;
+  x86_64-unknown-oak)
+	config_libnosys=false
+	config_oak=true
+	;;
 esac
 
 
@@ -3077,6 +3083,14 @@ fi
 else
   CONFIG_WINCE_TRUE='#'
   CONFIG_WINCE_FALSE=
+fi
+
+   if test x$config_oak = xtrue; then
+  CONFIG_OAK_TRUE=
+  CONFIG_OAK_FALSE='#'
+else
+  CONFIG_OAK_TRUE='#'
+  CONFIG_OAK_FALSE=
 fi
 
 
@@ -5345,6 +5359,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${CONFIG_WINCE_TRUE}" && test -z "${CONFIG_WINCE_FALSE}"; then
   as_fn_error $? "conditional \"CONFIG_WINCE\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${CONFIG_OAK_TRUE}" && test -z "${CONFIG_OAK_FALSE}"; then
+  as_fn_error $? "conditional \"CONFIG_OAK\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${AMDEP_TRUE}" && test -z "${AMDEP_FALSE}"; then

--- a/third_party/newlib/newlib-4.3.0/libgloss/configure.ac
+++ b/third_party/newlib/newlib-4.3.0/libgloss/configure.ac
@@ -241,13 +241,16 @@ case "${target}" in
   nios2-*-*)
 	config_nios2=true
 	;;
+  x86_64-unknown-oak)
+	config_oak=true
+	;;
 esac
 AC_SUBST(subdirs)
 
 dnl These subdirs have converted to non-recursive make.  Hopefully someday all
 dnl the ports above will too!
 m4_foreach_w([SUBDIR], [
-  aarch64 arc arm bfin csky d30v iq2000 libnosys lm32 nios2 riscv wince
+  aarch64 arc arm bfin csky d30v iq2000 libnosys lm32 nios2 riscv wince oak
 ], [dnl
   AM_CONDITIONAL([CONFIG_]m4_toupper(SUBDIR), [test x$config_]SUBDIR = xtrue)
 ])

--- a/third_party/newlib/newlib-4.3.0/libgloss/oak/Makefile.inc
+++ b/third_party/newlib/newlib-4.3.0/libgloss/oak/Makefile.inc
@@ -1,0 +1,5 @@
+multilibtool_LIBRARIES += %D%/liboak.a
+%C%_liboak_a_CPPFLAGS = -I$(srcdir)/%D%
+%C%_liboak_a_SOURCES = \
+    %D%/syscalls.c \
+    %D%/crt0.S

--- a/third_party/newlib/newlib-4.3.0/libgloss/oak/crt0.S
+++ b/third_party/newlib/newlib-4.3.0/libgloss/oak/crt0.S
@@ -1,0 +1,30 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+.text
+.global _start
+
+_start:
+    # argc = 0, argv = NULL, envp = NULL
+    xor %rdi, %rdi
+    xor %rsi, %rsi
+    xor %rdx, %rdx
+    call main
+    mov %rax, %rdi # rdi = rax
+    call _exit
+3:
+    nop
+    jmp 3b

--- a/third_party/newlib/newlib-4.3.0/libgloss/oak/syscalls.c
+++ b/third_party/newlib/newlib-4.3.0/libgloss/oak/syscalls.c
@@ -1,0 +1,151 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <reent.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+static long __syscall0(long n)
+{
+	unsigned long ret;
+	asm volatile (
+        "syscall"
+        : "=a"(ret)
+        : "a"(n)
+        : "rcx", "r11", "memory");
+	return ret;
+}
+
+static long __syscall3(long n, long a1, long a2, long a3)
+{
+	unsigned long ret;
+	asm volatile(
+        "syscall"
+        : "=a"(ret)
+        : "a"(n), "D"(a1), "S"(a2), "d"(a3)
+        : "rcx", "r11", "memory");
+	return ret;
+}
+
+static long __syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6)
+{
+	unsigned long ret;
+	register long r10 asm("r10") = a4;
+	register long r8 asm("r8") = a5;
+	register long r9 asm("r9") = a6;
+	asm volatile (
+        "syscall"
+        : "=a"(ret)
+        : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8), "r"(r9)
+        : "rcx", "r11", "memory");
+	return ret;
+}
+
+void _exit(int rc) {
+    __syscall0(60);
+    for (;;) {}
+}
+
+ssize_t _read_r(struct _reent* reent, int fd, void *buf, size_t len) {
+    int ret = __syscall3(0, fd, (long)buf, len);
+
+    if (ret < 0) {
+        reent->_errno = ret;
+        return -1;
+    }
+    return ret;
+}
+
+ssize_t _write_r(struct _reent* reent, int fd, const void* buf, size_t len) {
+    int ret = __syscall3(1, fd, (long)buf, len);
+
+    if (ret < 0) {
+        reent->_errno = ret;
+        return -1;
+    }
+    return ret;
+}
+
+ssize_t _lseek_r(struct _reent* reent, int fd, _off_t ptr, int dir) {
+    reent->_errno = ENOSYS;
+    return -1;
+}
+
+void* mmap(void* addr, int len, int prot, int flags, int fd, int offset) {
+    return __syscall6(9, (long)addr, len, prot, flags, fd, offset);
+}
+
+void* _sbrk_r (struct _reent* reent, ptrdiff_t incr) {
+    extern char end asm("_end"); // symbol provided by the linker
+    static char* heap_end;
+
+    if (heap_end == NULL) {
+        // If we haven't initialized the heap at all yet, let's start at the next 2 MiB page boundary
+        // after `_end`.
+        heap_end = &end;
+
+        if ((int)heap_end % 0x200000 != 0) {
+            heap_end += 0x200000 - (int)heap_end % 0x200000;
+        }
+    }
+
+    // We only increment in chunks of 2 MiB.
+    if (incr % 0x200000 != 0) {
+        incr += 0x200000 - incr % 0x200000;
+    }
+
+    char* prev_heap_end = heap_end;
+
+    if (mmap(heap_end,
+         incr,
+         0x1 | 0x2, // PROT_READ | PROT_WRITE
+         0x02 | 0x10 | 0x20, // MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS
+         -1,
+         0) != heap_end) {
+            reent->_errno = ENOMEM;
+            return -1;
+         }
+    
+    heap_end += incr;
+
+    return prev_heap_end;
+}
+
+int _close_r(struct _reent* reent, int fd) {
+    reent->_errno = ENOSYS;
+    return -1;
+}
+
+int _fstat_r(struct _reent* reent, int fd, struct stat* s) {
+    reent->_errno = ENOSYS;
+    return -1;
+}
+
+int _isatty_r(struct _reent* reent, int fd) {
+    reent->_errno = ENOSYS;
+    return -1;
+}
+
+int _getpid_r(struct _reent* reent) {
+    reent->_errno = ENOSYS;
+    return -1;
+}
+
+int _kill_r(struct _reent* reent, int pid, int signal) {
+    reent->_errno = ENOSYS;
+    return -1;
+}

--- a/third_party/newlib/newlib-4.3.0/newlib/configure.host
+++ b/third_party/newlib/newlib-4.3.0/newlib/configure.host
@@ -590,6 +590,10 @@ case "${host}" in
 	newlib_cflags="${newlib_cflags} -DHAVE_OPENDIR -DHAVE_RENAME -DGETREENT_PROVIDED -DSIGNAL_PROVIDED -DHAVE_BLKSIZE -DHAVE_FCNTL -DMALLOC_PROVIDED"
 	syscall_dir=syscalls
 	;;
+  *-*-oak*)
+	newlib_cflags="${newlib_cflags} -DREENTRANT_SYSCALLS_PROVIDED"
+	syscall_dir=syscalls
+	;;
 # RTEMS supplies its own versions of some routines:
 #       malloc()            (reentrant version)
 #       exit()              RTEMS has a "global" reent to flush

--- a/third_party/newlib/newlib-4.3.0/newlib/libc/include/sys/config.h
+++ b/third_party/newlib/newlib-4.3.0/newlib/libc/include/sys/config.h
@@ -1,0 +1,314 @@
+#ifndef __SYS_CONFIG_H__
+#define __SYS_CONFIG_H__
+
+#include <machine/ieeefp.h>  /* floating point macros */
+#include <sys/features.h>	/* POSIX defs */
+
+#ifdef __aarch64__
+#define MALLOC_ALIGNMENT 16
+#endif
+
+#ifdef __AMDGCN__
+#define __DYNAMIC_REENT__
+#endif
+
+/* exceptions first */
+#if defined(__H8500__) || defined(__W65__)
+#define __SMALL_BITFIELDS
+/* ???  This conditional is true for the h8500 and the w65, defining H8300
+   in those cases probably isn't the right thing to do.  */
+#define H8300 1
+#endif
+
+/* 16 bit integer machines */
+#if defined(__Z8001__) || defined(__Z8002__) || defined(__H8500__) || defined(__W65__) || defined (__mn10200__) || defined (__AVR__) || defined (__MSP430__)
+
+#undef INT_MAX
+#undef UINT_MAX
+#define INT_MAX 32767
+#define UINT_MAX 65535
+#endif
+
+#if defined (__H8300__) || defined (__H8300H__) || defined(__H8300S__) || defined (__H8300SX__)
+#define __SMALL_BITFIELDS
+#define H8300 1
+#undef INT_MAX
+#undef UINT_MAX
+#define INT_MAX __INT_MAX__
+#define UINT_MAX (__INT_MAX__ * 2U + 1)
+#endif
+
+#if (defined(__CR16__) || defined(__CR16C__) ||defined(__CR16CP__))
+#ifndef __INT32__
+#define __SMALL_BITFIELDS      
+#undef INT_MAX
+#undef UINT_MAX
+#define INT_MAX 32767
+#define UINT_MAX (__INT_MAX__ * 2U + 1)
+#else /* INT32 */
+#undef INT_MAX
+#undef UINT_MAX
+#define INT_MAX 2147483647
+#define UINT_MAX (__INT_MAX__ * 2U + 1)
+#endif /* INT32 */
+
+#endif /* CR16C */
+
+#if defined (__xc16x__) || defined (__xc16xL__) || defined (__xc16xS__)
+#define __SMALL_BITFIELDS
+#endif
+
+#ifdef __W65__
+#define __SMALL_BITFIELDS
+#endif
+
+#if defined(__D10V__)
+#define __SMALL_BITFIELDS
+#undef INT_MAX
+#undef UINT_MAX
+#define INT_MAX __INT_MAX__
+#define UINT_MAX (__INT_MAX__ * 2U + 1)
+#define _POINTER_INT short
+#endif
+
+#if defined(__mc68hc11__) || defined(__mc68hc12__) || defined(__mc68hc1x__)
+#undef INT_MAX
+#undef UINT_MAX
+#define INT_MAX __INT_MAX__
+#define UINT_MAX (__INT_MAX__ * 2U + 1)
+#define _POINTER_INT short
+#endif
+
+#if defined(__m68k__) || defined(__mc68000__) || defined(__riscv)
+#define _READ_WRITE_RETURN_TYPE _ssize_t
+#endif
+
+#ifdef ___AM29K__
+#define _FLOAT_RET double
+#endif
+
+#ifdef __i386__
+#ifndef __unix__
+/* in other words, go32 */
+#define _FLOAT_RET double
+#endif
+#if defined(__linux__) || defined(__RDOS__)
+/* we want the reentrancy structure to be returned by a function */
+#define __DYNAMIC_REENT__
+#define HAVE_GETDATE
+#define _READ_WRITE_RETURN_TYPE _ssize_t
+#define __LARGE64_FILES 1
+/* we use some glibc header files so turn on glibc large file feature */
+#define _LARGEFILE64_SOURCE 1
+#endif
+#endif
+
+#ifdef __mn10200__
+#define __SMALL_BITFIELDS
+#endif
+
+#ifdef __AVR__
+#define __SMALL_BITFIELDS
+#define _POINTER_INT short
+#endif
+
+#if defined(__v850) && !defined(__rtems__)
+#define __ATTRIBUTE_IMPURE_PTR__ __attribute__((__sda__))
+#endif
+
+/* For the PowerPC eabi, force the _impure_ptr to be in .sdata */
+#if defined(__PPC__)
+#if defined(_CALL_SYSV)
+#define __ATTRIBUTE_IMPURE_PTR__ __attribute__((__section__(".sdata")))
+#endif
+#ifdef __SPE__
+#define _LONG_DOUBLE double
+#endif
+#endif
+
+/* Configure small REENT structure for Xilinx MicroBlaze platforms */
+#if defined (__MICROBLAZE__) && !defined(__rtems__)
+#ifndef _REENT_SMALL
+#define _REENT_SMALL
+#endif
+/* Xilinx XMK uses Unix98 mutex */
+#ifdef __XMK__
+#define _UNIX98_THREAD_MUTEX_ATTRIBUTES
+#endif
+#endif
+
+#if defined(__mips__) && !defined(__rtems__)
+#define __ATTRIBUTE_IMPURE_PTR__ __attribute__((__section__(".sdata")))
+#endif
+
+#ifdef __xstormy16__
+#define __SMALL_BITFIELDS
+#undef INT_MAX
+#undef UINT_MAX
+#define INT_MAX __INT_MAX__
+#define UINT_MAX (__INT_MAX__ * 2U + 1)
+#define MALLOC_ALIGNMENT 8
+#define _POINTER_INT short
+#define __BUFSIZ__ 16
+#define _REENT_SMALL
+#endif
+
+#if defined __MSP430__
+#ifndef _REENT_SMALL
+#define _REENT_SMALL
+#endif
+
+#define __BUFSIZ__ 256
+#define __SMALL_BITFIELDS
+
+#ifdef __MSP430X_LARGE__
+#define _POINTER_INT __int20
+#else
+#define _POINTER_INT int
+#endif
+#endif
+
+#ifdef __m32c__
+#define __SMALL_BITFIELDS
+#undef INT_MAX
+#undef UINT_MAX
+#define INT_MAX __INT_MAX__
+#define UINT_MAX (__INT_MAX__ * 2U + 1)
+#define MALLOC_ALIGNMENT 8
+#if defined(__r8c_cpu__) || defined(__m16c_cpu__)
+#define _POINTER_INT short
+#else
+#define _POINTER_INT long
+#endif
+#define __BUFSIZ__ 16
+#define _REENT_SMALL
+#endif /* __m32c__ */
+
+#ifdef __SPU__
+#define MALLOC_ALIGNMENT 16
+#define __CUSTOM_FILE_IO__
+#endif
+
+#if defined(__or1k__) || defined(__or1knd__)
+#define __DYNAMIC_REENT__
+#endif
+
+/* This block should be kept in sync with GCC's limits.h.  The point
+   of having these definitions here is to not include limits.h, which
+   would pollute the user namespace, while still using types of the
+   the correct widths when deciding how to define __int32_t and
+   __int64_t.  */
+#ifndef __INT_MAX__
+# ifdef INT_MAX
+#  define __INT_MAX__ INT_MAX
+# else
+#  define __INT_MAX__ 2147483647
+# endif
+#endif
+
+#ifndef __LONG_MAX__
+# ifdef LONG_MAX
+#  define __LONG_MAX__ LONG_MAX
+# else
+#  if defined (__alpha__) || (defined (__sparc__) && defined(__arch64__)) \
+      || defined (__sparcv9)
+#   define __LONG_MAX__ 9223372036854775807L
+#  else
+#   define __LONG_MAX__ 2147483647L
+#  endif /* __alpha__ || sparc64 */
+# endif
+#endif
+/* End of block that should be kept in sync with GCC's limits.h.  */
+
+#ifndef _POINTER_INT
+#define _POINTER_INT long
+#endif
+
+#ifdef __frv__
+#define __ATTRIBUTE_IMPURE_PTR__ __attribute__((__section__(".sdata")))
+#endif
+#undef __RAND_MAX
+#if __INT_MAX__ == 32767
+#define __RAND_MAX 32767
+#else
+#define __RAND_MAX 0x7fffffff
+#endif
+
+#if defined(__CYGWIN__)
+#include <cygwin/config.h>
+#endif
+
+#if defined(__rtems__)
+#define __FILENAME_MAX__ 255
+#define _READ_WRITE_RETURN_TYPE _ssize_t
+#define __DYNAMIC_REENT__
+#endif
+
+#ifndef __EXPORT
+#define __EXPORT
+#endif
+
+#ifndef __IMPORT
+#define __IMPORT
+#endif
+
+/* Define return type of read/write routines.  In POSIX, the return type
+   for read()/write() is "ssize_t" but legacy newlib code has been using
+   "int" for some time.  If not specified, "int" is defaulted.  */
+#ifndef _READ_WRITE_RETURN_TYPE
+#define _READ_WRITE_RETURN_TYPE int
+#endif
+/* Define `count' parameter of read/write routines.  In POSIX, the `count'
+   parameter is "size_t" but legacy newlib code has been using "int" for some
+   time.  If not specified, "int" is defaulted.  */
+#ifndef _READ_WRITE_BUFSIZE_TYPE
+#define _READ_WRITE_BUFSIZE_TYPE int
+#endif
+
+#ifndef __WCHAR_MAX__
+#if __INT_MAX__ == 32767 || defined (_WIN32)
+#define __WCHAR_MAX__ 0xffffu
+#endif
+#endif
+
+/* See if small reent asked for at configuration time and
+   is not chosen by the platform by default.  */
+#ifdef _WANT_REENT_SMALL
+#ifndef _REENT_SMALL
+#define _REENT_SMALL
+#endif
+#endif
+
+#ifdef _WANT_USE_LONG_TIME_T
+#ifndef _USE_LONG_TIME_T
+#define _USE_LONG_TIME_T
+#endif
+#endif
+
+#ifdef _WANT_USE_GDTOA
+#ifndef _USE_GDTOA
+#define _USE_GDTOA
+#endif
+#endif
+
+#ifdef _WANT_REENT_BACKWARD_BINARY_COMPAT
+#ifndef _REENT_BACKWARD_BINARY_COMPAT
+#define _REENT_BACKWARD_BINARY_COMPAT
+#endif
+#endif
+
+#ifdef _WANT_REENT_THREAD_LOCAL
+#ifndef _REENT_THREAD_LOCAL
+#define _REENT_THREAD_LOCAL
+#endif
+#endif
+
+/* If _MB_EXTENDED_CHARSETS_ALL is set, we want all of the extended
+   charsets.  The extended charsets add a few functions and a couple
+   of tables of a few K each. */
+#ifdef _MB_EXTENDED_CHARSETS_ALL
+#define _MB_EXTENDED_CHARSETS_ISO 1
+#define _MB_EXTENDED_CHARSETS_WINDOWS 1
+#endif
+
+#endif /* __SYS_CONFIG_H__ */

--- a/third_party/newlib/newlib-4.3.0/newlib/newlib.hin
+++ b/third_party/newlib/newlib-4.3.0/newlib/newlib.hin
@@ -375,6 +375,9 @@
 /* nano version of malloc is used. */
 #undef _NANO_MALLOC
 
+/* "The newlib version in string format." */
+#undef _NEWLIB_VERSION
+
 /* Verify _REENT_CHECK macros allocate memory successfully. */
 #undef _REENT_CHECK_VERIFY
 
@@ -421,5 +424,14 @@
 
 /* Define if wide char orientation is supported. */
 #undef _WIDE_ORIENT
+
+/* "The newlib minor version number." */
+#undef __NEWLIB_MINOR__
+
+/* "The newlib patch level." */
+#undef __NEWLIB_PATCHLEVEL__
+
+/* "The newlib major version number." */
+#undef __NEWLIB__
 
 #endif /* !__NEWLIB_H__ */


### PR DESCRIPTION
Here we add a really trivial `oak_echo_raw` clone, and modify Newlib enough to be able to issue necessary syscalls.

Note that at this stage although it claims to be C++, it's more like C in a funny hat and a fake mustache: we don't really use the C++ standard library but rather rely on the libc primitives (`fprintf`, `read`, `write`).