### PR TITLE
Use the GHCB protocol for the MTRRDefType MSR if SEV-ES or SEV-SNP is active

### DIFF
--- a/oak_sev_guest/src/ghcb.rs
+++ b/oak_sev_guest/src/ghcb.rs
@@ -430,7 +430,7 @@ where
     /// See section 4.1.3 in <https://www.amd.com/system/files/TechDocs/56421-guest-hypervisor-communication-block-standardization.pdf>.
     pub fn msr_write(&mut self, msr: u32, data: u64) -> Result<(), &'static str> {
         self.ghcb.as_mut().sw_exit_code = SW_EXIT_CODE_MSR_PROT;
-        self.ghcb.as_mut().sw_exit_info_1 = 0;
+        self.ghcb.as_mut().sw_exit_info_1 = 1;
         self.ghcb.as_mut().sw_exit_info_2 = 0;
         self.ghcb.as_mut().rcx = msr as u64;
         // Split the data into the lower halves of RDX and RAX.

--- a/oak_sev_guest/src/ghcb.rs
+++ b/oak_sev_guest/src/ghcb.rs
@@ -115,12 +115,12 @@ pub struct Ghcb {
     pub rax: u64,
     /// Reserved. Must be 0.
     _reserved_4: [u8; 264],
-    /// The value of the RBX register.
-    pub rbx: u64,
     /// The value of the RCX register.
     pub rcx: u64,
     /// The value of the RDX register.
     pub rdx: u64,
+    /// The value of the RBX register.
+    pub rbx: u64,
     /// Reserved. Must be 0.
     _reserved_5: [u8; 112],
     /// Guest-controlled exit code.
@@ -206,9 +206,9 @@ bitflags! {
         const XSS = (1 << 40);
         const DR7 = (1 << 44);
         const RAX = (1 << 63);
-        const RBX = (1 << 97);
-        const RCX = (1 << 98);
-        const RDX = (1 << 99);
+        const RCX = (1 << 97);
+        const RDX = (1 << 98);
+        const RBX = (1 << 99);
         const SW_EXIT_CODE = (1 << 114);
         const SW_EXIT_INFO_1 = (1 << 115);
         const SW_EXIT_INFO_2 = (1 << 116);

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -176,7 +176,7 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
     let dma_access = BOOT_ALLOC.leak(fw_cfg::FwCfgDmaAccess::default()).unwrap();
     let dma_access_address = VirtAddr::from_ptr(dma_access as *const _);
     if encrypted > 0 {
-        // This is safe because we're using an originally supported mode of the Pentium 6:
+        // Safety: This is safe because we're using an originally supported mode of the Pentium 6:
         // Write-protect, with MTRR enabled.  If we get CPUID reads working, we may want to check
         // that MTRR is supported, but only if we want to support very old processors.
         unsafe {


### PR DESCRIPTION
Accessing the MTRRDefType MSR cuases a VC exception on SEV-ES and SEV-SNP, so we should access it via the GHCB protocol to avoid the need for a VC handler in stage 0.

There were also a couple of bugs in the GHCB implementation:

- When writing to an MSR the sw_exit_info_1 field must be set to 1
- The order of RBX, RCX and RDX in the GHCB was incorrect