### PR TITLE
devcontainer: use better extension for getting github links for code snippets

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -16,7 +16,7 @@
     "zixuanwang.linkerscript",
     "zxh404.vscode-proto3",
     "rust-lang.rust-analyzer",
-    "fabiospampinato.vscode-open-in-github",
+    "reduckted.vscode-gitweblinks",
     "eamodio.gitlens"
   ],
   "mounts": [


### PR DESCRIPTION
thanks @mariaschett for recommending this one. Unlike our previous extension for getting links to files on github, this one directly allows you to copy perma links to code snippets also