### PR TITLE
Use existing tools to generate OCI Runtime Bundles

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
             };
           craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
           src = ./.;
-          # Build xtask as a package so that we can use it in the devShell and cache it in the 
+          # Build xtask as a package so that we can use it in the devShell and cache it in the
           # future, without rebuilding it every time.
           xtask = craneLib.buildPackage {
             inherit src;
@@ -78,7 +78,7 @@
           # We define a recursive set of shells, so that we can easily create a shell with a subset
           # of the dependencies for specific CI steps, without having to pull everything all the time.
           #
-          # To add a new dependency, you can search it on https://search.nixos.org/packages and add its 
+          # To add a new dependency, you can search it on https://search.nixos.org/packages and add its
           # name to one of the shells defined below.
           devShells = rec {
             # Base shell with shared dependencies.
@@ -142,7 +142,7 @@
                 bazel-buildtools
               ];
             };
-            # Shell for building Oak Containers kernel and system image. This is not included in the 
+            # Shell for building Oak Containers kernel and system image. This is not included in the
             # default shell because it is not needed as part of the CI.
             containers = with pkgs; mkShell {
               inputsFrom = [
@@ -157,7 +157,6 @@
                 docker
                 elfutils
                 flex
-                jq
                 libelf
                 perl
                 glibc

--- a/flake.nix
+++ b/flake.nix
@@ -164,7 +164,7 @@
                 glibc.static
                 ncurses
                 netcat
-                runc
+                umoci
               ];
             };
             # Shell for most CI steps (i.e. without contaniners support).

--- a/oak_containers_hello_world_container/build_container_bundle
+++ b/oak_containers_hello_world_container/build_container_bundle
@@ -19,7 +19,10 @@ cargo build \
 
 # Export the container as an OCI Image.
 # Ref: https://docs.docker.com/build/exporters/oci-docker/
-docker buildx build \
+readonly BUILDER="$(docker buildx create --driver docker-container)"
+docker buildx \
+    --builder="${BUILDER}" \
+    build \
     --tag="latest" \
     --output="type=oci,dest=${OCI_IMAGE_FILE}" \
     .

--- a/oak_containers_hello_world_container/build_container_bundle
+++ b/oak_containers_hello_world_container/build_container_bundle
@@ -15,7 +15,8 @@ cargo build \
     -Zunstable-options \
     --out-dir="./target/"
 
-# Export the container as an OCI Image. Ref:
+# Export the container as an OCI Image.
+# Ref: https://docs.docker.com/build/exporters/oci-docker/
 docker buildx build \
     --tag="latest" \
     --output="type=oci,dest=${OCI_IMAGE_FILE}" \

--- a/oak_containers_hello_world_container/build_container_bundle
+++ b/oak_containers_hello_world_container/build_container_bundle
@@ -4,24 +4,23 @@
 # that can be executed on Oak Containers. Used for manual testing during
 # development. Down the line we probably want to replace this.
 
-readonly OCI_IMAGE_FILE='./target/oak_container_example_oci_image.tar'
+readonly OCI_IMAGE_FILE="./target/oak_container_example_oci_image.tar"
 set -e
 rm --recursive --force ./target
 mkdir --parents ./target
 
 cargo build \
-    --package='oak_containers_hello_world_trusted_app' \
-    --target='x86_64-unknown-linux-musl' \
+    --package="oak_containers_hello_world_trusted_app" \
+    --target="x86_64-unknown-linux-musl" \
     -Zunstable-options \
-    --out-dir='./target/'
+    --out-dir="./target/"
 
 # Export the container as an OCI Image. Ref:
 docker buildx build \
-    --tag latest \
+    --tag="latest" \
     --output="type=oci,dest=${OCI_IMAGE_FILE}" \
     .
 
-
 ../scripts/export_container_bundle \
     -c "${OCI_IMAGE_FILE}" \
-    -o './target/oak_container_example_oci_filesystem_bundle.tar'
+    -o "./target/oak_container_example_oci_filesystem_bundle.tar"

--- a/oak_containers_hello_world_container/build_container_bundle
+++ b/oak_containers_hello_world_container/build_container_bundle
@@ -4,7 +4,7 @@
 # that can be executed on Oak Containers. Used for manual testing during
 # development. Down the line we probably want to replace this.
 
-readonly CONTAINER_IMAGE='oak_container_example'
+readonly OCI_IMAGE_FILE='./target/oak_container_example_oci_image.tar'
 set -e
 rm --recursive --force ./target
 mkdir --parents ./target
@@ -15,8 +15,13 @@ cargo build \
     -Zunstable-options \
     --out-dir='./target/'
 
-docker build --tag="${CONTAINER_IMAGE}" .
+# Export the container as an OCI Image. Ref:
+docker buildx build \
+    --tag latest \
+    --output="type=oci,dest=${OCI_IMAGE_FILE}" \
+    .
+
 
 ../scripts/export_container_bundle \
-    -c "${CONTAINER_IMAGE}" \
+    -c "${OCI_IMAGE_FILE}" \
     -o './target/oak_container_example_oci_filesystem_bundle.tar'

--- a/oak_containers_hello_world_container/build_container_bundle
+++ b/oak_containers_hello_world_container/build_container_bundle
@@ -4,6 +4,8 @@
 # that can be executed on Oak Containers. Used for manual testing during
 # development. Down the line we probably want to replace this.
 
+set -o errexit
+
 readonly OCI_IMAGE_FILE="./target/oak_container_example_oci_image.tar"
 set -e
 rm --recursive --force ./target

--- a/scripts/export_container_bundle
+++ b/scripts/export_container_bundle
@@ -36,12 +36,12 @@ while getopts "hc:o:" opt; do
   esac
 done
 
-if [ -z "${INPUT_OCI_IMAGE_TAR}" ]; then
+if [[ -z "${INPUT_OCI_IMAGE_TAR}" ]]; then
   echo "Missing required option: -c <input-oci-image-tar>"
   exit 1
 fi
 
-if [ -z "${OUTPUT_OCI_BUNDLE_TAR}" ]; then
+if [[ -z "${OUTPUT_OCI_BUNDLE_TAR}" ]]; then
   echo "Missing required option: -o <output-oci-bundle-tar>"
   exit 1
 fi

--- a/scripts/export_container_bundle
+++ b/scripts/export_container_bundle
@@ -52,7 +52,7 @@ echo "[INFO] Exporting the container as an OCI image"
 readonly OCI_IMAGE_DIR="${WORK_DIR}/image"
 mkdir "${OCI_IMAGE_DIR}"
 tar --extract \
-    --tar="${WORK_DIR}/oci_image.tar" \
+    --file="${INPUT_OCI_IMAGE_TAR}" \
     --directory="${OCI_IMAGE_DIR}"
 
 echo "[INFO] Creating runtime bundle"
@@ -67,4 +67,4 @@ umoci unpack \
 
 # Bundle just the files and directories that constitute the deterministically
 # generated OCI bundle.
-tar --create --tar="${OUTPUT_OCI_BUNDLE_TAR}" --directory="${OCI_BUNDLE_DIR}" ./rootfs ./config.json
+tar --create --file="${OUTPUT_OCI_BUNDLE_TAR}" --directory="${OCI_BUNDLE_DIR}" ./rootfs ./config.json

--- a/scripts/export_container_bundle
+++ b/scripts/export_container_bundle
@@ -8,15 +8,17 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 source "$SCRIPTS_DIR/common"
 
 print_usage_and_exit() {
-  echo "Usage:"
-  echo "  $0 [options] -c <container-image>
+  echo "Usage:
+  ${0} [-h] \\
+       -c <input-oci-image-tar> \\
+       -o <output-oci-bundle-tar>
 
-  Exports the filesystem in the specified container image as an OCI Runtime Bundle.
+  Deterministically converts a container OCI Image to an OCI Runtime Bundle.
 
 Options:
     -h                    Display this help and exit.
-    -o <output-file>      The target output file for the bundle. If this is not specified
-                          the bundle will be created as <container-image>.tar"
+    -c                    The input tarball of an OCI Image. See: https://github.com/opencontainers/image-spec/blob/main/spec.md
+    -o                    The output tarball of an OCI Runtime Bundle. See: https://github.com/opencontainers/runtime-spec/blob/main/spec.md"
   exit 0
 }
 
@@ -25,62 +27,44 @@ while getopts "hc:o:" opt; do
     h)
       print_usage_and_exit;;
     o)
-      readonly OUTPUT_FILE="${OPTARG}";;
+      readonly OUTPUT_OCI_BUNDLE_TAR="${OPTARG}";;
     c)
-      readonly CONTAINER_IMAGE="${OPTARG}";;
+      readonly INPUT_OCI_IMAGE_TAR="${OPTARG}";;
     *)
       echo "Invalid argument: ${OPTARG}"
       exit 1;;
   esac
 done
 
-if [ -z "${CONTAINER_IMAGE}" ]; then
-  echo "Missing required option: -c <container-image>"
+if [ -z "${INPUT_OCI_IMAGE_TAR}" ]; then
+  echo "Missing required option: -c <input-oci-image-tar>"
   exit 1
 fi
 
-if [ -z "${OUTPUT_FILE}" ]; then
-  OUTPUT_FILE="${CONTAINER_IMAGE}.tar"
+if [ -z "${OUTPUT_OCI_BUNDLE_TAR}" ]; then
+  echo "Missing required option: -o <output-oci-bundle-tar>"
+  exit 1
 fi
 
 readonly WORK_DIR="$(mktemp --directory)"
-readonly ROOTFS_DIR="${WORK_DIR}/rootfs"
-mkdir "${ROOTFS_DIR}"
 
-echo "[INFO] Exporting the container image"
-docker export "$(docker create "${CONTAINER_IMAGE}")" \
-  | tar --directory="${ROOTFS_DIR}" --extract --file=-
-
-# Extract the container CMD if it is present.
-CONTAINER_CMD=$(docker \
-             inspect \
-             --format='{{json .Config.Cmd}}' \
-             "${CONTAINER_IMAGE}")
-
-if [ -z "${CONTAINER_CMD}" ]; then
-  echo "[INFO] 'CMD' not found in container image. Searching for 'ENTRY_POINT'"
-  CONTAINER_CMD=$(docker \
-               inspect \
-               --format='{{json .Config.Entrypoint}}' \
-               "${CONTAINER_IMAGE}") 
-fi
-
-if [ -z "${CONTAINER_CMD}" ]; then
-  echo "[ERROR] Neither 'CMD' or 'ENTRYPOINT' found in container image."
-  exit 1
-fi
-
-echo "[INFO] Container entry point cmd: \"${CONTAINER_CMD}\""
-
-echo "[INFO] Creating config.json"
-(
-    cd "${WORK_DIR}"
-    runc spec
-    # Replace the entrypoint.
-    jq ".process.args |= ${CONTAINER_CMD}" < config.json > new.json
-    mv --force new.json config.json
-)
+echo "[INFO] Exporting the container as an OCI image"
+readonly OCI_IMAGE_DIR="${WORK_DIR}/image"
+mkdir "${OCI_IMAGE_DIR}"
+tar --extract \
+    --tar="${WORK_DIR}/oci_image.tar" \
+    --directory="${OCI_IMAGE_DIR}"
 
 echo "[INFO] Creating runtime bundle"
+readonly OCI_BUNDLE_DIR="${WORK_DIR}/bundle"
+# Deterministically extract the OCI image into an OCI bundle.
+# Note that in addition to this, umoci also creates an mtree spec in the same
+# dir. This mtree is not deterministic. Ref: https://github.com/opencontainers/umoci/blob/main/doc/man/umoci-unpack.1.md
+umoci unpack \
+    --rootless \
+    --image="${OCI_IMAGE_DIR}" \
+    "${OCI_BUNDLE_DIR}"
 
-tar --create --file="${OUTPUT_FILE}" --directory="${WORK_DIR}" ./rootfs ./config.json
+# Bundle just the files and directories that constitute the deterministically
+# generated OCI bundle.
+tar --create --tar="${OUTPUT_OCI_BUNDLE_TAR}" --directory="${OCI_BUNDLE_DIR}" ./rootfs ./config.json


### PR DESCRIPTION
Closes #4331. 

We currently use our own [script](https://github.com/project-oak/oak/blob/main/scripts/export_container_bundle) to save a docker containers as an OCI runtime bundles. 

Imo that approach a little bit brittle and hard to maintain, since our script has to manually ensure that all relevant properties from the docker container (eg entrypoint/CMD, uid, gid etc) are preserved. 

Thankfully we can replace it with existing prod grade tools. 

Specifically that's 
1) use docker to export a spec compliant OCI Image instead of just the filesystem
2) use OCI's [umoci](https://github.com/opencontainers/umoci) to convert that OCI Image to an OCI Runtime Bundle