### PR TITLE
Remove system.exit() calls when calling JNI loadLibrary

### DIFF
--- a/java/src/main/java/com/google/oak/crypto/hpke/Context.java
+++ b/java/src/main/java/com/google/oak/crypto/hpke/Context.java
@@ -57,11 +57,7 @@ public final class Context {
 
   public static final class SenderResponseContext implements AutoCloseable {
     static {
-      try {
-        System.loadLibrary("hpke-jni");
-      } catch (UnsatisfiedLinkError e) {
-        System.exit(1);
-      }
+      System.loadLibrary("hpke-jni");
     }
     private final long nativePtr;
     public SenderResponseContext(long nativePtr) {
@@ -96,11 +92,7 @@ public final class Context {
 
   public static final class RecipientRequestContext implements AutoCloseable {
     static {
-      try {
-        System.loadLibrary("hpke-jni");
-      } catch (UnsatisfiedLinkError e) {
-        System.exit(1);
-      }
+      System.loadLibrary("hpke-jni");
     }
     private final long nativePtr;
     public RecipientRequestContext(long nativePtr) {
@@ -135,11 +127,7 @@ public final class Context {
 
   public static final class RecipientResponseContext implements AutoCloseable {
     static {
-      try {
-        System.loadLibrary("hpke-jni");
-      } catch (UnsatisfiedLinkError e) {
-        System.exit(1);
-      }
+      System.loadLibrary("hpke-jni");
     }
     private final long nativePtr;
     public RecipientResponseContext(long nativePtr) {

--- a/java/src/main/java/com/google/oak/crypto/hpke/Context.java
+++ b/java/src/main/java/com/google/oak/crypto/hpke/Context.java
@@ -22,11 +22,7 @@ import com.google.oak.util.Result;
 public final class Context {
   public static final class SenderRequestContext implements AutoCloseable {
     static {
-      try {
-        System.loadLibrary("hpke-jni");
-      } catch (UnsatisfiedLinkError e) {
-        System.exit(1);
-      }
+      System.loadLibrary("hpke-jni");
     }
     private final long nativePtr;
     public SenderRequestContext(long nativePtr) {

--- a/java/src/main/java/com/google/oak/crypto/hpke/Hpke.java
+++ b/java/src/main/java/com/google/oak/crypto/hpke/Hpke.java
@@ -21,11 +21,7 @@ import com.google.oak.util.Result;
 // TODO(#3642): Implement Java Hybrid Encryption.
 public final class Hpke {
   static {
-    try {
-      System.loadLibrary("hpke-jni");
-    } catch (UnsatisfiedLinkError e) {
-      System.exit(1);
-    }
+    System.loadLibrary("hpke-jni");
   }
 
   public static final class SenderContext {

--- a/java/src/main/java/com/google/oak/crypto/hpke/KeyPair.java
+++ b/java/src/main/java/com/google/oak/crypto/hpke/KeyPair.java
@@ -19,11 +19,7 @@ import com.google.oak.util.Result;
 
 public class KeyPair {
   static {
-    try {
-      System.loadLibrary("hpke-jni");
-    } catch (UnsatisfiedLinkError e) {
-      System.exit(1);
-    }
+    System.loadLibrary("hpke-jni");
   }
 
   public final byte[] privateKey;


### PR DESCRIPTION
This PR removes system.exit() calls when calling JNI loadLibrary as it is untestable.

This PR is part of the the Java implementation for (https://github.com/project-oak/oak/issues/3642).