### PR TITLE
Vet `autocfg`, `rustversion` and `unicode-xid`

### DIFF
--- a/stage0/supply-chain/audits.toml
+++ b/stage0/supply-chain/audits.toml
@@ -24,10 +24,22 @@ criteria = ["safe-to-deploy", "does-not-implement-crypto"]
 version = "0.1.1"
 notes = "Crate has no dependecies, includes a safe wrapper for `Layout` that makes unsafe code safer, and has no crypto code."
 
+[[audits.autocfg]]
+who = "Conrad Grobler <grobler@google.com>"
+criteria = "does-not-implement-crypto"
+version = "1.1.0"
+notes = "This crate does not implement any cryptographic algorithms."
+
 [[audits.doc-comment]]
 who = "Conrad Grobler <grobler@google.com>"
 criteria = "does-not-implement-crypto"
 version = "0.3.3"
+notes = "This crate does not implement any cryptographic algorithms."
+
+[[audits.rustversion]]
+who = "Conrad Grobler <grobler@google.com>"
+criteria = "does-not-implement-crypto"
+version = "1.0.9"
 notes = "This crate does not implement any cryptographic algorithms."
 
 [[audits.static_assertions]]
@@ -44,3 +56,9 @@ who = "Conrad Grobler <grobler@google.com>"
 criteria = "does-not-implement-crypto"
 version = "0.12.6"
 notes = "Crate does not implement any cryptographic algorithms"
+
+[[audits.unicode-xid]]
+who = "Conrad Grobler <grobler@google.com>"
+criteria = "does-not-implement-crypto"
+version = "0.2.4"
+notes = "This crate does not implement any cryptographic algorithms."

--- a/stage0/supply-chain/imports.lock
+++ b/stage0/supply-chain/imports.lock
@@ -1,6 +1,13 @@
 
 # cargo-vet imports lock
 
+[[publisher.unicode-xid]]
+version = "0.2.4"
+when = "2022-09-15"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
 [audits.google.criteria.crypto-safe]
 description = """
 All crypto algorithms in this crate have been reviewed by a relevant expert.
@@ -44,6 +51,15 @@ who = "ChromeOS"
 criteria = ["safe-to-run", "does-not-implement-crypto"]
 version = "1.1.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.mozilla.wildcard-audits.unicode-xid]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139
+start = "2019-07-25"
+end = "2024-05-03"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.autocfg]]
 who = "Josh Stone <jistone@redhat.com>"


### PR DESCRIPTION
These crates have already been vetted as "safe-to-deploy". This confirms that none of these crates implement any crypto.

Code for the crates:

- autocfg 1.1.0: https://sourcegraph.com/crates/autocfg@v1.1.0
- rustversion 1.0.9: https://sourcegraph.com/crates/rustversion@v1.0.9/
- unicode-xid 0.2.4: https://sourcegraph.com/crates/unicode-xid@v0.2.4

Fixes #3971
Fixes #3959
Fixes #3947
