### PR TITLE
Set up Bazel rules to use the precompiled toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# Should not be needed after Bazel 7.0 is released.
+build --incompatible_enable_cc_toolchain_resolution

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -135,3 +135,14 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 # This sets up some common toolchains for building targets. For more details, please see
 # https://bazelbuild.github.io/rules_foreign_cc/0.9.0/flatten.html#rules_foreign_cc_dependencies
 rules_foreign_cc_dependencies()
+
+http_archive(
+    name = "x86_64-unknown-oak",
+    build_file = "//toolchain:x86_64-unknown-oak.BUILD",
+    sha256 = "6f82ea9ac935810aeafd10cc9ca46456b01a15353d9c14d962764ad77f3ab457",
+    strip_prefix = "toolchain",
+    type = "tar.bz2",
+    url = "https://ent-server-62sa4xcfia-ew.a.run.app/raw/sha256:6f82ea9ac935810aeafd10cc9ca46456b01a15353d9c14d962764ad77f3ab457",
+)
+
+register_toolchains("//toolchain:oak")

--- a/cc/oak_echo_raw_enclave_app/BUILD
+++ b/cc/oak_echo_raw_enclave_app/BUILD
@@ -21,4 +21,8 @@ package(
 cc_binary(
     name = "oak_echo_raw_enclave_app",
     srcs = ["main.cc"],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "//:os_oak",
+    ],
 )

--- a/cc/oak_echo_raw_enclave_app/main.cc
+++ b/cc/oak_echo_raw_enclave_app/main.cc
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
 #include <unistd.h>
+
+#include <iostream>
 
 constexpr int CHANNEL_FD = 10;
 
-// Under C++ rules, the name is mangled to "_Z4mainiPPc" -- find out what's going on with that.
-extern "C" int main(int argc, char* argv[]) {
+int main(int argc, char* argv[]) {
   char buf;
 
-  fprintf(stderr, "In main!\n");
+  // This should be set up by the runtime for us, but it isn't. It's a bug in the toolchain we need
+  // to fix.
+  std::ios_base::Init init;
+
+  std::cerr << "In main!" << std::endl;
 
   while (true) {
     if (read(CHANNEL_FD, &buf, sizeof(buf)) != 1) {

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -1,0 +1,61 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+cc_toolchain_config(name = "oak_toolchain_config")
+
+filegroup(
+    name = "wrappers",
+    srcs = glob([
+        "wrappers/**",
+    ]),
+)
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":wrappers",
+        "@x86_64-unknown-oak//:toolchain",
+    ],
+)
+
+cc_toolchain(
+    name = "oak_toolchain",
+    all_files = ":all_files",
+    compiler_files = ":all_files",
+    dwp_files = ":empty",
+    linker_files = ":all_files",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    toolchain_config = ":oak_toolchain_config",
+    toolchain_identifier = "oak-toolchain",
+)
+
+toolchain(
+    name = "oak",
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "//:os_oak",
+    ],
+    toolchain = ":oak_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -1,0 +1,145 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""C++ toolchain for Oak applications."""
+
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool_path",
+)
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+all_compile_actions = [
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.lto_backend,
+    ACTION_NAMES.preprocess_assemble,
+]
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "wrappers/x86_64-unknown-oak-gcc",
+        ),
+        tool_path(
+            name = "ld",
+            path = "wrappers/x86_64-unknown-oak-ld",
+        ),
+        tool_path(
+            name = "ar",
+            path = "wrappers/x86_64-unknown-oak-ar",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "wrappers/x86_64-unknown-oak-cpp",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "wrappers/x86_64-unknown-oak-gcov",
+        ),
+        tool_path(
+            name = "nm",
+            path = "wrappers/x86_64-unknown-oak-nm",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "wrappers/x86_64-unknown-oak-objdump",
+        ),
+        tool_path(
+            name = "strip",
+            path = "wrappers/x86_64-unknown-oak-strip",
+        ),
+    ]
+
+    default_compiler_flags = feature(
+        name = "default_compiler_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "--sysroot=external/x86_64-unknown-oak",
+                            "-no-canonical-prefixes",
+                            "-fno-canonical-system-headers",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    default_linker_flags = feature(
+        name = "default_linker_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "--sysroot=external/x86_64-unknown-oak",
+                            "-zmax-page-size=0x200000",
+                            "-lstdc++",
+                        ],
+                    ),
+                ]),
+            ),
+        ],
+    )
+
+    features = [
+        default_compiler_flags,
+        default_linker_flags,
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        toolchain_identifier = "oak-toolchain",
+        host_system_name = "local",
+        target_system_name = "unknown",
+        target_cpu = "unknown",
+        target_libc = "unknown",
+        compiler = "gcc",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+        builtin_sysroot = "../external/x86_64-unknown-oak",
+    )
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/toolchain/wrappers/wrapper
+++ b/toolchain/wrappers/wrapper
@@ -1,0 +1,6 @@
+#!/bin/bash
+ 
+NAME=$(basename "$0")
+TOOLCHAIN_BINDIR=external/x86_64-unknown-oak/bin
+ 
+exec "${TOOLCHAIN_BINDIR}"/"${NAME}" "$@"

--- a/toolchain/wrappers/x86_64-unknown-oak-ar
+++ b/toolchain/wrappers/x86_64-unknown-oak-ar
@@ -1,0 +1,1 @@
+wrapper

--- a/toolchain/wrappers/x86_64-unknown-oak-cpp
+++ b/toolchain/wrappers/x86_64-unknown-oak-cpp
@@ -1,0 +1,1 @@
+wrapper

--- a/toolchain/wrappers/x86_64-unknown-oak-gcc
+++ b/toolchain/wrappers/x86_64-unknown-oak-gcc
@@ -1,0 +1,1 @@
+wrapper

--- a/toolchain/wrappers/x86_64-unknown-oak-gcov
+++ b/toolchain/wrappers/x86_64-unknown-oak-gcov
@@ -1,0 +1,1 @@
+wrapper

--- a/toolchain/wrappers/x86_64-unknown-oak-ld
+++ b/toolchain/wrappers/x86_64-unknown-oak-ld
@@ -1,0 +1,1 @@
+wrapper

--- a/toolchain/wrappers/x86_64-unknown-oak-nm
+++ b/toolchain/wrappers/x86_64-unknown-oak-nm
@@ -1,0 +1,1 @@
+wrapper

--- a/toolchain/wrappers/x86_64-unknown-oak-objdump
+++ b/toolchain/wrappers/x86_64-unknown-oak-objdump
@@ -1,0 +1,1 @@
+wrapper

--- a/toolchain/wrappers/x86_64-unknown-oak-strip
+++ b/toolchain/wrappers/x86_64-unknown-oak-strip
@@ -1,0 +1,1 @@
+wrapper

--- a/toolchain/x86_64-unknown-oak.BUILD
+++ b/toolchain/x86_64-unknown-oak.BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 The Project Oak Authors
+# Copyright 2023 The Project Oak Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,27 +14,14 @@
 # limitations under the License.
 #
 
-# An empty BUILD file in the project root is required for `bazel-gazelle` that is
-# loaded by `rules_docker`:
-# https://github.com/bazelbuild/bazel-gazelle/issues/609
-
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )
 
-# Export LICENSE file for projects that reference Oak in Bazel as an external dependency.
-exports_files(["LICENSE"])
-
-constraint_value(
-    name = "os_oak",
-    constraint_setting = "@platforms//os:os",
-)
-
-platform(
-    name = "oak",
-    constraint_values = [
-        "//:os_oak",
-        "@platforms//cpu:x86_64",
-    ],
+filegroup(
+    name = "toolchain",
+    srcs = glob([
+        "**",
+    ]),
 )


### PR DESCRIPTION
I'm yet again in territory that I don't know particularly well...

This is largely cargo culted from https://ltekieli.com/cross-compiling-with-bazel/ as a base.

How to use:
```
bazel build //cc/oak_echo_raw_enclave_app --platforms=//:oak
```

...and you should get a binary palatable for Restricted Kernel.
