### PR TITLE
Disable serial logins if Oak Containers is not started with `debug`

### DIFF
--- a/oak_containers_launcher/src/qemu.rs
+++ b/oak_containers_launcher/src/qemu.rs
@@ -189,6 +189,7 @@ impl Qemu {
         cmd.args([
             "-append",
             [
+                params.telnet_console.map_or_else(|| "", |_| "debug"),
                 "console=ttyS0",
                 "panic=-1",
                 "brd.rd_nr=1",

--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -27,11 +27,15 @@ RUN systemctl enable oak-orchestrator
 # Override the default journald configuration
 COPY journald.conf /etc/systemd/journald.conf.d/clear.conf
 
+# Only enable interactive logins if the kernel was booted with "debug" flag.
+COPY serial-getty@.override.conf /etc/systemd/system/serial-getty@.service.d/override.conf
+RUN systemctl disable getty@
+COPY root-passwd.service /etc/systemd/system
+RUN chmod 644 /etc/systemd/system/root-passwd.service
+RUN systemctl enable root-passwd
+
 # Don't bother starting the graphical interface, let's stick with the basic multi-user target.
 RUN systemctl set-default multi-user
 
 # Clean up some stuff we don't need
 RUN rm -rf /usr/share/doc /usr/share/info /usr/share/man
-
-# Debugging aid: if you get your hands on the console and try logging in as root, force a password change.
-RUN passwd --delete --expire root

--- a/oak_containers_system_image/root-passwd.service
+++ b/oak_containers_system_image/root-passwd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Reset root password
+ConditionKernelCommandLine=debug
+
+[Install]
+WantedBy=getty.target
+
+[Service]
+Type=oneshot
+ExecStart=passwd --delete --expire root

--- a/oak_containers_system_image/serial-getty@.override.conf
+++ b/oak_containers_system_image/serial-getty@.override.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionKernelCommandLine=debug


### PR DESCRIPTION
Both the Linux kernel and systemd already treat the `debug` kernel flag as special, so I thought it'd be a good criteria for our debugging aides as well.

By default, this (a) doesn't reset the root password and (b) disables the `getty` services, which means you will neither get a login prompt on the serial nor if you did could you log on with `root`.

However, if you _do_ specify `debug`, then we both reset the root password and enable `getty`, which means you can log on over the serial console.

And, in the Oak Containers launcher, I've tied the debug condition to whether the serial is exposed over telnet or not as a debugging aide.

Ref #4160 