### PR TITLE
Ensure 16-byte stack alignment in `_start`.

### DIFF
--- a/toolchain/newlib/crt0.S
+++ b/toolchain/newlib/crt0.S
@@ -18,6 +18,9 @@
 .global _start
 
 _start:
+    # Ensure the stack is 16-byte aligned (0x10) before we start, otherwise we may violate
+    # the calling convention for some instructions (SSE ones in particular).
+    andq $-10, %rsp
     movq $0, %rbp
     pushq %rbp
     pushq %rbp


### PR DESCRIPTION
Yet again stack alignment issues...

For whatever reason if:
(a) I remove the `rsp - 8` in Restricted Kernel and replace it with this alignment, the Rust applications break.
(b) if I don't force this 16-byte alignment, C++ applications break.

Things that are aligned to 16 bytes should _by definition_ be also aligned to 8 bytes, so we've got something broken with our alignments here. But this should be the minimum change to get things to work properly.

And now we get to recompile the toolchain!