### PR TITLE
Unshare fw_cfg DMA buffers earlier

### DIFF
--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -323,14 +323,15 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
 
     log::info!("jumping to kernel at {:#018x}", entry.as_u64());
 
+    if encrypted > 0 {
+        sev::unshare_page(Page::containing_address(dma_buf_address), snp, encrypted);
+        sev::unshare_page(Page::containing_address(dma_access_address), snp, encrypted);
+    }
+
     // Clean-ups we need to do just before we jump to the kernel proper: clean up the early GHCB we
     // used and switch back to a hugepage for the first 2M of memory.
     if ghcb_protocol.is_some() {
         sev::deinit_ghcb(snp, encrypted);
-    }
-    if encrypted > 0 {
-        sev::unshare_page(Page::containing_address(dma_buf_address), snp, encrypted);
-        sev::unshare_page(Page::containing_address(dma_access_address), snp, encrypted);
     }
 
     // Allow identity-op to keep the fact that the address we're talking about here is 0x00.

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -114,13 +114,13 @@ pub fn unshare_page(page: Page<Size4KiB>, snp: bool, encrypted: u64) {
     if snp {
         let request = SnpPageStateChangeRequest::new(page_start as usize, PageAssignment::Private)
             .expect("invalid address for page location");
-        change_snp_page_state(request).expect("couldn't change SNP state for page");
+        change_snp_page_state(request).expect("couldn't change SNP state for unsharing page");
         pvalidate(
             page_start as usize,
             SevPageSize::Page4KiB,
             Validation::Validated,
         )
-        .unwrap();
+        .expect("couldn't revalidate unshared page");
     }
 
     let PageTables { pdpt: _, pd } = get_page_tables(encrypted);


### PR DESCRIPTION
We suspect the sev-snp flakiness is caused by unsharing the buffers. This should cause the issue to happen before the GHCB is removed so we should be able to get logs.