### PR TITLE
Add encryption key provider to C++ crypto

### DIFF
--- a/cc/client/client_test.cc
+++ b/cc/client/client_test.cc
@@ -16,8 +16,6 @@
 
 #include "cc/client/client.h"
 
-#include <memory>
-
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "cc/crypto/hpke/recipient_context.h"
@@ -54,7 +52,7 @@ class TestTransport : public TransportWrapper {
   absl::StatusOr<AttestationBundle> GetEvidence() override {
     AttestationBundle endorsed_evidence;
     endorsed_evidence.mutable_attestation_evidence()->set_encryption_public_key(
-        encryption_key_provider_->GetSerializedPublicKey());
+        encryption_key_provider_.GetSerializedPublicKey());
     return endorsed_evidence;
   }
 
@@ -75,7 +73,7 @@ class TestTransport : public TransportWrapper {
   }
 
  private:
-  std::shared_ptr<EncryptionKeyProvider> encryption_key_provider_;
+  EncryptionKeyProvider encryption_key_provider_;
 };
 
 // Client can process attestation evidence and invoke the backend.

--- a/cc/client/client_test.cc
+++ b/cc/client/client_test.cc
@@ -47,7 +47,16 @@ constexpr uint8_t kTestSessionSize = 8;
 // TODO(#3641): Send test remote attestation report to the client and add corresponding tests.
 class TestTransport : public TransportWrapper {
  public:
-  TestTransport() : encryption_key_provider_(*EncryptionKeyProvider::Create()) {}
+  static absl::StatusOr<std::unique_ptr<TestTransport>> Create() {
+    auto encryption_key_provider = EncryptionKeyProvider::Create();
+    if (!encryption_key_provider.ok()) {
+      return encryption_key_provider.status();
+    }
+    return std::make_unique<TestTransport>(*encryption_key_provider);
+  }
+
+  explicit TestTransport(EncryptionKeyProvider encryption_key_provider)
+      : encryption_key_provider_(encryption_key_provider) {}
 
   absl::StatusOr<AttestationBundle> GetEvidence() override {
     AttestationBundle endorsed_evidence;
@@ -78,9 +87,10 @@ class TestTransport : public TransportWrapper {
 
 // Client can process attestation evidence and invoke the backend.
 TEST(EncryptorTest, ClientCreateAndInvokeSuccess) {
-  auto transport = std::make_unique<TestTransport>();
+  auto transport = TestTransport::Create();
+  ASSERT_TRUE(transport.ok());
   InsecureAttestationVerifier verifier = InsecureAttestationVerifier();
-  auto oak_client = OakClient::Create(std::move(transport), verifier);
+  auto oak_client = OakClient::Create(std::move(*transport), verifier);
   ASSERT_TRUE(oak_client.ok());
 
   for (int i = 0; i < kTestSessionSize; i++) {

--- a/cc/crypto/BUILD
+++ b/cc/crypto/BUILD
@@ -37,10 +37,23 @@ cc_library(
     srcs = ["server_encryptor.cc"],
     hdrs = ["server_encryptor.h"],
     deps = [
-        ":common",
+        # ":common",
         "//cc/crypto/hpke:recipient_context",
         "//oak_crypto/proto/v1:crypto_cc_proto",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "encryption_key_provider",
+    srcs = ["encryption_key_provider.cc"],
+    hdrs = ["encryption_key_provider.h"],
+    deps = [
+        ":common",
+        "//cc/crypto/hpke:recipient_context",
+        "//oak_crypto/proto/v1:crypto_cc_proto",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ],

--- a/cc/crypto/BUILD
+++ b/cc/crypto/BUILD
@@ -37,7 +37,8 @@ cc_library(
     srcs = ["server_encryptor.cc"],
     hdrs = ["server_encryptor.h"],
     deps = [
-        # ":common",
+        ":common",
+        ":encryption_key_provider",
         "//cc/crypto/hpke:recipient_context",
         "//oak_crypto/proto/v1:crypto_cc_proto",
         "@com_google_absl//absl/status",

--- a/cc/crypto/encryption_key_provider.cc
+++ b/cc/crypto/encryption_key_provider.cc
@@ -25,12 +25,12 @@
 
 namespace oak::crypto {
 
-absl::StatusOr<std::unique_ptr<EncryptionKeyProvider>> EncryptionKeyProvider::Create() {
+absl::StatusOr<std::shared_ptr<EncryptionKeyProvider>> EncryptionKeyProvider::Create() {
   absl::StatusOr<KeyPair> key_pair = KeyPair::Generate();
   if (!key_pair.ok()) {
     return key_pair.status();
   }
-  return std::make_unique<EncryptionKeyProvider>(*key_pair);
+  return std::make_shared<EncryptionKeyProvider>(*key_pair);
 }
 
 absl::StatusOr<RecipientContext> EncryptionKeyProvider::GenerateRecipientContext(

--- a/cc/crypto/encryption_key_provider.cc
+++ b/cc/crypto/encryption_key_provider.cc
@@ -16,8 +16,6 @@
 
 #include "cc/crypto/encryption_key_provider.h"
 
-#include <memory>
-
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "cc/crypto/common.h"
@@ -25,12 +23,12 @@
 
 namespace oak::crypto {
 
-absl::StatusOr<std::shared_ptr<EncryptionKeyProvider>> EncryptionKeyProvider::Create() {
+absl::StatusOr<EncryptionKeyProvider> EncryptionKeyProvider::Create() {
   absl::StatusOr<KeyPair> key_pair = KeyPair::Generate();
   if (!key_pair.ok()) {
     return key_pair.status();
   }
-  return std::make_shared<EncryptionKeyProvider>(*key_pair);
+  return EncryptionKeyProvider(*key_pair);
 }
 
 absl::StatusOr<RecipientContext> EncryptionKeyProvider::GenerateRecipientContext(

--- a/cc/crypto/encryption_key_provider.cc
+++ b/cc/crypto/encryption_key_provider.cc
@@ -38,6 +38,4 @@ absl::StatusOr<RecipientContext> EncryptionKeyProvider::GenerateRecipientContext
   return SetupBaseRecipient(serialized_encapsulated_public_key, key_pair_, kOakHPKEInfo);
 }
 
-std::string EncryptionKeyProvider::GetSerializedPublicKey() const { return key_pair_.public_key; }
-
 }  // namespace oak::crypto

--- a/cc/crypto/encryption_key_provider.cc
+++ b/cc/crypto/encryption_key_provider.cc
@@ -38,4 +38,6 @@ absl::StatusOr<RecipientContext> EncryptionKeyProvider::GenerateRecipientContext
   return SetupBaseRecipient(serialized_encapsulated_public_key, key_pair_, kOakHPKEInfo);
 }
 
+std::string EncryptionKeyProvider::GetSerializedPublicKey() const { return key_pair_.public_key; }
+
 }  // namespace oak::crypto

--- a/cc/crypto/encryption_key_provider.cc
+++ b/cc/crypto/encryption_key_provider.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cc/crypto/encryption_key_provider.h"
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "cc/crypto/common.h"
+#include "cc/crypto/hpke/recipient_context.h"
+
+namespace oak::crypto {
+
+absl::StatusOr<std::unique_ptr<EncryptionKeyProvider>> EncryptionKeyProvider::Create() {
+  absl::StatusOr<KeyPair> key_pair = KeyPair::Generate();
+  if (!key_pair.ok()) {
+    return key_pair.status();
+  }
+  return std::make_unique<EncryptionKeyProvider>(*key_pair);
+}
+
+absl::StatusOr<RecipientContext> EncryptionKeyProvider::GenerateRecipientContext(
+    absl::string_view serialized_encapsulated_public_key) {
+  return SetupBaseRecipient(serialized_encapsulated_public_key, key_pair_, kOakHPKEInfo);
+}
+
+}  // namespace oak::crypto

--- a/cc/crypto/encryption_key_provider.h
+++ b/cc/crypto/encryption_key_provider.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CC_CRYPTO_ENCRYPTION_KEY_PROVIDER_H_
+#define CC_CRYPTO_ENCRYPTION_KEY_PROVIDER_H_
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "cc/crypto/hpke/recipient_context.h"
+
+namespace oak::crypto {
+
+class RecipientContextGenerator {
+ public:
+  virtual absl::StatusOr<RecipientContext> GenerateRecipientContext(
+      absl::string_view serialized_encapsulated_public_key) = 0;
+};
+
+class EncryptionKeyProvider : public RecipientContextGenerator {
+ public:
+  absl::StatusOr<std::unique_ptr<EncryptionKeyProvider>> Create();
+
+  explicit EncryptionKeyProvider(KeyPair key_pair) : key_pair_(key_pair) {}
+
+  absl::StatusOr<RecipientContext> GenerateRecipientContext(
+      absl::string_view serialized_encapsulated_public_key) override;
+
+ private:
+  KeyPair key_pair_;
+};
+
+}  // namespace oak::crypto
+
+#endif  // CC_CRYPTO_ENCRYPTION_KEY_PROVIDER_H_

--- a/cc/crypto/encryption_key_provider.h
+++ b/cc/crypto/encryption_key_provider.h
@@ -17,7 +17,6 @@
 #ifndef CC_CRYPTO_ENCRYPTION_KEY_PROVIDER_H_
 #define CC_CRYPTO_ENCRYPTION_KEY_PROVIDER_H_
 
-#include <memory>
 #include <string>
 #include <tuple>
 
@@ -35,7 +34,7 @@ class RecipientContextGenerator {
 
 class EncryptionKeyProvider : public RecipientContextGenerator {
  public:
-  static absl::StatusOr<std::shared_ptr<EncryptionKeyProvider>> Create();
+  static absl::StatusOr<EncryptionKeyProvider> Create();
 
   explicit EncryptionKeyProvider(KeyPair key_pair) : key_pair_(key_pair) {}
 

--- a/cc/crypto/encryption_key_provider.h
+++ b/cc/crypto/encryption_key_provider.h
@@ -35,12 +35,14 @@ class RecipientContextGenerator {
 
 class EncryptionKeyProvider : public RecipientContextGenerator {
  public:
-  absl::StatusOr<std::unique_ptr<EncryptionKeyProvider>> Create();
+  static absl::StatusOr<std::unique_ptr<EncryptionKeyProvider>> Create();
 
   explicit EncryptionKeyProvider(KeyPair key_pair) : key_pair_(key_pair) {}
 
   absl::StatusOr<RecipientContext> GenerateRecipientContext(
       absl::string_view serialized_encapsulated_public_key) override;
+
+  std::string GetSerializedPublicKey() const;
 
  private:
   KeyPair key_pair_;

--- a/cc/crypto/encryption_key_provider.h
+++ b/cc/crypto/encryption_key_provider.h
@@ -42,7 +42,7 @@ class EncryptionKeyProvider : public RecipientContextGenerator {
   absl::StatusOr<RecipientContext> GenerateRecipientContext(
       absl::string_view serialized_encapsulated_public_key) override;
 
-  std::string GetSerializedPublicKey() const;
+  std::string GetSerializedPublicKey() const { return key_pair_.public_key; }
 
  private:
   KeyPair key_pair_;

--- a/cc/crypto/encryption_key_provider.h
+++ b/cc/crypto/encryption_key_provider.h
@@ -35,7 +35,7 @@ class RecipientContextGenerator {
 
 class EncryptionKeyProvider : public RecipientContextGenerator {
  public:
-  static absl::StatusOr<std::unique_ptr<EncryptionKeyProvider>> Create();
+  static absl::StatusOr<std::shared_ptr<EncryptionKeyProvider>> Create();
 
   explicit EncryptionKeyProvider(KeyPair key_pair) : key_pair_(key_pair) {}
 

--- a/cc/crypto/encryption_key_provider.h
+++ b/cc/crypto/encryption_key_provider.h
@@ -36,8 +36,6 @@ class EncryptionKeyProvider : public RecipientContextGenerator {
  public:
   static absl::StatusOr<EncryptionKeyProvider> Create();
 
-  explicit EncryptionKeyProvider(KeyPair key_pair) : key_pair_(key_pair) {}
-
   absl::StatusOr<RecipientContext> GenerateRecipientContext(
       absl::string_view serialized_encapsulated_public_key) override;
 
@@ -45,6 +43,8 @@ class EncryptionKeyProvider : public RecipientContextGenerator {
 
  private:
   KeyPair key_pair_;
+
+  explicit EncryptionKeyProvider(KeyPair key_pair) : key_pair_(key_pair) {}
 };
 
 }  // namespace oak::crypto

--- a/cc/crypto/encryptor_test.cc
+++ b/cc/crypto/encryptor_test.cc
@@ -35,7 +35,7 @@ TEST(EncryptorTest, ClientEncryptorAndServerEncryptorCommunicateSuccess) {
   std::string public_key = (*encryption_key_provider)->GetSerializedPublicKey();
   auto client_encryptor = ClientEncryptor::Create(public_key);
   ASSERT_TRUE(client_encryptor.ok());
-  ServerEncryptor server_encryptor = ServerEncryptor(std::move(*encryption_key_provider));
+  ServerEncryptor server_encryptor = ServerEncryptor(*encryption_key_provider);
 
   // Here we have the client send 2 encrypted messages to the server to ensure that nonce's align
   // for multi-message communication.
@@ -89,7 +89,7 @@ TEST(EncryptorTest, ClientEncryptorAndServerEncryptorCommunicateMismatchPublicKe
   wrong_public_key[0] = (wrong_public_key[0] + 1) % 128;
   auto client_encryptor = ClientEncryptor::Create(wrong_public_key);
   ASSERT_TRUE(client_encryptor.ok());
-  ServerEncryptor server_encryptor = ServerEncryptor(std::move(*encryption_key_provider));
+  ServerEncryptor server_encryptor = ServerEncryptor(*encryption_key_provider);
 
   std::string client_plaintext_message = "Hello server";
 

--- a/cc/crypto/encryptor_test.cc
+++ b/cc/crypto/encryptor_test.cc
@@ -32,7 +32,7 @@ TEST(EncryptorTest, ClientEncryptorAndServerEncryptorCommunicateSuccess) {
   // Set up client and server encryptors.
   auto encryption_key_provider = EncryptionKeyProvider::Create();
   ASSERT_TRUE(encryption_key_provider.ok());
-  std::string public_key = (*encryption_key_provider)->GetSerializedPublicKey();
+  std::string public_key = encryption_key_provider->GetSerializedPublicKey();
   auto client_encryptor = ClientEncryptor::Create(public_key);
   ASSERT_TRUE(client_encryptor.ok());
   ServerEncryptor server_encryptor = ServerEncryptor(*encryption_key_provider);
@@ -84,7 +84,7 @@ TEST(EncryptorTest, ClientEncryptorAndServerEncryptorCommunicateMismatchPublicKe
   // Set up client and server encryptors.
   auto encryption_key_provider = EncryptionKeyProvider::Create();
   ASSERT_TRUE(encryption_key_provider.ok());
-  std::string wrong_public_key = (*encryption_key_provider)->GetSerializedPublicKey();
+  std::string wrong_public_key = encryption_key_provider->GetSerializedPublicKey();
   // Edit the public key that the client uses to make it incorrect.
   wrong_public_key[0] = (wrong_public_key[0] + 1) % 128;
   auto client_encryptor = ClientEncryptor::Create(wrong_public_key);

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -91,7 +91,7 @@ absl::Status ServerEncryptor::InitializeRecipientContexts(const EncryptedRequest
 
   // Create recipient contexts.
   absl::StatusOr<RecipientContext> recipient_context =
-      SetupBaseRecipient(serialized_encapsulated_public_key, server_key_pair_, kOakHPKEInfo);
+      recipient_context_generator_->GenerateRecipientContext(serialized_encapsulated_public_key);
   if (!recipient_context.ok()) {
     return recipient_context.status();
   }

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -91,7 +91,7 @@ absl::Status ServerEncryptor::InitializeRecipientContexts(const EncryptedRequest
 
   // Create recipient contexts.
   absl::StatusOr<RecipientContext> recipient_context =
-      recipient_context_generator_->GenerateRecipientContext(serialized_encapsulated_public_key);
+      recipient_context_generator_.GenerateRecipientContext(serialized_encapsulated_public_key);
   if (!recipient_context.ok()) {
     return recipient_context.status();
   }

--- a/cc/crypto/server_encryptor.h
+++ b/cc/crypto/server_encryptor.h
@@ -39,8 +39,8 @@ namespace oak::crypto {
 // be multiple responses per request and multiple requests per response.
 class ServerEncryptor {
  public:
-  ServerEncryptor(std::unique_ptr<RecipientContextGenerator> recipient_context_generator)
-      : recipient_context_generator_(std::move(recipient_context_generator)),
+  ServerEncryptor(std::shared_ptr<RecipientContextGenerator> recipient_context_generator)
+      : recipient_context_generator_(recipient_context_generator),
         recipient_request_context_(nullptr),
         recipient_response_context_(nullptr){};
 
@@ -61,7 +61,7 @@ class ServerEncryptor {
                                       absl::string_view associated_data);
 
  private:
-  std::unique_ptr<RecipientContextGenerator> recipient_context_generator_;
+  std::shared_ptr<RecipientContextGenerator> recipient_context_generator_;
   std::unique_ptr<RecipientRequestContext> recipient_request_context_;
   std::unique_ptr<RecipientResponseContext> recipient_response_context_;
 

--- a/cc/crypto/server_encryptor.h
+++ b/cc/crypto/server_encryptor.h
@@ -39,7 +39,10 @@ namespace oak::crypto {
 // be multiple responses per request and multiple requests per response.
 class ServerEncryptor {
  public:
-  ServerEncryptor(std::shared_ptr<RecipientContextGenerator> recipient_context_generator)
+  // Constructor for `ServerEncryptor`.
+  // `RecipientContextGenerator` argument is a long-term object containing the private key and
+  // should outlive the per-session `ServerEncryptor` object.
+  ServerEncryptor(RecipientContextGenerator& recipient_context_generator)
       : recipient_context_generator_(recipient_context_generator),
         recipient_request_context_(nullptr),
         recipient_response_context_(nullptr){};
@@ -61,7 +64,7 @@ class ServerEncryptor {
                                       absl::string_view associated_data);
 
  private:
-  std::shared_ptr<RecipientContextGenerator> recipient_context_generator_;
+  RecipientContextGenerator& recipient_context_generator_;
   std::unique_ptr<RecipientRequestContext> recipient_request_context_;
   std::unique_ptr<RecipientResponseContext> recipient_response_context_;
 

--- a/cc/crypto/server_encryptor.h
+++ b/cc/crypto/server_encryptor.h
@@ -25,6 +25,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "cc/crypto/common.h"
+#include "cc/crypto/encryption_key_provider.h"
 #include "cc/crypto/hpke/recipient_context.h"
 #include "oak_crypto/proto/v1/crypto.pb.h"
 
@@ -38,8 +39,8 @@ namespace oak::crypto {
 // be multiple responses per request and multiple requests per response.
 class ServerEncryptor {
  public:
-  ServerEncryptor(const KeyPair& server_key_pair)
-      : server_key_pair_(server_key_pair),
+  ServerEncryptor(std::unique_ptr<RecipientContextGenerator> recipient_context_generator)
+      : recipient_context_generator_(std::move(recipient_context_generator)),
         recipient_request_context_(nullptr),
         recipient_response_context_(nullptr){};
 
@@ -60,7 +61,7 @@ class ServerEncryptor {
                                       absl::string_view associated_data);
 
  private:
-  KeyPair server_key_pair_;
+  std::unique_ptr<RecipientContextGenerator> recipient_context_generator_;
   std::unique_ptr<RecipientRequestContext> recipient_request_context_;
   std::unique_ptr<RecipientResponseContext> recipient_response_context_;
 


### PR DESCRIPTION
This PR adds 2 new abstractions to the C++ crypto code:
- `EncryptionKeyProvider` that contains a key pair and generates contexts
- `RecipientContextGenerator` that is an interface for generating contexts. The main purpose for this interface is to allow generating contexts in the Oak Containers Orchestrator and abstracting it with the interface implementation

It also makes it more similar to our Rust crypto implementation.