### PR TITLE
Store MNIST evaluation result to file and enable CI

### DIFF
--- a/.github/workflows/mnist_eval.yaml
+++ b/.github/workflows/mnist_eval.yaml
@@ -1,0 +1,27 @@
+name: SLSA3 Provenances for MNIST model evaluation
+
+# See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Ref: https://github.com/project-oak/hello-transparent-release/blob/main/.github/workflows/provenance.yaml
+jobs:
+  generate_provenance:
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml@v1.7.0
+    with:
+      builder-image: 'europe-west2-docker.pkg.dev/oak-ci/mnist-eval/mnist-eval'
+      builder-digest: 'sha256:7a0d8fd9d6f6d15d6175ceb442ea1fc96933b7c3368d8eced57048fc97ca39a2'
+      config-path: 'buildconfigs/oak_ml_transparency_eval.toml'
+      provenance-name: 'mnist_eval.intoto'
+      compile-builder: true

--- a/.github/workflows/mnist_eval.yaml
+++ b/.github/workflows/mnist_eval.yaml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
+  workflow_dispatch:
     branches: [main]
   pull_request:
     branches: [main]

--- a/buildconfigs/oak_ml_transparency_eval.toml
+++ b/buildconfigs/oak_ml_transparency_eval.toml
@@ -1,0 +1,11 @@
+command = [
+  "env",
+  "--chdir=oak_ml_transparency/mnist",
+  "python3",
+  "eval.py",
+  "--model",
+  "/project/mnist_model.tar.gz",
+  "--output",
+  "result.json"
+]
+artifact_path = "./oak_ml_transparency/mnist/result.json"

--- a/buildconfigs/oak_ml_transparency_eval.toml
+++ b/buildconfigs/oak_ml_transparency_eval.toml
@@ -3,9 +3,7 @@ command = [
   "--chdir=oak_ml_transparency/mnist",
   "python3",
   "eval.py",
-  "--model",
-  "/project/mnist_model.tar.gz",
-  "--output",
-  "result.json"
+  "--model=/project/mnist_model.tar.gz",
+  "--output=result.json"
 ]
 artifact_path = "./oak_ml_transparency/mnist/result.json"

--- a/oak_ml_transparency/mnist/Dockerfile
+++ b/oak_ml_transparency/mnist/Dockerfile
@@ -17,4 +17,4 @@ WORKDIR /project
 COPY . /project
 
 # Download model
-RUN curl --output mnist_model.tar.gz  https://ent-server-62sa4xcfia-ew.a.run.app/raw/sha256:c79e6ba6f862ecbce61237bd2c46b50ab7d7b843b4b999f2c951ec7decbf2230
+RUN curl --output mnist_model.tar.gz  https://ent-server-62sa4xcfia-ew.a.run.app/raw/sha256:9e3f569f0a791f4223fbb117020c6c4e3e1638c3b1c4a3500dbb9023009c723b

--- a/oak_ml_transparency/mnist/Dockerfile
+++ b/oak_ml_transparency/mnist/Dockerfile
@@ -17,4 +17,4 @@ WORKDIR /project
 COPY . /project
 
 # Download model
-RUN curl --output mnist_model.tar.gz  https://ent-server-62sa4xcfia-ew.a.run.app/raw/sha256:9e3f569f0a791f4223fbb117020c6c4e3e1638c3b1c4a3500dbb9023009c723b
+RUN curl --output mnist_model.tar.gz  https://ent-server-62sa4xcfia-ew.a.run.app/raw/sha256:63ea4a9906dbbb3a154f069a0d4bc6a2272b9b8151e69fbd57029c826c2cd779

--- a/oak_ml_transparency/mnist/README.md
+++ b/oak_ml_transparency/mnist/README.md
@@ -96,7 +96,7 @@ Inside the Docker image, we can run the following command to run the evaluation
 script on the model:
 
 ```bash
-tar -xzvf /project/mnist_model.tar.gz mnist-model --no-same-owner
+tar -xzvf /project/mnist_model.tar.gz --no-same-owner
 python3 eval.py mnist-model/
 ```
 
@@ -113,11 +113,13 @@ the given path:
 python3 build.py mnist-model/
 ```
 
-You can then compress the model into a tar file, and upload it to a storage, for
-instance [Ent](https://github.com/google/ent), for future use:
+You can then archive and compress the model into a tar.gz file, and upload it to
+a storage, for instance [Ent](https://github.com/google/ent), for future use.
+
+To create the archive file use the following command:
 
 ```bash
-tar -czvf mnist_model.tar.gz mnist-model/
+tar --create --gzip --verbose --file mnist_model.tar.gz mnist-model
 ```
 
 Note that uploading to Ent requires and API key that you need to acquire out of

--- a/oak_ml_transparency/mnist/README.md
+++ b/oak_ml_transparency/mnist/README.md
@@ -96,7 +96,7 @@ Inside the Docker image, we can run the following command to run the evaluation
 script on the model:
 
 ```bash
-python3 eval.py --model mnist_model.tar.gz --output result.json
+python3 eval.py --model=mnist_model.tar.gz --output=result.json
 ```
 
 The first command is needed because currently the model is downloaded and

--- a/oak_ml_transparency/mnist/README.md
+++ b/oak_ml_transparency/mnist/README.md
@@ -16,7 +16,7 @@ embed the evaluation script in the Docker image:
 ```dockerfile
 RUN mkdir /project
 WORKDIR /project
-ADD . /project
+COPY . /project
 ```
 
 Ideally, and as is the case in this example, the Dockerfile and the evaluation
@@ -96,8 +96,7 @@ Inside the Docker image, we can run the following command to run the evaluation
 script on the model:
 
 ```bash
-tar -xzvf /project/mnist_model.tar.gz --no-same-owner
-python3 eval.py mnist-model/
+python3 eval.py --model mnist_model.tar.gz --output result.json
 ```
 
 The first command is needed because currently the model is downloaded and
@@ -110,7 +109,7 @@ Similarly, you can use the following command to train the model, and save it in
 the given path:
 
 ```bash
-python3 build.py mnist-model/
+python3 build.py --output mnist-model
 ```
 
 You can then archive and compress the model into a tar.gz file, and upload it to

--- a/oak_ml_transparency/mnist/build.py
+++ b/oak_ml_transparency/mnist/build.py
@@ -40,10 +40,11 @@ def create_model():
 
 def main():
     parser = argparse.ArgumentParser(
-                prog='MNIST build',
-                description='Trains an MNIST model and stores it in the given path')
+        allow_abbrev=False,
+        prog='MNIST build',
+        description='Trains an MNIST model and stores it in the given path')
 
-    parser.add_argument('-o', '--output', help="path to store the model, as a SavedModel format") 
+    parser.add_argument('--output', help="path to store the model, as a SavedModel format") 
 
     args = parser.parse_args()
     saved_model_path = args.output

--- a/oak_ml_transparency/mnist/build.py
+++ b/oak_ml_transparency/mnist/build.py
@@ -1,24 +1,28 @@
-# Train an example model using the instructions in https://www.tensorflow.org/tutorials/keras/save_and_load and https://www.tensorflow.org/guide/keras/serialization_and_saving.
-import os
-import sys
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Train an example model using the instructions in
+# https://www.tensorflow.org/tutorials/keras/save_and_load and
+# https://www.tensorflow.org/guide/keras/serialization_and_saving.
+
+import argparse
 
 import tensorflow as tf
 from tensorflow import keras
 import keras as k
-
-if len(sys.argv) < 2:
-    exit("path to the mnist model is not given")
-
-saved_model_path = sys.argv[1]
-
-# Load the dataset
-(train_images, train_labels), (test_images, test_labels) = keras.datasets.mnist.load_data()
-
-train_labels = train_labels[:1000]
-test_labels = test_labels[:1000]
-
-train_images = train_images[:1000].reshape(-1, 28 * 28) / 255.0
-test_images = test_images[:1000].reshape(-1, 28 * 28) / 255.0
 
 # Define a simple sequential model
 def create_model():
@@ -34,18 +38,40 @@ def create_model():
     
     return model
 
-# Create a basic model instance
-model = create_model()
+def main():
+    parser = argparse.ArgumentParser(
+                prog='MNIST build',
+                description='Trains an MNIST model and stores it in the given path')
 
-# Display the model's architecture
-model.summary()
+    parser.add_argument('-o', '--output', help="path to store the model, as a SavedModel format") 
 
-# Train the model
-model.fit(train_images, 
-          train_labels,  
-          epochs=10,
-          validation_data=(test_images, test_labels)
-          ) 
+    args = parser.parse_args()
+    saved_model_path = args.output
 
-print(f"Training completed; saving the model in {saved_model_path}...")
-model.save(saved_model_path)
+    # Load the dataset
+    (train_images, train_labels), (test_images, test_labels) = keras.datasets.mnist.load_data()
+
+    train_labels = train_labels[:1000]
+    train_images = train_images[:1000].reshape(-1, 28 * 28) / 255.0
+
+    test_labels = test_labels[1000:]
+    test_images = test_images[1000:].reshape(-1, 28 * 28) / 255.0
+
+    # Create a basic model instance
+    model = create_model()
+
+    # Display the model's architecture
+    model.summary()
+
+    # Train the model
+    model.fit(train_images, 
+            train_labels,  
+            epochs=10,
+            validation_data=(test_images, test_labels)
+            ) 
+
+    print(f"Training completed; saving the model in {saved_model_path}...")
+    model.save(saved_model_path)
+
+if __name__ == "__main__":
+    main()

--- a/oak_ml_transparency/mnist/eval.py
+++ b/oak_ml_transparency/mnist/eval.py
@@ -86,11 +86,12 @@ def cleanup_archive(file: tarfile.TarFile):
 
 def main():
     parser = argparse.ArgumentParser(
-                prog='MNIST evaluation',
-                description='Evaluates an MNIST model against adversarial examples')
+        allow_abbrev=False,
+        prog='MNIST evaluation',
+        description='Evaluates an MNIST model against adversarial examples')
 
-    parser.add_argument('-m', '--model', help="the model as a compressed tar archive")
-    parser.add_argument('-o', '--output', help="path to store the evaluation result in") 
+    parser.add_argument('--model', help="the model as a compressed tar archive")
+    parser.add_argument('--output', help="path to store the evaluation result in") 
 
     args = parser.parse_args()
     model_path = args.model

--- a/oak_ml_transparency/mnist/eval.py
+++ b/oak_ml_transparency/mnist/eval.py
@@ -1,4 +1,24 @@
-import sys
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import json
+import os
+import shutil
+import tarfile
 
 import numpy as np
 import tensorflow as tf
@@ -9,49 +29,88 @@ from cleverhans.tf2.attacks.projected_gradient_descent import projected_gradient
 
 EPS = 0.01
 
-if len(sys.argv) < 2:
-    exit("path to the mnist model is not given")
+def evaluate_model(mnist_path: str) -> dict:
+    # Load the mnist model
+    mnist_model = keras.models.load_model(mnist_path)
+    print("Successfully loaded the model from", mnist_path)
 
-mnist_path = sys.argv[1]
+    # Load some dataset to use as input to the model and for generating adversarial examples.
+    (train_images, train_labels), (test_images, test_labels) = tf.keras.datasets.mnist.load_data()
+    test_images = test_images[:10].reshape(-1, 28 * 28) / 255.0
 
-# Load the mnist model
-mnist_model = keras.models.load_model(mnist_path)
-print("Successfully loaded the model from", mnist_path)
+    print("Input shape: ", test_images.shape)
+    out = mnist_model.predict(test_images)
 
-# Load some dataset to use as input to the model and for generating adversarial examples.
-(train_images, train_labels), (test_images, test_labels) = tf.keras.datasets.mnist.load_data()
-test_images = test_images[:10].reshape(-1, 28 * 28) / 255.0
+    # Generate adversarial examples from the input data, and get predictions for them. 
+    # Based on https://github.com/cleverhans-lab/cleverhans/blob/master/tutorials/jax/mnist_tutorial.py
 
-print("Input shape: ", test_images.shape)
-out = mnist_model.predict(test_images)
+    y_pred_fgm = []
+    y_pred_pgd = []
 
-# Generate adversarial examples from the input data, and get predictions for them. 
-# Based on https://github.com/cleverhans-lab/cleverhans/blob/master/tutorials/jax/mnist_tutorial.py
+    for i in range(10):
+        x = test_images[i:i+1]
+        y = test_labels[i:i+1]
+        x_fgm = fast_gradient_method(mnist_model, x, EPS, np.inf)
+        y_pred_fgm.append(mnist_model(x_fgm).numpy()[0])
 
-y_pred_fgm = []
-y_pred_pgd = []
+        x_pgd = projected_gradient_descent(mnist_model, x, EPS, 0.01, 40, np.inf)
+        y_pred_pgd.append(mnist_model(x_pgd).numpy()[0])
 
-for i in range(10):
-    x = test_images[i:i+1]
-    y = test_labels[i:i+1]
-    x_fgm = fast_gradient_method(mnist_model, x, EPS, np.inf)
-    y_pred_fgm.append(mnist_model(x_fgm).numpy()[0])
+    # Compute accuracy
+    metric = tf.keras.metrics.SparseCategoricalAccuracy()
+    metric.update_state(test_labels[:10], out)
+    test_acc = metric.result().numpy() * 100
 
-    x_pgd = projected_gradient_descent(mnist_model, x, EPS, 0.01, 40, np.inf)
-    y_pred_pgd.append(mnist_model(x_pgd).numpy()[0])
+    metric.reset_state()
+    metric.update_state(test_labels[:10], y_pred_fgm)
+    fgm_acc = metric.result().numpy() * 100
 
-# Compute accuracy
-metric = tf.keras.metrics.SparseCategoricalAccuracy()
-metric.update_state(test_labels[:10], out)
-acc = metric.result().numpy() * 100
-print(f"Accuracy on test:{acc:54.2f}%")
+    metric.reset_state()
+    metric.update_state(test_labels[:10], y_pred_pgd)
+    pgd_acc = metric.result().numpy() * 100
+    
+    result = {
+        "test_acc": test_acc,
+        "fgm_acc": fgm_acc,
+        "pgd_acc": pgd_acc
+    }
+    return result
 
-metric.reset_state()
-metric.update_state(test_labels[:10], y_pred_fgm)
-acc = metric.result().numpy() * 100
-print(f"Accuracy on adversarial examples from fast gradient method:{acc:12.2f}%")
+def cleanup_archive(file: tarfile.TarFile):
+    for member in file.getmembers():
+        if os.path.isdir(member.name):
+            shutil.rmtree(member.name, ignore_errors=True)
+        elif os.path.exists(member.name):
+            os.remove(member.name)
+    file.close()
 
-metric.reset_state()
-metric.update_state(test_labels[:10], y_pred_pgd)
-acc = metric.result().numpy() * 100
-print(f"Accuracy on adversarial examples from projected gradient descent:{acc:6.2f}%")
+def main():
+    parser = argparse.ArgumentParser(
+                prog='MNIST evaluation',
+                description='Evaluates an MNIST model against adversarial examples')
+
+    parser.add_argument('-m', '--model', help="the model as a compressed tar archive")
+    parser.add_argument('-o', '--output', help="path to store the evaluation result in") 
+
+    args = parser.parse_args()
+    model_path = args.model
+    output_path = args.output
+    
+    # Load the tar archive and decompress in the current working directory.
+    file = tarfile.open(model_path)
+    mnist_path = file.getmembers()[0].name
+    file.extractall()
+
+    result = evaluate_model(mnist_path)
+    cleanup_archive(file)
+     
+    # Serialize as json
+    json_object = json.dumps(result, indent=4)
+    
+    # Write to file at the given output path
+    with open(output_path, "w") as outfile:
+        outfile.write(json_object)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR:
- Updates the build.py and eval.py scripts for MNIST, and stores the result of the evaluation in an output file. 
- Enables CI for MNIST eval, and generates SLSA3 provenances for the result of the evaluation, on pull-request and workflow-dispatch (manual) events.

To be able to use the SLSA builder, I had to push the Docker image available in a registry. 
Roughly, I did the following steps (inspired by `scripts/docker_push`)

1. Build the image: `docker build -t europe-west2-docker.pkg.dev/oak-ci/mnist-eval/mnist-eval:latest .`
2. Push the image: `docker push europe-west2-docker.pkg.dev/oak-ci/mnist-eval/mnist-eval:latest`
3. Make the `mnist-eval` repository on artifact registry public. This is needed for GitHub Actions to be able to access the image.