### PR TITLE
Add readme for enclave apps

### DIFF
--- a/enclave_apps/README.md
+++ b/enclave_apps/README.md
@@ -1,0 +1,8 @@
+# Enclave Applications
+
+This directory contains applications that can be run using the Oak Restricted
+Kernel. The applications are intended to be run in a VM-based Trusted Execution
+Environment (such as AMD SEV-SNP).
+
+These applications all share the same Cargo configuration which is needed to
+make them compatible with the Oak Restricted Kernel.

--- a/enclave_apps/oak_functions_enclave_app/README.md
+++ b/enclave_apps/oak_functions_enclave_app/README.md
@@ -1,4 +1,4 @@
 # Oak Functions Enclave Application
 
 This is a version of the Oak Functions that can be run under Restricted Kernel
-using the [Oak Functions Launcher](../oak_functions_launcher/README.md).
+using the [Oak Functions Launcher](../../oak_functions_launcher/README.md).


### PR DESCRIPTION
This also fixes a broken link in the Oak Function Enclave App readme.