### PR TITLE
Use a fixed-size ramdrive instead of ramfs for the system root

### DIFF
--- a/oak_containers_launcher/src/qemu.rs
+++ b/oak_containers_launcher/src/qemu.rs
@@ -48,6 +48,10 @@ pub struct Params {
     /// Gigabyte).
     #[arg(long)]
     pub memory_size: Option<String>,
+
+    /// Size (in kilobytes) of the ramdrive used for the system root.
+    #[arg(long)]
+    pub ramdrive_size: u32,
 }
 
 pub struct Qemu {
@@ -68,7 +72,7 @@ impl Qemu {
         cmd.arg("-enable-kvm");
         // Needed to expose advanced CPU features. Specifically RDRAND which is required for remote
         // attestation.
-        cmd.args(["-cpu", "IvyBridge-IBRS,enforce"]);
+        cmd.args(["-cpu", "host"]);
         // Set memory size if given.
         if let Some(memory_size) = params.memory_size {
             cmd.args(["-m", &memory_size]);
@@ -135,7 +139,8 @@ impl Qemu {
         ]);
         cmd.args([
             "-fw_cfg",
-            "name=opt/stage0/cmdline,string=console=ttyS0 panic=-1",
+            format!(
+            "name=opt/stage0/cmdline,string=console=ttyS0 panic=-1 brd.rd_nr=1 brd.rd_size={} brd.max_part=1", params.ramdrive_size).as_str()
         ]);
 
         println!("QEMU command line: {:?}", cmd);

--- a/oak_containers_stage1/Cargo.toml
+++ b/oak_containers_stage1/Cargo.toml
@@ -15,7 +15,12 @@ futures-util = "*"
 nix = "*"
 prost = { workspace = true }
 tar = "*"
-tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { version = "*", features = [
+  "rt-multi-thread",
+  "macros",
+  "process",
+  "sync"
+] }
 tokio-vsock = { version = "*", features = ["tonic-conn"] }
 tonic = { workspace = true }
 tower = "*"

--- a/oak_containers_stage1/Makefile
+++ b/oak_containers_stage1/Makefile
@@ -3,9 +3,19 @@ all: ../target/stage1.cpio
 # Always try to recompile the Rust binary.
 .PHONY: ../target/x86_64-unknown-linux-musl/release/oak_containers_stage1
 
-../target/stage1.cpio: ../target/x86_64-unknown-linux-musl/release/oak_containers_stage1
+../target/stage1.cpio: ../target/x86_64-unknown-linux-musl/release/oak_containers_stage1 ../target/mke2fs
 	cp ../target/x86_64-unknown-linux-musl/release/oak_containers_stage1 ../target/init
-	echo "init" | cpio -o -R root:root -H newc -v --reproducible -D ../target | gzip -9 > ../target/stage1.cpio
+	echo "init\nmke2fs" | cpio -o -R root:root -H newc -v --reproducible -D ../target | gzip -9 > ../target/stage1.cpio
 
 ../target/x86_64-unknown-linux-musl/release/oak_containers_stage1:
 	cargo build --release --target x86_64-unknown-linux-musl
+	strip ../target/x86_64-unknown-linux-musl/release/oak_containers_stage1
+
+../target/mke2fs:
+	mkdir -p target
+	curl -O -L --output-dir target https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.0/e2fsprogs-1.47.0.tar.xz
+	tar -C target -Jxf target/e2fsprogs-1.47.0.tar.xz
+	cd target/e2fsprogs-1.47.0 && ./configure LDFLAGS="-static"
+	$(MAKE) -C target/e2fsprogs-1.47.0 -j `nproc`
+	strip target/e2fsprogs-1.47.0/misc/mke2fs
+	cp target/e2fsprogs-1.47.0/misc/mke2fs ../target/mke2fs


### PR DESCRIPTION
Most of the weird startup issues I saw when we were unpacking the system image onto a `ramfs` filesystem stemmed from the fact that `systemd` recognized it as a transient filesystem, and thus refused to do some operations on it.

Thus, instead of creating a `ramfs` root, let's create a real ext4 filesystem on a fixed-size ramdrive and unpack the system image onto that; `systemd` seems to be far more happer with that arrangement.

This unfortunately does mean we get another knob to tweak, namely the ramdrive size. Ramfs could just arbitrarily grow, ramdrives are of a fixed size. On the other hand, this also means we won't accidentally fill memory with garbage when writing files to the filesystem (but rather eventually we will get drive full errors if, say, logs back up), so it's more of a trade-off rather than a regression.

And apologies to the Rust `tar` crate, it works just fine, I was barking up the wrong tree with my previous PR.

