### PR TITLE
Get rid of Docker in the system image

### DIFF
--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -4,15 +4,9 @@ FROM debian@${debian_snapshot}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install Docker. This is a starting point only, we should switch to a more lightweight runtime later.
-RUN apt-get --yes update && apt-get install --no-install-recommends --yes curl gnupg2 gnupg-agent ca-certificates
-RUN curl --fail --silent --show-error --location https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN echo "deb [arch=amd64] https://download.docker.com/linux/debian bookworm stable"  > /etc/apt/sources.list.d/backports.list
-
 RUN apt-get --yes update \
   && apt-get install --yes --no-install-recommends \
   systemd systemd-sysv dbus udev\
-  docker-ce \
   # Cleanup
   && apt-get clean \
   && rm --recursive --force /var/lib/apt/lists/*
@@ -21,9 +15,6 @@ RUN apt-get --yes update \
 RUN systemctl enable systemd-networkd
 COPY 10-eth0.network /etc/systemd/network
 RUN chmod 644 /etc/systemd/network/10-eth0.network
-
-# Configure systemd to run docker at startup
-RUN systemctl enable docker
 
 # Copy the orchestartor binary & service
 COPY ./target/oak_containers_orchestrator /usr/bin/

--- a/oak_containers_system_image/oak-orchestrator.service
+++ b/oak_containers_system_image/oak-orchestrator.service
@@ -2,7 +2,6 @@
 Description=Oak Containers Orchestrator
 After=network-online.target
 Wants=network-online.target
-Requires=docker.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
As I understand we currently don't use Docker, and even if we switch to a richer container manager in the future, it'd be something more lightweight than Docker. Hence, let's get rid of Docker in our system image.

Result: the (compressed) system image is now 31 MB in size. I'd call that a successful slimming down operation, as we started from a gigabyte.