### PR TITLE
Create an initial version of stage1 (loader in initrd)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,6 +1762,20 @@ dependencies = [
 [[package]]
 name = "oak_containers_orchestrator"
 version = "0.1.0"
+
+[[package]]
+name = "oak_containers_stage1"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "futures-util",
+ "nix 0.26.2",
+ "oak_grpc_utils",
+ "prost",
+ "tar",
+ "tokio",
+ "tonic",
+]
 
 [[package]]
 name = "oak_core"
@@ -3376,6 +3402,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4027,13 +4064,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
@@ -4042,7 +4079,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4051,13 +4097,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -4067,10 +4128,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4079,10 +4152,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4091,16 +4176,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "wyz"
@@ -4141,6 +4244,15 @@ dependencies = [
  "bitflags",
  "rustversion",
  "volatile",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "micro_rpc_tests",
   "oak_channel",
   "oak_client",
+  "oak_containers_stage1",
   "oak_core",
   "oak_containers_orchestrator",
   "oak_crypto",

--- a/oak_containers_stage1/Cargo.toml
+++ b/oak_containers_stage1/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "oak_containers_stage1"
+version = "0.1.0"
+edition = "2021"
+authors = ["Andri Saar <andrisaar@google.com>"]
+license = "Apache-2.0"
+
+[build-dependencies]
+oak_grpc_utils = { workspace = true }
+
+[dependencies]
+clap = { version = "*", features = ["derive"] }
+futures-util = "*"
+nix = "*"
+prost = { workspace = true }
+tar = "*"
+tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
+tonic = { workspace = true }

--- a/oak_containers_stage1/build.rs
+++ b/oak_containers_stage1/build.rs
@@ -1,0 +1,31 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Generate gRPC code for exchanging messages with clients.
+    generate_grpc_code(
+        "../",
+        &["oak_containers_stage1/proto/stage1.proto"],
+        CodegenOptions {
+            build_server: true,
+            ..Default::default()
+        },
+    )?;
+
+    Ok(())
+}

--- a/oak_containers_stage1/proto/stage1.proto
+++ b/oak_containers_stage1/proto/stage1.proto
@@ -1,0 +1,29 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.containers;
+
+import "google/protobuf/empty.proto";
+
+message LoadRequest {
+  bytes image_chunk = 1;
+}
+
+service ImageLoader {
+  rpc Load(stream LoadRequest) returns (google.protobuf.Empty) {}
+}

--- a/oak_containers_stage1/src/image.rs
+++ b/oak_containers_stage1/src/image.rs
@@ -1,0 +1,65 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use nix::{
+    errno::Errno,
+    mount::{mount, umount, MsFlags},
+    unistd::{execve, pivot_root},
+};
+use std::{ffi::CString, fs::create_dir};
+use tar::{self, Archive};
+
+pub static RAMFS_TMP_DIR: &str = "/ramfs";
+static PIVOT_TMP_DIR: &str = "/initrd";
+
+#[derive(Clone)]
+pub struct Image {
+    ramfs_tmp_dir: String,
+}
+
+impl Image {
+    /// Prepares a new ramdrive.
+    pub fn new(ramfs_tmp_dir: String) -> Result<Self, std::io::Error> {
+        create_dir(ramfs_tmp_dir.as_str())?;
+        mount::<str, str, str, str>(
+            None,
+            ramfs_tmp_dir.as_str(),
+            Some("ramfs"),
+            MsFlags::empty(),
+            None,
+        )?;
+        Ok(Self { ramfs_tmp_dir })
+    }
+
+    /// Unpacks the buffer containing a TAR archive into the ramdrive.
+    pub fn unpack(&self, data: &[u8]) -> Result<(), std::io::Error> {
+        let mut archive = Archive::new(data);
+        archive.unpack(self.ramfs_tmp_dir.as_str())
+    }
+
+    /// Switches the root filesystem to the ramdrive and runs `/sbin/init` from there.
+    pub fn switch(self, init: &str) -> Result<!, Errno> {
+        pivot_root(self.ramfs_tmp_dir.as_str(), PIVOT_TMP_DIR)?;
+        umount(PIVOT_TMP_DIR)?;
+
+        // On one hand, I feel like this function should be marked `unsafe` as this will
+        // unconditionally switch over to the new executable (if it succeeds) without any
+        // more Rust code executing. On the other hand, the return type is `!`, so you
+        // shouldn't expect the control to return.
+        execve::<CString, CString>(CString::new(init).unwrap().as_c_str(), &[], &[])?;
+        unreachable!()
+    }
+}

--- a/oak_containers_stage1/src/main.rs
+++ b/oak_containers_stage1/src/main.rs
@@ -1,0 +1,57 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#![feature(never_type)]
+
+mod image;
+mod server;
+
+use clap::Parser;
+use std::{error::Error, net::SocketAddr};
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(required = true)]
+    addr: SocketAddr,
+
+    #[arg(default_value = "/sbin/init")]
+    init: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+
+    // We want to send back a meaningful answer to the caller that the RPC has been handled
+    // successfully. Thus, we need two channels: one to notify us that the image has been loaded,
+    // and another so that we could shut down the gRPC server.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let (loaded_tx, mut loaded_rx) = tokio::sync::mpsc::channel(1);
+
+    let join = tokio::spawn(server::ImageLoaderServer::serve(
+        args.addr,
+        shutdown_rx,
+        loaded_tx,
+    ));
+    let image = loaded_rx.recv().await.unwrap();
+    shutdown_tx.send(()).unwrap();
+    join.await??;
+
+    // At this point we've shut down the server, so we expect that the response has been sent back
+    // and the image has been unpacked into the correct directory. Switch roots and execute the
+    // correct init.
+    image.switch(&args.init)?;
+}

--- a/oak_containers_stage1/src/server.rs
+++ b/oak_containers_stage1/src/server.rs
@@ -1,0 +1,74 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::image::{self, Image};
+use futures_util::future::FutureExt;
+use proto::oak::containers::{image_loader_server::ImageLoader, LoadRequest};
+use std::net::SocketAddr;
+use tokio::sync::{mpsc::Sender, oneshot::Receiver};
+use tonic::{transport::Server, Code, Request, Response, Result, Status, Streaming};
+
+pub mod proto {
+    pub mod oak {
+        pub mod containers {
+            tonic::include_proto!("oak.containers");
+        }
+    }
+}
+
+pub struct ImageLoaderServer {
+    loaded_tx: Sender<Image>,
+}
+
+#[tonic::async_trait]
+impl ImageLoader for ImageLoaderServer {
+    async fn load(&self, request: Request<Streaming<LoadRequest>>) -> Result<Response<()>> {
+        let mut stream = request.into_inner();
+
+        // We should see if this could be streamed, somehow, instead of buffering the whole file in
+        // memory before unpacking it.
+        let mut buf = Vec::new();
+        while let Some(mut msg) = stream.message().await? {
+            buf.append(&mut msg.image_chunk);
+        }
+        let image = Image::new(String::from(image::RAMFS_TMP_DIR))?;
+        image.unpack(&buf)?;
+        // this is now ready to launch, but don't do it here, otherwise we will never be able to
+        // send a response back as it'd terminate stage1
+        self.loaded_tx
+            .send(image)
+            .await
+            .map_err(|err| Status::new(Code::Internal, err.to_string()))?;
+        Ok(Response::new(()))
+    }
+}
+
+impl ImageLoaderServer {
+    pub async fn serve(
+        addr: SocketAddr,
+        shutdown: Receiver<()>,
+        loaded_tx: Sender<Image>,
+    ) -> Result<(), tonic::transport::Error> {
+        let server = ImageLoaderServer { loaded_tx };
+
+        Server::builder()
+            .add_service(
+                proto::oak::containers::image_loader_server::ImageLoaderServer::new(server),
+            )
+            .serve_with_shutdown(addr, shutdown.map(drop))
+            .await
+    }
+}


### PR DESCRIPTION
As discussed, we first want to have a small initrd image (this binary compiles down to ~3 MB stripped, probably even smaller if we enable LTO) that loads a full-size filesystem image over a more high-bandwidth channel.

This PR creates the first version of that program; it's somewhat of a request for comments as there is no way to test it yet. But it exposes a gRPC service that can be used to upload a TAR archive, which is then unpacked to a ramdrive and stage1 executes the `/sbin/init` program from that ramdrive.

(Feel free to bikeshed about the name as well; I picked stage1 as it's (a) after stage0 and (b) much like stage0 once we've executed the next step the life of this stage is done, it will not stick around.)