### PR TITLE
Demonstrate running a docker container from oak's stage0 firmware.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,6 +1795,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_docker_linux_init"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "log",
+ "nix 0.26.2",
+ "simple_logger",
+ "subprocess",
+]
+
+[[package]]
 name = "oak_echo_linux_init"
 version = "0.1.0"
 dependencies = [
@@ -1820,7 +1831,7 @@ dependencies = [
 name = "oak_enclave_runtime_support"
 version = "0.1.0"
 dependencies = [
- "libm 0.1.4",
+ "libm 0.2.6",
  "log",
  "oak_restricted_kernel_api",
  "oak_restricted_kernel_interface",
@@ -2218,7 +2229,7 @@ dependencies = [
  "bitflags",
  "bitvec",
  "goblin",
- "libm 0.1.4",
+ "libm 0.2.6",
  "linked_list_allocator",
  "log",
  "oak_channel",
@@ -2231,7 +2242,7 @@ dependencies = [
  "ouroboros",
  "rust-hypervisor-firmware-virtio",
  "sev_serial",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "spinning_top",
  "static_assertions",
  "strum",
@@ -3311,6 +3322,16 @@ dependencies = [
  "quote",
  "rustversion",
  "syn",
+]
+
+[[package]]
+name = "subprocess"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "oak_client",
   "oak_core",
   "oak_crypto",
+  "oak_docker_linux_init",
   "oak_echo_linux_init",
   "oak_enclave_runtime_support",
   "oak_functions/examples/benchmark/module",

--- a/oak_docker_linux_init/Cargo.toml
+++ b/oak_docker_linux_init/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "oak_docker_linux_init"
+version = "0.1.0"
+authors = [
+  "Gogul Balakrishnan <bgogul@google.com>",
+  "Conrad Grobler <grobler@google.com>"
+]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "*"
+log = "*"
+nix = "*"
+simple_logger = "*"
+subprocess = "*"

--- a/oak_docker_linux_init/README.md
+++ b/oak_docker_linux_init/README.md
@@ -56,5 +56,7 @@ _Note:_ the initramfs can only be at most half the size of the machine's memory.
 You may get an error like '`Initramfs unpacking failed: write error`' if the
 size of the memory is not big enough. Increase the size of the virtual machine's
 memory should usually fix this error.
+
 _Note:_ the compressed initramfs image should also fit within the first 1G along
-with the Linux kernel. Otherwise, this approach of using initramfs will not work.
+with the Linux kernel. Otherwise, this approach of using initramfs will not
+work.

--- a/oak_docker_linux_init/README.md
+++ b/oak_docker_linux_init/README.md
@@ -4,10 +4,10 @@
 <h1><picture><source media="(prefers-color-scheme: dark)" srcset="../docs/oak-logo/svgs/oak-logo-negative.svg?sanitize=true"><source media="(prefers-color-scheme: light)" srcset="../docs/oak-logo/svgs/oak-logo.svg?sanitize=true"><img alt="Project Oak Logo" src="../docs/oak-logo/svgs/oak-logo.svg?sanitize=true"></picture></h1>
 <!-- Oak Logo End -->
 
-# Running a docker container from stage0
+# Running a Docker container from stage0
 
-This example shows how to run a docker container from Oak's stage0 firmware
-binary. We can achieve this by simply extracting the filesystem of the docker
+This example shows how to run a Docker container from Oak's stage0 firmware
+binary. We can achieve this by simply extracting the filesystem of the Docker
 container and packaging it as the
 [initial RAM disk](https://en.wikipedia.org/wiki/Initial_ramdisk) (initramfs)
 disk with an appropriate init binary. The easiest way to execute the initial RAM
@@ -18,7 +18,7 @@ Note: these steps assume that the commands will be executed from the project
 root.
 
 Suppose that we want to run the
-[`hello-world:latest`](https://hub.docker.com/_/hello-world) docker image, we
+[`hello-world:latest`](https://hub.docker.com/_/hello-world) Docker image, we
 can convert it to a initramfs with the
 [docker_to_initramfs.sh](docker_to_initramfs.sh) script as follows:
 
@@ -50,9 +50,11 @@ qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm" -m 1G \
 ```
 
 After initializing the rootfs, the `/init` in the initramfs will execute the
-`CMD` or `ENTRYPOINT` from the docker image.
+`CMD` or `ENTRYPOINT` from the Docker image.
 
 _Note:_ the initramfs can only be at most half the size of the machine's memory.
 You may get an error like '`Initramfs unpacking failed: write error`' if the
 size of the memory is not big enough. Increase the size of the virtual machine's
 memory should usually fix this error.
+_Note:_ the compressed initramfs image should also fit within the first 1G along
+with the Linux kernel. Otherwise, this approach of using initramfs will not work.

--- a/oak_docker_linux_init/README.md
+++ b/oak_docker_linux_init/README.md
@@ -1,0 +1,58 @@
+<!-- Oak Logo Start -->
+<!-- An HTML element is intentionally used since GitHub recommends this approach to handle different images in dark/light modes. Ref: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to -->
+<!-- markdownlint-disable-next-line MD033 -->
+<h1><picture><source media="(prefers-color-scheme: dark)" srcset="../docs/oak-logo/svgs/oak-logo-negative.svg?sanitize=true"><source media="(prefers-color-scheme: light)" srcset="../docs/oak-logo/svgs/oak-logo.svg?sanitize=true"><img alt="Project Oak Logo" src="../docs/oak-logo/svgs/oak-logo.svg?sanitize=true"></picture></h1>
+<!-- Oak Logo End -->
+
+# Running a docker container from stage0
+
+This example shows how to run a docker container from Oak's stage0 firmware
+binary. We can achieve this by simply extracting the filesystem of the docker
+container and packaging it as the
+[initial RAM disk](https://en.wikipedia.org/wiki/Initial_ramdisk) (initramfs)
+disk with an appropriate init binary. The easiest way to execute the initial RAM
+disk is to use
+[QEMU's direct Linux boot feature](https://qemu-project.gitlab.io/qemu/system/linuxboot.html).
+
+Note: these steps assume that the commands will be executed from the project
+root.
+
+Suppose that we want to run the
+[`hello-world:latest`](https://hub.docker.com/_/hello-world) docker image, we
+can convert it to a initramfs with the
+[docker_to_initramfs.sh](docker_to_initramfs.sh) script as follows:
+
+```bash
+sh oak_docker_linux_init/docker_to_initramfs.sh hello-world:latest bin/initramfs
+```
+
+Build the Stage 0 Firmware image:
+
+```bash
+( cd stage0; cargo build --release; )
+objcopy --output-format binary stage0/target/x86_64-unknown-none/release/oak_stage0 \
+    bin/stage0.bin
+```
+
+Execute the initial RAM disk with QEMU:
+
+Note: this assumes that an appropiate
+[uncompressed Linux kernel ELF binary](/docs/development.md#extracting-vmlinux-from-your-linux-installation)
+has been copied to `bin/vmlinux`.
+
+```bash
+qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm" -m 1G \
+    -nographic -nodefaults -no-reboot -serial stdio \
+    -bios "bin/stage0.bin" \
+    -fw_cfg "name=opt/stage0/elf_kernel,file=bin/vmlinux" \
+    -fw_cfg "name=opt/stage0/initramfs,file=bin/initramfs" \
+    -fw_cfg "name=opt/stage0/cmdline,string=console=ttyS0 quiet"
+```
+
+After initializing the rootfs, the `/init` in the initramfs will execute the
+`CMD` or `ENTRYPOINT` from the docker image.
+
+_Note:_ the initramfs can only be at most half the size of the machine's memory.
+You may get an error like '`Initramfs unpacking failed: write error`' if the
+size of the memory is not big enough. Increase the size of the virtual machine's
+memory should usually fix this error.

--- a/oak_docker_linux_init/docker_to_initramfs.sh
+++ b/oak_docker_linux_init/docker_to_initramfs.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# A proof-of-concept script to convert a docker image into an initramfs image.
+#
+
+# exit when any command fails
+set -e
+
+# Just a simple commandline handling for now.
+if [ $# -ne 2 ]; then
+  echo "Usage:"
+  echo "  $0 <docker-image> <output-initramfs-file> "
+  exit 1
+fi
+DOCKER_IMAGE=$1
+INITRAMFS_FILE=$2
+
+echo "[Info] Building init process..."
+cargo build --release --target=x86_64-unknown-linux-musl --package=oak_docker_linux_init
+
+# Create a temporary workspace directory.
+export SCRATCH_DIR=$(mktemp -d)
+
+echo -n "[INFO] Exporting the filesystem in the docker image..."
+DOCKER_IMAGE_FS=${SCRATCH_DIR}/filesystem.tar
+docker export $(docker create ${DOCKER_IMAGE}) \
+  -o ${DOCKER_IMAGE_FS}
+echo "done."
+
+# Extract the docker CMD if it is present.
+DOCKER_CMD=$(docker \
+             inspect \
+             --format='{{join .Config.Cmd " "}}' \
+             ${DOCKER_IMAGE})
+
+if [ -z "${DOCKER_CMD}" ]; then
+  echo "[INFO] 'CMD' not found in docker image. Searching for 'ENTRY_POINT'"
+  DOCKER_CMD=$(docker \
+               inspect \
+               --format='{{join .Config.Entrypoint " "}}' \
+               ${DOCKER_IMAGE}) 
+fi
+
+if [ -z "${DOCKER_CMD}" ]; then
+  echo "[ERROR] Neither 'CMD' or 'ENTRYPOINT' found in docker image."
+  exit 1
+fi
+
+echo "[INFO] Docker entry point cmd: \"${DOCKER_CMD}\""
+
+# Create initramfs 
+export RAMDIR=$(mktemp -d)
+
+# Extract the contents of the docker filesystem
+tar xf ${DOCKER_IMAGE_FS} -C ${RAMDIR}
+
+# Create a shell script for the docker command.
+cat > ${RAMDIR}/docker_cmd <<EOF
+${DOCKER_CMD}
+EOF
+chmod a+x ${RAMDIR}/docker_cmd
+
+# Create the init file for the initramfs
+cp --archive target/x86_64-unknown-linux-musl/release/oak_docker_linux_init \
+    ${RAMDIR}/init
+chmod a+x ${RAMDIR}/init
+
+# If /dev/console is present, we are not able to see the output
+# from qemu. I presume this is caused by incorrect setup  of character
+# devices or terminal. Remove it for now. 
+rm -f ${RAMDIR}/dev/console
+
+echo "[INFO] Creating initramfs file at ${INITRAMFS_FILE}..."
+( cd ${RAMDIR}; find . -print0 \
+    | cpio --null --create --format=newc ) \
+    | gzip \
+    > ${INITRAMFS_FILE}
+echo "[INFO] Creating initramfs file at ${INITRAMFS_FILE}...done"
+

--- a/oak_docker_linux_init/docker_to_initramfs.sh
+++ b/oak_docker_linux_init/docker_to_initramfs.sh
@@ -19,26 +19,26 @@ echo "[Info] Building init process..."
 cargo build --release --target=x86_64-unknown-linux-musl --package=oak_docker_linux_init
 
 # Create a temporary workspace directory.
-export SCRATCH_DIR=$(mktemp -d)
+SCRATCH_DIR=$(mktemp -d)
 
 echo -n "[INFO] Exporting the filesystem in the docker image..."
 DOCKER_IMAGE_FS=${SCRATCH_DIR}/filesystem.tar
-docker export $(docker create ${DOCKER_IMAGE}) \
-  -o ${DOCKER_IMAGE_FS}
+docker export "$(docker create "${DOCKER_IMAGE}")" \
+  -o "${DOCKER_IMAGE_FS}"
 echo "done."
 
 # Extract the docker CMD if it is present.
 DOCKER_CMD=$(docker \
              inspect \
              --format='{{join .Config.Cmd " "}}' \
-             ${DOCKER_IMAGE})
+             "${DOCKER_IMAGE}")
 
 if [ -z "${DOCKER_CMD}" ]; then
   echo "[INFO] 'CMD' not found in docker image. Searching for 'ENTRY_POINT'"
   DOCKER_CMD=$(docker \
                inspect \
                --format='{{join .Config.Entrypoint " "}}' \
-               ${DOCKER_IMAGE}) 
+               "${DOCKER_IMAGE}") 
 fi
 
 if [ -z "${DOCKER_CMD}" ]; then
@@ -49,31 +49,31 @@ fi
 echo "[INFO] Docker entry point cmd: \"${DOCKER_CMD}\""
 
 # Create initramfs 
-export RAMDIR=$(mktemp -d)
+RAMDIR=$(mktemp -d)
 
 # Extract the contents of the docker filesystem
-tar xf ${DOCKER_IMAGE_FS} -C ${RAMDIR}
+tar xf "${DOCKER_IMAGE_FS}" -C "${RAMDIR}"
 
 # Create a shell script for the docker command.
-cat > ${RAMDIR}/docker_cmd <<EOF
+cat > "${RAMDIR}/docker_cmd" <<EOF
 ${DOCKER_CMD}
 EOF
-chmod a+x ${RAMDIR}/docker_cmd
+chmod a+x "${RAMDIR}/docker_cmd"
 
 # Create the init file for the initramfs
 cp --archive target/x86_64-unknown-linux-musl/release/oak_docker_linux_init \
-    ${RAMDIR}/init
-chmod a+x ${RAMDIR}/init
+    "${RAMDIR}/init"
+chmod a+x "${RAMDIR}/init"
 
 # If /dev/console is present, we are not able to see the output
 # from qemu. I presume this is caused by incorrect setup  of character
 # devices or terminal. Remove it for now. 
-rm -f ${RAMDIR}/dev/console
+rm -f "${RAMDIR}/dev/console"
 
 echo "[INFO] Creating initramfs file at ${INITRAMFS_FILE}..."
-( cd ${RAMDIR}; find . -print0 \
+( cd "${RAMDIR}"; find . -print0 \
     | cpio --null --create --format=newc ) \
     | gzip \
-    > ${INITRAMFS_FILE}
+    > "${INITRAMFS_FILE}"
 echo "[INFO] Creating initramfs file at ${INITRAMFS_FILE}...done"
 

--- a/oak_docker_linux_init/src/init.rs
+++ b/oak_docker_linux_init/src/init.rs
@@ -1,0 +1,49 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use nix::mount::{mount, MsFlags};
+use std::env::set_current_dir;
+
+/// Performs the minimum initialization required from the initial process on Linux to allow an
+/// application on an initial RAM disk to operate as expected.
+pub fn init() -> anyhow::Result<()> {
+    set_current_dir("/")?;
+
+    // Mount pseudo file systems.
+    mount::<str, str, str, str>(
+        Some("proc"),
+        "proc",
+        Some("proc"),
+        MsFlags::MS_NODEV | MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC,
+        None,
+    )?;
+    mount::<str, str, str, str>(
+        Some("dev"),
+        "dev",
+        Some("devtmpfs"),
+        MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC,
+        None,
+    )?;
+    mount::<str, str, str, str>(
+        Some("sysfs"),
+        "sys",
+        Some("sysfs"),
+        MsFlags::MS_NODEV | MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC,
+        None,
+    )?;
+
+    Ok(())
+}

--- a/oak_docker_linux_init/src/main.rs
+++ b/oak_docker_linux_init/src/main.rs
@@ -1,0 +1,46 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#![feature(file_create_new)]
+
+use log::info;
+use std::fs;
+use subprocess::Exec;
+
+mod init;
+
+const DOCKER_COMMAND_PATH: &str = "/docker_cmd";
+
+fn main() -> ! {
+    simple_logger::SimpleLogger::new().init().unwrap();
+
+    // Set up the Linux environment, since we expect to be the initial process.
+    init::init().unwrap();
+
+    let contents = fs::read_to_string(DOCKER_COMMAND_PATH).expect("Error reading file");
+    let content_vec = contents.split_whitespace().collect::<Vec<_>>();
+    let (cmd, args) = content_vec.split_at(1);
+
+    info!("Docker command: {:?} {:?}", cmd[0], args);
+
+    let _exec_status = Exec::cmd(&cmd[0]).args(args).join();
+
+    // Linux does not expect the initial process to ever exit, so we keep sleeping 1 second at a
+    // time.
+    loop {
+        nix::unistd::sleep(1);
+    }
+}

--- a/oak_docker_linux_init/src/main.rs
+++ b/oak_docker_linux_init/src/main.rs
@@ -36,7 +36,11 @@ fn main() -> ! {
 
     info!("Docker command: {:?} {:?}", cmd[0], args);
 
-    let _exec_status = Exec::cmd(&cmd[0]).args(args).join();
+    let exit_status = Exec::cmd(cmd[0]).args(args).join();
+    match exit_status {
+        Ok(_) => println!("Docker command finished successfully!"),
+        Err(error) => println!("Error running docker command: {:?}", error),
+    }
 
     // Linux does not expect the initial process to ever exit, so we keep sleeping 1 second at a
     // time.


### PR DESCRIPTION
The idea is to convert the docker image into a initramfs image and use it when booting the kernel. The docker_to_initramfs.sh in this PR has all the details of how this is accomplished.