### PR TITLE
Enable sensitive logging in insecure Oak Functions

### DIFF
--- a/enclave_apps/oak_functions_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_functions_enclave_app/Cargo.toml
@@ -14,7 +14,7 @@ deny_sensitive_logging = ["oak_functions_service/deny_sensitive_logging"]
 allow_sensitive_logging = []
 
 [dependencies]
-oak_functions_service = { path = "../../oak_functions_service" }
+oak_functions_service = { path = "../../oak_functions_service", default-features = false }
 log = "*"
 micro_rpc = { workspace = true }
 oak_enclave_runtime_support = { workspace = true }


### PR DESCRIPTION
Because the `deny_sensitive_logging` feature is on by default on the `oak_functions_service` crate sensitive logging was disabled, even in the "insecure" version of the app.