### PR TITLE
Add optional flag `memory_size` in parameters of virtualized VM

### DIFF
--- a/oak_launcher_utils/src/launcher/virtualized.rs
+++ b/oak_launcher_utils/src/launcher/virtualized.rs
@@ -54,7 +54,8 @@ pub struct Params {
     #[arg(long = "gdb")]
     pub gdb: Option<u16>,
 
-    /// How much memory to give to the enclave binary.
+    /// How much memory to give to the enclave binary, e.g., 256M (M stands for Megabyte, G for
+    /// Gigabyte).
     #[arg(long)]
     pub memory_size: Option<String>,
 }
@@ -104,7 +105,7 @@ impl Instance {
         // Needed to expose advanced CPU features. Specifically RDRAND which is required for remote
         // attestation.
         cmd.args(["-cpu", "IvyBridge-IBRS,enforce"]);
-        // TODO(#3786): Make memory configurable.
+        // Set memory size if given.
         if let Some(memory_size) = params.memory_size {
             cmd.args(["-m", &memory_size]);
         };

--- a/oak_launcher_utils/src/launcher/virtualized.rs
+++ b/oak_launcher_utils/src/launcher/virtualized.rs
@@ -53,6 +53,10 @@ pub struct Params {
     /// Port to use for debugging with gdb
     #[arg(long = "gdb")]
     pub gdb: Option<u16>,
+
+    /// How much memory to give to the enclave binary.
+    #[arg(long)]
+    pub memory_size: Option<String>,
 }
 
 /// Checks if file with a given path exists.
@@ -101,7 +105,9 @@ impl Instance {
         // attestation.
         cmd.args(["-cpu", "IvyBridge-IBRS,enforce"]);
         // TODO(#3786): Make memory configurable.
-        cmd.args(["-m", "1G"]);
+        if let Some(memory_size) = params.memory_size {
+            cmd.args(["-m", &memory_size]);
+        };
         // Disable a bunch of hardware we don't need.
         cmd.arg("-nodefaults");
         cmd.arg("-nographic");


### PR DESCRIPTION
Fixes #3786 .

Now, the tests seem not to be failing with out-of-memory any more, so I didn't change anything in the tests. However, if we run out of memory again, we can increase the memory now.