### PR TITLE
Simplify Stage0 page table assembly code

### DIFF
--- a/stage0/src/asm/boot.s
+++ b/stage0/src/asm/boot.s
@@ -68,38 +68,29 @@ _protected_mode_start:
     # Switch to a flat 32-bit data segment, giving us access to all 4G of memory.
     mov $ds, %eax
     mov %eax, %ds
+    mov %eax, %es
     mov %eax, %ss
 
     # Set up a basic stack, as we may get interrupts.
     mov $stack_start, %esp
 
-    # Zero-out all the page tables: start address in EDI, value in AL, count in ECX.
-    mov $0x1000, %ecx         # each table is exactly 4096 bytes long.
-    xor %eax, %eax            # zero out eax
-    mov ${pml4}, %edi
-    rep stosb
-
-    mov ${pdpt}, %edi
-    rep stosb
-
-    mov ${pd_0}, %edi
-    rep stosb
-
-    mov ${pd_3}, %edi
-    rep stosb
-
-    mov ${pt_0}, %edi
-    rep stosb
+    # Clear BSS: base address goes to RDI, value (0) goes to AX,
+    # count/4 (we are updating 4 bytes at a time) goes into CX.
+    mov $bss_start, %edi
+    mov $bss_size, %ecx
+    shr $2, %ecx
+    xor %eax, %eax
+    rep stosl
 
     # Set the first entry of PML4 to point to PDPT (0..512GiB).
     mov ${pdpt}, %edi
     orl $3, %edi              # edi |= 3 (PRESENT and WRITABLE)
-    mov %edi, ({pml4})          # set first half of PML4[0]
+    mov %edi, ({pml4})        # set first half of PML4[0]
 
     # Set the first entry of PDPT to point to PD_0 (0..1GiB).
     mov ${pd_0}, %edi
     orl $3, %edi              # edi |= 3 (PRESENT and WRITABLE)
-    mov %edi, ({pdpt})          # set first half of PDPT[0]
+    mov %edi, ({pdpt})        # set first half of PDPT[0]
 
     # Set the fourth entry of PDPT to point to PD_3 (3..4GiB).
     mov ${pdpt}, %eax
@@ -107,10 +98,9 @@ _protected_mode_start:
     orl $3, %edi              # edi |= 3 (PRESENT and WRITABLE)
     mov %edi, 24(%eax)        # set first half of PDPT[3], each entry is 8 bytes
 
-    # Set the first entry of PD_0 to point to PT_0 (0..2MiB).
-    mov ${pt_0}, %edi
-    orl $3, %edi              # edi |= 3 (PRESENT and WRITABLE)
-    mov %edi, ({pd_0})          # set first half of PD_0[0]
+    # Set the first entry of PD_0 to point to and identity mapped huge page (0..2MiB).
+    mov $0x83, %edi           # edi = 0x0 | 131 (PRESENT and WRITABLE and HUGE_PAGE)
+    mov %edi, ({pd_0})        # set first half of PD_0[0]
 
     # Set the last entry of PD_3 to point to an identity-mapped 2MiB huge page ((4GiB-2MiB)..4GiB).
     # This is where the firmware ROM image is mapped, so we don't make it writable.
@@ -118,21 +108,6 @@ _protected_mode_start:
     mov $0xFFE00000, %edi     # address of 4GiB-2MiB
     orl $0x81, %edi           # edi |= 129 (PRESENT and HUGE_PAGE)
     mov %edi, 0xFF8(%eax)     # set first half of PML4[511], each entry is 8 bytes
-
-    # Set up the 4K page table for the lowest 2 MiB of memory. We set up an individual page table
-    # instead of using a 2MiB hugepage because we may need to change the encrypted bit and the
-    # RMP state on individual 4K pages.
-    mov ${pt_0}, %ecx       # base for page table
-    mov $1, %eax            # loop counter: we start at 1 so that 0 (the first 4K) would remain
-                            # unmapped (so that null pointers would trigger a page fault)
-    1:
-    mov %eax, %edx          # edx = eax
-    sal $12, %edx           # edx = edx << 12 (2^12 == 4K)
-    orl $3, %edx            # edx |= 3 (PRESENT and WRITABLE)
-    mov %edx, (%ecx,%eax,8) # PT[eax] = edx (memory address is ecx+8*eax)
-    inc %eax                # eax = eax + 1
-    cmp $512, %eax          # are we done with all 512 entries?
-    jne 1b                  # no, we were not
 
     # Determine if we're running under SEV. Keep track of which bit is the encrypted bit in %rsi.
     mov $0, %esi              # by default, no encryption
@@ -167,33 +142,24 @@ _protected_mode_start:
     xor %ecx, %ecx            # ECX = 0 - we're not interested in a subpage
     cpuid                     # EAX, EBX, ECX, EDX = CPUID(EAX, ECX)
     and $0b111111, %ebx       # zero out all but EBX[5:0], which the C-bit location
-    push %ebx                 # save the full C-bit location value for later
+    mov %ebx, %esi            # save the full C-bit location value for later to pass into main
     sub $32, %ebx             # let's assume the encrypted bit is > 32, as it simplifies logic below
     mov $1, %edi
     mov %ebx, %ecx
-    shl %cl, %edi             # construct the bit mask for the loop, store it in EDI
+    shl %cl, %edi             # construct the encrypted bit mask, store it in EDI
 
-    # Note that this sets the encrypted bit for _all_ entries in the page tables, even
-    # if they are unused. This is fine, as those entries will still not have the PRESENT
-    # bit set and thus will be ignored by the CPU.
-    mov ${pml4}, %eax         # Base values for all page tables.
-    mov ${pdpt}, %ebx
-    mov ${pd_0}, %ecx
-    mov ${pd_3}, %edx
-    mov ${pt_0}, %ebp
-    xor %esi, %esi            # zero out esi for use as the loop counter
-    1:
-    # Page table entries are 8 bytes and the encrypted bit is in the second 4 bytes,
-    # so these offsets boil down to base + (ESI * 8) + 4.
-    or %edi, 4(%eax,%esi,8)   # PML4[ESI] |= EDI
-    or %edi, 4(%ebx,%esi,8)   # PDPT[ESI] |= EDI
-    or %edi, 4(%ecx,%esi,8)   # PD_0[ESI] |= EDI
-    or %edi, 4(%edx,%esi,8)   # PD_3[ESI] |= EDI
-    or %edi, 4(%ebp,%esi,8)   # PT_0[ESI] |= EDI
-    inc %esi                  # ESI = ESI + 1
-    cmp $512, %esi            # have we changed all 512 entries?
-    jne 1b                    # ESI < 512, go back to square 1
-    pop %esi                  # keep track of the encrypted bit for main
+    # We set the encrypted bit for each of the page table entries that we previously created.
+    # The encrypted bit is in the second half of each 8-byte entry, so we add an extra offset of 4 bytes.
+    mov ${pml4}, %eax
+    mov %edi, 4(%eax)         # set second half of PML4[0]
+    mov ${pdpt}, %eax
+    mov %edi, 4(%eax)         # set second half of PDPT[0]
+    mov ${pdpt}, %eax
+    mov %edi, 28(%eax)        # set second half of PDPT[3], each entry is 8 bytes
+    mov ${pd_0}, %eax
+    mov %edi, 4(%eax)         # set second half of PD_0[0]
+    mov ${pd_3}, %eax
+    mov %edi, 0xFFC(%eax)     # set second half of PML4[511], each entry is 8 bytes
 no_encryption:
 
     # Load PML4
@@ -232,12 +198,6 @@ _long_mode_start:
     # Set up the stack.
     mov $stack_start, %esp
     push $0
-
-    # Clear BSS: base address goes to RDI, value goes to AX, count goes into CX.
-    mov $bss_start, %edi
-    mov $bss_size, %ecx
-    xor %rax, %rax
-    rep stosb
     
     # ESI should contain the encrypted bit number. Move it to EDI, as that's the first argument
     # according to sysv ABI.

--- a/stage0/src/asm/mod.rs
+++ b/stage0/src/asm/mod.rs
@@ -22,6 +22,5 @@ global_asm!(
     pdpt = sym crate::paging::PDPT,
     pd_0 = sym crate::paging::PD_0,
     pd_3 = sym crate::paging::PD_3,
-    pt_0 = sym crate::paging::PT_0,
     options(att_syntax));
 global_asm!(include_str!("reset_vector.s"), options(att_syntax, raw));

--- a/stage0/src/main.rs
+++ b/stage0/src/main.rs
@@ -127,7 +127,7 @@ pub extern "C" fn rust64_start(encrypted: u64) -> ! {
         None
     };
 
-    paging::init_page_table_refs();
+    paging::init_page_table_refs(encrypted);
 
     logging::init_logging(match ghcb_protocol {
         Some(protocol) => PortFactoryWrapper::new_ghcb(protocol),


### PR DESCRIPTION
This PR simplifies the Stage 0 assembly code related to page tables:

- Move the page tables to BSS
- Move the code to zeo-out BSS earlier so we don't have to separately zero out the page tables
- Only map 2MiB huge pages in assembly and create the 4KiB pages in Rust code
- Only update the actual page table entries we created with the encrypted bit rather than looping through all the page table entries