### PR TITLE
Print out some debug information when `mmap` can't allocate memory

### DIFF
--- a/oak_restricted_kernel/src/mm/frame_allocator.rs
+++ b/oak_restricted_kernel/src/mm/frame_allocator.rs
@@ -80,6 +80,26 @@ impl<const N: usize> PhysicalMemoryAllocator<N> {
     pub fn allocate_contiguous(&mut self, num: usize) -> Option<PhysFrameRange<Size2MiB>> {
         self.large_frames.allocate_contiguous(num)
     }
+
+    /// Returns the number of valid 2 MiB and 4 KiB frames.
+    pub fn num_valid_frames(&self) -> (usize, usize) {
+        (
+            self.large_frames.num_valid(),
+            self.small_frames
+                .as_ref()
+                .map_or(0, |frames| frames.num_valid()),
+        )
+    }
+
+    /// Returns the number of allocated 2 MiB and 4 KiB frames.
+    pub fn num_allocated_frames(&self) -> (usize, usize) {
+        (
+            self.large_frames.num_allocated(),
+            self.small_frames
+                .as_ref()
+                .map_or(0, |frames| frames.num_allocated()),
+        )
+    }
 }
 
 unsafe impl<const N: usize> FrameAllocator<Size2MiB> for PhysicalMemoryAllocator<N> {

--- a/oak_restricted_kernel/src/syscall/mmap.rs
+++ b/oak_restricted_kernel/src/syscall/mmap.rs
@@ -122,6 +122,19 @@ pub fn mmap(
                         log::warn!(
                             "mmap: could not get physical frame for request (memory exhausted?)"
                         );
+                        let valid = FRAME_ALLOCATOR.lock().num_valid_frames();
+                        log::debug!(
+                            "total number of physical memory frames: {} * 2 MiB, {} * 4 KiB",
+                            valid.0,
+                            valid.1
+                        );
+                        let allocated = FRAME_ALLOCATOR.lock().num_allocated_frames();
+                        log::debug!(
+                            "number of allocated physical memory frames: {} * 2 MiB, {} * 4 KiB",
+                            allocated.0,
+                            allocated.1
+                        );
+
                         Errno::ENOMEM
                     })?,
                     pt_flags,


### PR DESCRIPTION
Hopefully this gives a little bit more information into what's the current state when a call to `mmap` can't allocate the application more memory.

Ideally we'd give more information, e.g. how much of the physical memory has been allocated to the kernel and how much to the application, but currently we don't keep track of the users of the memory regions, just whether they are allocated or not.