### PR TITLE
Make derived key available via a file descriptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "bitflags 2.3.3",
  "bitvec",
  "goblin",
+ "hkdf",
  "libm 0.2.6",
  "linked_list_allocator",
  "log",

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -25,6 +25,7 @@ goblin = { version = "*", default-features = false, features = [
   "elf64",
   "endian_fd",
 ] }
+hkdf = "*"
 linked_list_allocator = { version = "*", features = ["alloc_ref"] }
 log = "*"
 libm = "*"

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -68,9 +68,11 @@ use crate::{
     acpi::Acpi,
     mm::Translator,
     snp::{get_snp_page_addresses, init_snp_pages},
+    snp_guest::DerivedKey,
 };
 use alloc::{alloc::Allocator, boxed::Box};
 use core::{marker::Sync, panic::PanicInfo, str::FromStr};
+use hkdf::HkdfExtract;
 use linked_list_allocator::LockedHeap;
 use log::{error, info};
 use mm::{
@@ -81,6 +83,7 @@ use oak_channel::Channel;
 use oak_core::sync::OnceCell;
 use oak_linux_boot_params::BootParams;
 use oak_sev_guest::msr::{change_snp_state_for_frame, get_sev_status, PageAssignment, SevStatus};
+use sha2::Sha256;
 use spinning_top::Spinlock;
 use strum::{EnumIter, EnumString, IntoEnumIterator};
 use x86_64::{
@@ -267,9 +270,6 @@ pub fn start_kernel(info: &BootParams) -> ! {
             snp_guest::get_attestation([42; 64]).expect("couldn't generate attestation report");
         info!("Attestation: {:?}", report);
         report.validate().expect("attestation report is invalid");
-
-        let key = snp_guest::get_derived_key().expect("couldn't derive key");
-        info!("Derived key: {:?}", key);
     }
 
     let mut channel = get_channel(
@@ -285,7 +285,19 @@ pub fn start_kernel(info: &BootParams) -> ! {
     let application = payload::Application::load_raw(&mut *channel)
         .expect("failed to load application binary from channel");
 
-    syscall::enable_syscalls(channel);
+    let derived_key = if sev_snp_enabled {
+        snp_guest::get_derived_key().expect("couldn't derive key")
+    } else {
+        // Zero fixed key since we can't derive a consistent key without SEV-SNP.
+        DerivedKey::default()
+    };
+    // Mix the application digest into the final derived key.
+    let mut extraction = HkdfExtract::<Sha256>::new(Some(b"Oak application key"));
+    extraction.input_ikm(&derived_key);
+    extraction.input_ikm(application.digest());
+    let (derived_key, _) = extraction.finalize();
+
+    syscall::enable_syscalls(channel, derived_key.into());
 
     // Safety: we've loaded the Restricted Application. Whether that's valid or not is no longer
     // under the kernel's control.

--- a/oak_restricted_kernel/src/payload.rs
+++ b/oak_restricted_kernel/src/payload.rs
@@ -101,6 +101,10 @@ impl Application {
         })
     }
 
+    pub fn digest(&self) -> &[u8] {
+        &self.digest[..]
+    }
+
     fn program_headers(&self) -> &ProgramHeaders {
         &self.binary.borrow_dependent().program_headers
     }

--- a/oak_restricted_kernel/src/snp_guest.rs
+++ b/oak_restricted_kernel/src/snp_guest.rs
@@ -22,6 +22,8 @@ use oak_sev_guest::guest::{
     AttestationRequest, AttestationResponse, GuestFieldFlags, KeyRequest, KeyResponse, ReportStatus,
 };
 
+pub type DerivedKey = [u8; 32];
+
 // The number of custom bytes that can be included in the attestation report.
 const REPORT_DATA_SIZE: usize = 64;
 
@@ -48,7 +50,7 @@ pub fn get_attestation(report_data: [u8; REPORT_DATA_SIZE]) -> anyhow::Result<At
 ///
 /// The key is derived from the VCEK. The key derivation mixes in the VM launch measurement and
 /// guest policy and uses VMPL0.
-pub fn get_derived_key() -> anyhow::Result<[u8; 32]> {
+pub fn get_derived_key() -> anyhow::Result<DerivedKey> {
     let mut key_request = KeyRequest::new();
     let selected_fields = GuestFieldFlags::MEASUREMENT | GuestFieldFlags::GUEST_POLICY;
     key_request.guest_field_select = selected_fields.bits();

--- a/oak_restricted_kernel/src/syscall/key.rs
+++ b/oak_restricted_kernel/src/syscall/key.rs
@@ -1,0 +1,51 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::snp_guest::DerivedKey;
+
+use super::fd::FileDescriptor;
+use alloc::boxed::Box;
+use core::cmp::min;
+use oak_restricted_kernel_interface::{Errno, DERIVED_KEY_FD};
+
+#[derive(Default)]
+struct DerivedKeyDescriptor {
+    key: DerivedKey,
+}
+
+impl FileDescriptor for DerivedKeyDescriptor {
+    fn read(&mut self, buf: &mut [u8]) -> Result<isize, oak_restricted_kernel_interface::Errno> {
+        let length = min(self.key.len(), buf.len());
+        buf.copy_from_slice(&self.key[..length]);
+        Ok(length as isize)
+    }
+
+    fn write(&mut self, _buf: &[u8]) -> Result<isize, oak_restricted_kernel_interface::Errno> {
+        // Writing is not supported.
+        Err(Errno::EINVAL)
+    }
+
+    fn sync(&mut self) -> Result<(), oak_restricted_kernel_interface::Errno> {
+        Ok(())
+    }
+}
+
+/// Registers a file descriptor for reading a derived key (0x21)
+pub fn register(key: DerivedKey) {
+    super::fd::register(DERIVED_KEY_FD, Box::new(DerivedKeyDescriptor { key }))
+        .map_err(|_| ()) // throw away the box
+        .expect("DerivedKeyDescriptor already registered");
+}

--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -16,6 +16,7 @@
 
 mod channel;
 mod fd;
+mod key;
 pub mod mmap;
 mod process;
 mod stdio;
@@ -25,7 +26,7 @@ use self::{
     mmap::syscall_mmap,
     process::syscall_exit,
 };
-use crate::mm;
+use crate::{mm, snp_guest::DerivedKey};
 use alloc::boxed::Box;
 use core::{arch::asm, ffi::c_void};
 use oak_channel::Channel;
@@ -57,9 +58,10 @@ struct GsData {
     user_flags: usize,
 }
 
-pub fn enable_syscalls(channel: Box<dyn Channel>) {
+pub fn enable_syscalls(channel: Box<dyn Channel>, derived_key: DerivedKey) {
     channel::register(channel);
     stdio::register();
+    key::register(derived_key);
 
     // Allocate a stack for the system call handler.
     let kernel_sp = mm::allocate_stack();

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -199,11 +199,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "generic-array",
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -313,6 +315,24 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "indexmap"
@@ -479,6 +499,7 @@ dependencies = [
  "bitflags 2.3.3",
  "bitvec",
  "goblin",
+ "hkdf",
  "libm",
  "linked_list_allocator",
  "log",
@@ -788,15 +809,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
- "block-buffer",
  "cfg-if",
  "cpufeatures",
  "digest",
- "opaque-debug",
 ]
 
 [[package]]

--- a/oak_restricted_kernel_interface/src/lib.rs
+++ b/oak_restricted_kernel_interface/src/lib.rs
@@ -23,4 +23,7 @@ pub use errno::Errno;
 pub use syscalls::Syscall;
 
 /// Predefined file descriptor for the Oak communication channel.
-pub const OAK_CHANNEL_FD: i32 = 10;
+pub const OAK_CHANNEL_FD: i32 = 0xa;
+
+/// Predefined file descriptor for reading a derived key.
+pub const DERIVED_KEY_FD: i32 = 0x21;


### PR DESCRIPTION
This change is currently untested.

It asks the secure processor (on AMD SEV-SNP) to derive a key from the intial launch measurement. It then uses and HKDF to derive a key based on this key and the application digest. The resulting application-specific key is available to enclave applications by reading on file descriptor 0x21.