### PR TITLE
Add a script to build a base system image based on Clear Linux

### DIFF
--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -1,0 +1,8 @@
+FROM clearlinux:base
+
+# Remove .dockerenv as we will not run this image in an actual Docker container.
+RUN rm /.dockerenv
+
+# Don't bother starting the graphical interface, let's stick with the basic multi-user target.
+RUN rm /usr/lib/systemd/system/default.target
+RUN ln -s /usr/lib/systemd/system/multi-user.target /usr/lib/systemd/system/default.target

--- a/oak_containers_system_image/build.sh
+++ b/oak_containers_system_image/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+docker build . --tag oak-containers-system-image
+# We need to actually create a container, otherwise we won't be able to use `docker export` that gives us a filesystem image.
+# (`docker save` creates a tarball which has all the layers separate, which is _not_ what we want.)
+readonly NEW_DOCKER_CONTAINER_ID="$(docker create oak-containers-system-image:latest)"
+
+mkdir -p target
+docker export "$NEW_DOCKER_CONTAINER_ID" > target/image.tar
+
+docker rm "$NEW_DOCKER_CONTAINER_ID"


### PR DESCRIPTION
Last piece of the puzzle for now: a script to build a tarball suitable for use as the system image in Oak Docker.