### PR TITLE
Use the GHCB MMIO protocol to talk to APIC under SEV-{ES,SNP}

### DIFF
--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -133,7 +133,7 @@ impl MTRRDefType {
     }
 }
 
-static GHCB_WRAPPER: OnceCell<Spinlock<GhcbProtocol<'static, Ghcb>>> = OnceCell::new();
+pub static GHCB_WRAPPER: OnceCell<Spinlock<GhcbProtocol<'static, Ghcb>>> = OnceCell::new();
 
 pub fn init_ghcb(
     ghcb: &'static mut Ghcb,


### PR DESCRIPTION
Instead of using `read_volatile` and `write_volatile` directly, unfortunately under SEV-ES we need to use the GHCB MMIO protocol.

To simplify the code I've also exposed the global GHCB static to the world. I think we should refactor all the code to use that instead of dragging the port factories through every piece of code, but that will be a future clean-up.

And, I think the APIC code itself now could use some clean-ups as well. But that's also for the future.

As of this PR stage0 should be able to wake up all the processors under all confidentiality modes, even if it doesn't park them correctly yet nor passes on the jump table.

Ref #4235 