### PR TITLE
Add MNIST example for ML Transparency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ tensorflow_model_server
 toolchain/build
 toolchain/toolchain
 toolchain/toolchain.tar.bz2
+
+# Python environment
+**/.venv/

--- a/oak_ml_transparency/mnist/Dockerfile
+++ b/oak_ml_transparency/mnist/Dockerfile
@@ -1,0 +1,20 @@
+# Using the same base image that is used in https://github.com/Trusted-AI/adversarial-robustness-toolbox
+FROM nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu20.04
+
+# Isntall all required dependencies and packages
+RUN apt-get update -y
+RUN apt-get install -y python3 python3-distutils python3-pip --no-install-recommends curl
+
+# Note installing keras directly resulted in some issues with saving the model.
+RUN pip3 install --no-cache-dir tensorflow==2.12.0
+
+# Install cleverhans for generating adversarial examples.
+RUN pip3 install --no-cache-dir cleverhans==4.0.0
+
+# Copy files in the current directory to project.
+RUN mkdir /project
+WORKDIR /project
+COPY . /project
+
+# Download model
+RUN curl --output mnist_model.tar.gz  https://ent-server-62sa4xcfia-ew.a.run.app/raw/sha256:c79e6ba6f862ecbce61237bd2c46b50ab7d7b843b4b999f2c951ec7decbf2230

--- a/oak_ml_transparency/mnist/README.md
+++ b/oak_ml_transparency/mnist/README.md
@@ -1,0 +1,136 @@
+# The MNIST example
+
+This folder contains scripts for building an MNIST model and evaluating it
+against adversarial examples. The build script is only included here to make the
+example self-contained. The eval script should work with any MNIST model in
+[Tensorflow SavedModel format](https://www.tensorflow.org/guide/saved_model).
+
+## Building the Docker image
+
+We use a Docker image, with all the required dependencies installed to build the
+model, and run the evaluation. Having such a Docker image is necessary for
+achieving transparency. The Dockerfile should include the script for running the
+evaluation. More specifically, with the following lines in the Dockerfile, we
+embed the evaluation script in the Docker image:
+
+```dockerfile
+RUN mkdir /project
+WORKDIR /project
+ADD . /project
+```
+
+Ideally, and as is the case in this example, the Dockerfile and the evaluation
+script should belong to the same repository, so that a single Git commit hash
+can uniquely specify both the content of the Dockerfile, and the script.
+
+Build the Docker image using the following command:
+
+```bash
+cd oak_ml_transparency/mnist
+docker build -t mnist-eval .
+```
+
+Note that if you make any changes to the script, you have to rebuild the Docker
+image for the changes to take effect.
+
+## Run the image
+
+For this example, we run the Docker image in the interactive mode:
+
+```console
+$ docker run --tty --interactive --rm \
+  --network=host \
+  mnist-eval bash
+```
+
+This gives us access to a shell:
+
+```bash
+==========
+== CUDA ==
+==========
+
+CUDA Version 11.3.1
+
+Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+This container image and its contents are governed by the NVIDIA Deep Learning Container License.
+By pulling and using the container, you accept the terms and conditions of this license:
+https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license
+
+A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.
+
+WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available.
+   Use the NVIDIA Container Toolkit to start this container with GPU support; see
+   https://docs.nvidia.com/datacenter/cloud-native/ .
+
+root@hostname:/project#
+```
+
+Inspect the directory structure using the `ls` command. You should see that the
+`eval.py` script is there:
+
+```console
+root@hostname:/project# ls
+Dockerfile  README.md  build.py  eval.py  mnist_model.tar.gz
+```
+
+For development and testing, you can mount the current directory, to run the
+code inside the Docker image as you change the script:
+
+```console
+$ docker run --tty --interactive --rm \
+  --volume=$PWD:/workspace \
+  --network=host \
+  mnist-eval bash
+```
+
+```console
+root@hostname:/project# ls /workspace
+Dockerfile  README.md  build.py  eval.py
+```
+
+## Running the evaluation
+
+Inside the Docker image, we can run the following command to run the evaluation
+script on the model:
+
+```bash
+tar -xzvf /project/mnist_model.tar.gz mnist-model --no-same-owner
+python3 eval.py mnist-model/
+```
+
+The first command is needed because currently the model is downloaded and
+embedded in the Docker image as a tar file. We need to decompress it before
+using it with the `eval` script.
+
+## Building the model
+
+Similarly, you can use the following command to train the model, and save it in
+the given path:
+
+```bash
+python3 build.py mnist-model/
+```
+
+You can then compress the model into a tar file, and upload it to a storage, for
+instance [Ent](https://github.com/google/ent), for future use:
+
+```bash
+tar -czvf mnist_model.tar.gz mnist-model/
+```
+
+Note that uploading to Ent requires and API key that you need to acquire out of
+band. You also need to install the Ent client and configure it. For more info,
+see
+[how it is done on Oak CI](https://github.com/project-oak/oak/blob/b25da5436345fb7e1539730d0a55e0d7b2a43768/.github/workflows/reusable_provenance.yaml#L76-L95).
+
+Once you have the Ent client, installed and configured, you can use the
+following command to upload the tar file:
+
+```bash
+./ent put mnist_model.tar.gz
+```
+
+The command returns the digest of the file, which you can use for downloading
+the file from Ent.

--- a/oak_ml_transparency/mnist/build.py
+++ b/oak_ml_transparency/mnist/build.py
@@ -1,0 +1,51 @@
+# Train an example model using the instructions in https://www.tensorflow.org/tutorials/keras/save_and_load and https://www.tensorflow.org/guide/keras/serialization_and_saving.
+import os
+import sys
+
+import tensorflow as tf
+from tensorflow import keras
+import keras as k
+
+if len(sys.argv) < 2:
+    exit("path to the mnist model is not given")
+
+saved_model_path = sys.argv[1]
+
+# Load the dataset
+(train_images, train_labels), (test_images, test_labels) = keras.datasets.mnist.load_data()
+
+train_labels = train_labels[:1000]
+test_labels = test_labels[:1000]
+
+train_images = train_images[:1000].reshape(-1, 28 * 28) / 255.0
+test_images = test_images[:1000].reshape(-1, 28 * 28) / 255.0
+
+# Define a simple sequential model
+def create_model():
+    inputs = keras.Input(shape=(784,))
+    layer1 = keras.layers.Dense(512, activation='relu')(inputs)
+    layer2 = keras.layers.Dropout(0.2)(layer1)
+    outputs = keras.layers.Dense(10)(layer2)
+
+    model = keras.Model(inputs, outputs)
+    model.compile(optimizer='adam',
+                loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+                metrics=[keras.metrics.SparseCategoricalAccuracy()])
+    
+    return model
+
+# Create a basic model instance
+model = create_model()
+
+# Display the model's architecture
+model.summary()
+
+# Train the model
+model.fit(train_images, 
+          train_labels,  
+          epochs=10,
+          validation_data=(test_images, test_labels)
+          ) 
+
+print(f"Training completed; saving the model in {saved_model_path}...")
+model.save(saved_model_path)

--- a/oak_ml_transparency/mnist/eval.py
+++ b/oak_ml_transparency/mnist/eval.py
@@ -1,0 +1,57 @@
+import sys
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import keras
+
+from cleverhans.tf2.attacks.fast_gradient_method import fast_gradient_method
+from cleverhans.tf2.attacks.projected_gradient_descent import projected_gradient_descent
+
+EPS = 0.01
+
+if len(sys.argv) < 2:
+    exit("path to the mnist model is not given")
+
+mnist_path = sys.argv[1]
+
+# Load the mnist model
+mnist_model = keras.models.load_model(mnist_path)
+print("Successfully loaded the model from", mnist_path)
+
+# Load some dataset to use as input to the model and for generating adversarial examples.
+(train_images, train_labels), (test_images, test_labels) = tf.keras.datasets.mnist.load_data()
+test_images = test_images[:10].reshape(-1, 28 * 28) / 255.0
+
+print("Input shape: ", test_images.shape)
+out = mnist_model.predict(test_images)
+
+# Generate adversarial examples from the input data, and get predictions for them. 
+# Based on https://github.com/cleverhans-lab/cleverhans/blob/master/tutorials/jax/mnist_tutorial.py
+
+y_pred_fgm = []
+y_pred_pgd = []
+
+for i in range(10):
+    x = test_images[i:i+1]
+    y = test_labels[i:i+1]
+    x_fgm = fast_gradient_method(mnist_model, x, EPS, np.inf)
+    y_pred_fgm.append(mnist_model(x_fgm).numpy()[0])
+
+    x_pgd = projected_gradient_descent(mnist_model, x, EPS, 0.01, 40, np.inf)
+    y_pred_pgd.append(mnist_model(x_pgd).numpy()[0])
+
+# Compute accuracy
+metric = tf.keras.metrics.SparseCategoricalAccuracy()
+metric.update_state(test_labels[:10], out)
+acc = metric.result().numpy() * 100
+print(f"Accuracy on test:{acc:54.2f}%")
+
+metric.reset_state()
+metric.update_state(test_labels[:10], y_pred_fgm)
+acc = metric.result().numpy() * 100
+print(f"Accuracy on adversarial examples from fast gradient method:{acc:12.2f}%")
+
+metric.reset_state()
+metric.update_state(test_labels[:10], y_pred_pgd)
+acc = metric.result().numpy() * 100
+print(f"Accuracy on adversarial examples from projected gradient descent:{acc:6.2f}%")


### PR DESCRIPTION
This is the first step for an ML transparency demo.

Remaining work:
- Add CI steps to make sure the code here continues to work
- The eval script currently only prints out the accuracy, but it should be wrapped into a claim, and be signed and stored. A trusted runner will be responsible for doing this. The runner will be added in future PRs. As part of this we should also clarify the API for calling the evaluation script.