### PR TITLE
Add initial orchestrator service definition

### DIFF
--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -33,6 +33,7 @@ message GetApplicationConfigResponse {
   bytes config = 1;
 }
 
+// Defines the service exposed by the launcher, that can be invoked by the orchestrator.
 service Launcher {
   // Provides stage1 with the Oak system image (which contains the Linux distribution and the
   // orchestrator binary).
@@ -41,9 +42,15 @@ service Launcher {
   // Provides orchestrator with the trusted container image.
   rpc GetContainerBundle(google.protobuf.Empty) returns (stream GetImageResponse) {}
 
-  // This could be anything that the application wants to attest to.
-  // e.g. whether it's in debug mode, or parameters for aggregation / DP,
-  // or digest of something else that the application will load later (e.g. Wasm module).
-  // It may be empty if the application does not require one
+  // This method is used by the orchestartor to load and measure the
+  // application config. The orchestrator will later, separately expose this
+  // config to the application.
+  rpc GetApplicationConfig(google.protobuf.Empty) returns (GetApplicationConfigResponse) {}
+}
+
+// Defines the service exposed by the orchestrator, that can be invoked by the application.
+service Orchestrator {
+  // Exposes the previously loaded application config to the application,
+  // which may choose to retrieve it.
   rpc GetApplicationConfig(google.protobuf.Empty) returns (GetApplicationConfigResponse) {}
 }

--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -33,7 +33,8 @@ message GetApplicationConfigResponse {
   bytes config = 1;
 }
 
-// Defines the service exposed by the launcher, that can be invoked by the orchestrator.
+// Defines the service exposed by the launcher, that can be invoked by the stage1 and the
+// orchestrator.
 service Launcher {
   // Provides stage1 with the Oak system image (which contains the Linux distribution and the
   // orchestrator binary).
@@ -42,7 +43,7 @@ service Launcher {
   // Provides orchestrator with the trusted container image.
   rpc GetContainerBundle(google.protobuf.Empty) returns (stream GetImageResponse) {}
 
-  // This method is used by the orchestartor to load and measure the
+  // This method is used by the orchestrator to load and measure the trusted
   // application config. The orchestrator will later, separately expose this
   // config to the application.
   rpc GetApplicationConfig(google.protobuf.Empty) returns (GetApplicationConfigResponse) {}
@@ -50,7 +51,7 @@ service Launcher {
 
 // Defines the service exposed by the orchestrator, that can be invoked by the application.
 service Orchestrator {
-  // Exposes the previously loaded application config to the application,
+  // Exposes the previously loaded trusted application config to the application,
   // which may choose to retrieve it.
   rpc GetApplicationConfig(google.protobuf.Empty) returns (GetApplicationConfigResponse) {}
 }

--- a/oak_containers_launcher_server/build.rs
+++ b/oak_containers_launcher_server/build.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the launcher.
     generate_grpc_code(
         "../",
-        &["oak_containers/proto/launcher.proto"],
+        &["oak_containers/proto/interfaces.proto"],
         CodegenOptions {
             build_server: true,
             ..Default::default()

--- a/oak_containers_orchestrator_client/build.rs
+++ b/oak_containers_orchestrator_client/build.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the launcher.
     generate_grpc_code(
         "../",
-        &["oak_containers/proto/launcher.proto"],
+        &["oak_containers/proto/interfaces.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_stage1/build.rs
+++ b/oak_containers_stage1/build.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
     generate_grpc_code(
         "../",
-        &["oak_containers/proto/launcher.proto"],
+        &["oak_containers/proto/interfaces.proto"],
         CodegenOptions {
             build_client: true,
             ..Default::default()


### PR DESCRIPTION
At the moment it only includes a method to load application config, we'll add encryption/decryption methods later. 

I defined it in the same file as the launcher service, since the `GetApplicationConfigResponse` is shared. Imo that seems simpler than using multiple files and importing messages, but open to different opinions. 