### PR TITLE
Temporarily stop unsharing pages in Stage0

### DIFF
--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -323,16 +323,6 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
 
     log::info!("jumping to kernel at {:#018x}", entry.as_u64());
 
-    // Clean-ups we need to do just before we jump to the kernel proper: clean up the early GHCB we
-    // used and switch back to a hugepage for the first 2M of memory.
-    if ghcb_protocol.is_some() {
-        sev::deinit_ghcb(snp, encrypted);
-    }
-    if encrypted > 0 {
-        sev::unshare_page(Page::containing_address(dma_buf_address), snp, encrypted);
-        sev::unshare_page(Page::containing_address(dma_access_address), snp, encrypted);
-    }
-
     // Allow identity-op to keep the fact that the address we're talking about here is 0x00.
     #[allow(clippy::identity_op)]
     pd[0].set_addr(


### PR DESCRIPTION
This is a temporary fix to hopefully resolve AMD SEV-SNP flakiness for now until we are able to find the root cause and make the unsharing more robust.

This should not affect the operation of the Oak Restricted Kernel as it avoids the lowest 2MiB of physical memory anyway.