### PR TITLE
Increase the amount of physical memory we can track to 512 GiB.

### DIFF
--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -95,8 +95,8 @@ use x86_64::{
 };
 
 /// Allocator for physical memory frames in the system.
-/// We reserve enough room to handle up to 128 GiB of memory, for now.
-pub static FRAME_ALLOCATOR: Spinlock<PhysicalMemoryAllocator<1024>> =
+/// We reserve enough room to handle up to 512 GiB of memory, for now.
+pub static FRAME_ALLOCATOR: Spinlock<PhysicalMemoryAllocator<4096>> =
     Spinlock::new(PhysicalMemoryAllocator::new());
 
 /// The allocator for allocating space in the memory area that is shared with the hypervisor.


### PR DESCRIPTION
Turns out 128 GiB is not enough for everybody.

This does increase the bitmap size significantly (it'll be 2* 32KiB), and at some point we may want to implement a cleverer algorithm to track physical memory. But 64K is still tiny in the grand scheme of things.