### PR TITLE
Parse the XSDT and extract the location of MADT in stage0

### DIFF
--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -250,6 +250,11 @@ pub fn rust64_start(encrypted: u64) -> ! {
     let rsdp = acpi::build_acpi_tables(&mut fwcfg).unwrap();
     zero_page.set_acpi_rsdp_addr(PhysAddr::new(rsdp as *const _ as u64));
 
+    // TODO(#4235): Bootstrap the APs.
+    if let Some(xsdt) = rsdp.xsdt().unwrap() {
+        let _madt = xsdt.get(b"MADT");
+    }
+
     if let Some(ram_disk) =
         initramfs::try_load_initial_ram_disk(&mut fwcfg, zero_page.e820_table(), &kernel_info)
     {


### PR DESCRIPTION
Second step in finding out how many CPUs we have on the machine: once we have the RSDP, find the reference to MADT (Multiple APIC Description Table) from that.

This is really starting to strain what's sensible in Rust, unfortunately. The XSDT has a dynamic length which is a pain to work with.

I hope that I've handled all the unsafety as safely as reasonably possible.

Ref #4235 