### PR TITLE
Spawn a QEMU instance in the Oak Containers launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,7 @@ dependencies = [
  "async-stream",
  "bytes",
  "clap",
+ "command-fds",
  "futures",
  "oak_grpc_utils",
  "prost",

--- a/oak_containers_launcher/Cargo.toml
+++ b/oak_containers_launcher/Cargo.toml
@@ -10,6 +10,7 @@ oak_grpc_utils = { workspace = true }
 
 [dependencies]
 anyhow = "*"
+command-fds = { version = "*", features = ["tokio"] }
 prost = "*"
 tokio = { version = "*", features = [
   "rt-multi-thread",

--- a/oak_containers_launcher/src/main.rs
+++ b/oak_containers_launcher/src/main.rs
@@ -17,6 +17,7 @@ mod qemu;
 mod server;
 
 use clap::Parser;
+use std::process;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -56,7 +57,8 @@ async fn main() -> Result<(), anyhow::Error> {
         args.container_bundle,
     )
 
-    let mut vmm = qemu::Qemu::start(args.qemu_params, args.vsock_cid)?;
+    // Use our PID for the CID of the guest.
+    let mut vmm = qemu::Qemu::start(args.qemu_params, process::id())?;
 
     tokio::select! {
         _ = server => {}

--- a/oak_containers_launcher/src/main.rs
+++ b/oak_containers_launcher/src/main.rs
@@ -31,7 +31,6 @@ struct Args {
     container_bundle: std::path::PathBuf,
     #[command(flatten)]
     qemu_params: qemu::Params,
-
 }
 
 pub fn path_exists(s: &str) -> Result<std::path::PathBuf, String> {
@@ -55,7 +54,7 @@ async fn main() -> Result<(), anyhow::Error> {
         args.vsock_port,
         args.system_image,
         args.container_bundle,
-    )
+    );
 
     // Use our PID for the CID of the guest.
     let mut vmm = qemu::Qemu::start(args.qemu_params, process::id())?;

--- a/oak_containers_launcher/src/qemu.rs
+++ b/oak_containers_launcher/src/qemu.rs
@@ -1,0 +1,172 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::Result;
+use clap::Parser;
+use command_fds::tokio::CommandFdAsyncExt;
+use std::{
+    fs,
+    io::{BufRead, BufReader},
+    os::{fd::AsRawFd, unix::net::UnixStream},
+    path::PathBuf,
+    process::Stdio,
+};
+
+/// Represents parameters used for launching VM instances.
+#[derive(Parser, Clone, Debug, PartialEq)]
+pub struct Params {
+    /// Path to the VMM binary to execute.
+    #[arg(long, value_parser = path_exists)]
+    pub vmm_binary: PathBuf,
+
+    /// Path to the stage0 image to use.
+    #[arg(long, value_parser = path_exists)]
+    pub stage0_binary: PathBuf,
+
+    /// Path to the Linux kernel file to use.
+    #[arg(long, value_parser = path_exists)]
+    pub kernel: PathBuf,
+
+    /// Path to the initrd image to use.
+    #[arg(long, value_parser = path_exists)]
+    pub initrd: PathBuf,
+
+    /// How much memory to give to the enclave binary, e.g., 256M (M stands for Megabyte, G for
+    /// Gigabyte).
+    #[arg(long)]
+    pub memory_size: Option<String>,
+}
+
+/// Checks if file with a given path exists.
+fn path_exists(s: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(s);
+    if !fs::metadata(s).map_err(|err| err.to_string())?.is_file() {
+        Err(String::from("path does not represent a file"))
+    } else {
+        Ok(path)
+    }
+}
+
+pub struct Qemu {
+    instance: tokio::process::Child,
+}
+
+impl Qemu {
+    pub fn start(params: Params, vsock_cid: u32) -> Result<Self> {
+        let mut cmd = tokio::process::Command::new(params.vmm_binary);
+        let (guest_socket, host_socket) = UnixStream::pair()?;
+
+        cmd.stderr(Stdio::inherit());
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::inherit());
+        cmd.preserved_fds(vec![guest_socket.as_raw_fd()]);
+
+        // Construct the command-line arguments for `qemu`.
+        cmd.arg("-enable-kvm");
+        // Needed to expose advanced CPU features. Specifically RDRAND which is required for remote
+        // attestation.
+        cmd.args(["-cpu", "IvyBridge-IBRS,enforce"]);
+        // Set memory size if given.
+        if let Some(memory_size) = params.memory_size {
+            cmd.args(["-m", &memory_size]);
+        };
+        // Disable a bunch of hardware we don't need.
+        cmd.arg("-nodefaults");
+        cmd.arg("-nographic");
+        // If the VM restarts, don't restart it (we're not expecting any restarts so any restart
+        // should be treated as a failure)
+        cmd.arg("-no-reboot");
+        // Use the `microvm` machine as the basis, and ensure ACPI and PCIe are enabled.
+        cmd.args(["-machine", "microvm,acpi=on,pcie=on"]);
+        // Route first serial port to console.
+        cmd.args([
+            "-chardev",
+            format!("socket,id=consock,fd={}", guest_socket.as_raw_fd()).as_str(),
+        ]);
+        cmd.args(["-serial", "chardev:consock"]);
+        // Set up the virtio-vsock device.
+        cmd.args([
+            "-device",
+            format!(
+                "vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid={}",
+                vsock_cid
+            )
+            .as_str(),
+        ]);
+        // And yes, use stage0 as the BIOS.
+        cmd.args([
+            "-bios",
+            params
+                .stage0_binary
+                .into_os_string()
+                .into_string()
+                .unwrap()
+                .as_str(),
+        ]);
+        // stage0 accoutrements: the kernel, initrd and inital kernel cmdline.
+        cmd.args([
+            "-fw_cfg",
+            format!(
+                "name=opt/stage0/elf_kernel,file={}",
+                params
+                    .kernel
+                    .into_os_string()
+                    .into_string()
+                    .unwrap()
+                    .as_str()
+            )
+            .as_str(),
+        ]);
+        cmd.args([
+            "-fw_cfg",
+            format!(
+                "name=opt/stage0/initramfs,file={}",
+                params
+                    .initrd
+                    .into_os_string()
+                    .into_string()
+                    .unwrap()
+                    .as_str()
+            )
+            .as_str(),
+        ]);
+        cmd.args([
+            "-fw_cfg",
+            "name=opt/stage0/cmdline,string=console=ttyS0 panic=-1",
+        ]);
+
+        println!("QEMU command line: {:?}", cmd);
+
+        // Spit out everything we read.
+        tokio::spawn(async {
+            let mut reader = BufReader::new(host_socket);
+
+            let mut line = String::new();
+            while reader.read_line(&mut line).expect("couldn't read line") > 0 {
+                print!("{}", line);
+                line.clear();
+            }
+        });
+
+        let instance = cmd.spawn()?;
+
+        Ok(Self { instance })
+    }
+
+    pub async fn wait(&mut self) -> Result<std::process::ExitStatus> {
+        self.instance.wait().await.map_err(anyhow::Error::from)
+    }
+}

--- a/oak_containers_launcher/src/qemu.rs
+++ b/oak_containers_launcher/src/qemu.rs
@@ -14,11 +14,11 @@
 // limitations under the License.
 //
 
+use crate::path_exists;
 use anyhow::Result;
 use clap::Parser;
 use command_fds::tokio::CommandFdAsyncExt;
 use std::{
-    fs,
     io::{BufRead, BufReader},
     os::{fd::AsRawFd, unix::net::UnixStream},
     path::PathBuf,
@@ -48,16 +48,6 @@ pub struct Params {
     /// Gigabyte).
     #[arg(long)]
     pub memory_size: Option<String>,
-}
-
-/// Checks if file with a given path exists.
-fn path_exists(s: &str) -> Result<PathBuf, String> {
-    let path = PathBuf::from(s);
-    if !fs::metadata(s).map_err(|err| err.to_string())?.is_file() {
-        Err(String::from("path does not represent a file"))
-    } else {
-        Ok(path)
-    }
 }
 
 pub struct Qemu {


### PR DESCRIPTION
Largely untested in real life (but we can spawn QEMU), but after this PR we should have all the pieces there to start trying plugging all of them together.

The code is mostly based on the Oak Functions launcher code; shortcuts were taken, but we can always refactor in the future.

Ref #4023 