### PR TITLE
Run only if post merge

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -17,7 +17,8 @@ on:
 jobs:
   build_binary:
     if: |
-      github.event_name == 'push' 
+      (github.event_name == 'pull-request' && contains( github.event.pull_request.labels.*.name, 'provenance:force-run') ) ||
+      github.event_name == 'push'
     # We use the same job template to generate provenances for multiple binaries.
     strategy:
       fail-fast: false

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -9,8 +9,8 @@ on:
   push:
     branches: [main]
   # This workflow builds several binaries and is very time and resource consuming. As a result it
-  # disabled disabled by default on pull-request events. If you need to test this workflow on your
-  # PR before merge, label it with `provenance:force-run` to trigger the workflow.
+  # is disabled by default on pull-request events. If you need to test this workflow on your PR
+  # before merge, label it with `provenance:force-run` to trigger the workflow.
   pull_request:
     branches: [main]
 

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -17,8 +17,7 @@ on:
 jobs:
   build_binary:
     if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull-request' && ${{ contains(github.event.pull_request.labels.*.name, 'provenance:force-run') }}
+      github.event_name == 'push' 
     # We use the same job template to generate provenances for multiple binaries.
     strategy:
       fail-fast: false

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   build_binary:
     if: |
-      (github.event_name == 'pull-request' && github.event.label.name == 'provenance:force-run') ||
+      (github.event_name == 'pull-request' && github.event.pull_request.labels.*.name == 'provenance:force-run') ||
       github.event_name == 'push'
     # We use the same job template to generate provenances for multiple binaries.
     strategy:

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   build_binary:
     if: |
-      (github.event_name == 'pull-request' && contains( github.event.pull_request.labels.*.name, 'provenance:force-run') ) ||
+      (github.event_name == 'pull-request' && github.event.label.name == 'provenance:force-run') ||
       github.event_name == 'push'
     # We use the same job template to generate provenances for multiple binaries.
     strategy:

--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -17,8 +17,8 @@ on:
 jobs:
   build_binary:
     if: |
-      (github.event_name == 'pull-request' && github.event.pull_request.labels.*.name == 'provenance:force-run') ||
-      github.event_name == 'push'
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'provenance:force-run')
     # We use the same job template to generate provenances for multiple binaries.
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fixes #4061

This seems to work. I've added and removed the label. 
If the label is there, the provenance workflow is run. Otherwise it is not.

Can you think of anything else I should test?