### PR TITLE
Rename `eth0` configuration file to `enp0s1`

### DIFF
--- a/oak_containers_system_image/10-enp0s1.network
+++ b/oak_containers_system_image/10-enp0s1.network
@@ -1,5 +1,5 @@
 [Match]
-Name=eth0
+Name=enp0s1
 
 [Network]
 Address=10.0.2.10/24

--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get --yes update \
 
 # Prepare network
 RUN systemctl enable systemd-networkd
-COPY 10-eth0.network /etc/systemd/network
-RUN chmod 644 /etc/systemd/network/10-eth0.network
+COPY 10-enp0s1.network /etc/systemd/network
+RUN chmod 644 /etc/systemd/network/10-enp0s1.network
 
 # Configure systemd to run docker at startup
 RUN systemctl enable docker


### PR DESCRIPTION
Follow-up to #4154 -- the system now automagically renames `eth0` to `enp0s1`, so the configuration file needs a different name as well.

After this the network in the container is properly configured:
```
root@10:~# networkctl -a
IDX LINK   TYPE     OPERATIONAL SETUP     
  1 lo     loopback carrier     unmanaged
  2 enp0s1 ether    routable    configured
  3 sit0   sit      off         unmanaged

3 links listed.
root@10:~# networkctl status enp0s1
● 2: enp0s1                                                                    
                     Link File: /usr/lib/systemd/network/99-default.link
                  Network File: /etc/systemd/network/10-enp0s1.network
                         State: routable (configured)
                  Online state: online                                         
                          Type: ether
                          Path: pci-0000:00:01.0
                        Driver: virtio_net
                        Vendor: Red Hat, Inc.
                         Model: Virtio network device
              Hardware Address: 52:54:00:12:34:56
                           MTU: 1500 (min: 68, max: 65535)
                         QDisc: pfifo_fast
  IPv6 Address Generation Mode: eui64
      Number of Queues (Tx/Rx): 1/1
              Auto negotiation: no
                       Address: 10.0.2.10
                                fec0::5054:ff:fe12:3456
                                fe80::5054:ff:fe12:3456
                       Gateway: fe80::2
             Activation Policy: up
           Required For Online: yes
             DHCP6 Client DUID: DUID-EN/Vendor:0000ab11ec1b7f4f09d305fa0000

Jul 10 19:17:47 10.0.2.10 systemd-networkd[166]: enp0s1: Configuring with /etc/systemd/network/10-enp0s1.network.
Jul 10 19:17:47 10.0.2.10 systemd-networkd[166]: enp0s1: Link UP
Jul 10 19:17:47 10.0.2.10 systemd-networkd[166]: enp0s1: Gained carrier
Jul 10 19:17:48 10.0.2.10 systemd-networkd[166]: enp0s1: Gained IPv6LL
root@10:~# 

```