### PR TITLE
Add support for loading and parsing an ELF kernel

### DIFF
--- a/oak_echo_linux_init/README.md
+++ b/oak_echo_linux_init/README.md
@@ -64,18 +64,20 @@ mkfifo /tmp/comms.in /tmp/comms.out
 Execute the initial RAM disk with QEMU:
 
 Note: this assumes that an appropiate uncompressed Linux kernel ELF binary has
-been copied to `bin/vmlinux`. The Linux Kernel must be built with PVH guest
-support so that it can be loaded as a kernel by QEMU. It must also be built with
-ACPI, ACPI Plug-and-Play, Virtio MMIO, and Virtio Console support, as this is
-needed for the `/dev/hvc0` device to become available.
+been copied to `bin/vmlinux`. The Linux Kernel must be built with ACPI, ACPI
+Plug-and-Play, Virtio MMIO, and Virtio Console support, as this is needed for
+the `/dev/hvc0` device to become available.
 
 ```bash
 qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm" -m 1G \
-    -nographic -nodefaults -no-reboot -serial stdio -append "console=ttyS0 quiet" \
+    -nographic -nodefaults -no-reboot -serial stdio \
     -chardev "pipe,id=comms,path=/tmp/comms" \
     -device "virtio-serial-device,max_ports=1" \
     -device "virtconsole,chardev=comms" \
-    -bios "bin/stage0.bin" -kernel "bin/vmlinux" -initrd "bin/initramfs"
+    -bios "bin/stage0.bin" \
+    -fw_cfg "name=opt/stage0/elf_kernel,file=bin/vmlinux" \
+    -fw_cfg "name=opt/stage0/initramfs,file=bin/initramfs" \
+    -fw_cfg "name=opt/stage0/cmdline,string=console=ttyS0 quiet"
 ```
 
 While the VM is running, listen for bytes on the output pipe in a separate

--- a/oak_hello_world_linux_init/README.md
+++ b/oak_hello_world_linux_init/README.md
@@ -64,6 +64,8 @@ copied to `bin/vmlinux`.
 
 ```bash
 qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm,acpi=on" -m 1G \
-    -nographic -nodefaults -no-reboot -serial stdio -append "console=ttyS0 quiet" \
-    -bios "bin/stage0.bin" -kernel "bin/vmlinux" -initrd "bin/initramfs"
+    -nographic -nodefaults -no-reboot -serial stdio -bios "bin/stage0.bin" \
+    -fw_cfg "name=opt/stage0/elf_kernel,file=bin/vmlinux" \
+    -fw_cfg "name=opt/stage0/initramfs,file=bin/initramfs" \
+    -fw_cfg "name=opt/stage0/cmdline,string=console=ttyS0 quiet"
 ```

--- a/stage0/.cargo/config.toml
+++ b/stage0/.cargo/config.toml
@@ -2,9 +2,9 @@
 target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
-rustflags = "-C relocation-model=static -C code-model=large"
+rustflags = "-C relocation-model=static -C code-model=large -C linker-plugin-lto"
 
 [unstable]
 # We need to build std / core because of the code model. This may be removed if / when it's possible to build stage0 without it in the future.
-build-std = ["core"]
+build-std = ["core", "alloc"]
 build-std-features = ["compiler-builtins-mem"]

--- a/stage0/.cargo/config.toml
+++ b/stage0/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
-rustflags = "-C relocation-model=static -C code-model=large -C linker-plugin-lto"
+rustflags = "-C relocation-model=static -C code-model=large"
 
 [unstable]
 # We need to build std / core because of the code model. This may be removed if / when it's possible to build stage0 without it in the future.

--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -50,6 +50,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
 dependencies = [
+ "log",
  "plain",
  "scroll",
 ]
@@ -170,6 +171,20 @@ name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sev_serial"

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -11,7 +11,11 @@ members = ["."]
 
 [dependencies]
 bitflags = "*"
-goblin = { version = "*", default-features = false, features = ["elf64"] }
+goblin = { version = "*", default-features = false, features = [
+  "elf32",
+  "elf64",
+  "endian_fd"
+] }
 log = "*"
 oak_core = { path = "../oak_core", default-features = false }
 oak_linux_boot_params = { path = "../linux_boot_params" }

--- a/stage0/src/initramfs.rs
+++ b/stage0/src/initramfs.rs
@@ -14,13 +14,15 @@
 // limitations under the License.
 //
 
-use crate::fw_cfg::FwCfg;
-use core::slice;
-use oak_linux_boot_params::{BootE820Entry, E820EntryType};
-use x86_64::{
-    structures::paging::{PageSize, Size2MiB, Size4KiB},
-    PhysAddr, VirtAddr,
+use crate::{
+    fw_cfg::{check_non_overlapping, find_suitable_dma_address, FwCfg},
+    kernel::KernelInfo,
 };
+use core::{ffi::CStr, slice};
+use oak_linux_boot_params::BootE820Entry;
+
+/// The file path used by Stage0 to read the initial RAM disk from the fw_cfg device.
+const INITIAL_RAM_DISK_FILE_PATH: &[u8] = b"opt/stage0/initramfs\0";
 
 /// Tries to load an initial RAM disk from the QEMU FW_CFG device.
 ///
@@ -28,123 +30,32 @@ use x86_64::{
 pub fn try_load_initial_ram_disk(
     fw_cfg: &mut FwCfg,
     e820_table: &[BootE820Entry],
+    kernel_info: &KernelInfo,
 ) -> Option<&'static [u8]> {
-    let size = fw_cfg
-        .read_initrd_size()
-        .expect("couldn't read initial RAM disk size") as usize;
-    if size == 0 {
-        log::debug!("No initial RAM disk");
-        return None;
-    }
-
-    let mut initrd_address = fw_cfg
-        .read_initrd_address()
-        .expect("couldn't read initial RAM disk address");
+    let path = CStr::from_bytes_with_nul(INITIAL_RAM_DISK_FILE_PATH).expect("invalid c-string");
+    let file = fw_cfg.find(path)?;
+    let size = file.size();
+    let initrd_address =
+        find_suitable_dma_address(size, e820_table).expect("no suitable DMA address available");
 
     log::debug!("Initial RAM disk size {}", size);
     log::debug!("Initial RAM disk address {:#018x}", initrd_address.as_u64());
 
-    let kernel_address = fw_cfg
-        .read_kernel_address()
-        .expect("couldn't read kernel address");
-    let kernel_size = fw_cfg
-        .read_kernel_size()
-        .expect("couldn't read kernel address") as u64;
+    let address = crate::phys_to_virt(initrd_address);
 
-    log::debug!("Kernel size {}", kernel_size);
-    log::debug!("Kernel start address {:#018x}", kernel_address.as_u64());
+    check_non_overlapping(address, size, kernel_info.start_address, kernel_info.size)
+        .expect("initial RAM disk location overlaps with the kernel");
 
-    if let Err(error) = check_initrd_address(
-        initrd_address,
-        initrd_address + (size as u64),
-        kernel_address,
-        kernel_address + kernel_size,
-        e820_table,
-    ) {
-        log::warn!("Unsuitable initial RAM disk address: {}", error);
-        initrd_address = find_suitable_initrd_address(size, e820_table)
-            .expect("couldn't a find suitable initial RAM disk address");
-        log::debug!(
-            "Suggested new initial RAM disk address: {:#018x}",
-            initrd_address.as_u64()
-        );
-    }
-
-    // If it is still not a suitable address, just panic.
-    check_initrd_address(
-        initrd_address,
-        initrd_address + size as u64,
-        kernel_address,
-        kernel_address + kernel_size,
-        e820_table,
-    )
-    .expect("couldn't find a suitable initial RAM disk address");
-
-    // We use an identity mapping for memory.
-    let address = VirtAddr::new(initrd_address.as_u64());
-
-    // Safety: We already checked that the slice falls within the mapped virtual memory, is backed
-    // by physical memory, does not overlap with the kernel, and does not overlap with the first
-    // 2MiB where our important data structures live. It can also not overlap with the firmware ROM
-    // image, since that is above the 1GiB upper limit we support. We only write to the slice and
-    // don't assume anything about its layout or alignment.
+    // Safety: We already checked that the slice falls in a suitable memory range and does not
+    // overlap with the kernel. We only write to the slice and don't assume anything about its
+    // layout or alignment.
     let buf = unsafe { slice::from_raw_parts_mut::<u8>(address.as_mut_ptr(), size) };
-    fw_cfg
-        .read_initrd_data(buf)
-        .expect("couldn't read initial RAM disk content");
+    let actual_size = fw_cfg
+        .read_file(&file, buf)
+        .expect("could not read initial RAM disk");
+    assert_eq!(
+        actual_size, size,
+        "initial RAM disk size did not match expected size"
+    );
     Some(buf)
-}
-
-fn check_initrd_address(
-    initrd_start: PhysAddr,
-    initrd_end: PhysAddr,
-    kernel_start: PhysAddr,
-    kernel_end: PhysAddr,
-    e820_table: &[BootE820Entry],
-) -> Result<(), &'static str> {
-    if initrd_start.as_u64() < Size2MiB::SIZE {
-        return Err("address falls in the first 2MiB");
-    }
-    if initrd_start < kernel_end && initrd_end > kernel_start {
-        return Err("initial RAM disk overlaps with the kernel");
-    }
-    if initrd_end.as_u64() > crate::TOP_OF_VIRTUAL_MEMORY {
-        return Err("initial RAM disk ends above the mapped virtual memory");
-    }
-    if !e820_table.iter().any(|entry| {
-        entry.entry_type() == Some(E820EntryType::RAM)
-            && entry.addr() as u64 <= initrd_start.as_u64()
-            && (entry.addr() + entry.size()) as u64 >= initrd_end.as_u64()
-    }) {
-        return Err("initial RAM disk is not backed by physical memory");
-    }
-
-    Ok(())
-}
-
-fn find_suitable_initrd_address(
-    initrd_size: usize,
-    e820_table: &[BootE820Entry],
-) -> Result<PhysAddr, &'static str> {
-    let padded_size = (initrd_size as u64)
-        .checked_next_multiple_of(Size4KiB::SIZE)
-        .unwrap();
-    // We use the end of the highest section of RAM that is big enough and falls below 1GiB.
-    e820_table
-        .iter()
-        .filter_map(|entry| {
-            if entry.entry_type() != Some(E820EntryType::RAM) {
-                return None;
-            }
-            let start = entry.addr() as u64;
-            let end = crate::TOP_OF_VIRTUAL_MEMORY.min(start + entry.size() as u64);
-            if padded_size.checked_add(start).unwrap() > end {
-                return None;
-            }
-
-            // Align the start address down in case the end was not aligned.
-            Some(PhysAddr::new(end.checked_sub(padded_size).unwrap()).align_down(Size4KiB::SIZE))
-        })
-        .max_by(PhysAddr::cmp)
-        .ok_or("no suitable memory available for the initial RAM disk")
 }

--- a/stage0/src/kernel.rs
+++ b/stage0/src/kernel.rs
@@ -1,0 +1,170 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::fw_cfg::{check_memory, check_non_overlapping, find_suitable_dma_address, FwCfg};
+use core::{ffi::CStr, slice};
+use goblin::{
+    container::{Container, Ctx, Endian},
+    elf::{header, Elf, ProgramHeader},
+    elf64::program_header::PT_LOAD,
+};
+use oak_linux_boot_params::BootE820Entry;
+use x86_64::{PhysAddr, VirtAddr};
+
+/// The default start location and entry point for the kernel if a kernel wasn't supplied via the
+/// QEMU fw_cfg device.
+const DEFAULT_KERNEL_START: u64 = 0x200000;
+
+/// The default size for the kernel if a kernel wasn't supplied via the QEMU fw_cfg device.
+///
+/// This is an arbitrary value, just to ensure it is non-zero.
+const DEFAULT_KERNEL_SIZE: usize = 0x100000;
+
+/// The file path used by Stage0 to read the kernel from the fw_cfg device.
+const KERNEL_FILE_PATH: &[u8] = b"opt/stage0/elf_kernel\0";
+
+/// Information about the kernel image.
+pub struct KernelInfo {
+    pub start_address: VirtAddr,
+    pub size: usize,
+    pub entry: VirtAddr,
+}
+
+impl Default for KernelInfo {
+    fn default() -> Self {
+        Self {
+            start_address: VirtAddr::new(DEFAULT_KERNEL_START),
+            size: DEFAULT_KERNEL_SIZE,
+            entry: VirtAddr::new(DEFAULT_KERNEL_START),
+        }
+    }
+}
+
+/// Tries to load a kernel image from the QEMU fw_cfg device.
+///
+/// We expect the kernel to be available with a filename of "opt/stage0/elf_kernel". We only support
+/// uncompressed ELF kernels at the moment.
+///
+/// If it finds a RAM disk it returns the information about the kernel, otherwise `None`.
+pub fn try_load_kernel_image(
+    fw_cfg: &mut FwCfg,
+    e820_table: &[BootE820Entry],
+) -> Option<KernelInfo> {
+    let path = CStr::from_bytes_with_nul(KERNEL_FILE_PATH).expect("invalid c-string");
+    let file = fw_cfg.find(path)?;
+    let size = file.size();
+
+    // We copy the kernel image to a temporary location where we can parse it.
+    let dma_address =
+        find_suitable_dma_address(size, e820_table).expect("no suitable DMA address available");
+    let start_address = crate::phys_to_virt(PhysAddr::new(dma_address.as_u64()));
+    log::debug!("Kernel image size {}", size);
+    log::debug!(
+        "Kernel image start address {:#018x}",
+        start_address.as_u64()
+    );
+    // Safety: We checked that the MDA address is suitable and big enough.
+    let buf = unsafe { slice::from_raw_parts_mut::<u8>(start_address.as_mut_ptr(), size) };
+
+    let actual_size = fw_cfg
+        .read_file(&file, buf)
+        .expect("could not read kernel file");
+    assert_eq!(actual_size, size, "kernel size did not match expected size");
+
+    let mut kernel_start = VirtAddr::new(crate::TOP_OF_VIRTUAL_MEMORY);
+    let mut kernel_end = VirtAddr::new(0);
+
+    // We expect an uncompressed ELF kernel, so we parse it and lay it out in memory.
+    let header = Elf::parse_header(buf).expect("couldn't parse kernel header");
+    if header.e_ident[0] != header::ELFMAG[0]
+        || header.e_ident[1] != header::ELFMAG[1]
+        || header.e_ident[2] != header::ELFMAG[2]
+        || header.e_ident[3] != header::ELFMAG[3]
+        || header.e_ident[4] != header::ELFCLASS64
+        || header.e_ident[5] != header::ELFDATA2LSB
+        || header.e_ident[6] != header::EV_CURRENT
+        || header.e_ident[7] != header::ELFOSABI_SYSV
+    {
+        panic!("kernel is not a valid little-endian 64-bit ELF file");
+    }
+
+    // We already confirmed that the kernel is 64-bit and uses little endian encoding.
+    let ctx = Ctx {
+        container: Container::Big,
+        le: Endian::Little,
+    };
+
+    let program_headers =
+        ProgramHeader::parse(buf, header.e_phoff as usize, header.e_phnum as usize, ctx)
+            .expect("couldn't parse ELF program headers");
+
+    for phdr in program_headers
+        .iter()
+        .filter(|&phdr| phdr.p_type == PT_LOAD)
+    {
+        let start = crate::phys_to_virt(PhysAddr::new(phdr.p_paddr));
+        let end = start + phdr.p_memsz;
+        if start < kernel_start {
+            kernel_start = start;
+        }
+        if end > kernel_end {
+            kernel_end = end;
+        }
+
+        load_segment(phdr, buf, e820_table).unwrap();
+    }
+
+    let kernel_size = (kernel_end - kernel_start) as usize;
+    let entry = crate::phys_to_virt(PhysAddr::new(header.e_entry));
+    log::debug!("Kernel size {}", kernel_size);
+    log::debug!("Kernel start address {:#018x}", kernel_start.as_u64());
+    log::debug!("Kernel entry point {:#018x}", entry.as_u64());
+
+    Some(KernelInfo {
+        start_address: kernel_start,
+        size: kernel_size,
+        entry,
+    })
+}
+
+/// Loads a segment from an ELF file into memory.
+fn load_segment(
+    phdr: &ProgramHeader,
+    buf: &[u8],
+    e820_table: &[BootE820Entry],
+) -> Result<(), &'static str> {
+    let file_offset = phdr.p_offset as usize;
+    let file_length = phdr.p_filesz as usize;
+    let source = &buf[file_offset..file_offset + file_length];
+    let start_address = crate::phys_to_virt(PhysAddr::new(phdr.p_paddr));
+    let size = phdr.p_memsz as usize;
+    check_memory(start_address, size, e820_table)?;
+    check_non_overlapping(
+        start_address,
+        size,
+        VirtAddr::from_ptr(buf.as_ptr()),
+        buf.len(),
+    )?;
+    // Safety: we checked that the target memory is valid and that it does not overlap with the
+    // source buffer.
+    let target = unsafe { slice::from_raw_parts_mut::<u8>(start_address.as_mut_ptr(), size) };
+
+    // Zero out the target in case the file content is shorter than the target.
+    target.fill(0);
+
+    target[..file_length].copy_from_slice(source);
+    Ok(())
+}

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -18,8 +18,10 @@
 #![no_main]
 #![feature(int_roundings)]
 
+extern crate alloc;
+
+use alloc::vec;
 use core::{
-    alloc::Layout,
     arch::asm,
     ffi::{c_void, CStr},
     mem::MaybeUninit,
@@ -50,10 +52,12 @@ mod asm;
 mod cmos;
 mod fw_cfg;
 mod initramfs;
+mod kernel;
 mod logging;
 mod sev;
 mod zero_page;
 
+#[global_allocator]
 static BOOT_ALLOC: Bump<[u8; 128 * 1024]> = Bump::uninit();
 
 #[link_section = ".boot"]
@@ -63,11 +67,11 @@ static SEV_SECRETS: MaybeUninit<oak_sev_guest::secrets::SecretsPage> = MaybeUnin
 #[no_mangle]
 static SEV_CPUID: MaybeUninit<oak_sev_guest::cpuid::CpuidPage> = MaybeUninit::uninit();
 
-/// The default entry point for the kernel if one wasn't supplied via the QEMU fw_cfg device.
-const DEFAULT_KERNEL_ENTRY: u64 = 0x200000;
-
 /// We create an identity map for the first 1GiB of memory.
 const TOP_OF_VIRTUAL_MEMORY: u64 = Size1GiB::SIZE;
+
+/// The file path used by Stage0 to read the kernel command-line from the fw_cfg device.
+const CMDLINE_FILE_PATH: &[u8] = b"opt/stage0/cmdline\0";
 
 extern "C" {
     #[link_name = "pd_addr"]
@@ -290,38 +294,30 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
         zero_page.add_setup_data(setup_data);
     }
 
-    if let Ok(cmdline_size) = fwcfg.read_cmdline_size() {
-        if cmdline_size > 0 {
-            let mut buf = BOOT_ALLOC
-                .alloc(
-                    Layout::from_size_align(cmdline_size as usize, 1)
-                        .expect("failed to create layout for kernel command line"),
-                )
-                .expect("failed to allocate memory for kernel command line");
-            // Safety: we've now allocated (at least) `cmdline_size` worth of bytes, so turning the
-            // memory into a slice is safe.
-            let buf =
-                unsafe { core::slice::from_raw_parts_mut(buf.as_mut(), cmdline_size as usize) };
-            fwcfg
-                .read_cmdline(buf)
-                .expect("failed to read kernel command line from fw_cfg");
-            zero_page
-                .set_cmdline(CStr::from_bytes_with_nul(buf).expect("invalid kernel command line"));
-        }
+    let cmdline_path = CStr::from_bytes_with_nul(CMDLINE_FILE_PATH).expect("invalid c-string");
+    if let Some(cmdline_file) = fwcfg.find(cmdline_path) {
+        let cmdline_size = cmdline_file.size();
+        // Make the buffer one byte longer so that the kernel command-line is null-terminated.
+        let buf = vec![0u8; cmdline_size + 1].leak();
+        let actual_size = fwcfg
+            .read_file(&cmdline_file, buf)
+            .expect("could not read cmdline");
+        assert_eq!(
+            actual_size, cmdline_size,
+            "cmdline size did not match expected size"
+        );
+
+        let cmdline = CStr::from_bytes_with_nul(buf).expect("invalid kernel command-line");
+        log::debug!(
+            "Kernel cmdline: {}",
+            cmdline.to_str().expect("invalid kernel commande-line")
+        );
+        zero_page.set_cmdline(cmdline);
     }
 
-    // For the Linux boot protocol we use the start address as the entry point. The kernel entry
-    // point provided by the fw_cfg device actually points to the entry point for the PVH boot
-    // protocol. We use an identity mapping.
-    let mut entry = VirtAddr::new(
-        fwcfg
-            .read_kernel_address()
-            .expect("failed to read kernel start addres from fw_cfg")
-            .as_u64(),
-    );
-    if entry.is_null() {
-        entry = VirtAddr::new(DEFAULT_KERNEL_ENTRY);
-    }
+    let kernel_info = kernel::try_load_kernel_image(&mut fwcfg, zero_page.e820_table())
+        .unwrap_or(kernel::KernelInfo::default());
+    let mut entry = kernel_info.entry;
 
     // Attempt to parse 64 bytes at the suggested entry point as an ELF header. If it works, extract
     // the entry point address from there; if there is no valid ELF header at that address, assume
@@ -345,7 +341,8 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
 
     zero_page.set_acpi_rsdp_addr(acpi::build_acpi_tables(&mut fwcfg).unwrap());
 
-    if let Some(ram_disk) = initramfs::try_load_initial_ram_disk(&mut fwcfg, zero_page.e820_table())
+    if let Some(ram_disk) =
+        initramfs::try_load_initial_ram_disk(&mut fwcfg, zero_page.e820_table(), &kernel_info)
     {
         zero_page.set_initial_ram_disk(ram_disk);
     }
@@ -386,4 +383,9 @@ fn panic(info: &PanicInfo) -> ! {
     loop {
         hlt();
     }
+}
+
+fn phys_to_virt(address: PhysAddr) -> VirtAddr {
+    // We use an identity mapping throughout.
+    VirtAddr::new(address.as_u64())
 }


### PR DESCRIPTION
This change adds support for Loading an ELF kernel from stage0 using the QEMU fw_cfg device, parsing it, and laying it out in memory.

QEMU assumes that an ELF kernel passed using the `-kernel` command-line argument will use the PVH boot protocol and lays it out into the guest memory. This causes a problem when booting with SEV enabled, since the kernel data in guest memory does not get encrypted. To work around it we pass the raw kernel ELF file manually via the fw_cfg device.

QEMU does not accept the `-append` or `-initrd` arguments if `-kernel` is not specified, so we also pass those in manually via the fw_cfg device.

Parsing an ELF kernel required adding a global allocator, since paring ELF program headers return a vector.

I also had to enable LTO to make sure stage0 still fits within the expected size with all the additional code added.