### PR TITLE
Build the trusted app as a standalone binary

### DIFF
--- a/oak_containers_hello_world_container/build_container_bundle
+++ b/oak_containers_hello_world_container/build_container_bundle
@@ -6,7 +6,7 @@
 
 rm -rf ./target
 mkdir -p ./target
-cargo build --package="oak_containers_hello_world_trusted_app" -Z unstable-options --out-dir="./target/"
+cargo build --package="oak_containers_hello_world_trusted_app" --target="x86_64-unknown-linux-musl" -Z unstable-options --out-dir="./target/"
 docker build --tag="oak_container_example" .
 mkdir -p ./target/oci_filesystem_bundle
 docker export --output="./target/oak_container_example_rootfs.tar" "$(docker create oak_container_example)"


### PR DESCRIPTION
Previously it was dynamically linked and failed to run with a very mysterious "Err(Os { code: 2, kind: NotFound, message: "No such file or directory" })" on main. 

Debugging this took me a while, hoping to get the E2E CI test (#4150) running soon, so we can prevent changes that would break functionality going forward. 