### PR TITLE
Step 3: build newlib (the C library) as part of the toolchain

### DIFF
--- a/toolchain/newlib-4.3.0-oak.patch
+++ b/toolchain/newlib-4.3.0-oak.patch
@@ -1,0 +1,508 @@
+diff '--color=auto' -r -N -u newlib-4.3.0.20230120.orig/config.sub newlib-4.3.0.20230120/config.sub
+--- newlib-4.3.0.20230120.orig/config.sub	2023-01-20 21:01:54.000000000 +0000
++++ newlib-4.3.0.20230120/config.sub	2023-03-03 17:46:32.227402238 +0000
+@@ -1725,7 +1725,7 @@
+ 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+ 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
+-	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx*)
++	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | oak*)
+ 		;;
+ 	# This one is extra strict with allowed versions
+ 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
+diff '--color=auto' -r -N -u newlib-4.3.0.20230120.orig/libgloss/configure newlib-4.3.0.20230120/libgloss/configure
+--- newlib-4.3.0.20230120.orig/libgloss/configure	2023-01-20 21:01:54.000000000 +0000
++++ newlib-4.3.0.20230120/libgloss/configure	2023-03-03 18:00:06.123675772 +0000
+@@ -630,6 +630,8 @@
+ LDFLAGS
+ CFLAGS
+ CC
++CONFIG_OAK_FALSE
++CONFIG_OAK_TRUE
+ CONFIG_WINCE_FALSE
+ CONFIG_WINCE_TRUE
+ CONFIG_RISCV_FALSE
+@@ -2980,6 +2982,10 @@
+   nios2-*-*)
+ 	config_nios2=true
+ 	;;
++  x86_64-*-oak*)
++	config_oak=true
++	config_libnosys=false
++	;;
+ esac
+ 
+ 
+@@ -3079,6 +3085,14 @@
+   CONFIG_WINCE_FALSE=
+ fi
+ 
++   if test x$config_oak = xtrue; then
++  CONFIG_OAK_TRUE=
++  CONFIG_OAK_FALSE='#'
++else
++  CONFIG_OAK_TRUE='#'
++  CONFIG_OAK_FALSE=
++fi
++
+ 
+ 
+ 
+@@ -5347,6 +5361,10 @@
+   as_fn_error $? "conditional \"CONFIG_WINCE\" was never defined.
+ Usually this means the macro was only invoked conditionally." "$LINENO" 5
+ fi
++if test -z "${CONFIG_OAK_TRUE}" && test -z "${CONFIG_OAK_FALSE}"; then
++  as_fn_error $? "conditional \"CONFIG_OAK\" was never defined.
++Usually this means the macro was only invoked conditionally." "$LINENO" 5
++fi
+ if test -z "${AMDEP_TRUE}" && test -z "${AMDEP_FALSE}"; then
+   as_fn_error $? "conditional \"AMDEP\" was never defined.
+ Usually this means the macro was only invoked conditionally." "$LINENO" 5
+diff '--color=auto' -r -N -u newlib-4.3.0.20230120.orig/libgloss/configure.ac newlib-4.3.0.20230120/libgloss/configure.ac
+--- newlib-4.3.0.20230120.orig/libgloss/configure.ac	2023-01-20 21:01:54.000000000 +0000
++++ newlib-4.3.0.20230120/libgloss/configure.ac	2023-03-03 17:50:02.333036913 +0000
+@@ -241,13 +241,17 @@
+   nios2-*-*)
+ 	config_nios2=true
+ 	;;
++  x86_64-*-oak*)
++	config_oak=true
++	config_libnosys=false
++	;;
+ esac
+ AC_SUBST(subdirs)
+ 
+ dnl These subdirs have converted to non-recursive make.  Hopefully someday all
+ dnl the ports above will too!
+ m4_foreach_w([SUBDIR], [
+-  aarch64 arc arm bfin csky d30v iq2000 libnosys lm32 nios2 riscv wince
++  aarch64 arc arm bfin csky d30v iq2000 libnosys lm32 nios2 riscv wince oak
+ ], [dnl
+   AM_CONDITIONAL([CONFIG_]m4_toupper(SUBDIR), [test x$config_]SUBDIR = xtrue)
+ ])
+diff '--color=auto' -r -N -u newlib-4.3.0.20230120.orig/libgloss/Makefile.am newlib-4.3.0.20230120/libgloss/Makefile.am
+--- newlib-4.3.0.20230120.orig/libgloss/Makefile.am	2023-01-20 21:01:54.000000000 +0000
++++ newlib-4.3.0.20230120/libgloss/Makefile.am	2023-03-03 17:50:56.733601324 +0000
+@@ -99,3 +99,6 @@
+ if CONFIG_WINCE
+ include wince/Makefile.inc
+ endif
++if CONFIG_OAK
++include oak/Makefile.inc
++endif
+diff '--color=auto' -r -N -u newlib-4.3.0.20230120.orig/libgloss/Makefile.in newlib-4.3.0.20230120/libgloss/Makefile.in
+--- newlib-4.3.0.20230120.orig/libgloss/Makefile.in	2023-01-20 21:01:54.000000000 +0000
++++ newlib-4.3.0.20230120/libgloss/Makefile.in	2023-03-03 18:00:08.543878683 +0000
+@@ -190,6 +190,7 @@
+ @CONFIG_RISCV_TRUE@	riscv/libsemihost.a
+ @CONFIG_WINCE_TRUE@am__append_36 = $(gdbdir)
+ @CONFIG_WINCE_TRUE@am__append_37 = wince/stub.exe
++@CONFIG_OAK_TRUE@am__append_38 = oak/libgloss.a
+ subdir = .
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/../config/depstand.m4 \
+@@ -450,6 +451,12 @@
+ @CONFIG_NIOS2_TRUE@	nios2/nios2_libnios2_a-kill.$(OBJEXT) \
+ @CONFIG_NIOS2_TRUE@	nios2/nios2_libnios2_a-sbrk.$(OBJEXT)
+ nios2_libnios2_a_OBJECTS = $(am_nios2_libnios2_a_OBJECTS)
++oak_libgloss_a_AR = $(AR) $(ARFLAGS)
++oak_libgloss_a_LIBADD =
++@CONFIG_OAK_TRUE@am_oak_libgloss_a_OBJECTS =  \
++@CONFIG_OAK_TRUE@	oak/oak_libgloss_a-syscalls.$(OBJEXT) \
++@CONFIG_OAK_TRUE@	oak/oak_libgloss_a-crt0.$(OBJEXT)
++oak_libgloss_a_OBJECTS = $(am_oak_libgloss_a_OBJECTS)
+ riscv_libgloss_a_AR = $(AR) $(ARFLAGS)
+ riscv_libgloss_a_LIBADD =
+ @CONFIG_RISCV_TRUE@am_riscv_libgloss_a_OBJECTS = riscv/riscv_libgloss_a-sys_access.$(OBJEXT) \
+@@ -573,9 +580,9 @@
+ 	$(csky_libsemi_a_SOURCES) $(d30v_libsim_a_SOURCES) \
+ 	$(iq2000_libeval_a_SOURCES) $(libnosys_libnosys_a_SOURCES) \
+ 	$(libobjs_a_SOURCES) $(lm32_libgloss_a_SOURCES) \
+-	$(nios2_libnios2_a_SOURCES) $(riscv_libgloss_a_SOURCES) \
+-	$(riscv_libsemihost_a_SOURCES) bfin/sim-test.c iq2000/test.c \
+-	$(wince_stub_exe_SOURCES)
++	$(nios2_libnios2_a_SOURCES) $(oak_libgloss_a_SOURCES) \
++	$(riscv_libgloss_a_SOURCES) $(riscv_libsemihost_a_SOURCES) \
++	bfin/sim-test.c iq2000/test.c $(wince_stub_exe_SOURCES)
+ AM_V_DVIPS = $(am__v_DVIPS_@AM_V@)
+ am__v_DVIPS_ = $(am__v_DVIPS_@AM_DEFAULT_V@)
+ am__v_DVIPS_0 = @echo "  DVIPS   " $@;
+@@ -802,7 +809,8 @@
+ multilibtool_LIBRARIES = $(am__append_2) $(am__append_5) \
+ 	$(am__append_9) $(am__append_11) $(am__append_20) \
+ 	$(am__append_21) $(am__append_24) $(am__append_28) \
+-	$(am__append_30) $(am__append_33) $(am__append_35)
++	$(am__append_30) $(am__append_33) $(am__append_35) \
++	$(am__append_38)
+ includetooldir = $(tooldir)/include
+ includetool_DATA = $(am__append_16)
+ includesystooldir = $(tooldir)/include/sys
+@@ -1092,6 +1100,11 @@
+ @CONFIG_WINCE_TRUE@wince_stub_exe_SOURCES = wince-stub.c
+ @CONFIG_WINCE_TRUE@wince_stub_exe_CPPFLAGS = $(AM_CPPFLAGS) -I$(gdbdir)
+ @CONFIG_WINCE_TRUE@wince_stub_exe_LDADD = -lwinsock $(WINCE_STUB_LIBS)
++@CONFIG_OAK_TRUE@oak_libgloss_a_CPPFLAGS = -I$(srcdir)/oak
++@CONFIG_OAK_TRUE@oak_libgloss_a_SOURCES = \
++@CONFIG_OAK_TRUE@    oak/syscalls.c \
++@CONFIG_OAK_TRUE@    oak/crt0.S
++
+ all: config.h
+ 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
+ 
+@@ -1099,7 +1112,7 @@
+ .SUFFIXES: .S .c .dvi .o .obj .ps
+ am--refresh: Makefile
+ 	@:
+-$(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am $(top_srcdir)/../multilib.am $(srcdir)/doc/Makefile.inc $(srcdir)/aarch64/Makefile.inc $(srcdir)/aarch64/cpu-init/Makefile.inc $(srcdir)/arc/Makefile.inc $(srcdir)/arm/Makefile.inc $(srcdir)/arm/cpu-init/Makefile.inc $(srcdir)/bfin/Makefile.inc $(srcdir)/csky/Makefile.inc $(srcdir)/d30v/Makefile.inc $(srcdir)/iq2000/Makefile.inc $(srcdir)/libnosys/Makefile.inc $(srcdir)/lm32/Makefile.inc $(srcdir)/nios2/Makefile.inc $(srcdir)/riscv/Makefile.inc $(srcdir)/wince/Makefile.inc $(am__configure_deps)
++$(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am $(top_srcdir)/../multilib.am $(srcdir)/doc/Makefile.inc $(srcdir)/aarch64/Makefile.inc $(srcdir)/aarch64/cpu-init/Makefile.inc $(srcdir)/arc/Makefile.inc $(srcdir)/arm/Makefile.inc $(srcdir)/arm/cpu-init/Makefile.inc $(srcdir)/bfin/Makefile.inc $(srcdir)/csky/Makefile.inc $(srcdir)/d30v/Makefile.inc $(srcdir)/iq2000/Makefile.inc $(srcdir)/libnosys/Makefile.inc $(srcdir)/lm32/Makefile.inc $(srcdir)/nios2/Makefile.inc $(srcdir)/riscv/Makefile.inc $(srcdir)/wince/Makefile.inc $(srcdir)/oak/Makefile.inc $(am__configure_deps)
+ 	@for dep in $?; do \
+ 	  case '$(am__configure_deps)' in \
+ 	    *$$dep*) \
+@@ -1121,7 +1134,7 @@
+ 	    echo ' cd $(top_builddir) && $(SHELL) ./config.status $@ $(am__depfiles_maybe)'; \
+ 	    cd $(top_builddir) && $(SHELL) ./config.status $@ $(am__depfiles_maybe);; \
+ 	esac;
+-$(top_srcdir)/../multilib.am $(srcdir)/doc/Makefile.inc $(srcdir)/aarch64/Makefile.inc $(srcdir)/aarch64/cpu-init/Makefile.inc $(srcdir)/arc/Makefile.inc $(srcdir)/arm/Makefile.inc $(srcdir)/arm/cpu-init/Makefile.inc $(srcdir)/bfin/Makefile.inc $(srcdir)/csky/Makefile.inc $(srcdir)/d30v/Makefile.inc $(srcdir)/iq2000/Makefile.inc $(srcdir)/libnosys/Makefile.inc $(srcdir)/lm32/Makefile.inc $(srcdir)/nios2/Makefile.inc $(srcdir)/riscv/Makefile.inc $(srcdir)/wince/Makefile.inc $(am__empty):
++$(top_srcdir)/../multilib.am $(srcdir)/doc/Makefile.inc $(srcdir)/aarch64/Makefile.inc $(srcdir)/aarch64/cpu-init/Makefile.inc $(srcdir)/arc/Makefile.inc $(srcdir)/arm/Makefile.inc $(srcdir)/arm/cpu-init/Makefile.inc $(srcdir)/bfin/Makefile.inc $(srcdir)/csky/Makefile.inc $(srcdir)/d30v/Makefile.inc $(srcdir)/iq2000/Makefile.inc $(srcdir)/libnosys/Makefile.inc $(srcdir)/lm32/Makefile.inc $(srcdir)/nios2/Makefile.inc $(srcdir)/riscv/Makefile.inc $(srcdir)/wince/Makefile.inc $(srcdir)/oak/Makefile.inc $(am__empty):
+ 
+ $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
+ 	$(SHELL) ./config.status --recheck
+@@ -1645,6 +1658,21 @@
+ 	$(AM_V_at)-rm -f nios2/libnios2.a
+ 	$(AM_V_AR)$(nios2_libnios2_a_AR) nios2/libnios2.a $(nios2_libnios2_a_OBJECTS) $(nios2_libnios2_a_LIBADD)
+ 	$(AM_V_at)$(RANLIB) nios2/libnios2.a
++oak/$(am__dirstamp):
++	@$(MKDIR_P) oak
++	@: > oak/$(am__dirstamp)
++oak/$(DEPDIR)/$(am__dirstamp):
++	@$(MKDIR_P) oak/$(DEPDIR)
++	@: > oak/$(DEPDIR)/$(am__dirstamp)
++oak/oak_libgloss_a-syscalls.$(OBJEXT): oak/$(am__dirstamp) \
++	oak/$(DEPDIR)/$(am__dirstamp)
++oak/oak_libgloss_a-crt0.$(OBJEXT): oak/$(am__dirstamp) \
++	oak/$(DEPDIR)/$(am__dirstamp)
++
++oak/libgloss.a: $(oak_libgloss_a_OBJECTS) $(oak_libgloss_a_DEPENDENCIES) $(EXTRA_oak_libgloss_a_DEPENDENCIES) oak/$(am__dirstamp)
++	$(AM_V_at)-rm -f oak/libgloss.a
++	$(AM_V_AR)$(oak_libgloss_a_AR) oak/libgloss.a $(oak_libgloss_a_OBJECTS) $(oak_libgloss_a_LIBADD)
++	$(AM_V_at)$(RANLIB) oak/libgloss.a
+ riscv/$(am__dirstamp):
+ 	@$(MKDIR_P) riscv
+ 	@: > riscv/$(am__dirstamp)
+@@ -1854,6 +1882,7 @@
+ 	-rm -f libnosys/*.$(OBJEXT)
+ 	-rm -f lm32/*.$(OBJEXT)
+ 	-rm -f nios2/*.$(OBJEXT)
++	-rm -f oak/*.$(OBJEXT)
+ 	-rm -f riscv/*.$(OBJEXT)
+ 
+ distclean-compile:
+@@ -1996,6 +2025,8 @@
+ @AMDEP_TRUE@@am__include@ @am__quote@nios2/$(DEPDIR)/nios2_libnios2_a-io-write.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@nios2/$(DEPDIR)/nios2_libnios2_a-kill.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@nios2/$(DEPDIR)/nios2_libnios2_a-sbrk.Po@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@oak/$(DEPDIR)/oak_libgloss_a-crt0.Po@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@oak/$(DEPDIR)/oak_libgloss_a-syscalls.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libgloss_a-sys_access.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libgloss_a-sys_chdir.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libgloss_a-sys_chmod.Po@am__quote@
+@@ -2141,6 +2172,20 @@
+ @AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+ @am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(nios2_libnios2_a_CPPFLAGS) $(CPPFLAGS) $(AM_CCASFLAGS) $(CCASFLAGS) -c -o nios2/nios2_libnios2_a-io-nios2.obj `if test -f 'nios2/io-nios2.S'; then $(CYGPATH_W) 'nios2/io-nios2.S'; else $(CYGPATH_W) '$(srcdir)/nios2/io-nios2.S'; fi`
+ 
++oak/oak_libgloss_a-crt0.o: oak/crt0.S
++@am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(oak_libgloss_a_CPPFLAGS) $(CPPFLAGS) $(AM_CCASFLAGS) $(CCASFLAGS) -MT oak/oak_libgloss_a-crt0.o -MD -MP -MF oak/$(DEPDIR)/oak_libgloss_a-crt0.Tpo -c -o oak/oak_libgloss_a-crt0.o `test -f 'oak/crt0.S' || echo '$(srcdir)/'`oak/crt0.S
++@am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) oak/$(DEPDIR)/oak_libgloss_a-crt0.Tpo oak/$(DEPDIR)/oak_libgloss_a-crt0.Po
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS)source='oak/crt0.S' object='oak/oak_libgloss_a-crt0.o' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(oak_libgloss_a_CPPFLAGS) $(CPPFLAGS) $(AM_CCASFLAGS) $(CCASFLAGS) -c -o oak/oak_libgloss_a-crt0.o `test -f 'oak/crt0.S' || echo '$(srcdir)/'`oak/crt0.S
++
++oak/oak_libgloss_a-crt0.obj: oak/crt0.S
++@am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(oak_libgloss_a_CPPFLAGS) $(CPPFLAGS) $(AM_CCASFLAGS) $(CCASFLAGS) -MT oak/oak_libgloss_a-crt0.obj -MD -MP -MF oak/$(DEPDIR)/oak_libgloss_a-crt0.Tpo -c -o oak/oak_libgloss_a-crt0.obj `if test -f 'oak/crt0.S'; then $(CYGPATH_W) 'oak/crt0.S'; else $(CYGPATH_W) '$(srcdir)/oak/crt0.S'; fi`
++@am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) oak/$(DEPDIR)/oak_libgloss_a-crt0.Tpo oak/$(DEPDIR)/oak_libgloss_a-crt0.Po
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS)source='oak/crt0.S' object='oak/oak_libgloss_a-crt0.obj' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(oak_libgloss_a_CPPFLAGS) $(CPPFLAGS) $(AM_CCASFLAGS) $(CCASFLAGS) -c -o oak/oak_libgloss_a-crt0.obj `if test -f 'oak/crt0.S'; then $(CYGPATH_W) 'oak/crt0.S'; else $(CYGPATH_W) '$(srcdir)/oak/crt0.S'; fi`
++
+ .c.o:
+ @am__fastdepCC_TRUE@	$(AM_V_CC)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\
+ @am__fastdepCC_TRUE@	$(COMPILE) -MT $@ -MD -MP -MF $$depbase.Tpo -c -o $@ $< &&\
+@@ -2969,6 +3014,20 @@
+ @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+ @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(nios2_libnios2_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o nios2/nios2_libnios2_a-sbrk.obj `if test -f 'nios2/sbrk.c'; then $(CYGPATH_W) 'nios2/sbrk.c'; else $(CYGPATH_W) '$(srcdir)/nios2/sbrk.c'; fi`
+ 
++oak/oak_libgloss_a-syscalls.o: oak/syscalls.c
++@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(oak_libgloss_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT oak/oak_libgloss_a-syscalls.o -MD -MP -MF oak/$(DEPDIR)/oak_libgloss_a-syscalls.Tpo -c -o oak/oak_libgloss_a-syscalls.o `test -f 'oak/syscalls.c' || echo '$(srcdir)/'`oak/syscalls.c
++@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) oak/$(DEPDIR)/oak_libgloss_a-syscalls.Tpo oak/$(DEPDIR)/oak_libgloss_a-syscalls.Po
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='oak/syscalls.c' object='oak/oak_libgloss_a-syscalls.o' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(oak_libgloss_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o oak/oak_libgloss_a-syscalls.o `test -f 'oak/syscalls.c' || echo '$(srcdir)/'`oak/syscalls.c
++
++oak/oak_libgloss_a-syscalls.obj: oak/syscalls.c
++@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(oak_libgloss_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT oak/oak_libgloss_a-syscalls.obj -MD -MP -MF oak/$(DEPDIR)/oak_libgloss_a-syscalls.Tpo -c -o oak/oak_libgloss_a-syscalls.obj `if test -f 'oak/syscalls.c'; then $(CYGPATH_W) 'oak/syscalls.c'; else $(CYGPATH_W) '$(srcdir)/oak/syscalls.c'; fi`
++@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) oak/$(DEPDIR)/oak_libgloss_a-syscalls.Tpo oak/$(DEPDIR)/oak_libgloss_a-syscalls.Po
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='oak/syscalls.c' object='oak/oak_libgloss_a-syscalls.obj' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(oak_libgloss_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o oak/oak_libgloss_a-syscalls.obj `if test -f 'oak/syscalls.c'; then $(CYGPATH_W) 'oak/syscalls.c'; else $(CYGPATH_W) '$(srcdir)/oak/syscalls.c'; fi`
++
+ riscv/riscv_libgloss_a-sys_access.o: riscv/sys_access.c
+ @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(riscv_libgloss_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT riscv/riscv_libgloss_a-sys_access.o -MD -MP -MF riscv/$(DEPDIR)/riscv_libgloss_a-sys_access.Tpo -c -o riscv/riscv_libgloss_a-sys_access.o `test -f 'riscv/sys_access.c' || echo '$(srcdir)/'`riscv/sys_access.c
+ @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) riscv/$(DEPDIR)/riscv_libgloss_a-sys_access.Tpo riscv/$(DEPDIR)/riscv_libgloss_a-sys_access.Po
+@@ -4224,6 +4283,8 @@
+ 	-rm -f lm32/$(am__dirstamp)
+ 	-rm -f nios2/$(DEPDIR)/$(am__dirstamp)
+ 	-rm -f nios2/$(am__dirstamp)
++	-rm -f oak/$(DEPDIR)/$(am__dirstamp)
++	-rm -f oak/$(am__dirstamp)
+ 	-rm -f riscv/$(DEPDIR)/$(am__dirstamp)
+ 	-rm -f riscv/$(am__dirstamp)
+ 	-rm -f wince/$(am__dirstamp)
+@@ -4239,7 +4300,7 @@
+ 
+ distclean: distclean-recursive
+ 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
+-	-rm -rf ./$(DEPDIR) aarch64/$(DEPDIR) arc/$(DEPDIR) arm/$(DEPDIR) bfin/$(DEPDIR) csky/$(DEPDIR) d30v/$(DEPDIR) iq2000/$(DEPDIR) libnosys/$(DEPDIR) lm32/$(DEPDIR) nios2/$(DEPDIR) riscv/$(DEPDIR)
++	-rm -rf ./$(DEPDIR) aarch64/$(DEPDIR) arc/$(DEPDIR) arm/$(DEPDIR) bfin/$(DEPDIR) csky/$(DEPDIR) d30v/$(DEPDIR) iq2000/$(DEPDIR) libnosys/$(DEPDIR) lm32/$(DEPDIR) nios2/$(DEPDIR) oak/$(DEPDIR) riscv/$(DEPDIR)
+ 	-rm -f Makefile
+ distclean-am: clean-am distclean-compile distclean-generic \
+ 	distclean-hdr distclean-local distclean-tags
+@@ -4382,7 +4443,7 @@
+ maintainer-clean: maintainer-clean-recursive
+ 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
+ 	-rm -rf $(top_srcdir)/autom4te.cache
+-	-rm -rf ./$(DEPDIR) aarch64/$(DEPDIR) arc/$(DEPDIR) arm/$(DEPDIR) bfin/$(DEPDIR) csky/$(DEPDIR) d30v/$(DEPDIR) iq2000/$(DEPDIR) libnosys/$(DEPDIR) lm32/$(DEPDIR) nios2/$(DEPDIR) riscv/$(DEPDIR)
++	-rm -rf ./$(DEPDIR) aarch64/$(DEPDIR) arc/$(DEPDIR) arm/$(DEPDIR) bfin/$(DEPDIR) csky/$(DEPDIR) d30v/$(DEPDIR) iq2000/$(DEPDIR) libnosys/$(DEPDIR) lm32/$(DEPDIR) nios2/$(DEPDIR) oak/$(DEPDIR) riscv/$(DEPDIR)
+ 	-rm -f Makefile
+ maintainer-clean-am: distclean-am maintainer-clean-aminfo \
+ 	maintainer-clean-generic maintainer-clean-local
+diff '--color=auto' -r -N -u newlib-4.3.0.20230120.orig/libgloss/oak/crt0.S newlib-4.3.0.20230120/libgloss/oak/crt0.S
+--- newlib-4.3.0.20230120.orig/libgloss/oak/crt0.S	1970-01-01 00:00:00.000000000 +0000
++++ newlib-4.3.0.20230120/libgloss/oak/crt0.S	2023-03-03 17:51:31.496517802 +0000
+@@ -0,0 +1,38 @@
++#
++# Copyright 2023 The Project Oak Authors
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++#
++
++.text
++.global _start
++
++_start:
++    movq $0, %rbp
++    pushq %rbp
++    pushq %rbp
++    movq %rsp, %rbp
++
++    call _init
++
++    # argc = 0, argv = NULL, envp = NULL
++    xor %rdi, %rdi
++    xor %rsi, %rsi
++    xor %rdx, %rdx
++    call main
++    mov %rax, %rdi # rdi = rax
++    call _exit
++
++3:
++    nop
++    jmp 3b
+diff '--color=auto' -r -N -u newlib-4.3.0.20230120.orig/libgloss/oak/Makefile.inc newlib-4.3.0.20230120/libgloss/oak/Makefile.inc
+--- newlib-4.3.0.20230120.orig/libgloss/oak/Makefile.inc	1970-01-01 00:00:00.000000000 +0000
++++ newlib-4.3.0.20230120/libgloss/oak/Makefile.inc	2023-03-03 17:51:48.669958515 +0000
+@@ -0,0 +1,5 @@
++multilibtool_LIBRARIES += %D%/libgloss.a
++%C%_libgloss_a_CPPFLAGS = -I$(srcdir)/%D%
++%C%_libgloss_a_SOURCES = \
++    %D%/syscalls.c \
++    %D%/crt0.S
+diff '--color=auto' -r -N -u newlib-4.3.0.20230120.orig/libgloss/oak/syscalls.c newlib-4.3.0.20230120/libgloss/oak/syscalls.c
+--- newlib-4.3.0.20230120.orig/libgloss/oak/syscalls.c	1970-01-01 00:00:00.000000000 +0000
++++ newlib-4.3.0.20230120/libgloss/oak/syscalls.c	2023-03-03 17:55:18.491557542 +0000
+@@ -0,0 +1,161 @@
++//
++// Copyright 2023 The Project Oak Authors
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++//
++
++#include <reent.h>
++#include <errno.h>
++#include <sys/stat.h>
++#include <sys/types.h>
++
++static long __syscall0(long n)
++{
++	unsigned long ret;
++	asm volatile (
++        "syscall"
++        : "=a"(ret)
++        : "a"(n)
++        : "rcx", "r11", "memory");
++	return ret;
++}
++
++static long __syscall3(long n, long a1, long a2, long a3)
++{
++	unsigned long ret;
++	asm volatile(
++        "syscall"
++        : "=a"(ret)
++        : "a"(n), "D"(a1), "S"(a2), "d"(a3)
++        : "rcx", "r11", "memory");
++	return ret;
++}
++
++static long __syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6)
++{
++	unsigned long ret;
++	register long r10 asm("r10") = a4;
++	register long r8 asm("r8") = a5;
++	register long r9 asm("r9") = a6;
++	asm volatile (
++        "syscall"
++        : "=a"(ret)
++        : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8), "r"(r9)
++        : "rcx", "r11", "memory");
++	return ret;
++}
++
++void _exit(int rc) {
++    __syscall0(60);
++    for (;;) {}
++}
++
++ssize_t _read_r(struct _reent* reent, int fd, void *buf, size_t len) {
++    int ret = __syscall3(0, fd, (long)buf, len);
++
++    if (ret < 0) {
++        reent->_errno = ret;
++        return -1;
++    }
++    return ret;
++}
++
++ssize_t _write_r(struct _reent* reent, int fd, const void* buf, size_t len) {
++    int ret = __syscall3(1, fd, (long)buf, len);
++
++    if (ret < 0) {
++        reent->_errno = ret;
++        return -1;
++    }
++    return ret;
++}
++
++ssize_t _lseek_r(struct _reent* reent, int fd, _off_t ptr, int dir) {
++    reent->_errno = ENOSYS;
++    return -1;
++}
++
++void* mmap(void* addr, int len, int prot, int flags, int fd, int offset) {
++    return __syscall6(9, (long)addr, len, prot, flags, fd, offset);
++}
++
++void* _sbrk_r (struct _reent* reent, ptrdiff_t incr) {
++    extern char end asm("_end"); // symbol provided by the linker
++    static char* heap_end;
++
++    if (heap_end == NULL) {
++        // If we haven't initialized the heap at all yet, let's start at the next 2 MiB page boundary
++        // after `_end`.
++        heap_end = &end;
++
++        if ((int)heap_end % 0x200000 != 0) {
++            heap_end += 0x200000 - (int)heap_end % 0x200000;
++        }
++    }
++
++    // We only increment in chunks of 2 MiB.
++    if (incr % 0x200000 != 0) {
++        incr += 0x200000 - incr % 0x200000;
++    }
++
++    char* prev_heap_end = heap_end;
++
++    if (mmap(heap_end,
++         incr,
++         0x1 | 0x2, // PROT_READ | PROT_WRITE
++         0x02 | 0x10 | 0x20, // MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS
++         -1,
++         0) != heap_end) {
++            reent->_errno = ENOMEM;
++            return -1;
++         }
++    
++    heap_end += incr;
++
++    return prev_heap_end;
++}
++
++int _open_r(struct _reent* reent, const char *file, int flags, int mode) {
++    asm volatile ("ud2");
++    reent->_errno = ENOSYS;
++    return -1;
++}
++
++int _close_r(struct _reent* reent, int fd) {
++    reent->_errno = ENOSYS;
++    return -1;
++}
++
++int _fstat_r(struct _reent* reent, int fd, struct stat* s) {
++    reent->_errno = ENOSYS;
++    return -1;
++}
++
++int _isatty_r(struct _reent* reent, int fd) {
++    reent->_errno = ENOSYS;
++    return -1;
++}
++
++int _getpid_r(struct _reent* reent) {
++    reent->_errno = ENOSYS;
++    return -1;
++}
++
++int _kill_r(struct _reent* reent, int pid, int signal) {
++    reent->_errno = ENOSYS;
++    return -1;
++}
++
++int getentropy(void *ptr, size_t n) {
++    return -1;
++}
+diff '--color=auto' -r -N -u newlib-4.3.0.20230120.orig/newlib/configure.host newlib-4.3.0.20230120/newlib/configure.host
+--- newlib-4.3.0.20230120.orig/newlib/configure.host	2023-01-20 21:01:54.000000000 +0000
++++ newlib-4.3.0.20230120/newlib/configure.host	2023-03-03 17:58:06.869677001 +0000
+@@ -590,6 +590,10 @@
+ 	newlib_cflags="${newlib_cflags} -DHAVE_OPENDIR -DHAVE_RENAME -DGETREENT_PROVIDED -DSIGNAL_PROVIDED -DHAVE_BLKSIZE -DHAVE_FCNTL -DMALLOC_PROVIDED"
+ 	syscall_dir=syscalls
+ 	;;
++  *-*-oak*)
++	newlib_cflags="${newlib_cflags} -DREENTRANT_SYSCALLS_PROVIDED"
++	syscall_dir=syscalls
++	;;
+ # RTEMS supplies its own versions of some routines:
+ #       malloc()            (reentrant version)
+ #       exit()              RTEMS has a "global" reent to flush


### PR DESCRIPTION
The diff contains some automake/autoconf junk because newlib is _really_ particular about which version of those tools you use to generate those files, and we don't have an old enough version in our Docker image.

Ref #3759
Fixes #3765 