### PR TITLE
Simplify how we track physical memory

### DIFF
--- a/oak_restricted_kernel/src/memory.rs
+++ b/oak_restricted_kernel/src/memory.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use core::{
     alloc::{GlobalAlloc, Layout},
-    ops::{Deref, DerefMut},
+    ops::Deref,
     ptr::NonNull,
     result::Result,
 };
@@ -71,8 +71,8 @@ impl GrowableHeap {
     fn extend(&mut self) -> Result<(), &'static str> {
         // We might want to do something more clever here, such as exponentially increasing the
         // number of frames we allocate. For now, let's just keep extending by one frame.
-        let mut frame_allocator = FRAME_ALLOCATOR.get().unwrap().lock();
-        let frame: PhysFrame<Size2MiB> = frame_allocator
+        let frame: PhysFrame<Size2MiB> = FRAME_ALLOCATOR
+            .lock()
             .allocate_frame()
             .ok_or("failed to allocate memory for kernel heap")?;
 
@@ -96,7 +96,6 @@ impl GrowableHeap {
                         | PageTableFlags::WRITABLE
                         | PageTableFlags::NO_EXECUTE
                         | PageTableFlags::ENCRYPTED,
-                    frame_allocator.deref_mut(),
                 )
                 .map_err(|_| "unable to create page mapping for kernel heap")?
                 .flush();

--- a/oak_restricted_kernel/src/mm/frame_allocator.rs
+++ b/oak_restricted_kernel/src/mm/frame_allocator.rs
@@ -15,8 +15,12 @@
 //
 
 use super::bitmap_frame_allocator::BitmapAllocator;
-use x86_64::structures::paging::{
-    frame::PhysFrameRange, FrameAllocator, FrameDeallocator, PhysFrame, Size2MiB, Size4KiB,
+use x86_64::{
+    structures::paging::{
+        frame::PhysFrameRange, FrameAllocator, FrameDeallocator, PageSize, PhysFrame, Size2MiB,
+        Size4KiB,
+    },
+    PhysAddr,
 };
 
 /// Allocator to track physical memory frames.
@@ -39,7 +43,22 @@ pub struct PhysicalMemoryAllocator<const N: usize> {
 }
 
 impl<const N: usize> PhysicalMemoryAllocator<N> {
-    pub fn new(range: PhysFrameRange<Size2MiB>) -> Self {
+    /// Assumes valid physical memory ranges from [0 ... N * 64 * Size2MiB::SIZE].
+    pub const fn new() -> Self {
+        // Safety: we have to resort to `unsafe` as we need to call the const fn-s, but both
+        // addresses are definitely Size2MiB::SIZE-aligned, so these operations are safe.
+        Self::new_range(PhysFrame::range(
+            unsafe { PhysFrame::from_start_address_unchecked(PhysAddr::zero()) },
+            // N u64-s * 64 frames per u64 * 2 MiB per frame
+            unsafe {
+                PhysFrame::from_start_address_unchecked(PhysAddr::new(
+                    N as u64 * 64 * Size2MiB::SIZE,
+                ))
+            },
+        ))
+    }
+
+    pub const fn new_range(range: PhysFrameRange<Size2MiB>) -> Self {
         PhysicalMemoryAllocator {
             large_frames: BitmapAllocator::new(range),
             small_frames: None,
@@ -117,7 +136,7 @@ mod tests {
     #[test]
     fn simple_allocator() {
         let mut allocator =
-            PhysicalMemoryAllocator::<1>::new(create_frame_range(0, 2 * Size2MiB::SIZE));
+            PhysicalMemoryAllocator::<1>::new_range(create_frame_range(0, 2 * Size2MiB::SIZE));
         allocator.mark_valid(create_frame_range(0, 2 * Size2MiB::SIZE), true);
         (&mut allocator as &mut dyn FrameAllocator<Size2MiB>)
             .allocate_frame()
@@ -130,7 +149,7 @@ mod tests {
     #[test]
     fn fill_small_frames() {
         let mut allocator =
-            PhysicalMemoryAllocator::<1>::new(create_frame_range(0, Size2MiB::SIZE));
+            PhysicalMemoryAllocator::<1>::new_range(create_frame_range(0, Size2MiB::SIZE));
         allocator.mark_valid(create_frame_range(0, Size2MiB::SIZE), true);
         let alloc_ref = &mut allocator as &mut dyn FrameAllocator<Size4KiB>;
         // 512 allocations should succeed (512 * 4K = 2M)

--- a/oak_restricted_kernel/src/syscall/mmap.rs
+++ b/oak_restricted_kernel/src/syscall/mmap.rs
@@ -22,7 +22,6 @@ use core::{
     cmp::max,
     ffi::{c_int, c_size_t, c_void},
     iter::repeat_with,
-    ops::DerefMut,
     slice,
 };
 use oak_restricted_kernel_interface::{
@@ -75,7 +74,7 @@ pub fn mmap(
 
     // Allocate enough physical frames to cover the request.
     // Iterator that keeps allocating physical frames.
-    let frames = repeat_with(|| FRAME_ALLOCATOR.get().unwrap().lock().allocate_frame());
+    let frames = repeat_with(|| FRAME_ALLOCATOR.lock().allocate_frame());
 
     let pt_flags = PageTableFlags::PRESENT
         | PageTableFlags::USER_ACCESSIBLE
@@ -130,7 +129,6 @@ pub fn mmap(
                         | PageTableFlags::WRITABLE
                         | PageTableFlags::ENCRYPTED
                         | PageTableFlags::USER_ACCESSIBLE,
-                    FRAME_ALLOCATOR.get().unwrap().lock().deref_mut(),
                 )
                 .map_err(|err| {
                     log::error!(


### PR DESCRIPTION
Although we have a global FRAME_ALLOCATOR static variable, at times we still carried a reference to it around. We don't really need to, and that simplifies the code. Physical memory is a global resource anyway, and it doesn't make much sense to have multiple frame allocators around.

Another insight is that when we create a `FrameAllocator` all of the memory will be marked as invalid (and you won't be able to acquire any physical memory until `mm::init()` is called). Thus, we can simplify things even further and just have it in a `Spinlock` without bothering with a `OnceCell` as nothing bad can happen if you call `FrameAllocator::allocate_frame` _before_ any memory there is marked as available.