### PR TITLE
vet getrandom 0.2.9

### DIFF
--- a/stage0_bin/supply-chain/audits.toml
+++ b/stage0_bin/supply-chain/audits.toml
@@ -54,6 +54,22 @@ criteria = "does-not-implement-crypto"
 version = "0.3.3"
 notes = "This crate does not implement any cryptographic algorithms."
 
+[[audits.getrandom]]
+who = "Juliette Pretot <julsh@google.com>"
+criteria = ["safe-to-deploy", "does-not-implement-crypto"]
+version = "0.2.9"
+notes = """
+Code is well commented and unsafe blocks generally have comments regarding safety.
+No obvious security issues uncovered.
+
+I reviewed the RDRAND implementation most closely, as this is what is used in oak_core & stage0.
+Implementations for other targets appear to be safe to deploy.
+I would not consider this crate to be implementing crypto algorithms itself.
+However, outside of RDRAND and js I'm not equipped to evaluate the trustworthiness of the random number generation itself.
+
+Therefore, I would not necessarily endorse this crate as a safe primitive for implementing crypo algorithms using its random number generation.
+"""
+
 [[audits.heck]]
 who = "Conrad Grobler <grobler@google.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Closes #3954.

Please carefully read audit notes before approving. 

While this crate imo qualifies for `does-not-implement-crypto`, I feel a bit hesitant about attaching the implied label `crypto-safe`. A label that could plausibly be considered to imply that the random number generators exposed by this crate are sufficiently trustworthy for implementing arbitrary crypto algorithms. An endorsement that I would not be prepared to make.

Imo fine but consider when reviewing.