### PR TITLE
Ensure the stack is 16-byte aligned when starting the application.

### DIFF
--- a/oak_restricted_kernel/src/payload.rs
+++ b/oak_restricted_kernel/src/payload.rs
@@ -115,6 +115,7 @@ pub fn run_payload(payload: &[u8]) -> ! {
     unsafe {
         asm! {
             "mov rsp, {}", // user stack
+            "and rsp, -10", // align stack to 16-byte boundary
             "sysretq",
             in(reg) rsp.as_u64() - 8, // maintain stack alignment
             in("rcx") elf.entry, // initial RIP


### PR DESCRIPTION
If you don't, weird things happen, like SSE instructions generating general protection faults or stack pointer arithmetic going awry and generating page faults at mysterious locations.