### PR TITLE
Deserialize crypto context in C++

### DIFF
--- a/cc/crypto/hpke/BUILD
+++ b/cc/crypto/hpke/BUILD
@@ -70,6 +70,7 @@ cc_test(
     deps = [
         ":recipient_context",
         ":sender_context",
+        "//oak_crypto/proto/v1:crypto_cc_proto",
         "@boringssl//:crypto",
         "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",

--- a/cc/crypto/hpke/BUILD
+++ b/cc/crypto/hpke/BUILD
@@ -27,6 +27,7 @@ cc_library(
     hdrs = ["recipient_context.h"],
     deps = [
         ":utils",
+        "//oak_crypto/proto/v1:crypto_cc_proto",
         "@boringssl//:crypto",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/cc/crypto/hpke/recipient_context.cc
+++ b/cc/crypto/hpke/recipient_context.cc
@@ -97,18 +97,19 @@ absl::StatusOr<std::unique_ptr<RecipientContext>> RecipientContext::Deserialize(
     return absl::AbortedError("Unable to deserialize response AEAD context");
   }
 
-  std::vector<uint8_t> request_nonce(serialized_recipient_context.request_base_nonce().begin(),
-                                     serialized_recipient_context.request_base_nonce().end());
+  std::vector<uint8_t> request_base_nonce(serialized_recipient_context.request_base_nonce().begin(),
+                                          serialized_recipient_context.request_base_nonce().end());
 
-  std::vector<uint8_t> response_nonce(serialized_recipient_context.response_base_nonce().begin(),
-                                      serialized_recipient_context.response_base_nonce().end());
+  std::vector<uint8_t> response_base_nonce(
+      serialized_recipient_context.response_base_nonce().begin(),
+      serialized_recipient_context.response_base_nonce().end());
 
   return std::make_unique<RecipientContext>(
       /* request_aead_context= */ std::move(request_aead_context),
-      /* request_base_nonce= */ request_nonce,
+      /* request_base_nonce= */ request_base_nonce,
       /* request_sequence_number= */ serialized_recipient_context.request_sequence_number(),
       /* response_aead_context= */ std::move(response_aead_context),
-      /* response_base_nonce= */ response_nonce,
+      /* response_base_nonce= */ response_base_nonce,
       /* response_sequence_number= */ serialized_recipient_context.response_sequence_number());
 }
 

--- a/cc/crypto/hpke/recipient_context.h
+++ b/cc/crypto/hpke/recipient_context.h
@@ -23,6 +23,7 @@
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "oak_crypto/proto/v1/crypto.pb.h"
 #include "openssl/hpke.h"
 
 namespace oak::crypto {
@@ -47,6 +48,9 @@ class RecipientContext {
         response_aead_context_(std::move(response_aead_context)),
         response_base_nonce_(response_base_nonce),
         response_sequence_number_(response_sequence_number) {}
+
+  absl::StatusOr<std::unique_ptr<RecipientContext>> Deserialize(
+      ::oak::crypto::v1::CryptoContext serialized_recipient_context);
 
   // Decrypts message and validates associated data using AEAD.
   // <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>

--- a/cc/crypto/hpke/recipient_context.h
+++ b/cc/crypto/hpke/recipient_context.h
@@ -49,7 +49,7 @@ class RecipientContext {
         response_base_nonce_(response_base_nonce),
         response_sequence_number_(response_sequence_number) {}
 
-  absl::StatusOr<std::unique_ptr<RecipientContext>> Deserialize(
+  static absl::StatusOr<std::unique_ptr<RecipientContext>> Deserialize(
       ::oak::crypto::v1::CryptoContext serialized_recipient_context);
 
   // Decrypts message and validates associated data using AEAD.


### PR DESCRIPTION
This PR adds deserialization for `RecipientContext` in C++.

Nore: Currently we have to serialize sequence numbers as well, since if we not include them, deserialization will restart them.

This change is required to allow generating crypto contexts in Oak Containers Orchestrator or Restricted Kernel and sending it to the C++ enclave application.

Ref https://github.com/project-oak/oak/issues/3841