### PR TITLE
Add C++ Client Encryptor implementation

### DIFF
--- a/cc/crypto/client_encryptor.cc
+++ b/cc/crypto/client_encryptor.cc
@@ -17,7 +17,73 @@
 #include "cc/crypto/client_encryptor.h"
 
 #include "absl/status/statusor.h"
+#include "cc/crypto/common.h"
 #include "cc/crypto/hpke/sender_context.h"
 #include "oak_crypto/proto/v1/crypto.pb.h"
 
-namespace oak::crypto {}  // namespace oak::crypto
+namespace oak::crypto {
+
+namespace {
+using oak::crypto::v1::EncryptedRequest;
+using oak::crypto::v1::EncryptedResponse;
+}  // namespace
+
+absl::StatusOr<std::unique_ptr<ClientEncryptor>> ClientEncryptor::Create(
+    absl::string_view serialized_server_public_key) {
+  absl::StatusOr<SenderContext> setup_base_sender_result =
+      SetupBaseSender(serialized_server_public_key, OAK_HPKE_INFO);
+  if (!setup_base_sender_result.ok()) {
+    return setup_base_sender_result.status();
+  }
+  SenderContext sender_context = std::move(*setup_base_sender_result);
+  return std::make_unique<ClientEncryptor>(ClientEncryptor(sender_context));
+}
+
+absl::StatusOr<std::string> ClientEncryptor::Encrypt(absl::string_view plaintext,
+                                                     absl::string_view associated_data) {
+  // Encrypt request.
+  absl::StatusOr<std::string> seal_result =
+      sender_request_context_->Seal(plaintext, associated_data);
+  if (!seal_result.ok()) {
+    return seal_result.status();
+  }
+  std::string ciphertext = std::move(*seal_result);
+
+  // Create request message.
+  EncryptedRequest request;
+  *request.mutable_encrypted_message()->mutable_ciphertext() = ciphertext;
+  *request.mutable_encrypted_message()->mutable_associated_data() = associated_data;
+
+  // Encapsulated public key is only sent in the initial request message of the session.
+  if (!serialized_encapsulated_public_key_.empty()) {
+    *request.mutable_serialized_encapsulated_public_key() = serialized_encapsulated_public_key_;
+    serialized_encapsulated_public_key_ = "";
+  }
+
+  // Serialize request.
+  std::string serialized_request;
+  if (!request.SerializeToString(&serialized_request)) {
+    return absl::InternalError("couldn't serialize request");
+  }
+  return serialized_request;
+}
+
+absl::StatusOr<DecryptionResult> ClientEncryptor::Decrypt(absl::string_view encrypted_response) {
+  // Deserialize response.
+  EncryptedResponse response;
+  if (!response.ParseFromString(encrypted_response)) {
+    return absl::InternalError("couldn't deserialize response");
+  }
+
+  // Decrypt response.
+  absl::StatusOr<std::string> open_result = sender_response_context_->Open(
+      response.encrypted_message().ciphertext(), response.encrypted_message().associated_data());
+  if (!open_result.ok()) {
+    return open_result.status();
+  }
+  std::string plaintext = std::move(*open_result);
+
+  return DecryptionResult{plaintext, response.encrypted_message().associated_data()};
+}
+
+}  // namespace oak::crypto

--- a/cc/crypto/client_encryptor.cc
+++ b/cc/crypto/client_encryptor.cc
@@ -72,7 +72,7 @@ absl::StatusOr<DecryptionResult> ClientEncryptor::Decrypt(absl::string_view encr
   // Deserialize response.
   EncryptedResponse response;
   if (!response.ParseFromString(encrypted_response)) {
-    return absl::InternalError("couldn't deserialize response");
+    return absl::InvalidArgumentError("couldn't deserialize response");
   }
 
   // Decrypt response.

--- a/cc/crypto/client_encryptor.h
+++ b/cc/crypto/client_encryptor.h
@@ -50,6 +50,7 @@ class ClientEncryptor {
   ClientEncryptor(SenderContext& sender_hpke_info)
       : serialized_encapsulated_public_key_(sender_hpke_info.encap_public_key.begin(),
                                             sender_hpke_info.encap_public_key.end()),
+        serialized_encapsulated_public_key_has_been_sent_(false),
         sender_request_context_(std::move(sender_hpke_info.sender_request_context)),
         sender_response_context_(std::move(sender_hpke_info.sender_response_context)){};
 
@@ -73,6 +74,7 @@ class ClientEncryptor {
   // Encapsulated public key needed to establish a symmetric session key.
   // Only sent in the initial request message of the session.
   std::string serialized_encapsulated_public_key_;
+  bool serialized_encapsulated_public_key_has_been_sent_;
   std::unique_ptr<SenderRequestContext> sender_request_context_;
   std::unique_ptr<SenderResponseContext> sender_response_context_;
 };


### PR DESCRIPTION
This PR adds an implementation for the Client Encryptor as part of C++ Hybrid Encryption implementation.

Ref https://github.com/project-oak/oak/issues/4026