### PR TITLE
PVALIDATE unshared pages in Stage 0

### DIFF
--- a/oak_sev_guest/src/ghcb.rs
+++ b/oak_sev_guest/src/ghcb.rs
@@ -26,7 +26,10 @@ use crate::{
     Translator,
 };
 use bitflags::bitflags;
-use x86_64::{PhysAddr, VirtAddr};
+use x86_64::{
+    structures::paging::{Page, Size4KiB},
+    PhysAddr, VirtAddr,
+};
 use zerocopy::FromBytes;
 
 /// The size of the GHCB page.
@@ -306,6 +309,12 @@ where
     /// Gets the guest-physical address for the guest-hypervisor communication block.
     pub fn get_gpa(&self) -> PhysAddr {
         self.gpa
+    }
+
+    /// Gets the memory page that contains the guest-hypervisor communication block.
+    pub fn get_page(&self) -> Page<Size4KiB> {
+        Page::from_start_address(VirtAddr::from_ptr(self.ghcb.as_ref() as *const Ghcb))
+            .expect("ghcb not aligned")
     }
 
     /// Registers the address of the GHCB with the hypervisor.

--- a/oak_sev_guest/src/ghcb.rs
+++ b/oak_sev_guest/src/ghcb.rs
@@ -26,10 +26,7 @@ use crate::{
     Translator,
 };
 use bitflags::bitflags;
-use x86_64::{
-    structures::paging::{Page, Size4KiB},
-    PhysAddr, VirtAddr,
-};
+use x86_64::{PhysAddr, VirtAddr};
 use zerocopy::FromBytes;
 
 /// The size of the GHCB page.
@@ -309,12 +306,6 @@ where
     /// Gets the guest-physical address for the guest-hypervisor communication block.
     pub fn get_gpa(&self) -> PhysAddr {
         self.gpa
-    }
-
-    /// Gets the memory page that contains the guest-hypervisor communication block.
-    pub fn get_page(&self) -> Page<Size4KiB> {
-        Page::from_start_address(VirtAddr::from_ptr(self.ghcb.as_ref() as *const Ghcb))
-            .expect("ghcb not aligned")
     }
 
     /// Registers the address of the GHCB with the hypervisor.

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -17,7 +17,6 @@
 #![no_std]
 #![feature(int_roundings)]
 
-use crate::sev::Validate;
 use core::{arch::asm, ffi::c_void, mem::MaybeUninit, panic::PanicInfo};
 use oak_sev_guest::io::PortFactoryWrapper;
 use x86_64::{
@@ -26,7 +25,7 @@ use x86_64::{
     structures::{
         gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector},
         idt::InterruptDescriptorTable,
-        paging::{Page, PageSize, Size1GiB, Size4KiB},
+        paging::{Page, PageSize, Size1GiB},
     },
     PhysAddr, VirtAddr,
 };
@@ -260,19 +259,13 @@ pub fn rust64_start(encrypted: u64) -> ! {
 
     // Clean-ups we need to do just before we jump to the kernel proper: clean up the early GHCB and
     // FW_CFG DMA buffers we used, and switch back to a hugepage for the first 2M of memory.
-    if snp {
-        sev::unshare_page(Page::<Size4KiB>::containing_address(dma_buf_address));
-        sev::unshare_page(Page::<Size4KiB>::containing_address(dma_access_address));
-        sev::unshare_page(ghcb_protocol.unwrap().lock().get_page());
-    }
     paging::remap_first_huge_page(encrypted);
-    // Call pvalidate again on the pages we just unshared now that they are marked as encrypted in
-    // the pages table.
     if snp {
-        // Ignore any errors. Th GHCB is unshared at this point, so we cannot log anymore.
-        let _ = Page::<Size4KiB>::containing_address(dma_buf_address).pvalidate();
-        let _ = Page::<Size4KiB>::containing_address(dma_access_address).pvalidate();
-        let _ = ghcb_protocol.unwrap().lock().get_page().pvalidate();
+        sev::unshare_page(Page::containing_address(dma_buf_address));
+        sev::unshare_page(Page::containing_address(dma_access_address));
+        if ghcb_protocol.is_some() {
+            sev::deinit_ghcb();
+        }
     }
 
     unsafe {

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -165,12 +165,6 @@ pub fn init_ghcb(
     GHCB_WRAPPER.get().unwrap()
 }
 
-/// Stops sharing the GHCB with the hypervisor when running with AMD SEV-SNP enabled.
-pub fn deinit_ghcb() {
-    let ghcb_addr = VirtAddr::new(GHCB_WRAPPER.get().unwrap().lock().get_gpa().as_u64());
-    unshare_page(Page::containing_address(ghcb_addr));
-}
-
 /// Shares a single 4KiB page with the hypervisor.
 pub fn share_page(page: Page<Size4KiB>, snp: bool) {
     let page_start = page.start_address().as_u64();
@@ -221,7 +215,7 @@ impl ValidatablePageSize for Size2MiB {
     const SEV_PAGE_SIZE: SevPageSize = SevPageSize::Page2MiB;
 }
 
-trait Validate<S: PageSize> {
+pub trait Validate<S: PageSize> {
     fn pvalidate(&self) -> Result<(), InstructionError>;
 }
 

--- a/stage0_bin/src/asm/boot.s
+++ b/stage0_bin/src/asm/boot.s
@@ -90,7 +90,7 @@ _protected_mode_start:
     and $0b100, %eax          # eax &= 0b100; -- SEV-SNP active
     test %eax, %eax           # is eax zero?
     je 2f                     # if yes, no SNP, skip validation and jump ahead
-    mov $0x1000, %ebx         # ebx = 0x1000 -- start address (skipping first page as that's not mapped)
+    mov $0x0000, %ebx         # ebx = 0x0000 -- start address
     xor %ecx, %ecx            # ecx = 0 -- we're using 4K pages
     mov $0b1, %edx            # edx = 1 -- set RMP VALIDATED bit
     1:


### PR DESCRIPTION
We must call pvalidate again on the pages that were unshared in Stage 0 before jumping to the kernel to make sure they are usable by the kernel.

PVALIDATE causes an exception if it is called on pages that are not marked as encrypted in the page tables, so the remapping of the first 2MiB huge page now happens earlier.

This change also pvalidates the first 4KiB page in the boot assembly code to make it usable by the kernel.