### PR TITLE
Use newline to separate args of docker command to prevent lossy representation.

### DIFF
--- a/oak_docker_linux_init/docker_to_initramfs.sh
+++ b/oak_docker_linux_init/docker_to_initramfs.sh
@@ -30,14 +30,14 @@ echo "done."
 # Extract the docker CMD if it is present.
 DOCKER_CMD=$(docker \
              inspect \
-             --format='{{join .Config.Cmd " "}}' \
+             --format='{{join .Config.Cmd "\n"}}' \
              "${DOCKER_IMAGE}")
 
 if [ -z "${DOCKER_CMD}" ]; then
   echo "[INFO] 'CMD' not found in docker image. Searching for 'ENTRY_POINT'"
   DOCKER_CMD=$(docker \
                inspect \
-               --format='{{join .Config.Entrypoint " "}}' \
+               --format='{{join .Config.Entrypoint "\n"}}' \
                "${DOCKER_IMAGE}") 
 fi
 


### PR DESCRIPTION
Earlier, we were using spaces to separate the elements of a Docker CMD/ENTRYPOINT. However, this caused a single argument to be split into multiple arguments at the time of execution in certain cases:

```
"Cmd": [                                                                                       
  "bash",                                                                                    
  "-c",                                                                                      
  "source /etc/bash.bashrc && jupyter notebook --notebook-dir=/tf --ip 0.0.0.0 --no-browser --allow-root"
],
```
This PR changes the separator to `\n`.