### PR TITLE
Add short-term allocator to Stage 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,6 +2241,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.3.3",
  "elf",
+ "linked_list_allocator",
  "log",
  "oak_core",
  "oak_linux_boot_params",

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 bitflags = "*"
 elf = { version = "*", default-features = false }
 log = "*"
+linked_list_allocator = "*"
 oak_core = { path = "../oak_core", default-features = false }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 oak_sev_guest = { path = "../oak_sev_guest", default-features = false }

--- a/stage0/src/allocator.rs
+++ b/stage0/src/allocator.rs
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn simple_alloc() {
-        let alloc = Allocator::<16>::uninit();
+        let alloc = BumpAllocator::<16>::uninit();
         let val = alloc.leak([0u8; 16]);
         assert!(val.is_some());
         let val = alloc.leak([0u8; 16]);
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn two_alloc() {
-        let alloc = Allocator::<16>::uninit();
+        let alloc = BumpAllocator::<16>::uninit();
         let val = alloc.leak([0u8; 8]);
         assert!(val.is_some());
         let val = alloc.leak([0u8; 8]);
@@ -159,7 +159,7 @@ mod tests {
         // Allow for max 7-byte alignment + 2*8 (size of Foo)
         // The padding we need to use is ~random; it depends where exactly in memory our buffer
         // lands, as that is not required to be perfectly aligned with any particular boundary.
-        let alloc = Allocator::<23>::uninit();
+        let alloc = BumpAllocator::<23>::uninit();
         let val = alloc.leak(Foo { x: 16, _y: 16 }).unwrap();
         assert_eq!(0, val as *const Foo as usize % core::mem::align_of::<Foo>());
         assert_eq!(16, val.x);
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn failing_alloc() {
-        let alloc = Allocator::<4>::uninit();
+        let alloc = BumpAllocator::<4>::uninit();
         assert!(alloc.leak(0u64).is_none());
         assert!(alloc.leak(0u32).is_some());
         assert!(alloc.leak(0u8).is_none());

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -55,7 +55,7 @@ type Measurement = [u8; 32];
 // Reserve 128K for boot data structures that will outlive Stage 0.
 static BOOT_ALLOC: allocator::BumpAllocator<0x20000> = allocator::BumpAllocator::uninit();
 
-// Heap for short-term allocations. These allocations are note expected to outlive Stage 0.
+// Heap for short-term allocations. These allocations are not expected to outlive Stage 0.
 #[cfg_attr(not(test), global_allocator)]
 static SHORT_TERM_ALLOC: LockedHeap = LockedHeap::empty();
 
@@ -223,9 +223,6 @@ pub fn rust64_start(encrypted: u64) -> ! {
     // Initialize the short-term heap. Any allocations that rely on a global allocator before this
     // point will fail.
     allocator::init_global_allocator(zero_page.e820_table());
-
-    let test = alloc::vec![1u8, 2];
-    log::info!("test: {test:?}");
 
     let setup_data_measurement = zero_page
         .try_fill_hdr_from_setup_data(&mut fwcfg)

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -17,7 +17,10 @@
 #![no_std]
 #![feature(int_roundings)]
 
+extern crate alloc;
+
 use core::{arch::asm, ffi::c_void, mem::MaybeUninit, panic::PanicInfo};
+use linked_list_allocator::LockedHeap;
 use oak_sev_guest::io::PortFactoryWrapper;
 use sha2::{Digest, Sha256};
 use x86_64::{
@@ -34,7 +37,7 @@ use zerocopy::AsBytes;
 
 mod acpi;
 mod acpi_tables;
-mod alloc;
+mod allocator;
 mod apic;
 mod cmos;
 mod fw_cfg;
@@ -49,8 +52,12 @@ mod zero_page;
 
 type Measurement = [u8; 32];
 
-// Reserve 128K for boot data structures.
-static BOOT_ALLOC: alloc::Allocator<0x20000> = alloc::Allocator::uninit();
+// Reserve 128K for boot data structures that will outlive Stage 0.
+static BOOT_ALLOC: allocator::BumpAllocator<0x20000> = allocator::BumpAllocator::uninit();
+
+// Heap for short-term allocations. These allocations are note expected to outlive Stage 0.
+#[cfg_attr(not(test), global_allocator)]
+static SHORT_TERM_ALLOC: LockedHeap = LockedHeap::empty();
 
 #[link_section = ".boot"]
 #[no_mangle]
@@ -212,6 +219,13 @@ pub fn rust64_start(encrypted: u64) -> ! {
     idt.load();
 
     paging::map_additional_memory(encrypted);
+
+    // Initialize the short-term heap. Any allocations that rely on a global allocator before this
+    // point will fail.
+    allocator::init_global_allocator(zero_page.e820_table());
+
+    let test = alloc::vec![1u8, 2];
+    log::info!("test: {test:?}");
 
     let setup_data_measurement = zero_page
         .try_fill_hdr_from_setup_data(&mut fwcfg)

--- a/stage0_bin/.cargo/config.toml
+++ b/stage0_bin/.cargo/config.toml
@@ -6,4 +6,4 @@ rustflags = "-C relocation-model=static -C code-model=large"
 
 [unstable]
 # We need to build std / core because of the code model. This may be removed if / when it's possible to build stage0 without it in the future.
-build-std = ["core"]
+build-std = ["alloc", "core"]

--- a/stage0_bin/Cargo.lock
+++ b/stage0_bin/Cargo.lock
@@ -122,6 +122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
+name = "linked_list_allocator"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
+dependencies = [
+ "spinning_top",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +187,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.4.0",
  "elf",
+ "linked_list_allocator",
  "log",
  "oak_core",
  "oak_linux_boot_params",


### PR DESCRIPTION
We need an allocator for short-term allocations in Stage 0 to support generationr of CBOR/COSE certificates. We have so far avoided using memory in the range between 1MiB and 2MiB, so I am using this as the location for the heap.f

I also renamed the `alloc` module to avoid conflicts with the alloc crate and `Allocator` to clarify the intended use.