### PR TITLE
Reset GHCB after marking memory as unencrypted

### DIFF
--- a/oak_sev_guest/src/ghcb.rs
+++ b/oak_sev_guest/src/ghcb.rs
@@ -287,6 +287,11 @@ where
         Self { ghcb, gpa }
     }
 
+    /// Resets all of the inner GHCB information to its original state.
+    pub fn reset(&mut self) {
+        self.ghcb.as_mut().reset();
+    }
+
     /// Gets the guest-physical address for the guest-hypervisor communication block.
     pub fn get_gpa(&self) -> PhysAddr {
         self.gpa
@@ -438,11 +443,11 @@ where
     fn do_vmg_exit(&mut self) -> Result<(), &'static str> {
         self.ghcb.as_mut().protocol_version = GHCB_PROTOCOL_VERSION;
         // Use a memory fence to ensure all writes happen before we hand over to the VMM.
-        core::sync::atomic::fence(core::sync::atomic::Ordering::Release);
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
         set_ghcb_address_and_exit(GhcbGpa::new(self.get_gpa().as_u64() as usize)?);
         // Use a memory fence to ensure that all earlier writes are commited before we read from the
         // GHCB.
-        core::sync::atomic::fence(core::sync::atomic::Ordering::Acquire);
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
 
         // The mask for extracting the hypervisor's return value from the sw_exit_info_1 field.
         const SW_EXIT_INFO_1_RETURN_MASK: u64 = 0xffff_ffff;

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -70,6 +70,8 @@ pub fn init_ghcb(
             .expect("couldn't register the GHCB address with the hypervisor");
     }
 
+    ghcb.reset();
+
     // We can't use `.expect()` here as Spinlock doesn't implement `fmt::Debug`.
     if GHCB_WRAPPER
         .set(Spinlock::new(GhcbProtocol::new(ghcb, |vaddr: VirtAddr| {


### PR DESCRIPTION
This change addresses some flakiness when running stage0 and the Oak Restricted Kernel with SEV-ES or SEV-SNP enabled.

There seems to be an occasional timing issue around the GHCB when marking it as unencrypted, with the GHCB becoming corrupted. To make sure it stays consistent we reset it to all zeros every time after the page has been marked as not encrypted and the TLB has been flushed.

This change also makes sure that stage0 and the restricted kernel follows the same order of steps when sharing the GHCB with the hypervisor (mark it unencrypted, flush TLB, mark it as shared in the RMP, register the location with the hypervisor) for consitency.

Lastly I also decided to add stronger memory fences around the VMGEXIT call as an extra assurance.