### PR TITLE
Configure `eth0` down before running systemd from the system image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,6 +1586,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6de2fe935f44cbdfcab77dce2150d68eda75be715cd42d4d6f52b0bd4dcc5b1"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842c6770fc4bb33dd902f41829c61ef872b8e38de1405aa0b938b27b8fba12c3"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "nix"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1886,7 @@ dependencies = [
  "nix 0.26.2",
  "oak_grpc_utils",
  "prost",
+ "rtnetlink",
  "tar",
  "tokio",
  "tonic",
@@ -2835,6 +2901,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6333af2adba73478936174a0ef3edf05fbfa058539c21d567344a53bb6d75cfd"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.26.2",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/oak_containers_stage1/Cargo.toml
+++ b/oak_containers_stage1/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "*", features = ["derive"] }
 futures-util = "*"
 nix = "*"
 prost = { workspace = true }
+rtnetlink = "*"
 tar = "*"
 tokio = { version = "*", features = [
   "rt-multi-thread",


### PR DESCRIPTION
The reason why systemd was unable to configure the network interface was overabundance of caution: as we need to set up the IP address for stage1 and left it as-is, `systemd-udevd` noticed that the interface is in use and refused to touch it. Which, in turn, meant it never notified `systemd-networkd` that the interface is indeed ready.

Therefore, let's do some more clean-up in stage1 and disable `eth0` before running the real init process.

As I didn't want to have a statically linked `ip` binary in the initrd (if anything, I want to get rid of the `mkfs.ext4` in there was well), I looked for some alternatives and someone has actually implemented netlink in a pure-Rust crate, which helps us a lot.