### PR TITLE
Add GHCB support for reading and writing MSRs

### DIFF
--- a/oak_restricted_kernel/src/interrupts.rs
+++ b/oak_restricted_kernel/src/interrupts.rs
@@ -141,7 +141,7 @@ mutable_interrupt_handler_with_error_code!(
                 } else {
                     let leaf = stack_frame.rax as u32;
                     // The MSR protocol does not support sub-leaf requests or leaf 0x0000_000D.
-                    // See section 2.3.1 in <https://developer.amd.com/wp-content/resources/56421.pdf>
+                    // See section 2.3.1 in <https://www.amd.com/system/files/TechDocs/56421-guest-hypervisor-communication-block-standardization.pdf>
                     // TODO(#3470): Improve handling of incorrect/missing CPUID requests.
                     if stack_frame.rcx != 0 || leaf == 0x0000_000D {
                         error!("KERNEL PANIC: CPUID SUB-LEAF OR INVALID LEAD REQUESTED");

--- a/oak_sev_guest/README.md
+++ b/oak_sev_guest/README.md
@@ -9,7 +9,7 @@ For more information see:
 - [https://developer.amd.com/sev/](https://developer.amd.com/sev/)
 - [AMD64 Architecture Programmer’s Manual, Volume 2: System Programming](https://www.amd.com/system/files/TechDocs/24593.pdf) -
   Sections 15.34 - 15.36
-- [SEV-ES Guest-Hypervisor Communication Block Standardization](https://developer.amd.com/wp-content/resources/56421.pdf)
+- [SEV-ES Guest-Hypervisor Communication Block Standardization](https://www.amd.com/system/files/TechDocs/56421-guest-hypervisor-communication-block-standardization.pdf)
 - [SEV Secure Nested Paging Firmware ABI Specification](https://www.amd.com/system/files/TechDocs/56860.pdf)
 - Whitepaper:
   [AMD SEV-SNP: Strengthening VM Isolation with Integrity Protection and More](https://www.amd.com/system/files/TechDocs/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more.pdf)

--- a/oak_sev_guest/src/cpuid.rs
+++ b/oak_sev_guest/src/cpuid.rs
@@ -64,7 +64,7 @@ impl From<&mut MutableInterruptStackFrame> for CpuidInput {
         let eax = value.rax as u32;
         let ecx = value.rcx as u32;
         // We only set the value of XCR0 for CPUID 0x0000_000D.
-        // See table 6 in <https://developer.amd.com/wp-content/resources/56421.pdf>.
+        // See table 6 in <https://www.amd.com/system/files/TechDocs/56421-guest-hypervisor-communication-block-standardization.pdf>.
         let xcr0 = if eax == 0xD {
             x86_64::registers::xcontrol::XCr0::read_raw()
         } else {

--- a/oak_sev_guest/src/msr.rs
+++ b/oak_sev_guest/src/msr.rs
@@ -27,12 +27,12 @@
 //!
 //! The MSR protocol is primarily used to set up the GHCB communications with the hypervisor.
 //!
-//! See section 2.3.1 in <https://developer.amd.com/wp-content/resources/56421.pdf> for more detail.
+//! See section 2.3.1 in <https://www.amd.com/system/files/TechDocs/56421-guest-hypervisor-communication-block-standardization.pdf> for more detail.
 //!
 //! Note: This implementation does not include the AP Reset Hold operations seeing that it is not
 //! the preferred mechanism for starting a new application processor (AP) under AMD SEV-SNP. The
 //! SEV-SNP AP creation NAE should be used instead. See section 4.3.2 of
-//! <https://developer.amd.com/wp-content/resources/56421.pdf>.
+//! <https://www.amd.com/system/files/TechDocs/56421-guest-hypervisor-communication-block-standardization.pdf>.
 
 use crate::{instructions::vmgexit, interrupts::MutableInterruptStackFrame};
 //use anyhow::{anyhow, bail, Result};
@@ -584,7 +584,7 @@ mod tests {
     //! These tests check the conversion logic between convenience request and response structs, and
     //! the u64 values used for the MSR protocol.
     //!
-    //! See section 2.3.1 in <https://developer.amd.com/wp-content/resources/56421.pdf> for details of
+    //! See section 2.3.1 in <https://www.amd.com/system/files/TechDocs/56421-guest-hypervisor-communication-block-standardization.pdf> for details of
     //! how the requests and responses are represented as u64 values.
 
     use super::*;

--- a/sev_serial/src/lib.rs
+++ b/sev_serial/src/lib.rs
@@ -61,7 +61,7 @@ const OUTPUT_EMPTY: u8 = 1 << 5;
 /// IOIO protocol, or using direct port-based IO, depending on which IO port factory is used in the
 /// wrapper enum.
 ///
-/// See section 4.1.2 in <https://developer.amd.com/wp-content/resources/56421.pdf> for more
+/// See section 4.1.2 in <https://www.amd.com/system/files/TechDocs/56421-guest-hypervisor-communication-block-standardization.pdf> for more
 /// information on the GHCB IOIO protocol.
 pub struct SerialPort {
     /// The base address of the serial port.


### PR DESCRIPTION
See section 4.1.3 in https://www.amd.com/system/files/TechDocs/56421-guest-hypervisor-communication-block-standardization.pdf for more information.

I also noticed that the URL of the GHCB spec changed, so I changed it throughout the codebase as well.