### PR TITLE
Step 1 in building a cross-compiling toolchain: binutils.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ tensorflow_model_server
 
 # Direnv
 .direnv/
+
+# Toolchain build
+toolchain/build
+toolchain/toolchain

--- a/toolchain/binutils-2.40-oak.patch
+++ b/toolchain/binutils-2.40-oak.patch
@@ -1,0 +1,50 @@
+diff '--color=auto' -u -r binutils-2.40.orig/bfd/config.bfd binutils-2.40/bfd/config.bfd
+--- binutils-2.40.orig/bfd/config.bfd	2023-01-14 00:00:00.000000000 +0000
++++ binutils-2.40/bfd/config.bfd	2023-02-22 17:41:23.665483982 +0000
+@@ -731,6 +731,11 @@
+     targ_selvecs=i386_elf32_vec
+     want64=true
+     ;;
++  x86_64-*-oak*)
++    targ_defvec=x86_64_elf64_vec
++    targ_selvecs=x86_64_elf64_vec
++    want64=true
++    ;;
+   x86_64-*-gnu*)
+     targ_defvec=x86_64_elf64_vec
+     targ_selvecs="i386_elf32_vec iamcu_elf32_vec x86_64_elf32_vec"
+diff '--color=auto' -u -r binutils-2.40.orig/config.sub binutils-2.40/config.sub
+--- binutils-2.40.orig/config.sub	2023-01-14 00:00:00.000000000 +0000
++++ binutils-2.40/config.sub	2023-02-22 17:31:37.208297056 +0000
+@@ -1754,7 +1754,7 @@
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+ 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
+ 	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr* \
+-	     | fiwix* )
++	     | fiwix* | oak* )
+ 		;;
+ 	# This one is extra strict with allowed versions
+ 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
+diff '--color=auto' -u -r binutils-2.40.orig/gas/configure.tgt binutils-2.40/gas/configure.tgt
+--- binutils-2.40.orig/gas/configure.tgt	2023-01-14 00:00:00.000000000 +0000
++++ binutils-2.40/gas/configure.tgt	2023-02-22 17:51:26.323997180 +0000
+@@ -248,6 +248,7 @@
+   i386-*-gnu*)				fmt=elf em=gnu ;;
+   i386-*-msdos*)			fmt=aout ;;
+   i386-*-moss*)				fmt=elf ;;
++  i386-*-oak*)				fmt=elf ;;
+   i386-*-pe)				fmt=coff em=pe ;;
+   i386-*-cygwin*)
+    case ${cpu} in
+diff '--color=auto' -u -r binutils-2.40.orig/ld/configure.tgt binutils-2.40/ld/configure.tgt
+--- binutils-2.40.orig/ld/configure.tgt	2023-01-14 00:00:00.000000000 +0000
++++ binutils-2.40/ld/configure.tgt	2023-02-22 17:37:26.665612440 +0000
+@@ -1012,6 +1012,8 @@
+ x86_64-*-redox*)	targ_emul=elf_x86_64
+ 			targ_extra_emuls=elf_i386
+ 			;;
++x86_64-*-oak*)		targ_emul=elf_x86_64
++			;;
+ x86_64-*-solaris2*)	targ_emul=elf_x86_64_sol2
+ 			targ_extra_emuls="elf_x86_64 elf_i386_sol2 elf_i386_ldso elf_i386 elf_iamcu"
+ 			targ_extra_libpath=$targ_extra_emuls

--- a/toolchain/build.sh
+++ b/toolchain/build.sh
@@ -1,0 +1,42 @@
+
+BINUTILS_VERSION=2.40
+
+TARGET=x86_64-unknown-oak
+
+# Clean up any previous build directory.
+if [ -d build ]; then
+  rm -rf build
+fi
+mkdir -p build
+
+mkdir -p toolchain
+DIR=`pwd`/toolchain
+cd build
+
+# Step 1: binutils
+echo "Building binutils..."
+curl -O -L https://ftpmirror.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.bz2 > build.log
+tar xf binutils-$BINUTILS_VERSION.tar.bz2
+(
+  cd binutils-$BINUTILS_VERSION
+  patch -p1 < ../../binutils-2.40-oak.patch > ../build.log
+)
+mkdir -p build-binutils
+(
+  cd build-binutils
+  echo "  running configure"
+  ../binutils-$BINUTILS_VERSION/configure \
+    --target=$TARGET \
+    --prefix=$DIR > ../build.log 2>&1 && \
+  echo "  running make" && \
+  make > ../build.log 2>&1 && \
+  echo "  running make install" && \
+  make install > ../build.log 2>&1
+  if [ $? -ne 0 ]; then
+    echo "Failed to build binutils! See build.log for more details."
+    exit 1
+  fi
+)
+
+rm -rf build
+echo "Toolchain built in $DIR."


### PR DESCRIPTION
This builds the basic tools for any cross compiler, like the assembler and linker.

The newly-introduced `x86_64-unknown-oak` platform is only 64-bit, available only on `x86_64`, and uses the ELF executable format.

Ref #3759 
