### PR TITLE
Remove oak_tensorflow_enclave_app.toml from provenance workflow

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -29,7 +29,6 @@ jobs:
           - buildconfigs/oak_restricted_kernel_bin.toml
           - buildconfigs/oak_restricted_kernel_simple_io_bin.toml
           - buildconfigs/oak_functions_enclave_app.toml
-          - buildconfigs/oak_tensorflow_enclave_app.toml
           - buildconfigs/quirk_echo_enclave_app.toml
           - buildconfigs/stage0_bin.toml
 


### PR DESCRIPTION
The #4125 was obviously the completely wrong way of disabling the provenance workflow for `oak_tensorflow_enclave_app`.