### PR TITLE
Add support for accepting memory pages on TDX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,6 +2280,7 @@ name = "oak_tdx_guest"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "strum",
  "x86_64",
 ]
 

--- a/oak_tdx_guest/Cargo.toml
+++ b/oak_tdx_guest/Cargo.toml
@@ -7,4 +7,5 @@ license = "Apache-2.0"
 
 [dependencies]
 bitflags = "*"
+strum = { version = "*", default-features = false, features = ["derive"] }
 x86_64 = "*"


### PR DESCRIPTION
Stage0 must accept all pending private pages on TDX, similar to how private pages are validated on AMD SEV-SNP.