### PR TITLE
Call `change_snp_page_state` only when really running under SEV-SNP

### DIFF
--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -196,10 +196,12 @@ pub fn share_page(page: Page<Size4KiB>) {
 
 /// Stops sharing a single 4KiB page with the hypervisor when running with AMD SEV-SNP enabled.
 pub fn unshare_page(page: Page<Size4KiB>) {
-    let page_start = page.start_address().as_u64();
-    let request = SnpPageStateChangeRequest::new(page_start as usize, PageAssignment::Private)
-        .expect("invalid address for page location");
-    change_snp_page_state(request).expect("couldn't change SNP state for page");
+    if sev_status().contains(SevStatus::SNP_ACTIVE) {
+        let page_start = page.start_address().as_u64();
+        let request = SnpPageStateChangeRequest::new(page_start as usize, PageAssignment::Private)
+            .expect("invalid address for page location");
+        change_snp_page_state(request).expect("couldn't change SNP state for page");
+    }
 }
 
 // Page tables come in three sizes: for 1 GiB, 2 MiB and 4 KiB pages. However, `PVALIDATE` can only


### PR DESCRIPTION
We have two functions, `share_page` and `unshare_page` to handle the sharedness of a page under SEV-{,ES,SNP}. Unfortunately the two are not perfectly symmetric: `share_page` removes the encrypted bit and if required (under SEV-SNP) changes the RMP state, whereas `unshare_page` unconditionally changed the RMP state.

After I introduced the "shared pages allocator" in #4318 sometimes we ended up calling `unshare_page` when just SEV was enabled, which obviously doesn't work.

This should fix the issue by making `unshare_page` a no-op when you're not calling it under SEV-SNP, meaning that if it is safe to call `share_page`, it's also safe to call `unshare_page`.

There are further questions in here about whether `unshare_page` should restore the encrypted bit to make it fully symmetric with `share_page`, and why my tests with linux (which should also exercise the SEV and SEV-ES paths) didn't uncover this.