### PR TITLE
Move stage1 to a separate Kokoro presubmit

### DIFF
--- a/justfile
+++ b/justfile
@@ -32,5 +32,7 @@ stage1_cpio:
 # Top level target to build all enclave apps and the kernel, and run tests.
 #
 # This is the entry point for Kokoro CI.
-kokoro: all_enclave_apps oak_restricted_kernel_bin stage0_bin stage1_cpio
+kokoro: all_enclave_apps oak_restricted_kernel_bin stage0_bin
     cargo nextest run --all-targets --hide-progress-bar
+
+kokoro_oak_containers: stage1_cpio

--- a/kokoro/oak_containers_presubmit.sh
+++ b/kokoro/oak_containers_presubmit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o xtrace
+set -o pipefail
+
+export CI=kokoro
+
+export RUST_BACKTRACE=1
+export RUST_LOG=debug
+export XDG_RUNTIME_DIR=/var/run
+
+./scripts/docker_pull
+./scripts/docker_run nix develop .#containers --command just kokoro_oak_containers
+
+mkdir -p "$KOKORO_ARTIFACTS_DIR/test_logs/"
+cp ./target/nextest/default/*.xml "$KOKORO_ARTIFACTS_DIR/test_logs/" || true
+
+mkdir -p "$KOKORO_ARTIFACTS_DIR/binaries/"
+
+# Store the git commit hash in a file.
+echo "${KOKORO_GIT_COMMIT_oak:?}" > "$KOKORO_ARTIFACTS_DIR/binaries/git_commit"
+
+# Copy the generated binaries to Placer.
+export GENERATED_BINARIES=(
+    ./target/stage1.cpio
+)
+cp "${GENERATED_BINARIES[@]}" "$KOKORO_ARTIFACTS_DIR/binaries/"
+
+ls -alsR "$KOKORO_ARTIFACTS_DIR/binaries"

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -12,7 +12,7 @@ export RUST_LOG=debug
 export XDG_RUNTIME_DIR=/var/run
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop --command just kokoro
+./scripts/docker_run nix develop .#ci --command just kokoro
 
 mkdir -p "$KOKORO_ARTIFACTS_DIR/test_logs/"
 cp ./target/nextest/default/*.xml "$KOKORO_ARTIFACTS_DIR/test_logs/"
@@ -31,7 +31,6 @@ export GENERATED_BINARIES=(
     ./enclave_apps/target/x86_64-unknown-none/release/oak_functions_enclave_app
     ./enclave_apps/target/x86_64-unknown-none/release/oak_tensorflow_enclave_app
     ./enclave_apps/target/x86_64-unknown-none/release/quirk_echo_enclave_app
-    ./target/stage1.cpio
 )
 cp "${GENERATED_BINARIES[@]}" "$KOKORO_ARTIFACTS_DIR/binaries/"
 


### PR DESCRIPTION
I'll have to follow this PR up with an internal change to actually call `oak-container-presubmit.sh` from Kokoro.