### PR TITLE
Avoid pvalidating memory between 640Kib and 1MiB

### DIFF
--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -198,7 +198,7 @@ fn build_e820_from_nvram(
     if rs > 0xFFFB_C000 {
         rs = 0xFFFB_C000;
     };
-    zero_page.e820_entries = 4;
+    zero_page.e820_entries = 5;
     zero_page.e820_table[0] = BootE820Entry::new(0, 0x80000, E820EntryType::RAM);
     // Region for ACPI data structures.
     zero_page.e820_table[1] = BootE820Entry::new(0x80000, 0x20000, E820EntryType::ACPI);

--- a/stage0_bin/src/asm/boot.s
+++ b/stage0_bin/src/asm/boot.s
@@ -85,8 +85,8 @@ _protected_mode_start:
                               # Bit 2 - SEV-SNP active
     mov %eax, %ebp            # store the result in EBP for later use
 
-    # See if we're under SEV-SNP, and if yes, pre-emptively PVALIDATE the first megabyte of memory, as that's
-    # where we'll be storing many data structures.
+    # See if we're under SEV-SNP, and if yes, pre-emptively PVALIDATE the first 640 KiB of memory,
+    # as that's where we'll be storing many data structures.
     and $0b100, %eax          # eax &= 0b100; -- SEV-SNP active
     test %eax, %eax           # is eax zero?
     je 2f                     # if yes, no SNP, skip validation and jump ahead
@@ -97,7 +97,7 @@ _protected_mode_start:
     mov %ebx, %eax            # eax = ebx (PVALIDATE will clobber EAX)
     pvalidate                 # set validated bit in RMP, but ignore results for now
     add $0x1000, %ebx         # ebx += 0x1000
-    cmp $0x100000, %ebx       # have we covered the full megabyte?
+    cmp $0xa0000, %ebx        # have we covered the full 640 KiB?
     jl 1b                     # if no, go back
     2:
 


### PR DESCRIPTION
The Linux kernel assumes that the BIOS will not call pvalidate on the video ROM area just below the 1MiB boundary. We don't use any memory between 640KiB and 1MiB in stage 0, so we can avoid pvalidating it by:

- Only pvalidating memory up to 640KiB in the boot assembly
- Marking memory bewteen 640KiB and 1MiB as reserved in the E820 table so that our later code won't see it as valid memory that needs to be validated