### PR TITLE
Add key derivation request and response structs

### DIFF
--- a/oak_sev_guest/src/guest.rs
+++ b/oak_sev_guest/src/guest.rs
@@ -259,6 +259,9 @@ pub struct KeyRequest {
     /// Reserved, must be zero.
     _reserved: u32,
     /// Mask indicating which guest data will be mixed into the derived key.
+    ///
+    /// Use `KeyRequest::get_guest_field_select_flags` to try to convert this to a
+    /// `GuestFieldFlags` enum.
     pub guest_field_select: u64,
     /// The VM Protection Level (VMPL) to mix into the derived key.
     ///
@@ -289,6 +292,11 @@ impl KeyRequest {
             guest_svn: 0,
             tcb_version: 0,
         }
+    }
+
+    /// Gets the `guest_field_select` field as a `GuestFieldFlags` representation if possible.
+    pub fn get_guest_field_select_flags(&self) -> Option<GuestFieldFlags> {
+        GuestFieldFlags::from_bits(self.guest_field_select)
     }
 
     /// Gets bit 0 of the `key_select` field as a `RootKeySelect` enum.
@@ -397,6 +405,25 @@ pub enum KeyStatus {
     InvalidParams = 0x16,
     /// The key selection field was invalid.
     InvalidKeySelection = 0x27,
+}
+
+bitflags! {
+    /// Flags indicating allowed policy options.
+    #[derive(Default)]
+    pub struct GuestFieldFlags: u64 {
+        /// The guest policy will be mixed into the key.
+        const GUEST_POLICY = (1 << 0);
+        /// The image ID provided in the ID block will be mixed into the key.
+        const IMAGE_ID = (1 << 1);
+        /// The family ID provided in the ID block will be mixed into the key.
+        const FAMILY_ID = (1 << 2);
+        /// The launch measurement of the VM will be mixed into the key.
+        const MEASUREMENT = (1 << 3);
+        /// The guest-provided SVN will be mixed into the key.
+        const GUEST_SVN = (1 << 4);
+        /// The guest-provided TCB version will be mixed into the key.
+        const TCB_VERSION = (1 << 5);
+    }
 }
 
 /// Request for an attestation report.

--- a/oak_sev_guest/src/guest.rs
+++ b/oak_sev_guest/src/guest.rs
@@ -279,13 +279,13 @@ pub struct KeyRequest {
 
 static_assertions::assert_eq_size!(KeyRequest, [u8; 32]);
 
-/// The bit mask for the root key select bit.
-const ROOT_KEY_SELECT_MASK: u32 = 1 << 0;
-
-/// The bit mask for the key select bits.
-const KEY_SELECT_MASK: u32 = (1 << 1) | (1 << 2);
-
 impl KeyRequest {
+    /// The bit mask for the root key select bit.
+    const ROOT_KEY_SELECT_MASK: u32 = 1 << 0;
+
+    /// The bit mask for the key select bits.
+    const KEY_SELECT_MASK: u32 = (1 << 1) | (1 << 2);
+
     pub const fn new() -> Self {
         Self {
             key_select: 0,
@@ -304,24 +304,24 @@ impl KeyRequest {
 
     /// Gets bit 0 of the `key_select` field as a `RootKeySelect` enum.
     pub fn get_root_key_select(&self) -> RootKeySelect {
-        RootKeySelect::from_repr(self.key_select & ROOT_KEY_SELECT_MASK).unwrap()
+        RootKeySelect::from_repr(self.key_select & KeyRequest::ROOT_KEY_SELECT_MASK).unwrap()
     }
 
     /// Gets bits 1 and 2 of the `key_select` field as a `KeySelect` enum.
     pub fn get_key_select(&self) -> KeySelect {
-        KeySelect::from_repr((self.key_select & KEY_SELECT_MASK) >> 1).unwrap()
+        KeySelect::from_repr((self.key_select & KeyRequest::KEY_SELECT_MASK) >> 1).unwrap()
     }
 
     /// Sets bit 0 of the `key_select` field.
     pub fn set_root_key_select(&mut self, root_key_select: RootKeySelect) {
-        self.key_select = self.key_select & !ROOT_KEY_SELECT_MASK
-            | (root_key_select as u32) & ROOT_KEY_SELECT_MASK;
+        self.key_select = self.key_select & !KeyRequest::ROOT_KEY_SELECT_MASK
+            | (root_key_select as u32) & KeyRequest::ROOT_KEY_SELECT_MASK;
     }
 
     /// Sets bits 1 and 2 of the `key_select` field.
     pub fn set_key_select(&mut self, key_select: KeySelect) {
-        self.key_select =
-            self.key_select & !KEY_SELECT_MASK | (key_select as u32) << 1 & KEY_SELECT_MASK;
+        self.key_select = self.key_select & !KeyRequest::KEY_SELECT_MASK
+            | (key_select as u32) << 1 & KeyRequest::KEY_SELECT_MASK;
     }
 }
 

--- a/oak_sev_guest/src/guest.rs
+++ b/oak_sev_guest/src/guest.rs
@@ -279,7 +279,10 @@ pub struct KeyRequest {
 
 static_assertions::assert_eq_size!(KeyRequest, [u8; 32]);
 
+/// The bit mask for the root key select bit.
 const ROOT_KEY_SELECT_MASK: u32 = 1 << 0;
+
+/// The bit mask for the key select bits.
 const KEY_SELECT_MASK: u32 = (1 << 1) | (1 << 2);
 
 impl KeyRequest {


### PR DESCRIPTION
These structs can be used with the guest message protocol to request derived keys from the secure processor on AMD SEV-SNP.