### PR TITLE
Fix broken links in oak_functions README

### DIFF
--- a/oak_functions/README.md
+++ b/oak_functions/README.md
@@ -52,7 +52,7 @@ from the conventional computing model.
 
 ## Features
 
-### Oak Functions Loader and the Trusted Runtime
+### Oak Functions Launcher and the Trusted Runtime
 
 The [Oak Functions Launcher](/oak_functions_launcher/) starts the Oak Functions
 trusted runtime and loads a Wasm module as workload. The Oak Functions trusted

--- a/oak_functions/README.md
+++ b/oak_functions/README.md
@@ -6,9 +6,9 @@ preserving way. Oak Functions leverages TEEs and remote attestation, Wasm
 sandboxing.
 
 At its core, Oak Functions consists of a **trusted runtime** compiled into a
-server binary ([`oak_functions_loader`](loader/)) that, for each incoming client
-gRPC request, executes a workload that operates on the request payload, and
-produces a response which is sent back to the same client.
+server binary ([`oak_functions_launcher`](/oak_functions_launcher/)) that, for
+each incoming client gRPC request, executes a workload that operates on the
+request payload, and produces a response which is sent back to the same client.
 
 The Oak Functions trusted runtime ensures that the workload may not violate the
 confidentiality of the client request data, preventing observers from learning
@@ -54,20 +54,18 @@ from the conventional computing model.
 
 ### Oak Functions Loader and the Trusted Runtime
 
-The [Oak Functions Loader](loader/) starts the Oak Functions trusted runtime and
-loads a Wasm module as workload. The Oak Functions trusted runtime and the Wasm
-module communicate through
-[ABI Functions and a Rust SDK](loader/README.md#abi-functions-and-the-rust-sdk).
-To serve client requests, the Oak Functions trusted runtime has
-[Read-Only Storage](loader/README.md#read-only-storage). The Oak Functions
-trusted runtime allows to specify [Policies](loader/README.md#read-only-storage)
-such as a fixed size and processing time for responses returned by the trusted
-runtime, and a fixed processing time.
+The [Oak Functions Launcher](/oak_functions_launcher/) starts the Oak Functions
+trusted runtime and loads a Wasm module as workload. The Oak Functions trusted
+runtime and the Wasm module communicate through
+[ABI Functions](/oak_functions_abi/) and [a Rust SDK](oak_functions_sdk).The Oak
+Functions trusted runtime allows to specify policies such as a fixed size and
+processing time for responses returned by the trusted runtime, and a fixed
+processing time.
 
 ### Remote Attestation
 
-The [Remote Attestation protocol](/remote_attestation) implemented in Oak is
-currently integrated in Oak Functions.
+The [Remote Attestation protocol](/docs/remote-attestation.md) implemented in
+Oak is currently integrated in Oak Functions.
 
 ## Applications
 


### PR DESCRIPTION
I removed the part about "Read-Only Storage" and the link to "Policies" as I cannot find them in the repo.