### PR TITLE
Force password change when trying to log in as root

### DIFF
--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -41,3 +41,6 @@ RUN systemctl set-default multi-user
 
 # Clean up some stuff we don't need
 RUN rm -rf /usr/share/doc /usr/share/info /usr/share/man
+
+# Debugging aid: if you get your hands on the console and try logging in as root, force a password change.
+RUN passwd --delete --expire root


### PR DESCRIPTION
Normally the root account has a disabled password, which means you can't log in a root. In most cases it won't matter as you won't be interactively log into the VM anyway.

However, to aid debugging, it sometimes makes sense to log in to poke around. #4151 adds a flag to expose the console via telnet; this change will make it possible to log in as `root` by forcing a password change when you try to do so.

Ref #4160 