### PR TITLE
Use a smaller linux distro for the oak containers example

### DIFF
--- a/oak_containers_hello_world_container/Dockerfile
+++ b/oak_containers_hello_world_container/Dockerfile
@@ -1,4 +1,5 @@
-FROM clearlinux:base
+ARG debian_snapshot=sha256:f0b8edb2e4436c556493dce86b941231eead97baebb484d0d5f6ecfe4f7ed193
+FROM debian@${debian_snapshot}
 
 COPY ./target/oak_containers_hello_world_trusted_app /usr/bin/
 


### PR DESCRIPTION
We don't need all of clear linux