### PR TITLE
Determine the C-bit position dynamically in stage0

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -237,7 +237,12 @@ SECTIONS {
         QUAD(0) /* 26 - reserved */
         QUAD(0) /* 27 - reserved */
         QUAD(0) /* 28 - #HV */
-        QUAD(0) /* 29 - #VC */
+        QUAD(   /* 29 - #VC */
+            (vc_handler & 0xFFFF0000) << 32 | /* target offset [31:16] */
+            DESCRIPTOR_PRESENT |
+            DESCRIPTOR_INTERRUPT_GATE |
+            cs32 << 16 |                      /* code segment selector */
+            vc_handler & 0xFFFF)              /* target offset [15:0] */
         QUAD(0) /* 30 - #SX */
         QUAD(0) /* 31 - reserved */
     } > bios


### PR DESCRIPTION
We used to assume that the C-bit was always bit 51 as that was true for the machines we were testing on, but it's not _always_ true. For example, Rome CPUs have that at bit 47.

This PR sets up enough machinery (VC handler, etc) to properly identify the C-bit position by inspecting CPUID.