### PR TITLE
Add C++ crypto template

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,6 +29,17 @@ http_archive(
     ],
 )
 
+# Google Abseil.
+# https://github.com/abseil/abseil-cpp
+http_archive(
+    name = "com_google_absl",
+    sha256 = "91ac87d30cc6d79f9ab974c51874a704de9c2647c40f6932597329a282217ba8",
+    strip_prefix = "abseil-cpp-20220623.1",
+    urls = [
+        "https://github.com/abseil/abseil-cpp/archive/20220623.1.tar.gz",
+    ],
+)
+
 http_archive(
     name = "tink_base",
     sha256 = "536a4ceb3e9e7e35bf52f7cc99838679de8463ab2a1a12b90121c00ee25fe252",

--- a/cc/crypto/BUILD
+++ b/cc/crypto/BUILD
@@ -1,0 +1,41 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "encryptor",
+    srcs = ["encryptor.cc"],
+    hdrs = ["encryptor.h"],
+    deps = [
+        ":hpke",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "hpke",
+    srcs = ["hpke.cc"],
+    hdrs = ["hpke.h"],
+    deps = [
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)

--- a/cc/crypto/encryptor.cc
+++ b/cc/crypto/encryptor.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "encryptor.h"
+
+namespace oak::crypto {}  // namespace oak::crypto

--- a/cc/crypto/encryptor.h
+++ b/cc/crypto/encryptor.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CC_CRYPTO_ENCRYPTOR_H_
+#define CC_CRYPTO_ENCRYPTOR_H_
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "cc/crypto/hpke.h"
+
+namespace oak::crypto {
+
+// Info string used by Hybrid Public Key Encryption.
+constexpr absl::string_view OAK_HPKE_INFO = "Oak Hybrid Public Key Encryption v1";
+
+// Encryptor class for encrypting client requests that will be sent to the server and decrypting
+// server responses that are received by the client. Each Encryptor object corresponds to a
+// single crypto session between the client and the server.
+//
+// Sequence numbers for requests and responses are incremented separately, meaning that there could
+// be multiple responses per request and multiple requests per response.
+class ClientEncryptor {
+ public:
+  // `serialized_server_public_key` must be a NIST P-256 SEC1 encoded point public key.
+  // <https://secg.org/sec1-v2.pdf>
+  static absl::StatusOr<std::unique_ptr<ClientEncryptor>> Create(
+      absl::string_view serialized_server_public_key);
+
+  // Encrypts `plaintext` and authenticates `associated_data` using AEAD.
+  // <https://datatracker.ietf.org/doc/html/rfc5116>
+  //
+  // Returns a serialized [`oak.crypto.EncryptedRequest`] message.
+  // TODO(#3843): Return unserialized proto messages once we have Java encryption without JNI.
+  absl::StatusOr<std::string> encrypt(absl::string_view plaintext,
+                                      absl::string_view associated_data);
+
+  // Decrypts a [`EncryptedResponse`] proto message using AEAD.
+  // <https://datatracker.ietf.org/doc/html/rfc5116>
+  //
+  // `encrypted_response` must be a serialized [`oak.crypto.EncryptedResponse`] message.
+  // Returns a response message plaintext and associated data.
+  // TODO(#3843): Accept unserialized proto messages once we have Java encryption without JNI.
+  std::tuple<std::string, std::string> decrypt(absl::string_view encrypted_response);
+
+ private:
+  // Encapsulated public key needed to establish a symmetric session key.
+  // Only sent in the initial request message of the session.
+  std::string serialized_encapsulated_public_key;
+  std::unique_ptr<SenderRequestContext> sender_request_context;
+  std::unique_ptr<SenderResponseContext> sender_response_context;
+};
+
+}  // namespace oak::crypto
+
+#endif  // CC_CRYPTO_ENCRYPTOR_H_

--- a/cc/crypto/hpke.cc
+++ b/cc/crypto/hpke.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hpke.h"
+
+namespace oak::crypto {}  // namespace oak::crypto

--- a/cc/crypto/hpke.h
+++ b/cc/crypto/hpke.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CC_CRYPTO_HPKE_H_
+#define CC_CRYPTO_HPKE_H_
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+namespace oak::crypto {
+
+class SenderRequestContext {
+ public:
+  // Encrypts message with associated data using AEAD.
+  // <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
+  absl::StatusOr<std::string> seal(absl::string_view plaintext, absl::string_view associated_data);
+};
+
+class SenderResponseContext {
+ public:
+  // Decrypts response message and validates associated data using AEAD as part of bidirectional
+  // communication.
+  // <https://www.rfc-editor.org/rfc/rfc9180.html#name-bidirectional-encryption>
+  absl::StatusOr<std::string> open(absl::string_view ciphertext, absl::string_view associated_data);
+};
+
+// Sets up an HPKE sender by generating an ephemeral keypair (and serializing the corresponding
+// public key) and creating a sender context.
+// Returns a tuple with an encapsulated public key, sender request and sender response contexts.
+// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-to-a-public-key>
+//
+// Encapsulated public key is represented as a NIST P-256 SEC1 encoded point public key.
+// <https://secg.org/sec1-v2.pdf>
+std::tuple<std::string, std::unique_ptr<SenderRequestContext>,
+           std::unique_ptr<SenderResponseContext>>
+setup_base_sender(absl::string_view serialized_recipient_public_key, absl::string_view info);
+
+}  // namespace oak::crypto
+
+#endif  // CC_CRYPTO_HPKE_H_

--- a/java/src/main/java/com/google/oak/crypto/BUILD
+++ b/java/src/main/java/com/google/oak/crypto/BUILD
@@ -1,0 +1,30 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+java_library(
+    name = "encryptor",
+    srcs = ["ClientEncryptor.java"],
+    deps = [
+        "//java/src/main/java/com/google/oak/util",
+    ],
+)

--- a/java/src/main/java/com/google/oak/crypto/ClientEncryptor.java
+++ b/java/src/main/java/com/google/oak/crypto/ClientEncryptor.java
@@ -1,0 +1,84 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.crypto;
+
+import com.google.oak.util.Result;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+/**
+ * Encryptor class for encrypting client requests that will be sent to the server and decrypting
+ * server responses that are received by the client. Each Encryptor object corresponds to a
+ * single crypto session between the client and the server.
+ *
+ * Sequence numbers for requests and responses are incremented separately, meaning that there could
+ * be multiple responses per request and multiple requests per response.
+ */
+public class ClientEncryptor {
+  // Info string used by Hybrid Public Key Encryption.
+  private static final String OAK_HPKE_INFO = "Oak Hybrid Public Key Encryption v1";
+
+  private final byte[] serializedServerPublicKey;
+
+  /**
+   * Creates a new instance of [`ClientEncryptor`].
+   *
+   * @param serializedServerPublicKey a NIST P-256 SEC1 encoded point public key.
+   * <https://secg.org/sec1-v2.pdf>
+   */
+  public ClientEncryptor(final byte[] serializedServerPublicKey) {
+    this.serializedServerPublicKey = serializedServerPublicKey;
+  }
+
+  /**
+   * Encrypts `plaintext` and authenticates `associatedData` using AEAD.
+   * <https://datatracker.ietf.org/doc/html/rfc5116>
+   *
+   * @param plaintext the input byte array to be encrypted
+   * @param associatedData the input byte array with associated data to be authenticated
+   * @return a serialized {@code EncryptedRequest} message wrapped in a {@code Result}
+   */
+  public final Result<byte[], Exception> encrypt(
+      final byte[] plaintext, final byte[] associatedData) {
+    // TODO(#3843): Return unserialized proto messages once we have Java encryption without JNI.
+    // TODO(#3642): Implement Java Hybrid Encryption.
+    return Result.success(new byte[0]);
+  }
+
+  public static final class DecryptionResult {
+    public final byte[] plaintext;
+    public final byte[] associatedData;
+
+    public DecryptionResult(byte[] plaintext, byte[] associatedData) {
+      this.plaintext = plaintext;
+      this.associatedData = associatedData;
+    }
+  }
+
+  /**
+   * Decrypts a [`EncryptedResponse`] proto message using AEAD.
+   * <https://datatracker.ietf.org/doc/html/rfc5116>
+   *
+   * @param encryptedResponse a serialized {@code EncryptedResponse} message
+   * @return a response message plaintext and associated data wrapped in a {@code Result}
+   */
+  public final Result<DecryptionResult, Exception> decrypt(final byte[] encryptedResponse) {
+    // TODO(#3843): Accept unserialized proto messages once we have Java encryption without JNI.
+    // TODO(#3642): Implement Java Hybrid Encryption.
+    return Result.success(new ClientEncryptor.DecryptionResult(new byte[0], new byte[0]));
+  }
+}

--- a/java/src/test/java/com/google/oak/crypto/BUILD
+++ b/java/src/test/java/com/google/oak/crypto/BUILD
@@ -1,0 +1,31 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_java//java:defs.bzl", "java_test")
+
+package(
+    licenses = ["notice"],
+)
+
+java_test(
+    name = "encryptor_test",
+    srcs = ["ClientEncryptorTest.java"],
+    test_class = "com.google.oak.crypto.ClientEncryptorTest",
+    deps = [
+        "//java/src/main/java/com/google/oak/crypto:encryptor",
+        "//java/src/main/java/com/google/oak/util",
+    ],
+)

--- a/java/src/test/java/com/google/oak/crypto/ClientEncryptorTest.java
+++ b/java/src/test/java/com/google/oak/crypto/ClientEncryptorTest.java
@@ -1,0 +1,51 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.crypto;
+
+import com.google.oak.crypto.ClientEncryptor;
+import com.google.oak.util.Result;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ClientEncryptorTest {
+  private static final byte[] TEST_SERIALIZED_SERVER_PUBLIC_KEY = new byte[0];
+  private static final byte[] TEST_PLAINTEXT = new byte[0];
+  private static final byte[] TEST_ASSOCIATED_DATA = new byte[0];
+  private static final byte[] TEST_ENCRYPTED_MESSAGE = new byte[0];
+
+  @Test
+  public void testEncryptDecrypt() throws Exception {
+    // TODO(#3644): Implement and test Java hybrid encryption.
+    ClientEncryptor encryptor = new ClientEncryptor(TEST_SERIALIZED_SERVER_PUBLIC_KEY);
+
+    Result<byte[], Exception> encrypt_result =
+        encryptor.encrypt(TEST_PLAINTEXT, TEST_ASSOCIATED_DATA);
+    Assert.assertTrue(encrypt_result.isSuccess());
+    Assert.assertArrayEquals(encrypt_result.success().get(), TEST_ENCRYPTED_MESSAGE);
+
+    Result<ClientEncryptor.DecryptionResult, Exception> decrypt_result =
+        encryptor.decrypt(TEST_ENCRYPTED_MESSAGE);
+    Assert.assertTrue(decrypt_result.isSuccess());
+    Assert.assertArrayEquals(decrypt_result.success().get().plaintext, TEST_PLAINTEXT);
+    Assert.assertArrayEquals(decrypt_result.success().get().associatedData, TEST_ASSOCIATED_DATA);
+  }
+}


### PR DESCRIPTION
This PR adds interfaces for C++ crypto library and Java `SenderEncryptor`.

Interfaces a made to resemble the Rust implementation: https://github.com/project-oak/oak/pull/3842

Ref https://github.com/project-oak/oak/issues/3644