### PR TITLE
Add some debug logging into the `mmap()` syscall in Restricted Kernel

### DIFF
--- a/oak_restricted_kernel/src/logging.rs
+++ b/oak_restricted_kernel/src/logging.rs
@@ -37,7 +37,7 @@ impl log::Log for Logger {
     fn log(&self, record: &log::Record) {
         writeln!(
             SERIAL1.lock().as_mut().unwrap(),
-            "{}: {}",
+            "kernel {}: {}",
             record.level(),
             record.args()
         )


### PR DESCRIPTION
a) prefix logs from the kernel with a explicit "kernel" to distinguish them from logs from the application, as both of them use a similar format and go into the same channel
b) add a bunch of logging into `mmap()` to get more information about allocation failures in particular

We will likely want to remove the debug calls at some point, but `mmap()` should not be called too often so I don't expect there to be too much noise from those statement.