### PR TITLE
Create a `RootPageTable` struct to encapsulate all page operations

### DIFF
--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -74,8 +74,7 @@ use core::{marker::Sync, panic::PanicInfo, str::FromStr};
 use linked_list_allocator::LockedHeap;
 use log::{error, info};
 use mm::{
-    encrypted_mapper::{EncryptedPageTable, PhysOffset},
-    frame_allocator::PhysicalMemoryAllocator,
+    frame_allocator::PhysicalMemoryAllocator, page_tables::RootPageTable,
     virtual_address_allocator::VirtualAddressAllocator,
 };
 use oak_channel::Channel;
@@ -85,7 +84,7 @@ use oak_sev_guest::msr::{change_snp_state_for_frame, get_sev_status, PageAssignm
 use spinning_top::Spinlock;
 use strum::{EnumIter, EnumString, IntoEnumIterator};
 use x86_64::{
-    structures::paging::{MappedPageTable, Page, Size2MiB},
+    structures::paging::{Page, Size2MiB},
     PhysAddr, VirtAddr,
 };
 
@@ -98,8 +97,7 @@ pub static FRAME_ALLOCATOR: Spinlock<PhysicalMemoryAllocator<4096>> =
 pub static GUEST_HOST_HEAP: OnceCell<LockedHeap> = OnceCell::new();
 
 /// Active page tables.
-pub static PAGE_TABLES: OnceCell<EncryptedPageTable<MappedPageTable<'static, PhysOffset>>> =
-    OnceCell::new();
+pub static PAGE_TABLES: OnceCell<RootPageTable> = OnceCell::new();
 
 /// Allocator for long-lived pages in the kernel.
 pub static VMA_ALLOCATOR: Spinlock<VirtualAddressAllocator<Size2MiB>> =

--- a/oak_restricted_kernel/src/mm/page_tables.rs
+++ b/oak_restricted_kernel/src/mm/page_tables.rs
@@ -18,12 +18,18 @@ use goblin::elf64::program_header::{ProgramHeader, PF_W, PF_X, PT_LOAD};
 use x86_64::{
     align_down, align_up,
     structures::paging::{
-        frame::PhysFrameRange, mapper::MapToError, Page, PageSize, PhysFrame, Size2MiB, Size4KiB,
+        frame::PhysFrameRange,
+        mapper::{FlagUpdateError, MapToError, MapperFlush, UnmapError},
+        page::PageRange,
+        MappedPageTable, Page, PageSize, PageTable, PhysFrame, Size2MiB, Size4KiB,
     },
     PhysAddr, VirtAddr,
 };
 
-use super::{Mapper, PageTableFlags, KERNEL_OFFSET};
+use super::{
+    encrypted_mapper::{EncryptedPageTable, MemoryEncryption, PhysOffset},
+    Mapper, PageTableFlags, Translator, KERNEL_OFFSET,
+};
 
 /// Map a region of physical memory to a virtual address using 2 MiB pages.
 ///
@@ -116,4 +122,148 @@ pub unsafe fn create_kernel_map<M: Mapper<Size2MiB> + Mapper<Size4KiB>>(
             )
         })
         .try_for_each(|(range, offset, flags)| create_offset_map(range, offset, flags, mapper))
+}
+
+pub struct RootPageTable {
+    inner: EncryptedPageTable<MappedPageTable<'static, PhysOffset>>,
+}
+
+impl RootPageTable {
+    pub fn new(
+        pml4: &'static mut PageTable,
+        offset: VirtAddr,
+        encryption: MemoryEncryption,
+    ) -> Self {
+        RootPageTable {
+            inner: EncryptedPageTable::new(pml4, offset, encryption),
+        }
+    }
+    /// Checks wheter all the pages in the range are unallocated.
+    ///
+    /// Even though the pages may be of arbitrary size, we check all 4KiB-aligned addresses in the
+    /// range, as the mappings may be done with a smaller page size.
+    ///
+    /// If we find an address with a valid mapping, we return the page which contains a valid
+    /// mapping.
+    pub fn is_unallocated<S: PageSize>(&self, range: PageRange<S>) -> Result<(), Page<S>> {
+        if let Some(item) = Page::<Size4KiB>::range(
+            Page::containing_address(range.start.start_address()),
+            Page::containing_address(range.end.start_address()),
+        )
+        .find(|page| self.translate_virtual(page.start_address()).is_some())
+        {
+            // We found a page that had a valid mapping in that range, bail out.
+            Err(Page::<S>::containing_address(item.start_address()))
+        } else {
+            // No valid mappings found, the whole range is unmapped!
+            Ok(())
+        }
+    }
+
+    /// Finds a range of unallocated pages of the requested size.
+    ///
+    /// Args:
+    ///   - start: the pages must start at, or after, `start`
+    ///   - count: number of pages to allocate
+    ///
+    /// Returns:
+    /// The range of unallocated pages, if there was a big enough unallocated gap in the virtual
+    /// address space. The range may start at exactly `start`.
+    pub fn find_unallocated_pages<S: PageSize>(
+        &self,
+        mut start: Page<S>,
+        count: usize,
+    ) -> Option<PageRange<S>> {
+        // This is highly inefficient, but it should be called rarely enough that it doesn't matter
+        // (famous last words...)
+        // We assume virtual addresses are 48 bits, with the gap in the middle.
+        let limit = Page::containing_address(if start.start_address().as_u64() < u64::pow(2, 47) {
+            VirtAddr::new(u64::pow(2, 47) - 1)
+        } else {
+            VirtAddr::new(0xFFFF_FFFF_FFFF_FFFF - 1)
+        });
+        while start < limit {
+            let range = Page::range(start, start + count as u64);
+
+            // If it turns out something in that range was allocated, we move forward to the page
+            // after that and try again.
+            match self.is_unallocated(range) {
+                Ok(()) => return Some(range),
+                Err(page) => start = page + 1,
+            }
+        }
+
+        // given the size of the 64-bit address space, this should never happen
+        None
+    }
+}
+
+impl Mapper<Size4KiB> for RootPageTable {
+    unsafe fn map_to_with_table_flags(
+        &self,
+        page: Page<Size4KiB>,
+        frame: PhysFrame<Size4KiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>> {
+        self.inner
+            .map_to_with_table_flags(page, frame, flags, parent_table_flags)
+    }
+
+    unsafe fn unmap(
+        &self,
+        page: Page<Size4KiB>,
+    ) -> Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> {
+        self.inner.unmap(page)
+    }
+
+    unsafe fn update_flags(
+        &self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size4KiB>, FlagUpdateError> {
+        self.inner.update_flags(page, flags)
+    }
+}
+
+impl Mapper<Size2MiB> for RootPageTable {
+    unsafe fn map_to_with_table_flags(
+        &self,
+        page: Page<Size2MiB>,
+        frame: PhysFrame<Size2MiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>> {
+        self.inner
+            .map_to_with_table_flags(page, frame, flags, parent_table_flags)
+    }
+
+    unsafe fn unmap(
+        &self,
+        page: Page<Size2MiB>,
+    ) -> Result<(PhysFrame<Size2MiB>, MapperFlush<Size2MiB>), UnmapError> {
+        self.inner.unmap(page)
+    }
+
+    unsafe fn update_flags(
+        &self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size2MiB>, FlagUpdateError> {
+        self.inner.update_flags(page, flags)
+    }
+}
+
+impl Translator for RootPageTable {
+    fn translate_virtual(&self, addr: VirtAddr) -> Option<PhysAddr> {
+        self.inner.translate_virtual(addr)
+    }
+
+    fn translate_physical(&self, addr: PhysAddr) -> Option<VirtAddr> {
+        self.inner.translate_physical(addr)
+    }
+
+    fn translate_physical_frame<S: PageSize>(&self, frame: PhysFrame<S>) -> Option<Page<S>> {
+        self.inner.translate_physical_frame(frame)
+    }
 }


### PR DESCRIPTION
The idea is that in the future every process would have it's very own `RootPageTable`, and as part of context switches we load the appropriate PML4 inside the `RootPageTable` into `cr3`.

For now, `RootPageTable` does almost nothing; it just wraps `EncryptedPageTable` and delegates all operations to that. But it will gain more features in the future.