### PR TITLE
Make the Restricted Kernel Wrapper relocatable

### DIFF
--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -527,6 +527,7 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "async-trait",
  "bytes",
  "hkdf",
  "hpke",

--- a/oak_restricted_kernel_wrapper/.cargo/config.toml
+++ b/oak_restricted_kernel_wrapper/.cargo/config.toml
@@ -2,4 +2,8 @@
 target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
-rustflags = "-C relocation-model=static"
+rustflags = "-C relocation-model=pie"
+
+[unstable]
+build-std = ["core", "panic_abort"]
+build-std-features = ["panic_immediate_abort"]

--- a/oak_restricted_kernel_wrapper/src/asm/boot.s
+++ b/oak_restricted_kernel_wrapper/src/asm/boot.s
@@ -25,7 +25,7 @@ _wrapper_entry:
     # Note: don't touch %rsi, as that contains the address of the zero page.
 
     # Set up the new stack.
-    mov $stack_start, %rsp
+    lea stack_start(%rip), %rsp
     # Push 8 bytes to fix stack alignment issue. Because we enter rust64_start with a jmp rather
     # than a call the function prologue means that the stack is no longer 16-byte aligned.
     push $0

--- a/oak_restricted_kernel_wrapper/src/elf.rs
+++ b/oak_restricted_kernel_wrapper/src/elf.rs
@@ -68,7 +68,14 @@ fn load_segment(
     // Zero out the target in case the file content is shorter than the target.
     target.fill(0);
 
-    target[..file_length].copy_from_slice(source);
+    // Manually copy between slices to avoid the compiler's intrinsic memcpy which uses an indirect
+    // call, causing a relocation entry in the resulting ELF binary.
+    #[allow(clippy::manual_memcpy)]
+    {
+        for i in 0..file_length {
+            target[i] = source[i]
+        }
+    }
     Ok(())
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -654,7 +654,10 @@ fn run_cargo_udeps(scope: &Scope) -> Step {
         steps: workspace_manifest_files()
             .filter(|path| all_affected_crates.contains_path(path))
             // TODO(#4129): Remove when cargo-udeps supports build-std.
-            .filter(|path| path != Path::new("./stage0_bin/Cargo.toml"))
+            .filter(|path| {
+                path != Path::new("./stage0_bin/Cargo.toml")
+                    && path != Path::new("./oak_restricted_kernel_wrapper/Cargo.toml")
+            })
             .map(|entry| Step::Single {
                 name: entry.to_str().unwrap().to_string(),
                 command: Cmd::new_in_dir(


### PR DESCRIPTION
This change resolves part of #4319 by making the wrapper binary position-independent.