### PR TITLE
Vet `static_assertions` as `safe-to-deploy`

### DIFF
--- a/stage0/supply-chain/audits.toml
+++ b/stage0/supply-chain/audits.toml
@@ -31,3 +31,12 @@ who = "Conrad Grobler <grobler@google.com>"
 criteria = "does-not-implement-crypto"
 version = "0.3.3"
 notes = "This crate does not implement any cryptographic algorithms."
+
+[[audits.static_assertions]]
+who = "Andri Saar <andrisaar@google.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = """
+By design, all the macros in `static_assertions` run at compile time, which means they do not deal with untrusted input at all.
+Only one short block of unsafe code in `assert_eq_size_ptr`, which looks reasonable.
+"""

--- a/stage0/supply-chain/imports.lock
+++ b/stage0/supply-chain/imports.lock
@@ -39,6 +39,12 @@ criteria = ["safe-to-run", "does-not-implement-crypto"]
 version = "1.0.23"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.static_assertions]]
+who = "ChromeOS"
+criteria = ["safe-to-run", "does-not-implement-crypto"]
+version = "1.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.mozilla.audits.autocfg]]
 who = "Josh Stone <jistone@redhat.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
See https://sourcegraph.com/crates/static_assertions@v1.1.0 for the source.

Fixes #3965 