### PR TITLE
Refactor oak_channel to be less reliant on vectors

### DIFF
--- a/oak_channel/src/client.rs
+++ b/oak_channel/src/client.rs
@@ -51,7 +51,7 @@ impl RequestEncoder {
         let invocation_id = self.invocation_id_counter.next_invocation_id();
         RequestMessage {
             invocation_id,
-            body: request_body.to_vec(),
+            body: request_body.into(),
         }
     }
 }

--- a/oak_channel/src/server.rs
+++ b/oak_channel/src/server.rs
@@ -30,7 +30,10 @@ pub fn start_blocking_server<T: micro_rpc::Transport<Error = !>>(
             .read_request()
             .context("couldn't receive message")?;
         let request_message_invocation_id = request_message.invocation_id;
-        let response = server.invoke(request_message.body.as_ref()).into_ok();
+        let response = server
+            .invoke(request_message.body.as_ref())
+            .into_ok()
+            .into_boxed_slice();
         let response_message = message::ResponseMessage {
             invocation_id: request_message_invocation_id,
             body: response,

--- a/oak_launcher_utils/src/channel.rs
+++ b/oak_launcher_utils/src/channel.rs
@@ -71,7 +71,7 @@ impl Connector {
             response_message.invocation_id
         );
 
-        Ok(response_message.body)
+        Ok(response_message.body.to_vec())
     }
 }
 


### PR DESCRIPTION
The overarching goal here is to reduce the amount of data copies we do: for example, right now we build a Vec for each frame, then copy data from those Vec-s to a larger Vec, and so on. It's inefficient.

I'm aiming to get to a point where `read_frame` writes data directly into the `encoded_message` buffer. This PR changes some signatures to take just `&[u8]` instead of `Vec<u8>`, specifically.

And while I'm in here... `Vec`s have the nice property of you being able to extend them at will... but most of the time, we don't need it, and a bog-standard `Box<[u8]>` is enough as we know the fixed size beforehand.


