### PR TITLE
Set MTRR caching mode to enable recent kernels to boot into SEV

### DIFF
--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -177,6 +177,7 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
     let dma_access = BOOT_ALLOC.leak(fw_cfg::FwCfgDmaAccess::default()).unwrap();
     let dma_access_address = VirtAddr::from_ptr(dma_access as *const _);
     if encrypted > 0 {
+        sev::enable_mtrr();
         sev::share_page(Page::containing_address(dma_buf_address), snp, encrypted);
         sev::share_page(Page::containing_address(dma_access_address), snp, encrypted);
     }


### PR DESCRIPTION
I accidentally pushed my change before syncing with upstream which is why there are 2 commits: one to enable MTRR and then the merge with upstream.

This PR sets the MTRR register to use write-protect caching mode by default.  This enables the kernel to pass its check that MTRR and PAT are enabled, and that caching mode is set to write-protect.  A warning is still issued by the kernel since Stage0 only sets the MTRR register on one CPU.  The kernel then propagates this setting to the other CPUs.