### PR TITLE
Disable building mnist-eval on pull-requests

### DIFF
--- a/.github/workflows/mnist_eval.yaml
+++ b/.github/workflows/mnist_eval.yaml
@@ -14,6 +14,9 @@ on:
 # Ref: https://github.com/project-oak/hello-transparent-release/blob/main/.github/workflows/provenance.yaml
 jobs:
   generate_provenance:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'provenance:force-run')
     permissions:
       actions: read
       id-token: write

--- a/java/src/main/java/com/google/oak/transport/BUILD
+++ b/java/src/main/java/com/google/oak/transport/BUILD
@@ -47,7 +47,6 @@ java_library(
         "//oak_remote_attestation/proto/v1:messages_java_proto",
         "//oak_remote_attestation/proto/v1:service_streaming_java_proto",
         "@com_google_protobuf//:protobuf_javalite",
-        "@io_grpc_grpc_java//api",
         "@io_grpc_grpc_java//stub",
     ],
 )

--- a/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
+++ b/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
@@ -16,7 +16,10 @@
 
 package com.google.oak.transport;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import java.time.Duration;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.google.oak.session.v1.AttestationBundle;
 import com.google.oak.session.v1.GetPublicKeyRequest;
@@ -25,21 +28,15 @@ import com.google.oak.session.v1.InvokeRequest;
 import com.google.oak.session.v1.InvokeResponse;
 import com.google.oak.session.v1.RequestWrapper;
 import com.google.oak.session.v1.ResponseWrapper;
-import com.google.oak.transport.EvidenceProvider;
-import com.google.oak.transport.Transport;
 import com.google.oak.util.Result;
 import com.google.protobuf.ByteString;
+
 import io.grpc.stub.StreamObserver;
-import java.time.Duration;
-import java.util.concurrent.BlockingQueue;
-import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class GrpcStreamingTransport implements EvidenceProvider, Transport {
   private static final Logger logger = Logger.getLogger(GrpcStreamingTransport.class.getName());
 
-  private static final int MESSAGE_QUEUE_TIMEOUT_SECONDS = 10;
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
 
   /**
    * QueueingStreamObserver with a queue containing responses received from the
@@ -78,7 +75,7 @@ public class GrpcStreamingTransport implements EvidenceProvider, Transport {
     ResponseWrapper responseWrapper;
     try {
       // TODO(#3644): Add retry for client messages.
-      responseWrapper = this.responseObserver.poll(Duration.ofSeconds(MESSAGE_QUEUE_TIMEOUT_SECONDS));
+      responseWrapper = this.responseObserver.poll(TIMEOUT);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return Result.error("Thread interrupted while waiting for a response");
@@ -114,7 +111,7 @@ public class GrpcStreamingTransport implements EvidenceProvider, Transport {
     ResponseWrapper responseWrapper;
     try {
       // TODO(#3644): Add retry for client messages.
-      responseWrapper = this.responseObserver.poll(Duration.ofSeconds(MESSAGE_QUEUE_TIMEOUT_SECONDS));
+      responseWrapper = this.responseObserver.poll(TIMEOUT);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return Result.error("Thread interrupted while waiting for a response");

--- a/java/src/main/java/com/google/oak/transport/QueueingStreamObserver.java
+++ b/java/src/main/java/com/google/oak/transport/QueueingStreamObserver.java
@@ -24,6 +24,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
 /**

--- a/java/src/main/java/com/google/oak/transport/QueueingStreamObserver.java
+++ b/java/src/main/java/com/google/oak/transport/QueueingStreamObserver.java
@@ -16,17 +16,19 @@
 
 package com.google.oak.transport;
 
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import io.grpc.stub.StreamObserver;
+
 /**
- * A thread-safe StreamObserver that queues received messages, so that they can be picked from the
+ * A thread-safe StreamObserver that queues received messages, so that they can
+ * be picked from the
  * queue once needed.
  *
  * @param <T> Type of the message
@@ -49,7 +51,7 @@ public final class QueueingStreamObserver<T> implements StreamObserver<T> {
   }
 
   public T poll(Duration timeout) throws InterruptedException {
-    return messages.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    return messages.poll(timeout.toMillis(), MILLISECONDS);
   }
 
   @Override


### PR DESCRIPTION
Applies a condition similar to the one in provenance generation to disable building mnist-eval on pull-requests by default.