### PR TITLE
Use AttestationEvidence for evidence coming from the enclave

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,9 +3252,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
 
 [[package]]
 name = "spinning_top"
@@ -3905,7 +3905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677160b1166881badada1137afc6457777126f328ae63a18058b504f546f0828"
 dependencies = [
  "smallvec",
- "spin 0.9.6",
+ "spin 0.9.7",
  "wasmi_arena",
  "wasmi_core",
  "wasmparser-nostd",

--- a/oak_functions_enclave_app/Cargo.lock
+++ b/oak_functions_enclave_app/Cargo.lock
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
 
 [[package]]
 name = "spinning_top"

--- a/oak_remote_attestation_noninteractive/proto/v1/messages.proto
+++ b/oak_remote_attestation_noninteractive/proto/v1/messages.proto
@@ -21,7 +21,9 @@ package oak.session.noninteractive.v1;
 option java_multiple_files = true;
 option java_package = "oak.session.noninteractive.v1";
 
-// AttestationEvidence contains the evidence provided by the enclave.
+// AttestationEvidence contains all the information that originates in the TEE and can serve as
+// claims about the Target Environment. The name is chosen to match the RATS terminology
+// (see https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence).
 message AttestationEvidence {
   // The serialized public key part of the enclave encryption key.
   // TODO(#3442): Specify key format.
@@ -41,24 +43,31 @@ message AttestationEvidence {
   bytes signed_application_data = 4;
 }
 
-// AttestationVerificationEvidence contains the information that the untrusted launcher provides to
-// the client in response to its request for the enclave's public key(s). The name is chosen to
-// match the RATS terminology (see https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence).
-message AttestationVerificationEvidence {
+// AttestationBundle contains the information that the untrusted launcher provides to the client
+// in response to its request for the enclave's public key(s).
+message AttestationBundle {
   // Attestation evidence from the enclave.
   AttestationEvidence attestation_evidence = 1;
 
+  // Supporting evidence required for verifying the integrity of attestation evidence.
+  AttestationEndorsement attestation_endorsement = 2;
+}
+
+// AttestationEndorsement contains statements that some entity (e.g., a hardware provider) vouches
+// for the integrity of claims about the TEE or the software running on it.
+// (see https://www.rfc-editor.org/rfc/rfc9334.html#name-endorsements).
+message AttestationEndorsement {
   // The serialized TEE certificate(s). The details of the format and how the certificate(s) are
   // encoded into this byte array are implementation-specific. In case of AMD-SEV-SNP, as described
   // in https://www.amd.com/system/files/TechDocs/57230.pdf, there are three different certificates
   // packaged in two different files.
-  bytes tee_certificates = 2;
+  bytes tee_certificates = 1;
 
-  // The binary attestation evidence.
-  BinaryAttestation binary_attestation = 3;
+  // The binary attestation.
+  BinaryAttestation binary_attestation = 2;
 
   // The optional application-specific data.
-  optional ApplicationData application_data = 4;
+  optional ApplicationData application_data = 3;
 }
 
 message BinaryAttestation {
@@ -81,7 +90,7 @@ message GetPublicKeyRequest {}
 
 message GetPublicKeyResponse {
   // The enclave's signing and encryption public keys and attestation evidence about them.
-  AttestationVerificationEvidence attestation_verification_evidence = 1;
+  AttestationBundle attestation_bundle = 1;
 }
 
 message InvokeRequest {

--- a/oak_remote_attestation_noninteractive/proto/v1/messages.proto
+++ b/oak_remote_attestation_noninteractive/proto/v1/messages.proto
@@ -21,9 +21,7 @@ package oak.session.noninteractive.v1;
 option java_multiple_files = true;
 option java_package = "oak.session.noninteractive.v1";
 
-// AttestationEvidence contains the information that the untrusted launcher provides to the client
-// in response to its request for the enclave's public key(s). The name is chosen to match the RATS
-// terminology (see https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence).
+// AttestationEvidence contains the evidence provided by the enclave.
 message AttestationEvidence {
   // The serialized public key part of the enclave encryption key.
   // TODO(#3442): Specify key format.
@@ -37,22 +35,30 @@ message AttestationEvidence {
   // The serialized attestation report binding the public key.
   bytes attestation = 3;
 
+  // The signature over the application_data, signed by the enclave using its signing key. This
+  // field is optional, and must be left empty if application_data is not provided.
+  // TODO(#3442): Specify the signing details, or link to a specification.
+  bytes signed_application_data = 4;
+}
+
+// AttestationVerificationEvidence contains the information that the untrusted launcher provides to
+// the client in response to its request for the enclave's public key(s). The name is chosen to
+// match the RATS terminology (see https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence).
+message AttestationVerificationEvidence {
+  // Attestation evidence from the enclave.
+  AttestationEvidence attestation_evidence = 1;
+
   // The serialized TEE certificate(s). The details of the format and how the certificate(s) are
   // encoded into this byte array are implementation-specific. In case of AMD-SEV-SNP, as described
   // in https://www.amd.com/system/files/TechDocs/57230.pdf, there are three different certificates
   // packaged in two different files.
-  bytes tee_certificates = 4;
+  bytes tee_certificates = 2;
 
   // The binary attestation evidence.
-  BinaryAttestation binary_attestation = 5;
+  BinaryAttestation binary_attestation = 3;
 
   // The optional application-specific data.
-  optional ApplicationData application_data = 6;
-
-  // The signature over the application_data, signed by the enclave using its signing key. This
-  // field is optional, and must be left empty if application_data is not provided.
-  // TODO(#3442): Specify the signing details, or link to a specification.
-  bytes signed_application_data = 7;
+  optional ApplicationData application_data = 4;
 }
 
 message BinaryAttestation {
@@ -75,7 +81,7 @@ message GetPublicKeyRequest {}
 
 message GetPublicKeyResponse {
   // The enclave's signing and encryption public keys and attestation evidence about them.
-  AttestationEvidence attestation_evidence = 1;
+  AttestationVerificationEvidence attestation_verification_evidence = 1;
 }
 
 message InvokeRequest {

--- a/oak_remote_attestation_noninteractive/tests/integration_test.rs
+++ b/oak_remote_attestation_noninteractive/tests/integration_test.rs
@@ -20,8 +20,7 @@ use oak_remote_attestation_noninteractive::proto::{
     request_wrapper, response_wrapper,
     streaming_session_client::StreamingSessionClient,
     streaming_session_server::{StreamingSession, StreamingSessionServer},
-    AttestationVerificationEvidence, GetPublicKeyRequest, GetPublicKeyResponse, RequestWrapper,
-    ResponseWrapper,
+    AttestationBundle, GetPublicKeyRequest, GetPublicKeyResponse, RequestWrapper, ResponseWrapper,
 };
 use std::pin::Pin;
 use tonic::{
@@ -108,14 +107,12 @@ impl StreamingSession for TestEvidenceProviderServer {
             return Err(tonic::Status::invalid_argument("request wrapper must have get_public_key_request field set"));
         };
 
-        // TODO(#3641): Respond with a more interesting AttestationVerificationEvidence.
-        let attestation_verification_evidence = Some(AttestationVerificationEvidence::default());
+        // TODO(#3641): Respond with a more interesting AttestationBundle.
+        let attestation_bundle = Some(AttestationBundle::default());
         Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
             ResponseWrapper {
                 response: Some(response_wrapper::Response::GetPublicKeyResponse(
-                    GetPublicKeyResponse {
-                        attestation_verification_evidence,
-                    },
+                    GetPublicKeyResponse { attestation_bundle },
                 )),
             },
         )]))))

--- a/oak_remote_attestation_noninteractive/tests/integration_test.rs
+++ b/oak_remote_attestation_noninteractive/tests/integration_test.rs
@@ -20,7 +20,7 @@ use oak_remote_attestation_noninteractive::proto::{
     request_wrapper, response_wrapper,
     streaming_session_client::StreamingSessionClient,
     streaming_session_server::{StreamingSession, StreamingSessionServer},
-    AttestationEvidence, GetPublicKeyRequest, GetPublicKeyResponse, RequestWrapper,
+    AttestationVerificationEvidence, GetPublicKeyRequest, GetPublicKeyResponse, RequestWrapper,
     ResponseWrapper,
 };
 use std::pin::Pin;
@@ -108,13 +108,13 @@ impl StreamingSession for TestEvidenceProviderServer {
             return Err(tonic::Status::invalid_argument("request wrapper must have get_public_key_request field set"));
         };
 
-        // TODO(#3641): Respond with a more interesting AttestationEvidence.
-        let attestation_evidence = Some(AttestationEvidence::default());
+        // TODO(#3641): Respond with a more interesting AttestationVerificationEvidence.
+        let attestation_verification_evidence = Some(AttestationVerificationEvidence::default());
         Ok(Response::new(Box::pin(futures::stream::iter(vec![Ok(
             ResponseWrapper {
                 response: Some(response_wrapper::Response::GetPublicKeyResponse(
                     GetPublicKeyResponse {
-                        attestation_evidence,
+                        attestation_verification_evidence,
                     },
                 )),
             },


### PR DESCRIPTION
Some renaming and refactoring based on a chat with @ipetr0v to make the terminology more consistent with RATS.