### PR TITLE
Refactor launcher for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,7 @@ dependencies = [
  "prost",
  "tempfile",
  "tokio",
+ "ubyte",
 ]
 
 [[package]]

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -20,8 +20,13 @@
 
 use crate::schema::InitializeResponse;
 use anyhow::Context;
-use oak_launcher_utils::{channel, launcher};
-use std::{fs, path::PathBuf};
+use oak_launcher_utils::{
+    channel::{self, ConnectorHandle},
+    launcher,
+};
+use schema::OakFunctionsAsyncClient;
+use std::{fs, path::PathBuf, time::Duration};
+use ubyte::ByteUnit;
 
 pub mod schema {
     #![allow(dead_code)]
@@ -32,9 +37,16 @@ pub mod schema {
 mod lookup;
 pub mod server;
 
+pub struct LookupDataConfig {
+    pub lookup_data_path: PathBuf,
+    // Only periodically updates if interval is given.
+    pub update_interval: Option<Duration>,
+    pub max_chunk_size: ByteUnit,
+}
+
 pub async fn create(
     mode: launcher::GuestMode,
-    lookup_data_path: PathBuf,
+    lookup_data_config: LookupDataConfig,
     wasm_path: PathBuf,
     constant_response_size: u32,
 ) -> Result<
@@ -46,7 +58,7 @@ pub async fn create(
     Box<dyn std::error::Error>,
 > {
     let (launched_instance, connector_handle) = launcher::launch(mode).await?;
-    setup_lookup_data(connector_handle.clone(), lookup_data_path).await?;
+    setup_lookup_data(connector_handle.clone(), lookup_data_config).await?;
     let intialize_response =
         setup_wasm(connector_handle.clone(), &wasm_path, constant_response_size).await?;
     Ok((launched_instance, connector_handle, intialize_response))
@@ -55,24 +67,39 @@ pub async fn create(
 // Initially loads lookup data and spawns task to periodically refresh lookup data.
 async fn setup_lookup_data(
     connector_handle: channel::ConnectorHandle,
-    lookup_data_path: PathBuf,
+    config: LookupDataConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut client = schema::OakFunctionsAsyncClient::new(connector_handle);
 
     // Block for [invariant that lookup data is fully loaded](https://github.com/project-oak/oak/tree/main/oak_functions/lookup/README.md#invariant-fully-loaded-lookup-data)
-    lookup::update_lookup_data(&mut client, &lookup_data_path).await?;
+    lookup::update_lookup_data(&mut client, &config.lookup_data_path, config.max_chunk_size)
+        .await?;
 
     // Spawn task to periodically refresh lookup data.
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_millis(1000 * 60 * 10));
-        loop {
-            // Wait before updating because we just loaded the lookup data.
-            interval.tick().await;
-            let _ = lookup::update_lookup_data(&mut client, &lookup_data_path).await;
-            // Ignore errors in updates of lookup data after the initial update.
-        }
-    });
+    if let Some(_) = config.update_interval {
+        tokio::spawn(setup_periodic_update(client, config));
+    }
     Ok(())
+}
+
+async fn setup_periodic_update(
+    mut client: OakFunctionsAsyncClient<ConnectorHandle>,
+    config: LookupDataConfig,
+) {
+    // Only set periodic update if an interval is given.
+    let mut interval =
+        tokio::time::interval(config.update_interval.expect("No update interval given."));
+    loop {
+        // Wait before updating because we just loaded the lookup data.
+        interval.tick().await;
+        let _ = lookup::update_lookup_data(
+            &mut client,
+            &config.lookup_data_path,
+            config.max_chunk_size,
+        )
+        .await;
+        // Ignore errors in updates of lookup data after the initial update.
+    }
 }
 
 // Loads wasm bytes.

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -76,7 +76,7 @@ async fn setup_lookup_data(
         .await?;
 
     // Spawn task to periodically refresh lookup data.
-    if let Some(_) = config.update_interval {
+    if config.update_interval.is_some() {
         tokio::spawn(setup_periodic_update(client, config));
     }
     Ok(())

--- a/oak_functions_launcher/src/lookup.rs
+++ b/oak_functions_launcher/src/lookup.rs
@@ -28,10 +28,8 @@ use ubyte::ByteUnit;
 pub async fn update_lookup_data(
     client: &mut OakFunctionsAsyncClient<ConnectorHandle>,
     lookup_data_path: &PathBuf,
+    max_chunk_size: ByteUnit,
 ) -> anyhow::Result<()> {
-    // Fix the maximum size of a chunk to the proto limit size of 2 GiB.
-    let max_chunk_size = ByteUnit::Gibibyte(2);
-
     let lookup_data = load_lookup_data(lookup_data_path)?;
     let mut chunks = chunk_up_lookup_data(lookup_data, max_chunk_size);
 

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -19,12 +19,14 @@
 #![feature(array_chunks)]
 
 use clap::Parser;
+use oak_functions_launcher::LookupDataConfig;
 use std::{
     fs,
     net::{Ipv6Addr, SocketAddr},
     path::PathBuf,
 };
 use tokio::signal;
+use ubyte::ByteUnit;
 
 pub mod schema {
     #![allow(dead_code)]
@@ -74,10 +76,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Args::parse();
     env_logger::init();
 
+    let lookup_data_config = LookupDataConfig {
+        lookup_data_path: cli.lookup_data,
+        // Hard-coded because we are not sure whether we want to configure the update interval.
+        update_interval: Some(std::time::Duration::from_millis(1000 * 60 * 10)),
+        // Fix the maximum size of a chunk to the proto limit size of 2 GiB.
+        max_chunk_size: ByteUnit::Gibibyte(2),
+    };
+
     let (mut launched_instance, connector_handle, initialize_response) =
         oak_functions_launcher::create(
             cli.mode,
-            cli.lookup_data,
+            lookup_data_config,
             cli.wasm,
             cli.constant_response_size,
         )

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -138,7 +138,7 @@ async fn test_load_large_lookup_data() {
         max_chunk_size,
     };
 
-    let constant_response_size = (10 / 2) + 1024; // Add some margin be on the safe side.
+    let constant_response_size = (10 / 2) + 1024; // Add some margin to be on the safe side.
 
     let status = oak_functions_launcher::create(
         launcher::GuestMode::Native(params),

--- a/oak_functions_test_utils/Cargo.toml
+++ b/oak_functions_test_utils/Cargo.toml
@@ -20,3 +20,4 @@ port_check = "*"
 prost = { workspace = true }
 tempfile = "*"
 tokio = { workspace = true, features = ["sync"] }
+ubyte = "*"

--- a/oak_functions_test_utils/src/lib.rs
+++ b/oak_functions_test_utils/src/lib.rs
@@ -27,6 +27,7 @@ use std::{
     time::Duration,
 };
 use tokio::{sync::oneshot, task::JoinHandle};
+use ubyte::ByteUnit;
 
 /// Returns the path to the Wasm file produced by compiling the provided `Cargo.toml` file.
 fn build_wasm_module_path(metadata: &cargo_metadata::Metadata) -> String {
@@ -82,6 +83,26 @@ pub fn serialize_entries(entries: HashMap<Vec<u8>, Vec<u8>>) -> Vec<u8> {
             .expect("couldn't encode entry as length delimited");
     }
     buf
+}
+
+// Create lookup data entries mapping keys to themselves. The keys range from start
+// to exclusive end and are padded to entry size (which has to be larger than 8 to fit two u32).
+pub fn create_test_lookup_data(
+    entry_size: ByteUnit,
+    start: u32,
+    end: u32,
+) -> HashMap<Vec<u8>, Vec<u8>> {
+    let mut entries = std::collections::HashMap::new();
+    let entry_size = entry_size.as_u64() as usize;
+
+    let key_prefix = vec![0u8; (entry_size / 2) - 8];
+
+    for i in start..end {
+        let mut n = key_prefix.clone();
+        n.append(&mut format!("{}", i).into_bytes());
+        entries.insert(n.clone(), n);
+    }
+    entries
 }
 
 pub fn write_to_temp_file(content: &[u8]) -> tempfile::NamedTempFile {

--- a/oak_functions_test_utils/src/lib.rs
+++ b/oak_functions_test_utils/src/lib.rs
@@ -95,7 +95,7 @@ pub fn create_test_lookup_data(
     let mut entries = std::collections::HashMap::new();
     let entry_size = entry_size.as_u64() as usize;
 
-    let key_prefix = vec![0u8; (entry_size / 2) - 8];
+    let key_prefix = vec![0u8; (entry_size / 2) - 4];
 
     for i in start..end {
         let mut n = key_prefix.clone();


### PR DESCRIPTION
Refactoring launcher to make it possible to test `update_lookup_data`. 

Major changes:
- make `max_chunk_size` configurable,
- make it possible to not periodically update the lookup data
- extract functionality to create test lookup data entries of a certain size