### PR TITLE
Fix Kokoro tests

### DIFF
--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o nounset
+set -o xtrace
+set -o pipefail
+
 # On Kokoro instances /dev/kvm, /dev/vhost-vsock and /dev/vsock are owned by root:root.
 # Set the permissions so that these are owned by the `kvm` group as our scripts expect it to be.
 readonly KVM_GID="$(getent group kvm | cut -d: -f3)"
@@ -16,8 +21,9 @@ export RUST_BACKTRACE=1
 export RUST_LOG=debug
 
 ./scripts/docker_pull
-./scripts/docker_run cargo nextest run --hide-progress-bar --package=oak_functions_launcher
-./scripts/docker_run cargo nextest run --hide-progress-bar --package=quirk_echo_launcher
+./scripts/docker_run cargo nextest run --hide-progress-bar \
+  --package=oak_functions_launcher \
+  --package=quirk_echo_launcher
 
 cp ./target/nextest/default/junit.xml "$KOKORO_ARTIFACTS_DIR/"
 ls -als "$KOKORO_ARTIFACTS_DIR"


### PR DESCRIPTION
Add the usual stanza to make bash scripts sensible. Before this change, a failure in any of the steps was silently ignored by bash.

Also combine tests for multiple packages in a single step.

Ref #3756