### PR TITLE
Vet zerocopy 0.6.1 as "safe-to-deploy"

### DIFF
--- a/stage0_bin/supply-chain/audits.toml
+++ b/stage0_bin/supply-chain/audits.toml
@@ -126,6 +126,16 @@ safety. The unsafe blocks in the code are tiny and usually cover one or two line
 The crate does not implement any cryptograhic algorithms.
 """
 
+[[audits.zerocopy]]
+who = "Conrad Grobler <grobler@google.com>"
+criteria = ["safe-to-deploy", "does-not-implement-crypto"]
+version = "0.6.1"
+notes = """
+There is a lot of unsafe code, but it is well documented and the reasoning about soundness in the comments is clear and logical.
+
+This crate does not implement any cryptographic algorithms.
+"""
+
 [[audits.zerocopy-derive]]
 who = "Andri Saar <andrisaar@google.com>"
 criteria = ["safe-to-deploy", "does-not-implement-crypto"]

--- a/stage0_bin/supply-chain/config.toml
+++ b/stage0_bin/supply-chain/config.toml
@@ -2,7 +2,7 @@
 # cargo-vet config file
 
 [cargo-vet]
-version = "0.6"
+version = "0.8"
 
 [imports.google]
 url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"

--- a/stage0_bin/supply-chain/imports.lock
+++ b/stage0_bin/supply-chain/imports.lock
@@ -67,7 +67,7 @@ aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust
 [[audits.mozilla.wildcard-audits.unicode-xid]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 1139
+user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
 end = "2024-05-03"
 notes = "All code written or reviewed by Manish"


### PR DESCRIPTION
Reveiwed from https://sourcegraph.com/crates/zerocopy@v0.6.1

Fixes #3974