### PR TITLE
Update the bitflags crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ name = "oak_channel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "bytes",
  "micro_rpc",
  "oak_core",
@@ -2128,7 +2128,7 @@ dependencies = [
 name = "oak_linux_boot_params"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "static_assertions",
  "strum",
  "zerocopy",
@@ -2173,7 +2173,7 @@ dependencies = [
  "arrayvec",
  "assertables",
  "atomic_refcell",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "bitvec",
  "goblin",
  "libm 0.2.6",
@@ -2215,7 +2215,7 @@ dependencies = [
 name = "oak_restricted_kernel_interface"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "strum",
 ]
 
@@ -2224,7 +2224,7 @@ name = "oak_sev_guest"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "lock_api",
  "snafu",
  "spinning_top",
@@ -2246,7 +2246,7 @@ dependencies = [
 name = "oak_stage0"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "elf",
  "log",
  "oak_core",
@@ -2264,7 +2264,7 @@ dependencies = [
 name = "oak_tdx_guest"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "strum",
  "x86_64",
 ]
@@ -2299,7 +2299,7 @@ name = "oak_virtio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "log",
  "rand 0.8.5",
  "rust-hypervisor-firmware-virtio",

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -84,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,7 +491,7 @@ name = "oak_channel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.4.0",
  "bytes",
  "micro_rpc",
  "oak_core",
@@ -674,7 +680,7 @@ dependencies = [
 name = "oak_restricted_kernel_interface"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "strum",
 ]
 
@@ -874,7 +880,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -910,7 +916,7 @@ version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/linux_boot_params/Cargo.toml
+++ b/linux_boot_params/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "*"
 static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
 zerocopy = "*"

--- a/oak_channel/Cargo.toml
+++ b/oak_channel/Cargo.toml
@@ -15,5 +15,5 @@ anyhow = { version = "*", default-features = false }
 micro_rpc = { workspace = true }
 oak_core = { workspace = true }
 static_assertions = "*"
-bitflags = "1.3.2"
+bitflags = "*"
 bytes = { version = "*", default-features = false }

--- a/oak_channel/src/frame.rs
+++ b/oak_channel/src/frame.rs
@@ -32,7 +32,7 @@ pub const LENGTH_SIZE: usize = 2;
 static_assertions::assert_eq_size!([u8; LENGTH_SIZE], Length);
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Clone, Debug, Default)]
     pub struct Flags: u16 {
         const START = 1;
         const END = 2;
@@ -75,7 +75,7 @@ impl Frame<'_> {
         };
         channel.write(PADDING)?;
         channel.write(&frame_length.to_le_bytes())?;
-        channel.write(&self.flags.bits.to_le_bytes())?;
+        channel.write(&self.flags.bits().to_le_bytes())?;
         channel.write(self.body)?;
         Ok(())
     }

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -18,12 +18,12 @@ aml = "*"
 anyhow = { version = "*", default-features = false }
 arrayvec = { version = "*", default-features = false }
 atomic_refcell = "*"
-bitflags = "1.3.2"
+bitflags = "*"
 bitvec = { version = "*", default-features = false }
 goblin = { version = "*", default-features = false, features = [
   "elf32",
   "elf64",
-  "endian_fd"
+  "endian_fd",
 ] }
 linked_list_allocator = { version = "*", features = ["alloc_ref"] }
 log = "*"

--- a/oak_restricted_kernel/src/mm/mod.rs
+++ b/oak_restricted_kernel/src/mm/mod.rs
@@ -74,6 +74,7 @@ bitflags::bitflags! {
     /// Possible flags for a page table entry.
     ///
     /// See <x86_64::structures::paging::PageTableFlags> for more details.
+    #[derive(Clone, Copy, Debug)]
     pub struct PageTableFlags: u64 {
         const PRESENT = 1;
         const WRITABLE = 1 << 1;

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -441,7 +441,7 @@ name = "oak_channel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "bytes",
  "micro_rpc",
  "oak_core",
@@ -461,7 +461,7 @@ dependencies = [
 name = "oak_linux_boot_params"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "static_assertions",
  "strum",
  "zerocopy",
@@ -476,7 +476,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "atomic_refcell",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "bitvec",
  "goblin",
  "libm",
@@ -515,7 +515,7 @@ dependencies = [
 name = "oak_restricted_kernel_interface"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "strum",
 ]
 
@@ -524,7 +524,7 @@ name = "oak_sev_guest"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "lock_api",
  "snafu",
  "spinning_top",
@@ -547,7 +547,7 @@ name = "oak_virtio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "log",
  "rust-hypervisor-firmware-virtio",
  "strum",
@@ -721,7 +721,7 @@ name = "rust-hypervisor-firmware-virtio"
 version = "0.1.0"
 dependencies = [
  "atomic_refcell",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "log",
  "x86_64",
 ]

--- a/oak_restricted_kernel_interface/Cargo.toml
+++ b/oak_restricted_kernel_interface/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/oak_restricted_kernel_interface/src/syscalls.rs
+++ b/oak_restricted_kernel_interface/src/syscalls.rs
@@ -100,6 +100,7 @@ bitflags! {
 }
 
 bitflags! {
+    #[derive(Debug)]
     #[repr(C)]
     pub struct MmapFlags: i32 {
         /// Private copy-on-write mapping.

--- a/oak_sev_guest/Cargo.toml
+++ b/oak_sev_guest/Cargo.toml
@@ -11,9 +11,9 @@ rust-crypto = ["aes-gcm"]
 
 [dependencies]
 aes-gcm = { version = "*", optional = true, default-features = false, features = [
-  "aes"
+  "aes",
 ] }
-bitflags = "1.3.2"
+bitflags = "*"
 lock_api = "*"
 spinning_top = "*"
 static_assertions = "*"

--- a/oak_sev_guest/src/ghcb.rs
+++ b/oak_sev_guest/src/ghcb.rs
@@ -198,10 +198,13 @@ impl AsRef<Ghcb> for Ghcb {
 
 static_assertions::assert_eq_size!(Ghcb, [u8; GHCB_PAGE_SIZE]);
 
+/// Flags indicating which fields in a specific GHCB instance are valid.
+#[derive(Debug, Default, FromBytes)]
+#[repr(transparent)]
+pub struct ValidBitmap(u128);
+
 bitflags! {
-    /// Flags indicating which fields in a specific GHCB instance are valid.
-    #[derive(Default, FromBytes)]
-    pub struct ValidBitmap: u128 {
+    impl ValidBitmap: u128 {
         const CPL = (1 << 25);
         const XSS = (1 << 40);
         const DR7 = (1 << 44);

--- a/oak_sev_guest/src/instructions.rs
+++ b/oak_sev_guest/src/instructions.rs
@@ -99,6 +99,7 @@ bitflags! {
     /// Permission mask used by the RMP.
     ///
     /// See Table 15-38 in <https://www.amd.com/system/files/TechDocs/24593.pdf> for more details.
+    #[derive(Clone, Debug, PartialEq)]
     pub struct PermissionMask: u8 {
         /// The target VMPL can read the page.
         const READ = 1;

--- a/oak_sev_guest/src/msr.rs
+++ b/oak_sev_guest/src/msr.rs
@@ -442,7 +442,7 @@ impl From<HypervisorFeatureSupportRequest> for u64 {
 
 bitflags! {
     /// Flags indicating which features are supported by the hypervisor.
-    #[derive(Default)]
+    #[derive(Debug, Default, PartialEq)]
     pub struct HypervisorFeatureSupportResponse: u64 {
         /// AMD SEV-SNP is supported.
         const SEV_SNP = (1 << 0);

--- a/oak_sev_guest/src/msr.rs
+++ b/oak_sev_guest/src/msr.rs
@@ -511,7 +511,7 @@ pub fn request_termination(request: TerminationRequest) -> ! {
 
 bitflags! {
     /// Flags indicating which SEV features are active.
-    #[derive(Default)]
+    #[derive(Clone, Copy, Default)]
     pub struct SevStatus: u64 {
         /// SEV is enabled for this guest.
         const SEV_ENABLED = (1 << 0);

--- a/oak_tdx_guest/Cargo.toml
+++ b/oak_tdx_guest/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
 x86_64 = "*"

--- a/oak_tdx_guest/src/vmcall.rs
+++ b/oak_tdx_guest/src/vmcall.rs
@@ -147,7 +147,7 @@ pub unsafe fn map_gpa(frames: PhysFrameRange<Size4KiB>) -> Result<(), MapGpaErro
         asm!(
             "tdcall",
             inout("rax") VM_CALL_LEAF => vm_call_result,
-            in("rcx") registers.bits,
+            in("rcx") registers.bits(),
             inout("r10") DEFAULT_SUB_FUNCTION_USAGE => sub_function_result,
             inout("r11") SUB_FUNCTION => failing_gpa,
             in("r12") gpa_start,
@@ -212,7 +212,7 @@ pub fn call_cpuid(leaf: u32, sub_leaf: u32) -> Result<CpuidResult, &'static str>
         asm!(
             "tdcall",
             inout("rax") VM_CALL_LEAF => vm_call_result,
-            in("rcx") registers.bits,
+            in("rcx") registers.bits(),
             inout("r10") DEFAULT_SUB_FUNCTION_USAGE => sub_function_result,
             in("r11") SUB_FUNCTION,
             inout("r12") leaf as u64 => eax,
@@ -328,7 +328,7 @@ fn io_read(port: u32, size: IoWidth) -> Result<u64, &'static str> {
         asm!(
             "tdcall",
             inout("rax") VM_CALL_LEAF => vm_call_result,
-            in("rcx") registers.bits,
+            in("rcx") registers.bits(),
             inout("r10") DEFAULT_SUB_FUNCTION_USAGE => sub_function_result,
             inout("r11") SUB_FUNCTION => data,
             in("r12") size as u64,
@@ -389,7 +389,7 @@ fn io_write(port: u32, size: IoWidth, data: u64) -> Result<(), &'static str> {
         asm!(
             "tdcall",
             inout("rax") VM_CALL_LEAF => vm_call_result,
-            in("rcx") registers.bits,
+            in("rcx") registers.bits(),
             inout("r10") DEFAULT_SUB_FUNCTION_USAGE => sub_function_result,
             in("r11") SUB_FUNCTION,
             in("r12") size as u64,
@@ -450,7 +450,7 @@ pub unsafe fn msr_write(msr: u32, data: u64) -> Result<(), &'static str> {
         asm!(
             "tdcall",
             inout("rax") VM_CALL_LEAF => vm_call_result,
-            in("rcx") registers.bits,
+            in("rcx") registers.bits(),
             inout("r10") DEFAULT_SUB_FUNCTION_USAGE => sub_function_result,
             in("r11") SUB_FUNCTION,
             in("r12") msr as u64,
@@ -505,7 +505,7 @@ pub fn msr_read(msr: u32) -> Result<u64, &'static str> {
         asm!(
             "tdcall",
             inout("rax") VM_CALL_LEAF => vm_call_result,
-            in("rcx") registers.bits,
+            in("rcx") registers.bits(),
             inout("r10") DEFAULT_SUB_FUNCTION_USAGE => sub_function_result,
             inout("r11") SUB_FUNCTION => data,
             in("r12") msr as u64,

--- a/oak_virtio/Cargo.toml
+++ b/oak_virtio/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = { version = "*", default-features = false }
-bitflags = "1.3.2"
+bitflags = "*"
 log = "*"
 rust-hypervisor-firmware-virtio = { path = "../third_party/rust-hypervisor-firmware-virtio" }
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/oak_virtio/src/queue/virtq.rs
+++ b/oak_virtio/src/queue/virtq.rs
@@ -22,6 +22,7 @@ bitflags! {
     /// Flags about a descriptor.
     ///
     /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-320005>.
+    #[derive(Clone, Copy, Debug)]
     pub struct DescFlags: u16 {
         /// This marks a buffer as continuing via the next field to chain descriptors together.
         ///
@@ -77,6 +78,7 @@ impl Desc {
 
 bitflags! {
     /// Flags about the available and used rings.
+    #[derive(Debug)]
     pub struct RingFlags: u16 {
         /// This indicates that the owner of the ring does not require queue notifications.
         const NO_NOTIFY = 1;

--- a/oak_virtio/src/vsock/packet.rs
+++ b/oak_virtio/src/vsock/packet.rs
@@ -347,6 +347,7 @@ bitflags! {
     ///
     /// Used in a connection shutdown request.
     /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-4070005>.
+    #[derive(Debug)]
     pub struct VSockFlags: u32 {
         /// Indicates that no more payload data will be received.
         const NO_RECEIVE = 1;

--- a/oak_virtio/src/vsock/packet.rs
+++ b/oak_virtio/src/vsock/packet.rs
@@ -347,7 +347,7 @@ bitflags! {
     ///
     /// Used in a connection shutdown request.
     /// See <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-4070005>.
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq)]
     pub struct VSockFlags: u32 {
         /// Indicates that no more payload data will be received.
         const NO_RECEIVE = 1;

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "*"
 elf = { version = "*", default-features = false }
 log = "*"
 oak_core = { path = "../oak_core", default-features = false }

--- a/stage0_bin/Cargo.lock
+++ b/stage0_bin/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,7 +104,7 @@ dependencies = [
 name = "oak_linux_boot_params"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "static_assertions",
  "strum",
  "zerocopy",
@@ -108,7 +114,7 @@ dependencies = [
 name = "oak_sev_guest"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "lock_api",
  "snafu",
  "spinning_top",
@@ -122,7 +128,7 @@ dependencies = [
 name = "oak_stage0"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "elf",
  "log",
  "oak_core",
@@ -294,7 +300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 1.3.2",
  "rustversion",
  "volatile",
 ]

--- a/testing/sev_snp_hello_world_kernel/Cargo.lock
+++ b/testing/sev_snp_hello_world_kernel/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,7 +82,7 @@ dependencies = [
 name = "oak_linux_boot_params"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "static_assertions",
  "strum",
  "zerocopy",
@@ -86,7 +92,7 @@ dependencies = [
 name = "oak_sev_guest"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "lock_api",
  "snafu",
  "spinning_top",
@@ -243,7 +249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 1.3.2",
  "rustversion",
  "volatile",
 ]


### PR DESCRIPTION
The implementation of the `bitflags` crate changed between v1 and v2:

- `Copy`, `Clone`, `Debug`  and `PartialEq` are no longer derived by default
- The `bits` field is no longer accessible
- `FromBytes` cannot be derived on the default implementation

Fixes #4223