### PR TITLE
Don't pvalidate memory twice

### DIFF
--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -435,8 +435,13 @@ pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
         PageTableFlags::PRESENT,
     );
 
+    // We already pvalidated the memory in the first 640KiB of RAM in the boot assembly code. We
+    // avoid redoing this as calling pvalidate again on these pages leads to unexpected results,
+    // such us removing the shared state from the RMP for the fw_cfg DMA buffer.
+    let min_addr = 0xA0000;
+
     for entry in e820_table {
-        if entry.entry_type() != Some(E820EntryType::RAM) {
+        if entry.entry_type() != Some(E820EntryType::RAM) || entry.addr() < min_addr {
             continue;
         }
 


### PR DESCRIPTION
DMA access in the fw_cfg device failed on SEV-SNP due to an RMP write violation. This was a side effect of calling pvalidate again on these pages after sharing them. It seems like the pages got into an unexpected state in the RMP due to this.

It is not clear why the GHCB was not affected by the same issue, but I have 2 guesses:

- It is written to by the VMM before we call pvalidate
- We register it as the GHCB in a separate call

Either way, if we avoid pvalidating the pages after sharing them it works fine.