### PR TITLE
Step 2: build GCC as a cross compiler for Oak

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:ccfeb50a2b2823bccf504cf6a7fbff91efaad7948adb7d1e448119547fae8dc5",
+  "image": "sha256:bbba8cb1d16b6faa40dd2140b394d51938d0bf354c663cfd59b6fbea9b202746",
   "extensions": [
     "13xforever.language-x86-64-assembly",
     "bazelbuild.vscode-bazel",

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get --yes update \
   libcap-dev \
   libc++-${llvm_version}-dev \
   libfl2 \
+  libgmp-dev \
+  libmpc-dev \
   libncurses5 \
   libssl-dev \
   lldb-${llvm_version} \

--- a/scripts/common
+++ b/scripts/common
@@ -20,10 +20,10 @@ readonly DOCKER_IMAGE_NAME='europe-west2-docker.pkg.dev/oak-ci/oak-development/o
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:ccfeb50a2b2823bccf504cf6a7fbff91efaad7948adb7d1e448119547fae8dc5'
+readonly DOCKER_IMAGE_ID='sha256:bbba8cb1d16b6faa40dd2140b394d51938d0bf354c663cfd59b6fbea9b202746'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development@sha256:7751fbbecd9727a9655299a002bfc2c9be6a773a8c2a2185feb8383dfef57b06'
+readonly DOCKER_IMAGE_REPO_DIGEST='europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development@sha256:64ba75fbfe281966d62c443a025936bbe49624b9551d538493a7d53c4bb69065'
 
 readonly CACHE_DIR='bazel-cache'
 readonly SERVER_BIN_DIR="${PWD}/oak_loader/bin"

--- a/toolchain/gcc-12.2.0-oak.patch
+++ b/toolchain/gcc-12.2.0-oak.patch
@@ -1,0 +1,100 @@
+diff '--color=auto' -r -N -u gcc-12.2.0.orig/config.sub gcc-12.2.0/config.sub
+--- gcc-12.2.0.orig/config.sub	2022-08-19 08:09:52.128656687 +0000
++++ gcc-12.2.0/config.sub	2023-02-28 16:31:39.352907968 +0000
+@@ -1749,7 +1749,7 @@
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+ 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
+ 	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr* \
+-	     | fiwix* )
++	     | fiwix* | oak* )
+ 		;;
+ 	# This one is extra strict with allowed versions
+ 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
+diff '--color=auto' -r -N -u gcc-12.2.0.orig/fixincludes/mkfixinc.sh gcc-12.2.0/fixincludes/mkfixinc.sh
+--- gcc-12.2.0.orig/fixincludes/mkfixinc.sh	2022-08-19 08:09:52.160657095 +0000
++++ gcc-12.2.0/fixincludes/mkfixinc.sh	2023-02-28 16:32:05.155070023 +0000
+@@ -14,6 +14,7 @@
+     i?86-*-cygwin* | \
+     i?86-*-mingw32* | \
+     x86_64-*-mingw32* | \
++    x86_64-*-oak* | \
+     powerpc-*-eabisim* | \
+     powerpc-*-eabi*    | \
+     powerpc-*-rtems*   | \
+diff '--color=auto' -r -N -u gcc-12.2.0.orig/gcc/config/oak.h gcc-12.2.0/gcc/config/oak.h
+--- gcc-12.2.0.orig/gcc/config/oak.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-12.2.0/gcc/config/oak.h	2023-03-03 16:09:06.085615021 +0000
+@@ -0,0 +1,10 @@
++
++#undef LIB_SPEC
++#define LIB_SPEC "-lc -lgloss"
++
++#undef STARTFILE_SPEC
++#define STARTFILE_SPEC "crti%O%s crtbegin%O%s"
++
++#undef ENDFILE_SPEC
++#define ENDFILE_SPEC "crtend%O%s crtn%O%s"
++
+diff '--color=auto' -r -N -u gcc-12.2.0.orig/gcc/config.gcc gcc-12.2.0/gcc/config.gcc
+--- gcc-12.2.0.orig/gcc/config.gcc	2022-08-19 08:09:52.552662114 +0000
++++ gcc-12.2.0/gcc/config.gcc	2023-02-28 18:03:13.733254937 +0000
+@@ -1901,6 +1901,9 @@
+ x86_64-*-elf*)
+ 	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h"
+ 	;;
++x86_64-*-oak*)
++	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h oak.h"
++	;;
+ x86_64-*-rtems*)
+ 	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h i386/rtemself.h rtems.h"
+ 	;;
+@@ -2246,6 +2249,13 @@
+ 	tmake_file="${tmake_file} i386/t-x86_64-elf"
+ 	tm_file="${tm_file} i386/unix.h i386/att.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h fuchsia.h"
+ 	;;
++x86_64-*-oak*)
++	gas=yes
++	enable_threads=no
++	gnu_ld=yes
++	default_use_cxa_atexit=yes
++	use_gcc_stdint=provide
++	;;
+ ia64*-*-elf*)
+ 	tm_file="${tm_file} dbxelf.h elfos.h newlib-stdint.h ia64/sysv4.h ia64/elf.h"
+ 	tmake_file="ia64/t-ia64"
+diff '--color=auto' -r -N -u gcc-12.2.0.orig/libgcc/config.host gcc-12.2.0/libgcc/config.host
+--- gcc-12.2.0.orig/libgcc/config.host	2022-08-19 08:09:54.664689148 +0000
++++ gcc-12.2.0/libgcc/config.host	2023-02-28 19:38:15.207043353 +0000
+@@ -714,12 +714,15 @@
+ i[34567]86-*-elf*)
+ 	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
+ 	;;
+-x86_64-*-elf* | x86_64-*-rtems*)
++x86_64-*-elf* | x86_64-*-rtems* | x86_64-*-oak*)
+ 	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
+ 	case ${host} in
+ 	  x86_64-*-rtems*)
+ 	    extra_parts="$extra_parts crti.o crtn.o"
+ 	    ;;
++	  x86_64-*-oak*)
++	    extra_parts="$extra_parts crti.o crtn.o crtbegin.o crtend.o"
++	    ;;
+ 	esac
+ 	;;
+ x86_64-*-fuchsia*)
+diff '--color=auto' -r -N -u gcc-12.2.0.orig/libstdc++-v3/crossconfig.m4 gcc-12.2.0/libstdc++-v3/crossconfig.m4
+--- gcc-12.2.0.orig/libstdc++-v3/crossconfig.m4	2022-08-19 08:09:55.420698825 +0000
++++ gcc-12.2.0/libstdc++-v3/crossconfig.m4	2023-02-28 16:38:42.792390076 +0000
+@@ -227,6 +227,12 @@
+     AC_CHECK_FUNCS(timespec_get)
+     AC_CHECK_FUNCS(sockatmark)
+     ;;
++  *-oak*)
++    GLIBCXX_CHECK_COMPILER_FEATURES
++    GLIBCXX_CHECK_LINKER_FEATURES
++    GLIBCXX_CHECK_MATH_SUPPORT
++    GLIBCXX_CHECK_STDLIB_SUPPORT
++    ;;
+   *-qnx6.1* | *-qnx6.2*)
+     SECTION_FLAGS='-ffunction-sections -fdata-sections'
+     AC_SUBST(SECTION_FLAGS) 


### PR DESCRIPTION
Unfortunately I also had to add two libraries to `Dockerfile` as they are needed to build GCC itself.

Although after this PR we have a compiler, it *won't* be able to produce executables yet as we're missing libc (and libgloss). Those come from newlib, which is the next step.

Ref #3759
Fixes #3762 