### PR TITLE
Set up a jump table and the 16-bit code to park APs under SEV-ES/SNP

### DIFF
--- a/oak_sev_guest/src/secrets.rs
+++ b/oak_sev_guest/src/secrets.rs
@@ -29,6 +29,55 @@ pub const SECRETS_PAGE_MIN_VERSION: u32 = 2;
 /// The mmaximum version of the secrets pages that we expect to receive.
 pub const SECRETS_PAGE_MAX_VERSION: u32 = 3;
 
+/// Representation of the Secrets Page Guest Reserved Area.
+///
+/// See Table 4 in <https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56421-guest-hypervisor-communication-block-standardization.pdf>
+#[repr(C)]
+#[derive(Debug, FromBytes)]
+pub struct GuestReservedArea {
+    /// VMPL0 Current Guest Message Sequence Number \[31:0\]
+    pub vmpl0_guest_seq_low: u32,
+
+    /// VMPL1 Current Guest Message Sequence Number \[31:0\]
+    pub vmpl1_guest_seq_low: u32,
+
+    /// VMPL2 Current Guest Message Sequence Number \[31:0\]
+    pub vmpl2_guest_seq_low: u32,
+
+    /// VMPL3 Current Guest Message Sequence Number \[31:0\]
+    pub vmpl3_guest_seq_low: u32,
+
+    /// AP Jump Table Physical Address
+    pub ap_jump_table_pa: u64,
+
+    /// (Rev 2.01+) VMPL0 Current Guest Message Sequence Number \[63:32\]
+    /// Otherwise: Reseved, MBZ
+    pub vmpl0_guest_seq_high: u32,
+
+    /// (Rev 2.01+) VMPL1 Current Guest Message Sequence Number \[63:32\]
+    /// Otherwise: Reseved, MBZ
+    pub vmpl1_guest_seq_high: u32,
+
+    /// (Rev 2.01+) VMPL2 Current Guest Message Sequence Number \[63:32\]
+    /// Otherwise: Reseved, MBZ
+    pub vmpl2_guest_seq_high: u32,
+
+    /// (Rev 2.01+) VMPL3 Current Guest Message Sequence Number \[63:32\]
+    /// Otherwise: Reseved, MBZ
+    pub vmpl3_guest_seq_high: u32,
+
+    /// Reserved: MBZ
+    _reserved_4: [u8; 0x16],
+
+    /// (Rev 2.01+) Version (1 = 2.01)
+    /// Otherwise: Reserved, MBZ
+    pub version: u16,
+
+    /// Guest Usage
+    pub guest_usage: [u8; 0x20],
+}
+static_assertions::assert_eq_size!(GuestReservedArea, [u8; 96]);
+
 /// Representation of the secrets page.
 ///
 /// See: Table 68 in <https://www.amd.com/system/files/TechDocs/56860.pdf>
@@ -59,7 +108,7 @@ pub struct SecretsPage {
     /// VM-platform communication key 3. AES key used for encrypting messages to the platform.
     pub vmpck_3: [u8; 32],
     /// Area reserved for guest OS use.
-    pub guest_area_0: [u8; 96],
+    pub guest_area_0: GuestReservedArea,
     /// Bitmap indicating which quadwords of the VM Save Area have been tweaked. This is only used
     /// if the VMSA Register Protection feature is enabled.
     pub vmsa_tweak_bitmap: [u8; 64],

--- a/stage0/src/smp.rs
+++ b/stage0/src/smp.rs
@@ -17,10 +17,11 @@
 use core::{
     arch::x86_64::_mm_pause,
     ffi::c_void,
+    mem::MaybeUninit,
     sync::atomic::{AtomicU32, Ordering},
 };
 
-use oak_sev_guest::io::PortFactoryWrapper;
+use oak_sev_guest::{ap_jump_table::ApJumpTable, io::PortFactoryWrapper};
 use x86_64::PhysAddr;
 
 use crate::{
@@ -40,6 +41,10 @@ extern "C" {
 #[no_mangle]
 #[link_section = ".ap_bss"]
 static LIVE_AP_COUNT: AtomicU32 = AtomicU32::new(0);
+
+#[no_mangle]
+#[link_section = ".ap_bss"]
+pub static AP_JUMP_TABLE: MaybeUninit<ApJumpTable> = MaybeUninit::uninit();
 
 pub fn start_ap(lapic: &mut Lapic, physical_apic_id: u32) -> Result<(), &'static str> {
     lapic.send_init_ipi(physical_apic_id)?;

--- a/stage0_bin/layout.ld
+++ b/stage0_bin/layout.ld
@@ -129,7 +129,7 @@ SECTIONS {
     /* Everything below this line interacts with 16-bit code, so should be kept as close to the end of the file as
      * possible; max TOP - 32k. */
 
-    .text16 ALIGN(TOP - 4K + SIZEOF(.data), 16) : {
+    .text16 ALIGN(TOP - 4K + SIZEOF(.ap_text), 16) : {
         *(.text16 .text16.*)
     } > bios
 
@@ -314,7 +314,7 @@ SECTIONS {
 
         /* SEV-ES reset block: uint32 addr, uint16 size, 16-byte GUID */
         HIDDEN(sev_es_reset_block_start = .);
-        LONG(ap_start)
+        LONG(sev_es_start)
         SHORT(sev_es_reset_block_end - sev_es_reset_block_start)
         LONG(0x00f771de)
         SHORT(0x1a7e)

--- a/stage0_bin/src/asm/ap_boot.s
+++ b/stage0_bin/src/asm/ap_boot.s
@@ -9,3 +9,39 @@ ap_start:
 1:
     hlt
     jmp 1b
+
+# Under SEV-ES, we need to use the AP Reset Hold and AP Jump Tables. We could munge all of it into
+# `ap_start` above, but it's simpler to keep it separate as if we ever run this code we know we're
+# under SEV-ES without risking any exceptions (and thus avoid the need for an IDT).
+.global sev_es_start
+sev_es_start:
+    lock incl (LIVE_AP_COUNT)
+1:
+    xor %edx, %edx          # EDX = 0x0
+    mov $0x006, %eax        # EAX = 0x007 - AP Reset Hold
+    mov $0xC0010130, %ecx   # ECX = 0xC001_0130 -- GHCB MSR
+    wrmsr                   # MSR[ECX] = EDX:EAX
+    rep vmmcall             # VMGEXIT
+    rdmsr                   # EDX:EAX = MSR[ECX]
+    # Check return value: GHCBData[63:12] must be non-zero, GHCBData[12:0] must be 0x007
+    mov %eax, %ebx          # EBX = EAX
+    and $0xFFF, %ebx        # EBX |= 0xFFF (leave lowest 12 bits)
+    cmp $0x007, %ebx        # is the response AP Reset Hold Response?
+    jne 1b                  # No. Go back to sleep.
+    and $-0xFFF, %eax       # EAX |= ~0xFFF (mask lowest 12 bits)
+    add %edx, %eax          # EAX += EDX
+    test %eax, %eax         # is GHDBData[63:12] zero?
+    je 1b                   # Yes. Go back to sleep.
+    # Determine where to jump from the AP Jump Table and off we go
+    # First is IP, second is CS
+    mov $AP_JUMP_TABLE, %sp # treat the jump table as stack
+    iret                    # pop IP, pop CS, pop EFLAGS
+    # if we're still here, something has gone wrong
+    xor %edx, %edx          # EDX = 0x0
+    mov $0x100, %eax        # EAX = 0x100 - Termination Request
+    mov $0xC0010130, %ecx   # ECX = 0xC001_0130 -- GHCB MSR
+    wrmsr                   # MSR[ECX] = EDX:EAX
+    rep vmmcall             # VMGEXIT
+1:                          # If we're still alive, just go into a HLT loop.
+    hlt
+    jmp 1b


### PR DESCRIPTION
This is enough to hand over APs to Linux under SEV-ES:

```
stage0 INFO: starting...
stage0 INFO: Expected number of APs: 1, started number of APs: 1
stage0 INFO: jumping to kernel at 0x0000000000200200
Linux version 6.1.33 (root@kokoro-gcp-ubuntu-docker-prod-423502096) (gcc (GCC) 12.3.0, GNU ld (GNU Binutils) 2.40) #1 SMP Wed Aug  9 15:45:05 UTC 2023
Memory Encryption Features active: AMD SEV SEV-ES
smp: Bringing up secondary CPUs ...
x86: Booting SMP configuration:
.... node  #0, CPUs:      #1
smp: Brought up 1 node, 2 CPUs
smpboot: Max logical packages: 1
smpboot: Total of 2 processors activated (9799.99 BogoMIPS)
```
After fixing the validation issue SEV-SNP starts up as well:
```
Memory Encryption Features active: AMD SEV SEV-ES SEV-SNP
smp: Bringing up secondary CPUs ...
x86: Booting SMP configuration:
.... node  #0, CPUs:      #1
smp: Brought up 1 node, 2 CPUs
smpboot: Max logical packages: 1
smpboot: Total of 2 processors activated (9799.99 BogoMIPS)
```

Ref #4235