### PR TITLE
Allow stage0 fw_cfg DMA to fall back to non-DMA

### DIFF
--- a/stage0/src/initramfs.rs
+++ b/stage0/src/initramfs.rs
@@ -51,7 +51,7 @@ pub fn try_load_initial_ram_disk(
     // layout or alignment.
     let buf = unsafe { slice::from_raw_parts_mut::<u8>(address.as_mut_ptr(), size) };
     let actual_size = fw_cfg
-        .read_file_dma(&file, buf)
+        .read_file(&file, buf)
         .expect("could not read initial RAM disk");
     assert_eq!(
         actual_size, size,

--- a/stage0/src/kernel.rs
+++ b/stage0/src/kernel.rs
@@ -113,7 +113,7 @@ pub fn try_load_kernel_image(
     let buf = unsafe { slice::from_raw_parts_mut::<u8>(start_address.as_mut_ptr(), size) };
 
     let actual_size = fw_cfg
-        .read_file_dma(&file, buf)
+        .read_file(&file, buf)
         .expect("could not read kernel file");
     assert_eq!(actual_size, size, "kernel size did not match expected size");
 


### PR DESCRIPTION
If the QEMU fw_cfg device does not support DMA access, we can fall back to using the older byte-by-byte mechanism. It will fetch the same data, only more slowly.