### PR TITLE
Fix provenance file name in upload_provenance

### DIFF
--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -106,6 +106,10 @@ jobs:
             ${{ needs.generate_provenance.outputs.attestations-download-name }}
           path: downloads
 
+      - name: Debug step - Display structure of downloaded files
+        run: ls -R
+        working-directory: downloads
+
       - name: Upload binary to Ent
         id: ent_upload_binary
         working-directory: downloads
@@ -115,8 +119,10 @@ jobs:
       - name: Upload provenance to Ent
         id: ent_upload_provenance
         working-directory: downloads
+        # The output on any trigger other than "pull_request" has an addition ".sigstore" suffix.
+        # See https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/docker#workflow-outputs
         run: |
-          echo "provenance_digest=$(ent put ${{ needs.get_inputs.outputs.provenance-name }})" >> $GITHUB_OUTPUT
+          echo "provenance_digest=$(ent put ${{ needs.get_inputs.outputs.provenance-name }}.sigstore)" >> $GITHUB_OUTPUT
 
       # Add the provenance digest to the ./comment file.
       - name: Format artifact and provenance digest (post-merge only)


### PR DESCRIPTION
Follow up fix after ##3669

The name of the downloaded provenance has an extra `.sigstore` suffix on triggers other than `pull_request`. The suffix was missing, resulting in empty provenance digest in the post-merge comments published on the PR. 

Note that the fix cannot be verified until this PR is merged!

Also it looks like my fancy trick to control running the provenance CI steps with the `provenance:force-run` label does not quite work. I'll look into it later.