### PR TITLE
Send empty Attestation Evidence to the Containers Launcher

### DIFF
--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -19,6 +19,7 @@ syntax = "proto3";
 package oak.containers;
 
 import "google/protobuf/empty.proto";
+import "oak_remote_attestation/proto/v1/messages.proto";
 
 // As images can be large (hundreds of megabytes), the launcher chunks up the response into smaller
 // pieces to respect proto/gRPC limits. The image needs to be reassembled in the stage1 or the
@@ -31,6 +32,10 @@ message GetApplicationConfigResponse {
   // Arbitrary config that the container can retrieve from the orchestrator.
   // Included in the attestation measurements conducted by the orchestrator.
   bytes config = 1;
+}
+
+message SendAttestationEvidenceRequest {
+  oak.session.v1.AttestationEvidence evidence = 1;
 }
 
 // Defines the service exposed by the launcher, that can be invoked by the stage1 and the
@@ -47,6 +52,12 @@ service Launcher {
   // application config. The orchestrator will later, separately expose this
   // config to the application.
   rpc GetApplicationConfig(google.protobuf.Empty) returns (GetApplicationConfigResponse) {}
+
+  // Sends Attestation Evidence containing the Attestation Report with corresponding measurements
+  // and public keys to the Launcher.
+  // This API is called exactly once after the Attestation Evidence is generated. Calling this API
+  // a second time will result in an error.
+  rpc SendAttestationEvidence(SendAttestationEvidenceRequest) returns (google.protobuf.Empty) {}
 }
 
 // Defines the service exposed by the orchestrator, that can be invoked by the application.

--- a/oak_containers_launcher_server/build.rs
+++ b/oak_containers_launcher_server/build.rs
@@ -19,7 +19,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the launcher.
     generate_grpc_code(
         "../",
-        &["oak_containers/proto/interfaces.proto"],
+        &[
+            "oak_containers/proto/interfaces.proto",
+            "oak_remote_attestation/proto/v1/messages.proto",
+        ],
         CodegenOptions {
             build_server: true,
             ..Default::default()

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -18,7 +18,9 @@ mod logging;
 
 use anyhow::anyhow;
 use clap::Parser;
-use oak_containers_orchestrator_client::LauncherClient;
+use oak_containers_orchestrator_client::{
+    proto::oak::session::v1::AttestationEvidence, LauncherClient,
+};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -49,6 +51,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .get_application_config()
         .await
         .map_err(|error| anyhow!("couldn't get application config: {:?}", error))?;
+
+    let evidence = AttestationEvidence {
+        encryption_public_key: vec![],
+        signing_public_key: vec![],
+        attestation: vec![],
+        signed_application_data: vec![],
+    };
+    launcher_client
+        .send_attestation_evidence(evidence)
+        .await
+        .map_err(|error| anyhow!("couldn't send attestation evidence: {:?}", error))?;
 
     container_runtime::run(&container_bundle).await?;
 

--- a/oak_containers_orchestrator_client/build.rs
+++ b/oak_containers_orchestrator_client/build.rs
@@ -19,7 +19,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the launcher.
     generate_grpc_code(
         "../",
-        &["oak_containers/proto/interfaces.proto"],
+        &[
+            "oak_containers/proto/interfaces.proto",
+            "oak_remote_attestation/proto/v1/messages.proto",
+        ],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_stage1/build.rs
+++ b/oak_containers_stage1/build.rs
@@ -20,7 +20,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
     generate_grpc_code(
         "../",
-        &["oak_containers/proto/interfaces.proto"],
+        &[
+            "oak_containers/proto/interfaces.proto",
+            "oak_remote_attestation/proto/v1/messages.proto",
+        ],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_stage1/src/client.rs
+++ b/oak_containers_stage1/src/client.rs
@@ -19,6 +19,11 @@ mod proto {
         pub mod containers {
             tonic::include_proto!("oak.containers");
         }
+        pub mod session {
+            pub mod v1 {
+                tonic::include_proto!("oak.session.v1");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR makes the Orchestrator send an empty Attestation Evidence to the Containers Launcher.