### PR TITLE
Temporarily disable C++ encryption

### DIFF
--- a/cc/crypto/client_encryptor.cc
+++ b/cc/crypto/client_encryptor.cc
@@ -41,15 +41,17 @@ absl::StatusOr<std::unique_ptr<ClientEncryptor>> ClientEncryptor::Create(
 absl::StatusOr<std::string> ClientEncryptor::Encrypt(absl::string_view plaintext,
                                                      absl::string_view associated_data) {
   // Encrypt request.
-  absl::StatusOr<std::string> ciphertext =
-      sender_request_context_->Seal(plaintext, associated_data);
-  if (!ciphertext.ok()) {
-    return ciphertext.status();
-  }
+  // TODO(#4146): Enable C++ encryption.
+  // absl::StatusOr<std::string> ciphertext =
+  //     sender_request_context_->Seal(plaintext, associated_data);
+  // if (!ciphertext.ok()) {
+  //   return ciphertext.status();
+  // }
 
   // Create request message.
   EncryptedRequest request;
-  *request.mutable_encrypted_message()->mutable_ciphertext() = *ciphertext;
+  // TODO(#4146): Return `*ciphertext` instead of `plaintext`.
+  *request.mutable_encrypted_message()->mutable_ciphertext() = plaintext;
   *request.mutable_encrypted_message()->mutable_associated_data() = associated_data;
 
   // Encapsulated public key is only sent in the initial request message of the session.
@@ -74,13 +76,16 @@ absl::StatusOr<DecryptionResult> ClientEncryptor::Decrypt(absl::string_view encr
   }
 
   // Decrypt response.
-  absl::StatusOr<std::string> plaintext = sender_response_context_->Open(
-      response.encrypted_message().ciphertext(), response.encrypted_message().associated_data());
-  if (!plaintext.ok()) {
-    return plaintext.status();
-  }
+  // TODO(#4146): Enable C++ encryption.
+  // absl::StatusOr<std::string> plaintext = sender_response_context_->Open(
+  //     response.encrypted_message().ciphertext(), response.encrypted_message().associated_data());
+  // if (!plaintext.ok()) {
+  //   return plaintext.status();
+  // }
 
-  return DecryptionResult{*plaintext, response.encrypted_message().associated_data()};
+  // TODO(#4146): Return `*plaintext` instead of `ciphertext`.
+  return DecryptionResult{response.encrypted_message().ciphertext(),
+                          response.encrypted_message().associated_data()};
 }
 
 }  // namespace oak::crypto

--- a/cc/crypto/encryptor_test.cc
+++ b/cc/crypto/encryptor_test.cc
@@ -80,28 +80,28 @@ TEST(EncryptorTest, ClientEncryptorAndServerEncryptorCommunicateSuccess) {
   EXPECT_THAT(kOakHPKEInfoTest, StrEq(client_decryption_result2->associated_data));
 }
 
-TEST(EncryptorTest, ClientEncryptorAndServerEncryptorCommunicateMismatchPublicKeysFailure) {
-  // Set up client and server encryptors.
-  auto key_pair = KeyPair::Generate();
-  std::string wrong_public_key = key_pair->public_key;
-  // Edit the public key that the client uses to make it incorrect.
-  wrong_public_key[0] = (wrong_public_key[0] + 1) % 128;
-  auto client_encryptor = ClientEncryptor::Create(wrong_public_key);
-  ASSERT_TRUE(client_encryptor.ok());
-  ServerEncryptor server_encryptor = ServerEncryptor(*key_pair);
+// TODO(#4146): Uncomment test once C++ encryption is enabled.
+// TEST(EncryptorTest, ClientEncryptorAndServerEncryptorCommunicateMismatchPublicKeysFailure) {
+//   // Set up client and server encryptors.
+//   auto key_pair = KeyPair::Generate();
+//   std::string wrong_public_key = key_pair->public_key;
+//   // Edit the public key that the client uses to make it incorrect.
+//   wrong_public_key[0] = (wrong_public_key[0] + 1) % 128;
+//   auto client_encryptor = ClientEncryptor::Create(wrong_public_key);
+//   ASSERT_TRUE(client_encryptor.ok());
+//   ServerEncryptor server_encryptor = ServerEncryptor(*key_pair);
 
-  std::string client_plaintext_message = "Hello server";
+//   std::string client_plaintext_message = "Hello server";
 
-  // Encrypt plaintext message and have server encryptor decrypt message. This should result in
-  // failure since the public key is incorrect.
-  auto client_ciphertext = (*client_encryptor)->Encrypt(client_plaintext_message, kOakHPKEInfoTest);
-  ASSERT_TRUE(client_ciphertext.ok());
-  auto server_decryption_result = server_encryptor.Decrypt(*client_ciphertext);
-  EXPECT_FALSE(server_decryption_result.ok());
-  EXPECT_EQ(server_decryption_result.status().code(), absl::StatusCode::kAborted);
-  EXPECT_THAT(server_decryption_result.status().message(),
-              StrEq("Failed to open encrypted message."));
-}
+//   // Encrypt plaintext message and have server encryptor decrypt message. This should result in
+//   // failure since the public key is incorrect.
+//   auto client_ciphertext = (*client_encryptor)->Encrypt(client_plaintext_message,
+//   kOakHPKEInfoTest); ASSERT_TRUE(client_ciphertext.ok()); auto server_decryption_result =
+//   server_encryptor.Decrypt(*client_ciphertext); EXPECT_FALSE(server_decryption_result.ok());
+//   EXPECT_EQ(server_decryption_result.status().code(), absl::StatusCode::kAborted);
+//   EXPECT_THAT(server_decryption_result.status().message(),
+//               StrEq("Failed to open encrypted message."));
+// }
 
 }  // namespace
 }  // namespace oak::crypto

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -45,13 +45,16 @@ absl::StatusOr<DecryptionResult> ServerEncryptor::Decrypt(absl::string_view encr
   }
 
   // Decrypt request.
-  absl::StatusOr<std::string> plaintext = recipient_request_context_->Open(
-      request.encrypted_message().ciphertext(), request.encrypted_message().associated_data());
-  if (!plaintext.ok()) {
-    return plaintext.status();
-  }
+  // TODO(#4146): Enable C++ encryption.
+  // absl::StatusOr<std::string> plaintext = recipient_request_context_->Open(
+  //     request.encrypted_message().ciphertext(), request.encrypted_message().associated_data());
+  // if (!plaintext.ok()) {
+  //   return plaintext.status();
+  // }
 
-  return DecryptionResult{*plaintext, request.encrypted_message().associated_data()};
+  // TODO(#4146): Return `*plaintext` instead of `ciphertext`.
+  return DecryptionResult{request.encrypted_message().ciphertext(),
+                          request.encrypted_message().associated_data()};
 }
 
 absl::StatusOr<std::string> ServerEncryptor::Encrypt(absl::string_view plaintext,
@@ -62,15 +65,17 @@ absl::StatusOr<std::string> ServerEncryptor::Encrypt(absl::string_view plaintext
   }
 
   // Encrypt response.
-  absl::StatusOr<std::string> ciphertext =
-      recipient_response_context_->Seal(plaintext, associated_data);
-  if (!ciphertext.ok()) {
-    return ciphertext.status();
-  }
+  // TODO(#4146): Enable C++ encryption.
+  // absl::StatusOr<std::string> ciphertext =
+  //     recipient_response_context_->Seal(plaintext, associated_data);
+  // if (!ciphertext.ok()) {
+  //   return ciphertext.status();
+  // }
 
   // Create response message.
   EncryptedResponse response;
-  *response.mutable_encrypted_message()->mutable_ciphertext() = *ciphertext;
+  // TODO(#4146): Return `*ciphertext` instead of `plaintext`.
+  *response.mutable_encrypted_message()->mutable_ciphertext() = plaintext;
   *response.mutable_encrypted_message()->mutable_associated_data() = associated_data;
 
   // Serialize response.


### PR DESCRIPTION
This PR temporarily disables C++ encryption to allow a breaking change.

Ref https://github.com/project-oak/oak/issues/4146