### PR TITLE
Keep track of APs that come online in a counter

### DIFF
--- a/stage0_bin/src/asm/boot.s
+++ b/stage0_bin/src/asm/boot.s
@@ -4,9 +4,8 @@
 .align 4096
 .global ap_start
 ap_start:
-    mov $'!', %al
-    mov $0x3f8, %dx
-    out %al, %dx
+    # Let the BSP know we're alive.
+    lock incl (LIVE_AP_COUNT)
 1:
     hlt
     jmp 1b


### PR DESCRIPTION
Instead of printing out `!`, make the APs increment a counter when they come online.

The main benefit here is that accessing said memory location should work under SEV-ES and SEV-SNP as well (whereas writing `!` to the serial would have involved the GHCB protocol), so we should be able to detect that the CPUs come online if we bootstrap them properly under those conditions as well. (Obviously there is no code yet to properly park them yet.)

The downside is that if, say, a core enters a reset loop, or we spam it with SIPI messages, it's possible to make the counter increase too much. But given that we only send one SIPI right now this shouldn't occur.