### PR TITLE
Move JNI .so binary to bazel deps.

### DIFF
--- a/java/src/main/java/com/google/oak/client/weather_lookup_client/BUILD
+++ b/java/src/main/java/com/google/oak/client/weather_lookup_client/BUILD
@@ -23,7 +23,6 @@ package(
 java_binary(
     name = "weather_lookup_client",
     srcs = ["Main.java"],
-    jvm_flags = ["-Djava.library.path=cc/crypto/hpke/jni"],
     main_class = "com.google.oak.client.weather_lookup_client.Main",
     deps = [
         "//java/src/main/java/com/google/oak/client",

--- a/java/src/main/java/com/google/oak/crypto/BUILD
+++ b/java/src/main/java/com/google/oak/crypto/BUILD
@@ -38,7 +38,6 @@ java_library(
     ],
     deps = [
         ":encryptor",
-        "//cc/crypto/hpke/jni:libhpke-jni.so",
         "//java/src/main/java/com/google/oak/crypto/hpke",
         "//java/src/main/java/com/google/oak/util",
         "//oak_crypto/proto/v1:crypto_java_proto",
@@ -54,7 +53,6 @@ java_library(
     ],
     deps = [
         ":encryptor",
-        "//cc/crypto/hpke/jni:libhpke-jni.so",
         "//java/src/main/java/com/google/oak/crypto/hpke",
         "//java/src/main/java/com/google/oak/util",
         "//oak_crypto/proto/v1:crypto_java_proto",

--- a/java/src/main/java/com/google/oak/crypto/BUILD
+++ b/java/src/main/java/com/google/oak/crypto/BUILD
@@ -38,6 +38,7 @@ java_library(
     ],
     deps = [
         ":encryptor",
+        "//cc/crypto/hpke/jni:libhpke-jni.so",
         "//java/src/main/java/com/google/oak/crypto/hpke",
         "//java/src/main/java/com/google/oak/util",
         "//oak_crypto/proto/v1:crypto_java_proto",
@@ -53,6 +54,7 @@ java_library(
     ],
     deps = [
         ":encryptor",
+        "//cc/crypto/hpke/jni:libhpke-jni.so",
         "//java/src/main/java/com/google/oak/crypto/hpke",
         "//java/src/main/java/com/google/oak/util",
         "//oak_crypto/proto/v1:crypto_java_proto",

--- a/java/src/main/java/com/google/oak/crypto/hpke/BUILD
+++ b/java/src/main/java/com/google/oak/crypto/hpke/BUILD
@@ -28,10 +28,8 @@ java_library(
         "Hpke.java",
         "KeyPair.java",
     ],
-    data = [
-        "//cc/crypto/hpke/jni:libhpke-jni.so",
-    ],
     deps = [
+        "//cc/crypto/hpke/jni:libhpke-jni.so",
         "//java/src/main/java/com/google/oak/util",
     ],
 )

--- a/java/src/test/java/com/google/oak/client/BUILD
+++ b/java/src/test/java/com/google/oak/client/BUILD
@@ -23,7 +23,6 @@ package(
 java_test(
     name = "client_test",
     srcs = glob(["*.java"]),
-    jvm_flags = ["-Djava.library.path=cc/crypto/hpke/jni"],
     test_class = "com.google.oak.client.OakClientTest",
     deps = [
         "//java/src/main/java/com/google/oak/client",

--- a/java/src/test/java/com/google/oak/crypto/BUILD
+++ b/java/src/test/java/com/google/oak/crypto/BUILD
@@ -23,7 +23,6 @@ package(
 java_test(
     name = "encryptor_test",
     srcs = ["EncryptorTest.java"],
-    jvm_flags = ["-Djava.library.path=cc/crypto/hpke/jni"],
     test_class = "com.google.oak.crypto.EncryptorTest",
     deps = [
         "//java/src/main/java/com/google/oak/crypto:client_encryptor",


### PR DESCRIPTION
This PR moves the  libhpke.so binary to bazel deps.

This PR is part of the the Java implementation for (https://github.com/project-oak/oak/issues/3642).