### PR TITLE
Store shared data structures in a Box instead of leaking memory.

### DIFF
--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -17,6 +17,7 @@
 #![no_std]
 #![feature(int_roundings)]
 #![feature(allocator_api)]
+#![feature(slice_ptr_get)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Instead of managing sharing in the `Shared` struct, I thought it'd be better to introduce an allocator wrapper that will always return shared memory. This guarantees that (a) even if the data structure is not page-aligned, it will be the sole tenant on a page, and (b) if the data structure is bigger than a page, all of the pages it lands on will be properly marked as shared.

