### PR TITLE
Get rid of one data copy in `oak_channel`

### DIFF
--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -5,16 +5,6 @@ set -o nounset
 set -o xtrace
 set -o pipefail
 
-# On Kokoro instances /dev/kvm, /dev/vhost-vsock and /dev/vsock are owned by root:root.
-# Set the permissions so that these are owned by the `kvm` group as our scripts expect it to be.
-readonly KVM_GID="$(getent group kvm | cut -d: -f3)"
-sudo chown "$USER:$KVM_GID" /dev/kvm
-
-sudo /etc/init.d/docker stop
-sudo mv /var/lib/docker /tmpfs/
-sudo ln -s /tmpfs/docker /var/lib/docker
-sudo /etc/init.d/docker start
-
 export CI=kokoro
 
 export RUST_BACKTRACE=1

--- a/oak_channel/src/message.rs
+++ b/oak_channel/src/message.rs
@@ -33,7 +33,7 @@ pub const BODY_OFFSET: usize = 8;
 pub trait Message {
     fn len(&self) -> usize;
     fn encode(self) -> Vec<u8>;
-    fn decode(frames: Vec<u8>) -> Self;
+    fn decode(frames: &[u8]) -> Self;
 }
 
 /// Rust implementation of the Request Message structure defined in
@@ -64,7 +64,7 @@ impl Message for RequestMessage {
         message_bytes
     }
 
-    fn decode(mut encoded_message: Vec<u8>) -> Self {
+    fn decode(encoded_message: &[u8]) -> Self {
         let invocation_id = {
             let mut invocation_id_bytes: [u8; INVOCATION_ID_SIZE] = [0; INVOCATION_ID_SIZE];
             invocation_id_bytes.copy_from_slice(
@@ -74,7 +74,7 @@ impl Message for RequestMessage {
         };
         // TODO(#2848): Avoid reallocating here by using slices + lifetimes, or
         // reference counting.
-        let body: Vec<u8> = encoded_message.drain(BODY_OFFSET..).collect();
+        let body: Vec<u8> = encoded_message[BODY_OFFSET..].into();
 
         Self {
             invocation_id,
@@ -111,7 +111,7 @@ impl Message for ResponseMessage {
         message_bytes
     }
 
-    fn decode(mut encoded_message: Vec<u8>) -> Self {
+    fn decode(encoded_message: &[u8]) -> Self {
         let invocation_id = {
             let mut invocation_id_bytes: [u8; INVOCATION_ID_SIZE] = [0; INVOCATION_ID_SIZE];
             invocation_id_bytes.copy_from_slice(
@@ -121,7 +121,7 @@ impl Message for ResponseMessage {
         };
         // TODO(#2848): Avoid reallocating here by using slices + lifetimes, or
         // reference counting.
-        let body: Vec<u8> = encoded_message.drain(BODY_OFFSET..).collect();
+        let body: Vec<u8> = encoded_message[BODY_OFFSET..].into();
 
         Self {
             invocation_id,


### PR DESCRIPTION
Instead of passing around vectors, this changes some APIs to take in references to slices instead.

After all that, we can now instantiate one vector for the whole frame and read directly into that, instead of allocating many smaller vectors that need to be copied into `encoded_message`.

Unfortunately we still need some special treatment (which may involve a copy) for the first frame, as at that point we don't yet know how much space we need for the whole message.