### PR TITLE
Replace Clear Linux with Debian in the Oak Containers system image

### DIFF
--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -1,13 +1,21 @@
-FROM clearlinux@sha256:88652d2682bd63208e55f069c0ca4d3c30fe3acf2c5b730d16f8099a6d437162
+# FROM clearlinux@sha256:88652d2682bd63208e55f069c0ca4d3c30fe3acf2c5b730d16f8099a6d437162
+ARG debian_snapshot=sha256:f0b8edb2e4436c556493dce86b941231eead97baebb484d0d5f6ecfe4f7ed193
+FROM debian@${debian_snapshot}
 
-# Remove .dockerenv as we will not run this image in an actual Docker container.
-RUN rm /.dockerenv
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install Clear Linux's containers-basic bundle. This gives an installation of
-# docker to run containers. This is a starting point only, we should switch to
-# a more lightweight runtime later.
-# Ref: https://clearlinux.github.io/clear-linux-documentation/tutorials/docker.html#install-the-containers-basic-bundle
-RUN swupd bundle-add containers-basic
+# Install Docker. This is a starting point only, we should switch to a more lightweight runtime later.
+RUN apt-get --yes update && apt-get install --no-install-recommends --yes curl gnupg2 gnupg-agent ca-certificates
+RUN curl --fail --silent --show-error --location https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN echo "deb [arch=amd64] https://download.docker.com/linux/debian bookworm stable"  > /etc/apt/sources.list.d/backports.list
+
+RUN apt-get --yes update \
+  && apt-get install --yes --no-install-recommends \
+  systemd systemd-sysv \
+  docker-ce \
+  # Cleanup
+  && apt-get clean \
+  && rm --recursive --force /var/lib/apt/lists/*
 
 # Configure systemd to run docker at startup
 RUN systemctl enable docker
@@ -26,6 +34,5 @@ COPY journald.conf /etc/systemd/journald.conf.d/clear.conf
 # Don't bother starting the graphical interface, let's stick with the basic multi-user target.
 RUN systemctl set-default multi-user
 
-# Clean up some stuff we don't need (like the `swupd` tool itself)
-RUN swupd bundle-remove trurl os-core-update os-core-webproxy
-RUN rm -rf ./var/lib/swupd
+# Clean up some stuff we don't need
+RUN rm -rf /usr/share/doc /usr/share/info /usr/share/man


### PR DESCRIPTION
This reduces the system image size from 1.1G to 400M -- or, once we compress it, from 300M to 95M.

And we can likely prune more stuff that's in there right now.