### PR TITLE
Vet `zerocopy-derive` as `safe-to-deploy`, `does-not-implement-crypto`

### DIFF
--- a/stage0/supply-chain/audits.toml
+++ b/stage0/supply-chain/audits.toml
@@ -62,3 +62,12 @@ who = "Conrad Grobler <grobler@google.com>"
 criteria = "does-not-implement-crypto"
 version = "0.2.4"
 notes = "This crate does not implement any cryptographic algorithms."
+
+[[audits.zerocopy-derive]]
+who = "Andri Saar <andrisaar@google.com>"
+criteria = ["safe-to-deploy", "does-not-implement-crypto"]
+version = "0.3.1"
+notes = """
+Handling of untrusted input data is delegated to the `zerocopy` crate itself.
+This crate does not implement any cryptographic algorithms.
+"""


### PR DESCRIPTION
https://sourcegraph.com/crates/zerocopy-derive@v0.3.1

Fixes #3975 