### PR TITLE
Clarify git diffs in error message

### DIFF
--- a/scripts/git_check_diff
+++ b/scripts/git_check_diff
@@ -6,6 +6,10 @@ source "$SCRIPTS_DIR/common"
 
 # Check that any generated files match those that are checked in.
 if [[ $(git status --short) ]]; then
+    echo "Some files are either modified or newly generated, please commit them and try again."
+    echo "Here is a list of files that are different:"
+    git status
+    git diff
     # One or more files are either modified or newly generated, exit with an error code
     exit 1
 fi


### PR DESCRIPTION
Currently the output of the git diff step is not very explicative, and does not actually show the diff.