### PR TITLE
Vet `x86_64`

### DIFF
--- a/stage0_bin/supply-chain/audits.toml
+++ b/stage0_bin/supply-chain/audits.toml
@@ -83,6 +83,17 @@ criteria = "does-not-implement-crypto"
 version = "0.2.4"
 notes = "This crate does not implement any cryptographic algorithms."
 
+[[audits.x86_64]]
+who = "Andri Saar <andrisaar@google.com>"
+criteria = ["safe-to-deploy", "does-not-implement-crypto"]
+version = "0.14.10"
+notes = """
+This crate contains a lot of unsafe code as it deals with low-level machine state, which is obviously unsafe to call with untrusted input.
+All potentially dangerous operations look like they have been marked as `unsafe` appropriately, so the onus is on the caller to ensure
+safety. The unsafe blocks in the code are tiny and usually cover one or two lines of assembly (for example, to load a data structure).
+The crate does not implement any cryptograhic algorithms.
+"""
+
 [[audits.zerocopy-derive]]
 who = "Andri Saar <andrisaar@google.com>"
 criteria = ["safe-to-deploy", "does-not-implement-crypto"]


### PR DESCRIPTION
Probably one of the most risky crates we have, so I'd appreciate at least a cursory look at the crate source do double-check my conclusion.

There's a ton of `unsafe` code in there, but that's to be expected -- however, I think all potentially dangerous methods are properly marked as `unsafe`; therefore, if the caller is calling them with untrusted inputs it's up to them to guarantee that we don't load, say, a troll Youtube video as the interrupt descriptor table.

Source: https://sourcegraph.com/crates/x86_64@v0.14.10

Fixes #3973 