### PR TITLE
Rename the auto-built `stage0.bin` to just `stage0`

### DIFF
--- a/buildconfigs/stage0.toml
+++ b/buildconfigs/stage0.toml
@@ -11,6 +11,6 @@ command = [
   "--release",
   "--",
   "--output-target=binary",
-  "target/x86_64-unknown-none/release/stage0.bin"
+  "target/x86_64-unknown-none/release/stage0"
 ]
-output_path = "./stage0/target/x86_64-unknown-none/release/stage0.bin"
+output_path = "./stage0/target/x86_64-unknown-none/release/stage0"


### PR DESCRIPTION
When we try to import `stage0.bin` for internal use, it generates a directory named `stage0.bin` which Bazel doesn't like.

Thus, let's rename `stage0.bin` to just plain `stage0`.