### PR TITLE
Temporarily ignore Ouroboros failure

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,8 @@ notice = "deny"
 ignore = [
   # TODO(#3845): Stop ignoring when the colored crate no longer relies on atty.
   "RUSTSEC-2021-0145",
+  # TODO(#4016): Fix "Ouroboros is Unsound" failure.
+  "RUSTSEC-2023-0042",
 ]
 
 [bans]


### PR DESCRIPTION
We need to temporarily ignore the "Ouroboros is Unsound" failure to allow other PRs finish the CI

Ref https://github.com/project-oak/oak/issues/4016