### PR TITLE
Split C++ encryptor file

### DIFF
--- a/cc/crypto/BUILD
+++ b/cc/crypto/BUILD
@@ -20,14 +20,46 @@ package(
 )
 
 cc_library(
-    name = "encryptor",
-    srcs = ["encryptor.cc"],
-    hdrs = ["encryptor.h"],
+    name = "client_encryptor",
+    srcs = ["client_encryptor.cc"],
+    hdrs = ["client_encryptor.h"],
     deps = [
-        "//cc/crypto/hpke:recipient_context",
+        ":common",
         "//cc/crypto/hpke:sender_context",
         "//oak_crypto/proto/v1:crypto_cc_proto",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "server_encryptor",
+    srcs = ["server_encryptor.cc"],
+    hdrs = ["server_encryptor.h"],
+    deps = [
+        ":common",
+        "//cc/crypto/hpke:recipient_context",
+        "//oak_crypto/proto/v1:crypto_cc_proto",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "common",
+    hdrs = ["common.h"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "encryptor_test",
+    size = "small",
+    srcs = ["encryptor_test.cc"],
+    deps = [
+        ":client_encryptor",
+        ":server_encryptor",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cc/crypto/client_encryptor.cc
+++ b/cc/crypto/client_encryptor.cc
@@ -15,6 +15,9 @@
  */
 
 #include "cc/crypto/client_encryptor.h"
-#include "cc/crypto/server_encryptor.h"
+
+#include "absl/status/statusor.h"
+#include "cc/crypto/hpke/sender_context.h"
+#include "oak_crypto/proto/v1/crypto.pb.h"
 
 namespace oak::crypto {}  // namespace oak::crypto

--- a/cc/crypto/client_encryptor.h
+++ b/cc/crypto/client_encryptor.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef CC_CRYPTO_ENCRYPTOR_H_
-#define CC_CRYPTO_ENCRYPTOR_H_
+#ifndef CC_CRYPTO_CLIENT_ENCRYPTOR_H_
+#define CC_CRYPTO_CLIENT_ENCRYPTOR_H_
 
 #include <memory>
 #include <string>
@@ -23,18 +23,10 @@
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
-#include "cc/crypto/hpke/recipient_context.h"
+#include "cc/crypto/common.h"
 #include "cc/crypto/hpke/sender_context.h"
 
 namespace oak::crypto {
-
-// Info string used by Hybrid Public Key Encryption.
-constexpr absl::string_view OAK_HPKE_INFO = "Oak Hybrid Public Key Encryption v1";
-
-struct DecryptionResult {
-  std::string plaintext;
-  std::string associated_data;
-};
 
 // Encryptor class for encrypting client requests that will be sent to the server and decrypting
 // server responses that are received by the client. Each Encryptor corresponds to a single crypto
@@ -73,7 +65,7 @@ class ClientEncryptor {
   // <https://datatracker.ietf.org/doc/html/rfc5116>
   //
   // `encrypted_response` must be a serialized [`oak.crypto.EncryptedResponse`] message.
-  // Returns a response message plaintext.
+  // Returns a response message plaintext and associated data.
   // TODO(#3843): Accept unserialized proto messages once we have Java encryption without JNI.
   absl::StatusOr<DecryptionResult> Decrypt(absl::string_view encrypted_response);
 
@@ -85,38 +77,6 @@ class ClientEncryptor {
   std::unique_ptr<SenderResponseContext> sender_response_context_;
 };
 
-// Encryptor class for decrypting client requests that are received by the server and encrypting
-// server responses that will be sent back to the client. Each Encryptor corresponds to a single
-// crypto session between the client and the server.
-//
-// Sequence numbers for requests and responses are incremented separately, meaning that there could
-// be multiple responses per request and multiple requests per response.
-class ServerEncryptor {
- public:
-  ServerEncryptor(KeyPair server_key_pair);
-
-  // Decrypts a [`EncryptedRequest`] proto message using AEAD.
-  // <https://datatracker.ietf.org/doc/html/rfc5116>
-  //
-  // `encrypted_request` must be a serialized [`oak.crypto.EncryptedRequest`] message.
-  // Returns a response message plaintext and associated data.
-  // TODO(#3843): Accept unserialized proto messages once we have Java encryption without JNI.
-  absl::StatusOr<DecryptionResult> Decrypt(absl::string_view encrypted_request);
-
-  // Encrypts `plaintext` and authenticates `associated_data` using AEAD.
-  // <https://datatracker.ietf.org/doc/html/rfc5116>
-  //
-  // Returns a serialized [`oak.crypto.EncryptedResponse`] message.
-  // TODO(#3843): Return unserialized proto messages once we have Java encryption without JNI.
-  absl::StatusOr<std::string> Encrypt(absl::string_view plaintext,
-                                      absl::string_view associated_data);
-
- private:
-  KeyPair server_key_pair_;
-  std::unique_ptr<RecipientRequestContext> recipient_request_context_;
-  std::unique_ptr<RecipientResponseContext> recipient_response_context_;
-};
-
 }  // namespace oak::crypto
 
-#endif  // CC_CRYPTO_ENCRYPTOR_H_
+#endif  // CC_CRYPTO_CLIENT_ENCRYPTOR_H_

--- a/cc/crypto/common.h
+++ b/cc/crypto/common.h
@@ -14,10 +14,21 @@
  * limitations under the License.
  */
 
-#include "cc/crypto/encryptor.h"
+#ifndef CC_CRYPTO_COMMON_H_
+#define CC_CRYPTO_COMMON_H_
 
-#include "absl/status/statusor.h"
-#include "cc/crypto/hpke/sender_context.h"
-#include "oak_crypto/proto/v1/crypto.pb.h"
+#include "absl/strings/string_view.h"
 
-namespace oak::crypto {}  // namespace oak::crypto
+namespace oak::crypto {
+
+// Info string used by Hybrid Public Key Encryption.
+constexpr absl::string_view OAK_HPKE_INFO = "Oak Hybrid Public Key Encryption v1";
+
+struct DecryptionResult {
+  std::string plaintext;
+  std::string associated_data;
+};
+
+}  // namespace oak::crypto
+
+#endif  // CC_CRYPTO_COMMON_H_

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-#include "cc/crypto/client_encryptor.h"
 #include "cc/crypto/server_encryptor.h"
+
+#include "absl/status/statusor.h"
+#include "cc/crypto/hpke/recipient_context.h"
+#include "oak_crypto/proto/v1/crypto.pb.h"
 
 namespace oak::crypto {}  // namespace oak::crypto

--- a/cc/crypto/server_encryptor.h
+++ b/cc/crypto/server_encryptor.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CC_CRYPTO_SERVER_ENCRYPTOR_H_
+#define CC_CRYPTO_SERVER_ENCRYPTOR_H_
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "cc/crypto/common.h"
+#include "cc/crypto/hpke/recipient_context.h"
+
+namespace oak::crypto {
+
+// Encryptor class for decrypting client requests that are received by the server and encrypting
+// server responses that will be sent back to the client. Each Encryptor corresponds to a single
+// crypto session between the client and the server.
+//
+// Sequence numbers for requests and responses are incremented separately, meaning that there could
+// be multiple responses per request and multiple requests per response.
+class ServerEncryptor {
+ public:
+  ServerEncryptor(KeyPair server_key_pair);
+
+  // Decrypts a [`EncryptedRequest`] proto message using AEAD.
+  // <https://datatracker.ietf.org/doc/html/rfc5116>
+  //
+  // `encrypted_request` must be a serialized [`oak.crypto.EncryptedRequest`] message.
+  // Returns a response message plaintext and associated data.
+  // TODO(#3843): Accept unserialized proto messages once we have Java encryption without JNI.
+  absl::StatusOr<DecryptionResult> Decrypt(absl::string_view encrypted_request);
+
+  // Encrypts `plaintext` and authenticates `associated_data` using AEAD.
+  // <https://datatracker.ietf.org/doc/html/rfc5116>
+  //
+  // Returns a serialized [`oak.crypto.EncryptedResponse`] message.
+  // TODO(#3843): Return unserialized proto messages once we have Java encryption without JNI.
+  absl::StatusOr<std::string> Encrypt(absl::string_view plaintext,
+                                      absl::string_view associated_data);
+
+ private:
+  KeyPair server_key_pair_;
+  std::unique_ptr<RecipientRequestContext> recipient_request_context_;
+  std::unique_ptr<RecipientResponseContext> recipient_response_context_;
+};
+
+}  // namespace oak::crypto
+
+#endif  // CC_CRYPTO_SERVER_ENCRYPTOR_H_


### PR DESCRIPTION
This PR splits `cc/crypto/encryptor.h` into `cc/crypto/client_encryptor.h` and `cc/crypto/server_encryptor.h`

Ref https://github.com/project-oak/oak/issues/4026