### PR TITLE
Move the stage0 data segment to low memory

### DIFF
--- a/stage0/layout.ld
+++ b/stage0/layout.ld
@@ -75,6 +75,13 @@ SECTIONS {
         bss_size = . - bss_start;
     } > ram_low
 
+    .data : 
+    AT ( ADDR (.text) + SIZEOF (.text) ) {
+        data_start = .;
+        *(.data .data.*)
+        data_size = . - data_start;
+    } > ram_low
+
     /* Put the stack just below the EBDA, at the end of 512K. */
     .stack (0x80000 - 32K) (NOLOAD) : {
         . += 32K;
@@ -101,10 +108,7 @@ SECTIONS {
 
     .text : {
         *(.text .text.*)
-    } > bios
-
-    .data : {
-        *(.data .data.*)
+        text_end = .;
     } > bios
 
     /* Everything below this line interacts with 16-bit code, so should be kept as close to the end of the file as

--- a/stage0/src/asm/boot.s
+++ b/stage0/src/asm/boot.s
@@ -68,7 +68,7 @@ _protected_mode_start:
     # Switch to a flat 32-bit data segment, giving us access to all 4G of memory.
     mov $ds, %eax
     mov %eax, %ds
-    mov %eax, %es
+    mov %eax, %es         # needed for destination of stosb and movsb
     mov %eax, %ss
 
     # Set up a basic stack, as we may get interrupts.
@@ -79,6 +79,13 @@ _protected_mode_start:
     mov $bss_size, %ecx
     xor %eax, %eax
     rep stosb
+
+    # Copy DATA from ROM image just after TEXT.
+    # Source address goes to ESI, destination goes to EDI, count goes to ECX.
+    mov $text_end, %esi
+    mov $data_start, %edi
+    mov $data_size, %ecx
+    rep movsb
 
     # Set the first entry of PML4 to point to PDPT (0..512GiB).
     mov ${pdpt}, %edi

--- a/stage0/src/asm/boot.s
+++ b/stage0/src/asm/boot.s
@@ -80,7 +80,7 @@ _protected_mode_start:
     xor %eax, %eax
     rep stosb
 
-    # Copy DATA from ROM image just after TEXT.
+    # Copy DATA from the ROM image (stored just after TEXT) to the expected location.
     # Source address goes to ESI, destination goes to EDI, count goes to ECX.
     mov $text_end, %esi
     mov $data_start, %edi


### PR DESCRIPTION
This moves the target location DATA segment into low memory, while still storing the content in the ROM image. The bootstrap assembly then copies it from the ROM image into the expected memory location in low memory.