### PR TITLE
Refactor Oak Functions to separate encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.3.3",
  "bytes",
+ "log",
  "micro_rpc",
  "oak_core",
  "static_assertions",
@@ -2024,6 +2025,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "byteorder",
+ "env_logger",
  "hashbrown 0.13.2",
  "log",
  "micro_rpc",
@@ -2089,6 +2091,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "micro_rpc_build",
+ "oak_crypto",
  "oak_remote_attestation",
  "prost",
 ]
@@ -2126,7 +2129,7 @@ name = "oak_remote_attestation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "micro_rpc",
+ "log",
  "micro_rpc_build",
  "oak_crypto",
  "prost",

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.4.0",
  "bytes",
+ "log",
  "micro_rpc",
  "oak_core",
  "static_assertions",
@@ -650,6 +651,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "micro_rpc_build",
+ "oak_crypto",
  "oak_remote_attestation",
  "prost",
 ]
@@ -659,7 +661,7 @@ name = "oak_remote_attestation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "micro_rpc",
+ "log",
  "micro_rpc_build",
  "oak_crypto",
  "prost",

--- a/oak_channel/Cargo.toml
+++ b/oak_channel/Cargo.toml
@@ -12,6 +12,7 @@ client = ["std"]
 
 [dependencies]
 anyhow = { version = "*", default-features = false }
+log = { version = "*", default-features = false }
 micro_rpc = { workspace = true }
 oak_core = { workspace = true }
 static_assertions = "*"

--- a/oak_channel/src/server.rs
+++ b/oak_channel/src/server.rs
@@ -28,11 +28,22 @@ pub fn start_blocking_server<T: micro_rpc::Transport<Error = !>>(
 ) -> anyhow::Result<!> {
     let channel_handle = &mut ServerChannelHandle::new(channel);
     loop {
+        log::debug!("waiting for a request message");
         let (request_message, timer) = channel_handle
             .read_request()
             .context("couldn't receive message")?;
         let request_message_invocation_id = request_message.invocation_id;
+        log::debug!(
+            "received request message with invocation id {} ({} bytes)",
+            request_message_invocation_id,
+            request_message.body.len()
+        );
         let response = server.invoke(request_message.body.as_ref()).into_ok();
+        log::debug!(
+            "sending response message with invocation id {} ({} bytes)",
+            request_message_invocation_id,
+            response.len()
+        );
         let response_message = message::ResponseMessage {
             invocation_id: request_message_invocation_id,
             body: response,

--- a/oak_functions/examples/key_value_lookup/module/src/tests.rs
+++ b/oak_functions/examples/key_value_lookup/module/src/tests.rs
@@ -46,7 +46,7 @@ async fn test_server() {
         .await;
 
     // Wait for the server to start up.
-    std::thread::sleep(Duration::from_secs(20));
+    std::thread::sleep(Duration::from_secs(10));
 
     {
         // Lookup match.

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -69,10 +69,11 @@ pub async fn create(
     ),
     Box<dyn std::error::Error>,
 > {
+    log::info!("creating Oak Functions guest instance");
     let (launched_instance, connector_handle) = launcher::launch(params).await?;
-    setup_lookup_data(connector_handle.clone(), lookup_data_config).await?;
     let intialize_response =
         intialize_enclave(connector_handle.clone(), &wasm_path, constant_response_size).await?;
+    setup_lookup_data(connector_handle.clone(), lookup_data_config).await?;
     Ok((launched_instance, connector_handle, intialize_response))
 }
 
@@ -81,6 +82,7 @@ async fn setup_lookup_data(
     connector_handle: channel::ConnectorHandle,
     config: LookupDataConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    log::info!("setting up lookup data");
     let mut client = OakFunctionsAsyncClient::new(connector_handle);
 
     // Block for [invariant that lookup data is fully loaded](https://github.com/project-oak/oak/tree/main/oak_functions/lookup/README.md#invariant-fully-loaded-lookup-data)
@@ -114,10 +116,11 @@ pub async fn update_lookup_data(
     client: &mut OakFunctionsAsyncClient<ConnectorHandle>,
     config: &LookupDataConfig,
 ) -> anyhow::Result<()> {
+    log::info!("updating lookup data");
     lookup::update_lookup_data(client, &config.lookup_data_path, config.max_chunk_size).await
 }
 
-// Loads application config (including wasm bytes) into the enclave and returns a remote attestation
+// Loads application config (including Wasm bytes) into the enclave and returns a remote attestation
 // evidence.
 async fn intialize_enclave(
     connector_handle: channel::ConnectorHandle,
@@ -139,12 +142,12 @@ async fn intialize_enclave(
     };
 
     let mut client = OakFunctionsAsyncClient::new(connector_handle);
+    log::info!("sending initialize request");
     let initialize_response = client
         .initialize(&request)
         .await
         .flatten()
         .expect("couldn't initialize service");
-
     log::info!("service initialized: {:?}", initialize_response);
 
     Ok(initialize_response)

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -68,6 +68,7 @@ fn path_exists(s: &str) -> Result<PathBuf, String> {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Args::parse();
     env_logger::init();
+    log::info!("Oak Functions Launcher args: {:?}", cli);
 
     let lookup_data_config = LookupDataConfig {
         lookup_data_path: cli.lookup_data,

--- a/oak_functions_service/Cargo.toml
+++ b/oak_functions_service/Cargo.toml
@@ -23,6 +23,7 @@ wasmi = { version = "*", default-features = false }
 micro_rpc_build = { workspace = true }
 
 [dev-dependencies]
+env_logger = { version = "*", default-features = false }
 oak_functions_test_utils = { workspace = true }
 oak_remote_attestation = { workspace = true }
 async-trait = "*"

--- a/oak_functions_service/proto/oak_functions.proto
+++ b/oak_functions_service/proto/oak_functions.proto
@@ -20,10 +20,12 @@ package oak.functions;
 
 service OakFunctions {
   // Initializes the service and remote attestation keys.
+  //
   // method_id: 0
   rpc Initialize(InitializeRequest) returns (InitializeResponse);
 
   // Handles an invocation coming from a client.
+  //
   // method_id: 1
   rpc Invoke(InvokeRequest) returns (InvokeResponse);
 

--- a/oak_functions_service/src/instance.rs
+++ b/oak_functions_service/src/instance.rs
@@ -1,0 +1,105 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::{
+    logger::StandaloneLogger,
+    lookup::{Data, LookupDataManager},
+    proto::oak::functions::{
+        AbortNextLookupDataResponse, Empty, ExtendNextLookupDataRequest,
+        ExtendNextLookupDataResponse, FinishNextLookupDataRequest, FinishNextLookupDataResponse,
+        InitializeRequest, LookupDataChunk,
+    },
+    wasm,
+};
+use alloc::{format, sync::Arc};
+use micro_rpc::{Status, Vec};
+use oak_functions_abi::Request;
+
+pub struct OakFunctionsInstance {
+    lookup_data_manager: Arc<LookupDataManager<StandaloneLogger>>,
+    wasm_handler: wasm::WasmHandler<StandaloneLogger>,
+}
+
+impl OakFunctionsInstance {
+    /// See [`crate::proto::oak::functions::OakFunctions::initialize`].
+    pub fn new(request: &InitializeRequest) -> Result<Self, micro_rpc::Status> {
+        let lookup_data_manager =
+            Arc::new(LookupDataManager::new_empty(StandaloneLogger::default()));
+        let wasm_handler =
+            wasm::new_wasm_handler(&request.wasm_module, lookup_data_manager.clone()).map_err(
+                |err| {
+                    micro_rpc::Status::new_with_message(
+                        micro_rpc::StatusCode::Internal,
+                        format!("couldn't initialize Wasm handler: {:?}", err),
+                    )
+                },
+            )?;
+        Ok(Self {
+            lookup_data_manager,
+            wasm_handler,
+        })
+    }
+    /// See [`crate::proto::oak::functions::OakFunctions::invoke`].
+    pub fn invoke(&mut self, request: &[u8]) -> Result<Vec<u8>, micro_rpc::Status> {
+        // TODO(#3442): Implement constant response size policy.
+        self.wasm_handler
+            .handle_invoke(Request {
+                body: request.to_vec(),
+            })
+            .map(|response| response.body)
+            .map_err(|err| {
+                micro_rpc::Status::new_with_message(
+                    micro_rpc::StatusCode::Internal,
+                    format!("couldn't handle invoke: {:?}", err),
+                )
+            })
+    }
+    /// See [`crate::proto::oak::functions::OakFunctions::extend_next_lookup_data`].
+    pub fn extend_next_lookup_data(
+        &mut self,
+        request: ExtendNextLookupDataRequest,
+    ) -> Result<ExtendNextLookupDataResponse, micro_rpc::Status> {
+        self.lookup_data_manager
+            .extend_next_lookup_data(to_data(request.chunk));
+        Ok(ExtendNextLookupDataResponse {})
+    }
+    /// See [`crate::proto::oak::functions::OakFunctions::finish_next_lookup_data`].
+    pub fn finish_next_lookup_data(
+        &mut self,
+        _request: FinishNextLookupDataRequest,
+    ) -> Result<FinishNextLookupDataResponse, micro_rpc::Status> {
+        self.lookup_data_manager.finish_next_lookup_data();
+        Ok(FinishNextLookupDataResponse {})
+    }
+    /// See [`crate::proto::oak::functions::OakFunctions::abort_next_lookup_data`].
+    pub fn abort_next_lookup_data(
+        &mut self,
+        _request: Empty,
+    ) -> Result<AbortNextLookupDataResponse, Status> {
+        self.lookup_data_manager.abort_next_lookup_data();
+        Ok(AbortNextLookupDataResponse {})
+    }
+}
+
+// Helper function to convert [`LookupDataChunk`] to [`Data`].
+fn to_data(chunk: Option<LookupDataChunk>) -> Data {
+    chunk
+        .unwrap()
+        .items
+        .into_iter()
+        .map(|entry| (entry.key, entry.value))
+        .collect()
+}

--- a/oak_functions_service/src/wasm/mod.rs
+++ b/oak_functions_service/src/wasm/mod.rs
@@ -244,7 +244,7 @@ where
         // `memory` is not available.
         instance
             .get_memory(&store, MEMORY_NAME)
-            .ok_or(anyhow::anyhow!("couldn't find Wasm `memory` export"))?;
+            .ok_or_else(|| anyhow::anyhow!("couldn't find Wasm `memory` export"))?;
 
         Ok((instance, store))
     }
@@ -478,21 +478,14 @@ where
         );
 
         let response_bytes = response.lock().clone();
+        store.data().logger.log_sensitive(
+            Level::Info,
+            &format!("response bytes: {:?}", response_bytes),
+        );
 
         let invoke_response =
             Response::create(oak_functions_abi::StatusCode::Success, response_bytes);
         Ok(invoke_response)
-    }
-}
-
-impl<L: OakLogger> micro_rpc::Transport for WasmHandler<L> {
-    type Error = anyhow::Error;
-    fn invoke(&mut self, request: &[u8]) -> anyhow::Result<Vec<u8>> {
-        let request = Request {
-            body: request.to_vec(),
-        };
-        let response = self.handle_invoke(request)?;
-        Ok(response.body)
     }
 }
 

--- a/oak_functions_service/tests/integration_test.rs
+++ b/oak_functions_service/tests/integration_test.rs
@@ -37,8 +37,14 @@ const LOOKUP_TEST_KEY: &[u8] = b"test_key";
 const LOOKUP_TEST_VALUE: &[u8] = b"test_value";
 const EMPTY_ASSOCIATED_DATA: &[u8] = b"";
 
+fn init() {
+    // See https://github.com/rust-cli/env_logger/#in-tests.
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
 #[test]
 fn it_should_not_handle_user_requests_before_initialization() {
+    init();
     let service = OakFunctionsService::new(Arc::new(EmptyAttestationReportGenerator));
     let mut client = OakFunctionsClient::new(OakFunctionsServer::new(service));
 
@@ -58,6 +64,7 @@ fn it_should_not_handle_user_requests_before_initialization() {
 
 #[test]
 fn it_should_handle_user_requests_after_initialization() {
+    init();
     let service = OakFunctionsService::new(Arc::new(EmptyAttestationReportGenerator));
     let mut client = OakFunctionsClient::new(OakFunctionsServer::new(service));
 
@@ -97,6 +104,7 @@ fn it_should_handle_user_requests_after_initialization() {
 
 #[test]
 fn it_should_only_initialize_once() {
+    init();
     let service = OakFunctionsService::new(Arc::new(EmptyAttestationReportGenerator));
     let mut client = OakFunctionsClient::new(OakFunctionsServer::new(service));
 
@@ -121,6 +129,7 @@ fn it_should_only_initialize_once() {
 
 #[tokio::test]
 async fn it_should_support_lookup_data() {
+    init();
     let service = OakFunctionsService::new(Arc::new(EmptyAttestationReportGenerator));
     let mut client = OakFunctionsClient::new(OakFunctionsServer::new(service));
 

--- a/oak_iree_service/Cargo.toml
+++ b/oak_iree_service/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = { version = "*", default-features = false }
 log = "*"
 hashbrown = "*"
 micro_rpc = { workspace = true }
+oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
 prost = { workspace = true }
 

--- a/oak_iree_service/src/lib.rs
+++ b/oak_iree_service/src/lib.rs
@@ -33,19 +33,19 @@ mod iree;
 use crate::proto::oak::iree::{
     AttestationEvidence, InitializeRequest, InitializeResponse, InvokeRequest, InvokeResponse, Iree,
 };
-use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
+use alloc::{format, sync::Arc, vec::Vec};
 use anyhow::Context;
+use oak_crypto::encryptor::EncryptionKeyProvider;
 use oak_remote_attestation::{
-    attester::AttestationReportGenerator,
-    handler::{AttestationHandler, AttestationSessionHandler},
+    attester::{AttestationReportGenerator, Attester},
+    handler::EncryptionHandler,
 };
 
-struct IreeHandler {
+struct OakIreeInstance {
     iree_model: iree::IreeModel,
 }
 
-impl micro_rpc::Transport for IreeHandler {
-    type Error = anyhow::Error;
+impl OakIreeInstance {
     fn invoke(&mut self, request: &[u8]) -> anyhow::Result<Vec<u8>> {
         self.iree_model
             .run(request)
@@ -53,22 +53,27 @@ impl micro_rpc::Transport for IreeHandler {
     }
 }
 
-enum InitializationState {
-    Uninitialized,
-    Initialized(Box<dyn AttestationHandler>),
-}
-
 pub struct IreeService {
     attestation_report_generator: Arc<dyn AttestationReportGenerator>,
-    initialization_state: InitializationState,
+    encryption_key_provider: Arc<EncryptionKeyProvider>,
+    instance: Option<OakIreeInstance>,
 }
 
 impl IreeService {
     pub fn new(attestation_report_generator: Arc<dyn AttestationReportGenerator>) -> Self {
         Self {
             attestation_report_generator,
-            initialization_state: InitializationState::Uninitialized,
+            encryption_key_provider: Arc::new(EncryptionKeyProvider::new()),
+            instance: None,
         }
+    }
+    fn get_instance(&mut self) -> Result<&mut OakIreeInstance, micro_rpc::Status> {
+        self.instance.as_mut().ok_or_else(|| {
+            micro_rpc::Status::new_with_message(
+                micro_rpc::StatusCode::FailedPrecondition,
+                "not initialized",
+            )
+        })
     }
 }
 
@@ -77,42 +82,31 @@ impl Iree for IreeService {
         &mut self,
         _initialization: InitializeRequest,
     ) -> Result<InitializeResponse, micro_rpc::Status> {
-        match &mut self.initialization_state {
-            InitializationState::Initialized(_attestation_handler) => {
-                Err(micro_rpc::Status::new_with_message(
-                    micro_rpc::StatusCode::FailedPrecondition,
-                    "already initialized",
-                ))
-            }
-            InitializationState::Uninitialized => {
-                let mut iree_model = iree::IreeModel::new();
-                iree_model
-                    .initialize()
-                    .map_err(|_err| micro_rpc::Status::new(micro_rpc::StatusCode::Internal))?;
-
-                let attestation_handler = Box::new(
-                    AttestationSessionHandler::create(
-                        self.attestation_report_generator.clone(),
-                        IreeHandler { iree_model },
-                    )
-                    .map_err(|err| {
-                        micro_rpc::Status::new_with_message(
-                            micro_rpc::StatusCode::Internal,
-                            format!("couldn't create attestation handler: {:?}", err),
-                        )
-                    })?,
+        match &mut self.instance {
+            Some(_) => Err(micro_rpc::Status::new_with_message(
+                micro_rpc::StatusCode::FailedPrecondition,
+                "already initialized",
+            )),
+            None => {
+                let instance = {
+                    let mut iree_model = iree::IreeModel::new();
+                    iree_model
+                        .initialize()
+                        .map_err(|_err| micro_rpc::Status::new(micro_rpc::StatusCode::Internal))?;
+                    OakIreeInstance { iree_model }
+                };
+                let attester = Attester::new(
+                    self.attestation_report_generator.clone(),
+                    self.encryption_key_provider.clone(),
                 );
                 let attestation_evidence =
-                    attestation_handler
-                        .get_attestation_evidence()
-                        .map_err(|err| {
-                            micro_rpc::Status::new_with_message(
-                                micro_rpc::StatusCode::Internal,
-                                format!("couldn't get attestation evidence: {:?}", err),
-                            )
-                        })?;
-                self.initialization_state = InitializationState::Initialized(attestation_handler);
-
+                    attester.generate_attestation_evidence().map_err(|err| {
+                        micro_rpc::Status::new_with_message(
+                            micro_rpc::StatusCode::Internal,
+                            format!("couldn't get attestation evidence: {:?}", err),
+                        )
+                    })?;
+                self.instance = Some(instance);
                 Ok(InitializeResponse {
                     attestation_evidence: Some(AttestationEvidence {
                         attestation_report: attestation_evidence.attestation,
@@ -127,23 +121,20 @@ impl Iree for IreeService {
         &mut self,
         request_message: InvokeRequest,
     ) -> Result<InvokeResponse, micro_rpc::Status> {
-        match &mut self.initialization_state {
-            InitializationState::Uninitialized => Err(micro_rpc::Status::new_with_message(
-                micro_rpc::StatusCode::FailedPrecondition,
-                "not initialized",
-            )),
-            InitializationState::Initialized(attestation_handler) => {
-                let response =
-                    attestation_handler
-                        .invoke(&request_message.body)
-                        .map_err(|err| {
-                            micro_rpc::Status::new_with_message(
-                                micro_rpc::StatusCode::Internal,
-                                format!("{:?}", err),
-                            )
-                        })?;
-                Ok(InvokeResponse { body: response })
-            }
-        }
+        let encryption_key_provider = self.encryption_key_provider.clone();
+        let instance = self.get_instance()?;
+        EncryptionHandler::create(encryption_key_provider, |r| {
+            instance
+                .invoke(&r)
+                .map_err(|err| anyhow::anyhow!("couldn't handle invoke: {:?}", err))
+        })
+        .invoke(&request_message.body)
+        .map(|response| InvokeResponse { body: response })
+        .map_err(|err| {
+            micro_rpc::Status::new_with_message(
+                micro_rpc::StatusCode::Internal,
+                format!("couldn't invoke handler: {:?}", err),
+            )
+        })
     }
 }

--- a/oak_remote_attestation/Cargo.toml
+++ b/oak_remote_attestation/Cargo.toml
@@ -6,8 +6,8 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = { version = "*", default-features = false }
+log = { version = "*", default-features = false }
 oak_crypto = { workspace = true }
-micro_rpc = { workspace = true }
 prost = { workspace = true }
 
 [build-dependencies]

--- a/oak_remote_attestation/src/handler.rs
+++ b/oak_remote_attestation/src/handler.rs
@@ -14,10 +14,6 @@
 // limitations under the License.
 //
 
-use crate::{
-    attester::{AttestationReportGenerator, Attester},
-    proto::oak::session::v1::AttestationEvidence,
-};
 use alloc::{sync::Arc, vec, vec::Vec};
 use anyhow::{anyhow, Context};
 use oak_crypto::{
@@ -38,39 +34,26 @@ pub struct PublicKeyInfo {
     pub attestation: Vec<u8>,
 }
 
-pub trait AttestationHandler: micro_rpc::Transport<Error = anyhow::Error> {
-    fn get_attestation_evidence(&self) -> anyhow::Result<AttestationEvidence>;
-}
-
-pub struct AttestationSessionHandler<H: micro_rpc::Transport<Error = anyhow::Error>> {
+/// Wraps a closure to an underlying function with request encryption and response decryption logic,
+/// based on the provided encryption key.
+pub struct EncryptionHandler<H: FnOnce(Vec<u8>) -> anyhow::Result<Vec<u8>>> {
     // TODO(#3442): Use attester to attest to the public key.
-    attester: Arc<Attester>,
     encryption_key_provider: Arc<EncryptionKeyProvider>,
     request_handler: H,
 }
 
-impl<H: micro_rpc::Transport<Error = anyhow::Error>> AttestationSessionHandler<H> {
-    pub fn create(
-        attestation_report_generator: Arc<dyn AttestationReportGenerator>,
-        request_handler: H,
-    ) -> anyhow::Result<Self> {
-        let encryption_key_provider = Arc::new(EncryptionKeyProvider::new());
-        Ok(Self {
-            attester: Arc::new(Attester::new(
-                attestation_report_generator,
-                encryption_key_provider.clone(),
-            )),
+// TODO(#4249): Make the inner function infallible.
+impl<H: FnOnce(Vec<u8>) -> anyhow::Result<Vec<u8>>> EncryptionHandler<H> {
+    pub fn create(encryption_key_provider: Arc<EncryptionKeyProvider>, request_handler: H) -> Self {
+        Self {
             encryption_key_provider,
             request_handler,
-        })
+        }
     }
 }
 
-impl<H: micro_rpc::Transport<Error = anyhow::Error>> micro_rpc::Transport
-    for AttestationSessionHandler<H>
-{
-    type Error = anyhow::Error;
-    fn invoke(&mut self, request_body: &[u8]) -> anyhow::Result<Vec<u8>> {
+impl<H: FnOnce(Vec<u8>) -> anyhow::Result<Vec<u8>>> EncryptionHandler<H> {
+    pub fn invoke(self, request_body: &[u8]) -> anyhow::Result<Vec<u8>> {
         let mut server_encryptor = ServerEncryptor::new(self.encryption_key_provider.clone());
 
         // Deserialize and decrypt request.
@@ -81,10 +64,8 @@ impl<H: micro_rpc::Transport<Error = anyhow::Error>> micro_rpc::Transport
             .context("couldn't decrypt request")?;
 
         // Handle request.
-        let response = self
-            .request_handler
-            .invoke(&request)
-            .context("couldn't handle request")?;
+        let response = (self.request_handler)(request).context("couldn't handle request")?;
+        log::info!("plaintext response: {:?}", response);
 
         // Encrypt and serialize response.
         // The resulting decryptor for consequent requests is discarded because we don't expect
@@ -98,15 +79,5 @@ impl<H: micro_rpc::Transport<Error = anyhow::Error>> micro_rpc::Transport
             .map_err(|error| anyhow!("couldn't serialize response: {:?}", error))?;
 
         Ok(serialized_response)
-    }
-}
-
-impl<H: micro_rpc::Transport<Error = anyhow::Error>> AttestationHandler
-    for AttestationSessionHandler<H>
-{
-    fn get_attestation_evidence(&self) -> anyhow::Result<AttestationEvidence> {
-        self.attester
-            .generate_attestation_evidence()
-            .context("couldn't generate attestation evidence")
     }
 }

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.3.3",
  "bytes",
+ "log",
  "micro_rpc",
  "oak_core",
  "static_assertions",

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -21,6 +21,8 @@ pub static MOCK_LOOKUP_DATA_PATH: Lazy<PathBuf> =
 static STAGE_0_DIR: Lazy<PathBuf> = Lazy::new(|| workspace_path(&["stage0_bin"]));
 pub static OAK_RESTRICTED_KERNEL_BIN_DIR: Lazy<PathBuf> =
     Lazy::new(|| workspace_path(&["oak_restricted_kernel_bin"]));
+static OAK_FUNCTIONS_LAUNCHER_BIN_DIR: Lazy<PathBuf> =
+    Lazy::new(|| workspace_path(&["oak_functions_launcher"]));
 static OAK_FUNCTIONS_LAUNCHER_BIN: Lazy<PathBuf> = Lazy::new(|| {
     workspace_path(&[
         "target",
@@ -208,6 +210,13 @@ pub async fn run_oak_functions_example_in_background(
             .unwrap(),
     ))
     .await;
+    crate::testing::run_step(crate::launcher::build_binary(
+        "build Oak Functions Launcher binary",
+        crate::launcher::OAK_FUNCTIONS_LAUNCHER_BIN_DIR
+            .to_str()
+            .unwrap(),
+    ))
+    .await;
     let variant = crate::launcher::App::from_crate_name("oak_functions_enclave_app");
     crate::testing::run_step(crate::launcher::build_binary(
         "build Oak Functions enclave app",
@@ -215,7 +224,7 @@ pub async fn run_oak_functions_example_in_background(
     ))
     .await;
 
-    eprintln!("using wasm module {}", wasm_path);
+    eprintln!("using Wasm module {}", wasm_path);
 
     let port = portpicker::pick_unused_port().expect("failed to pick a port");
     eprintln!("using port {}", port);


### PR DESCRIPTION
Refactor the core logic of Oak Functions into a separate `OakFunctionsInstance` object. This object is still in the same crate as `OakFunctionsService` for now, but does not have any logic related to remote attestation nor encryption at all. Instead, that logic now only exists in the `OakFunctionsService` wrapper.

I changed the `InitializationState` from an enum to an `Option` so that it behaves like a proper functor (being able to use map and other methods on it).

`AttestationHandler` is changed to take an `FnOnce` and is expected to be constructed on the fly around a single invocation of an individual method, therefore it does not need to own the entire object being invoked, but can borrow a specific method when needed (and could be applied to several methods if necessary). The way around the ownership in the previous version was to have an `Arc<LookupDataManager>` instance shared between the outer service and the initialized instance, which is not a generally applicable pattern, while the current pattern should be fully generic.

The methods that do not require encryption defer to the inner methods directly (there may be a way of reducing the boilerplate in the future), while `invoke` creates a temporary `AttestationSessionHandler` object and uses it immediately for the invocation, then discards it.

Ref #4182