### PR TITLE
Add the simple-io version of the restricted kernel

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ all_oak_containers_binaries: stage0_bin stage1_cpio oak_containers_kernel oak_co
 
 # Entry points for Kokoro CI.
 
-kokoro_build_binaries_rust: all_enclave_apps oak_restricted_kernel_bin stage0_bin
+kokoro_build_binaries_rust: all_enclave_apps oak_restricted_kernel_bin oak_restricted_kernel_simple_io_bin stage0_bin
 
 kokoro_oak_containers: all_oak_containers_binaries
     cargo nextest run --all-targets --hide-progress-bar --package='oak_containers_hello_world_untrusted_app'

--- a/kokoro/build_binaries_rust.sh
+++ b/kokoro/build_binaries_rust.sh
@@ -31,6 +31,7 @@ touch "$KOKORO_ARTIFACTS_DIR/binaries/git_commit_${KOKORO_GIT_COMMIT_oak:?}"
 # the creation time.
 export GENERATED_BINARIES=(
     ./oak_restricted_kernel_bin/target/x86_64-unknown-none/release/oak_restricted_kernel_bin
+    ./oak_restricted_kernel_bin/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_bin
     ./stage0_bin/target/x86_64-unknown-none/release/stage0_bin
     ./enclave_apps/target/x86_64-unknown-none/release/key_xor_test_app
     ./enclave_apps/target/x86_64-unknown-none/release/oak_echo_enclave_app


### PR DESCRIPTION
The simple-io version of the restricted kernel is not currently included in the list of generated binaries.