### PR TITLE
Fix Stage0 SEV-SNP errors

### DIFF
--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -242,6 +242,21 @@ impl FwCfg {
     pub fn read_file(&mut self, file: &DirEntry, buf: &mut [u8]) -> Result<usize, &'static str> {
         self.write_selector(file.selector())?;
         let len = min(buf.len(), file.size());
+        self.read_buf(&mut buf[..len])?;
+        Ok(len)
+    }
+
+    /// Reads contents of a file using DMA; returns the number of bytes actually read.
+    ///
+    /// The buffer `buf` will be filled to capacity if the file is larger;
+    /// if it is shorter, the trailing bytes will not be touched.
+    pub fn read_file_dma(
+        &mut self,
+        file: &DirEntry,
+        buf: &mut [u8],
+    ) -> Result<usize, &'static str> {
+        self.write_selector(file.selector())?;
+        let len = min(buf.len(), file.size());
         self.read_buf_dma(&mut buf[..len])?;
         Ok(len)
     }

--- a/stage0/src/initramfs.rs
+++ b/stage0/src/initramfs.rs
@@ -51,7 +51,7 @@ pub fn try_load_initial_ram_disk(
     // layout or alignment.
     let buf = unsafe { slice::from_raw_parts_mut::<u8>(address.as_mut_ptr(), size) };
     let actual_size = fw_cfg
-        .read_file(&file, buf)
+        .read_file_dma(&file, buf)
         .expect("could not read initial RAM disk");
     assert_eq!(
         actual_size, size,

--- a/stage0/src/kernel.rs
+++ b/stage0/src/kernel.rs
@@ -106,7 +106,7 @@ pub fn try_load_kernel_image(
     let buf = unsafe { slice::from_raw_parts_mut::<u8>(start_address.as_mut_ptr(), size) };
 
     let actual_size = fw_cfg
-        .read_file(&file, buf)
+        .read_file_dma(&file, buf)
         .expect("could not read kernel file");
     assert_eq!(actual_size, size, "kernel size did not match expected size");
 

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -82,9 +82,10 @@ pub fn init_ghcb(
     GHCB_WRAPPER.get().unwrap()
 }
 
-pub fn deinit_ghcb(snp: bool, encrypted: u64) {
+/// Stops sharing the GHCB with the hypervisor when running with AMD SEV-SNP enabled.
+pub fn deinit_ghcb() {
     let ghcb_addr = VirtAddr::new(GHCB_WRAPPER.get().unwrap().lock().get_gpa().as_u64());
-    unshare_page(Page::containing_address(ghcb_addr), snp, encrypted);
+    unshare_page(Page::containing_address(ghcb_addr));
 }
 
 /// Shares a single 4KiB page with the hypervisor.
@@ -108,29 +109,12 @@ pub fn share_page(page: Page<Size4KiB>, snp: bool, encrypted: u64) {
     }
 }
 
-/// Stops sharing a single 4KiB page with the hypervisor.
-pub fn unshare_page(page: Page<Size4KiB>, snp: bool, encrypted: u64) {
+/// Stops sharing a single 4KiB page with the hypervisor when running with AMD SEV-SNP enabled.
+pub fn unshare_page(page: Page<Size4KiB>) {
     let page_start = page.start_address().as_u64();
-    if snp {
-        let request = SnpPageStateChangeRequest::new(page_start as usize, PageAssignment::Private)
-            .expect("invalid address for page location");
-        change_snp_page_state(request).expect("couldn't change SNP state for page");
-        pvalidate(
-            page_start as usize,
-            SevPageSize::Page4KiB,
-            Validation::Validated,
-        )
-        .unwrap();
-    }
-
-    let PageTables { pdpt: _, pd } = get_page_tables(encrypted);
-    let pt = unsafe { &mut *((pd[0].addr().as_u64() & !encrypted) as *mut PageTable) };
-    let idx = (page_start / Size4KiB::SIZE) as usize;
-    pt[idx].set_addr(
-        PhysAddr::new(page_start | encrypted),
-        PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
-    );
-    tlb::flush_all();
+    let request = SnpPageStateChangeRequest::new(page_start as usize, PageAssignment::Private)
+        .expect("invalid address for page location");
+    change_snp_page_state(request).expect("couldn't change SNP state for page");
 }
 
 // Page tables come in three sizes: for 1 GiB, 2 MiB and 4 KiB pages. However, `PVALIDATE` can only


### PR DESCRIPTION
When testing the latest Stage0 image on AMD SEV-SNP we found some issues. To fix these:

- Don't PVALIDATE pages when unsharing pages
  - Also, we don't need to change the encryption bit for the pages when unsharing, as we set it for the entire first 2MiB huge page when we switch back to using a huge page
- Loading the ACPI tables using fw_cfg DMA is not currently supported, so we only use DMA for the kernel image and initial RAM disk when booting Linux
