### PR TITLE
A bash script that prepares minirootfs + docker image as initramfs.

### DIFF
--- a/oak_docker_linux_init/README.md
+++ b/oak_docker_linux_init/README.md
@@ -117,8 +117,8 @@ to use as the Linux kernel when launching QEMU later:
 cp ${NETBOOT_VMLINUX} bin/vmlinux
 ```
 
-Note that you need to extract the kernel from so that it will be compatible with
-the drivers we will extract from the Alpine's initramfs file.
+Note that you need to extract the kernel from Alpine's distribution so that it will
+be compatible with the drivers we will extract from the Alpine's initramfs file.
 
 Build the initramfs with minirootfs, drivers, and a Docker image
 ([`tensorflow/tensorflow`](https://hub.docker.com/r/tensorflow/tensorflow/)

--- a/oak_docker_linux_init/README.md
+++ b/oak_docker_linux_init/README.md
@@ -7,15 +7,28 @@
 # Running a Docker container from stage0
 
 This example shows how to run a Docker container from Oak's stage0 firmware
-binary. We can achieve this by simply extracting the filesystem of the Docker
-container and packaging it as the
+binary. We can achieve this by preparing an
 [initial RAM disk](https://en.wikipedia.org/wiki/Initial_ramdisk) (initramfs)
-disk with an appropriate init binary. The easiest way to execute the initial RAM
-disk is to use
+that sets up the environment and launches the entry point of the docker image.
+Once we have the appropriate initial RAM disk, the easiest way to execute it is
+to use
 [QEMU's direct Linux boot feature](https://qemu-project.gitlab.io/qemu/system/linuxboot.html).
 
-Note: these steps assume that the commands will be executed from the project
+**Note:** these steps assume that the commands will be executed from the project
 root.
+
+## Prepare the initial RAM disk (initramfs)
+
+To run a Docker image on top of stage0 firmware binary, the key idea is to
+extract the filesystem from the Docker image and package it either as an
+initramfs image or a chroot tree.
+
+### Docker filesystem as the initial RAM disk
+
+If the Docker image is self sufficient and does not need any drivers, we can
+simply extract the filesystem of the Docker image and package it as an initramfs
+image. This is generally suitable for docker images that were built from
+scratch.
 
 Suppose that we want to run the
 [`hello-world:latest`](https://hub.docker.com/_/hello-world) Docker image, we
@@ -23,10 +36,115 @@ can convert it to a initramfs with the
 [docker_to_initramfs.sh](docker_to_initramfs.sh) script as follows:
 
 ```bash
-sh oak_docker_linux_init/docker_to_initramfs.sh hello-world:latest bin/initramfs
+sh oak_docker_linux_init/docker_to_rootfs.sh -d hello-world:latest -o bin/initramfs
 ```
 
-Build the Stage 0 Firmware image:
+Note that if you simply want to extract the filesystem in the Docker image
+without packaging it as an initramfs image, you can omit the `-o` option and use
+the `-r` option to specify the destination for the extracted filesystem as
+follows:
+
+```bash
+sh oak_docker_linux_init/docker_to_rootfs.sh -d hello-world:latest -r /tmp/docker_rootfs
+```
+
+Note that the script `docker_to_rootfs.sh` puts an `init` binary at the root of
+the directory, which launches the docker entry point after setting up the
+necessary environment. You can use this `init` binary as the `/init` for the
+initramfs or as the initial binary when you `chroot` to the filesystem extracted
+from the Docker image.
+
+### Docker filesystem as a chroot tree
+
+If the Docker image requires drivers and additional setup, we can have custom
+Docker launcher that is packaged as an initramfs image and then launch the
+docker container. We will use an [Alpine Linux](https://www.alpinelinux.org/)
+distribution for the purposes of this prototype. Ideally, we want to implement
+the Docker launcher from scratch and build a custom Linux kernel with all
+drivers, but the Alpine Linux distribution will help illustrate and derisk the
+changes needed to support Docker on top of Oak stage0.
+
+We will need the following packages from
+[Alpine Linux Downloads](https://www.alpinelinux.org/downloads/) Page:
+
+- [Alpine Minirootfs](https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-minirootfs-3.17.3-x86_64.tar.gz):
+  for an initial filesystem.
+- [Alpine Netboot](https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-netboot-3.17.3-x86_64.tar.gz):
+  for a Linux kernel and drivers.
+
+Download the necesary files:
+
+```bash
+OAK_DOCKER_PREP_DIR=$(mktemp -d)
+MINIROOTFS_TGZ="${OAK_DOCKER_PREP_DIR}/alpine-minirootfs.tar.gz"
+wget https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-minirootfs-3.17.3-x86_64.tar.gz \
+ -O "${MINIROOTFS_TGZ}"
+
+NETBOOT_TGZ="${OAK_DOCKER_PREP_DIR}/alpine-netboot.tar.gz"
+wget https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-netboot-3.17.3-x86_64.tar.gz \
+ -O "${NETBOOT_TGZ}"
+
+EXTRACT_VMLINUX="${OAK_DOCKER_PREP_DIR}/extract-vmlinux.sh"
+wget https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/extract-vmlinux \
+ -O "${EXTRACT_VMLINUX}"
+
+```
+
+Extract the initramfs from netboot:
+
+```bash
+NETBOOT_INITRAMFS="${OAK_DOCKER_PREP_DIR}/netboot-initramfs"
+tar xzvf "${NETBOOT_TGZ}" boot/initramfs-virt -O > "${NETBOOT_INITRAMFS}"
+```
+
+Also extract the corresponding compressed kernel and extract the vmlinux file.
+You will need the
+[extract-vmlinux](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/extract-vmlinux)
+script from the kernel source code.
+
+```bash
+NETBOOT_COMPRESSED_KERNEL="${OAK_DOCKER_PREP_DIR}/netboot-vmlinuz"
+NETBOOT_VMLINUX="${OAK_DOCKER_PREP_DIR}/netboot-vmlinux"
+
+tar xzvf "${NETBOOT_TGZ}" boot/vmlinuz-virt -O > "${NETBOOT_COMPRESSED_KERNEL}"
+sh "${EXTRACT_VMLINUX}" "${NETBOOT_COMPRESSED_KERNEL}" > "${NETBOOT_VMLINUX}"
+```
+
+You might want to copy the kernel to the `bin/` at the root of Oak's workspace
+to use as the Linux kernel when launching QEMU later:
+
+```bash
+cp ${NETBOOT_VMLINUX} bin/vmlinux
+```
+
+Note that you need to extract the kernel from so that it will be compatible with
+the drivers we will extract from the Alpine's initramfs file.
+
+Build the initramfs with minirootfs, drivers, and a Docker image
+([`tensorflow/tensorflow`](https://hub.docker.com/r/tensorflow/tensorflow/)
+here):
+
+```bash
+sh oak_docker_linux_init/prepare_docker_launcher_initramfs.sh \
+  -k ${NETBOOT_VMLINUX} \
+  -i ${NETBOOT_INITRAMFS} \
+  -m ${MINIROOTFS_TGZ} \
+  -o bin/initramfs \
+  -d tensorflow/tensorflow
+```
+
+To create an initramfs that will simply boot into a working shell, you can skip
+the `-d` option:
+
+```bash
+sh oak_docker_linux_init/prepare_docker_launcher_initramfs.sh \
+  -k ${NETBOOT_VMLINUX} \
+  -i ${NETBOOT_INITRAMFS} \
+  -m ${MINIROOTFS_TGZ} \
+  -o bin/initramfs
+```
+
+## Build the Stage 0 Firmware image
 
 ```bash
 ( cd stage0; cargo build --release; )
@@ -34,19 +152,29 @@ objcopy --output-format binary stage0/target/x86_64-unknown-none/release/oak_sta
     bin/stage0.bin
 ```
 
-Execute the initial RAM disk with QEMU:
+## Execute the initial RAM disk with QEMU with virtual net device
 
 Note: this assumes that an appropiate
 [uncompressed Linux kernel ELF binary](/docs/development.md#extracting-vmlinux-from-your-linux-installation)
 has been copied to `bin/vmlinux`.
 
 ```bash
-qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm" -m 1G \
+qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm" -m 8G \
     -nographic -nodefaults -no-reboot -serial stdio \
     -bios "bin/stage0.bin" \
-    -fw_cfg "name=opt/stage0/elf_kernel,file=bin/vmlinux" \
+    -fw_cfg "name=opt/stage0/elf_kernel,file=${NETBOOT_VMLINUX}" \
     -fw_cfg "name=opt/stage0/initramfs,file=bin/initramfs" \
-    -fw_cfg "name=opt/stage0/cmdline,string=console=ttyS0 quiet"
+    -fw_cfg "name=opt/stage0/cmdline,string=console=ttyS0 quiet" \
+    -netdev user,ipv6=off,id=user \
+    -device virtio-net-device,netdev=user
+```
+
+Note that you can forward ports from host device to the guest device by using
+the `hostfwd` option in QEMU. For example, to forward tcp port 8888 from host to
+guest, you replace the `netdev` option on the above command line as follows:
+
+```text
+  -netdev user,ipv6=off,id=user,hostfwd=tcp::8888-:8888
 ```
 
 After initializing the rootfs, the `/init` in the initramfs will execute the
@@ -60,3 +188,31 @@ memory should usually fix this error.
 _Note:_ the compressed initramfs image should also fit within the first 1G along
 with the Linux kernel. Otherwise, this approach of using initramfs will not
 work.
+
+# Examples
+
+## Serve Jupyter notebooks with a Tensorflow runtime
+
+Build initramfs:
+
+```bash
+sh oak_docker_linux_init/prepare_docker_launcher_initramfs.sh \
+  -k ${NETBOOT_VMLINUX} \
+  -i ${NETBOOT_INITRAMFS} \
+  -m ${MINIROOTFS_TGZ} \
+  -o bin/initramfs \
+  -d tensorflow/tensorflow:nightly-jupyter
+```
+
+Launch QEMU with network, where tcp port `8888` is forwarded from host to guest:
+
+```bash
+qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm" -m 8G \
+    -nographic -nodefaults -no-reboot -serial stdio \
+    -bios "bin/stage0.bin" \
+    -fw_cfg "name=opt/stage0/elf_kernel,file=${NETBOOT_VMLINUX}" \
+    -fw_cfg "name=opt/stage0/initramfs,file=bin/initramfs" \
+    -fw_cfg "name=opt/stage0/cmdline,string=console=ttyS0 quiet" \
+    -netdev user,ipv6=off,id=user,hostfwd=tcp::8888-:8888 \
+    -device virtio-net-device,netdev=user
+```

--- a/oak_docker_linux_init/README.md
+++ b/oak_docker_linux_init/README.md
@@ -117,8 +117,9 @@ to use as the Linux kernel when launching QEMU later:
 cp ${NETBOOT_VMLINUX} bin/vmlinux
 ```
 
-Note that you need to extract the kernel from Alpine's distribution so that it will
-be compatible with the drivers we will extract from the Alpine's initramfs file.
+Note that you need to extract the kernel from Alpine's distribution so that it
+will be compatible with the drivers we will extract from the Alpine's initramfs
+file.
 
 Build the initramfs with minirootfs, drivers, and a Docker image
 ([`tensorflow/tensorflow`](https://hub.docker.com/r/tensorflow/tensorflow/)

--- a/oak_docker_linux_init/prepare_docker_launcher_initramfs.sh
+++ b/oak_docker_linux_init/prepare_docker_launcher_initramfs.sh
@@ -7,7 +7,7 @@
 #
 #
 
- # exit when any command fails
+ # exit when any command fails.
 set -e
 
 readonly SCRIPT_DIR=$(dirname "$0")
@@ -86,7 +86,7 @@ readonly LINUX_KERNEL_VERSION="$(strings "${LINUX_KERNEL}" | \
 echo "[INFO] Linux kernel version is ${LINUX_KERNEL_VERSION}"
 
 
-# Extract Alpine's initramfs to a scratch directory
+# Extract Alpine's initramfs to a scratch directory.
 ALPINE_INITRAMFS_DIR="${SCRATCH_DIR}/alpine-initramfs"
 echo "[INFO] Extracting  ${ALPINE_INITRAMFS} to ${ALPINE_INITRAMFS_DIR}"
 mkdir "${ALPINE_INITRAMFS_DIR}"
@@ -94,11 +94,10 @@ mkdir "${ALPINE_INITRAMFS_DIR}"
 (cd "${ALPINE_INITRAMFS_DIR}" && \
   gzip -cd "${ALPINE_INITRAMFS}" | cpio -idm)
 
-# Extract the minirootfs to the root of the ramdisk
+# Extract the minirootfs to the root of the ramdisk.
 tar xzf "${ALPINE_MINIROOTFS_TAR}" -C "${RAMDIR}"
 
-# Extract the drivers from the initramfs and put them in ${RAMDIR}
-#
+# Extract the drivers from the initramfs and put them in ${RAMDIR}.
 echo "[INFO] Extracting necessary drivers from ${ALPINE_INITRAMFS}"
 readonly DRIVERS="
 kernel/drivers/net/virtio_net.ko
@@ -135,7 +134,7 @@ cp -f /etc/resolv.conf /docker_rootfs/etc/resolv.conf
 exec /usr/sbin/chroot /docker_rootfs /init"
 fi
 
-# Create the /init file in the initramfs file
+# Create the /init file in the initramfs file.
 echo "[INFO] Preparing /init file for initramfs"
 cat > "${RAMDIR}/init" <<EOF
 #!/bin/sh
@@ -155,7 +154,7 @@ ip link set up dev lo
 ip link set eth0 up
 udhcpc -i eth0
 
-# Launch terminal or docker as needed
+# Launch terminal or docker as needed.
 ${LAUNCH_CMD}
 EOF
 chmod a+x "${RAMDIR}/init"

--- a/oak_docker_linux_init/prepare_docker_launcher_initramfs.sh
+++ b/oak_docker_linux_init/prepare_docker_launcher_initramfs.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+#
+# Prepares an initramfs file by combining the following:
+#    - Alpine Linux's minirootfs.
+#    - Necessary drivers copied from an Alpine Linux distribution.
+#    - Filesystem extracted from the given docker image.
+#
+#
+
+ # exit when any command fails
+set -e
+
+readonly SCRIPT_DIR=$(dirname "$0")
+
+print_usage_and_exit() {
+  echo "Usage:
+  ${0} [-h] \\
+       -k <uncompressed-kernel> \\
+       -i <alpine-initiramfs>   \\
+       -m <alpine-minirootfs>   \\
+       -o <output-initramfs>    \\
+       -d <docker-image>
+
+Creates an initramfs with minirootfs+networking support as docker launcher.
+
+Options:
+  -k      Uncompressed kernel with which we use the drivers.
+  -i      Initramfs extracted from an Alpine iso distribution.
+  -m      Alpine's minirootfs tarball.
+  -d      Docker image that should be launched.
+  -o      Output initramfs file.
+  -h      Print this help message and exit."
+  exit 0
+}
+
+while getopts "hk:i:m:d:o:" opt; do
+  case $opt in
+    h)
+      print_usage_and_exit;;
+    k)
+      readonly LINUX_KERNEL="${OPTARG}";;
+    i)
+      readonly ALPINE_INITRAMFS="${OPTARG}";;
+    m)
+      readonly ALPINE_MINIROOTFS_TAR="${OPTARG}";;
+    d)
+      readonly DOCKER_IMAGE="${OPTARG}";;
+    o)
+      readonly OUTPUT_INITRAMFS="${OPTARG}";;
+    *)
+      echo "Invalid argument: ${OPTARG}"
+      exit 1;;
+  esac
+done
+
+if [ -z "${LINUX_KERNEL}" ]; then
+  echo "Missing required option: -k <uncompressed-kernel>"
+  exit 1
+fi
+
+if [ -z "${ALPINE_INITRAMFS}" ]; then
+  echo "Missing required option: -i <alpine-initramfs>"
+  exit 1
+fi
+
+if [ -z "${OUTPUT_INITRAMFS}" ]; then
+  echo "Missing required option: -o <output-initramfs>"
+  exit 1
+fi
+
+if [ -z "${ALPINE_MINIROOTFS_TAR}" ]; then
+  echo "Missing required option: -m <alpine-minirootfs>"
+  exit 1
+fi
+
+# Create a temporary workspace directory.
+readonly SCRATCH_DIR=$(mktemp -d)
+echo "[INFO] Scratch directory is ${SCRATCH_DIR}"
+# Make a directory for the initramfs.
+readonly RAMDIR=$(mktemp -d)
+echo "[INFO] Ramdisk staging directory is ${RAMDIR}"
+
+# Extract the linux version string from the kernel image.
+readonly LINUX_KERNEL_VERSION="$(strings "${LINUX_KERNEL}" | \
+                                 grep "Linux version" | cut -d\  -f3)"
+echo "[INFO] Linux kernel version is ${LINUX_KERNEL_VERSION}"
+
+
+# Extract Alpine's initramfs to a scratch directory
+ALPINE_INITRAMFS_DIR="${SCRATCH_DIR}/alpine-initramfs"
+echo "[INFO] Extracting  ${ALPINE_INITRAMFS} to ${ALPINE_INITRAMFS_DIR}"
+mkdir "${ALPINE_INITRAMFS_DIR}"
+# () is necessary to avoid changing pwd to ${ALPINE_INITRAMFS_DIR}
+(cd "${ALPINE_INITRAMFS_DIR}" && \
+  gzip -cd "${ALPINE_INITRAMFS}" | cpio -idm)
+
+# Extract the minirootfs to the root of the ramdisk
+tar xzf "${ALPINE_MINIROOTFS_TAR}" -C "${RAMDIR}"
+
+# Extract the drivers from the initramfs and put them in ${RAMDIR}
+#
+echo "[INFO] Extracting necessary drivers from ${ALPINE_INITRAMFS}"
+readonly DRIVERS="
+kernel/drivers/net/virtio_net.ko
+kernel/drivers/net/net_failover.ko
+kernel/net/core/failover.ko
+kernel/net/packet/af_packet.ko
+"
+
+readonly MODULES_DEP="lib/modules/${LINUX_KERNEL_VERSION}/modules.dep"
+for DRIVER in ${DRIVERS}; do
+  DRIVER_PATH="lib/modules/${LINUX_KERNEL_VERSION}/${DRIVER}"
+  DRIVER_DIR=$(dirname "${DRIVER_PATH}")
+  echo "[INFO] Extracting ${DRIVER}"
+  mkdir -p "${RAMDIR}/${DRIVER_DIR}" &&
+    cp "${ALPINE_INITRAMFS_DIR}/${DRIVER_PATH}" "${RAMDIR}/${DRIVER_PATH}"
+  # Extract the module depedency info.
+  grep "^$DRIVER:" "${ALPINE_INITRAMFS_DIR}/${MODULES_DEP}" \
+    >> "${RAMDIR}/${MODULES_DEP}"
+done
+
+if [ -z "${DOCKER_IMAGE}" ]; then
+  echo "[WARN] No docker image specified. initramfs will launch a shell."
+  echo "       Use -d option to specify docker image if needed."
+  LAUNCH_CMD="exec /sbin/getty -n -l /bin/sh 115200 /dev/console"
+else
+  echo "[INFO] Preparing docker image as a rootfs."
+  readonly DOCKER_ROOTFS_DIR="${RAMDIR}/docker_rootfs"
+  mkdir -p "${DOCKER_ROOTFS_DIR}"
+  sh "$SCRIPT_DIR/docker_to_rootfs.sh" \
+    -d "${DOCKER_IMAGE}" -r "${DOCKER_ROOTFS_DIR}"
+  LAUNCH_CMD="
+# copy the resolv.conf file to the chroot.
+cp -f /etc/resolv.conf /docker_rootfs/etc/resolv.conf
+exec /usr/sbin/chroot /docker_rootfs /init"
+fi
+
+# Create the /init file in the initramfs file
+echo "[INFO] Preparing /init file for initramfs"
+cat > "${RAMDIR}/init" <<EOF
+#!/bin/sh
+#
+# /init executable file in the initramfs
+#
+mount -t devtmpfs dev /dev
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+
+# Load drivers
+modprobe virtio-net
+modprobe af_packet
+
+# Bring up network interfaces.
+ip link set up dev lo
+ip link set eth0 up
+udhcpc -i eth0
+
+# Launch terminal or docker as needed
+${LAUNCH_CMD}
+EOF
+chmod a+x "${RAMDIR}/init"
+
+echo "[INFO] Creating initramfs file at ${OUTPUT_INITRAMFS}..."
+(cd "${RAMDIR}"; find . -print0 \
+    | cpio --null --create --format=newc ) \
+    | gzip > "${OUTPUT_INITRAMFS}"
+echo "[INFO] Creating initramfs file at ${OUTPUT_INITRAMFS}...done"

--- a/oak_docker_linux_init/src/main.rs
+++ b/oak_docker_linux_init/src/main.rs
@@ -33,6 +33,11 @@ fn main() -> ! {
     // Set up the Linux environment, since we expect to be the initial process.
     init::init().unwrap();
 
+    // For now, just set PATH to some common locations. Docker image has information about
+    // the environment variables that need to be set up before the container is launched. We
+    // should use that information to set up all the necessary environment variables.
+    std::env::set_var("PATH", "/usr/local/bin:/sbin:/usr/sbin:/bin:/usr/bin");
+
     let file = File::open(DOCKER_COMMAND_PATH).expect("Error reading file");
     let content_vec = BufReader::new(file)
         .lines()


### PR DESCRIPTION
This PR has a a bunch of changes:

1. A `prepare_docker_launcher_initramfs.sh` script combines the following to create the initramfs:
   - Alpine's minirootfs
   - Necessary drivers from an Alpine Linux distribution.
   - Filesystem extracted from the given docker image.
Note that if the docker image is not provided, the script creates an initramfs that provides a working shell.
1. Generalize the `docker_to_initramfs.sh` script to generate a chroot directory or initramfs images
1. A hack to set up PATH environment variables to some common locations.

Note that this PR is meant to demonstrate the steps that are needed to launch a docker container with networking support. To achieve the task, we pull drivers and kernel from the [Alpine Linux](www.alpinelinux.org) distribution. We also use Alpine's minirootfs as the docker launcher. Ideally, we will have to build the Linux kernel, drivers, and a docker launcher from scratch. However, this prototype provides a good step towards making progress on the Oak Docker project. For example, using this prototype, we were able to launch and interact with a docker container running Tensorflow Jupyter notebook running TF+CPU runtime.


