### PR TITLE
Vet `alloc-traits` as `does-not-implement-crypto` and `safe-to-deploy`

### DIFF
--- a/stage0/supply-chain/audits.toml
+++ b/stage0/supply-chain/audits.toml
@@ -1,4 +1,6 @@
+
 # cargo-vet audits file
+
 [criteria.crypto-safe]
 description = """
 All crypto algorithms in this crate have been reviewed by a relevant expert.
@@ -18,4 +20,8 @@ so they'll at least be forthcoming if they try to implement something
 cryptographic. When in doubt, please ask an expert."""
 implies = "crypto-safe"
 
-[audits]
+[[audits.alloc-traits]]
+who = "Andri Saar <andrisaar@google.com>"
+criteria = ["safe-to-deploy", "does-not-implement-crypto"]
+version = "0.1.1"
+notes = "Crate has no dependecies, includes a safe wrapper for `Layout` that makes unsafe code safer, and has no crypto code."

--- a/stage0/supply-chain/config.toml
+++ b/stage0/supply-chain/config.toml
@@ -1,4 +1,6 @@
+
 # cargo-vet config file
+
 [cargo-vet]
 version = "0.6"
 

--- a/stage0/supply-chain/imports.lock
+++ b/stage0/supply-chain/imports.lock
@@ -1,7 +1,31 @@
 
 # cargo-vet imports lock
 
-[audits.google.audits]
+[audits.google.criteria.crypto-safe]
+description = """
+All crypto algorithms in this crate have been reviewed by a relevant expert.
+
+**Note**: If a crate does not implement crypto, use `does-not-implement-crypto`,
+which implies `crypto-safe`, but does not require expert review in order to
+audit for."""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[audits.google.criteria.does-not-implement-crypto]
+description = """
+Inspection reveals that the crate in question does not attempt to implement any
+cryptographic algorithms on its own.
+
+Note that certification of this does not require an expert on all forms of
+cryptography: it's expected for crates we import to be \"good enough\" citizens,
+so they'll at least be forthcoming if they try to implement something
+cryptographic. When in doubt, please ask an expert."""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "ChromeOS"
+criteria = ["safe-to-run", "does-not-implement-crypto"]
+version = "0.4.17"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.mozilla.audits.autocfg]]
 who = "Josh Stone <jistone@redhat.com>"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -323,14 +323,18 @@ fn run_buildifier(mode: FormatMode) -> Step {
 fn run_prettier(mode: FormatMode) -> Step {
     // We run prettier as a single command on all the files at once instead of once per file,
     // because it takes a considerable time to start up for each invocation. See #1680.
+    // We also filter out `supply-chain/{config,audits}.toml` as `cargo vet` insists on its own
+    // formatting of the files that is incompatible with Prettier's opinions.
     let files = source_files()
         .filter(|path| {
-            is_markdown_file(path)
+            (is_markdown_file(path)
                 || is_yaml_file(path)
                 || is_toml_file(path)
                 || is_html_file(path)
                 || is_javascript_file(path)
-                || is_typescript_file(path)
+                || is_typescript_file(path))
+                && !path.ends_with("supply-chain/config.toml")
+                && !path.ends_with("supply-chain/audits.toml")
         })
         .map(to_string)
         .collect::<Vec<_>>();


### PR DESCRIPTION
If you want to double-check the source you can do it here: https://sourcegraph.com/crates/alloc-traits@v0.1.1

Some unsafe code in there as it deals with allocators (which is inherently unsafe), but it's well-contained and easy to reason about.

I've also included a change to `xtask` that makes it not run Prettier on the `cargo vet` TOML files, as `cargo vet` insists on its own format that clashes with Prettier's opinions.

Fixes #3946 