### PR TITLE
Use empty reference value in the verifier

### DIFF
--- a/java/src/main/java/com/google/oak/remote_attestation/AmdAttestationVerifier.java
+++ b/java/src/main/java/com/google/oak/remote_attestation/AmdAttestationVerifier.java
@@ -53,6 +53,10 @@ public class AmdAttestationVerifier implements AttestationVerifier {
   public final Result<Boolean, Exception> verify(
       final AttestationEvidence evidence, final AttestationEndorsement endorsement) {
     // TODO(#3641): Implement AMD SEV-SNP attestation verification.
-    return Result.success(true);
+    if (referenceValue.length == 0) {
+      return Result.success(true);
+    } else {
+      return Result.error(new Exception("unsupported reference value"));
+    }
   }
 }


### PR DESCRIPTION
Use empty reference value in the AMD verifier to prevent internal checks from failing.

Attestation verification will be implemented in https://github.com/project-oak/oak/issues/3641