### PR TITLE
Add initial TDX enlightenment helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,6 +2312,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_tdx_guest"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "oak_tensorflow_service"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
   "oak_restricted_kernel_interface",
   "oak_sev_guest",
   "oak_simple_io",
+  "oak_tdx_guest",
   "oak_tensorflow_service",
   "oak_virtio",
   "sev_serial",
@@ -112,6 +113,7 @@ oak_restricted_kernel_api = { path = "./oak_restricted_kernel_api" }
 oak_restricted_kernel_interface = { path = "./oak_restricted_kernel_interface" }
 oak_sev_guest = { path = "./oak_sev_guest", default-features = false }
 oak_simple_io = { path = "./oak_simple_io" }
+oak_tdx_guest = { path = "./oak_tdx_guest" }
 oak_virtio = { path = "./oak_virtio" }
 sev_serial = { path = "./sev_serial" }
 xtask = { path = "./xtask" }

--- a/oak_tdx_guest/Cargo.toml
+++ b/oak_tdx_guest/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "oak_tdx_guest"
+version = "0.1.0"
+authors = ["Conrad Grobler <grobler@google.com>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+bitflags = "*"

--- a/oak_tdx_guest/README.md
+++ b/oak_tdx_guest/README.md
@@ -1,0 +1,8 @@
+# Intel TDX Guest Library
+
+Rust helpers for enlightening a guest operating system to run on Intel TDX.
+
+For more information see:
+
+- [Architecture Specification: Intel® Trust Domain Extensions(Intel® TDX) Module](https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-module-1eas.pdf)
+- [Guest-Host-Communication Interface (GHCI) for Intel® Trust Domain Extensions (Intel® TDX)](https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf)

--- a/oak_tdx_guest/src/lib.rs
+++ b/oak_tdx_guest/src/lib.rs
@@ -1,0 +1,23 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Rust implementation of features needed to implement guest enlightenment for operating systems
+//! running under Intel TDX.
+
+#![no_std]
+#![feature(split_array)]
+
+pub mod tdcall;

--- a/oak_tdx_guest/src/tdcall.rs
+++ b/oak_tdx_guest/src/tdcall.rs
@@ -25,13 +25,14 @@ const SUCCESS: u64 = 0;
 bitflags! {
     /// Attributes of a TD.
     ///
-    /// See section 18.2.1 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-module-1eas.pdf>
+    /// See section 18.2.1 of [Architecture Specification: Intel® Trust Domain Extensions(Intel® TDX)
+    /// Module](https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-module-1eas.pdf)
     /// for more information.
     #[derive(Default)]
     pub struct Attributes: u64 {
         /// The guest TD runs in off-TD debug mode.
         ///
-        /// If this is enabled the TD should be consisdered untrusted.
+        /// If this is enabled the TD should be considered untrusted.
         const DEBUG = 1 << 0;
         /// Whether system profiling is enabled on the TD.
         ///
@@ -50,7 +51,8 @@ bitflags! {
 
 /// Information about the TD's execution environment.
 ///
-/// See section 2.4.2 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf>
+/// See section 2.4.2 of [Guest-Host-Communication Interface (GHCI) for Intel® Trust Domain
+/// Extensions (Intel® TDX)](https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf)
 /// for more information.
 pub struct TdInfo {
     /// The effective GPA width. The "shared" bit is at position gpa_width - 1.
@@ -68,7 +70,8 @@ pub struct TdInfo {
 /// Gets information about the TD's execution environment by calling the TDCALL[TDG.VP.INFO]
 /// leaf.
 ///
-/// See section 2.4.2 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf>
+/// See section 2.4.2 of [Guest-Host-Communication Interface (GHCI) for Intel® Trust Domain
+/// Extensions (Intel® TDX)](https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf)
 /// for more information.
 pub fn get_td_info() -> TdInfo {
     // The TDCALL leaf for TDG.VP.INFO.
@@ -116,7 +119,8 @@ pub fn get_td_info() -> TdInfo {
 
 /// Information about a virtualization exception (#VE).
 ///
-/// See section 2.4.4 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf>
+/// See section 2.4.4 of [Guest-Host-Communication Interface (GHCI) for Intel® Trust Domain
+/// Extensions (Intel® TDX)](https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf)
 /// for more information.
 pub struct VeInfo {
     /// The exit reason.
@@ -136,7 +140,8 @@ pub struct VeInfo {
 /// Gets information about the recent virtualization exception (#VE) by calling the
 /// TDCALL[TDG.VP.VEINFO.GET] leaf.
 ///
-/// See section 2.4.4 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf>
+/// See section 2.4.4 of [Guest-Host-Communication Interface (GHCI) for Intel® Trust Domain
+/// Extensions (Intel® TDX)]( https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf)
 /// for more information.
 pub fn get_ve_info() -> Option<VeInfo> {
     // The TDCALL leaf for TDG.VP.VEINFO.GET.
@@ -200,8 +205,8 @@ pub fn get_ve_info() -> Option<VeInfo> {
 /// The first value represents the lower 32-bits and the second the higher bits.
 fn split_u64(value: u64) -> (u32, u32) {
     const SIZE: usize = size_of::<u32>();
-    let mut bytes = value.to_le_bytes();
-    let (lower, higher) = bytes.split_array_mut::<SIZE>();
+    let bytes = value.to_le_bytes();
+    let (lower, higher) = bytes.split_array_ref::<SIZE>();
     (
         u32::from_le_bytes(*lower),
         u32::from_le_bytes(higher.try_into().unwrap()),

--- a/oak_tdx_guest/src/tdcall.rs
+++ b/oak_tdx_guest/src/tdcall.rs
@@ -1,0 +1,209 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Rust implementation of the TDX TDCALL instruction.
+
+use bitflags::bitflags;
+use core::{arch::asm, mem::size_of};
+
+/// The result from an instruction that indicates success.
+const SUCCESS: u64 = 0;
+
+bitflags! {
+    /// Attributes of a TD.
+    ///
+    /// See section 18.2.1 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-module-1eas.pdf>
+    /// for more information.
+    #[derive(Default)]
+    pub struct Attributes: u64 {
+        /// The guest TD runs in off-TD debug mode.
+        ///
+        /// If this is enabled the TD should be consisdered untrusted.
+        const DEBUG = 1 << 0;
+        /// Whether system profiling is enabled on the TD.
+        ///
+        /// If this is enabled the TD should be considered untrusted.
+        const SYSPROF = 1 << 1;
+        /// Whether the TD is allowed to use Supervisor Protection Keys.
+        const PKS = 1 << 30;
+        /// Whether the TD is allowed to use Key Locker.
+        ///
+        /// Must be 0 for the current version.
+        const KL = 1 << 31;
+        /// Wehther the TD is allowed to use Perfmon and PERF_METRICS.
+        const PERFMON = 1 << 63;
+    }
+}
+
+/// Information about the TD's execution environment.
+///
+/// See section 2.4.2 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf>
+/// for more information.
+pub struct TdInfo {
+    /// The effective GPA width. The "shared" bit is at position gpa_width - 1.
+    ///
+    /// Currently only values of 48 or 52 are possible.
+    pub gpa_width: usize,
+    /// The TD attributes passed as part of TDINIT.
+    pub attributes: Attributes,
+    /// The number of vCPUs enabled on this TD.
+    pub num_vcpus: u32,
+    /// The maximum possible number of vCPUs for this TD.
+    pub max_vcpus: u32,
+}
+
+/// Gets information about the TD's execution environment by calling the TDCALL[TDG.VP.INFO]
+/// leaf.
+///
+/// See section 2.4.2 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf>
+/// for more information.
+pub fn get_td_info() -> TdInfo {
+    // The TDCALL leaf for TDG.VP.INFO.
+    const LEAF: u64 = 1;
+
+    let mut result: i64;
+    let mut gpa_width: usize;
+    let mut attributes: u64;
+    let mut vcpu_info: u64;
+    // The TDCALL leaf goes into RAX. RAX returns the result (0 is success). RCX returns the GPA
+    // width in the first 6 bits. RDX returns the TD attributes. R8 contains the number of active or
+    // ready vCPUs in bits 0..32 and the maximum number of vCPUs in bits 32..64. R9, R10 and R11 are
+    // reserved for future use.
+    //
+    // Safety: calling TDCALL here is safe since it does not alter memory and all the affected
+    // registers are specified, so no unspecified registers will be clobbered.
+    unsafe {
+        asm!(
+            "tdcall",
+            inout("rax") LEAF => result,
+            out("rcx") gpa_width,
+            out("rdx") attributes,
+            out("r8") vcpu_info,
+            out("r9") _,
+            out("r10") _,
+            out("r11") _,
+
+            options(nomem, nostack),
+        );
+    }
+    // According to the spec this instruction will always return 0 in RAX.
+    assert_eq!(
+        result, SUCCESS as i64,
+        "TDCALL[TDG.VP.INFO] returned an invalid result"
+    );
+    let attributes = Attributes::from_bits(attributes).expect("invalid TD attributes");
+    let (num_vcpus, max_vcpus) = split_u64(vcpu_info);
+    TdInfo {
+        gpa_width,
+        attributes,
+        num_vcpus,
+        max_vcpus,
+    }
+}
+
+/// Information about a virtualization exception (#VE).
+///
+/// See section 2.4.4 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf>
+/// for more information.
+pub struct VeInfo {
+    /// The exit reason.
+    pub exit_reason: u32,
+    /// The exit qualification.
+    pub exit_qualification: u64,
+    /// The guest-linear address (virtual address).
+    pub guest_linear_address: u64,
+    /// The guest-physical address.
+    pub guest_physical_address: u64,
+    /// The length of the instruction that caused the #VE.
+    pub instruction_length: u32,
+    /// Additional context for the instruction that caused the #VE.
+    pub instruction_info: u32,
+}
+
+/// Gets information about the recent virtualization exception (#VE) by calling the
+/// TDCALL[TDG.VP.VEINFO.GET] leaf.
+///
+/// See section 2.4.4 of <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf>
+/// for more information.
+pub fn get_ve_info() -> Option<VeInfo> {
+    // The TDCALL leaf for TDG.VP.VEINFO.GET.
+    const LEAF: u64 = 3;
+    // The result if there were no recent #VE exepctions.
+    const NO_VE_INFO: u64 = 1 << 63;
+
+    let mut result: u64;
+    let mut exit_reason: u64;
+    let mut exit_qualification: u64;
+    let mut guest_linear_address: u64;
+    let mut guest_physical_address: u64;
+    let mut instruction: u64;
+
+    // The TDCALL leaf goes into RAX. RAX returns the result (0 is success). RCX returns the exit
+    // reason. RDX returns the exit qualification. R8 returns the guest-linear address. R9 returns
+    // the guest-physical address. R10 returns the instructions length in bits 0..32 and the
+    // additional instruction info in bits 32..64.
+    //
+    // Safety: calling TDCALL here is safe since it does not alter memory and all the affected
+    // registers are specified, so no unspecified registers will be clobbered.
+    unsafe {
+        asm!(
+            "tdcall",
+            inout("rax") LEAF => result,
+            out("rcx") exit_reason,
+            out("rdx") exit_qualification,
+            out("r8") guest_linear_address,
+            out("r9") guest_physical_address,
+            out("r10") instruction,
+
+            options(nomem, nostack),
+        );
+    }
+
+    if result == NO_VE_INFO {
+        // No recent #VE.
+        return None;
+    }
+    // According to the spec this instruction will always return either 0 or NO_VE_INFO in RAX.
+    assert_eq!(
+        result, SUCCESS,
+        "TDCALL[TDG.VP.VEINFO.GET] returned an invalid result"
+    );
+
+    let exit_reason: u32 = exit_reason.try_into().expect("invalid exit reason");
+    let (instruction_length, instruction_info) = split_u64(instruction);
+
+    Some(VeInfo {
+        exit_reason,
+        exit_qualification,
+        guest_linear_address,
+        guest_physical_address,
+        instruction_length,
+        instruction_info,
+    })
+}
+
+/// Splits a 64-bit little-endian unsigned integer into two 32-bit little-endian unsigned integers.
+///
+/// The first value represents the lower 32-bits and the second the higher bits.
+fn split_u64(value: u64) -> (u32, u32) {
+    const SIZE: usize = size_of::<u32>();
+    let mut bytes = value.to_le_bytes();
+    let (lower, higher) = bytes.split_array_mut::<SIZE>();
+    (
+        u32::from_le_bytes(*lower),
+        u32::from_le_bytes(higher.try_into().unwrap()),
+    )
+}


### PR DESCRIPTION
Adds a new helper crate to support TDX enlightenment. Also adds support for the first two TDCALL leaves that we will use:

- Getting information about the encrypted VM (TD)
- Getting information about a recent virtualisation exception (#VE)

Support for the TDG.VP.VMCALL leaf and its sub-functions will be added in a follow-up PR.

Support for other leaves will only be added later when needed.

For more information see https://www.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf