### PR TITLE
Support booting older Linux kernels with Stage 0

### DIFF
--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -78,7 +78,7 @@ impl ZeroPage {
             // If we are loading an older kernel, the setup header might a bit shorter. New fields
             // for more recent versions of the boot protocol are added to the end for the setup
             // header and there is padding after header, so the resulting data stucture should still
-            // be understood correclty by the kernel.
+            // be understood correctly by the kernel.
             let dest = &mut self.inner.hdr.as_bytes_mut()[..src.len()];
             dest.copy_from_slice(src);
         }

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -75,10 +75,10 @@ impl ZeroPage {
             // byte as offset 0x201 to the value 0x202.
             let hdr_end = 0x202usize + (buf[0x201] as usize);
             let src = &buf[hdr_start..hdr_end];
-            // If we are loading an older kernel, the setup header might a bit shorter. New fields
-            // for more recent versions of the boot protocol are added to the end for the setup
-            // header and there is padding after header, so the resulting data stucture should still
-            // be understood correctly by the kernel.
+            // If we are loading an older kernel, the setup header might be a bit shorter. New
+            // fields for more recent versions of the boot protocol are added to the end of the
+            // setup header and there is padding after header, so the resulting data stucture should
+            // still be understood correctly by the kernel.
             let dest = &mut self.inner.hdr.as_bytes_mut()[..src.len()];
             dest.copy_from_slice(src);
         }

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -75,7 +75,11 @@ impl ZeroPage {
             // byte as offset 0x201 to the value 0x202.
             let hdr_end = 0x202usize + (buf[0x201] as usize);
             let src = &buf[hdr_start..hdr_end];
-            let dest = self.inner.hdr.as_bytes_mut();
+            // If we are loading an older kernel, the setup header might a bit shorter. New fields
+            // for more recent versions of the boot protocol are added to the end for the setup
+            // header and there is padding after header, so the resulting data stucture should still
+            // be understood correclty by the kernel.
+            let dest = &mut self.inner.hdr.as_bytes_mut()[..src.len()];
             dest.copy_from_slice(src);
         }
     }


### PR DESCRIPTION
When booting bzImage kernels older than v5.5 the setup header that is included in the kernel image is shorter. The mismatch in the sizes caused a crash.

We still want a crash if we get more data than expected, as that would indicate that we are dealing with a newer kernel version that we don't yet support.