### PR TITLE
Update Android tools in Docker image and Bazel workspace

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:b229d16b1df7ee7c87525ccb8c72e8e256f0f141ffde98180f8930e046d21c78",
+  "image": "sha256:68c0e818b16e316ca171edbd6caf6f1b0c8b932dfb4776f06c1da83b2cb707f5",
   "extensions": [
     "13xforever.language-x86-64-assembly",
     "bazelbuild.vscode-bazel",

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ Makefile.conf
 
 # TensorFlow model server binary
 tensorflow_model_server
+
+# Direnv
+.direnv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -309,24 +309,24 @@ ARG android_sdk_version=8512546
 ENV ANDROID_HOME /opt/android-sdk
 ENV android_temp /tmp/android-sdk
 RUN mkdir --parents "{android_temp}" \
-    && mkdir --parents "${ANDROID_HOME}/cmdline-tools/latest" \
-    && curl --location "https://dl.google.com/android/repository/commandlinetools-linux-${android_sdk_version}_latest.zip" > android_sdk.zip \
-    && unzip android_sdk.zip -d "${android_temp}" \
-    && mv ${android_temp}/cmdline-tools/* "${ANDROID_HOME}/cmdline-tools/latest/" \
-    && rm android_sdk.zip
+  && mkdir --parents "${ANDROID_HOME}/cmdline-tools/latest" \
+  && curl --location "https://dl.google.com/android/repository/commandlinetools-linux-${android_sdk_version}_latest.zip" > android_sdk.zip \
+  && unzip android_sdk.zip -d "${android_temp}" \
+  && mv ${android_temp}/cmdline-tools/* "${ANDROID_HOME}/cmdline-tools/latest/" \
+  && rm android_sdk.zip
 
 # Install Android Platform Tools.
 # https://developer.android.com/studio/releases/platform-tools
 # https://developer.android.com/studio/releases/platforms
 # https://developer.android.com/studio/releases/build-tools
 ARG platform=30
-ARG tools=30.0.0
+ARG tools=32.0.0
 RUN "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --update \
-    && (yes || true) | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses \
-    && (yes || true) | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
-    'tools' 'platform-tools' 'cmake;3.6.4111459' \
-    "platforms;android-${platform}" "build-tools;${tools}" \
-    "system-images;android-${platform};default;x86_64"
+  && (yes || true) | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses \
+  && (yes || true) | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
+  'tools' 'platform-tools' 'cmake;3.6.4111459' \
+  "platforms;android-${platform}" "build-tools;${tools}" \
+  "system-images;android-${platform};default;x86_64"
 
 # Set up Android SDK paths.
 ENV PATH "${PATH}:${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools/bin"
@@ -337,10 +337,10 @@ ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${ANDROID_HOME}/emulator/lib64:${ANDROID
 ARG android_ndk_version=r25b
 ENV ANDROID_NDK_HOME /opt/android-ndk
 RUN mkdir --parents "${ANDROID_NDK_HOME}" \
-    && curl --location "https://dl.google.com/android/repository/android-ndk-${android_ndk_version}-linux.zip" > android_ndk.zip \
-    && unzip android_ndk.zip -d "${ANDROID_NDK_HOME}" \
-    && mv ${ANDROID_NDK_HOME}/android-ndk-${android_ndk_version}/* "${ANDROID_NDK_HOME}" \
-    && rm android_ndk.zip
+  && curl --location "https://dl.google.com/android/repository/android-ndk-${android_ndk_version}-linux.zip" > android_ndk.zip \
+  && unzip android_ndk.zip -d "${ANDROID_NDK_HOME}" \
+  && mv ${ANDROID_NDK_HOME}/android-ndk-${android_ndk_version}/* "${ANDROID_NDK_HOME}" \
+  && rm android_ndk.zip
 
 # To make the scripts available to call from everywhere.
 ENV PATH "/workspace/scripts:${PATH}"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -202,7 +202,7 @@ load("@build_bazel_rules_android//android:rules.bzl", "android_ndk_repository", 
 android_sdk_repository(
     name = "androidsdk",
     api_level = 30,
-    build_tools_version = "30.0.0",
+    build_tools_version = "32.0.0",
 )
 
 android_ndk_repository(

--- a/scripts/common
+++ b/scripts/common
@@ -20,10 +20,10 @@ readonly DOCKER_IMAGE_NAME='europe-west2-docker.pkg.dev/oak-ci/oak-development/o
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:b229d16b1df7ee7c87525ccb8c72e8e256f0f141ffde98180f8930e046d21c78'
+readonly DOCKER_IMAGE_ID='sha256:68c0e818b16e316ca171edbd6caf6f1b0c8b932dfb4776f06c1da83b2cb707f5'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development@sha256:96e3903cf0eafcebff9bb36fac1c77dad695353af7f842103bd128e7028ce6cc'
+readonly DOCKER_IMAGE_REPO_DIGEST='europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development@sha256:9952090946cb79d8535f9924d8e149c03d34d239246c4a69ae5f6f52088f0e17'
 
 readonly CACHE_DIR='bazel-cache'
 readonly SERVER_BIN_DIR="${PWD}/oak_loader/bin"


### PR DESCRIPTION
This will make it easier to integrate with Nix if we want to (it seems that version 32 is more easily available there)