### PR TITLE
Update virtio-drivers crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,12 +3513,13 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "virtio-drivers"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70fa25d0e1ed9095580f2882fb065331ff531017b08c5dd7528a2ef0227f468e"
+checksum = "aedaf1192446dc383b6bfb02d6a47813078932a96c0589e42b87ce684b934c40"
 dependencies = [
  "bitflags",
  "log",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,8 +3514,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "virtio-drivers"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedaf1192446dc383b6bfb02d6a47813078932a96c0589e42b87ce684b934c40"
+source = "git+https://github.com/conradgrobler/virtio-drivers?branch=fix-console#67183ee2622d3c267763e235b116992b85b0671c"
 dependencies = [
  "bitflags",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,7 +3514,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "virtio-drivers"
 version = "0.3.0"
-source = "git+https://github.com/conradgrobler/virtio-drivers?branch=fix-console#67183ee2622d3c267763e235b116992b85b0671c"
+source = "git+https://github.com/conradgrobler/virtio-drivers?branch=fix-console#5135aceffb9c69f950a7afa115abe9ed9ac7239c"
 dependencies = [
  "bitflags",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,7 @@ prost-types = "*"
 tokio = "*"
 tonic = "*"
 tonic-build = { version = "*", default-features = false }
+
+# TODO(#3706): Remove when patching PR is merged upstream and released.
+[patch.crates-io]
+virtio-drivers = { git = 'https://github.com/conradgrobler/virtio-drivers', branch = 'fix-console' }

--- a/oak_restricted_kernel/src/virtio_console.rs
+++ b/oak_restricted_kernel/src/virtio_console.rs
@@ -74,7 +74,7 @@ unsafe impl Hal for OakHal {
         );
         GUEST_HOST_HEAP.get().unwrap().deallocate(
             vaddr,
-            Layout::from_size_align(pages * 0x1000, 0x1000).unwrap(),
+            Layout::from_size_align(pages * PAGE_SIZE, PAGE_SIZE).unwrap(),
         );
 
         0

--- a/oak_restricted_kernel/src/virtio_console.rs
+++ b/oak_restricted_kernel/src/virtio_console.rs
@@ -32,43 +32,45 @@ use core::{
 use log::info;
 use oak_channel::{Read, Write};
 use spinning_top::Spinlock;
-use virtio_drivers::{DeviceType, Hal, MmioTransport, Transport, VirtIOConsole};
+use virtio_drivers::{
+    device::console::VirtIOConsole,
+    transport::{mmio::MmioTransport, DeviceType, Transport},
+    BufferDirection, Hal, PAGE_SIZE,
+};
 use x86_64::{PhysAddr, VirtAddr};
 
 struct OakHal;
 
 impl Hal for OakHal {
-    fn dma_alloc(pages: usize) -> virtio_drivers::PhysAddr {
-        // virtio_drivers::PAGE_SIZE is private right now, this has been fixed but not in the latest
-        // release
-        let vaddr = VirtAddr::from_ptr(
-            GUEST_HOST_HEAP
-                .get()
-                .unwrap()
-                .allocate(Layout::from_size_align(pages * 0x1000, 0x1000).unwrap())
-                .expect("Failed to allocate memory for virtio MMIO")
-                .cast::<u8>()
-                .as_ptr(),
-        );
-        PAGE_TABLES
+    fn dma_alloc(
+        pages: usize,
+        _direction: BufferDirection,
+    ) -> (virtio_drivers::PhysAddr, NonNull<u8>) {
+        let vaddr = GUEST_HOST_HEAP
+            .get()
+            .unwrap()
+            .allocate(Layout::from_size_align(pages * PAGE_SIZE, PAGE_SIZE).unwrap())
+            .expect("Failed to allocate memory for virtio MMIO")
+            .cast::<u8>();
+        let phys_addr = PAGE_TABLES
             .get()
             .unwrap()
             .lock()
-            .translate_virtual(vaddr)
+            .translate_virtual(VirtAddr::from_ptr(vaddr.as_ptr()))
             .unwrap()
-            .as_u64() as usize
+            .as_u64() as usize;
+        (phys_addr, vaddr)
     }
 
-    fn dma_dealloc(paddr: virtio_drivers::PhysAddr, pages: usize) -> i32 {
-        let vaddr = PAGE_TABLES
-            .get()
-            .unwrap()
-            .lock()
-            .translate_physical(PhysAddr::new(paddr as u64))
-            .unwrap();
+    fn dma_dealloc(paddr: virtio_drivers::PhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
+        let vaddr_check = Self::mmio_phys_to_virt(paddr, 0);
+        assert_eq!(
+            vaddr_check, vaddr,
+            "dma buffer physical and virtual addresses don't match",
+        );
         unsafe {
             GUEST_HOST_HEAP.get().unwrap().deallocate(
-                NonNull::new(vaddr.as_mut_ptr()).unwrap(),
+                vaddr,
                 Layout::from_size_align(pages * 0x1000, 0x1000).unwrap(),
             );
         }
@@ -76,24 +78,38 @@ impl Hal for OakHal {
         0
     }
 
-    fn phys_to_virt(paddr: virtio_drivers::PhysAddr) -> virtio_drivers::VirtAddr {
+    fn mmio_phys_to_virt(paddr: virtio_drivers::PhysAddr, _size: usize) -> NonNull<u8> {
+        NonNull::new(
+            PAGE_TABLES
+                .get()
+                .unwrap()
+                .lock()
+                .translate_physical(PhysAddr::new(paddr as u64))
+                .unwrap()
+                .as_mut_ptr(),
+        )
+        .unwrap()
+    }
+
+    fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> virtio_drivers::PhysAddr {
+        // No additional work needed for sharing as the buffer was allocated from the guest-host
+        // allocator.
         PAGE_TABLES
             .get()
             .unwrap()
             .lock()
-            .translate_physical(PhysAddr::new(paddr as u64))
+            .translate_virtual(VirtAddr::from_ptr(buffer.cast::<u8>().as_ptr()))
             .unwrap()
             .as_u64() as usize
     }
 
-    fn virt_to_phys(vaddr: virtio_drivers::VirtAddr) -> virtio_drivers::PhysAddr {
-        PAGE_TABLES
-            .get()
-            .unwrap()
-            .lock()
-            .translate_virtual(VirtAddr::new(vaddr as u64))
-            .unwrap()
-            .as_u64() as usize
+    fn unshare(
+        _paddr: virtio_drivers::PhysAddr,
+        _buffer: NonNull<[u8]>,
+        _direction: BufferDirection,
+    ) {
+        // No additional work needed for unsharing as the buffer was allocated from the guest-host
+        // allocator.
     }
 }
 

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -831,8 +831,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "virtio-drivers"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedaf1192446dc383b6bfb02d6a47813078932a96c0589e42b87ce684b934c40"
+source = "git+https://github.com/conradgrobler/virtio-drivers?branch=fix-console#a3691f0b8d74c02be0633073d35a2e7506c9cc43"
 dependencies = [
  "bitflags",
  "log",

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -831,7 +831,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "virtio-drivers"
 version = "0.3.0"
-source = "git+https://github.com/conradgrobler/virtio-drivers?branch=fix-console#a3691f0b8d74c02be0633073d35a2e7506c9cc43"
+source = "git+https://github.com/conradgrobler/virtio-drivers?branch=fix-console#5135aceffb9c69f950a7afa115abe9ed9ac7239c"
 dependencies = [
  "bitflags",
  "log",

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -830,12 +830,13 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "virtio-drivers"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70fa25d0e1ed9095580f2882fb065331ff531017b08c5dd7528a2ef0227f468e"
+checksum = "aedaf1192446dc383b6bfb02d6a47813078932a96c0589e42b87ce684b934c40"
 dependencies = [
  "bitflags",
  "log",
+ "zerocopy",
 ]
 
 [[package]]

--- a/oak_restricted_kernel_bin/Cargo.toml
+++ b/oak_restricted_kernel_bin/Cargo.toml
@@ -25,3 +25,7 @@ oak_restricted_kernel = { path = "../oak_restricted_kernel", default-features = 
 name = "oak_restricted_kernel_bin"
 test = false
 bench = false
+
+# TODO(#3706): Remove when patching PR is merged upstream and released.
+[patch.crates-io]
+virtio-drivers = { git = 'https://github.com/conradgrobler/virtio-drivers', branch = 'fix-console' }


### PR DESCRIPTION
This updates the virtio-drivers crate to the latest released version, which contains a number of fixes.

I had to create a patch PR (https://github.com/rcore-os/virtio-drivers/pull/62) to make the virtio-console work for us as a comms channel. Once the PR is merged and a new version release we can stop overriding the dependency (see #3706).