### PR TITLE
Permit containers to set the working directory of the trusted application

### DIFF
--- a/oak_containers_hello_world_container/config.json
+++ b/oak_containers_hello_world_container/config.json
@@ -7,7 +7,8 @@
 		},
 		"args": [
 			"/bin/oak_containers_hello_world_trusted_app"
-		]
+		],
+		"cwd": "/bin"
 	},
 	"root": {
 		"path": "rootfs"

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -140,7 +140,7 @@ pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
     // given the orchestrators current feature set, but may become one later.
     std::os::unix::fs::chroot(container_rootfs_path)?;
 
-    // Change to specifed working directory
+    // Change to the specifed working directory.
     std::env::set_current_dir(oci_filesystem_bundle_config.process.cwd)?;
 
     // Start the trusted application.

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -159,12 +159,9 @@ pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
     // unexpectedly. For our case that's fine though, since we just use it to
     // make chdir & chroot syscalls.
     // Ref: https://docs.rs/tokio/latest/tokio/process/struct.Command.html#safety
-    unsafe {
-        let _output =
-            tokio::process::Command::pre_exec(&mut start_trusted_app_cmd, prep_trusted_app_process)
-                .output()
-                .await;
-    }
+    unsafe { start_trusted_app_cmd.pre_exec(prep_trusted_app_process) };
+
+    run_command_and_log_output(&mut start_trusted_app_cmd).await?;
 
     Ok(())
 }

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -157,7 +157,7 @@ pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
     // method, allowing us to use a closure to prep the newly forked child
     // process. That closure runs in a special enviroment so it can behave a bit
     // unexpectedly. For our case that's fine though, since we just use it to
-    // make chdir & chroot syscall.
+    // make chdir & chroot syscalls.
     // Ref: https://docs.rs/tokio/latest/tokio/process/struct.Command.html#safety
     unsafe {
         let _output =


### PR DESCRIPTION
…
This will be important when running internally built docker images that reference relative paths. Supporting the [cwd](https://github.com/opencontainers/runtime-spec/blob/v1.0.2/config.md#process) key in the OCI filesystem bundle config also means we can support the significantly newer version of 1.0.2 (vs 0.2.0 previously)