### PR TITLE
Configure logging in system image + minor cleanups and tweaks

### DIFF
--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -14,12 +14,18 @@ RUN systemctl enable docker
 
 # Copy the orchestartor binary & service
 COPY ./target/oak_containers_orchestrator /usr/bin/
-COPY oak-orchestrator.service /lib/systemd/system/
-RUN chmod 644 /lib/systemd/system/oak-orchestrator.service
+COPY oak-orchestrator.service /etc/systemd/system/
+RUN chmod 644 /etc/systemd/system/oak-orchestrator.service
 
 # Start the orchestartor at boot
 RUN systemctl enable oak-orchestrator
 
+# Override the default journald configuration
+COPY journald.conf /etc/systemd/journald.conf.d/clear.conf
+
 # Don't bother starting the graphical interface, let's stick with the basic multi-user target.
-RUN rm /usr/lib/systemd/system/default.target
-RUN ln -s /usr/lib/systemd/system/multi-user.target /usr/lib/systemd/system/default.target
+RUN systemctl set-default multi-user
+
+# Clean up some stuff we don't need (like the `swupd` tool itself)
+RUN swupd bundle-remove trurl os-core-update os-core-webproxy
+RUN rm -rf ./var/lib/swupd

--- a/oak_containers_system_image/journald.conf
+++ b/oak_containers_system_image/journald.conf
@@ -1,0 +1,4 @@
+[Journal]
+Storage=volatile
+ForwardToConsole=yes
+MaxLevelConsole=info


### PR DESCRIPTION
The key change here is that `journald` will now output system logs to the console. We may want to build a more clever way how to extract logs in the future, but for now, that'll do.

I've also included a couple more tweaks:
  - don't copy the orchestrator unit file to `/lib/systemd` but rather to `/etc/systemd`, which is supposed to be the place for the system-specific overrides
  - conversely, don't directly change the default target link, but rather use `systemctl target` to create a default override under `/etc/systemd`
  - and finally, delete some packages we don't need in the system image (for example, we will never run an OS updater in there) -- this shaves ~200 MB off the image size.