### PR TITLE
Shut down orchestrator if the container exits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,6 +1791,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "futures",
  "log",
  "oak_containers_orchestrator_client",
  "oak_crypto",

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -8,23 +8,24 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "*"
 clap = { version = "*", features = ["derive"] }
+futures = "*"
+log = "*"
 oak_containers_orchestrator_client = { workspace = true }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
+prost = "*"
+serde = { version = "*", features = ["derive"] }
+serde_json = "*"
+syslog = "*"
+tar = "*"
 tokio = { version = "*", features = [
   "rt-multi-thread",
   "macros",
   "sync",
   "fs",
   "process",
-  "net"
+  "net",
 ] }
-log = "*"
-syslog = "*"
-tar = "*"
-serde = { version = "*", features = ["derive"] }
-serde_json = "*"
-prost = "*"
 tokio-stream = { version = "*", features = ["net"] }
 tonic = { workspace = true }
 

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -76,7 +76,7 @@ async fn rmount_dir(source: PathBuf, target: PathBuf) -> Result<(), anyhow::Erro
 
 pub async fn run(
     container_bundle: &[u8],
-    shutdown_sender: Sender<()>,
+    exit_notification_sender: Sender<()>,
 ) -> Result<(), anyhow::Error> {
     tokio::fs::create_dir(CONTAINER_DIR).await?;
     log::info!("Unpacking container bundle");
@@ -181,6 +181,6 @@ pub async fn run(
         .await?;
     log::info!("Container exited with status {status:?}");
 
-    let _ = shutdown_sender.send(());
+    let _ = exit_notification_sender.send(());
     Ok(())
 }

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -19,6 +19,7 @@
 
 use anyhow::Context;
 use std::path::PathBuf;
+use tokio::sync::oneshot::Sender;
 
 /// Representation of a minimal OCI filesystem bundle config, including just the required fields.
 /// Ref: <https://github.com/opencontainers/runtime-spec/blob/c4ee7d12c742ffe806cd9350b6af3b4b19faed6f/config.md>
@@ -73,7 +74,10 @@ async fn rmount_dir(source: PathBuf, target: PathBuf) -> Result<(), anyhow::Erro
     Ok(())
 }
 
-pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
+pub async fn run(
+    container_bundle: &[u8],
+    shutdown_sender: Sender<()>,
+) -> Result<(), anyhow::Error> {
     tokio::fs::create_dir(CONTAINER_DIR).await?;
     log::info!("Unpacking container bundle");
     tar::Archive::new(container_bundle).unpack(CONTAINER_DIR)?;
@@ -177,5 +181,6 @@ pub async fn run(container_bundle: &[u8]) -> Result<(), anyhow::Error> {
         .await?;
     log::info!("Container exited with status {status:?}");
 
+    let _ = shutdown_sender.send(());
     Ok(())
 }

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         path.push(IPC_SOCKET_FILE_NAME);
         path
     };
-    let (shutdown_sender, shutdown_receiver) = channel::<()>();
+    let (exit_notification_sender, shutdown_receiver) = channel::<()>();
 
     tokio::try_join!(
         oak_containers_orchestrator::ipc_server::create(
@@ -80,7 +80,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             launcher_client,
             shutdown_receiver
         ),
-        oak_containers_orchestrator::container_runtime::run(&container_bundle, shutdown_sender)
+        oak_containers_orchestrator::container_runtime::run(
+            &container_bundle,
+            exit_notification_sender
+        )
     )?;
 
     Ok(())

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -20,6 +20,7 @@ use oak_containers_orchestrator_client::LauncherClient;
 use oak_crypto::encryptor::EncryptionKeyProvider;
 use oak_remote_attestation::attester::{Attester, EmptyAttestationReportGenerator};
 use std::sync::Arc;
+use tokio::sync::oneshot::channel;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -68,6 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         path.push(IPC_SOCKET_FILE_NAME);
         path
     };
+    let (shutdown_sender, shutdown_receiver) = channel::<()>();
 
     tokio::try_join!(
         oak_containers_orchestrator::ipc_server::create(
@@ -75,9 +77,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             encryption_key_provider,
             attester,
             application_config,
-            launcher_client
+            launcher_client,
+            shutdown_receiver
         ),
-        oak_containers_orchestrator::container_runtime::run(&container_bundle)
+        oak_containers_orchestrator::container_runtime::run(&container_bundle, shutdown_sender)
     )?;
 
     Ok(())

--- a/oak_containers_system_image/oak-orchestrator.service
+++ b/oak_containers_system_image/oak-orchestrator.service
@@ -2,11 +2,12 @@
 Description=Oak Containers Orchestrator
 After=network-online.target
 Wants=network-online.target
+FailureAction=poweroff-force
+SuccessAction=poweroff-force
 
 [Service]
 Type=simple
 ExecStart=/bin/oak_containers_orchestrator
-FailureAction=poweroff-force
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If the main process in the container exits we no longer need the orchestrator gRPC service to remain active.

This change also modifies the systemd service definition so that the VM shuts down if the orchestrator exits.