### PR TITLE
Install docker container runtime in oak container system image

### DIFF
--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -6,6 +6,7 @@ RUN rm /.dockerenv
 # Install Clear Linux's containers-basic bundle. This gives an installation of
 # docker to run containers. This is a starting point only, we should switch to
 # a more lightweight runtime later.
+# Ref: https://clearlinux.github.io/clear-linux-documentation/tutorials/docker.html#install-the-containers-basic-bundle
 RUN swupd bundle-add containers-basic
 
 # Configure systemd to run docker at startup

--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -3,6 +3,14 @@ FROM clearlinux:base
 # Remove .dockerenv as we will not run this image in an actual Docker container.
 RUN rm /.dockerenv
 
+# Install Clear Linux's containers-basic bundle. This gives an installation of
+# docker to run containers. This is a starting point only, we should switch to
+# a more lightweight runtime later.
+RUN swupd bundle-add containers-basic
+
+# Configure systemd to run docker at startup
+RUN systemctl enable docker
+
 # Don't bother starting the graphical interface, let's stick with the basic multi-user target.
 RUN rm /usr/lib/systemd/system/default.target
 RUN ln -s /usr/lib/systemd/system/multi-user.target /usr/lib/systemd/system/default.target


### PR DESCRIPTION
The docker runtime is seriously overkill for us. However it's fasted way to unblock running containers, which imo makes it the right fit for now.