### PR TITLE
Replace `goblin` with `elf`

### DIFF
--- a/stage0/Cargo.lock
+++ b/stage0/Cargo.lock
@@ -45,15 +45,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "goblin"
-version = "0.5.4"
+name = "elf"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
+checksum = "e2b183d6ce6ca4cf30e3db37abf5b52568b5f9015c97d9fbdd7026aa5dcdd758"
 
 [[package]]
 name = "heck"
@@ -116,7 +111,7 @@ name = "oak_stage0"
 version = "0.1.0"
 dependencies = [
  "bitflags",
- "goblin",
+ "elf",
  "log",
  "oak_core",
  "oak_linux_boot_params",
@@ -129,12 +124,6 @@ dependencies = [
  "x86_64",
  "zerocopy",
 ]
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
@@ -165,26 +154,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "sev_serial"

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -11,11 +11,7 @@ members = ["."]
 
 [dependencies]
 bitflags = "*"
-goblin = { version = "*", default-features = false, features = [
-  "elf32",
-  "elf64",
-  "endian_fd"
-] }
+elf = { version = "*", default-features = false }
 log = "*"
 oak_core = { path = "../oak_core", default-features = false }
 oak_linux_boot_params = { path = "../linux_boot_params" }


### PR DESCRIPTION
`goblin` is large and comes with a bunch of unnecessary dependencies. `elf` is smaller, more self-contained, but still has all the features we need.

As a side effect, the resulting binary is about 4K smaller (although it won't be visible in the fixed-size BIOS blob), and I think we can get rid of the global allocator (again), as the only thing that requires the allocator now is the vector allocation for the kernel command line in `kernel.rs`.