### PR TITLE
Vet `bitflags` v2.4.0

### DIFF
--- a/stage0_bin/supply-chain/audits.toml
+++ b/stage0_bin/supply-chain/audits.toml
@@ -32,6 +32,12 @@ criteria = ["safe-to-deploy", "does-not-implement-crypto"]
 version = "1.3.2"
 notes = "Limited use of unsafe code that is well commented and unproblematic. Does not implement crypto algorithms."
 
+[[audits.bitflags]]
+who = "Conrad Grobler <grobler@google.com>"
+criteria = ["safe-to-deploy", "does-not-implement-crypto"]
+delta = "1.3.2 -> 2.4.0"
+notes = "Version 2.4.0 has significantly less unsafe code than the previous version. The two new unsafe blocks that have been added are well documented."
+
 [[audits.byteorder]]
 who = "Conrad Grobler <grobler@google.com>"
 criteria = ["safe-to-deploy", "does-not-implement-crypto"]


### PR DESCRIPTION
Reviewed diff between `bitflags` v2.4.0 and v1.3.2 for "safe-to-deploy" and "does-not-implement-crypto"

Reviewed from https://sourcegraph.com/crates/bitflags/-/compare/v1.3.2...v2.4.0?visible=53