### PR TITLE
Use oak_client crate for Oak Functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,9 +1754,12 @@ name = "oak_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "futures-util",
  "log",
+ "micro_rpc",
  "oak_grpc_utils",
+ "oak_remote_attestation_noninteractive",
  "prost",
  "tonic",
 ]
@@ -1845,6 +1848,7 @@ dependencies = [
  "hex",
  "http",
  "log",
+ "oak_client",
  "oak_functions_abi",
  "oak_remote_attestation_noninteractive",
  "p256",
@@ -1886,8 +1890,8 @@ dependencies = [
  "oak_functions_abi",
  "oak_functions_client",
  "oak_functions_test_utils",
+ "oak_grpc_utils",
  "oak_launcher_utils",
- "oak_remote_attestation_noninteractive",
  "prost",
  "rand 0.8.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,6 @@ dependencies = [
  "log",
  "micro_rpc",
  "oak_grpc_utils",
- "oak_remote_attestation_noninteractive",
  "prost",
  "tonic",
 ]
@@ -1850,7 +1849,6 @@ dependencies = [
  "log",
  "oak_client",
  "oak_functions_abi",
- "oak_remote_attestation_noninteractive",
  "p256",
  "prost",
  "regex",
@@ -2032,7 +2030,6 @@ dependencies = [
  "nix 0.26.2",
  "oak_functions_abi",
  "oak_functions_client",
- "oak_remote_attestation_noninteractive",
  "port_check",
  "prost",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ location_utils = { path = "./oak_functions/location_utils" }
 micro_rpc = { path = "./micro_rpc" }
 micro_rpc_build = { path = "./micro_rpc_build" }
 oak_channel = { path = "./oak_channel" }
+oak_client = { path = "./oak_client" }
 oak_core = { path = "./oak_core" }
 oak_enclave_runtime_support = { path = "./oak_enclave_runtime_support" }
 oak_functions_abi = { path = "./oak_functions_abi" }

--- a/oak_client/Cargo.toml
+++ b/oak_client/Cargo.toml
@@ -7,8 +7,11 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "*"
+async-trait = "*"
 futures-util = "*"
 log = "*"
+micro_rpc = { workspace = true }
+oak_remote_attestation_noninteractive = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }
 

--- a/oak_client/Cargo.toml
+++ b/oak_client/Cargo.toml
@@ -11,7 +11,6 @@ async-trait = "*"
 futures-util = "*"
 log = "*"
 micro_rpc = { workspace = true }
-oak_remote_attestation_noninteractive = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }
 

--- a/oak_client/build.rs
+++ b/oak_client/build.rs
@@ -24,7 +24,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "oak_remote_attestation_noninteractive/proto/v1/service_streaming.proto",
         ],
         CodegenOptions {
-            build_server: true,
             build_client: true,
             ..Default::default()
         },

--- a/oak_client/src/transport.rs
+++ b/oak_client/src/transport.rs
@@ -14,29 +14,49 @@
 // limitations under the License.
 //
 
-use crate::proto::streaming_session_client::StreamingSessionClient;
+use crate::proto::{
+    request_wrapper, response_wrapper, streaming_session_client::StreamingSessionClient,
+    InvokeRequest, RequestWrapper,
+};
+use anyhow::Context;
 use tonic::transport::Channel;
 
-pub trait AsyncTransport {
-    // TODO(#3643): Make transport async and update the Rust version to support this.
-    fn invoke(&mut self, request_bytes: &[u8]) -> anyhow::Result<Vec<u8>>;
-}
-
 pub struct GrpcStreamingTransport {
-    _rpc_client: StreamingSessionClient<Channel>,
+    rpc_client: StreamingSessionClient<Channel>,
 }
 
 impl GrpcStreamingTransport {
     pub fn new(rpc_client: StreamingSessionClient<Channel>) -> Self {
-        Self {
-            _rpc_client: rpc_client,
-        }
+        Self { rpc_client }
     }
 }
 
-impl AsyncTransport for GrpcStreamingTransport {
-    // TODO(#3643): Implement gRPC Rust client.
-    fn invoke(&mut self, _request_bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
-        Ok(vec![])
+#[async_trait::async_trait]
+impl micro_rpc::AsyncTransport for GrpcStreamingTransport {
+    type Error = anyhow::Error;
+    async fn invoke(&mut self, request_bytes: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        let mut response_stream = self
+            .rpc_client
+            .stream(futures_util::stream::iter(vec![RequestWrapper {
+                request: Some(request_wrapper::Request::InvokeRequest(InvokeRequest {
+                    encrypted_body: request_bytes.to_vec(),
+                })),
+            }]))
+            .await
+            .context("couldn't send invoke request")?
+            .into_inner();
+
+        // Read the next (and only) message from the response stream.
+        let response_wrapper = response_stream
+            .message()
+            .await
+            .context("gRPC server error when invoking method")?
+            .context("received empty response stream")?;
+
+        let Some(response_wrapper::Response::InvokeResponse(invoke_response)) = response_wrapper.response else {
+            return Err(anyhow::anyhow!("response_wrapper does not have a valid invoke_response message"))
+        };
+
+        Ok(invoke_response.encrypted_body)
     }
 }

--- a/oak_functions/load_test/src/main.rs
+++ b/oak_functions/load_test/src/main.rs
@@ -16,7 +16,7 @@
 
 use anyhow::Context;
 use bencher::stats::Stats;
-use oak_functions_client::Client;
+use oak_functions_client::OakFunctionsClient;
 use std::time::Instant;
 
 // From https://pantheon.corp.google.com/api-gateway/gateway/weather-lookup-grpc/location/europe-west2?project=oak-ci.
@@ -27,7 +27,9 @@ const TOTAL_REQUESTS: usize = 50;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let mut client = Client::new(URL).await.context("couldn't create client")?;
+    let mut client = OakFunctionsClient::new(URL)
+        .await
+        .context("couldn't create client")?;
 
     let mut latencies_millis = Vec::<f64>::with_capacity(TOTAL_REQUESTS);
 

--- a/oak_functions_client/Cargo.toml
+++ b/oak_functions_client/Cargo.toml
@@ -15,6 +15,7 @@ env_logger = "*"
 hex = "*"
 http = "*"
 log = "*"
+oak_client = { workspace = true }
 oak_functions_abi = { workspace = true }
 oak_remote_attestation_noninteractive = { workspace = true }
 p256 = { version = "*", features = ["ecdsa-core", "ecdsa", "pem"] }

--- a/oak_functions_client/Cargo.toml
+++ b/oak_functions_client/Cargo.toml
@@ -17,7 +17,6 @@ http = "*"
 log = "*"
 oak_client = { workspace = true }
 oak_functions_abi = { workspace = true }
-oak_remote_attestation_noninteractive = { workspace = true }
 p256 = { version = "*", features = ["ecdsa-core", "ecdsa", "pem"] }
 prost = { workspace = true }
 regex = "*"

--- a/oak_functions_client/src/main.rs
+++ b/oak_functions_client/src/main.rs
@@ -20,7 +20,7 @@
 use anyhow::Context;
 use clap::Parser;
 use oak_functions_abi::Request;
-use oak_functions_client::Client;
+use oak_functions_client::OakFunctionsClient;
 use regex::Regex;
 
 const TWO_MIB: usize = 2 * 1024 * 1024;
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let opt = Opt::parse();
 
-    let mut client = Client::new(&opt.uri)
+    let mut client = OakFunctionsClient::new(&opt.uri)
         .await
         .context("couldn't create Oak Functions client")?;
 

--- a/oak_functions_launcher/Cargo.toml
+++ b/oak_functions_launcher/Cargo.toml
@@ -28,7 +28,6 @@ tonic = "*"
 tonic-web = { version = "*", optional = true }
 oak_functions_abi = { workspace = true }
 oak_launcher_utils = { workspace = true }
-oak_remote_attestation_noninteractive = { workspace = true }
 micro_rpc = { workspace = true }
 oak_channel = { workspace = true, features = ["client"] }
 hashbrown = "*"
@@ -36,6 +35,7 @@ ubyte = "*"
 
 [build-dependencies]
 micro_rpc_build = { workspace = true }
+oak_grpc_utils = { workspace = true }
 
 [dev-dependencies]
 oak_functions_client = { workspace = true }

--- a/oak_functions_launcher/build.rs
+++ b/oak_functions_launcher/build.rs
@@ -14,7 +14,23 @@
 // limitations under the License.
 //
 
+use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Generate gRPC code for exchanging messages with clients.
+    generate_grpc_code(
+        "../",
+        &[
+            "oak_remote_attestation_noninteractive/proto/v1/messages.proto",
+            "oak_remote_attestation_noninteractive/proto/v1/service_streaming.proto",
+        ],
+        CodegenOptions {
+            build_server: true,
+            ..Default::default()
+        },
+    )?;
+
+    // Generate micro RPC code for exchanging messages with the enclave.
     micro_rpc_build::compile(
         &[format!(
             "{}oak_functions_service/proto/oak_functions.proto",

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -18,6 +18,19 @@
 #![feature(result_flattening)]
 #![feature(array_chunks)]
 
+mod lookup;
+pub mod server;
+
+pub mod proto {
+    #![allow(clippy::return_self_not_must_use)]
+    tonic::include_proto!("oak.session.noninteractive.v1");
+}
+pub mod schema {
+    #![allow(dead_code)]
+    use prost::Message;
+    include!(concat!(env!("OUT_DIR"), "/oak.functions.rs"));
+}
+
 use crate::schema::InitializeResponse;
 use anyhow::Context;
 use oak_launcher_utils::{
@@ -27,15 +40,6 @@ use oak_launcher_utils::{
 use schema::OakFunctionsAsyncClient;
 use std::{fs, path::PathBuf, time::Duration};
 use ubyte::ByteUnit;
-
-pub mod schema {
-    #![allow(dead_code)]
-    use prost::Message;
-    include!(concat!(env!("OUT_DIR"), "/oak.functions.rs"));
-}
-
-mod lookup;
-pub mod server;
 
 pub struct LookupDataConfig {
     pub lookup_data_path: PathBuf,

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -14,12 +14,16 @@
 // limitations under the License.
 //
 
-use crate::{channel::ConnectorHandle, schema};
-use futures::{Future, Stream, StreamExt};
-use oak_remote_attestation_noninteractive::proto::{
-    request_wrapper, response_wrapper, streaming_session_server::StreamingSessionServer,
-    InvokeResponse, RequestWrapper, ResponseWrapper,
+use crate::{
+    channel::ConnectorHandle,
+    proto::{
+        request_wrapper, response_wrapper,
+        streaming_session_server::{StreamingSession, StreamingSessionServer},
+        InvokeResponse, RequestWrapper, ResponseWrapper,
+    },
+    schema,
 };
+use futures::{Future, Stream, StreamExt};
 use std::{net::SocketAddr, pin::Pin};
 use tonic::{transport::Server, Request, Response, Status, Streaming};
 
@@ -31,9 +35,7 @@ pub struct SessionProxy {
 }
 
 #[tonic::async_trait]
-impl oak_remote_attestation_noninteractive::proto::streaming_session_server::StreamingSession
-    for SessionProxy
-{
+impl StreamingSession for SessionProxy {
     type StreamStream = Pin<Box<dyn Stream<Item = Result<ResponseWrapper, Status>> + Send>>;
 
     async fn stream(

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -57,7 +57,7 @@ async fn test_launcher_virtual() {
     // Wait for the server to start up.
     tokio::time::sleep(Duration::from_secs(8)).await;
 
-    let mut client = oak_functions_client::Client::new("http://localhost:8080")
+    let mut client = oak_functions_client::OakFunctionsClient::new("http://localhost:8080")
         .await
         .unwrap();
 

--- a/oak_functions_test_utils/Cargo.toml
+++ b/oak_functions_test_utils/Cargo.toml
@@ -15,7 +15,6 @@ hyper = { version = "*", features = ["client", "http1", "runtime", "server"] }
 nix = "*"
 oak_functions_abi = { workspace = true }
 oak_functions_client = { workspace = true }
-oak_remote_attestation_noninteractive = { workspace = true }
 port_check = "*"
 prost = { workspace = true }
 tempfile = "*"

--- a/oak_functions_test_utils/src/lib.rs
+++ b/oak_functions_test_utils/src/lib.rs
@@ -266,7 +266,9 @@ pub async fn make_request(port: u16, request_body: &[u8]) -> Vec<u8> {
     let uri = format!("http://localhost:{port}/");
 
     // Create client
-    let mut client = OakFunctionsClient::new(&uri).await.expect("couldn't create client");
+    let mut client = OakFunctionsClient::new(&uri)
+        .await
+        .expect("couldn't create client");
 
     client
         .invoke(request_body)

--- a/oak_functions_test_utils/src/lib.rs
+++ b/oak_functions_test_utils/src/lib.rs
@@ -20,7 +20,7 @@ use anyhow::Context;
 use log::info;
 use nix::unistd::Pid;
 use oak_functions_abi::Response;
-use oak_functions_client::Client;
+use oak_functions_client::OakFunctionsClient;
 use prost::Message;
 use std::{
     collections::HashMap, future::Future, io::Write, pin::Pin, process::Command, task::Poll,
@@ -266,7 +266,7 @@ pub async fn make_request(port: u16, request_body: &[u8]) -> Vec<u8> {
     let uri = format!("http://localhost:{port}/");
 
     // Create client
-    let mut client = Client::new(&uri).await.expect("couldn't create client");
+    let mut client = OakFunctionsClient::new(&uri).await.expect("couldn't create client");
 
     client
         .invoke(request_body)


### PR DESCRIPTION
This PR adds `oak_client` dependency to `oak_functions_client` and removes the oak_remote_attestation_noninteractive` crate dependency from `oak_functions_launcher`.

This PR is a split from https://github.com/project-oak/oak/pull/3790

Ref https://github.com/project-oak/oak/issues/3643