### PR TITLE
If the orchestrator dies, take the rest of the system down with it

### DIFF
--- a/oak_containers_system_image/build.sh
+++ b/oak_containers_system_image/build.sh
@@ -12,6 +12,6 @@ readonly NEW_DOCKER_CONTAINER_ID="$(docker create oak-containers-system-image:la
 
 docker export "$NEW_DOCKER_CONTAINER_ID" > target/image.tar
 ls -lah target/image.tar
-xz target/image.tar
+xz --force target/image.tar
 
 docker rm "$NEW_DOCKER_CONTAINER_ID"

--- a/oak_containers_system_image/oak-orchestrator.service
+++ b/oak_containers_system_image/oak-orchestrator.service
@@ -6,6 +6,7 @@ Requires=docker.service
 [Service]
 Type=simple
 ExecStart=/bin/oak_containers_orchestrator
+FailureAction=poweroff-force
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If the orchestrator dies, then it doesn't make much sense to keep the system around. We can configure systemd to restart the service, but I'm worried that might mask other errors that might happen.

Having the system shut down when the orchestrator dies lets us handle the (unexpected) error on a higher level. We can always retry by restarting the whole VM, if we want to -- with the benefit of starting from a clean slate.

(I've also sneaked in a change to force `xz` to always overwrite the system image file.)