### PR TITLE
Remove several unnecessary uses of WORKSPACE_ROOT.

### DIFF
--- a/micro_rpc/build.rs
+++ b/micro_rpc/build.rs
@@ -15,11 +15,5 @@
 //
 
 fn main() {
-    micro_rpc_build::compile(
-        &[format!(
-            "{}micro_rpc/proto/messages.proto",
-            env!("WORKSPACE_ROOT")
-        )],
-        &[format!("{}micro_rpc/proto", env!("WORKSPACE_ROOT"))],
-    );
+    micro_rpc_build::compile(&["proto/messages.proto"], &["proto"]);
 }

--- a/oak_crypto/build.rs
+++ b/oak_crypto/build.rs
@@ -15,13 +15,7 @@
 //
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    micro_rpc_build::compile(
-        &[format!(
-            "{}oak_crypto/proto/v1/crypto.proto",
-            env!("WORKSPACE_ROOT")
-        )],
-        &[format!("{}oak_crypto/proto", env!("WORKSPACE_ROOT"))],
-    );
+    micro_rpc_build::compile(&["proto/v1/crypto.proto"], &["proto"]);
 
     Ok(())
 }

--- a/oak_remote_attestation/build.rs
+++ b/oak_remote_attestation/build.rs
@@ -15,16 +15,7 @@
 //
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    micro_rpc_build::compile(
-        &[format!(
-            "{}oak_remote_attestation/proto/v1/messages.proto",
-            env!("WORKSPACE_ROOT")
-        )],
-        &[format!(
-            "{}oak_remote_attestation/proto/v1",
-            env!("WORKSPACE_ROOT")
-        )],
-    );
+    micro_rpc_build::compile(&["proto/v1/messages.proto"], &["proto/v1"]);
 
     Ok(())
 }


### PR DESCRIPTION
When run, each build script's working directory is set to the source directory of the build script's package
(https://doc.rust-lang.org/cargo/reference/build-scripts.html#inputs-to-the-build-script), so these paths can all be made relative.

Using relative paths makes it much easier to use these crates from another workspace since it's no longer necessary to set WORKSPACE_ROOT to the right path within the Cargo home.

Tested by running `cargo build`.