### PR TITLE
Create a special sections for the 16-bit AP boot code and data

### DIFF
--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -267,19 +267,17 @@ pub fn rust64_start(encrypted: u64) -> ! {
     let mut acpi_measurement = Measurement::default();
     acpi_measurement[..].copy_from_slice(&acpi_digest[..]);
 
-    if !es {
-        if let Err(err) = smp::bootstrap_aps(
-            rsdp,
-            &match ghcb_protocol {
-                Some(protocol) => PortFactoryWrapper::new_ghcb(protocol),
-                None => PortFactoryWrapper::new_raw(),
-            },
-        ) {
-            log::warn!(
-                "Failed to bootstrap APs: {}. APs may not be properly initialized.",
-                err
-            );
-        }
+    if let Err(err) = smp::bootstrap_aps(
+        rsdp,
+        &match ghcb_protocol {
+            Some(protocol) => PortFactoryWrapper::new_ghcb(protocol),
+            None => PortFactoryWrapper::new_raw(),
+        },
+    ) {
+        log::warn!(
+            "Failed to bootstrap APs: {}. APs may not be properly initialized.",
+            err
+        );
     }
 
     let ram_disk_measurement =

--- a/stage0_bin/layout.ld
+++ b/stage0_bin/layout.ld
@@ -70,6 +70,20 @@ SECTIONS {
         . = ALIGN(4K);
     } > ram_low
 
+    .ap_text : AT(TOP - 4K) {
+        ap_text_start = .;
+        *(.ap_text .ap_text.*)
+        ap_text_size = . - ap_text_start;
+    } > ram_low
+
+    .ap_bss (NOLOAD) : AT (ADDR(.ap_text) + SIZEOF(.ap_text)) {
+        ap_bss_start = .;
+        *(.ap_bss .ap_bss.*)
+        ap_bss_size = . - ap_bss_start;
+    } > ram_low
+
+    ASSERT(. <= 0x10000, "AP bootstrap code needs to be in the first 64K")
+
     .bss (NOLOAD) : {
         bss_start = .;
         *(.bss .bss.*)
@@ -115,7 +129,7 @@ SECTIONS {
     /* Everything below this line interacts with 16-bit code, so should be kept as close to the end of the file as
      * possible; max TOP - 32k. */
 
-    .text16 TOP - 4K : {
+    .text16 ALIGN(TOP - 4K + SIZEOF(.data), 16) : {
         *(.text16 .text16.*)
     } > bios
 
@@ -300,7 +314,7 @@ SECTIONS {
 
         /* SEV-ES reset block: uint32 addr, uint16 size, 16-byte GUID */
         HIDDEN(sev_es_reset_block_start = .);
-        LONG(0xDEADBEEF) /* Placeholder values */
+        LONG(ap_start)
         SHORT(sev_es_reset_block_end - sev_es_reset_block_start)
         LONG(0x00f771de)
         SHORT(0x1a7e)

--- a/stage0_bin/src/asm/ap_boot.s
+++ b/stage0_bin/src/asm/ap_boot.s
@@ -1,0 +1,11 @@
+.code16
+.section .ap_text, "ax"
+# Entry point for APs. This needs to be page-aligned.
+.align 4096
+.global ap_start
+ap_start:
+    # Let the BSP know we're alive.
+    lock incl (LIVE_AP_COUNT)
+1:
+    hlt
+    jmp 1b

--- a/stage0_bin/src/asm/mod.rs
+++ b/stage0_bin/src/asm/mod.rs
@@ -23,4 +23,5 @@ global_asm!(
     pd_0 = sym crate::paging::PD_0,
     pd_3 = sym crate::paging::PD_3,
     options(att_syntax));
+global_asm!(include_str!("ap_boot.s"), options(att_syntax, raw));
 global_asm!(include_str!("reset_vector.s"), options(att_syntax, raw));


### PR DESCRIPTION
Although QEMU was fine with the AP bootstrap code being up high in the BIOS area, the docs do actually say (and some VMMs expect) the AP bootstrap code to be within the first megabyte.

To simplify things, I've set it up so that the AP bootstrap code (`.ap_text`) and any data it references (`.ap_bss`) land within the first 64K of memory, meaning that we don't have to deal with segments.

We also change the SEV-ES reset block to point to `ap_start` (but mind you that we can't bootstrap APs under SEV-ES yet as MMIO is not properly set up).

Ref #4235 