### PR TITLE
Use gRPC bidirectional streaming in Oak Launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,7 @@ name = "oak_functions_launcher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bmrng",
  "clap",

--- a/oak_functions_launcher/Cargo.toml
+++ b/oak_functions_launcher/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "*"
+async-stream = "*"
 async-trait = "*"
 bmrng = "*"
 clap = { version = "*", features = ["derive"] }


### PR DESCRIPTION
This PR updates the Oak Launcher to use gRPC bidirectional streaming.
Previously it was just returning a single response and closing the stream.