### PR TITLE
Consolidate all MSRs and operations on them into one file

### DIFF
--- a/stage0/src/apic.rs
+++ b/stage0/src/apic.rs
@@ -14,12 +14,18 @@
 // limitations under the License.
 //
 
-use bitflags::bitflags;
+use crate::{
+    msr::{
+        ApicBase, ApicBaseFlags, ApicErrorFlags, DestinationMode, DestinationShorthand, Level,
+        MessageType, SpuriousInterruptFlags, TriggerMode, X2ApicErrorStatusRegister,
+        X2ApicIdRegister, X2ApicInterruptCommandRegister, X2ApicSpuriousInterruptRegister,
+        X2ApicVersionRegister,
+    },
+    sev::GHCB_WRAPPER,
+};
 use core::arch::x86_64::__cpuid;
 use oak_sev_guest::cpuid::CpuidInput;
-use x86_64::{registers::model_specific::Msr, PhysAddr};
-
-use crate::sev::GHCB_WRAPPER;
+use x86_64::PhysAddr;
 
 /// Interrupt Command.
 ///
@@ -251,52 +257,19 @@ mod xapic {
 
 mod x2apic {
     use super::{ApicErrorFlags, SpuriousInterruptFlags};
-    use crate::sev::GHCB_WRAPPER;
-    use x86_64::registers::model_specific::Msr;
-
-    pub(crate) const APIC_ID_REGISTER: X2ApicIdRegister = X2ApicIdRegister;
-    pub(crate) const APIC_VERSION_REGISTER: ApicVersionRegister = ApicVersionRegister;
-    pub(crate) const ERROR_STATUS_REGISTER: ErrorStatusRegister = ErrorStatusRegister;
-    pub(crate) const INTERRUPT_COMMAND_REGISTER: InterruptCommandRegister =
-        InterruptCommandRegister;
-    pub(crate) const SPURIOUS_INTERRUPT_REGISTER: SpuriousInterruptRegister =
-        SpuriousInterruptRegister;
-
-    /// The x2APIC_ID register.
-    ///
-    /// Contains the 32-bit local x2APIC ID. It is assigned by hardware at reset time, and the exact
-    /// structure is manufacturer-dependent.
-    ///
-    /// See Section 16.12 (x2APIC_ID) in the AMD64 Architecture Programmer's Manual, Volume 2 for
-    /// more details.
-    pub(crate) struct X2ApicIdRegister;
-
-    impl X2ApicIdRegister {
-        const MSR_ID: u32 = 0x0000_00802;
-        const MSR: Msr = Msr::new(Self::MSR_ID);
-    }
+    use crate::msr::{
+        X2ApicErrorStatusRegister, X2ApicIdRegister, X2ApicInterruptCommandRegister,
+        X2ApicSpuriousInterruptRegister, X2ApicVersionRegister,
+    };
 
     impl super::ApicId for X2ApicIdRegister {
         fn apic_id(&self) -> u32 {
             // Safety: we've estabished we're using x2APIC, so accessing the MSR is safe.
-            if let Some(ghcb) = GHCB_WRAPPER.get() {
-                ghcb.lock()
-                    .msr_read(Self::MSR_ID)
-                    .expect("couldn't read the MSR using the GHCB protocol") as u32
-            } else {
-                unsafe { Self::MSR.read() as u32 }
-            }
+            unsafe { Self::apic_id() }
         }
     }
 
-    pub(crate) struct InterruptCommandRegister;
-
-    impl InterruptCommandRegister {
-        const MSR_ID: u32 = 0x0000_00830;
-        const MSR: Msr = Msr::new(Self::MSR_ID);
-    }
-
-    impl super::InterprocessorInterrupt for InterruptCommandRegister {
+    impl super::InterprocessorInterrupt for X2ApicInterruptCommandRegister {
         fn send(
             &mut self,
             destination: u32,
@@ -307,326 +280,60 @@ mod x2apic {
             trigger_mode: super::TriggerMode,
             destination_shorthand: super::DestinationShorthand,
         ) -> Result<(), &'static str> {
-            let mut value: u64 = (destination as u64) << 32;
-            value |= destination_shorthand as u64;
-            value |= trigger_mode as u64;
-            value |= level as u64;
-            value |= destination_mode as u64;
-            value |= message_type as u64;
-            value |= vector as u64;
             // Safety: we've estabished we're using x2APIC, so accessing the MSR is safe.
-            if let Some(ghcb) = GHCB_WRAPPER.get() {
-                ghcb.lock().msr_write(Self::MSR_ID, value)
-            } else {
-                let mut msr = Self::MSR;
-                unsafe { msr.write(value) };
-                Ok(())
+            unsafe {
+                Self::send(
+                    vector,
+                    message_type,
+                    destination_mode,
+                    level,
+                    trigger_mode,
+                    destination_shorthand,
+                    destination,
+                )
             }
+            Ok(())
         }
     }
 
-    pub(crate) struct ErrorStatusRegister;
-
-    impl ErrorStatusRegister {
-        const MSR_ID: u32 = 0x0000_0828;
-        const MSR: Msr = Msr::new(Self::MSR_ID);
-    }
-
-    impl super::ErrorStatus for ErrorStatusRegister {
+    impl super::ErrorStatus for X2ApicErrorStatusRegister {
         fn read(&self) -> ApicErrorFlags {
             // Safety: we've estabished we're using x2APIC, so accessing the MSR is safe.
-            let val = if let Some(ghcb) = GHCB_WRAPPER.get() {
-                ghcb.lock()
-                    .msr_read(Self::MSR_ID)
-                    .expect("couldn't read the MSR using the GHCB protocol")
-            } else {
-                unsafe { Self::MSR.read() }
-            };
-            ApicErrorFlags::from_bits_truncate(val.try_into().unwrap())
+            unsafe { Self::read() }
         }
         fn clear(&mut self) {
             // Safety: we've estabished we're using x2APIC, so accessing the MSR is safe.
-            if let Some(ghcb) = GHCB_WRAPPER.get() {
-                ghcb.lock()
-                    .msr_write(Self::MSR_ID, 0)
-                    .expect("couldn't write the MSR using the GHCB protocol");
-            } else {
-                let mut msr = Self::MSR;
-                unsafe { msr.write(0) };
-            }
+            unsafe { Self::clear() }
         }
     }
 
-    pub(crate) struct ApicVersionRegister;
-
-    impl ApicVersionRegister {
-        const MSR_ID: u32 = 0x0000_0803;
-        const MSR: Msr = Msr::new(Self::MSR_ID);
-    }
-
-    impl super::ApicVersion for ApicVersionRegister {
+    impl super::ApicVersion for X2ApicVersionRegister {
         fn read(&self) -> (bool, u8, u8) {
             // Safety: we've estabished we're using x2APIC, so accessing the MSR is safe.
-            let val = if let Some(ghcb) = GHCB_WRAPPER.get() {
-                ghcb.lock()
-                    .msr_read(Self::MSR_ID)
-                    .expect("couldn't read the MSR using the GHCB protocol")
-            } else {
-                unsafe { Self::MSR.read() }
-            };
-
-            (
-                val & (1 << 31) > 0,            // EAS
-                ((val & 0xFF0000) >> 16) as u8, // MLE
-                (val & 0xFF) as u8,             // VER
-            )
+            unsafe { Self::read() }
         }
     }
 
-    pub(crate) struct SpuriousInterruptRegister;
-
-    impl SpuriousInterruptRegister {
-        const MSR_ID: u32 = 0x0000_080F;
-        const MSR: Msr = Msr::new(Self::MSR_ID);
-    }
-
-    impl super::SpuriousInterrupts for SpuriousInterruptRegister {
+    impl super::SpuriousInterrupts for X2ApicSpuriousInterruptRegister {
         fn read(&self) -> (SpuriousInterruptFlags, u8) {
             // Safety: we've estabished we're using x2APIC, so accessing the MSR is safe.
-            let val = if let Some(ghcb) = GHCB_WRAPPER.get() {
-                ghcb.lock()
-                    .msr_read(Self::MSR_ID)
-                    .expect("couldn't read the MSR using the GHCB protocol")
-            } else {
-                unsafe { Self::MSR.read() }
-            } as u32;
-
-            (
-                SpuriousInterruptFlags::from_bits_truncate(val),
-                (val & 0xFF) as u8,
-            )
+            unsafe { Self::read() }
         }
 
         fn write(&mut self, flags: SpuriousInterruptFlags, vec: u8) {
             // Safety: we've estabished we're using x2APIC, so accessing the MSR is safe.
-            let val = flags.bits() as u64 | vec as u64;
-            if let Some(ghcb) = GHCB_WRAPPER.get() {
-                ghcb.lock()
-                    .msr_write(Self::MSR_ID, val)
-                    .expect("couldn't write the MSR using the GHCB protocol");
-            } else {
-                let mut msr = Self::MSR;
-                unsafe { msr.write(val) };
-            }
+            unsafe { Self::write(flags, vec) };
         }
     }
-}
-
-bitflags! {
-    /// Flags in the APIC Base Address Register (MSR 0x1B)
-    #[derive(Clone, Copy, Debug)]
-    pub struct ApicBaseFlags: u64 {
-        /// APIC Enable
-        ///
-        /// The local APIC is enabled and all interruption types are accepted.
-        const AE = (1 << 11);
-
-        /// x2APIC Mode Enable
-        ///
-        /// The local APIC must first be enabled before enabling x2APIC mode.
-        /// Support for x2APIC mode is indicated by CPUID Fn0000_0001_ECX[21] = 1.
-        const EXTD = (1 << 10);
-
-        /// Boot Strap CPU Core
-        ///
-        /// Indicates that this CPU core is the boot core of the BSP.
-        const BSC = (1 << 8);
-    }
-
-    /// Flags in the APIC Error Status Register (offset 0x280)
-    ///
-    /// See Section 16.4.6, APIC Error Interrupts, in the AMD64 Architecture Programmer's Manual, Volume 2 for more details.
-    #[derive(Clone, Copy, Debug)]
-    pub struct ApicErrorFlags: u32 {
-        /// Sent Accept Error
-        ///
-        /// Message sent by the local APIC was not accepted by any other APIC.
-        const SAE = (1 << 2);
-
-        /// Receive Accept Error
-        ///
-        /// Message received by the local APIC was not accepted by this or any other APIC.
-        const RAE = (1 << 3);
-
-        /// Sent Illegal Vector
-        ///
-        /// Local APIC attempted to send a message with an illegal vector value.
-        const SIV = (1 << 5);
-
-        /// Received Illegal Vector
-        ///
-        /// Local APIC has received a message with an illegal vector value.
-        const RIV = (1 << 6);
-
-        /// Illegal Register Address
-        ///
-        /// An access to an unimplementer registed within the APIC register range was attempted.
-        const IRA = (1 << 7);
-    }
-
-    /// Flags in the Spurious Interrupt Register (offset 0x0F0)
-    ///
-    /// See Section 16.4.7, Spurious Interrupts, in the AMD64 Architecture Programmer's Manual, Volume 2 for more details.
-    #[derive(Clone, Copy, Debug)]
-    pub struct SpuriousInterruptFlags: u32 {
-        /// APIC Software Enable
-        const ASE = (1 << 8);
-
-        /// Focus CPU Core Checking
-        const FCC = (1 << 9);
-    }
-}
-
-/// The APIC Base Address Register.
-///
-/// See Sections 16.3.1 (Local APIC Enable) and 16.9 (Detecting and Enabling x2APIC Mode) in the
-/// AMD64 Architecture Programmer's Manual, Volume 2 for more details.
-pub struct ApicBase;
-
-impl ApicBase {
-    const MSR_ID: u32 = 0x0000_001B;
-    pub const MSR: Msr = Msr::new(Self::MSR_ID);
-
-    fn read_raw() -> u64 {
-        if let Some(ghcb) = GHCB_WRAPPER.get() {
-            ghcb.lock()
-                .msr_read(Self::MSR_ID)
-                .expect("couldn't read the MSR using the GHCB protocol")
-        } else {
-            // Safety: the APIC base register is supported in all modern CPUs.
-            unsafe { Self::MSR.read() }
-        }
-    }
-
-    fn write_raw(value: u64) {
-        if let Some(ghcb) = GHCB_WRAPPER.get() {
-            ghcb.lock()
-                .msr_write(Self::MSR_ID, value)
-                .expect("couldn't write the MSR using the GHCB protocol")
-        } else {
-            let mut msr = Self::MSR;
-            // Safety: the APIC base register is supported in all modern CPUs.
-            unsafe { msr.write(value) }
-        }
-    }
-
-    /// Returns the APIC Base Address and flags.
-    pub fn read() -> (PhysAddr, ApicBaseFlags) {
-        let val = Self::read_raw();
-        let aba = PhysAddr::new(val & 0x000F_FFFF_FFFF_F000u64);
-        let flags = ApicBaseFlags::from_bits_truncate(val);
-
-        (aba, flags)
-    }
-
-    pub fn write(aba: PhysAddr, flags: ApicBaseFlags) {
-        Self::write_raw(flags.bits() | aba.as_u64());
-    }
-}
-
-/// Interrupt types that can be sent via the Interrupt Command Register.
-///
-/// Note that this enum contains only values supported by x2APIC; the legacy xAPIC supports some
-/// extra message types that are deprecated (and reserved) under x2APIC.
-///
-/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
-/// Volume 2 for more details.
-#[allow(dead_code, clippy::upper_case_acronyms)]
-#[repr(u32)]
-pub enum MessageType {
-    /// IPI delivers an interrupt to the target local APIC specified in the Destination field.
-    Fixed = 0b000 << 8,
-
-    /// IPI delivers an SMI interrupt to the target local APIC(s). Trigger mode is edge-triggered
-    /// and Vector must be 0x00.
-    SMI = 0b010 << 8,
-
-    // IPI delivers an non-maskable interrupt to the target local APIC specified in the
-    // Destination field. Vector is ignored.
-    NMI = 0b100 << 8,
-
-    /// IPI delivers an INIT request to the target local APIC(s), causing the CPU core to assume
-    /// INIT state. Trigger mode is edge-triggered, Vector must be 0x00. After INIT, target APIC
-    /// will only accept a Startup IPI, all other interrupts will be held pending.
-    Init = 0b101 << 8,
-
-    /// IPI delives a start-up request (SIPI) to the target local APIC(s) in the Destination field,
-    /// causing the core to start processing the routing whose address is specified by the Vector
-    /// field.
-    Startup = 0b110 << 8,
-}
-
-/// Values for the destination mode flag in the Interrupt Command Register.
-///
-/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
-/// Volume 2 for more details.
-#[allow(dead_code)]
-#[repr(u32)]
-pub enum DestinationMode {
-    // Physical destination, single local APIC ID.
-    Physical = 0 << 11,
-
-    /// Logical destination, one or more local APICs with a common destination logical ID.
-    Logical = 1 << 11,
-}
-
-/// Values for the level flag in the Interrupt Command Register.
-///
-/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
-/// Volume 2 for more details.
-#[repr(u32)]
-pub enum Level {
-    Deassert = 0 << 14,
-    Assert = 1 << 14,
-}
-
-/// Values for the trigger mode flag in the Interrupt Command Register.
-///
-/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
-/// Volume 2 for more details.
-#[repr(u32)]
-pub enum TriggerMode {
-    Edge = 0 << 15,
-    Level = 1 << 15,
-}
-
-/// Values for the destination shorthand flag in the Interrupt Command Register.
-///
-/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
-/// Volume 2 for more details.
-#[allow(dead_code)]
-#[repr(u32)]
-pub enum DestinationShorthand {
-    /// Destination field is required to specify the destination.
-    DestinationField = 0b00 << 18,
-
-    /// The issuing APIC is the only destination.
-    SelfOnly = 0b01 << 18,
-
-    /// The IPI is sent to all local APICs including itself (destination field = 0xFF)
-    AllInclSelf = 0b10 << 18,
-
-    /// The IPI is sent to all local APICs except itself (destination field = 0xFF)
-    AllExclSelf = 0b11 << 18,
 }
 
 enum Apic {
     Xapic(xapic::Xapic),
     X2apic(
-        x2apic::InterruptCommandRegister,
-        x2apic::ErrorStatusRegister,
-        x2apic::ApicVersionRegister,
-        x2apic::SpuriousInterruptRegister,
+        X2ApicInterruptCommandRegister,
+        X2ApicErrorStatusRegister,
+        X2ApicVersionRegister,
+        X2ApicSpuriousInterruptRegister,
     ),
 }
 
@@ -670,12 +377,12 @@ impl Lapic {
         let mut apic = if x2apic {
             log::info!("Using x2APIC for AP initialization.");
             Lapic {
-                apic_id: x2apic::APIC_ID_REGISTER.apic_id(),
+                apic_id: unsafe { X2ApicIdRegister::apic_id() },
                 interface: Apic::X2apic(
-                    x2apic::INTERRUPT_COMMAND_REGISTER,
-                    x2apic::ERROR_STATUS_REGISTER,
-                    x2apic::APIC_VERSION_REGISTER,
-                    x2apic::SPURIOUS_INTERRUPT_REGISTER,
+                    X2ApicInterruptCommandRegister,
+                    X2ApicErrorStatusRegister,
+                    X2ApicVersionRegister,
+                    X2ApicSpuriousInterruptRegister,
                 ),
             }
         } else {

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -46,6 +46,7 @@ mod fw_cfg;
 mod initramfs;
 mod kernel;
 mod logging;
+mod msr;
 pub mod paging;
 mod pic;
 mod sev;
@@ -158,7 +159,7 @@ pub fn rust64_start(encrypted: u64) -> ! {
         // support very old processors. However, note that, this branch is only executed if
         // we have encryption, and this wouldn't be true for very old processors.
         unsafe {
-            sev::MTRRDefType::write(sev::MTRRDefTypeFlags::MTRR_ENABLE, sev::MemoryType::WP);
+            msr::MTRRDefType::write(msr::MTRRDefTypeFlags::MTRR_ENABLE, msr::MemoryType::WP);
         }
         sev::share_page(Page::containing_address(dma_buf_address), snp);
         sev::share_page(Page::containing_address(dma_access_address), snp);

--- a/stage0/src/msr.rs
+++ b/stage0/src/msr.rs
@@ -1,0 +1,443 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::sev::GHCB_WRAPPER;
+use bitflags::bitflags;
+use strum::FromRepr;
+use x86_64::{registers::model_specific::Msr as DirectMsr, PhysAddr};
+
+/// Wrapper that can access a MSR either directly or through the GHCB, depending on the environment.
+pub struct Msr {
+    msr_id: u32,
+    msr: DirectMsr,
+}
+
+impl Msr {
+    pub const fn new(reg: u32) -> Self {
+        Self {
+            msr_id: reg,
+            msr: DirectMsr::new(reg),
+        }
+    }
+
+    /// Read the MSR.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must guarantee that the MSR is valid.
+    pub unsafe fn read(&self) -> u64 {
+        if let Some(ghcb) = GHCB_WRAPPER.get() {
+            ghcb.lock()
+                .msr_read(self.msr_id)
+                .expect("couldn't read the MSR using the GHCB protocol")
+        } else {
+            self.msr.read()
+        }
+    }
+
+    /// Write the MSR.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must guarantee that the MSR is valid.
+    pub unsafe fn write(&mut self, val: u64) {
+        if let Some(ghcb) = GHCB_WRAPPER.get() {
+            ghcb.lock()
+                .msr_write(self.msr_id, val)
+                .expect("couldn't write the MSR using the GHCB protocol")
+        } else {
+            self.msr.write(val)
+        }
+    }
+}
+
+bitflags! {
+    /// Flags in the APIC Base Address Register (MSR 0x1B)
+    #[derive(Clone, Copy, Debug)]
+    pub struct ApicBaseFlags: u64 {
+        /// APIC Enable
+        ///
+        /// The local APIC is enabled and all interruption types are accepted.
+        const AE = (1 << 11);
+
+        /// x2APIC Mode Enable
+        ///
+        /// The local APIC must first be enabled before enabling x2APIC mode.
+        /// Support for x2APIC mode is indicated by CPUID Fn0000_0001_ECX[21] = 1.
+        const EXTD = (1 << 10);
+
+        /// Boot Strap CPU Core
+        ///
+        /// Indicates that this CPU core is the boot core of the BSP.
+        const BSC = (1 << 8);
+    }
+}
+
+/// The APIC Base Address Register.
+///
+/// See Sections 16.3.1 (Local APIC Enable) and 16.9 (Detecting and Enabling x2APIC Mode) in the
+/// AMD64 Architecture Programmer's Manual, Volume 2 for more details.
+pub struct ApicBase;
+
+impl ApicBase {
+    const MSR: Msr = Msr::new(0x0000_001B);
+
+    fn write_raw(value: u64) {
+        let mut msr = Self::MSR;
+        // Safety: the APIC base register is supported in all modern CPUs.
+        unsafe { msr.write(value) }
+    }
+
+    /// Returns the APIC Base Address and flags.
+    pub fn read() -> (PhysAddr, ApicBaseFlags) {
+        // Safety: the APIC base register is supported in all modern CPUs.
+        let val = unsafe { Self::MSR.read() };
+        let aba = PhysAddr::new(val & 0x000F_FFFF_FFFF_F000u64);
+        let flags = ApicBaseFlags::from_bits_truncate(val);
+
+        (aba, flags)
+    }
+
+    pub fn write(aba: PhysAddr, flags: ApicBaseFlags) {
+        Self::write_raw(flags.bits() | aba.as_u64());
+    }
+}
+
+bitflags! {
+    /// Flags of the MTRRDefType Register.
+    pub struct MTRRDefTypeFlags: u64 {
+        /// Set this to enable MTRR.
+        const MTRR_ENABLE = 1 << 11;
+        /// Set to enable fixed-range support.
+        const FIXED_RANGE_ENABLE = 1 << 10;
+    }
+}
+
+/// The cache memory type used with MTRR.  We only use Write-Protect mode which the Linux kernel
+/// expects to be enabled by the firmware in order to enable SEV.
+#[repr(u8)]
+#[allow(dead_code)] // Remove if this is ever ported to a public crate.
+#[derive(FromRepr)]
+pub enum MemoryType {
+    UC = 0, // Uncacheable.
+    WC = 1, // Write-Combining.
+    WT = 4, // Writethrough	Reads.
+    WP = 5, // Write-Protect.
+    WB = 6, // Writeback.
+}
+
+impl TryFrom<u8> for MemoryType {
+    type Error = &'static str;
+    fn try_from(value: u8) -> Result<MemoryType, &'static str> {
+        MemoryType::from_repr(value).ok_or("invalid value for MemoryType")
+    }
+}
+
+/// IA32_MTRR_DefType base model specific register.
+/// See <https://wiki.osdev.org/MTRR> for documentation.
+#[derive(Debug)]
+pub struct MTRRDefType;
+
+impl MTRRDefType {
+    // The underlying model specific register.
+    const MSR: Msr = Msr::new(0x0000_02FF);
+
+    pub fn read() -> (MTRRDefTypeFlags, MemoryType) {
+        // If the GHCB is available we are running on SEV-ES or SEV-SNP, so we use the GHCB protocol
+        // to read the MSR, otherwise we read the MSR directly.
+        // Safety: This is safe because this MSR has been supported since the P6 family of
+        // Pentium processors (see https://en.wikipedia.org/wiki/Memory_type_range_register).
+        let msr_value = unsafe { Self::MSR.read() };
+        let memory_type: MemoryType = (msr_value as u8)
+            .try_into()
+            .expect("invalid MemoryType value");
+        (MTRRDefTypeFlags::from_bits_truncate(msr_value), memory_type)
+    }
+
+    /// Write the MTRRDefType flags and caching mode, preserving reserved values.
+    /// The Linux kernel requires the mode be set to `MemoryType::WP` since
+    /// July, 2022, with this requirement back-ported to 5.15.X, or it will silently crash when
+    /// SEV is enabled.
+    ///
+    /// The Linux kernel gives a warning that MTRR is not setup properly, which we can igore:
+    /// [    0.120763] mtrr: your CPUs had inconsistent MTRRdefType settings
+    /// [    0.121529] mtrr: probably your BIOS does not setup all CPUs.
+    /// [    0.122245] mtrr: corrected configuration.
+    ///
+    /// ## Safety
+    ///
+    /// Unsafe in rare cases such as when ROM is memory mapped, and we write to ROM, in a mode that
+    /// caches the write, although this would require unsafe code to do.
+    ///
+    /// When called with MTRRDefType::MTRR_ENABLE and MemoryType::WP, this operation is safe because
+    /// this specific MSR and mode has been supported since the P6 family of Pentium processors
+    /// (see <https://en.wikipedia.org/wiki/Memory_type_range_register>).
+    pub unsafe fn write(flags: MTRRDefTypeFlags, default_type: MemoryType) {
+        // Preserve values of reserved bits.
+        let (old_flags, _old_memory_type) = Self::read();
+        let reserved = old_flags.bits() & !MTRRDefTypeFlags::all().bits();
+        let new_value = reserved | flags.bits() | (default_type as u64);
+        let mut msr = Self::MSR;
+        msr.write(new_value);
+    }
+}
+
+/// The x2APIC_ID register.
+///
+/// Contains the 32-bit local x2APIC ID. It is assigned by hardware at reset time, and the exact
+/// structure is manufacturer-dependent.
+///
+/// See Section 16.12 (x2APIC_ID) in the AMD64 Architecture Programmer's Manual, Volume 2 for
+/// more details.
+pub struct X2ApicIdRegister;
+
+impl X2ApicIdRegister {
+    const MSR: Msr = Msr::new(0x0000_00802);
+
+    pub unsafe fn apic_id() -> u32 {
+        (Self::MSR.read() & 0xFFFF_FFFF) as u32
+    }
+}
+
+/// x2APIC APIC Version Register
+pub struct X2ApicVersionRegister;
+
+impl X2ApicVersionRegister {
+    const MSR: Msr = Msr::new(0x0000_0803);
+}
+
+impl X2ApicVersionRegister {
+    pub unsafe fn read() -> (bool, u8, u8) {
+        let val = Self::MSR.read();
+
+        (
+            val & (1 << 31) > 0,            // EAS
+            ((val & 0xFF0000) >> 16) as u8, // MLE
+            (val & 0xFF) as u8,             // VER
+        )
+    }
+}
+
+bitflags! {
+    /// Flags in the Spurious Interrupt Register (offset 0x0F0)
+    ///
+    /// See Section 16.4.7, Spurious Interrupts, in the AMD64 Architecture Programmer's Manual, Volume 2 for more details.
+    #[derive(Clone, Copy, Debug)]
+    pub struct SpuriousInterruptFlags: u32 {
+        /// APIC Software Enable
+        const ASE = (1 << 8);
+
+        /// Focus CPU Core Checking
+        const FCC = (1 << 9);
+    }
+}
+
+/// x2APIC Spurious Interrupt Register
+pub struct X2ApicSpuriousInterruptRegister;
+
+impl X2ApicSpuriousInterruptRegister {
+    const MSR: Msr = Msr::new(0x0000_080F);
+}
+
+impl X2ApicSpuriousInterruptRegister {
+    pub unsafe fn read() -> (SpuriousInterruptFlags, u8) {
+        let val = Self::MSR.read();
+
+        (
+            SpuriousInterruptFlags::from_bits_truncate((val & 0xFFFF_FF00) as u32),
+            (val & 0xFF) as u8,
+        )
+    }
+
+    pub unsafe fn write(flags: SpuriousInterruptFlags, vec: u8) {
+        // Safety: we've estabished we're using x2APIC, so accessing the MSR is safe.
+        let val = flags.bits() as u64 | vec as u64;
+        let mut msr = Self::MSR;
+        unsafe { msr.write(val) };
+    }
+}
+
+bitflags! {
+    /// Flags in the APIC Error Status Register (offset 0x280)
+    ///
+    /// See Section 16.4.6, APIC Error Interrupts, in the AMD64 Architecture Programmer's Manual, Volume 2 for more details.
+    #[derive(Clone, Copy, Debug)]
+    pub struct ApicErrorFlags: u32 {
+        /// Sent Accept Error
+        ///
+        /// Message sent by the local APIC was not accepted by any other APIC.
+        const SAE = (1 << 2);
+
+        /// Receive Accept Error
+        ///
+        /// Message received by the local APIC was not accepted by this or any other APIC.
+        const RAE = (1 << 3);
+
+        /// Sent Illegal Vector
+        ///
+        /// Local APIC attempted to send a message with an illegal vector value.
+        const SIV = (1 << 5);
+
+        /// Received Illegal Vector
+        ///
+        /// Local APIC has received a message with an illegal vector value.
+        const RIV = (1 << 6);
+
+        /// Illegal Register Address
+        ///
+        /// An access to an unimplementer registed within the APIC register range was attempted.
+        const IRA = (1 << 7);
+    }
+}
+
+/// x2APIC Error Status Register.
+pub struct X2ApicErrorStatusRegister;
+
+impl X2ApicErrorStatusRegister {
+    const MSR: Msr = Msr::new(0x0000_0828);
+}
+
+impl X2ApicErrorStatusRegister {
+    pub unsafe fn read() -> ApicErrorFlags {
+        let val = Self::MSR.read();
+        ApicErrorFlags::from_bits_truncate(val.try_into().unwrap())
+    }
+
+    pub unsafe fn write(val: ApicErrorFlags) {
+        let mut msr = Self::MSR;
+        msr.write(val.bits() as u64)
+    }
+
+    pub unsafe fn clear() {
+        Self::write(ApicErrorFlags::empty())
+    }
+}
+
+/// Interrupt types that can be sent via the Interrupt Command Register.
+///
+/// Note that this enum contains only values supported by x2APIC; the legacy xAPIC supports some
+/// extra message types that are deprecated (and reserved) under x2APIC.
+///
+/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
+/// Volume 2 for more details.
+#[allow(dead_code, clippy::upper_case_acronyms)]
+#[repr(u32)]
+pub enum MessageType {
+    /// IPI delivers an interrupt to the target local APIC specified in the Destination field.
+    Fixed = 0b000 << 8,
+
+    /// IPI delivers an SMI interrupt to the target local APIC(s). Trigger mode is edge-triggered
+    /// and Vector must be 0x00.
+    SMI = 0b010 << 8,
+
+    // IPI delivers an non-maskable interrupt to the target local APIC specified in the
+    // Destination field. Vector is ignored.
+    NMI = 0b100 << 8,
+
+    /// IPI delivers an INIT request to the target local APIC(s), causing the CPU core to assume
+    /// INIT state. Trigger mode is edge-triggered, Vector must be 0x00. After INIT, target APIC
+    /// will only accept a Startup IPI, all other interrupts will be held pending.
+    Init = 0b101 << 8,
+
+    /// IPI delives a start-up request (SIPI) to the target local APIC(s) in the Destination field,
+    /// causing the core to start processing the routing whose address is specified by the Vector
+    /// field.
+    Startup = 0b110 << 8,
+}
+
+/// Values for the destination mode flag in the Interrupt Command Register.
+///
+/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
+/// Volume 2 for more details.
+#[allow(dead_code)]
+#[repr(u32)]
+pub enum DestinationMode {
+    // Physical destination, single local APIC ID.
+    Physical = 0 << 11,
+
+    /// Logical destination, one or more local APICs with a common destination logical ID.
+    Logical = 1 << 11,
+}
+
+/// Values for the level flag in the Interrupt Command Register.
+///
+/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
+/// Volume 2 for more details.
+#[repr(u32)]
+pub enum Level {
+    Deassert = 0 << 14,
+    Assert = 1 << 14,
+}
+
+/// Values for the trigger mode flag in the Interrupt Command Register.
+///
+/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
+/// Volume 2 for more details.
+#[repr(u32)]
+pub enum TriggerMode {
+    Edge = 0 << 15,
+    Level = 1 << 15,
+}
+
+/// Values for the destination shorthand flag in the Interrupt Command Register.
+///
+/// See Section 16.5 (Interprocessor Interrupts) in the AMD64 Architecture Programmer's Manual,
+/// Volume 2 for more details.
+#[allow(dead_code)]
+#[repr(u32)]
+pub enum DestinationShorthand {
+    /// Destination field is required to specify the destination.
+    DestinationField = 0b00 << 18,
+
+    /// The issuing APIC is the only destination.
+    SelfOnly = 0b01 << 18,
+
+    /// The IPI is sent to all local APICs including itself (destination field = 0xFF)
+    AllInclSelf = 0b10 << 18,
+
+    /// The IPI is sent to all local APICs except itself (destination field = 0xFF)
+    AllExclSelf = 0b11 << 18,
+}
+
+/// x2APIC Interrupt Command Register.
+///
+/// Merges the two xAPIC ICR-s into one 64-bit MSR.
+pub struct X2ApicInterruptCommandRegister;
+
+impl X2ApicInterruptCommandRegister {
+    const MSR: Msr = Msr::new(0x0000_00830);
+
+    pub unsafe fn send(
+        vec: u8,
+        mt: MessageType,
+        dm: DestinationMode,
+        l: Level,
+        tmg: TriggerMode,
+        dsh: DestinationShorthand,
+        dest: u32,
+    ) {
+        let mut value: u64 = (dest as u64) << 32;
+        value |= dsh as u64;
+        value |= tmg as u64;
+        value |= l as u64;
+        value |= dm as u64;
+        value |= mt as u64;
+        value |= vec as u64;
+
+        let mut msr = Self::MSR;
+        unsafe { msr.write(value) }
+    }
+}

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-use bitflags::bitflags;
 use oak_core::sync::OnceCell;
 use oak_linux_boot_params::{BootE820Entry, E820EntryType};
 pub use oak_sev_guest::ghcb::Ghcb;
@@ -27,111 +26,14 @@ use oak_sev_guest::{
     },
 };
 use spinning_top::Spinlock;
-use strum::FromRepr;
 use x86_64::{
     instructions::tlb,
-    registers::model_specific::Msr,
     structures::paging::{
         frame::PhysFrameRange, page::AddressNotAligned, Page, PageSize, PageTable, PageTableFlags,
         PhysFrame, Size1GiB, Size2MiB, Size4KiB,
     },
     PhysAddr, VirtAddr,
 };
-
-/// The cache memory type used with MTRR.  We only use Write-Protect mode which the Linux kernel
-/// expects to be enabled by the firmware in order to enable SEV.
-#[repr(u8)]
-#[allow(dead_code)] // Remove if this is ever ported to a public crate.
-#[derive(FromRepr)]
-pub enum MemoryType {
-    UC = 0, // Uncacheable.
-    WC = 1, // Write-Combining.
-    WT = 4, // Writethrough	Reads.
-    WP = 5, // Write-Protect.
-    WB = 6, // Writeback.
-}
-
-impl TryFrom<u8> for MemoryType {
-    type Error = &'static str;
-    fn try_from(value: u8) -> Result<MemoryType, &'static str> {
-        MemoryType::from_repr(value).ok_or("invalid value for MemoryType")
-    }
-}
-
-/// IA32_MTRR_DefType base model specific register.
-/// See <https://wiki.osdev.org/MTRR> for documentation.
-#[derive(Debug)]
-pub struct MTRRDefType;
-
-bitflags! {
-    /// Flags of the MTRRDefType Register.
-    pub struct MTRRDefTypeFlags: u64 {
-        /// Set this to enable MTRR.
-        const MTRR_ENABLE = 1 << 11;
-        /// Set to enable fixed-range support.
-        const FIXED_RANGE_ENABLE = 1 << 10;
-    }
-}
-
-impl MTRRDefType {
-    // The numeric ID of the model specific register.
-    const MSR_ID: u32 = 0x2ff;
-    // The underlying model specific register.
-    const MSR: Msr = Msr::new(Self::MSR_ID);
-
-    pub fn read() -> (MTRRDefTypeFlags, MemoryType) {
-        // If the GHCB is available we are running on SEV-ES or SEV-SNP, so we use the GHCB protocol
-        // to read the MSR, otherwise we read the MSR directly.
-        let msr_value = if let Some(ghcb) = GHCB_WRAPPER.get() {
-            ghcb.lock()
-                .msr_read(Self::MSR_ID)
-                .expect("couldn't read the MSR using the GHCB protocol")
-        } else {
-            // Safety: This is safe because this MSR has been supported since the P6 family of
-            // Pentium processors (see https://en.wikipedia.org/wiki/Memory_type_range_register).
-            unsafe { Self::MSR.read() }
-        };
-        let memory_type: MemoryType = (msr_value as u8)
-            .try_into()
-            .expect("invalid MemoryType value");
-        (MTRRDefTypeFlags::from_bits_truncate(msr_value), memory_type)
-    }
-
-    /// Write the MTRRDefType flags and caching mode, preserving reserved values.
-    /// The Linux kernel requires the mode be set to `MemoryType::WP` since
-    /// July, 2022, with this requirement back-ported to 5.15.X, or it will silently crash when
-    /// SEV is enabled.
-    ///
-    /// The Linux kernel gives a warning that MTRR is not setup properly, which we can igore:
-    /// [    0.120763] mtrr: your CPUs had inconsistent MTRRdefType settings
-    /// [    0.121529] mtrr: probably your BIOS does not setup all CPUs.
-    /// [    0.122245] mtrr: corrected configuration.
-    ///
-    /// ## Safety
-    ///
-    /// Unsafe in rare cases such as when ROM is memory mapped, and we write to ROM, in a mode that
-    /// caches the write, although this would require unsafe code to do.
-    ///
-    /// When called with MTRRDefType::MTRR_ENABLE and MemoryType::WP, this operation is safe because
-    /// this specific MSR and mode has been supported since the P6 family of Pentium processors
-    /// (see <https://en.wikipedia.org/wiki/Memory_type_range_register>).
-    pub unsafe fn write(flags: MTRRDefTypeFlags, default_type: MemoryType) {
-        // Preserve values of reserved bits.
-        let (old_flags, _old_memory_type) = Self::read();
-        let reserved = old_flags.bits() & !MTRRDefTypeFlags::all().bits();
-        let new_value = reserved | flags.bits() | (default_type as u64);
-        let mut msr = Self::MSR;
-        // If the GHCB is available we are running on SEV-ES or SEV-SNP, so we use the GHCB protocol
-        // to write the MSR, otherwise we write the MSR directly.
-        if let Some(ghcb) = GHCB_WRAPPER.get() {
-            ghcb.lock()
-                .msr_write(Self::MSR_ID, new_value)
-                .expect("couldn't write the MSR using the GHCB protocol");
-        } else {
-            msr.write(new_value);
-        }
-    }
-}
 
 pub static GHCB_WRAPPER: OnceCell<Spinlock<GhcbProtocol<'static, Ghcb>>> = OnceCell::new();
 


### PR DESCRIPTION
Lots of stuff moving around, but conceptually just a big copy-paste in hopes of improving readability.

Accessing MSRs requires a different approach under SEV-ES/SNP. We had at least two independent implementations of that in stage0 (one for the APIC stuff, and one for MTRRs) -- this consolidates all of it into one common base struct, mirroring the `Msr` in `x86_64` crate, and moves all the MSR implementations themselves into one common file.