### PR TITLE
Update Oak Functions logger to only log in debug

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -30,6 +30,7 @@ jobs:
           - buildconfigs/oak_restricted_kernel_bin.toml
           - buildconfigs/oak_restricted_kernel_simple_io_bin.toml
           - buildconfigs/oak_functions_enclave_app.toml
+          - buildconfigs/oak_functions_insecure_enclave_app.toml
           - buildconfigs/quirk_echo_enclave_app.toml
           - buildconfigs/stage0_bin.toml
 

--- a/buildconfigs/oak_functions_insecure_enclave_app.toml
+++ b/buildconfigs/oak_functions_insecure_enclave_app.toml
@@ -1,0 +1,17 @@
+# This is the static build configuration that we use with the docker-based SLSA3 generator for
+# building the `oak_functions_insecure_enclave_app` binary, and its provenance.
+# See https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/docker.
+command = [
+  "nix",
+  "develop",
+  ".#rust",
+  "--command",
+  "env",
+  "--chdir=enclave_apps/oak_functions_enclave_app",
+  "cargo",
+  "build",
+  "--release",
+  "--no-default-features",
+  "--features=allow_sensitive_logging",
+]
+artifact_path = "./enclave_apps/target/x86_64-unknown-none/release/oak_functions_insecure_enclave_app"

--- a/enclave_apps/oak_functions_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_functions_enclave_app/Cargo.toml
@@ -5,6 +5,14 @@ authors = ["Andri Saar <andrisaar@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = ["deny_sensitive_logging"]
+# Disable sensitive logging.
+deny_sensitive_logging = ["oak_functions_service/deny_sensitive_logging"]
+# Feature allow_sensitive_logging is not actually used in the code. It is only used as a
+# required feature to differentiate between the two binaries.
+allow_sensitive_logging = []
+
 [dependencies]
 oak_functions_service = { path = "../../oak_functions_service" }
 log = "*"
@@ -20,3 +28,11 @@ static_assertions = "*"
 name = "oak_functions_enclave_app"
 test = false
 bench = false
+required-features = ["deny_sensitive_logging"]
+
+[[bin]]
+path = "src/main.rs"
+name = "oak_functions_insecure_enclave_app"
+test = false
+bench = false
+required-features = ["allow_sensitive_logging"]

--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -32,20 +32,19 @@ static LOGGER: StderrLogger = StderrLogger {};
 #[no_mangle]
 fn _start() -> ! {
     log::set_logger(&LOGGER).unwrap();
-    #[cfg(debug_assertions)]
-    {
-        log::set_max_level(log::LevelFilter::Debug);
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        log::set_max_level(log::LevelFilter::Warn);
-    }
+    log::set_max_level(log::LevelFilter::Debug);
     oak_enclave_runtime_support::init();
     main();
 }
 
 fn main() -> ! {
     info!("In main!");
+    #[cfg(feature = "deny_sensitive_logging")]
+    {
+        // Only log warnings and errors to reduce the risk of accidentally leaking execution
+        // information through debug logs.
+        log::set_max_level(log::LevelFilter::Warn);
+    }
     let mut invocation_stats = StaticSampleStore::<1000>::new().unwrap();
     let service =
         oak_functions_service::OakFunctionsService::new(Arc::new(EmptyAttestationReportGenerator));

--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -32,7 +32,14 @@ static LOGGER: StderrLogger = StderrLogger {};
 #[no_mangle]
 fn _start() -> ! {
     log::set_logger(&LOGGER).unwrap();
-    log::set_max_level(log::LevelFilter::Debug);
+    #[cfg(debug_assertions)]
+    {
+        log::set_max_level(log::LevelFilter::Debug);
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        log::set_max_level(log::LevelFilter::Warn);
+    }
     oak_enclave_runtime_support::init();
     main();
 }

--- a/justfile
+++ b/justfile
@@ -12,11 +12,14 @@ oak_functions_enclave_app: (build_enclave_app "oak_functions_enclave_app")
 oak_tensorflow_enclave_app: (build_enclave_app "oak_tensorflow_enclave_app")
 quirk_echo_enclave_app: (build_enclave_app "quirk_echo_enclave_app")
 
-all_enclave_apps: key_xor_test_app oak_echo_enclave_app oak_echo_raw_enclave_app oak_functions_enclave_app oak_tensorflow_enclave_app quirk_echo_enclave_app
+all_enclave_apps: key_xor_test_app oak_echo_enclave_app oak_echo_raw_enclave_app oak_functions_enclave_app oak_functions_insecure_enclave_app oak_tensorflow_enclave_app quirk_echo_enclave_app
 
 # Build a single enclave app, given its name.
 build_enclave_app name:
     env --chdir=enclave_apps/$(name) cargo build --release
+
+oak_functions_insecure_enclave_app:
+    env --chdir=enclave_apps/oak_functions_enclave_app cargo build --release --no-default-features --feature=allow_sensitive_logging
 
 oak_restricted_kernel_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ build_enclave_app name:
     env --chdir=enclave_apps/$(name) cargo build --release
 
 oak_functions_insecure_enclave_app:
-    env --chdir=enclave_apps/oak_functions_enclave_app cargo build --release --no-default-features --feature=allow_sensitive_logging
+    env --chdir=enclave_apps/oak_functions_enclave_app cargo build --release --no-default-features --features=allow_sensitive_logging
 
 oak_restricted_kernel_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release

--- a/kokoro/build_binaries_rust.sh
+++ b/kokoro/build_binaries_rust.sh
@@ -37,6 +37,7 @@ export GENERATED_BINARIES=(
     ./enclave_apps/target/x86_64-unknown-none/release/oak_echo_enclave_app
     ./enclave_apps/target/x86_64-unknown-none/release/oak_echo_raw_enclave_app
     ./enclave_apps/target/x86_64-unknown-none/release/oak_functions_enclave_app
+    ./enclave_apps/target/x86_64-unknown-none/release/oak_functions_insecure_enclave_app
     ./enclave_apps/target/x86_64-unknown-none/release/oak_tensorflow_enclave_app
     ./enclave_apps/target/x86_64-unknown-none/release/quirk_echo_enclave_app
 )

--- a/oak_functions_service/Cargo.toml
+++ b/oak_functions_service/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Andri Saar <andrisaar@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = ["deny_sensitive_logging"]
+# Disable sensitive logging.
+deny_sensitive_logging = []
+
 [dependencies]
 anyhow = { version = "*", default-features = false }
 byteorder = { version = "*", default-features = false }

--- a/oak_functions_service/src/logger.rs
+++ b/oak_functions_service/src/logger.rs
@@ -38,9 +38,13 @@ pub struct StandaloneLogger {}
 
 // TODO(#2783): Implement a logger that differentiates between public and sensitive loges.
 impl OakLogger for StandaloneLogger {
+    #[cfg(debug_assertions)]
     fn log_sensitive(&self, level: Level, message: &str) {
         log::log!(level, "{}", message,);
     }
+
+    #[cfg(not(debug_assertions))]
+    fn log_sensitive(&self, _level: Level, _message: &str) {}
 
     fn log_public(&self, level: Level, message: &str) {
         log::log!(level, "{}", message,);

--- a/oak_functions_service/src/logger.rs
+++ b/oak_functions_service/src/logger.rs
@@ -38,12 +38,12 @@ pub struct StandaloneLogger {}
 
 // TODO(#2783): Implement a logger that differentiates between public and sensitive loges.
 impl OakLogger for StandaloneLogger {
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "deny_sensitive_logging"))]
     fn log_sensitive(&self, level: Level, message: &str) {
         log::log!(level, "{}", message,);
     }
 
-    #[cfg(not(debug_assertions))]
+    #[cfg(feature = "deny_sensitive_logging")]
     fn log_sensitive(&self, _level: Level, _message: &str) {}
 
     fn log_public(&self, level: Level, message: &str) {


### PR DESCRIPTION
We should not be logging sensitive information in release builds of Oak Functions.

This change also restricts direct logging (e.g. in the oak_channel crate) to only log warnings and errors in release mode.