### PR TITLE
Add C++ gRPC client to the Oak Functions integration test

### DIFF
--- a/cc/client/grpc_client_cli.cc
+++ b/cc/client/grpc_client_cli.cc
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
   // Create Oak Client.
   LOG(INFO) << "creating Oak Client";
   std::unique_ptr<GrpcStreamingTransport> transport = std::make_unique<GrpcStreamingTransport>(
-      GrpcStreamingTransport(std::move(channel_reader_writer)));
+      std::move(channel_reader_writer));
   InsecureAttestationVerifier verifier = InsecureAttestationVerifier();
   absl::StatusOr<std::unique_ptr<OakClient>> oak_client =
       OakClient::Create(std::move(transport), verifier);

--- a/cc/client/grpc_client_cli.cc
+++ b/cc/client/grpc_client_cli.cc
@@ -61,8 +61,8 @@ int main(int argc, char* argv[]) {
 
   // Create Oak Client.
   LOG(INFO) << "creating Oak Client";
-  std::unique_ptr<GrpcStreamingTransport> transport = std::make_unique<GrpcStreamingTransport>(
-      std::move(channel_reader_writer));
+  std::unique_ptr<GrpcStreamingTransport> transport =
+      std::make_unique<GrpcStreamingTransport>(std::move(channel_reader_writer));
   InsecureAttestationVerifier verifier = InsecureAttestationVerifier();
   absl::StatusOr<std::unique_ptr<OakClient>> oak_client =
       OakClient::Create(std::move(transport), verifier);

--- a/cc/transport/BUILD
+++ b/cc/transport/BUILD
@@ -31,6 +31,7 @@ cc_library(
 
 cc_library(
     name = "grpc_streaming_transport",
+    srcs = ["grpc_streaming_transport.cc"],
     hdrs = ["grpc_streaming_transport.h"],
     deps = [
         ":transport",
@@ -38,6 +39,7 @@ cc_library(
         "//oak_remote_attestation/proto/v1:service_streaming_cc_grpc",
         "//oak_remote_attestation/proto/v1:service_streaming_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ],

--- a/cc/transport/BUILD
+++ b/cc/transport/BUILD
@@ -40,6 +40,7 @@ cc_library(
         "//oak_remote_attestation/proto/v1:service_streaming_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ],

--- a/cc/transport/grpc_streaming_transport.cc
+++ b/cc/transport/grpc_streaming_transport.cc
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cc/transport/grpc_streaming_transport.h"
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "grpcpp/channel.h"
+#include "grpcpp/client_context.h"
+#include "grpcpp/create_channel.h"
+#include "grpcpp/grpcpp.h"
+
+namespace oak::transport {
+
+namespace {
+using ::oak::session::v1::AttestationBundle;
+using ::oak::session::v1::GetPublicKeyRequest;
+using ::oak::session::v1::InvokeRequest;
+using ::oak::session::v1::RequestWrapper;
+using ::oak::session::v1::ResponseWrapper;
+}  // namespace
+
+absl::StatusOr<AttestationBundle> GrpcStreamingTransport::GetEvidence() {
+  // Create request.
+  RequestWrapper request;
+  GetPublicKeyRequest get_public_key_request;
+  *request.mutable_get_public_key_request() = get_public_key_request;
+
+  // Send request.
+  auto response = Send(request);
+  if (!response.ok()) {
+    return response.status();
+  }
+
+  // Process response.
+  switch (response->response_case()) {
+    case ResponseWrapper::kGetPublicKeyResponseFieldNumber:
+      return response->get_public_key_response().attestation_bundle();
+    case ResponseWrapper::kInvokeResponseFieldNumber:
+      return absl::InternalError("received InvokeResponse instead of GetPublicKeyResponse");
+    case ResponseWrapper::RESPONSE_NOT_SET:
+    default:
+      return absl::InternalError("received unsupported response: " + response->DebugString());
+  }
+}
+
+absl::StatusOr<std::string> GrpcStreamingTransport::Invoke(absl::string_view request_bytes) {
+  // Create request.
+  RequestWrapper request;
+  InvokeRequest* invoke_request = request.mutable_invoke_request();
+  invoke_request->set_encrypted_body(request_bytes);
+
+  // Send request.
+  auto response = Send(request);
+  if (!response.ok()) {
+    return response.status();
+  }
+
+  // Process response.
+  switch (response->response_case()) {
+    case ResponseWrapper::kGetPublicKeyResponseFieldNumber:
+      return absl::InternalError("received GetPublicKeyResponse instead of InvokeResponse");
+    case ResponseWrapper::kInvokeResponseFieldNumber:
+      return response->invoke_response().encrypted_body();
+    case ResponseWrapper::RESPONSE_NOT_SET:
+    default:
+      return absl::InternalError("received unsupported response: " + response->DebugString());
+  }
+}
+
+GrpcStreamingTransport::~GrpcStreamingTransport() {
+  absl::Status status = Close();
+  if (!status.ok()) {
+    LOG(WARNING) << "couldn't stop gRPC stream: " << status.message();
+  }
+}
+
+absl::StatusOr<ResponseWrapper> GrpcStreamingTransport::Send(const RequestWrapper& request) {
+  // Send a request.
+  if (!channel_reader_writer_->Write(request)) {
+    return absl::InternalError("couldn't send request");
+  }
+
+  // Receive a response.
+  ResponseWrapper response;
+  if (!channel_reader_writer_->Read(&response)) {
+    return absl::InternalError("couldn't receive response");
+  }
+  return response;
+}
+
+absl::Status GrpcStreamingTransport::Close() {
+  if (!channel_reader_writer_->WritesDone()) {
+    return absl::InternalError("couldn't close writing stream");
+  }
+  ::grpc::Status status = channel_reader_writer_->Finish();
+  if (!status.ok()) {
+    return absl::InternalError("couldn't close reading stream: " + status.error_message());
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace oak::transport

--- a/cc/transport/grpc_streaming_transport.h
+++ b/cc/transport/grpc_streaming_transport.h
@@ -88,19 +88,6 @@ class GrpcStreamingTransport : public TransportWrapper {
     }
   }
 
-  // // Disable move.
-  // GrpcStreamingTransport(GrpcStreamingTransport&& other) = delete;
-  // GrpcStreamingTransport& operator=(GrpcStreamingTransport&& other) = delete;
-
-  // // Disable copy.
-  // GrpcStreamingTransport(const GrpcStreamingTransport&) = delete;
-  // GrpcStreamingTransport& operator=(const GrpcStreamingTransport&) = delete;
-
-  // ~GrpcStreamingTransport() override {
-  //   // channel_reader_writer_->WritesDone();
-  //   // ::grpc::Status status = channel_reader_writer_->Finish();
-  // }
-
  private:
   std::unique_ptr<::grpc::ClientReaderWriter<::oak::session::v1::RequestWrapper,
                                              ::oak::session::v1::ResponseWrapper>>
@@ -112,22 +99,13 @@ class GrpcStreamingTransport : public TransportWrapper {
     if (!channel_reader_writer_->Write(request)) {
       return absl::InternalError("couldn't send request");
     }
-    // if (!channel_reader_writer_->WritesDone()) {
-    //   return absl::InternalError("couldn't notify the backend that request has been sent");
-    // }
 
     // Receive a response.
     ::oak::session::v1::ResponseWrapper response;
     if (!channel_reader_writer_->Read(&response)) {
       return absl::InternalError("couldn't receive response");
     }
-
-    // ::grpc::Status status = channel_reader_writer_->Finish();
-    // if (status.ok()) {
-    //   return response;
-    // } else {
-    //   return absl::InternalError("couldn't receive response: " + status.error_message());
-    // }
+    return response;
   }
 };
 

--- a/cc/transport/transport.h
+++ b/cc/transport/transport.h
@@ -44,10 +44,7 @@ class Transport {
 };
 
 // Wrapper for `EvidenceProvider` and `Transport` abstract classes.
-class TransportWrapper : public EvidenceProvider, public Transport {
- public:
-  virtual ~TransportWrapper() = default;
-};
+class TransportWrapper : public EvidenceProvider, public Transport {};
 
 }  // namespace oak::transport
 

--- a/cc/transport/transport.h
+++ b/cc/transport/transport.h
@@ -44,7 +44,10 @@ class Transport {
 };
 
 // Wrapper for `EvidenceProvider` and `Transport` abstract classes.
-class TransportWrapper : public EvidenceProvider, public Transport {};
+class TransportWrapper : public EvidenceProvider, public Transport {
+ public:
+  virtual ~TransportWrapper() = default;
+};
 
 }  // namespace oak::transport
 

--- a/cc/transport/transport.h
+++ b/cc/transport/transport.h
@@ -28,7 +28,7 @@ namespace oak::transport {
 // Abstract class for providing an enclave evidence.
 class EvidenceProvider {
  public:
-  // virtual ~EvidenceProvider() = default;
+  virtual ~EvidenceProvider() = default;
 
   // Returns evidence about the trustworthiness of a remote server.
   virtual absl::StatusOr<::oak::session::v1::AttestationBundle> GetEvidence() = 0;
@@ -37,7 +37,7 @@ class EvidenceProvider {
 // Abstract class for sending messages to the enclave.
 class Transport {
  public:
-  // virtual ~Transport() = default;
+  virtual ~Transport() = default;
 
   // Sends a request to the enclave and returns a response.
   virtual absl::StatusOr<std::string> Invoke(absl::string_view request_bytes) = 0;
@@ -46,8 +46,7 @@ class Transport {
 // Wrapper for `EvidenceProvider` and `Transport` abstract classes.
 class TransportWrapper : public EvidenceProvider, public Transport {
  public:
-  // virtual ~TransportWrapper() = default;
-
+  virtual ~TransportWrapper() = default;
 };
 
 }  // namespace oak::transport

--- a/cc/transport/transport.h
+++ b/cc/transport/transport.h
@@ -28,7 +28,7 @@ namespace oak::transport {
 // Abstract class for providing an enclave evidence.
 class EvidenceProvider {
  public:
-  virtual ~EvidenceProvider() = default;
+  // virtual ~EvidenceProvider() = default;
 
   // Returns evidence about the trustworthiness of a remote server.
   virtual absl::StatusOr<::oak::session::v1::AttestationBundle> GetEvidence() = 0;
@@ -37,14 +37,18 @@ class EvidenceProvider {
 // Abstract class for sending messages to the enclave.
 class Transport {
  public:
-  virtual ~Transport() = default;
+  // virtual ~Transport() = default;
 
   // Sends a request to the enclave and returns a response.
   virtual absl::StatusOr<std::string> Invoke(absl::string_view request_bytes) = 0;
 };
 
 // Wrapper for `EvidenceProvider` and `Transport` abstract classes.
-class TransportWrapper : public EvidenceProvider, public Transport {};
+class TransportWrapper : public EvidenceProvider, public Transport {
+ public:
+  // virtual ~TransportWrapper() = default;
+
+};
 
 }  // namespace oak::transport
 

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -113,40 +113,42 @@ async fn test_launcher_weather_lookup_virtual() {
     // Wait for the server to start up.
     tokio::time::sleep(Duration::from_secs(20)).await;
 
-    let mut client = OakFunctionsClient::new(&format!("http://localhost:{port}"))
-        .await
-        .expect("failed to create client");
+    // let mut client = OakFunctionsClient::new(&format!("http://localhost:{port}"))
+    //     .await
+    //     .expect("failed to create client");
 
-    let response = client
-        .invoke(br#"{"lat":0,"lng":0}"#)
-        .await
-        .expect("failed to invoke");
-    assert_eq!(
-        std::str::from_utf8(&response).unwrap(),
-        r#"{"temperature_degrees_celsius":29}"#
-    );
+    // let response = client
+    //     .invoke(br#"{"lat":0,"lng":0}"#)
+    //     .await
+    //     .expect("failed to invoke");
+    // assert_eq!(
+    //     std::str::from_utf8(&response).unwrap(),
+    //     r#"{"temperature_degrees_celsius":29}"#
+    // );
 
-    // Run Java client via Bazel.
-    let status = tokio::process::Command::new("bazel")
-        .arg("run")
-        .arg("//java/src/main/java/com/google/oak/client/weather_lookup_client")
-        .arg("--")
-        .arg(format!("http://localhost:{port}"))
-        .current_dir(workspace_path(&[]))
-        .spawn()
-        .expect("failed to spawn bazel")
-        .wait()
-        .await
-        .expect("failed to wait for bazel");
-    eprintln!("bazel status: {:?}", status);
-    assert!(status.success());
+    // TODO(#4177): Check response in the integration test.
+    // // Run Java client via Bazel.
+    // let status = tokio::process::Command::new("bazel")
+    //     .arg("run")
+    //     .arg("//java/src/main/java/com/google/oak/client/weather_lookup_client")
+    //     .arg("--")
+    //     .arg(format!("http://localhost:{port}"))
+    //     .current_dir(workspace_path(&[]))
+    //     .spawn()
+    //     .expect("failed to spawn bazel")
+    //     .wait()
+    //     .await
+    //     .expect("failed to wait for bazel");
+    // eprintln!("bazel status: {:?}", status);
+    // assert!(status.success());
 
+    // TODO(#4177): Check response in the integration test.
     // Run C++ client via Bazel.
     let status = tokio::process::Command::new("bazel")
         .arg("run")
         .arg("//cc/client:cli")
         .arg("--")
-        .arg(format!("--address=http://localhost:{port}"))
+        .arg(format!("--address=localhost:{port}"))
         .arg("--request=\'{\"lat\":0,\"lng\":0}\'")
         .current_dir(workspace_path(&[]))
         .spawn()

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -140,6 +140,22 @@ async fn test_launcher_weather_lookup_virtual() {
         .expect("failed to wait for bazel");
     eprintln!("bazel status: {:?}", status);
     assert!(status.success());
+
+    // Run C++ client via Bazel.
+    let status = tokio::process::Command::new("bazel")
+        .arg("run")
+        .arg("//cc/client:cli")
+        .arg("--")
+        .arg(format!("--address=http://localhost:{port}"))
+        .arg("--request=\'{\"lat\":0,\"lng\":0}\'")
+        .current_dir(workspace_path(&[]))
+        .spawn()
+        .expect("failed to spawn bazel")
+        .wait()
+        .await
+        .expect("failed to wait for bazel");
+    eprintln!("bazel status: {:?}", status);
+    assert!(status.success());
 }
 
 #[tokio::test]

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -113,34 +113,34 @@ async fn test_launcher_weather_lookup_virtual() {
     // Wait for the server to start up.
     tokio::time::sleep(Duration::from_secs(20)).await;
 
-    // let mut client = OakFunctionsClient::new(&format!("http://localhost:{port}"))
-    //     .await
-    //     .expect("failed to create client");
+    let mut client = OakFunctionsClient::new(&format!("http://localhost:{port}"))
+        .await
+        .expect("failed to create client");
 
-    // let response = client
-    //     .invoke(br#"{"lat":0,"lng":0}"#)
-    //     .await
-    //     .expect("failed to invoke");
-    // assert_eq!(
-    //     std::str::from_utf8(&response).unwrap(),
-    //     r#"{"temperature_degrees_celsius":29}"#
-    // );
+    let response = client
+        .invoke(br#"{"lat":0,"lng":0}"#)
+        .await
+        .expect("failed to invoke");
+    assert_eq!(
+        std::str::from_utf8(&response).unwrap(),
+        r#"{"temperature_degrees_celsius":29}"#
+    );
 
     // TODO(#4177): Check response in the integration test.
-    // // Run Java client via Bazel.
-    // let status = tokio::process::Command::new("bazel")
-    //     .arg("run")
-    //     .arg("//java/src/main/java/com/google/oak/client/weather_lookup_client")
-    //     .arg("--")
-    //     .arg(format!("http://localhost:{port}"))
-    //     .current_dir(workspace_path(&[]))
-    //     .spawn()
-    //     .expect("failed to spawn bazel")
-    //     .wait()
-    //     .await
-    //     .expect("failed to wait for bazel");
-    // eprintln!("bazel status: {:?}", status);
-    // assert!(status.success());
+    // Run Java client via Bazel.
+    let status = tokio::process::Command::new("bazel")
+        .arg("run")
+        .arg("//java/src/main/java/com/google/oak/client/weather_lookup_client")
+        .arg("--")
+        .arg(format!("http://localhost:{port}"))
+        .current_dir(workspace_path(&[]))
+        .spawn()
+        .expect("failed to spawn bazel")
+        .wait()
+        .await
+        .expect("failed to wait for bazel");
+    eprintln!("bazel status: {:?}", status);
+    assert!(status.success());
 
     // TODO(#4177): Check response in the integration test.
     // Run C++ client via Bazel.
@@ -149,7 +149,7 @@ async fn test_launcher_weather_lookup_virtual() {
         .arg("//cc/client:cli")
         .arg("--")
         .arg(format!("--address=localhost:{port}"))
-        .arg("--request=\'{\"lat\":0,\"lng\":0}\'")
+        .arg("--request={\"lat\":0,\"lng\":0}")
         .current_dir(workspace_path(&[]))
         .spawn()
         .expect("failed to spawn bazel")


### PR DESCRIPTION
This PR makes Oak Functions integration test to run C++ gRPC client CLI.

Fixes https://github.com/project-oak/oak/issues/4069