### PR TITLE
Move jni.so import to runtime_deps.

### DIFF
--- a/java/src/main/java/com/google/oak/crypto/hpke/BUILD
+++ b/java/src/main/java/com/google/oak/crypto/hpke/BUILD
@@ -28,8 +28,10 @@ java_library(
         "Hpke.java",
         "KeyPair.java",
     ],
-    deps = [
+    runtime_deps = [
         "//cc/crypto/hpke/jni:libhpke-jni.so",
+    ],
+    deps = [
         "//java/src/main/java/com/google/oak/util",
     ],
 )


### PR DESCRIPTION
This PR moves the Java deps for the libhpke-jni.so file from deps to runtime_deps in the BUILD file.

This PR is part of the the Java implementation for (https://github.com/project-oak/oak/issues/3642).