### PR TITLE
Stub more WASI functions

### DIFF
--- a/oak_functions/wasm/src/lib.rs
+++ b/oak_functions/wasm/src/lib.rs
@@ -65,6 +65,28 @@ pub struct UserState<L: OakLogger> {
     logger: L,
 }
 
+/// Stubs a Wasm imported function in the provided linker.
+///
+/// The stubbed function logs an error and returns an error in the form of a Wasm trap (similar to
+/// an exception).
+macro_rules! stub_wasm_function {
+    ($linker:ident, $function_mod:ident . $function_name:ident, ($($t:ty),*) -> $r:ty) => {
+        $linker.func_wrap(
+            stringify!($function_mod),
+            stringify!($function_name),
+            |caller: wasmi::Caller<'_, UserState<L>>, $(_: $t),*| {
+                caller
+                    .data()
+                    .log_error(concat!("called stubbed ", stringify!($function_mod), ".", stringify!($function_name)));
+                Err::<$r, wasmi::core::Trap>(
+                    wasmi::core::Trap::new(
+                        concat!("called stubbed ", stringify!($function_mod), ".", stringify!($function_name))))
+            },
+        )
+        .expect(concat!("failed to define ", stringify!($function_mod), ".", stringify!($function_name), " in linker"));
+    };
+}
+
 impl<L> UserState<L>
 where
     L: OakLogger,
@@ -237,23 +259,49 @@ where
             )
             .expect("failed to define invoke in linker");
 
-        // TODO(#3929): One of our dependency requires this WASI function to be linked, but, to the
-        // best of our knowledge, does not use it at run time. As a workaround, we stub it
-        // for now but we should remove them, if possible.
-        linker
-            .func_wrap(
-                "wasi_snapshot_preview1",
-                "clock_time_get",
-                |caller: wasmi::Caller<'_, UserState<L>>, _: i32, _: i64, _: i32| {
-                    caller
-                        .data()
-                        .log_error("Called stubbed wasi_snapshot_preview1.clock_time_get");
-                    Err::<i32, wasmi::core::Trap>(wasmi::core::Trap::new(
-                        "wasi_snapshot_preview1.clock_time_get",
-                    ))
-                },
-            )
-            .expect("failed to define clock_time_get in linker");
+        // TODO(#3929): One of our dependency requires various WASI functions to be linked, but, to
+        // the best of our knowledge, does not use them at run time. As a workaround, we stub
+        // them for now but we should remove them, if possible.
+        stub_wasm_function!(
+            linker,
+            wasi_snapshot_preview1.clock_time_get,
+            (i32, i64, i32) -> i32
+        );
+        stub_wasm_function!(
+            linker,
+            wasi_snapshot_preview1.proc_exit,
+            (i32) -> ()
+        );
+        stub_wasm_function!(
+            linker,
+            wasi_snapshot_preview1.environ_sizes_get,
+            (i32, i32) -> i32
+        );
+        stub_wasm_function!(
+            linker,
+            wasi_snapshot_preview1.environ_get,
+            (i32, i32) -> i32
+        );
+        stub_wasm_function!(
+            linker,
+            wasi_snapshot_preview1.fd_close,
+            (i32) -> i32
+        );
+        stub_wasm_function!(
+            linker,
+            wasi_snapshot_preview1.fd_write,
+            (i32, i32, i32, i32) -> i32
+        );
+        stub_wasm_function!(
+            linker,
+            wasi_snapshot_preview1.fd_read,
+            (i32, i32, i32, i32) -> i32
+        );
+        stub_wasm_function!(
+            linker,
+            wasi_snapshot_preview1.fd_seek,
+            (i32, i64, i32, i32) -> i32
+        );
 
         OakLinker { linker }
     }


### PR DESCRIPTION
Create a handy proc macro to stub multiple functions easily.

Follow up from 75bbbcf1418489dfe4c05392c150a496ff62dcbb