### PR TITLE
Define the service interface between launcher and (stage1/orhcestrator)

### DIFF
--- a/oak_containers/proto/launcher.proto
+++ b/oak_containers/proto/launcher.proto
@@ -1,0 +1,37 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.containers;
+
+import "google/protobuf/empty.proto";
+
+// As images can be large (hundreds of megabytes), the launcher chunks up the response into smaller
+// pieces to respect proto/gRPC limits. The image needs to be reassembled in the stage1 or the
+// orchestrator.
+message GetImageResponse {
+  bytes image_chunk = 1;
+}
+
+service Launcher {
+  // Provides stage1 with the Oak system image (which contains the Linux distribution and the
+  // orchestrator binary).
+  rpc GetOakSystemImage(google.protobuf.Empty) returns (stream GetImageResponse) {}
+
+  // Provides orchestrator with the trusted container image.
+  rpc GetContainerBundle(google.protobuf.Empty) returns (stream GetImageResponse) {}
+}


### PR DESCRIPTION
As discussed the launcher will be the server, and stage1/orchestrator will fetch their images from them (pull, not push).

This adds the first version of the service proto (as it's needed for my stage1 experiments).