### PR TITLE
Add oak_client Rust template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,11 +995,8 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -2015,7 +2012,6 @@ name = "oak_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger 0.8.4",
  "futures-util",
  "log",
  "oak_grpc_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,8 +995,11 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
+ "atty",
+ "humantime",
  "log",
  "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -2005,6 +2008,19 @@ dependencies = [
  "bitflags",
  "micro_rpc",
  "static_assertions",
+]
+
+[[package]]
+name = "oak_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger 0.8.4",
+ "futures-util",
+ "log",
+ "oak_grpc_utils",
+ "prost 0.11.2",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "micro_rpc_build",
   "micro_rpc_tests",
   "oak_channel",
+  "oak_client",
   "oak_core",
   "oak_enclave_runtime_support",
   "oak_functions/examples/benchmark/module",

--- a/oak_client/Cargo.toml
+++ b/oak_client/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "oak_client"
+version = "0.1.0"
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "*"
+env_logger = "*"
+futures-util = "*"
+log = "*"
+prost = "*"
+tonic = "*"
+
+[build-dependencies]
+oak_grpc_utils = { path = "../oak_grpc_utils" }

--- a/oak_client/Cargo.toml
+++ b/oak_client/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "*"
-env_logger = "*"
 futures-util = "*"
 log = "*"
 prost = "*"

--- a/oak_client/build.rs
+++ b/oak_client/build.rs
@@ -1,0 +1,34 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    generate_grpc_code(
+        "../",
+        &[
+            "oak_remote_attestation_noninteractive/proto/v1/messages.proto",
+            "oak_remote_attestation_noninteractive/proto/v1/service_streaming.proto",
+        ],
+        CodegenOptions {
+            build_server: true,
+            build_client: true,
+            ..Default::default()
+        },
+    )?;
+
+    Ok(())
+}

--- a/oak_client/src/lib.rs
+++ b/oak_client/src/lib.rs
@@ -23,11 +23,11 @@ pub mod transport;
 pub mod verifier;
 
 use crate::{
-    verifier::{EvidenceProvider, ReferenceValue, Verifier},
     transport::AsyncTransport,
+    verifier::{EvidenceProvider, ReferenceValue, Verifier},
 };
-use std::{vec, vec::Vec};
 use anyhow::Context;
+use std::{vec, vec::Vec};
 
 pub struct OakClientBuilder {
     transport: Box<dyn AsyncTransport>,
@@ -38,12 +38,20 @@ pub struct OakClientBuilder {
 }
 
 impl OakClientBuilder {
-    pub fn new(transport: Box<dyn AsyncTransport>,
-               evidence_provider: Box<dyn EvidenceProvider>,
-               reference_value: ReferenceValue,
-               verifier: Box<dyn Verifier>,
-               crypto_provider: CryptoProvider) -> Self {
-        Self { transport, evidence_provider, reference_value, verifier, crypto_provider }
+    pub fn new(
+        transport: Box<dyn AsyncTransport>,
+        evidence_provider: Box<dyn EvidenceProvider>,
+        reference_value: ReferenceValue,
+        verifier: Box<dyn Verifier>,
+        crypto_provider: CryptoProvider,
+    ) -> Self {
+        Self {
+            transport,
+            evidence_provider,
+            reference_value,
+            verifier,
+            crypto_provider,
+        }
     }
 
     pub fn build(mut self) -> anyhow::Result<OakClient> {
@@ -52,9 +60,9 @@ impl OakClientBuilder {
             .get_evidence()
             .context("couldn't get evidence")?;
 
-        self.verifier.verify(
-            &evidence, &self.reference_value,
-        ).context("couldn't verify evidence")?;
+        self.verifier
+            .verify(&evidence, &self.reference_value)
+            .context("couldn't verify evidence")?;
 
         let encryptor = self
             .crypto_provider
@@ -78,7 +86,8 @@ pub struct OakClient {
 
 impl OakClient {
     pub async fn invoke(&mut self, request_body: &[u8]) -> anyhow::Result<Vec<u8>> {
-        let (encrypted_request, decryptor) = self.encryptor
+        let (encrypted_request, decryptor) = self
+            .encryptor
             .encrypt(request_body)
             .context("couldn't encrypt request")?;
         let encrypted_response = self
@@ -97,25 +106,22 @@ pub struct CryptoProvider {}
 
 impl CryptoProvider {
     fn get_encryptor(&self, _enclave_public_key: &[u8]) -> anyhow::Result<Encryptor> {
-        Ok(Encryptor{})
+        Ok(Encryptor {})
     }
 }
 
 struct Encryptor {}
 
 impl Encryptor {
-    fn encrypt(&mut self, _message: &[u8]) -> anyhow::Result<(Vec<u8>, Decryptor)>{
-        Ok((
-            vec![],
-            Decryptor {},
-        ))
+    fn encrypt(&mut self, _message: &[u8]) -> anyhow::Result<(Vec<u8>, Decryptor)> {
+        Ok((vec![], Decryptor {}))
     }
 }
 
 struct Decryptor {}
 
 impl Decryptor {
-    fn decrypt(&self, _encrypted_message: &[u8]) -> anyhow::Result<Vec<u8>>{
+    fn decrypt(&self, _encrypted_message: &[u8]) -> anyhow::Result<Vec<u8>> {
         Ok(vec![])
     }
 }

--- a/oak_client/src/lib.rs
+++ b/oak_client/src/lib.rs
@@ -29,53 +29,6 @@ use crate::{
 use anyhow::Context;
 use std::{vec, vec::Vec};
 
-pub struct OakClientBuilder {
-    transport: Box<dyn AsyncTransport>,
-    evidence_provider: Box<dyn EvidenceProvider>,
-    reference_value: ReferenceValue,
-    verifier: Box<dyn Verifier>,
-    crypto_provider: CryptoProvider,
-}
-
-impl OakClientBuilder {
-    pub fn new(
-        transport: Box<dyn AsyncTransport>,
-        evidence_provider: Box<dyn EvidenceProvider>,
-        reference_value: ReferenceValue,
-        verifier: Box<dyn Verifier>,
-        crypto_provider: CryptoProvider,
-    ) -> Self {
-        Self {
-            transport,
-            evidence_provider,
-            reference_value,
-            verifier,
-            crypto_provider,
-        }
-    }
-
-    pub fn build(mut self) -> anyhow::Result<OakClient> {
-        let evidence = self
-            .evidence_provider
-            .get_evidence()
-            .context("couldn't get evidence")?;
-
-        self.verifier
-            .verify(&evidence, &self.reference_value)
-            .context("couldn't verify evidence")?;
-
-        let encryptor = self
-            .crypto_provider
-            .get_encryptor(&evidence.enclave_public_key)
-            .context("couldn't create encryptor")?;
-
-        Ok(OakClient {
-            transport: self.transport,
-            encryptor,
-        })
-    }
-}
-
 /// Client for connecting to Oak.
 /// Represents a Relying Party from the RATS Architecture:
 /// <https://www.rfc-editor.org/rfc/rfc9334.html#name-relying-party>

--- a/oak_client/src/lib.rs
+++ b/oak_client/src/lib.rs
@@ -1,0 +1,121 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub mod proto {
+    #![allow(clippy::return_self_not_must_use)]
+    tonic::include_proto!("oak.session.noninteractive.v1");
+}
+
+pub mod transport;
+pub mod verifier;
+
+use crate::{
+    verifier::{EvidenceProvider, ReferenceValue, Verifier},
+    transport::AsyncTransport,
+};
+use std::{vec, vec::Vec};
+use anyhow::Context;
+
+pub struct OakClientBuilder {
+    transport: Box<dyn AsyncTransport>,
+    evidence_provider: Box<dyn EvidenceProvider>,
+    reference_value: ReferenceValue,
+    verifier: Box<dyn Verifier>,
+    crypto_provider: CryptoProvider,
+}
+
+impl OakClientBuilder {
+    pub fn new(transport: Box<dyn AsyncTransport>,
+               evidence_provider: Box<dyn EvidenceProvider>,
+               reference_value: ReferenceValue,
+               verifier: Box<dyn Verifier>,
+               crypto_provider: CryptoProvider) -> Self {
+        Self { transport, evidence_provider, reference_value, verifier, crypto_provider }
+    }
+
+    pub fn build(mut self) -> anyhow::Result<OakClient> {
+        let evidence = self
+            .evidence_provider
+            .get_evidence()
+            .context("couldn't get evidence")?;
+
+        self.verifier.verify(
+            &evidence, &self.reference_value,
+        ).context("couldn't verify evidence")?;
+
+        let encryptor = self
+            .crypto_provider
+            .get_encryptor(&evidence.enclave_public_key)
+            .context("couldn't create encryptor")?;
+
+        Ok(OakClient {
+            transport: self.transport,
+            encryptor,
+        })
+    }
+}
+
+/// Client for connecting to Oak.
+/// Represents a Relying Party from the RATS Architecture:
+/// <https://www.rfc-editor.org/rfc/rfc9334.html#name-relying-party>
+pub struct OakClient {
+    transport: Box<dyn AsyncTransport>,
+    encryptor: Encryptor,
+}
+
+impl OakClient {
+    pub async fn invoke(&mut self, request_body: &[u8]) -> anyhow::Result<Vec<u8>> {
+        let (encrypted_request, decryptor) = self.encryptor
+            .encrypt(request_body)
+            .context("couldn't encrypt request")?;
+        let encrypted_response = self
+            .transport
+            .invoke(&encrypted_request)
+            .context("couldn't send request")?;
+        let decrypted_response = decryptor
+            .decrypt(&encrypted_response)
+            .context("couldn't decrypt response")?;
+        Ok(decrypted_response)
+    }
+}
+
+// TODO(#3654): Implement client crypto provider.
+pub struct CryptoProvider {}
+
+impl CryptoProvider {
+    fn get_encryptor(&self, _enclave_public_key: &[u8]) -> anyhow::Result<Encryptor> {
+        Ok(Encryptor{})
+    }
+}
+
+struct Encryptor {}
+
+impl Encryptor {
+    fn encrypt(&mut self, _message: &[u8]) -> anyhow::Result<(Vec<u8>, Decryptor)>{
+        Ok((
+            vec![],
+            Decryptor {},
+        ))
+    }
+}
+
+struct Decryptor {}
+
+impl Decryptor {
+    fn decrypt(&self, _encrypted_message: &[u8]) -> anyhow::Result<Vec<u8>>{
+        Ok(vec![])
+    }
+}

--- a/oak_client/src/transport.rs
+++ b/oak_client/src/transport.rs
@@ -28,7 +28,9 @@ pub struct GrpcStreamingTransport {
 
 impl GrpcStreamingTransport {
     pub fn new(rpc_client: StreamingSessionClient<Channel>) -> Self {
-        Self { _rpc_client: rpc_client }
+        Self {
+            _rpc_client: rpc_client,
+        }
     }
 }
 

--- a/oak_client/src/transport.rs
+++ b/oak_client/src/transport.rs
@@ -1,0 +1,40 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::proto::streaming_session_client::StreamingSessionClient;
+use tonic::transport::Channel;
+
+pub trait AsyncTransport {
+    // TODO(#3643): Make transport async and update the Rust version to support this.
+    fn invoke(&mut self, request_bytes: &[u8]) -> anyhow::Result<Vec<u8>>;
+}
+
+pub struct GrpcStreamingTransport {
+    _rpc_client: StreamingSessionClient<Channel>,
+}
+
+impl GrpcStreamingTransport {
+    pub fn new(rpc_client: StreamingSessionClient<Channel>) -> Self {
+        Self { _rpc_client: rpc_client }
+    }
+}
+
+impl AsyncTransport for GrpcStreamingTransport {
+    // TODO(#3643): Implement gRPC Rust client.
+    fn invoke(&mut self, _request_bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
+        Ok(vec![])
+    }
+}

--- a/oak_client/src/verifier.rs
+++ b/oak_client/src/verifier.rs
@@ -31,7 +31,7 @@ pub struct ReferenceValue {
     pub binary_hash: String,
 }
 
-/// Verifier that 
+/// Verifier that
 /// <https://www.rfc-editor.org/rfc/rfc9334.html#name-verifier>
 pub trait Verifier {
     fn verify(&self, evidence: &Evidence, reference_value: &ReferenceValue) -> anyhow::Result<()>;
@@ -40,7 +40,11 @@ pub trait Verifier {
 pub struct AmdSevSnpVerifier {}
 
 impl Verifier for AmdSevSnpVerifier {
-    fn verify(&self, _evidence: &Evidence, _reference_value: &ReferenceValue) -> anyhow::Result<()> {
+    fn verify(
+        &self,
+        _evidence: &Evidence,
+        _reference_value: &ReferenceValue,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/oak_client/src/verifier.rs
+++ b/oak_client/src/verifier.rs
@@ -1,0 +1,46 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub trait EvidenceProvider {
+    fn get_evidence(&mut self) -> anyhow::Result<Evidence>;
+}
+
+/// Attestation evidence used to verify the validity of the Trusted Execution
+/// Environment and the binary running on it.
+/// <https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence>
+pub struct Evidence {
+    pub enclave_public_key: Vec<u8>,
+}
+
+/// Reference values used by the verifier to appraise the attestation evidence.
+/// <https://www.rfc-editor.org/rfc/rfc9334.html#name-reference-values>
+pub struct ReferenceValue {
+    pub binary_hash: String,
+}
+
+/// Verifier that 
+/// <https://www.rfc-editor.org/rfc/rfc9334.html#name-verifier>
+pub trait Verifier {
+    fn verify(&self, evidence: &Evidence, reference_value: &ReferenceValue) -> anyhow::Result<()>;
+}
+
+pub struct AmdSevSnpVerifier {}
+
+impl Verifier for AmdSevSnpVerifier {
+    fn verify(&self, _evidence: &Evidence, _reference_value: &ReferenceValue) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/oak_client/src/verifier.rs
+++ b/oak_client/src/verifier.rs
@@ -31,7 +31,8 @@ pub struct ReferenceValue {
     pub binary_hash: String,
 }
 
-/// Verifier that
+/// Verifier that appraises the attestation evidence and produces an attestation
+/// result.
 /// <https://www.rfc-editor.org/rfc/rfc9334.html#name-verifier>
 pub trait Verifier {
     fn verify(&self, evidence: &Evidence, reference_value: &ReferenceValue) -> anyhow::Result<()>;

--- a/oak_client/src/verifier.rs
+++ b/oak_client/src/verifier.rs
@@ -40,6 +40,7 @@ pub trait Verifier {
 
 pub struct AmdSevSnpVerifier {}
 
+// TODO(#3641): Implement client-side attestation verification.
 impl Verifier for AmdSevSnpVerifier {
     fn verify(
         &self,


### PR DESCRIPTION
This PR adds a template for the Rust client, which will be built upon as part of the https://github.com/project-oak/oak/issues/3643