### PR TITLE
Add C++ Server Encryptor implementation

### DIFF
--- a/cc/crypto/BUILD
+++ b/cc/crypto/BUILD
@@ -40,6 +40,7 @@ cc_library(
         ":common",
         "//cc/crypto/hpke:recipient_context",
         "//oak_crypto/proto/v1:crypto_cc_proto",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ],

--- a/cc/crypto/hpke/recipient_context.h
+++ b/cc/crypto/hpke/recipient_context.h
@@ -69,6 +69,12 @@ struct RecipientContext {
   std::unique_ptr<RecipientResponseContext> recipient_response_context;
 };
 
+// Holds all necessary recipient contexts.
+struct RecipientContext {
+  std::unique_ptr<RecipientRequestContext> recipient_request_context;
+  std::unique_ptr<RecipientResponseContext> recipient_response_context;
+};
+
 // Sets up an HPKE recipient by creating a recipient context.
 // <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-to-a-public-key>
 // Returns a tuple with a recipient request and recipient response contexts.

--- a/cc/crypto/hpke/recipient_context.h
+++ b/cc/crypto/hpke/recipient_context.h
@@ -64,11 +64,6 @@ class RecipientResponseContext {
   std::vector<uint8_t> response_nonce_;
 };
 
-struct RecipientContext {
-  std::unique_ptr<RecipientRequestContext> recipient_request_context;
-  std::unique_ptr<RecipientResponseContext> recipient_response_context;
-};
-
 // Holds all necessary recipient contexts.
 struct RecipientContext {
   std::unique_ptr<RecipientRequestContext> recipient_request_context;

--- a/cc/crypto/hpke/recipient_context.h
+++ b/cc/crypto/hpke/recipient_context.h
@@ -76,7 +76,6 @@ struct RecipientContext {
 };
 
 // Sets up an HPKE recipient by creating a recipient context.
-// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-to-a-public-key>
 // Returns a tuple with a recipient request and recipient response contexts.
 // <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-to-a-public-key>
 absl::StatusOr<RecipientContext> SetupBaseRecipient(

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -16,8 +16,89 @@
 
 #include "cc/crypto/server_encryptor.h"
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "cc/crypto/common.h"
 #include "cc/crypto/hpke/recipient_context.h"
 #include "oak_crypto/proto/v1/crypto.pb.h"
 
-namespace oak::crypto {}  // namespace oak::crypto
+namespace oak::crypto {
+
+namespace {
+using ::oak::crypto::v1::EncryptedRequest;
+using ::oak::crypto::v1::EncryptedResponse;
+}  // namespace
+
+absl::StatusOr<DecryptionResult> ServerEncryptor::Decrypt(absl::string_view encrypted_request) {
+  // Deserialize request.
+  EncryptedRequest request;
+  if (!request.ParseFromString(encrypted_request)) {
+    return absl::InvalidArgumentError("couldn't deserialize request");
+  }
+
+  // Get recipient context.
+  if (!recipient_request_context_) {
+    absl::Status status = InitializeRecipientContexts(request);
+    if (!status.ok()) {
+      return status;
+    }
+  }
+
+  // Decrypt request.
+  absl::StatusOr<std::string> plaintext = recipient_request_context_->Open(
+      request.encrypted_message().ciphertext(), request.encrypted_message().associated_data());
+  if (!plaintext.ok()) {
+    return plaintext.status();
+  }
+
+  return DecryptionResult{*plaintext, request.encrypted_message().associated_data()};
+}
+
+absl::StatusOr<std::string> ServerEncryptor::Encrypt(absl::string_view plaintext,
+                                                     absl::string_view associated_data) {
+  // Get recipient context.
+  if (!recipient_response_context_) {
+    return absl::InternalError("server encryptor is not initialized");
+  }
+
+  // Encrypt response.
+  absl::StatusOr<std::string> ciphertext =
+      recipient_response_context_->Seal(plaintext, associated_data);
+  if (!ciphertext.ok()) {
+    return ciphertext.status();
+  }
+
+  // Create response message.
+  EncryptedResponse response;
+  *response.mutable_encrypted_message()->mutable_ciphertext() = *ciphertext;
+  *response.mutable_encrypted_message()->mutable_associated_data() = associated_data;
+
+  // Serialize response.
+  std::string serialized_response;
+  if (!response.SerializeToString(&serialized_response)) {
+    return absl::InternalError("couldn't serialize response");
+  }
+  return serialized_response;
+}
+
+absl::Status ServerEncryptor::InitializeRecipientContexts(const EncryptedRequest& request) {
+  // Get serialized encapsulated public key.
+  if (!request.has_serialized_encapsulated_public_key()) {
+    return absl::InvalidArgumentError(
+        "serialized encapsulated public key is not present in the initial request message");
+  }
+  std::string serialized_encapsulated_public_key = request.serialized_encapsulated_public_key();
+
+  // Create recipient contexts.
+  absl::StatusOr<RecipientContext> recipient_context =
+      SetupBaseRecipient(serialized_encapsulated_public_key, server_key_pair_);
+  if (!recipient_context.ok()) {
+    return recipient_context.status();
+  }
+  recipient_request_context_ = std::move(recipient_context->recipient_request_context);
+  recipient_response_context_ = std::move(recipient_context->recipient_response_context);
+
+  return absl::OkStatus();
+}
+
+}  // namespace oak::crypto

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -91,7 +91,7 @@ absl::Status ServerEncryptor::InitializeRecipientContexts(const EncryptedRequest
 
   // Create recipient contexts.
   absl::StatusOr<RecipientContext> recipient_context =
-      SetupBaseRecipient(serialized_encapsulated_public_key, server_key_pair_);
+      SetupBaseRecipient(serialized_encapsulated_public_key, server_key_pair_, OAK_HPKE_INFO);
   if (!recipient_context.ok()) {
     return recipient_context.status();
   }

--- a/cc/crypto/server_encryptor.h
+++ b/cc/crypto/server_encryptor.h
@@ -21,10 +21,12 @@
 #include <string>
 #include <tuple>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "cc/crypto/common.h"
 #include "cc/crypto/hpke/recipient_context.h"
+#include "oak_crypto/proto/v1/crypto.pb.h"
 
 namespace oak::crypto {
 
@@ -36,7 +38,10 @@ namespace oak::crypto {
 // be multiple responses per request and multiple requests per response.
 class ServerEncryptor {
  public:
-  ServerEncryptor(KeyPair server_key_pair);
+  ServerEncryptor(KeyPair server_key_pair)
+      : server_key_pair_(server_key_pair),
+        recipient_request_context_(nullptr),
+        recipient_response_context_(nullptr){};
 
   // Decrypts a [`EncryptedRequest`] proto message using AEAD.
   // <https://datatracker.ietf.org/doc/html/rfc5116>
@@ -58,6 +63,8 @@ class ServerEncryptor {
   KeyPair server_key_pair_;
   std::unique_ptr<RecipientRequestContext> recipient_request_context_;
   std::unique_ptr<RecipientResponseContext> recipient_response_context_;
+
+  absl::Status InitializeRecipientContexts(const oak::crypto::v1::EncryptedRequest& request);
 };
 
 }  // namespace oak::crypto

--- a/java/src/main/java/com/google/oak/crypto/ServerEncryptor.java
+++ b/java/src/main/java/com/google/oak/crypto/ServerEncryptor.java
@@ -98,7 +98,7 @@ public class ServerEncryptor implements AutoCloseable, Encryptor {
     byte[] ciphertext = aeadEncryptedMessage.getCiphertext().toByteArray();
     byte[] associatedData = aeadEncryptedMessage.getAssociatedData().toByteArray();
 
-    // Get recipient context;
+    // Get recipient context.
     if (this.recipientRequestContext.isEmpty()) {
       // Get serialized encapsulated public key.
       if (encryptedRequest.getSerializedEncapsulatedPublicKey().equals(ByteString.EMPTY)) {
@@ -140,7 +140,7 @@ public class ServerEncryptor implements AutoCloseable, Encryptor {
   @Override
   public final Result<byte[], Exception> encrypt(
       final byte[] plaintext, final byte[] associatedData) {
-    // Get recipient context;
+    // Get recipient context.
     if (this.recipientResponseContext.isEmpty()) {
       return Result.error(new Exception("server encryptor is not initialized"));
     }


### PR DESCRIPTION
This PR adds an implementation for the Server Encryptor as part of C++ Hybrid Encryption implementation.

Ref https://github.com/project-oak/oak/issues/4026