### PR TITLE
Implement simple chroot container runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1128,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.6",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -1456,6 +1476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,7 +1735,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "log",
  "oak_containers_orchestrator_client",
+ "serde",
+ "serde_json",
+ "syslog",
+ "tar",
  "tokio",
 ]
 
@@ -3270,6 +3301,19 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "syslog"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7434e95bcccce1215d30f4bf84fe8c00e8de1b9be4fb736d747ca53d36e7f96f"
+dependencies = [
+ "error-chain",
+ "hostname",
+ "libc",
+ "log",
+ "time",
 ]
 
 [[package]]

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -12,4 +12,6 @@ oak_containers_orchestrator_client = { workspace = true }
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync", "fs", "process"] }
 log = "*"
 syslog = "*"
-
+tar = "*"
+serde = { version = "*", features = ["derive"] }
+serde_json = "*"

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -9,4 +9,7 @@ license = "Apache-2.0"
 anyhow = "*"
 clap = { version = "*", features = ["derive"] }
 oak_containers_orchestrator_client = { workspace = true }
-tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync", "fs", "process"] }
+log = "*"
+syslog = "*"
+

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -9,7 +9,13 @@ license = "Apache-2.0"
 anyhow = "*"
 clap = { version = "*", features = ["derive"] }
 oak_containers_orchestrator_client = { workspace = true }
-tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync", "fs", "process"] }
+tokio = { version = "*", features = [
+  "rt-multi-thread",
+  "macros",
+  "sync",
+  "fs",
+  "process"
+] }
 log = "*"
 syslog = "*"
 tar = "*"

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -1,0 +1,113 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Representation of a minimal OCI filesystem bundle config, including just the required fields
+/// Ref: https://github.com/opencontainers/runtime-spec/blob/467fd17d4f2a987fa00051ce44b69bf9620e2ee6/config.md
+#[derive(serde::Deserialize)]
+struct OciFilesystemBundleConfig {
+    process: OciFilesystemBundleConfigProcess,
+    root: OciFilesystemBundleConfigRoot,
+}
+
+#[derive(serde::Deserialize)]
+struct OciFilesystemBundleConfigProcess {
+    user: OciFilesystemBundleConfigProcessUser,
+    args: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct OciFilesystemBundleConfigProcessUser {
+    uid: u32,
+    gid: u32,
+}
+
+#[derive(serde::Deserialize)]
+struct OciFilesystemBundleConfigRoot {
+    path: std::path::PathBuf,
+}
+
+async fn run_command_and_log_output(
+    command: &mut tokio::process::Command,
+) -> Result<(), Box<std::io::Error>> {
+    let output = command.output().await;
+    log::info!("{:?}: {:?}", command, output);
+    Ok(())
+}
+
+// Directory at which the container OCI filesystem bundle will be unpacked
+const CONTAINER_DIR: &str = "/oak_container";
+
+pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
+    tokio::fs::create_dir(CONTAINER_DIR).await?;
+    tar::Archive::new(&container_bundle[..]).unpack(CONTAINER_DIR)?;
+
+    let oci_filesystem_bundle_config: OciFilesystemBundleConfig = {
+        let file_path = {
+            let mut base = std::path::PathBuf::from(CONTAINER_DIR);
+            base.push("config.json");
+            base
+        };
+        let oci_filesystem_bundle_config_file = tokio::fs::read_to_string(file_path).await?;
+
+        serde_json::from_str(&oci_filesystem_bundle_config_file)?
+    };
+
+    // mount host devices inside the container directory to allow the
+    // trusted application to communicate with the outside
+    {
+        run_command_and_log_output(
+            tokio::process::Command::new("rm")
+                .current_dir(CONTAINER_DIR)
+                .arg("-rf")
+                .arg("dev"),
+        )
+        .await?;
+        run_command_and_log_output(
+            tokio::process::Command::new("mkdir")
+                .current_dir(CONTAINER_DIR)
+                .arg("dev"),
+        )
+        .await?;
+        run_command_and_log_output(
+            tokio::process::Command::new("mount")
+                .current_dir(CONTAINER_DIR)
+                .arg("--rbind")
+                .arg("/dev")
+                .arg("dev/"),
+        )
+        .await?;
+    }
+
+    let container_rootfs_path = {
+        let mut base = std::path::PathBuf::from(CONTAINER_DIR);
+        base.push(oci_filesystem_bundle_config.root.path);
+        base
+    };
+
+    // start the trusted application in a chroot jail of the container
+    run_command_and_log_output(
+        tokio::process::Command::new("chroot")
+            .arg(format!(
+                "--userspec={}:{}",
+                oci_filesystem_bundle_config.process.user.uid,
+                oci_filesystem_bundle_config.process.user.gid,
+            ))
+            .arg(container_rootfs_path)
+            .args(oci_filesystem_bundle_config.process.args),
+    )
+    .await?;
+
+    Ok(())
+}

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -77,6 +77,7 @@ pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
         run_command_and_log_output(
             tokio::process::Command::new("mkdir")
                 .current_dir(CONTAINER_DIR)
+                .arg("-p")
                 .arg("dev/vsock"),
         )
         .await?;

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Representation of a minimal OCI filesystem bundle config, including just the required fields
+/// Representation of a minimal OCI filesystem bundle config, including just the required fields.
 /// Ref: <https://github.com/opencontainers/runtime-spec/blob/467fd17d4f2a987fa00051ce44b69bf9620e2ee6/config.md>
 #[derive(serde::Deserialize)]
 struct OciFilesystemBundleConfig {
@@ -46,7 +46,7 @@ async fn run_command_and_log_output(
     Ok(())
 }
 
-// Directory at which the container OCI filesystem bundle will be unpacked
+// Directory at which the container OCI filesystem bundle will be unpacked.
 const CONTAINER_DIR: &str = "/oak_container";
 
 pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
@@ -64,8 +64,8 @@ pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
         serde_json::from_str(&oci_filesystem_bundle_config_file)?
     };
 
-    // mount host vsock device inside the container directory to allow the
-    // trusted application to communicate with the outside
+    // Mount host vsock device inside the container directory to allow the
+    // trusted application to communicate with the outside.
     {
         run_command_and_log_output(
             tokio::process::Command::new("rm")
@@ -97,7 +97,7 @@ pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
         base
     };
 
-    // start the trusted application in a chroot jail of the container
+    // Start the trusted application in a chroot jail of the container.
     run_command_and_log_output(
         tokio::process::Command::new("chroot")
             .arg(format!(

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -52,14 +52,9 @@ async fn run_command_and_log_output(
 const CONTAINER_DIR: &str = "/oak_container";
 
 async fn rmount_dir(source: PathBuf, target: PathBuf) -> Result<(), anyhow::Error> {
-    run_command_and_log_output(tokio::process::Command::new("rm").arg("-rf").arg(&target)).await?;
-    run_command_and_log_output(
-        tokio::process::Command::new("mkdir")
-            .current_dir(CONTAINER_DIR)
-            .arg("-p")
-            .arg(&target),
-    )
-    .await?;
+    tokio::fs::remove_dir_all(&target).await?;
+    tokio::fs::create_dir_all(&target).await?;
+
     run_command_and_log_output(
         tokio::process::Command::new("mount")
             .current_dir(CONTAINER_DIR)

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -64,7 +64,7 @@ pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
         serde_json::from_str(&oci_filesystem_bundle_config_file)?
     };
 
-    // mount host devices inside the container directory to allow the
+    // mount host vsock device inside the container directory to allow the
     // trusted application to communicate with the outside
     {
         run_command_and_log_output(
@@ -77,15 +77,15 @@ pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
         run_command_and_log_output(
             tokio::process::Command::new("mkdir")
                 .current_dir(CONTAINER_DIR)
-                .arg("dev"),
+                .arg("dev/vsock"),
         )
         .await?;
         run_command_and_log_output(
             tokio::process::Command::new("mount")
                 .current_dir(CONTAINER_DIR)
                 .arg("--rbind")
-                .arg("/dev")
-                .arg("dev/"),
+                .arg("/dev/vsock")
+                .arg("dev/vsock/"),
         )
         .await?;
     }

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 /// Representation of a minimal OCI filesystem bundle config, including just the required fields
-/// Ref: https://github.com/opencontainers/runtime-spec/blob/467fd17d4f2a987fa00051ce44b69bf9620e2ee6/config.md
+/// Ref: <https://github.com/opencontainers/runtime-spec/blob/467fd17d4f2a987fa00051ce44b69bf9620e2ee6/config.md>
 #[derive(serde::Deserialize)]
 struct OciFilesystemBundleConfig {
     process: OciFilesystemBundleConfigProcess,
@@ -51,7 +51,7 @@ const CONTAINER_DIR: &str = "/oak_container";
 
 pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
     tokio::fs::create_dir(CONTAINER_DIR).await?;
-    tar::Archive::new(&container_bundle[..]).unpack(CONTAINER_DIR)?;
+    tar::Archive::new(container_bundle).unpack(CONTAINER_DIR)?;
 
     let oci_filesystem_bundle_config: OciFilesystemBundleConfig = {
         let file_path = {

--- a/oak_containers_orchestrator/src/logging.rs
+++ b/oak_containers_orchestrator/src/logging.rs
@@ -1,0 +1,40 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate log;
+
+use log::LevelFilter;
+use syslog::{BasicLogger, Facility, Formatter3164};
+
+/// Setup logging to syslog
+// Based on syslog's example of integrating with the log crate.
+// Ref: https://docs.rs/syslog/6.1.0/syslog/
+pub fn setup() -> Result<(), Box<dyn std::error::Error>> {
+    let formatter = Formatter3164 {
+        facility: Facility::LOG_DAEMON,
+        hostname: None,
+        process: "oak_containers_orchestrator".into(),
+        pid: std::process::id(),
+    };
+
+    let logger =
+        syslog::unix(formatter).map_err(|e| format!("impossible to connect to syslog: {:?}", e))?;
+
+    log::set_boxed_logger(Box::new(BasicLogger::new(logger)))
+        .map(|()| log::set_max_level(LevelFilter::Trace))
+        .map_err(|e| format!("failed to set logger: {:?}", e))?;
+
+    Ok(())
+}

--- a/oak_containers_orchestrator/src/logging.rs
+++ b/oak_containers_orchestrator/src/logging.rs
@@ -18,10 +18,11 @@ extern crate log;
 use log::LevelFilter;
 use syslog::{BasicLogger, Facility, Formatter3164};
 
-/// Setup logging to syslog
-// Based on syslog's example of integrating with the log crate.
-// Ref: https://docs.rs/syslog/6.1.0/syslog/
+/// Setup logging to syslog.
 pub fn setup() -> Result<(), Box<dyn std::error::Error>> {
+    // Based on syslog's example of integrating with the log crate.
+    // Ref: https://docs.rs/syslog/6.1.0/syslog/
+
     let formatter = Formatter3164 {
         facility: Facility::LOG_DAEMON,
         hostname: None,

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod logging;
+
 use anyhow::anyhow;
 use clap::Parser;
 use oak_containers_orchestrator_client::LauncherClient;
@@ -28,6 +30,8 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = logging::setup()?;
+
     let args = Args::parse();
 
     let mut launcher_client =
@@ -35,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await
             .map_err(|error| anyhow!("couldn't create client: {:?}", error))?;
 
-    let _container_bundle = launcher_client
+    let container_bundle = launcher_client
         .get_container_bundle()
         .await
         .map_err(|error| anyhow!("couldn't get container bundle: {:?}", error))?;

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod container_runtime;
 mod logging;
 
 use anyhow::anyhow;
@@ -48,6 +49,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .get_application_config()
         .await
         .map_err(|error| anyhow!("couldn't get application config: {:?}", error))?;
+
+    container_runtime::run(&container_bundle).await?;
 
     Ok(())
 }

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -31,7 +31,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let _ = logging::setup()?;
+    logging::setup()?;
 
     let args = Args::parse();
 


### PR DESCRIPTION
Implements a simple chroot based container runtime. I welcome opinions on the choice of the runtime. 

On the pro side: small!
- small and easy to reason about 
- small and probably integratable into a statically linked linux distro

On the con side: executes an [OCI filesystem bundle](https://github.com/opencontainers/runtime-spec/blob/main/bundle.md) in a likely non-standard/unexpected way
- newest version of the OCI filesystem bundle it supports all req attributes of is v0.2.0 (v old). Newer versions afaik cannot be supported with chroot, since chroot fixes the workdir to root
- does not implement any of the optional settings of the OCI filesystem bundle config file, most certainly leading to unexpected things happening by default.
- in essence this means containers must likely be tailored to run on this runtime