### PR TITLE
Query fw_cfg device to check if DMA is enabled

### DIFF
--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -34,6 +34,9 @@ const FWCFG_PORT_DMA: u16 = 0x514;
 
 const SIGNATURE: &[u8] = b"QEMU";
 
+// Bit 1 indicates that DMA access is enabled on the fw_cfg device.
+const DMA_ENABLED: u8 = 1 << 1;
+
 /// A single 4KiB buffer that is 4KiB page-aligned.
 #[repr(C, align(4096))]
 #[derive(Debug)]
@@ -58,6 +61,7 @@ impl Default for DmaBuffer {
 #[repr(u16)]
 enum FwCfgItems {
     Signature = 0x0000,
+    Features = 0x0001,
     KernelAddr = 0x0007,
     KernelSize = 0x0008,
     InitrdAddr = 0x000a,
@@ -131,6 +135,7 @@ pub struct FwCfg {
     dma_low: PortWrapper<u32>,
     dma_buf: &'static mut DmaBuffer,
     dma_access: &'static mut FwCfgDmaAccess,
+    dma_enabled: bool,
 }
 
 impl FwCfg {
@@ -156,6 +161,7 @@ impl FwCfg {
             dma_low: port_factory.new_writer(FWCFG_PORT_DMA + 4),
             dma_buf,
             dma_access,
+            dma_enabled: false,
         };
 
         // Make sure the fw_cfg device is available. If the device is not available, writing and
@@ -163,6 +169,15 @@ impl FwCfg {
         fwcfg.write_selector(FwCfgItems::Signature as u16)?;
         let mut signature = [0u8; SIGNATURE.len()];
         fwcfg.read(&mut signature)?;
+
+        // Check whether DMA is enabled.
+        let mut features = 0u8;
+        fwcfg.write_selector(FwCfgItems::Features as u16)?;
+        fwcfg.read(&mut features)?;
+
+        if features & DMA_ENABLED == DMA_ENABLED {
+            fwcfg.dma_enabled = true;
+        }
 
         if signature == SIGNATURE {
             Ok(fwcfg)
@@ -245,7 +260,9 @@ impl FwCfg {
     pub fn read_file(&mut self, file: &DirEntry, buf: &mut [u8]) -> Result<usize, &'static str> {
         self.write_selector(file.selector())?;
         let len = min(buf.len(), file.size());
-        if self.read_buf_dma(&mut buf[..len]).is_err() {
+        if self.dma_enabled {
+            self.read_buf_dma(&mut buf[..len])?;
+        } else {
             self.read_buf(&mut buf[..len])?;
         }
         Ok(len)


### PR DESCRIPTION
Rather than always trying to use DMA access on the fw_cfg device (and falling back to byte-by-byte reading on failure) we can query the device to check whether DMA is enabled.