### PR TITLE
Add support for booting a bzImage Linux Kernel

### DIFF
--- a/linux_boot_params/src/lib.rs
+++ b/linux_boot_params/src/lib.rs
@@ -143,7 +143,7 @@ impl CCSetupData {
 /// For more details see the Linux kernel docs:
 /// <https://www.kernel.org/doc/html/latest/x86/boot.html#the-real-mode-kernel-header>
 #[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, FromBytes, AsBytes)]
 pub struct SetupHeader {
     /// The size of the setup code in 512-byte sectors.
     ///
@@ -254,7 +254,7 @@ pub struct SetupHeader {
     /// Boot protocol option flags
     ///
     /// Type: modify (obligatory)
-    pub loadflags: LoadFlags,
+    pub loadflags: u8,
     /// Move to high memory size (used with hooks)
     ///
     /// Type: modify (obligatory)
@@ -389,7 +389,7 @@ pub struct SetupHeader {
     /// Boot protocol option flags
     ///
     /// Type: read
-    pub xloadflags: XLoadFlags,
+    pub xloadflags: u16,
     /// Maximum size of the kernel command line
     ///
     /// Type: read
@@ -440,7 +440,7 @@ pub struct SetupHeader {
     ///
     /// The 64-bit physical pointer to NULL terminated single linked list of struct setup_data.
     /// This is used to define a more extensible boot parameters passing mechanism.
-    pub setup_data: *const SetupData,
+    pub setup_data: u64,
     /// Preferred loading address
     ///
     /// Type: read (reloc)
@@ -477,6 +477,20 @@ pub struct SetupHeader {
     pub kernel_info_offset: u32,
 }
 static_assertions::assert_eq_size!(SetupHeader, [u8; 123usize]);
+
+impl SetupHeader {
+    pub fn setup_data(&self) -> *const SetupData {
+        self.setup_data as *const SetupData
+    }
+
+    pub fn load_flags(&self) -> Option<LoadFlags> {
+        LoadFlags::from_bits(self.loadflags)
+    }
+
+    pub fn x_load_flags(&self) -> Option<XLoadFlags> {
+        XLoadFlags::from_bits(self.xloadflags)
+    }
+}
 
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone, FromBytes, AsBytes)]

--- a/oak_restricted_kernel/src/snp.rs
+++ b/oak_restricted_kernel/src/snp.rs
@@ -63,7 +63,7 @@ pub fn get_snp_page_addresses(info: &BootParams) -> SnpPageAddresses {
     assert_page_in_valid_range(phys);
     // The setup data is stored in a null-terminated linked list, so we step through the list until
     // we find an entry with the right type or reach the end.
-    let mut setup_data_ptr = info.hdr.setup_data;
+    let mut setup_data_ptr = info.hdr.setup_data();
     while !setup_data_ptr.is_null() {
         assert_pointer_in_valid_range(setup_data_ptr);
         // Safety: we have checked that the pointer is not null and at least points to memory within

--- a/stage0/src/initramfs.rs
+++ b/stage0/src/initramfs.rs
@@ -32,8 +32,10 @@ pub fn try_load_initial_ram_disk(
     e820_table: &[BootE820Entry],
     kernel_info: &KernelInfo,
 ) -> Option<&'static [u8]> {
-    let path = CStr::from_bytes_with_nul(INITIAL_RAM_DISK_FILE_PATH).expect("invalid c-string");
-    let file = fw_cfg.find(path)?;
+    let file = fw_cfg.get_initrd_file().or_else(|| {
+        let path = CStr::from_bytes_with_nul(INITIAL_RAM_DISK_FILE_PATH).expect("invalid c-string");
+        fw_cfg.find(path)
+    })?;
     let size = file.size();
     let initrd_address =
         find_suitable_dma_address(size, e820_table).expect("no suitable DMA address available");

--- a/stage0/src/kernel.rs
+++ b/stage0/src/kernel.rs
@@ -24,7 +24,7 @@ use oak_linux_boot_params::BootE820Entry;
 use x86_64::{PhysAddr, VirtAddr};
 
 /// The default start location and entry point for the kernel if a kernel wasn't supplied via the
-/// QEMU fw_cfg device.
+/// QEMU fw_cfg device. This is also used for the default location when loading a compressed kernel.
 const DEFAULT_KERNEL_START: u64 = 0x200000;
 
 /// The default size for the kernel if a kernel wasn't supplied via the QEMU fw_cfg device.
@@ -55,18 +55,29 @@ impl Default for KernelInfo {
     }
 }
 
+/// Tries to load the kernel command-line from the fw_cfg device.
+///
+/// We first try to read it using the traditional selector. If it is not available there we try to
+/// read it using a custom file path.
 pub fn try_load_cmdline(fw_cfg: &mut FwCfg) -> Option<&'static CStr> {
-    let cmdline_path = CStr::from_bytes_with_nul(CMDLINE_FILE_PATH).expect("invalid c-string");
-    let cmdline_file = fw_cfg.find(cmdline_path)?;
+    let (cmdline_file, buffer_size) = if let Some(cmdline_file) = fw_cfg.get_cmdline_file() {
+        // The provided value is already null-terminated.
+        let size = cmdline_file.size() as usize;
+        (cmdline_file, size)
+    } else {
+        let cmdline_path = CStr::from_bytes_with_nul(CMDLINE_FILE_PATH).expect("invalid c-string");
+        let cmdline_file = fw_cfg.find(cmdline_path)?;
+        // Make the buffer one byte longer so that the kernel command-line is null-terminated.
+        let size = cmdline_file.size() as usize + 1;
+        (cmdline_file, size)
+    };
     let cmdline_size = cmdline_file.size();
-    // Make the buffer one byte longer so that the kernel command-line is null-terminated.
     // Safety: len will always be at least 1 byte, and we don't care about alignment. If the
     // allocation fails, we won't try coercing it into a slice.
     let buf = unsafe {
-        let len = cmdline_size + 1;
         NonNull::slice_from_raw_parts(
-            BOOT_ALLOC.allocate(Layout::from_size_align(len, 1).unwrap())?,
-            len,
+            BOOT_ALLOC.allocate(Layout::from_size_align(buffer_size, 1).unwrap())?,
+            buffer_size,
         )
         .as_mut()
     };
@@ -88,22 +99,33 @@ pub fn try_load_cmdline(fw_cfg: &mut FwCfg) -> Option<&'static CStr> {
 
 /// Tries to load a kernel image from the QEMU fw_cfg device.
 ///
-/// We expect the kernel to be available with a filename of "opt/stage0/elf_kernel". We only support
-/// uncompressed ELF kernels at the moment.
+/// We assume that a kernel file provided via the traditional seletor is a compressed kernel using
+/// the bzImage format. We assume that a kernel file provided via the custom filename of
+/// "opt/stage0/elf_kernel" is an uncompressed ELF file.
 ///
-/// If it finds a RAM disk it returns the information about the kernel, otherwise `None`.
+/// If it finds a kernel it returns the information about the kernel, otherwise `None`.
 pub fn try_load_kernel_image(
     fw_cfg: &mut FwCfg,
     e820_table: &[BootE820Entry],
 ) -> Option<KernelInfo> {
-    let path = CStr::from_bytes_with_nul(KERNEL_FILE_PATH).expect("invalid c-string");
-    let file = fw_cfg.find(path)?;
+    let (file, bzimage) = if let Some(file) = fw_cfg.get_kernel_file() {
+        (file, true)
+    } else {
+        let path = CStr::from_bytes_with_nul(KERNEL_FILE_PATH).expect("invalid c-string");
+        let file = fw_cfg.find(path)?;
+        (file, false)
+    };
     let size = file.size();
 
-    // We copy the kernel image to a temporary location where we can parse it.
-    let dma_address =
-        find_suitable_dma_address(size, e820_table).expect("no suitable DMA address available");
-    let start_address = crate::phys_to_virt(PhysAddr::new(dma_address.as_u64()));
+    let dma_address = if bzimage {
+        // For a compressed kernel we use the default start address.
+        PhysAddr::new(DEFAULT_KERNEL_START)
+    } else {
+        // For an Elf kernel we copy the kernel image to a temporary location at the end of
+        // available mapped virtual memory where we can parse it.
+        find_suitable_dma_address(size, e820_table).expect("no suitable DMA address available")
+    };
+    let start_address = crate::phys_to_virt(dma_address);
     log::debug!("Kernel image size {}", size);
     log::debug!(
         "Kernel image start address {:#018x}",
@@ -117,9 +139,24 @@ pub fn try_load_kernel_image(
         .expect("could not read kernel file");
     assert_eq!(actual_size, size, "kernel size did not match expected size");
 
+    if bzimage {
+        // For a bzImage the 64-bit entry point is at offset 0x200 from the start of the 64-bit
+        // kernel. See <https://www.kernel.org/doc/html/v6.3/x86/boot.html>.
+        let entry = start_address + 0x200usize;
+        log::debug!("Kernel entry point {:#018x}", entry.as_u64());
+        Some(KernelInfo {
+            start_address,
+            size,
+            entry,
+        })
+    } else {
+        Some(parse_elf_file(buf, e820_table))
+    }
+}
+
+fn parse_elf_file(buf: &[u8], e820_table: &[BootE820Entry]) -> KernelInfo {
     let mut kernel_start = VirtAddr::new(crate::TOP_OF_VIRTUAL_MEMORY);
     let mut kernel_end = VirtAddr::new(0);
-
     // We expect an uncompressed ELF kernel, so we parse it and lay it out in memory.
     let file = ElfBytes::<AnyEndian>::minimal_parse(buf).expect("couldn't parse kernel header");
 
@@ -147,11 +184,11 @@ pub fn try_load_kernel_image(
     log::debug!("Kernel start address {:#018x}", kernel_start.as_u64());
     log::debug!("Kernel entry point {:#018x}", entry.as_u64());
 
-    Some(KernelInfo {
+    KernelInfo {
         start_address: kernel_start,
         size: kernel_size,
         entry,
-    })
+    }
 }
 
 /// Loads a segment from an ELF file into memory.

--- a/stage0/src/kernel.rs
+++ b/stage0/src/kernel.rs
@@ -62,16 +62,15 @@ impl Default for KernelInfo {
 pub fn try_load_cmdline(fw_cfg: &mut FwCfg) -> Option<&'static CStr> {
     let (cmdline_file, buffer_size) = if let Some(cmdline_file) = fw_cfg.get_cmdline_file() {
         // The provided value is already null-terminated.
-        let size = cmdline_file.size() as usize;
+        let size = cmdline_file.size();
         (cmdline_file, size)
     } else {
         let cmdline_path = CStr::from_bytes_with_nul(CMDLINE_FILE_PATH).expect("invalid c-string");
         let cmdline_file = fw_cfg.find(cmdline_path)?;
         // Make the buffer one byte longer so that the kernel command-line is null-terminated.
-        let size = cmdline_file.size() as usize + 1;
+        let size = cmdline_file.size() + 1;
         (cmdline_file, size)
     };
-    let cmdline_size = cmdline_file.size();
     // Safety: len will always be at least 1 byte, and we don't care about alignment. If the
     // allocation fails, we won't try coercing it into a slice.
     let buf = unsafe {
@@ -85,7 +84,8 @@ pub fn try_load_cmdline(fw_cfg: &mut FwCfg) -> Option<&'static CStr> {
         .read_file(&cmdline_file, buf)
         .expect("could not read cmdline");
     assert_eq!(
-        actual_size, cmdline_size,
+        actual_size,
+        cmdline_file.size(),
         "cmdline size did not match expected size"
     );
 

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -205,6 +205,8 @@ pub fn rust64_start(encrypted: u64) -> ! {
 
     paging::map_additional_memory(encrypted);
 
+    zero_page.try_fill_hdr_from_setup_data(&mut fwcfg);
+
     if snp {
         let cc_blob = BOOT_ALLOC
             .leak(oak_linux_boot_params::CCBlobSevInfo::new(

--- a/testing/sev_snp_hello_world_kernel/src/main.rs
+++ b/testing/sev_snp_hello_world_kernel/src/main.rs
@@ -84,7 +84,7 @@ pub extern "C" fn rust64_start(_: u64, boot_params: &BootParams) -> ! {
         log::info!("SNP active");
 
         // Walk the null-terminated setup_data list until we find the CC blob.
-        let mut setup_data = boot_params.hdr.setup_data;
+        let mut setup_data = boot_params.hdr.setup_data();
 
         // Safety: there's a lot of dereferences of raw pointers here; unfortunately necessary as we
         // need to access the C data structures set up by the bootloader. It is safe as long as the


### PR DESCRIPTION
Stage 0 can now boot either an uncompressed 64-bit ELF kernel, or a 64-bit compressed Linux kernel using the bzImage format.

To boot using an ELF kernel, use the custom file paths in QEMU, e.g:

```
qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm,acpi=on" -m 1G \
  -nographic -nodefaults -no-reboot -serial stdio -bios "bin/stage0.bin" \
  -fw_cfg "name=opt/stage0/elf_kernel,file=bin/vmlinux" \
  -fw_cfg "name=opt/stage0/initramfs,file=bin/initramfs" \
  -fw_cfg "name=opt/stage0/cmdline,string=console=ttyS0 quiet"
```

To boot using a bzImage kernel, use the normal QEMU direct-booting paramters, e.g.

```
qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm,acpi=on" -m 1G \
  -nographic -nodefaults -no-reboot -serial stdio -bios "bin/stage0.bin" \
  -append "console=ttyS0 quiet" -kernel "bin/bzImage" -initrd "bin/initramfs"
```

Removing support for parsing ELF kernels in Stage 0 will be done as a future cleanup.