### PR TITLE
Add Java Attestation Verifier template

### DIFF
--- a/java/src/main/java/com/google/oak/remote_attestation/AmdAttestationVerifier.java
+++ b/java/src/main/java/com/google/oak/remote_attestation/AmdAttestationVerifier.java
@@ -1,0 +1,46 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.remote_attestation;
+
+import com.google.oak.util.Result;
+import oak.session.noninteractive.v1.AttestationEndorsement;
+import oak.session.noninteractive.v1.AttestationEvidence;
+
+/**
+ * Attestation verifier implementation for AMD SEV-SNP.
+ * <https://www.amd.com/system/files/TechDocs/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more.pdf>
+ */
+public class AmdAttestationVerifier implements AttestationVerifier {
+  /**
+   * Verify that the provided evidence was endorsed and contains specified reference values.
+   *
+   * @param evidence contains claims about the Trusted Execution Environment
+   * <https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence>
+   * @param endorsement contains statements that the endorsers vouch for the integrity of claims
+   * provided in the evidence
+   * <https://www.rfc-editor.org/rfc/rfc9334.html#name-endorsements>
+   * @param reference_value contains values used to verify the evidence
+   * <https://www.rfc-editor.org/rfc/rfc9334.html#name-reference-values>
+   * @return boolean corresponding to the sussess of the verification wrapped in a {@code Result}
+   */
+  @Override
+  public final Result<Boolean, Exception> verify(final AttestationEvidence evidence,
+      final AttestationEndorsement endorsement, byte[] reference_value) {
+    // TODO(#3641): Implement AMD SEV-SNP attestation verification.
+    return Result.success(true);
+  }
+}

--- a/java/src/main/java/com/google/oak/remote_attestation/AttestationVerifier.java
+++ b/java/src/main/java/com/google/oak/remote_attestation/AttestationVerifier.java
@@ -1,0 +1,43 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.remote_attestation;
+
+import com.google.oak.util.Result;
+import oak.session.noninteractive.v1.AttestationEndorsement;
+import oak.session.noninteractive.v1.AttestationEvidence;
+
+/**
+ * An interface implementing the functionality of a verifier that appraises the attestation evidence
+ * and produces an attestation result. <https://www.rfc-editor.org/rfc/rfc9334.html#name-verifier>
+ */
+public interface AttestationVerifier {
+  /**
+   * Verify that the provided evidence was endorsed and contains specified reference values.
+   *
+   * @param evidence contains claims about the Trusted Execution Environment
+   * <https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence>
+   * @param endorsement contains statements that the endorsers vouch for the integrity of claims
+   * provided in the evidence
+   * <https://www.rfc-editor.org/rfc/rfc9334.html#name-endorsements>
+   * @param reference_value contains values used to verify the evidence
+   * <https://www.rfc-editor.org/rfc/rfc9334.html#name-reference-values>
+   * @return boolean corresponding to the sussess of the verification wrapped in a {@code Result}
+   */
+  // TODO(#3641): Add reference value implementation.
+  Result<Boolean, Exception> verify(final AttestationEvidence evidence,
+      final AttestationEndorsement endorsement, byte[] reference_value);
+}

--- a/java/src/main/java/com/google/oak/remote_attestation/BUILD
+++ b/java/src/main/java/com/google/oak/remote_attestation/BUILD
@@ -22,6 +22,35 @@ package(
 )
 
 java_library(
+    name = "attestation_verifier",
+    srcs = ["AttestationVerifier.java"],
+    deps = [
+        "//java/src/main/java/com/google/oak/util",
+        "//oak_remote_attestation_noninteractive/proto/v1:messages_java_proto",
+    ],
+)
+
+java_library(
+    name = "amd_attestation_verifier",
+    srcs = ["AmdAttestationVerifier.java"],
+    deps = [
+        ":attestation_verifier",
+        "//java/src/main/java/com/google/oak/util",
+        "//oak_remote_attestation_noninteractive/proto/v1:messages_java_proto",
+    ],
+)
+
+java_library(
+    name = "insecure_attestation_verifier",
+    srcs = ["InsecureAttestationVerifier.java"],
+    deps = [
+        ":attestation_verifier",
+        "//java/src/main/java/com/google/oak/util",
+        "//oak_remote_attestation_noninteractive/proto/v1:messages_java_proto",
+    ],
+)
+
+java_library(
     name = "remote_attestation",
     srcs = [
         "AeadEncryptor.java",

--- a/java/src/main/java/com/google/oak/remote_attestation/InsecureAttestationVerifier.java
+++ b/java/src/main/java/com/google/oak/remote_attestation/InsecureAttestationVerifier.java
@@ -1,0 +1,44 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.remote_attestation;
+
+import com.google.oak.util.Result;
+import oak.session.noninteractive.v1.AttestationEndorsement;
+import oak.session.noninteractive.v1.AttestationEvidence;
+
+/**
+ * A test verifier implementation that doesn't verify attestation evidence and is used for testing.
+ */
+public class InsecureAttestationVerifier implements AttestationVerifier {
+  /**
+   * Verify that the provided evidence was endorsed and contains specified reference values.
+   *
+   * @param evidence contains claims about the Trusted Execution Environment
+   * <https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence>
+   * @param endorsement contains statements that the endorsers vouch for the integrity of claims
+   * provided in the evidence
+   * <https://www.rfc-editor.org/rfc/rfc9334.html#name-endorsements>
+   * @param reference_value contains values used to verify the evidence
+   * <https://www.rfc-editor.org/rfc/rfc9334.html#name-reference-values>
+   * @return boolean corresponding to the sussess of the verification wrapped in a {@code Result}
+   */
+  @Override
+  public final Result<Boolean, Exception> verify(final AttestationEvidence evidence,
+      final AttestationEndorsement endorsement, byte[] reference_value) {
+    return Result.success(true);
+  }
+}

--- a/java/src/test/java/com/google/oak/remote_attestation/AmdAttestationVerifierTest.java
+++ b/java/src/test/java/com/google/oak/remote_attestation/AmdAttestationVerifierTest.java
@@ -1,0 +1,34 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.remote_attestation;
+
+import com.google.oak.remote_attestation.AmdAttestationVerifier;
+import com.google.oak.util.Result;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AmdAttestationVerifierTest {
+  @Test
+  public void testVerify() throws Exception {
+    // TODO(#3641): Implement AMD SEV-SNP attestation verification.
+  }
+}

--- a/java/src/test/java/com/google/oak/remote_attestation/BUILD
+++ b/java/src/test/java/com/google/oak/remote_attestation/BUILD
@@ -21,6 +21,16 @@ package(
 )
 
 java_test(
+    name = "amd_attestation_verifier_test",
+    srcs = ["AmdAttestationVerifierTest.java"],
+    test_class = "com.google.oak.remote_attestation.AmdAttestationVerifierTest",
+    deps = [
+        "//java/src/main/java/com/google/oak/remote_attestation:amd_attestation_verifier",
+        "//java/src/main/java/com/google/oak/util",
+    ],
+)
+
+java_test(
     name = "message_test",
     srcs = ["MessageTest.java"],
     test_class = "com.google.oak.remote_attestation.MessageTest",


### PR DESCRIPTION
This PR adds a template for the remote attestation verifier in Java.

Ref https://github.com/project-oak/oak/issues/3644

This PR is a split from https://github.com/project-oak/oak/pull/3854