### PR TITLE
Measure the kernel command line, setup data, and initial RAM disk

### DIFF
--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -13,7 +13,7 @@ oak_core = { path = "../oak_core", default-features = false }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 oak_sev_guest = { path = "../oak_sev_guest", default-features = false }
 sev_serial = { path = "../sev_serial" }
-sha2 = { version = "*", default-features = false }
+sha2 = { version = "*", default-features = false, features = ["force-soft"] }
 spinning_top = "*"
 static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/stage0/src/kernel.rs
+++ b/stage0/src/kernel.rs
@@ -21,7 +21,6 @@ use crate::{
 use core::{alloc::Layout, ffi::CStr, ptr::NonNull, slice};
 use elf::{abi::PT_LOAD, endian::AnyEndian, segment::ProgramHeader, ElfBytes};
 use oak_linux_boot_params::BootE820Entry;
-use sha2::{Digest, Sha384};
 use x86_64::{PhysAddr, VirtAddr};
 
 /// The default start location and entry point for the kernel if a kernel wasn't supplied via the
@@ -146,11 +145,8 @@ pub fn try_load_kernel_image(
         .expect("could not read kernel file");
     assert_eq!(actual_size, size, "kernel size did not match expected size");
 
-    let mut digest = Sha384::default();
-    digest.update(&buf);
-    let digest = digest.finalize();
     let mut measurement = [0u8; 48];
-    measurement[..].copy_from_slice(&digest[..]);
+    crate::populate_measurement(&mut measurement, buf);
 
     if bzimage {
         // For a bzImage the 64-bit entry point is at offset 0x200 from the start of the 64-bit

--- a/stage0/src/kernel.rs
+++ b/stage0/src/kernel.rs
@@ -46,8 +46,8 @@ pub struct KernelInfo {
     pub size: usize,
     /// The entry point for the kernel.
     pub entry: VirtAddr,
-    /// The SHA2-384 digest of the raw kernel image.
-    pub measurement: [u8; 48],
+    /// The SHA2-256 digest of the raw kernel image.
+    pub measurement: [u8; 32],
 }
 
 impl Default for KernelInfo {
@@ -56,7 +56,7 @@ impl Default for KernelInfo {
             start_address: VirtAddr::new(DEFAULT_KERNEL_START),
             size: DEFAULT_KERNEL_SIZE,
             entry: VirtAddr::new(DEFAULT_KERNEL_START),
-            measurement: [0u8; 48],
+            measurement: [0u8; 32],
         }
     }
 }
@@ -145,7 +145,7 @@ pub fn try_load_kernel_image(
         .expect("could not read kernel file");
     assert_eq!(actual_size, size, "kernel size did not match expected size");
 
-    let mut measurement = [0u8; 48];
+    let mut measurement = [0u8; 32];
     crate::populate_measurement(&mut measurement, buf);
 
     if bzimage {
@@ -164,7 +164,7 @@ pub fn try_load_kernel_image(
     }
 }
 
-fn parse_elf_file(buf: &[u8], e820_table: &[BootE820Entry], measurement: [u8; 48]) -> KernelInfo {
+fn parse_elf_file(buf: &[u8], e820_table: &[BootE820Entry], measurement: [u8; 32]) -> KernelInfo {
     let mut kernel_start = VirtAddr::new(crate::TOP_OF_VIRTUAL_MEMORY);
     let mut kernel_end = VirtAddr::new(0);
     // We expect an uncompressed ELF kernel, so we parse it and lay it out in memory.

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -311,7 +311,7 @@ fn phys_to_virt(address: PhysAddr) -> VirtAddr {
 /// Overwrites `measurement` with the SHA2-384 digest or `source`.
 fn populate_measurement(measurement: &mut [u8; 48], source: &[u8]) {
     let mut digest = Sha384::default();
-    digest.update(&source);
+    digest.update(source);
     let digest = digest.finalize();
     measurement[..].copy_from_slice(&digest[..]);
 }

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -58,8 +58,8 @@ impl ZeroPage {
     ///
     /// Returns the measurement (SHA2-384 digest) of the setup data if it was found, otherwise the
     /// measurement is all zeros.
-    pub fn try_fill_hdr_from_setup_data(&mut self, fw_cfg: &mut FwCfg) -> [u8; 48] {
-        let mut measurement = [0u8; 48];
+    pub fn try_fill_hdr_from_setup_data(&mut self, fw_cfg: &mut FwCfg) -> [u8; 32] {
+        let mut measurement = [0u8; 32];
         if let Some(file) = fw_cfg.get_setup_file() {
             let size = file.size();
             // We temporarily copy the setup data to the end of available mapped virtual memory.


### PR DESCRIPTION
This change also switches the measurement to using SHA2-256 instead of SHA2-384 for now.

Ref #4074