### PR TITLE
Be more lenient about ACPI RSDP size in stage0

### DIFF
--- a/stage0/src/acpi.rs
+++ b/stage0/src/acpi.rs
@@ -106,7 +106,10 @@ impl Allocate {
         let name = self.file().to_str().map_err(|_| "invalid file name")?;
 
         if name.ends_with(RSDP_FILE_NAME_SUFFIX) {
-            if file.size() != RSDP_SIZE {
+            // ACPI 1.0 RSDP is 20 bytes, ACPI 2.0 RSDP is 36 bytes.
+            // We don't really care which version we're dealing with, as long as the data structure
+            // is one of the two.
+            if file.size() > RSDP_SIZE || (file.size() != 20 && file.size() != 36) {
                 return Err("RSDP doesn't match expected size");
             }
 


### PR DESCRIPTION
We just build ACPI tables in stage0, so we don't care whether we're dealing with ACPI 1.0 or 2.0.