### PR TITLE
Move IoPortFactory creation down to where we need it

### DIFF
--- a/stage0/src/cmos.rs
+++ b/stage0/src/cmos.rs
@@ -14,7 +14,8 @@
 // limitations under the License.
 //
 
-use oak_sev_guest::io::{IoPortFactory, PortFactoryWrapper, PortReader, PortWrapper, PortWriter};
+use crate::io_port_factory;
+use oak_sev_guest::io::{IoPortFactory, PortReader, PortWrapper, PortWriter};
 
 const CMOS_INDEX_PORT: u16 = 0x0070;
 const CMOS_DATA_PORT: u16 = 0x0071;
@@ -43,10 +44,10 @@ impl Cmos {
     /// It's up to the caller to guarantee that there will be no other readers/writers to the CMOS
     /// ports (0x70, 0x71) and that CMOS is actually available on those ports, otherwise the
     /// behaviour is undefined.
-    pub unsafe fn new(port_factory: PortFactoryWrapper) -> Self {
+    pub unsafe fn new() -> Self {
         Self {
-            index_port: port_factory.new_writer(CMOS_INDEX_PORT),
-            data_port: port_factory.new_reader(CMOS_DATA_PORT),
+            index_port: io_port_factory().new_writer(CMOS_INDEX_PORT),
+            data_port: io_port_factory().new_reader(CMOS_DATA_PORT),
         }
     }
 

--- a/stage0/src/fw_cfg.rs
+++ b/stage0/src/fw_cfg.rs
@@ -20,12 +20,14 @@
 use bitflags::bitflags;
 use core::{cmp::min, ffi::CStr};
 use oak_linux_boot_params::{BootE820Entry, E820EntryType};
-use oak_sev_guest::io::{IoPortFactory, PortFactoryWrapper, PortReader, PortWrapper, PortWriter};
+use oak_sev_guest::io::{IoPortFactory, PortReader, PortWrapper, PortWriter};
 use x86_64::{
     structures::paging::{PageSize, Size2MiB, Size4KiB},
     PhysAddr, VirtAddr,
 };
 use zerocopy::{AsBytes, FromBytes};
+
+use crate::io_port_factory;
 
 // See https://www.qemu.org/docs/master/specs/fw_cfg.html for documentation about the various data structures and constants.
 const FWCFG_PORT_SELECTOR: u16 = 0x510;
@@ -166,17 +168,16 @@ impl FwCfg {
     /// The caller has to guarantee that at least doing the probe will not cause any adverse
     /// effects.
     pub unsafe fn new(
-        port_factory: PortFactoryWrapper,
         dma_buf: &'static mut DmaBuffer,
         dma_access: &'static mut FwCfgDmaAccess,
     ) -> Result<Self, &'static str> {
         let mut fwcfg = Self {
-            selector: port_factory.new_writer(FWCFG_PORT_SELECTOR),
-            data: port_factory.new_reader(FWCFG_PORT_DATA),
-            dma_high: port_factory.new_writer(FWCFG_PORT_DMA),
+            selector: io_port_factory().new_writer(FWCFG_PORT_SELECTOR),
+            data: io_port_factory().new_reader(FWCFG_PORT_DATA),
+            dma_high: io_port_factory().new_writer(FWCFG_PORT_DMA),
             // The DMA address must be big-endian encoded, so the low address is 4 bytes further
             // than the high address.
-            dma_low: port_factory.new_writer(FWCFG_PORT_DMA + 4),
+            dma_low: io_port_factory().new_writer(FWCFG_PORT_DMA + 4),
             dma_buf,
             dma_access,
             dma_enabled: false,

--- a/stage0/src/logging.rs
+++ b/stage0/src/logging.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
+use crate::io_port_factory;
 use core::{fmt::Write, ops::DerefMut};
-use oak_sev_guest::io::PortFactoryWrapper;
 use sev_serial::SerialPort;
 use spinning_top::Spinlock;
 
@@ -47,10 +47,10 @@ impl log::Log for Logger {
 
 static LOGGER: Logger = Logger {};
 
-pub fn init_logging(port_factory: PortFactoryWrapper) {
+pub fn init_logging() {
     // Our contract with the launcher requires the first serial port to be
     // available, so assuming the loader adheres to it, this is safe.
-    let mut port = unsafe { SerialPort::new(SERIAL_BASE, port_factory) };
+    let mut port = unsafe { SerialPort::new(SERIAL_BASE, io_port_factory()) };
     port.init()
         .expect("couldn't initialize logging serial port");
     {

--- a/stage0/src/pic.rs
+++ b/stage0/src/pic.rs
@@ -14,7 +14,8 @@
 // limitations under the License.
 //
 
-use oak_sev_guest::io::{IoPortFactory, PortFactoryWrapper, PortWrapper, PortWriter};
+use crate::io_port_factory;
+use oak_sev_guest::io::{IoPortFactory, PortWrapper, PortWriter};
 
 const PIC0_BASE: u16 = 0x20;
 const PIC1_BASE: u16 = 0xA0;
@@ -25,10 +26,10 @@ pub struct Pic {
 }
 
 impl Pic {
-    pub fn new(port_factory: &PortFactoryWrapper, base: u16) -> Self {
+    pub fn new(base: u16) -> Self {
         Self {
-            command: port_factory.new_writer(base),
-            data: port_factory.new_writer(base + 1),
+            command: io_port_factory().new_writer(base),
+            data: io_port_factory().new_writer(base + 1),
         }
     }
 
@@ -67,9 +68,9 @@ impl Pic {
 ///
 /// The caller needs to guarantee that the PIC0 and PIC1 are at their well-known I/O ports of 0x20
 /// and 0xA0.
-pub unsafe fn disable_pic8259(port_factory: &PortFactoryWrapper) -> Result<(), &'static str> {
-    let mut pic0 = Pic::new(port_factory, PIC0_BASE);
-    let mut pic1 = Pic::new(port_factory, PIC1_BASE);
+pub unsafe fn disable_pic8259() -> Result<(), &'static str> {
+    let mut pic0 = Pic::new(PIC0_BASE);
+    let mut pic1 = Pic::new(PIC1_BASE);
 
     // PIC0 interrupts will start at 0x20 (32), PIC1 at IRQ2, disable all interrupts
     pic0.init(0x20, 4, 0xFF)?;

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -37,10 +37,7 @@ use x86_64::{
 
 pub static GHCB_WRAPPER: OnceCell<Spinlock<GhcbProtocol<'static, Ghcb>>> = OnceCell::new();
 
-pub fn init_ghcb(
-    ghcb: &'static mut Ghcb,
-    snp: bool,
-) -> &'static Spinlock<GhcbProtocol<'static, Ghcb>> {
+pub fn init_ghcb(ghcb: &'static mut Ghcb, snp: bool) {
     let ghcb_addr = VirtAddr::from_ptr(ghcb as *const _);
 
     share_page(Page::containing_address(ghcb_addr), snp);
@@ -64,7 +61,6 @@ pub fn init_ghcb(
     {
         panic!("couldn't initialize GHCB wrapper");
     }
-    GHCB_WRAPPER.get().unwrap()
 }
 
 /// Stops sharing the GHCB with the hypervisor when running with AMD SEV-SNP enabled.

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -20,7 +20,6 @@ use crate::{
 };
 use core::{ffi::CStr, mem::size_of, slice};
 use oak_linux_boot_params::{BootE820Entry, BootParams, E820EntryType};
-use oak_sev_guest::io::PortFactoryWrapper;
 use x86_64::PhysAddr;
 use zerocopy::AsBytes;
 
@@ -93,7 +92,7 @@ impl ZeroPage {
     ///
     /// We first try to read "etc/e820" via the QEMU fw_cfg interface, and if that is not available,
     /// fall back to querying RTC NVRAM.
-    pub fn fill_e820_table(&mut self, fw_cfg: &mut FwCfg, port_factory: PortFactoryWrapper) {
+    pub fn fill_e820_table(&mut self, fw_cfg: &mut FwCfg) {
         // Try to load the E820 table from fw_cfg.
         // Safety: BootE820Entry has the same structure as what qemu uses, and we're limiting
         // ourselves to up to 128 entries.
@@ -118,8 +117,7 @@ impl ZeroPage {
                     panic!("QEMU_E820_RESERVATION_TABLE was not empty!");
                 }
 
-                build_e820_from_nvram(&mut self.inner, port_factory)
-                    .expect("failed to read from CMOS");
+                build_e820_from_nvram(&mut self.inner).expect("failed to read from CMOS");
             }
         };
 
@@ -180,14 +178,11 @@ impl ZeroPage {
 /// The code is largely based on what SeaBIOS is doing (see `qemu_preinit()` and `qemu_cfg_e820()`
 /// in <https://github.com/qemu/seabios/blob/b0d61ecef66eb05bd7a4eb7ada88ec5dab06dfee/src/fw/paravirt.c>),
 /// but <https://wiki.osdev.org/Detecting_Memory_%28x86%29> is also a good read on the topic.
-fn build_e820_from_nvram(
-    zero_page: &mut BootParams,
-    port_factory: PortFactoryWrapper,
-) -> Result<(), &'static str> {
+fn build_e820_from_nvram(zero_page: &mut BootParams) -> Result<(), &'static str> {
     // Safety: (a) fw_cfg is available, so we're running under QEMU(ish) and (b) there was no
     // pre-built E820 table in fw_cfg; thus, we can reasonably expect CMOS to available, as that's
     // what SeaBIOS would use in that situation to build the E820 table.
-    let mut cmos = unsafe { Cmos::new(port_factory) };
+    let mut cmos = unsafe { Cmos::new() };
     let mut rs = cmos.low_ram_size()?;
     let high = cmos.high_ram_size()?;
 


### PR DESCRIPTION
We have the GHCB as a static anyway, so there's no point in expliclity dragging it along in all the code that uses I/O ports.

This pattern is also used for MSRs (which also may need access to the GHCB), so it both simplifies the code and makes it more uniform.