### PR TITLE
Fix justfile name interpolation

### DIFF
--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -527,6 +527,7 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "async-trait",
  "bytes",
  "hkdf",
  "hpke",

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ all_enclave_apps: key_xor_test_app oak_echo_enclave_app oak_echo_raw_enclave_app
 
 # Build a single enclave app, given its name.
 build_enclave_app name:
-    env --chdir=enclave_apps/$(name) cargo build --release
+    env --chdir=enclave_apps/{{name}} cargo build --release
 
 oak_functions_insecure_enclave_app:
     env --chdir=enclave_apps/oak_functions_enclave_app cargo build --release --no-default-features --features=allow_sensitive_logging


### PR DESCRIPTION
The name interpolation format in the justfile was incorrect, meaning that the name of the enclave app wasn't used.