### PR TITLE
fix: verify ent sha256sum

### DIFF
--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -79,9 +79,11 @@ jobs:
         if: steps.cache-ent.outputs.cache-hit != 'true'
         env:
           ENT_URL: https://ent-server-62sa4xcfia-ew.a.run.app
-          ENT_DIGEST: sha256:944a34854a2bf9c5d32f3bffa93885ee1c7ef8ab0f4fcc30898a981050ae4233
+          ENT_DIGEST: 944a34854a2bf9c5d32f3bffa93885ee1c7ef8ab0f4fcc30898a981050ae4233
         run: |
-          curl --fail ${ENT_URL}/raw/${ENT_DIGEST} > /usr/local/bin/ent
+          set -e
+          curl --fail ${ENT_URL}/raw/sha256:${ENT_DIGEST} > /usr/local/bin/ent
+          echo "${ENT_DIGEST} /usr/local/bin/ent" | sha256sum -c
           chmod +x /usr/local/bin/ent
           ent
           cat <<EOF > ~/.config/ent.toml


### PR DESCRIPTION
Add a sha256sum check after downloading the ent binary.
The check prevents an RCE within the workflow if the ent server is compromised.

Potential attack:
1. A malicious actor overrides the ent binary on the server with a malicious one.
2. The malicious ent binary uses the `pull-reuqest: write` permission to push malicious code to the main branch.
3. The malicious code pushed to the main branch triggers the workflows, thus being injected into the next application version.
4. The malicious version also generates a legitimate provenance document.

Moreover, the attacker can create a new workflow with ALL write permissions, resulting in a complete compromise of the repository and its secrets, and the ability to remove the code and actions from the git history -- making the attack even more challenging to detect (i.e. no leftovers except for the audit log).

---
As a side note, it is highly recommended to avoid the use of action outputs/variables directly in the bash scripts within the different workflows ( `${{ ... }}` ), and rather go through the `env:` field first.
External contributors cannot exploit them now, but it makes the workflow vulnerable to injection attacks upon almost any "bad" change in the workflows or pull reuqest permissions.