### PR TITLE
Add HPKE proto messages to oak_crypto

### DIFF
--- a/oak_crypto/proto/crypto.proto
+++ b/oak_crypto/proto/crypto.proto
@@ -21,6 +21,26 @@ package oak.crypto;
 option java_multiple_files = true;
 option java_package = "oak.crypto";
 
+// Request message encrypted using Hybrid Public Key Encryption (HPKE).
+// <https://www.rfc-editor.org/rfc/rfc9180.html>
+message HpkeRequest {
+  // Message encrypted with Authenticated Encryption with Associated Data (AEAD)
+  // using the derived session key.
+  AeadEncryptedMessage encrypted_message = 1;
+  // Ephemeral Diffie-Hellman key that is needed to derive a session key.
+  // Only sent in the first message of the secure session.
+  optional bytes serialized_encapsulated_public_key = 2;
+}
+
+// Response message encrypted Hybrid Public Key Encryption (HPKE), which uses a
+// response key generated as part of bidirectional encryption.
+// <https://www.rfc-editor.org/rfc/rfc9180.html#name-bidirectional-encryption>
+message HpkeResponse {
+  // Message encrypted with Authenticated Encryption with Associated Data (AEAD)
+  // using the derived session key.
+  AeadEncryptedMessage encrypted_message = 1;
+}
+
 // Message encrypted with Authenticated Encryption with Associated Data (AEAD).
 // <https://datatracker.ietf.org/doc/html/rfc5116>
 message AeadEncryptedMessage {


### PR DESCRIPTION
This PR adds `HpkeRequest` and `HpkeResponse` proto messages.

This PR is a split from https://github.com/project-oak/oak/pull/3790

Ref https://github.com/project-oak/oak/issues/3767