### PR TITLE
Include rekor public key in BinaryAttestation message

### DIFF
--- a/oak_client/src/lib.rs
+++ b/oak_client/src/lib.rs
@@ -19,6 +19,7 @@ pub mod proto {
         pub mod session {
             pub mod v1 {
                 #![allow(clippy::return_self_not_must_use)]
+                #![allow(clippy::large_enum_variant)]
                 tonic::include_proto!("oak.session.v1");
             }
         }

--- a/oak_containers_hello_world_trusted_app/src/lib.rs
+++ b/oak_containers_hello_world_trusted_app/src/lib.rs
@@ -26,6 +26,7 @@ mod proto {
         pub mod session {
             pub mod v1 {
                 #![allow(clippy::return_self_not_must_use)]
+                #![allow(clippy::large_enum_variant)]
                 tonic::include_proto!("oak.session.v1");
             }
         }

--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -147,6 +147,7 @@ impl Launcher {
                 binary_attestation: Some(BinaryAttestation {
                     endorsement_statement: vec![],
                     rekor_log_entry: vec![],
+                    base64_pem_encoded_rekor_public_key: "".to_string(),
                 }),
                 application_data: None,
             },

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -31,6 +31,7 @@ pub mod proto {
         pub mod session {
             pub mod v1 {
                 #![allow(clippy::return_self_not_must_use)]
+                #![allow(clippy::large_enum_variant)]
                 tonic::include_proto!("oak.session.v1");
             }
         }

--- a/oak_remote_attestation/proto/v1/messages.proto
+++ b/oak_remote_attestation/proto/v1/messages.proto
@@ -75,6 +75,9 @@ message BinaryAttestation {
   bytes endorsement_statement = 1;
   // The serialized Rekor LogEntry as proof of the inclusion of the endorsement statement in Rekor.
   bytes rekor_log_entry = 2;
+  // Public key of rekor at the time of uploading the endorsement statement. This is required for
+  // verifying the log entry.
+  string base64_pem_encoded_rekor_public_key = 3;
 }
 
 message ApplicationData {

--- a/oak_remote_attestation_verification/src/rekor.rs
+++ b/oak_remote_attestation_verification/src/rekor.rs
@@ -182,7 +182,7 @@ pub fn verify_rekor_log_entry(
 ) -> anyhow::Result<()> {
     verify_rekor_signature(log_entry_bytes, pem_encoded_rekor_public_key_bytes)?;
 
-    let body = parse_rekor_log_entry_body(log_entry_bytes)?;
+    let body = get_rekor_log_entry_body(log_entry_bytes)?;
 
     let pem_encoded_endorser_public_key_bytes = BASE64_STANDARD
         .decode(body.spec.signature.public_key.content.clone())
@@ -198,7 +198,9 @@ pub fn verify_rekor_log_entry(
     Ok(())
 }
 
-pub fn parse_rekor_log_entry_body(log_entry_bytes: &[u8]) -> anyhow::Result<Body> {
+/// Parses the given bytes into a Rekor `LogEntry` object, and returns its `body` parsed into an
+/// instance of `Body`.
+pub fn get_rekor_log_entry_body(log_entry_bytes: &[u8]) -> anyhow::Result<Body> {
     let parsed: BTreeMap<String, LogEntry> = serde_json::from_slice(log_entry_bytes)
         .context("couldn't parse bytes into a LogEntry object")?;
     let entry = parsed.values().next().context("no entry in the map")?;

--- a/oak_remote_attestation_verification/src/tests.rs
+++ b/oak_remote_attestation_verification/src/tests.rs
@@ -18,6 +18,7 @@ use crate::rekor::*;
 use std::fs;
 
 use alloc::{sync::Arc, vec};
+use base64::{prelude::BASE64_STANDARD, Engine as _};
 use oak_crypto::encryptor::EncryptionKeyProvider;
 use oak_remote_attestation::{
     attester::{Attester, EmptyAttestationReportGenerator},
@@ -89,7 +90,7 @@ fn test_verify_rekor_log_entry() {
     let result = verify_rekor_log_entry(
         &testdata.log_entry_bytes,
         &testdata.rekor_public_key_pem_bytes,
-        &testdata.endorser_public_key_pem_bytes,
+        // &testdata.endorser_public_key_pem_bytes,
         &testdata.endorsement_bytes,
     );
     assert!(result.is_ok(), "{:?}", result);
@@ -140,9 +141,12 @@ fn test_empty_attestation() {
 #[test]
 fn test_verify_binary_attestation() {
     let testdata = load_testdata();
+    let base64_pem_encoded_rekor_public_key =
+        BASE64_STANDARD.encode(&testdata.rekor_public_key_pem_bytes);
     let binary_attestation = BinaryAttestation {
         endorsement_statement: testdata.endorsement_bytes,
         rekor_log_entry: testdata.log_entry_bytes,
+        base64_pem_encoded_rekor_public_key,
     };
     let reference_value = ReferenceValue {
         binary_hash: BINARY_HASH.as_bytes().to_vec(),

--- a/oak_remote_attestation_verification/src/tests.rs
+++ b/oak_remote_attestation_verification/src/tests.rs
@@ -90,7 +90,6 @@ fn test_verify_rekor_log_entry() {
     let result = verify_rekor_log_entry(
         &testdata.log_entry_bytes,
         &testdata.rekor_public_key_pem_bytes,
-        // &testdata.endorser_public_key_pem_bytes,
         &testdata.endorsement_bytes,
     );
     assert!(result.is_ok(), "{:?}", result);

--- a/oak_remote_attestation_verification/src/verifier.rs
+++ b/oak_remote_attestation_verification/src/verifier.rs
@@ -15,11 +15,13 @@
 //
 
 use alloc::vec::Vec;
+use anyhow::Context;
 use oak_remote_attestation::proto::oak::session::v1::{
     AttestationEndorsement, AttestationEvidence, BinaryAttestation,
 };
 
-use crate::rekor::verify_rekor_log_entry;
+use crate::rekor::{parse_rekor_log_entry_body, verify_rekor_log_entry};
+use base64::{prelude::BASE64_STANDARD, Engine as _};
 use oak_transparency_claims::claims::{parse_endorsement_statement, validate_endorsement};
 
 /// Reference values used by the verifier to appraise the attestation evidence.
@@ -76,12 +78,15 @@ pub fn verify_binary_attestation(
     pem_encoded_rekor_public_key_bytes: &[u8],
     pem_encoded_endorser_public_key_bytes: &[u8],
 ) -> anyhow::Result<()> {
+    let rekor_public_key_bytes =
+        BASE64_STANDARD.decode(&binary_attestation.base64_pem_encoded_rekor_public_key)?;
     verify_rekor_log_entry(
         &binary_attestation.rekor_log_entry,
-        pem_encoded_rekor_public_key_bytes,
-        pem_encoded_endorser_public_key_bytes,
+        &rekor_public_key_bytes,
         &binary_attestation.endorsement_statement,
     )?;
+    verify_rekor_public_key(binary_attestation, pem_encoded_rekor_public_key_bytes)?;
+    verify_endorser_public_key(binary_attestation, pem_encoded_endorser_public_key_bytes)?;
     verify_endorsement_statement(&binary_attestation.endorsement_statement, reference_value)
 }
 
@@ -108,5 +113,43 @@ pub fn verify_endorsement_statement(
             claim.subject[0].digest["sha256"]
         );
     }
+    Ok(())
+}
+
+// Verifies that the rekor public key in the given BinaryAttestation is the same as the given
+// public key, signed by it, or derived from it.
+fn verify_rekor_public_key(
+    binary_attestation: &BinaryAttestation,
+    pem_encoded_rekor_public_key_bytes: &[u8],
+) -> anyhow::Result<()> {
+    let rekor_public_key_bytes =
+        BASE64_STANDARD.decode(&binary_attestation.base64_pem_encoded_rekor_public_key)?;
+
+    // Currently, we only check that the public keys are the same. Once Rekor starts using rolling
+    // keys, the verification logic will have to be updated.
+    if rekor_public_key_bytes != pem_encoded_rekor_public_key_bytes {
+        anyhow::bail!("Rekor public key verification failed: expected {pem_encoded_rekor_public_key_bytes:?}, got {rekor_public_key_bytes:?}");
+    }
+
+    Ok(())
+}
+
+// Verifies that the endorser's public key in the Rekor log entry in the given BinaryAttestation is
+// the same as the given public key, signed by it, or derived from it.
+fn verify_endorser_public_key(
+    binary_attestation: &BinaryAttestation,
+    pem_encoded_endorser_public_key_bytes: &[u8],
+) -> anyhow::Result<()> {
+    let body = parse_rekor_log_entry_body(&binary_attestation.rekor_log_entry)?;
+
+    let endorser_public_key_bytes = BASE64_STANDARD
+        .decode(body.spec.signature.public_key.content.clone())
+        .context("couldn't decode Base64 endorser public key")?;
+
+    // Currently, we only check that the public keys are the same.
+    if endorser_public_key_bytes != pem_encoded_endorser_public_key_bytes {
+        anyhow::bail!("endorser public key verification failed: expected {pem_encoded_endorser_public_key_bytes:?}, got {endorser_public_key_bytes:?}");
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Includes Rekor public key in the BinaryAttestation message. 

Rationale: Rekor may in future start using rolling keys. To be able to successfully verify the signature in a Rekor log entry, the client will need the public key at the time of the creation of the log entry. 

The client still needs to acquire to actual or the parent public key out of band, to be able to trust the key. 

The same applies to the endorser's public key. The log entry contains the public key with which the uploaded artifact was signed. The client still needs the actual or the parent public key to be able to verify the public key in the Rekor log entry.

The PR also splits the verification logic into two steps:
- Verify the signatures in the log entry, using the public keys coming from the server (either in the log entry itself, or in the binary attestation)
- Verify the public keys received from the server against client-side trusted public keys.