### PR TITLE
Fix cargo deny error and warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,9 +3256,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spinning_top"
@@ -3909,7 +3909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677160b1166881badada1137afc6457777126f328ae63a18058b504f546f0828"
 dependencies = [
  "smallvec",
- "spin 0.9.7",
+ "spin 0.9.8",
  "wasmi_arena",
  "wasmi_core",
  "wasmparser-nostd",

--- a/deny.toml
+++ b/deny.toml
@@ -8,12 +8,12 @@ targets = [{ triple = "x86_64-unknown-linux-musl" }]
 [advisories]
 vulnerability = "deny"
 unmaintained = "deny"
+unsound = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = [
-  "RUSTSEC-2021-0146",
-  # TODO(#3377): Remove when updated.
-  "RUSTSEC-2022-0061",
+  # TODO(#3845): Stop ignoring when the colored crate no longer relies on atty.
+  "RUSTSEC-2021-0145",
 ]
 
 [bans]
@@ -32,12 +32,10 @@ allow = [
   "Apache-2.0 WITH LLVM-exception",
   "BSD-2-Clause",
   "BSD-3-Clause",
-  "CC0-1.0",
   "ISC",
   "MIT",
   "MPL-2.0",
   "OpenSSL",
-  "Zlib",
   "Unicode-DFS-2016",
 ]
 copyleft = "deny"

--- a/oak_functions_enclave_app/Cargo.lock
+++ b/oak_functions_enclave_app/Cargo.lock
@@ -1186,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spinning_top"

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -62,7 +62,7 @@ async fn test_launcher_virtual() {
     .await;
 
     // Wait for the server to start up.
-    tokio::time::sleep(Duration::from_secs(8)).await;
+    tokio::time::sleep(Duration::from_secs(20)).await;
 
     let mut client = oak_functions_client::OakFunctionsClient::new("http://localhost:8080")
         .await

--- a/oak_restricted_kernel_bin/deny.toml
+++ b/oak_restricted_kernel_bin/deny.toml
@@ -24,5 +24,11 @@ unknown-git = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = ["Apache-2.0", "BSD-2-Clause", "MIT", "Unicode-DFS-2016"]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "MIT",
+    "Unicode-DFS-2016"
+]
 copyleft = "deny"

--- a/oak_restricted_kernel_bin/deny.toml
+++ b/oak_restricted_kernel_bin/deny.toml
@@ -25,10 +25,10 @@ unknown-git = "allow"
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
 allow = [
-    "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "MIT",
-    "Unicode-DFS-2016"
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MIT",
+  "Unicode-DFS-2016"
 ]
 copyleft = "deny"

--- a/oak_tensorflow_enclave_app/deny.toml
+++ b/oak_tensorflow_enclave_app/deny.toml
@@ -8,6 +8,7 @@ targets = [{ triple = "x86_64-unknown-linux-musl" }]
 [advisories]
 vulnerability = "deny"
 unmaintained = "deny"
+unsound = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = []
@@ -23,11 +24,5 @@ unknown-git = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = [
-  "Apache-2.0",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "MIT",
-  "Unicode-DFS-2016"
-]
+allow = ["Apache-2.0", "MIT", "Unicode-DFS-2016"]
 copyleft = "deny"

--- a/quirk_echo_enclave_app/deny.toml
+++ b/quirk_echo_enclave_app/deny.toml
@@ -8,6 +8,7 @@ targets = [{ triple = "x86_64-unknown-linux-musl" }]
 [advisories]
 vulnerability = "deny"
 unmaintained = "deny"
+unsound = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = []
@@ -23,11 +24,5 @@ unknown-git = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = [
-  "Apache-2.0",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "MIT",
-  "Unicode-DFS-2016"
-]
+allow = ["Apache-2.0", "MIT", "Unicode-DFS-2016"]
 copyleft = "deny"

--- a/testing/oak_echo_enclave_app/deny.toml
+++ b/testing/oak_echo_enclave_app/deny.toml
@@ -8,6 +8,7 @@ targets = [{ triple = "x86_64-unknown-linux-musl" }]
 [advisories]
 vulnerability = "deny"
 unmaintained = "deny"
+unsound = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = []
@@ -23,11 +24,5 @@ unknown-git = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = [
-  "Apache-2.0",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "MIT",
-  "Unicode-DFS-2016"
-]
+allow = ["Apache-2.0", "MIT", "Unicode-DFS-2016"]
 copyleft = "deny"

--- a/testing/oak_echo_raw_enclave_app/deny.toml
+++ b/testing/oak_echo_raw_enclave_app/deny.toml
@@ -8,6 +8,7 @@ targets = [{ triple = "x86_64-unknown-linux-musl" }]
 [advisories]
 vulnerability = "deny"
 unmaintained = "deny"
+unsound = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = []
@@ -23,11 +24,5 @@ unknown-git = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = [
-  "Apache-2.0",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "MIT",
-  "Unicode-DFS-2016"
-]
+allow = ["Apache-2.0", "MIT", "Unicode-DFS-2016"]
 copyleft = "deny"

--- a/testing/sev_snp_hello_world_kernel/deny.toml
+++ b/testing/sev_snp_hello_world_kernel/deny.toml
@@ -8,6 +8,7 @@ targets = [{ triple = "x86_64-unknown-linux-musl" }]
 [advisories]
 vulnerability = "deny"
 unmaintained = "deny"
+unsound = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = []
@@ -23,11 +24,5 @@ unknown-git = "allow"
 # List of allowed licenses.
 # For more detailed information see http://go/thirdpartylicenses.
 [licenses]
-allow = [
-  "Apache-2.0",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "MIT",
-  "Unicode-DFS-2016"
-]
+allow = ["Apache-2.0", "BSD-2-Clause", "MIT", "Unicode-DFS-2016"]
 copyleft = "deny"


### PR DESCRIPTION
This change updates the `spin` crate to a version that has not been yanked.

It also resolves the warning and starts treating unsound advisories as errors rather than warnings.

Side note: I also increase the time the oak functions launcher integration tests waited for the server to start up, as the Kokoro tests were very flaky due to the server not always starting up in time.