### PR TITLE
Specify default target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -36,3 +36,7 @@ WORKSPACE_ROOT = { value = "", relative = true }
 # TODO(#3702): Remove exception when deps are updated.
 [future-incompat-report]
 frequency = "never"
+
+[build]
+# Specify a default target so that cache is not invalidated between builds.
+target = "x86_64-unknown-linux-gnu"

--- a/scripts/build_gh_pages
+++ b/scripts/build_gh_pages
@@ -13,6 +13,7 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 source "$SCRIPTS_DIR/common"
 
 readonly TARGET_DIR="${1:-}"
+readonly DEFAULT_TARGET=x86_64-unknown-linux-gnu
 
 if [[ -z "${TARGET_DIR}" ]]; then
   echo 'target dir not specified'
@@ -32,13 +33,13 @@ fi
 cargo doc --no-deps --target-dir="${TARGET_DIR}"
 
 # Remove non-doc artifacts from the target dir.
-rm --recursive --force "${TARGET_DIR}/debug"
+rm --recursive --force "${TARGET_DIR}/${DEFAULT_TARGET}/debug"
 
 # Remove non-deterministic files.
 rm "${TARGET_DIR}/.rustc_info.json"
 
 # Remove unnecessary lock file, which is also owned by root and therefore problematic.
-rm "${TARGET_DIR}/doc/.lock"
+rm "${TARGET_DIR}/${DEFAULT_TARGET}/doc/.lock"
 
 # The docs generated from the Cargo workspace do not include a workspace-level index, so we generate
 # one here and redirect to the appropriate documentation.
@@ -47,10 +48,10 @@ cat <<-END > "${TARGET_DIR}/index.html"
   <!DOCTYPE html>
   <html>
     <head>
-      <meta http-equiv="Refresh" content="0; url=./doc/${REDIRECT_CRATE_NAME}/index.html" />
+      <meta http-equiv="Refresh" content="0; url=./${DEFAULT_TARGET}/doc/${REDIRECT_CRATE_NAME}/index.html" />
     </head>
     <body>
-      <p><a href="./doc/${REDIRECT_CRATE_NAME}/index.html">${REDIRECT_CRATE_NAME}</a></p>
+      <p><a href="./${DEFAULT_TARGET}/doc/${REDIRECT_CRATE_NAME}/index.html">${REDIRECT_CRATE_NAME}</a></p>
     </body>
   </html>
 END

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -21,10 +21,22 @@ pub static MOCK_LOOKUP_DATA_PATH: Lazy<PathBuf> =
 static STAGE_0_DIR: Lazy<PathBuf> = Lazy::new(|| workspace_path(&["stage0"]));
 pub static OAK_RESTRICTED_KERNEL_BIN_DIR: Lazy<PathBuf> =
     Lazy::new(|| workspace_path(&["oak_restricted_kernel_bin"]));
-static OAK_FUNCTIONS_LAUNCHER_BIN: Lazy<PathBuf> =
-    Lazy::new(|| workspace_path(&["target", "debug", "oak_functions_launcher"]));
-pub static QUIRK_ECHO_LAUNCHER_BIN: Lazy<PathBuf> =
-    Lazy::new(|| workspace_path(&["target", "debug", "quirk_echo_launcher"]));
+static OAK_FUNCTIONS_LAUNCHER_BIN: Lazy<PathBuf> = Lazy::new(|| {
+    workspace_path(&[
+        "target",
+        "x86_64-unknown-linux-gnu",
+        "debug",
+        "oak_functions_launcher",
+    ])
+});
+pub static QUIRK_ECHO_LAUNCHER_BIN: Lazy<PathBuf> = Lazy::new(|| {
+    workspace_path(&[
+        "target",
+        "x86_64-unknown-linux-gnu",
+        "debug",
+        "quirk_echo_launcher",
+    ])
+});
 
 use crate::{internal::*, workspace_path};
 use once_cell::sync::Lazy;


### PR DESCRIPTION
Running `cargo bench --package` twice, takes for the second iteration:

- before this change: 54s
- after this change: 6s

Fix #3941