### PR TITLE
Build `stage1.cpio` on Kokoro

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,8 @@
                 flex
                 libelf
                 perl
+                glibc
+                glibc.static
               ];
             };
             # Shell for most CI steps (i.e. without contaniners support).

--- a/justfile
+++ b/justfile
@@ -26,8 +26,11 @@ oak_restricted_kernel_simple_io_bin:
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin
 
+stage1_cpio:
+    env --chdir=oak_containers_stage1 make
+
 # Top level target to build all enclave apps and the kernel, and run tests.
 #
 # This is the entry point for Kokoro CI.
-kokoro: all_enclave_apps oak_restricted_kernel_bin stage0_bin
+kokoro: all_enclave_apps oak_restricted_kernel_bin stage0_bin stage1_cpio
     cargo nextest run --all-targets --hide-progress-bar

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -12,7 +12,7 @@ export RUST_LOG=debug
 export XDG_RUNTIME_DIR=/var/run
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#ci --command just kokoro
+./scripts/docker_run nix develop --command just kokoro
 
 mkdir -p "$KOKORO_ARTIFACTS_DIR/test_logs/"
 cp ./target/nextest/default/*.xml "$KOKORO_ARTIFACTS_DIR/test_logs/"
@@ -31,6 +31,7 @@ export GENERATED_BINARIES=(
     ./enclave_apps/target/x86_64-unknown-none/release/oak_functions_enclave_app
     ./enclave_apps/target/x86_64-unknown-none/release/oak_tensorflow_enclave_app
     ./enclave_apps/target/x86_64-unknown-none/release/quirk_echo_enclave_app
+    ./target/stage1.cpio
 )
 cp "${GENERATED_BINARIES[@]}" "$KOKORO_ARTIFACTS_DIR/binaries/"
 

--- a/oak_containers_stage1/Makefile
+++ b/oak_containers_stage1/Makefile
@@ -5,7 +5,7 @@ all: ../target/stage1.cpio
 
 ../target/stage1.cpio: ../target/x86_64-unknown-linux-musl/release/oak_containers_stage1 ../target/mke2fs
 	cp ../target/x86_64-unknown-linux-musl/release/oak_containers_stage1 ../target/init
-	echo "init\nmke2fs" | cpio -o -R root:root -H newc -v --reproducible -D ../target | gzip -9 > ../target/stage1.cpio
+	echo -e "init\nmke2fs" | cpio -o -R root:root -H newc -v --reproducible -D ../target | gzip -9 > ../target/stage1.cpio
 
 ../target/x86_64-unknown-linux-musl/release/oak_containers_stage1:
 	cargo build --release --target x86_64-unknown-linux-musl


### PR DESCRIPTION
I've changed Kokoro to use the default shell, as sooner or later we'll also want to build the kernel and everything else related to containers in Kokoro as well.