### PR TITLE
Replace `static-alloc` with a home-grown bump allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,12 +116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
-name = "alloc-traits"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2d54853319fd101b8dd81de382bcbf3e03410a64d8928bbee85a3e7dcde483"
-
-[[package]]
 name = "aml"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,7 +2295,6 @@ dependencies = [
  "oak_sev_guest",
  "sev_serial",
  "spinning_top",
- "static-alloc",
  "static_assertions",
  "strum",
  "x86_64",
@@ -3309,15 +3302,6 @@ checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "static-alloc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570b7e840addf99f80c5b26abba410e21537002316fc82f2747fd87c171e9d7e"
-dependencies = [
- "alloc-traits",
 ]
 
 [[package]]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -14,7 +14,6 @@ oak_linux_boot_params = { path = "../linux_boot_params" }
 oak_sev_guest = { path = "../oak_sev_guest", default-features = false }
 sev_serial = { path = "../sev_serial" }
 spinning_top = "*"
-static-alloc = "*"
 static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
 x86_64 = "*"

--- a/stage0/src/alloc.rs
+++ b/stage0/src/alloc.rs
@@ -1,0 +1,153 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use core::{
+    alloc::Layout,
+    mem::MaybeUninit,
+    ptr::{write, NonNull},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+use spinning_top::Spinlock;
+
+struct Inner<const N: usize> {
+    index: AtomicUsize,
+    storage: MaybeUninit<[u8; N]>,
+}
+
+impl<const N: usize> Inner<N> {
+    const fn new() -> Self {
+        Self {
+            index: AtomicUsize::new(0),
+            storage: MaybeUninit::uninit(),
+        }
+    }
+}
+
+/// Basic bump allocator that never deallocates memory.
+///
+/// The algorithm is rather simple: we maintain an index into the buffer we hold, that marks the
+/// high water mark (already allocated memory). Whenever a request for memory comes in, me move the
+/// index forward by the padding necessary to maintain proper alighment for the structure plus the
+/// size of the structure.
+///
+/// We do not support deallocation, and there is no optimizations to pack the allocations as
+/// efficiently as possible.
+///
+/// For stage0 uses these limitations are not an issue because (a) we use the allocator to allocate
+/// data structures we expect to outive stage0 and (b) we allocate only a small number of data
+/// structures, so the padding overhead is minimal.
+pub struct Allocator<const N: usize> {
+    inner: Spinlock<Inner<N>>,
+}
+
+impl<const N: usize> Allocator<N> {
+    pub const fn uninit() -> Self {
+        Self {
+            inner: Spinlock::new(Inner::new()),
+        }
+    }
+
+    pub fn allocate(&self, layout: Layout) -> Option<NonNull<u8>> {
+        let mut inner = self.inner.lock();
+        let offset = inner.index.load(Ordering::Acquire);
+        let storage_ptr = inner.storage.as_mut_ptr() as *mut u8;
+
+        // We may need to allocate extra bytes to ensure proper alignment in memory.
+        let align = if (storage_ptr as usize + offset) % layout.align() > 0 {
+            layout.align() - ((storage_ptr as usize + offset) % layout.align())
+        } else {
+            0
+        };
+
+        if offset + align + layout.size() > N {
+            // memory exhausted
+            return None;
+        }
+
+        inner
+            .index
+            .fetch_add(align + layout.size(), Ordering::SeqCst);
+
+        // Safety: we've reserved memory from [offset, offset + align + size) so this will not
+        // exceed the bounds of `self.storage` and is not aliased.
+        NonNull::new(unsafe { storage_ptr.add(offset + align) })
+    }
+
+    pub fn leak<T>(&self, val: T) -> Option<&mut T> {
+        let ptr = self.allocate(Layout::for_value(&val))?.cast().as_ptr();
+
+        // Safety: we've successfully allocated enough memory that is of the correct size, therefore
+        // writing `val` to it is safe. We also ensure that the pointer is properly initialized and
+        // aligned, so dereferencing it as a reference is fine.
+        unsafe {
+            write(ptr, val);
+            ptr.as_mut()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_alloc() {
+        let alloc = Allocator::<16>::uninit();
+        let val = alloc.leak([0u8; 16]);
+        assert!(val.is_some());
+        let val = alloc.leak([0u8; 16]);
+        assert!(val.is_none());
+        let val = alloc.leak(0u8);
+        assert!(val.is_none());
+    }
+
+    #[test]
+    fn two_alloc() {
+        let alloc = Allocator::<16>::uninit();
+        let val = alloc.leak([0u8; 8]);
+        assert!(val.is_some());
+        let val = alloc.leak([0u8; 8]);
+        assert!(val.is_some());
+    }
+
+    #[test]
+    fn aligned_alloc() {
+        #[repr(align(8))]
+        struct Foo {
+            x: u64,
+            _y: u64,
+        }
+        // Allow for max 7-byte alignment + 2*8 (size of Foo)
+        // The padding we need to use is ~random; it depends where exactly in memory our buffer
+        // lands, as that is not required to be perfectly aligned with any particular boundary.
+        let alloc = Allocator::<23>::uninit();
+        let val = alloc.leak(Foo { x: 16, _y: 16 }).unwrap();
+        assert_eq!(0, val as *const Foo as usize % core::mem::align_of::<Foo>());
+        assert_eq!(16, val.x);
+        // Even if the initial alignment was perfect by chance, we've used up 16 bytes, so this
+        // won't fit
+        let val = alloc.leak(Foo { x: 1, _y: 1 });
+        assert!(val.is_none());
+    }
+
+    #[test]
+    fn failing_alloc() {
+        let alloc = Allocator::<4>::uninit();
+        assert!(alloc.leak(0u64).is_none());
+        assert!(alloc.leak(0u32).is_some());
+        assert!(alloc.leak(0u8).is_none());
+    }
+}

--- a/stage0/src/kernel.rs
+++ b/stage0/src/kernel.rs
@@ -14,9 +14,11 @@
 // limitations under the License.
 //
 
-use crate::fw_cfg::{check_memory, check_non_overlapping, find_suitable_dma_address, FwCfg};
-use alloc::vec;
-use core::{ffi::CStr, slice};
+use crate::{
+    fw_cfg::{check_memory, check_non_overlapping, find_suitable_dma_address, FwCfg},
+    BOOT_ALLOC,
+};
+use core::{alloc::Layout, ffi::CStr, ptr::NonNull, slice};
 use elf::{abi::PT_LOAD, endian::AnyEndian, segment::ProgramHeader, ElfBytes};
 use oak_linux_boot_params::BootE820Entry;
 use x86_64::{PhysAddr, VirtAddr};
@@ -58,7 +60,16 @@ pub fn try_load_cmdline(fw_cfg: &mut FwCfg) -> Option<&'static CStr> {
     let cmdline_file = fw_cfg.find(cmdline_path)?;
     let cmdline_size = cmdline_file.size();
     // Make the buffer one byte longer so that the kernel command-line is null-terminated.
-    let buf = vec![0u8; cmdline_size + 1].leak();
+    // Safety: len will always be at least 1 byte, and we don't care about alignment. If the
+    // allocation fails, we won't try coercing it into a slice.
+    let buf = unsafe {
+        let len = cmdline_size + 1;
+        NonNull::slice_from_raw_parts(
+            BOOT_ALLOC.allocate(Layout::from_size_align(len, 1).unwrap())?,
+            len,
+        )
+        .as_mut()
+    };
     let actual_size = fw_cfg
         .read_file(&cmdline_file, buf)
         .expect("could not read cmdline");
@@ -67,7 +78,7 @@ pub fn try_load_cmdline(fw_cfg: &mut FwCfg) -> Option<&'static CStr> {
         "cmdline size did not match expected size"
     );
 
-    let cmdline = &CStr::from_bytes_with_nul(buf).expect("invalid kernel command-line");
+    let cmdline = CStr::from_bytes_with_nul(buf).expect("invalid kernel command-line");
     log::debug!(
         "Kernel cmdline: {}",
         cmdline.to_str().expect("invalid kernel commande-line")

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -16,12 +16,10 @@
 
 #![no_std]
 #![feature(int_roundings)]
-
-extern crate alloc;
+#![feature(nonnull_slice_from_raw_parts)]
 
 use core::{arch::asm, ffi::c_void, mem::MaybeUninit, panic::PanicInfo};
 use oak_sev_guest::io::PortFactoryWrapper;
-use static_alloc::bump::Bump;
 use x86_64::{
     instructions::{hlt, interrupts::int3, segmentation::Segment},
     registers::segmentation::*,
@@ -34,6 +32,7 @@ use x86_64::{
 };
 
 mod acpi;
+mod alloc;
 mod cmos;
 mod fw_cfg;
 mod initramfs;
@@ -43,8 +42,8 @@ pub mod paging;
 mod sev;
 mod zero_page;
 
-#[global_allocator]
-static BOOT_ALLOC: Bump<[u8; 128 * 1024]> = Bump::uninit();
+// Reserve 128K for boot data structures.
+static BOOT_ALLOC: alloc::Allocator<0x20000> = alloc::Allocator::uninit();
 
 #[link_section = ".boot"]
 #[no_mangle]

--- a/stage0_bin/.cargo/config.toml
+++ b/stage0_bin/.cargo/config.toml
@@ -6,5 +6,4 @@ rustflags = "-C relocation-model=static -C code-model=large"
 
 [unstable]
 # We need to build std / core because of the code model. This may be removed if / when it's possible to build stage0 without it in the future.
-build-std = ["core", "alloc"]
-build-std-features = ["compiler-builtins-mem"]
+build-std = ["core"]

--- a/stage0_bin/Cargo.lock
+++ b/stage0_bin/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "alloc-traits"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2d54853319fd101b8dd81de382bcbf3e03410a64d8928bbee85a3e7dcde483"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,7 +130,6 @@ dependencies = [
  "oak_sev_guest",
  "sev_serial",
  "spinning_top",
- "static-alloc",
  "static_assertions",
  "strum",
  "x86_64",
@@ -217,15 +210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "static-alloc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570b7e840addf99f80c5b26abba410e21537002316fc82f2747fd87c171e9d7e"
-dependencies = [
- "alloc-traits",
 ]
 
 [[package]]

--- a/stage0_bin/supply-chain/audits.toml
+++ b/stage0_bin/supply-chain/audits.toml
@@ -20,12 +20,6 @@ so they'll at least be forthcoming if they try to implement something
 cryptographic. When in doubt, please ask an expert."""
 implies = "crypto-safe"
 
-[[audits.alloc-traits]]
-who = "Andri Saar <andrisaar@google.com>"
-criteria = ["safe-to-deploy", "does-not-implement-crypto"]
-version = "0.1.1"
-notes = "Crate has no dependecies, includes a safe wrapper for `Layout` that makes unsafe code safer, and has no crypto code."
-
 [[audits.autocfg]]
 who = "Conrad Grobler <grobler@google.com>"
 criteria = "does-not-implement-crypto"

--- a/stage0_bin/supply-chain/config.toml
+++ b/stage0_bin/supply-chain/config.toml
@@ -38,9 +38,6 @@ criteria = ["safe-to-deploy", "crypto-safe"]
 [policy.spinning_top]
 criteria = ["safe-to-deploy", "crypto-safe"]
 
-[policy.static-alloc]
-criteria = ["safe-to-deploy", "crypto-safe"]
-
 [policy.static_assertions]
 criteria = ["safe-to-deploy", "crypto-safe"]
 


### PR DESCRIPTION
This PR does three things:

First, get rid of a`vec!` in `kernel.rs`. After we do that, we no longer need to pull in anything from the `alloc` crate.

Second, replace the `Bump` allocator from `static-alloc` with a simplified home-grown version. This means there's less crates to vet, at the expense of introducing some `unsafe` code straight to stage0 (as we're dealing with raw pointers here, but there's only two small blocks of unsafe code).

Third, rescind the vet for `alloc-traits`, as that was only used by `static-alloc`, which is no longer used.

Fixes #3964 