### PR TITLE
Oak Containers Hello World: Expose service in Trusted App

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,6 +1729,7 @@ dependencies = [
  "oak_grpc_utils",
  "prost",
  "tokio",
+ "tokio-stream",
  "tokio-vsock",
  "tonic",
  "tower",

--- a/oak_containers_hello_world_trusted_app/Cargo.toml
+++ b/oak_containers_hello_world_trusted_app/Cargo.toml
@@ -12,6 +12,7 @@ oak_grpc_utils = { workspace = true }
 anyhow = "*"
 prost = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
+tokio-stream = "*"
 tonic = { workspace = true }
 tokio-vsock = { version = "*", features = ["tonic-conn"] }
 vsock = "*"

--- a/oak_containers_hello_world_trusted_app/build.rs
+++ b/oak_containers_hello_world_trusted_app/build.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "../",
         &["oak_containers_hello_world_trusted_app/proto/interface.proto"],
         CodegenOptions {
-            build_client: true,
+            build_server: true,
             ..Default::default()
         },
     )?;

--- a/oak_containers_hello_world_trusted_app/proto/interface.proto
+++ b/oak_containers_hello_world_trusted_app/proto/interface.proto
@@ -26,17 +26,6 @@ message HelloResponse {
   string greeting = 1;
 }
 
-// Simple service that permits the trusted application to send a request to the
-// untrusted application. In this example the trusted application will send a
-// name and the untrusted application will return a greeting.
-// In real world application communication would more likely take the form
-// of a stream, in which the untrusted application sends new request, and the
-// trusted application responds.
-// The current architecture of the untrusted applicatin being the service was
-// chosen purely because it conceptually follows the pattern of all other
-// vsock communication between the trusted and untrusted parts. The untrusted
-// part exposes a listener/service, the trusted part connects to it once it has
-// booted up.
-service UntrustedApplication {
+service TrustedApplication {
   rpc Hello(HelloRequest) returns (HelloResponse) {}
 }

--- a/oak_containers_hello_world_trusted_app/src/main.rs
+++ b/oak_containers_hello_world_trusted_app/src/main.rs
@@ -13,8 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod app_service;
 mod orchestrator_client;
-mod untrusted_app_client;
+
+const UNTRUSTED_APP_VSOCK_CID: u32 = vsock::VMADDR_CID_HOST;
+const UNTRUSTED_APP_VSOCK_PORT: u32 = 8081;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -22,12 +25,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?
         .get_application_config()
         .await?;
-    let name = format!(
-        "Trusted Application with a {} byte long config",
-        application_config.len()
-    );
-    let mut untrusted_app_client =
-        untrusted_app_client::UntrustedApplicationClient::create(2, 6969).await?;
-    let _greeting = untrusted_app_client.hello(&name).await?;
+
+    app_service::create(
+        UNTRUSTED_APP_VSOCK_CID,
+        UNTRUSTED_APP_VSOCK_PORT,
+        application_config,
+    )
+    .await?;
     Ok(())
 }

--- a/oak_containers_hello_world_untrusted_app/Cargo.toml
+++ b/oak_containers_hello_world_untrusted_app/Cargo.toml
@@ -11,7 +11,12 @@ oak_grpc_utils = { workspace = true }
 [dependencies]
 anyhow = "*"
 prost = "*"
-tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { version = "*", features = [
+  "rt-multi-thread",
+  "macros",
+  "sync",
+  "time"
+] }
 tonic = "*"
 tower = "*"
 tokio-vsock = { version = "*", features = ["tonic-conn"] }

--- a/oak_containers_hello_world_untrusted_app/Cargo.toml
+++ b/oak_containers_hello_world_untrusted_app/Cargo.toml
@@ -11,7 +11,7 @@ oak_grpc_utils = { workspace = true }
 [dependencies]
 anyhow = "*"
 prost = "*"
-tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tonic = "*"
 tower = "*"
 tokio-vsock = { version = "*", features = ["tonic-conn"] }

--- a/oak_containers_hello_world_untrusted_app/build.rs
+++ b/oak_containers_hello_world_untrusted_app/build.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "../",
         &["oak_containers_hello_world_trusted_app/proto/interface.proto"],
         CodegenOptions {
-            build_server: true,
+            build_client: true,
             ..Default::default()
         },
     )?;

--- a/oak_containers_hello_world_untrusted_app/src/main.rs
+++ b/oak_containers_hello_world_untrusted_app/src/main.rs
@@ -13,17 +13,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod service;
+mod app_client;
+
 use clap::Parser;
+
+const UNTRUSTED_APP_VSOCK_CID: u32 = vsock::VMADDR_CID_HOST;
+const UNTRUSTED_APP_VSOCK_PORT: u32 = 8081;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let args = oak_containers_launcher::Args::parse();
+    let launcher_handle = tokio::task::spawn(oak_containers_launcher::create(args));
 
-    tokio::select! {
-        _ = service::create(2, 6969) => {}
-        _ = oak_containers_launcher::create(args) => {}
-    };
+    let mut trusted_app_client = app_client::TrustedApplicationClient::create(
+        UNTRUSTED_APP_VSOCK_CID,
+        UNTRUSTED_APP_VSOCK_PORT,
+    )
+    .await
+    .map_err(|error| anyhow::anyhow!("couldn't create trusted app client: {}", error))?;
+
+    let greeting = trusted_app_client
+        .hello("Untrusted App")
+        .await
+        .map_err(|error| anyhow::anyhow!("couldn't invoke trusted app: {}", error))?;
+
+    println!("Received a greeting from the trusted app: {:?}", greeting);
+
+    launcher_handle.abort();
 
     Ok(())
 }


### PR DESCRIPTION
This inverts the prior hello world example in which the trusted app implemented a gRPC client that invoked a gRPC service exposed by the untrusted app.

Now the trusted app exposes the service and the untrusted app invokes it, which is closer to a real world example of Oak Containers.