### PR TITLE
Vet `synstructure` 0.12.6 as `does-not-implement-crypto`

### DIFF
--- a/stage0/supply-chain/audits.toml
+++ b/stage0/supply-chain/audits.toml
@@ -1,6 +1,4 @@
-
 # cargo-vet audits file
-
 [criteria.crypto-safe]
 description = """
 All crypto algorithms in this crate have been reviewed by a relevant expert.
@@ -40,3 +38,9 @@ notes = """
 By design, all the macros in `static_assertions` run at compile time, which means they do not deal with untrusted input at all.
 Only one short block of unsafe code in `assert_eq_size_ptr`, which looks reasonable.
 """
+
+[[audits.synstructure]]
+who = "Conrad Grobler <grobler@google.com>"
+criteria = "does-not-implement-crypto"
+version = "0.12.6"
+notes = "Crate does not implement any cryptographic algorithms"


### PR DESCRIPTION
Based on https://sourcegraph.com/crates/synstructure@v0.12.6

Fixes #3969