### PR TITLE
Fix memory fences in fw_cfg DMA

### DIFF
--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -357,13 +357,11 @@ impl FwCfg {
         // safe.
         unsafe {
             self.dma_high.try_write(dma_high.to_be())?;
-            // Memory fence to make sure the high half is written before the low half.
-            core::sync::atomic::fence(core::sync::atomic::Ordering::Acquire);
             self.dma_low.try_write(dma_low.to_be())?;
         }
 
         // Memory fence to make sure that the DMA operation is complete before we read the result.
-        core::sync::atomic::fence(core::sync::atomic::Ordering::Release);
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
 
         // The control field will be cleared if the DMA operation is complete and successful.
         if dma_access.control != 0 {


### PR DESCRIPTION
The first fence was not needed, since neither the compiler nor the CPU will reorder instructions that have side effect (like writing to IO ports).

The second fence was not strong enough. It has not caused any issues so far, but I believe the stronger fence is more correct.