### PR TITLE
Make Quirk tests actual Rust tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,6 +2464,7 @@ dependencies = [
  "oak_launcher_utils",
  "prost",
  "tokio",
+ "xtask",
 ]
 
 [[package]]

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
                 cargo-deadlinks
                 cargo-binutils
                 cargo-deny
+                cargo-nextest
                 cargo-udeps
                 protobuf
                 qemu_kvm

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -16,9 +16,8 @@ export RUST_BACKTRACE=1
 export RUST_LOG=debug
 
 ./scripts/docker_pull
-# ./scripts/docker_run cargo test --package=oak_functions_launcher
 ./scripts/docker_run cargo nextest run --hide-progress-bar --package=oak_functions_launcher
-./scripts/docker_run ./scripts/xtask run-launcher-test
-./scripts/docker_run ./scripts/xtask run-quirk-test
+./scripts/docker_run cargo nextest run --hide-progress-bar --package=quirk_echo_launcher
 
 cp ./target/nextest/default/junit.xml "$KOKORO_ARTIFACTS_DIR/"
+ls -als "$KOKORO_ARTIFACTS_DIR"

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -29,19 +29,10 @@ lazy_static! {
     };
 }
 
-/// Whether to skip the test. For instance, GitHub Actions does not support KVM, so we cannot run
-/// tests that require nested virtualization.
-fn skip_test() -> bool {
-    std::env::var("OAK_KVM_TESTS")
-        .unwrap_or_default()
-        .to_lowercase()
-        == "skip"
-}
-
 // Allow enough worker threads to collect output from background tasks.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_launcher_virtual() {
-    if skip_test() {
+    if xtask::testing::skip_test() {
         log::info!("skipping test");
         return;
     }

--- a/quirk_echo_launcher/Cargo.toml
+++ b/quirk_echo_launcher/Cargo.toml
@@ -32,3 +32,4 @@ micro_rpc_build = { path = "../micro_rpc_build" }
 
 [dev-dependencies]
 lazy_static = "*"
+xtask = { workspace = true }

--- a/quirk_echo_launcher/src/lib.rs
+++ b/quirk_echo_launcher/src/lib.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The Project Oak Authors
+// Copyright 2023 The Project Oak Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
-#![allow(dead_code)]
-use prost::Message;
-include!(concat!(env!("OUT_DIR"), "/quirk.echo.rs"));
+#![feature(never_type)]
+
+pub mod schema {
+    #![allow(dead_code)]
+    use prost::Message;
+    include!(concat!(env!("OUT_DIR"), "/quirk.echo.rs"));
+}

--- a/quirk_echo_launcher/src/main.rs
+++ b/quirk_echo_launcher/src/main.rs
@@ -21,7 +21,11 @@
 use clap::Parser;
 use oak_launcher_utils::launcher;
 
-mod schema;
+pub mod schema {
+    #![allow(dead_code)]
+    use prost::Message;
+    include!(concat!(env!("OUT_DIR"), "/quirk.echo.rs"));
+}
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -42,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     log::info!("calling launcher");
     let (guest_instance, connector_handle) = launcher::launch(cli.mode).await?;
 
-    let mut client = schema::EchoAsyncClient::new(connector_handle);
+    let mut client = crate::schema::EchoAsyncClient::new(connector_handle);
     let body = b"test_msg".to_vec();
     let echo_request = schema::EchoRequest { body: body.clone() };
 

--- a/quirk_echo_launcher/tests/integration_test.rs
+++ b/quirk_echo_launcher/tests/integration_test.rs
@@ -1,0 +1,53 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the Quirk Echo Launcher.
+
+use std::time::Duration;
+
+// Allow enough worker threads to collect output from background tasks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_launcher_virtual() {
+    if xtask::testing::skip_test() {
+        log::info!("skipping test");
+        return;
+    }
+
+    xtask::testing::run_step(xtask::launcher::build_stage0()).await;
+    xtask::testing::run_step(xtask::launcher::build_binary(
+        "build Oak Restricted Kernel binary",
+        xtask::launcher::OAK_RESTRICTED_KERNEL_BIN_DIR
+            .to_str()
+            .unwrap(),
+    ))
+    .await;
+    let variant = xtask::launcher::LauncherMode::Virtual("quirk_echo_enclave_app".to_string());
+    xtask::testing::run_step(xtask::launcher::build_binary(
+        "build Quirk Echo enclave app",
+        &variant.enclave_crate_path(),
+    ))
+    .await;
+
+    let _background = xtask::testing::run_background(xtask::launcher::run_launcher(
+        xtask::launcher::QUIRK_ECHO_LAUNCHER_BIN.to_str().unwrap(),
+        &variant,
+    ))
+    .await;
+
+    // Wait for the server to start up.
+    // Currently the Quirk Echo Launcher does not expose a gRPC service, it just invokes a method on
+    // the Enclave application directly and then immediately terminates.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+}

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -26,6 +26,8 @@ pub static OAK_RESTRICTED_KERNEL_BIN_DIR: Lazy<PathBuf> =
     Lazy::new(|| workspace_path(&["oak_restricted_kernel_bin"]));
 static OAK_FUNCTIONS_LAUNCHER_BIN: Lazy<PathBuf> =
     Lazy::new(|| workspace_path(&["target", "debug", "oak_functions_launcher"]));
+pub static QUIRK_ECHO_LAUNCHER_BIN: Lazy<PathBuf> =
+    Lazy::new(|| workspace_path(&["target", "debug", "quirk_echo_launcher"]));
 
 use crate::{internal::*, workspace_path};
 use once_cell::sync::Lazy;
@@ -208,6 +210,12 @@ pub fn run_oak_functions_launcher_example(variant: &LauncherMode) -> Box<dyn Run
     ];
     args.append(&mut variant.variant_subcommand());
     Cmd::new(OAK_FUNCTIONS_LAUNCHER_BIN.to_str().unwrap(), args)
+}
+
+pub fn run_launcher(launcher_bin: &str, variant: &LauncherMode) -> Box<dyn Runnable> {
+    let mut args = vec![];
+    args.append(&mut variant.variant_subcommand());
+    Cmd::new(launcher_bin, args)
 }
 
 fn run_client(request: &str, expected_response: &str, iterations: usize) -> Step {

--- a/xtask/src/testing.rs
+++ b/xtask/src/testing.rs
@@ -43,3 +43,12 @@ pub async fn run_background(step: Box<dyn Runnable>) -> Box<dyn Running> {
     tokio::spawn(read_to_end(running.stderr()));
     running
 }
+
+/// Whether to skip the test. For instance, GitHub Actions does not support KVM, so we cannot run
+/// tests that require nested virtualization.
+pub fn skip_test() -> bool {
+    std::env::var("OAK_KVM_TESTS")
+        .unwrap_or_default()
+        .to_lowercase()
+        == "skip"
+}


### PR DESCRIPTION
Running them via xtask is quite inconvenient, so now there is a regular Rust test, that can be customized with extra logic in the future.

Ref #2591