### PR TITLE
Remove the version from `vmlinux` path

### DIFF
--- a/kokoro/oak_containers_presubmit.sh
+++ b/kokoro/oak_containers_presubmit.sh
@@ -25,7 +25,7 @@ echo "${KOKORO_GIT_COMMIT_oak:?}" > "$KOKORO_ARTIFACTS_DIR/binaries/git_commit"
 # Copy the generated binaries to Placer.
 export GENERATED_BINARIES=(
     ./target/stage1.cpio
-    ./oak_containers_kernel/target/vmlinux-6.1.33
+    ./oak_containers_kernel/target/vmlinux
     ./oak_containers_system_image/target/image.tar
 )
 cp "${GENERATED_BINARIES[@]}" "$KOKORO_ARTIFACTS_DIR/binaries/"

--- a/oak_containers_kernel/Makefile
+++ b/oak_containers_kernel/Makefile
@@ -1,7 +1,7 @@
-all: target/vmlinux-6.1.33
+all: target/vmlinux
 
-target/vmlinux-6.1.33: target/linux-6.1.33/arch/x86/boot/bzImage
-	target/linux-6.1.33/scripts/extract-vmlinux  target/linux-6.1.33/arch/x86/boot/bzImage > target/vmlinux-6.1.33
+target/vmlinux: target/linux-6.1.33/arch/x86/boot/bzImage
+	target/linux-6.1.33/scripts/extract-vmlinux  target/linux-6.1.33/arch/x86/boot/bzImage > target/vmlinux
 
 target/linux-6.1.33/arch/x86/boot/bzImage: target/linux-6.1.33 configs/6.1.33/minimal.config
 	KCONFIG_CONFIG=../../configs/6.1.33/minimal.config $(MAKE) -C target/linux-6.1.33 bzImage -j `nproc`


### PR DESCRIPTION
We can reasonably expect that the kernel version is going to change in the future, so it's best not to hard-code the version in the final binary paths.