### PR TITLE
Include `bzImage` with the Oak Containers generated binaries

### DIFF
--- a/kokoro/build_binaries_oak_containers.sh
+++ b/kokoro/build_binaries_oak_containers.sh
@@ -29,6 +29,7 @@ touch "$KOKORO_ARTIFACTS_DIR/binaries/git_commit_${KOKORO_GIT_COMMIT_oak:?}"
 export GENERATED_BINARIES=(
     ./target/stage1.cpio
     ./oak_containers_kernel/target/vmlinux
+    ./oak_containers_kernel/target/bzImage
     ./oak_containers_system_image/target/image.tar.xz
     ./oak_containers_hello_world_container/target/oak_container_example_oci_filesystem_bundle.tar
 )


### PR DESCRIPTION
Instead of the raw ELF `vmlinux` file, we will use the normal `bzImage`. Hence, include that in the list of files that are copied to Placer; removal of vmlinux from there will be in a follow-up PR once we no longer need it for tests.