### PR TITLE
Fix commands to run docker container from stage0

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
 // - https://code.visualstudio.com/docs/remote/devcontainerjson-reference
 {
   // Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-  "image": "sha256:7993e00b67efef8728d13e40731b664e7da1154258966f9d64ceab1fa9b30582",
+  "image": "sha256:f48ec237afe33447dadb24071ef38a5bd472a2fcae2c1ef61bab0244ee9c0e03",
   "extensions": [
     "13xforever.language-x86-64-assembly",
     "bazelbuild.vscode-bazel",
@@ -22,8 +22,16 @@
   "mounts": [
     // Crosvm wants access to syslog.
     "source=/dev/log,target=/dev/log,type=bind",
+    # Enable Docker-in-Docker by giving the container access to the host docker
+    # daemon.
     "source=${localEnv:XDG_RUNTIME_DIR}/docker.sock,target=/var/run/docker.sock,type=bind",
+    # The container uses the host docker daemon, so docker commands running in
+    # the container actually access the host filesystem. Thus mount the /tmp
+    # directory as a volume in the container so that it can access the outputs of
+    # docker commands that write to /tmp.
     "source=/tmp,target=/tmp,type=bind",
+    # Provide readonly access to the kernel image and kernel volumes of the host
+    # to enable virt-make-fs which requires access to a kernel.
     "source=/boot,target=/boot,type=bind,readonly",
     "source=/lib/modules,target=/lib/modules,type=bind,readonly"
   ],

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -22,16 +22,16 @@
   "mounts": [
     // Crosvm wants access to syslog.
     "source=/dev/log,target=/dev/log,type=bind",
-    # Enable Docker-in-Docker by giving the container access to the host docker
-    # daemon.
+    // Enable Docker-in-Docker by giving the container access to the host docker
+    // daemon.
     "source=${localEnv:XDG_RUNTIME_DIR}/docker.sock,target=/var/run/docker.sock,type=bind",
-    # The container uses the host docker daemon, so docker commands running in
-    # the container actually access the host filesystem. Thus mount the /tmp
-    # directory as a volume in the container so that it can access the outputs of
-    # docker commands that write to /tmp.
+    // The container uses the host docker daemon, so docker commands running in
+    // the container actually access the host filesystem. Thus mount the /tmp
+    // directory as a volume in the container so that it can access the outputs of
+    // docker commands that write to /tmp.
     "source=/tmp,target=/tmp,type=bind",
-    # Provide readonly access to the kernel image and kernel volumes of the host
-    # to enable virt-make-fs which requires access to a kernel.
+    // Provide readonly access to the kernel image and kernel volumes of the host
+    // to enable virt-make-fs which requires access to a kernel.
     "source=/boot,target=/boot,type=bind,readonly",
     "source=/lib/modules,target=/lib/modules,type=bind,readonly"
   ],

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -21,7 +21,11 @@
   ],
   "mounts": [
     // Crosvm wants access to syslog.
-    "source=/dev/log,target=/dev/log,type=bind"
+    "source=/dev/log,target=/dev/log,type=bind",
+    "source=${localEnv:XDG_RUNTIME_DIR}/docker.sock,target=/var/run/docker.sock,type=bind",
+    "source=/tmp,target=/tmp,type=bind",
+    "source=/boot,target=/boot,type=bind,readonly",
+    "source=/lib/modules,target=/lib/modules,type=bind,readonly"
   ],
   "runArgs": [
     // Required by the VMM.

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN apt-get --yes update \
   libc++-${llvm_version}-dev \
   libfl2 \
   libgmp-dev \
+  # `virt-make-fs` from `libguestfs-tools` is needed for creating qcow2 images.
+  libguestfs-tools \
   libmpc-dev \
   libncurses5 \
   libssl-dev \

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -9,6 +9,7 @@ export CI=kokoro
 
 export RUST_BACKTRACE=1
 export RUST_LOG=debug
+export XDG_RUNTIME_DIR=/var/run
 
 ./scripts/docker_pull
 # --all-targets is needed to also run tests for examples and benches.

--- a/oak_docker_linux_init/Dockerfile
+++ b/oak_docker_linux_init/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.17.3
 RUN apk --no-cache add \
-  linux-virt=5.15.109-r0 \
-  linux-virt-dev=5.15.109-r0 \
+  linux-virt=5.15.115-r0 \
+  linux-virt-dev=5.15.115-r0 \
   alpine-sdk=1.0-r1 \
   grep=3.8-r1 \
   coreutils=9.1-r0

--- a/oak_docker_linux_init/README.md
+++ b/oak_docker_linux_init/README.md
@@ -119,21 +119,21 @@ has been copied to `bin/vmlinux`.
 qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm" -m 8G \
     -nographic -nodefaults -no-reboot -serial stdio \
     -bios "bin/stage0.bin" \
-    -fw_cfg "name=opt/stage0/elf_kernel,file=${NETBOOT_VMLINUX}" \
+    -fw_cfg "name=opt/stage0/elf_kernel,file=bin/vmlinux" \
     -fw_cfg "name=opt/stage0/initramfs,file=bin/initramfs" \
     -fw_cfg "name=opt/stage0/cmdline,string=console=ttyS0 quiet" \
     -netdev user,id=user \
     -device virtio-net-device,netdev=user \
+    -drive id=docker_root,if=none,format=qcow2,file=bin/docker.qcow2 \
     -device virtio-blk-device,drive=docker_root
-    -drive id=docker_root,if=none,format=qcow2,file=bin/docker.qcow2
 ```
 
 If the Docker image was packaged as part of the initramfs image, you can skip
 the following options from the command line:
 
 ```text
-  -device virtio-blk-device,drive=docker_root
   -drive id=docker_root,if=none,format=qcow2,file=bin/docker.qcow2
+  -device virtio-blk-device,drive=docker_root
 ```
 
 Note that you can forward ports from host device to the guest device by using
@@ -175,7 +175,7 @@ Launch QEMU with network, where tcp port `8888` is forwarded from host to guest:
 qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm" -m 8G \
     -nographic -nodefaults -no-reboot -serial stdio \
     -bios "bin/stage0.bin" \
-    -fw_cfg "name=opt/stage0/elf_kernel,file=${NETBOOT_VMLINUX}" \
+    -fw_cfg "name=opt/stage0/elf_kernel,file=bin/vmlinux" \
     -fw_cfg "name=opt/stage0/initramfs,file=bin/initramfs" \
     -fw_cfg "name=opt/stage0/cmdline,string=console=ttyS0 quiet" \
     -netdev user,ipv6=off,id=user,hostfwd=tcp::8888-:8888 \

--- a/oak_docker_linux_init/prepare_docker_launcher_initramfs.sh
+++ b/oak_docker_linux_init/prepare_docker_launcher_initramfs.sh
@@ -73,6 +73,7 @@ docker run -v "${RAMDIR}:/output" -it mkinitramfs \
   sh -c "/app/mk_base_initramfs.sh -k /output/vmlinux -r /output"
 
 echo "[INFO] Updating Linux kernel at ${LINUX_KERNEL}"
+mkdir -p $(dirname "${LINUX_KERNEL}")
 mv "${RAMDIR}/vmlinux" "${LINUX_KERNEL}"
 
 if [ -z "${DOCKER_IMAGE}" ]; then

--- a/oak_docker_linux_init/prepare_docker_launcher_initramfs.sh
+++ b/oak_docker_linux_init/prepare_docker_launcher_initramfs.sh
@@ -73,7 +73,7 @@ docker run -v "${RAMDIR}:/output" -it mkinitramfs \
   sh -c "/app/mk_base_initramfs.sh -k /output/vmlinux -r /output"
 
 echo "[INFO] Updating Linux kernel at ${LINUX_KERNEL}"
-mkdir -p $(dirname "${LINUX_KERNEL}")
+mkdir -p "$(dirname "${LINUX_KERNEL}")"
 mv "${RAMDIR}/vmlinux" "${LINUX_KERNEL}"
 
 if [ -z "${DOCKER_IMAGE}" ]; then

--- a/scripts/common
+++ b/scripts/common
@@ -20,10 +20,10 @@ readonly DOCKER_IMAGE_NAME='europe-west2-docker.pkg.dev/oak-ci/oak-development/o
 # from a registry first.
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_build .
-readonly DOCKER_IMAGE_ID='sha256:7993e00b67efef8728d13e40731b664e7da1154258966f9d64ceab1fa9b30582'
+readonly DOCKER_IMAGE_ID='sha256:f48ec237afe33447dadb24071ef38a5bd472a2fcae2c1ef61bab0244ee9c0e03'
 
 # Do not modify manually. This value is automatically updated by ./scripts/docker_push .
-readonly DOCKER_IMAGE_REPO_DIGEST='europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development@sha256:51532c757d1008bbff696d053a1d05226f6387cf232aa80b6f9c13b0759ccea0'
+readonly DOCKER_IMAGE_REPO_DIGEST='europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development@sha256:7b6e401df8e90fec2597806a8c912649b9802de83abe9f6724c3dffe7772f07d'
 
 readonly CACHE_DIR='bazel-cache'
 readonly SERVER_BIN_DIR="${PWD}/oak_loader/bin"

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -24,7 +24,19 @@ docker_run_flags=(
   "--volume=$PWD/cargo-cache:/home/docker/.cargo"
   "--volume=$PWD/sccache-cache:/home/docker/.cache/sccache"
   "--volume=$PWD:/workspace"
+  # Enable Docker-in-Docker by giving the container access to the host docker
+  # daemon.
+  "--volume=$XDG_RUNTIME_DIR/docker.sock:/var/run/docker.sock"
+  # The container uses the host docker daemon, so docker commands running in
+  # the container actually access the host filesystem. Thus mount the /tmp
+  # directory as a volume in the container so that it can access the outputs of
+  # docker commands that write to /tmp.
+  '--volume=/tmp:/tmp'
   '--volume=/dev/log:/dev/log'
+  # Provide readonly access to the kernel image and kernel volumes of the host
+  # to enable virt-make-fs which requires access to a kernel.
+  '--volume=/boot:/boot:ro'
+  '--volume=/lib/modules:/lib/modules:ro'
   '--workdir=/workspace'
   '--network=host'
 )


### PR DESCRIPTION
Make it possible to successfully run the commands in the README without modifications.

Additionally, to enable running the commands without having to manually get the proper dependencies, the commands in the README should work within the Oak development docker container. Make this possible by adding dependencies to the Oak development docker
image and providing the docker container with access to necessary files on the host machine.

Tested by running the commands in the README both from within a docker container started from VSCode, from within a docker container started via the scripts/docker_sh, and from outside Docker with dependencies downloaded manually.