### PR TITLE
Fix key response message type

### DIFF
--- a/oak_sev_guest/src/guest.rs
+++ b/oak_sev_guest/src/guest.rs
@@ -351,7 +351,7 @@ static_assertions::assert_eq_size!(KeyResponse, [u8; 64]);
 
 impl Message for KeyResponse {
     fn get_message_type() -> MessageType {
-        MessageType::ReportResponse
+        MessageType::KeyResponse
     }
 }
 


### PR DESCRIPTION
The incorrect message type caused key derivation to fail on AMD SEV-SNP.