### PR TITLE
Introduce a bazel OS entry and toolchain for Oak

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,3 +25,16 @@ package(
 
 # Export LICENSE file for projects that reference Oak in Bazel as an external dependency.
 exports_files(["LICENSE"])
+
+constraint_value(
+    name = "os_oak",
+    constraint_setting = "@platforms//os:os",
+)
+
+platform(
+    name = "oak",
+    constraint_values = [
+        "//:os_oak",
+        "@platforms//cpu:x86_64",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -135,3 +135,5 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 # This sets up some common toolchains for building targets. For more details, please see
 # https://bazelbuild.github.io/rules_foreign_cc/0.9.0/flatten.html#rules_foreign_cc_dependencies
 rules_foreign_cc_dependencies()
+
+register_toolchains("//toolchain:oak")

--- a/cc/oak_echo_raw_enclave_app/BUILD
+++ b/cc/oak_echo_raw_enclave_app/BUILD
@@ -28,7 +28,11 @@ cc_binary(
     features = ["fully_static_link"],
     linkopts = [
         "-nostdlib",
-        "-zmax-page-size=0x200000",
+        "-Wl,-zmax-page-size=0x200000",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "//:os_oak",
     ],
     deps = ["//third_party/newlib"],
 )

--- a/cc/oak_echo_raw_enclave_app/main.cc
+++ b/cc/oak_echo_raw_enclave_app/main.cc
@@ -19,7 +19,8 @@
 
 constexpr int CHANNEL_FD = 10;
 
-int main(int argc, char* argv[]) {
+// Under C++ rules, the name is mangled to "_Z4mainiPPc" -- find out what's going on with that.
+extern "C" int main(int argc, char* argv[]) {
   char buf;
 
   fprintf(stderr, "In main!\n");

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -1,0 +1,56 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+cc_toolchain_suite(
+    name = "clang_suite",
+    toolchains = {
+        "k8": ":k8_toolchain",
+    },
+)
+
+filegroup(name = "empty")
+
+cc_toolchain(
+    name = "k8_toolchain",
+    all_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+    toolchain_config = ":k8_toolchain_config",
+    toolchain_identifier = "k8-toolchain",
+)
+
+cc_toolchain_config(name = "k8_toolchain_config")
+
+toolchain(
+    name = "oak",
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "//:os_oak",
+    ],
+    toolchain = ":k8_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -1,0 +1,77 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""C++ toolchain config that wraps clang installed on the host machine."""
+
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "tool_path")
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "/usr/bin/clang-16",
+        ),
+        tool_path(
+            name = "ld",
+            path = "/usr/bin/ld",
+        ),
+        tool_path(
+            name = "ar",
+            path = "/usr/bin/ar",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "/usr/bin/clang++-16",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "/usr/bin/gcov",
+        ),
+        tool_path(
+            name = "nm",
+            path = "/usr/bin/nm",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "/usr/bin/objdump",
+        ),
+        tool_path(
+            name = "strip",
+            path = "/usr/bin/strip",
+        ),
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        cxx_builtin_include_directories = [
+            "/usr/lib/llvm-16/lib/clang/16/include",
+        ],
+        toolchain_identifier = "k8-toolchain",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_cpu = "k8",
+        target_libc = "unknown",
+        compiler = "clang",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+    )
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)


### PR DESCRIPTION
It should be noted that I really have no idea what I'm doing here...

What I hope I achieved is:
  - using the Bazel `platforms` mechanism, introduce a new OS constraint for Oak
  - create a toolchain, compatible with the aforementioned OS constraint, that compiles things with clang.

The downside is that if you just invoke `blaze build :all`, it won't compile the app. You have to explicitly say `blaze build :oak_echo_raw_enclave_app --platforms=//:oak`.

There's a ton of things to figure out how to do better here, but it seems to work.