### PR TITLE
Start keeping statistics about how long a RPC invocation took

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,6 +1732,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "micro_rpc",
+ "oak_core",
  "static_assertions",
 ]
 
@@ -1909,6 +1910,7 @@ dependencies = [
  "clap",
  "log",
  "oak_channel",
+ "oak_core",
  "oak_functions_service",
  "oak_remote_attestation_amd",
  "oak_remote_attestation_interactive",

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -692,7 +692,17 @@ dependencies = [
  "bitflags",
  "bytes",
  "micro_rpc",
+ "oak_core",
  "static_assertions",
+]
+
+[[package]]
+name = "oak_core"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "lock_api",
+ "spinning_top",
 ]
 
 [[package]]
@@ -718,6 +728,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "oak_channel",
+ "oak_core",
  "oak_echo_service",
  "oak_enclave_runtime_support",
  "oak_restricted_kernel_api",
@@ -778,6 +789,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "oak_channel",
+ "oak_core",
  "oak_enclave_runtime_support",
  "oak_functions_service",
  "oak_remote_attestation_amd",
@@ -860,6 +872,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "oak_channel",
+ "oak_core",
  "oak_enclave_runtime_support",
  "oak_iree_service",
  "oak_restricted_kernel_api",
@@ -937,6 +950,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "oak_channel",
+ "oak_core",
  "oak_enclave_runtime_support",
  "oak_restricted_kernel_api",
  "oak_tensorflow_service",
@@ -1101,6 +1115,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "oak_channel",
+ "oak_core",
  "oak_enclave_runtime_support",
  "oak_restricted_kernel_api",
  "quirk_echo_service",

--- a/enclave_apps/Cargo.toml
+++ b/enclave_apps/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 micro_rpc = { path = "../micro_rpc" }
 oak_enclave_runtime_support = { path = "../oak_enclave_runtime_support" }
 oak_channel = { path = "../oak_channel" }
+oak_core = { path = "../oak_core" }
 oak_restricted_kernel_api = { path = "../oak_restricted_kernel_api" }
 oak_remote_attestation_interactive = { path = "../oak_remote_attestation_interactive", default-features = false, features = [
   "rust-crypto"

--- a/enclave_apps/oak_echo_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_echo_enclave_app/Cargo.toml
@@ -11,6 +11,7 @@ log = "*"
 micro_rpc = { workspace = true }
 oak_enclave_runtime_support = { workspace = true }
 oak_channel = { workspace = true }
+oak_core = { workspace = true }
 oak_restricted_kernel_api = { workspace = true }
 static_assertions = "*"
 

--- a/enclave_apps/oak_echo_enclave_app/src/main.rs
+++ b/enclave_apps/oak_echo_enclave_app/src/main.rs
@@ -23,6 +23,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::panic::PanicInfo;
 use log::info;
+use oak_core::samplestore::StaticSampleStore;
 use oak_restricted_kernel_api::{FileDescriptorChannel, StderrLogger};
 
 static LOGGER: StderrLogger = StderrLogger {};
@@ -43,10 +44,15 @@ fn main() -> ! {
 // Starts an echo server that uses the Oak communication channel:
 // https://github.com/project-oak/oak/blob/main/oak_channel/SPEC.md
 fn start_echo_server() -> ! {
+    let mut invocation_stats = StaticSampleStore::<1000>::new().unwrap();
     let service = oak_echo_service::EchoService::default();
     let server = oak_echo_service::proto::EchoServer::new(service);
-    oak_channel::server::start_blocking_server(Box::<FileDescriptorChannel>::default(), server)
-        .expect("server encountered an unrecoverable error");
+    oak_channel::server::start_blocking_server(
+        Box::<FileDescriptorChannel>::default(),
+        server,
+        &mut invocation_stats,
+    )
+    .expect("server encountered an unrecoverable error");
 }
 
 #[alloc_error_handler]

--- a/enclave_apps/oak_functions_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_functions_enclave_app/Cargo.toml
@@ -10,6 +10,7 @@ oak_functions_service = { path = "../../oak_functions_service", default-features
 log = "*"
 micro_rpc = { workspace = true }
 oak_enclave_runtime_support = { workspace = true }
+oak_core = { workspace = true }
 oak_channel = { workspace = true }
 oak_remote_attestation_interactive = { workspace = true }
 oak_remote_attestation_amd = { workspace = true }

--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -23,6 +23,7 @@ extern crate alloc;
 use alloc::{boxed::Box, sync::Arc};
 use core::panic::PanicInfo;
 use log::info;
+use oak_core::samplestore::StaticSampleStore;
 use oak_remote_attestation_amd::PlaceholderAmdAttestationGenerator;
 use oak_restricted_kernel_api::{FileDescriptorChannel, StderrLogger};
 
@@ -38,12 +39,17 @@ fn _start() -> ! {
 
 fn main() -> ! {
     info!("In main!");
+    let mut invocation_stats = StaticSampleStore::<1000>::new().unwrap();
     let service = oak_functions_service::OakFunctionsService::new(Arc::new(
         PlaceholderAmdAttestationGenerator,
     ));
     let server = oak_functions_service::proto::oak::functions::OakFunctionsServer::new(service);
-    oak_channel::server::start_blocking_server(Box::<FileDescriptorChannel>::default(), server)
-        .expect("server encountered an unrecoverable error");
+    oak_channel::server::start_blocking_server(
+        Box::<FileDescriptorChannel>::default(),
+        server,
+        &mut invocation_stats,
+    )
+    .expect("server encountered an unrecoverable error");
 }
 
 #[alloc_error_handler]

--- a/enclave_apps/oak_iree_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_iree_enclave_app/Cargo.toml
@@ -11,6 +11,7 @@ log = "*"
 micro_rpc = { workspace = true }
 oak_enclave_runtime_support = { workspace = true }
 oak_channel = { workspace = true }
+oak_core = { workspace = true }
 oak_restricted_kernel_api = { workspace = true }
 static_assertions = "*"
 

--- a/enclave_apps/oak_iree_enclave_app/src/main.rs
+++ b/enclave_apps/oak_iree_enclave_app/src/main.rs
@@ -23,6 +23,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::panic::PanicInfo;
 use log::info;
+use oak_core::samplestore::StaticSampleStore;
 use oak_restricted_kernel_api::{FileDescriptorChannel, StderrLogger};
 
 static LOGGER: StderrLogger = StderrLogger {};
@@ -43,8 +44,13 @@ fn main() -> ! {
 fn start_server() -> ! {
     let service = oak_iree_service::IreeService::new();
     let server = oak_iree_service::proto::oak::iree::IreeServer::new(service);
-    oak_channel::server::start_blocking_server(Box::<FileDescriptorChannel>::default(), server)
-        .expect("server encountered an unrecoverable error")
+    let mut invocation_stats = StaticSampleStore::<1000>::new().unwrap();
+    oak_channel::server::start_blocking_server(
+        Box::<FileDescriptorChannel>::default(),
+        server,
+        &mut invocation_stats,
+    )
+    .expect("server encountered an unrecoverable error")
 }
 
 #[alloc_error_handler]

--- a/enclave_apps/oak_tensorflow_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_tensorflow_enclave_app/Cargo.toml
@@ -11,6 +11,7 @@ log = "*"
 micro_rpc = { workspace = true }
 oak_enclave_runtime_support = { workspace = true }
 oak_channel = { workspace = true }
+oak_core = { workspace = true }
 oak_restricted_kernel_api = { workspace = true }
 static_assertions = "*"
 

--- a/enclave_apps/oak_tensorflow_enclave_app/src/main.rs
+++ b/enclave_apps/oak_tensorflow_enclave_app/src/main.rs
@@ -23,6 +23,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::panic::PanicInfo;
 use log::info;
+use oak_core::samplestore::StaticSampleStore;
 use oak_restricted_kernel_api::{FileDescriptorChannel, StderrLogger};
 
 static LOGGER: StderrLogger = StderrLogger {};
@@ -41,10 +42,15 @@ fn main() -> ! {
 }
 
 fn start_server() -> ! {
+    let mut invocation_stats = StaticSampleStore::<1000>::new().unwrap();
     let service = oak_tensorflow_service::TensorflowService::new();
     let server = oak_tensorflow_service::proto::oak::tensorflow::TensorflowServer::new(service);
-    oak_channel::server::start_blocking_server(Box::<FileDescriptorChannel>::default(), server)
-        .expect("server encountered an unrecoverable error")
+    oak_channel::server::start_blocking_server(
+        Box::<FileDescriptorChannel>::default(),
+        server,
+        &mut invocation_stats,
+    )
+    .expect("server encountered an unrecoverable error")
 }
 
 #[alloc_error_handler]

--- a/enclave_apps/quirk_echo_enclave_app/Cargo.toml
+++ b/enclave_apps/quirk_echo_enclave_app/Cargo.toml
@@ -11,6 +11,7 @@ log = "*"
 micro_rpc = { workspace = true }
 oak_enclave_runtime_support = { workspace = true }
 oak_channel = { workspace = true }
+oak_core = { workspace = true }
 oak_restricted_kernel_api = { workspace = true }
 static_assertions = "*"
 

--- a/enclave_apps/quirk_echo_enclave_app/src/main.rs
+++ b/enclave_apps/quirk_echo_enclave_app/src/main.rs
@@ -23,6 +23,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::panic::PanicInfo;
 use log::info;
+use oak_core::samplestore::StaticSampleStore;
 use oak_restricted_kernel_api::{FileDescriptorChannel, StderrLogger};
 
 static LOGGER: StderrLogger = StderrLogger {};
@@ -45,10 +46,15 @@ fn main() -> ! {
 // Starts an echo server that uses the Oak communication channel:
 // https://github.com/project-oak/oak/blob/main/oak_channel/SPEC.md
 fn start_echo_server() -> ! {
+    let mut invocation_stats = StaticSampleStore::<1000>::new().unwrap();
     let service = quirk_echo_service::EchoService::default();
     let server = quirk_echo_service::proto::quirk::echo::EchoServer::new(service);
-    oak_channel::server::start_blocking_server(Box::<FileDescriptorChannel>::default(), server)
-        .expect("server encountered an unrecoverable error");
+    oak_channel::server::start_blocking_server(
+        Box::<FileDescriptorChannel>::default(),
+        server,
+        &mut invocation_stats,
+    )
+    .expect("server encountered an unrecoverable error");
 }
 
 #[alloc_error_handler]

--- a/oak_channel/Cargo.toml
+++ b/oak_channel/Cargo.toml
@@ -13,6 +13,7 @@ client = ["std"]
 [dependencies]
 anyhow = { version = "*", default-features = false }
 micro_rpc = { workspace = true }
+oak_core = { workspace = true }
 static_assertions = "*"
 bitflags = "*"
 bytes = { version = "*", default-features = false }

--- a/oak_channel/src/client.rs
+++ b/oak_channel/src/client.rs
@@ -21,6 +21,7 @@ use crate::{
     Channel, InvocationChannel,
 };
 use alloc::boxed::Box;
+use oak_core::timer::Timer;
 
 pub struct ClientChannelHandle {
     inner: InvocationChannel,
@@ -35,9 +36,9 @@ impl ClientChannelHandle {
     pub fn write_request(&mut self, request: RequestMessage) -> anyhow::Result<()> {
         self.inner.write_message(request)
     }
-    pub fn read_response(&mut self) -> anyhow::Result<ResponseMessage> {
-        let message = self.inner.read_message()?;
-        Ok(message)
+
+    pub fn read_response(&mut self) -> anyhow::Result<(ResponseMessage, Timer)> {
+        self.inner.read_message()
     }
 }
 

--- a/oak_channel/src/tests.rs
+++ b/oak_channel/src/tests.rs
@@ -108,7 +108,8 @@ fn test_invocation_channel() {
 
     invocation_channel.write_message(message.clone()).unwrap();
 
-    let reconstructed_message: RequestMessage = invocation_channel.read_message().unwrap();
+    let (reconstructed_message, _): (RequestMessage, _) =
+        invocation_channel.read_message().unwrap();
     assert_eq!(message, reconstructed_message);
 }
 

--- a/oak_core/src/timer.rs
+++ b/oak_core/src/timer.rs
@@ -40,17 +40,19 @@ pub fn rdtsc() -> u64 {
 /// Measures the number of clock cycles between `new()` and `elapsed()`. This measurement only makes
 /// sense if the process is running on the same CPU, as different CPUs will have different tick
 /// counter values.
+#[derive(Debug)]
 pub struct Timer {
     start: u64,
 }
 
-// Don't implement `Default` on purpose, as we'll be reading the TSC when calling `new()` and thus
-// two calls to `Timer::default()` would yield different Timers.
-#[allow(clippy::new_without_default)]
 impl Timer {
+    pub fn new(start: u64) -> Self {
+        Self { start }
+    }
+
     /// Constructs a new timer, recording the current tick counter value.
-    pub fn new() -> Self {
-        Self { start: rdtsc() }
+    pub fn new_rdtsc() -> Self {
+        Self::new(rdtsc())
     }
 
     /// Returns the approximate number of clock cycles it took to execute `func`.
@@ -58,7 +60,7 @@ impl Timer {
     where
         F: FnOnce(),
     {
-        let timer = Timer::new();
+        let timer = Timer::new_rdtsc();
         func();
         timer.elapsed()
     }
@@ -77,7 +79,7 @@ mod tests {
 
     #[test]
     pub fn simple_timer() {
-        let timer = Timer::new();
+        let timer = Timer::new_rdtsc();
         let duration = timer.elapsed();
         assert!(duration > 0);
     }

--- a/oak_functions_linux_fd_bin/Cargo.toml
+++ b/oak_functions_linux_fd_bin/Cargo.toml
@@ -10,6 +10,7 @@ log = "*"
 anyhow = { version = "*", default-features = false }
 clap = { version = "*", features = ["derive"] }
 oak_remote_attestation_interactive = { workspace = true }
+oak_core = { workspace = true }
 oak_channel = { workspace = true, features = ["std"] }
 oak_functions_service = { workspace = true }
 oak_remote_attestation_amd = { workspace = true }

--- a/oak_functions_linux_fd_bin/src/main.rs
+++ b/oak_functions_linux_fd_bin/src/main.rs
@@ -15,6 +15,7 @@
 //
 
 use clap::Parser;
+use oak_core::samplestore::StaticSampleStore;
 use oak_remote_attestation_amd::PlaceholderAmdAttestationGenerator;
 use std::{os::unix::io::FromRawFd, sync::Arc};
 
@@ -60,9 +61,11 @@ fn main() -> ! {
     let service = oak_functions_service::OakFunctionsService::new(Arc::new(
         PlaceholderAmdAttestationGenerator,
     ));
+    let mut stats = StaticSampleStore::<1000>::new().unwrap();
     oak_channel::server::start_blocking_server(
         channel,
         oak_functions_service::proto::oak::functions::OakFunctionsServer::new(service),
+        &mut stats,
     )
     .expect("server encountered an unrecoverable error");
 }

--- a/oak_launcher_utils/src/channel.rs
+++ b/oak_launcher_utils/src/channel.rs
@@ -58,7 +58,7 @@ impl Connector {
             .write_request(request_message)
             .map_err(|_| micro_rpc::Status::new(micro_rpc::StatusCode::Internal))?;
 
-        let response_message = self
+        let (response_message, _) = self
             .inner
             .read_response()
             .map_err(|_| micro_rpc::Status::new(micro_rpc::StatusCode::Internal))?;

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "micro_rpc",
+ "oak_core",
  "static_assertions",
 ]
 


### PR DESCRIPTION
First steps toward exposing some details about what's going on inside the enclave...

This should start measuring how long it takes for the enclave to service a RPC, all the way from reading the request to writing the response back.

There are multiple caveats here:
 - as calling the `read` syscall can block, I start measuring time after we've read the padding for the start frame. (I can't start the timer _before_ reading the padding, otherwise we'd potentially count the idle time it took for the loader to write anything to the channel as time it took to read the frame.)
 - right now we do nothing with the gathered stats as we don't have a mechanism for exporting them
 - this doesn't distinguish between the different types of RPCs; from my cursory read that will require extensive modifications to `micro_rpc`
 - we somehow want to track time it takes for the stages inside handling the RPC (eg how much time is spent setting up the wasm sandbox, how much time it takes to invoke in the wasm sandbox, etc) -- that requires even more plumbing
 - we don't have a timer that exposes any form of seconds in the `no_std` world, so the unit of time is "clock cycles". This is less than ideal as the duration (in seconds) of a clock cycle can change dynamically when the CPU frequency changes, but this is the best we can do right now.