### PR TITLE
C++ Encryption Testing using X25519

### DIFF
--- a/cc/crypto/BUILD
+++ b/cc/crypto/BUILD
@@ -60,7 +60,10 @@ cc_test(
     srcs = ["encryptor_test.cc"],
     deps = [
         ":client_encryptor",
+        ":common",
         ":server_encryptor",
+        "//cc/crypto/hpke:recipient_context",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cc/crypto/client_encryptor.cc
+++ b/cc/crypto/client_encryptor.cc
@@ -31,7 +31,7 @@ using ::oak::crypto::v1::EncryptedResponse;
 absl::StatusOr<std::unique_ptr<ClientEncryptor>> ClientEncryptor::Create(
     absl::string_view serialized_server_public_key) {
   absl::StatusOr<SenderContext> sender_context =
-      SetupBaseSender(serialized_server_public_key, OAK_HPKE_INFO);
+      SetupBaseSender(serialized_server_public_key, kOakHPKEInfo);
   if (!sender_context.ok()) {
     return sender_context.status();
   }

--- a/cc/crypto/common.h
+++ b/cc/crypto/common.h
@@ -22,7 +22,7 @@
 namespace oak::crypto {
 
 // Info string used by Hybrid Public Key Encryption.
-constexpr absl::string_view OAK_HPKE_INFO = "Oak Hybrid Public Key Encryption v1";
+inline constexpr absl::string_view kOakHPKEInfo = "Oak Hybrid Public Key Encryption v1";
 
 struct DecryptionResult {
   std::string plaintext;

--- a/cc/crypto/encryptor_test.cc
+++ b/cc/crypto/encryptor_test.cc
@@ -14,7 +14,72 @@
  * limitations under the License.
  */
 
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "cc/crypto/client_encryptor.h"
+#include "cc/crypto/hpke/recipient_context.h"
 #include "cc/crypto/server_encryptor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
-namespace oak::crypto {}  // namespace oak::crypto
+namespace oak::crypto {
+namespace {
+
+using ::testing::StrEq;
+
+constexpr absl::string_view kOakHPKEInfoTest = "Oak Hybrid Public Key Encryption Test";
+// Client Encryptor and Server Encryptor can communicate.
+TEST(EncryptorTest, ClientEncryptorAndServerEncryptorCommunicateSuccess) {
+  // Set up client and server encryptors.
+  auto key_pair = KeyPair::Generate();
+  std::string public_key = key_pair->public_key;
+  auto client_encryptor = ClientEncryptor::Create(public_key);
+  ASSERT_TRUE(client_encryptor.ok());
+  ServerEncryptor server_encryptor = ServerEncryptor(*key_pair);
+
+  std::string client_plaintext_message = "Hello server";
+
+  // Encrypt plaintext message and have server encryptor decrypt message.
+  auto client_ciphertext = (*client_encryptor)->Encrypt(client_plaintext_message, kOakHPKEInfoTest);
+  ASSERT_TRUE(client_ciphertext.ok());
+  auto server_decryption_result = server_encryptor.Decrypt(*client_ciphertext);
+  ASSERT_TRUE(server_decryption_result.ok());
+  EXPECT_THAT(client_plaintext_message, StrEq(server_decryption_result->plaintext));
+  EXPECT_THAT(kOakHPKEInfoTest, StrEq(server_decryption_result->associated_data));
+
+  std::string server_plaintext_message = "Hello client";
+
+  // Server responds with an encrypted message that the client successfully decrypts.
+  auto server_ciphertext = server_encryptor.Encrypt(server_plaintext_message, kOakHPKEInfoTest);
+  ASSERT_TRUE(server_ciphertext.ok());
+  auto client_decryption_result = (*client_encryptor)->Decrypt(*server_ciphertext);
+  ASSERT_TRUE(client_decryption_result.ok());
+  EXPECT_THAT(server_plaintext_message, StrEq(client_decryption_result->plaintext));
+  EXPECT_THAT(kOakHPKEInfoTest, StrEq(client_decryption_result->associated_data));
+}
+
+TEST(EncryptorTest, ClientEncryptorAndServerEncryptorCommunicateMismatchPublicKeysFailure) {
+  // Set up client and server encryptors.
+  auto key_pair = KeyPair::Generate();
+  std::string wrong_public_key = key_pair->public_key;
+  // Edit the public key that the client uses to make it incorrect.
+  wrong_public_key[0] = (wrong_public_key[0] + 1) % 128;
+  auto client_encryptor = ClientEncryptor::Create(wrong_public_key);
+  ASSERT_TRUE(client_encryptor.ok());
+  ServerEncryptor server_encryptor = ServerEncryptor(*key_pair);
+
+  std::string client_plaintext_message = "Hello server";
+
+  // Encrypt plaintext message and have server encryptor decrypt message. This should result in
+  // failure since the public key is incorrect.
+  auto client_ciphertext = (*client_encryptor)->Encrypt(client_plaintext_message, kOakHPKEInfoTest);
+  ASSERT_TRUE(client_ciphertext.ok());
+  auto server_decryption_result = server_encryptor.Decrypt(*client_ciphertext);
+  EXPECT_FALSE(server_decryption_result.ok());
+  EXPECT_EQ(server_decryption_result.status().code(), absl::StatusCode::kAborted);
+  EXPECT_THAT(server_decryption_result.status().message(),
+              StrEq("Failed to open encrypted message."));
+}
+
+}  // namespace
+}  // namespace oak::crypto

--- a/cc/crypto/hpke/recipient_context.cc
+++ b/cc/crypto/hpke/recipient_context.cc
@@ -81,7 +81,7 @@ absl::StatusOr<std::string> RecipientRequestContext::Open(absl::string_view ciph
           /* in_len= */ ciphertext_bytes.size(),
           /* ad= */ associated_data_bytes.data(),
           /* ad_len= */ associated_data_bytes.size())) {
-    return absl::AbortedError("Fail to open encrypted message.");
+    return absl::AbortedError("Failed to open encrypted message.");
   }
   plaintext_bytes.resize(plaintext_bytes_len);
   std::string plaintext(plaintext_bytes.begin(), plaintext_bytes.end());
@@ -126,7 +126,7 @@ RecipientResponseContext::~RecipientResponseContext() {
 }
 
 absl::StatusOr<RecipientContext> SetupBaseRecipient(
-    absl::string_view serialized_encapsulated_public_key, KeyPair recipient_key_pair,
+    absl::string_view serialized_encapsulated_public_key, const KeyPair& recipient_key_pair,
     absl::string_view info) {
   // First verify that the supplied key pairing is valid using the BoringSSL library.
   std::vector<uint8_t> private_key_bytes(recipient_key_pair.private_key.begin(),

--- a/cc/crypto/hpke/recipient_context.h
+++ b/cc/crypto/hpke/recipient_context.h
@@ -75,7 +75,7 @@ struct RecipientContext {
 // Returns a tuple with a recipient request and recipient response contexts.
 // <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-to-a-public-key>
 absl::StatusOr<RecipientContext> SetupBaseRecipient(
-    absl::string_view serialized_encapsulated_public_key, KeyPair recipient_key_pair,
+    absl::string_view serialized_encapsulated_public_key, const KeyPair& recipient_key_pair,
     absl::string_view info);
 
 }  // namespace oak::crypto

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -91,7 +91,7 @@ absl::Status ServerEncryptor::InitializeRecipientContexts(const EncryptedRequest
 
   // Create recipient contexts.
   absl::StatusOr<RecipientContext> recipient_context =
-      SetupBaseRecipient(serialized_encapsulated_public_key, server_key_pair_, OAK_HPKE_INFO);
+      SetupBaseRecipient(serialized_encapsulated_public_key, server_key_pair_, kOakHPKEInfo);
   if (!recipient_context.ok()) {
     return recipient_context.status();
   }

--- a/cc/crypto/server_encryptor.h
+++ b/cc/crypto/server_encryptor.h
@@ -38,7 +38,7 @@ namespace oak::crypto {
 // be multiple responses per request and multiple requests per response.
 class ServerEncryptor {
  public:
-  ServerEncryptor(KeyPair server_key_pair)
+  ServerEncryptor(const KeyPair& server_key_pair)
       : server_key_pair_(server_key_pair),
         recipient_request_context_(nullptr),
         recipient_response_context_(nullptr){};


### PR DESCRIPTION
This contains some basic testing for the communication between client and server encryptors.

The most common error seen in the communication should be related to mismatched keys (i.e. the client uses the wrong public key). All other errors are likely bugs related to the internal context classes.

Ref #4026 