### PR TITLE
Forward non-critical log messages to the launcher via the gRPC interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,12 +322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-env"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
-
-[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,16 +586,6 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "cstr-argument"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
-dependencies = [
- "cfg-if",
- "memchr",
 ]
 
 [[package]]
@@ -874,33 +858,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1398,17 +1355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
-name = "libsystemd-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed080163caa59cc29b34bce2209b737149a4bac148cd9a8b04e4c12822798119"
-dependencies = [
- "build-env",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,6 +1822,7 @@ dependencies = [
  "oak_remote_attestation",
  "prost",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tower",
 ]
@@ -1905,11 +1852,13 @@ name = "oak_containers_syslogd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitflags 1.3.2",
  "clap",
+ "nix 0.22.3",
  "oak_containers_orchestrator_client",
  "oak_grpc_utils",
- "systemd",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3434,21 +3383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "systemd"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afec0101d9ae8ab26aedf0840109df689938ea7e538aa03df4369f1854f11562"
-dependencies = [
- "cstr-argument",
- "foreign-types",
- "libc",
- "libsystemd-sys",
- "log",
- "memchr",
- "utf8-cstr",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3877,12 +3811,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "utf8-cstr"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-env"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +592,16 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "cstr-argument"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
+dependencies = [
+ "cfg-if",
+ "memchr",
 ]
 
 [[package]]
@@ -858,6 +874,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1355,6 +1398,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "libsystemd-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed080163caa59cc29b34bce2209b737149a4bac148cd9a8b04e4c12822798119"
+dependencies = [
+ "build-env",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +1898,18 @@ dependencies = [
  "tonic",
  "tower",
  "xz2",
+]
+
+[[package]]
+name = "oak_containers_syslogd"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "oak_containers_orchestrator_client",
+ "oak_grpc_utils",
+ "systemd",
+ "tokio",
 ]
 
 [[package]]
@@ -3368,6 +3434,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "systemd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afec0101d9ae8ab26aedf0840109df689938ea7e538aa03df4369f1854f11562"
+dependencies = [
+ "cstr-argument",
+ "foreign-types",
+ "libc",
+ "libsystemd-sys",
+ "log",
+ "memchr",
+ "utf8-cstr",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,6 +3877,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "utf8-cstr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "oak_containers_orchestrator",
   "oak_containers_orchestrator_client",
   "oak_containers_launcher",
+  "oak_containers_syslogd",
   "oak_crypto",
   "oak_docker_linux_init",
   "oak_echo_linux_init",

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,7 @@
                 cargo-udeps
                 cargo-vet
                 protobuf
+                systemd
                 qemu_kvm
                 python312
               ];
@@ -163,7 +164,6 @@
                 glibc.static
                 ncurses
                 netcat
-                systemd
                 umoci
               ];
             };

--- a/flake.nix
+++ b/flake.nix
@@ -163,6 +163,7 @@
                 glibc.static
                 ncurses
                 netcat
+                systemd
                 umoci
               ];
             };

--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -61,10 +61,6 @@ message LogEntry {
   map<string, string> fields = 1;
 }
 
-message LogRequest {
-  repeated LogEntry entry = 1;
-}
-
 // Defines the service exposed by the launcher, that can be invoked by the stage1 and the
 // orchestrator.
 service Launcher {
@@ -91,7 +87,7 @@ service Launcher {
   rpc NotifyAppReady(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
   // Logs a set of log entries from the guest.
-  rpc Log(LogRequest) returns (google.protobuf.Empty) {}
+  rpc Log(stream LogEntry) returns (google.protobuf.Empty) {}
 }
 
 // Defines the service exposed by the orchestrator, that can be invoked by the application.

--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -53,6 +53,18 @@ message GetCryptoContextResponse {
   oak.crypto.v1.CryptoContext context = 1;
 }
 
+// One log entry; a key-value map of strings.
+//
+// Log entries should use the (semi-standard) systemd journal field definitions:
+// https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
+message LogEntry {
+  map<string, string> fields = 1;
+}
+
+message LogRequest {
+  repeated LogEntry entry = 1;
+}
+
 // Defines the service exposed by the launcher, that can be invoked by the stage1 and the
 // orchestrator.
 service Launcher {
@@ -77,6 +89,9 @@ service Launcher {
   // Notifies the launcher that the trusted app is ready to serve requests and listening on the
   // pre-arranged port (8080).
   rpc NotifyAppReady(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+
+  // Logs a set of log entries from the guest.
+  rpc Log(LogRequest) returns (google.protobuf.Empty) {}
 }
 
 // Defines the service exposed by the orchestrator, that can be invoked by the application.

--- a/oak_containers_launcher/src/qemu.rs
+++ b/oak_containers_launcher/src/qemu.rs
@@ -196,6 +196,7 @@ impl Qemu {
                 format!("brd.rd_size={ramdrive_size}").as_str(),
                 "brd.max_part=1",
                 format!("ip={vm_address}:::255.255.255.0::eth0:off").as_str(),
+                "quiet",
             ]
             .join(" ")
             .as_str(),

--- a/oak_containers_launcher/src/server.rs
+++ b/oak_containers_launcher/src/server.rs
@@ -16,7 +16,7 @@
 use crate::proto::oak::{
     containers::{
         launcher_server::{Launcher, LauncherServer},
-        GetApplicationConfigResponse, GetImageResponse, SendAttestationEvidenceRequest,
+        GetApplicationConfigResponse, GetImageResponse, LogRequest, SendAttestationEvidenceRequest,
     },
     session::v1::AttestationEvidence,
 };
@@ -168,6 +168,21 @@ impl Launcher for LauncherServerImplementation {
             })?
             .send(())
             .map_err(|_err| tonic::Status::internal(format!("couldn't send notification")))?;
+        Ok(tonic::Response::new(()))
+    }
+
+    async fn log(&self, request: Request<LogRequest>) -> Result<Response<()>, tonic::Status> {
+        for ref message in request.into_inner().entry {
+            let unit = message
+                .fields
+                .get("_SYSTEMD_UNIT")
+                .map_or("", |unit| unit.as_str());
+            let message = message
+                .fields
+                .get("MESSAGE")
+                .map_or("", |message| message.as_str());
+            println!("{}: {}", unit, message);
+        }
         Ok(tonic::Response::new(()))
     }
 }

--- a/oak_containers_orchestrator_client/Cargo.toml
+++ b/oak_containers_orchestrator_client/Cargo.toml
@@ -14,5 +14,6 @@ oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
 prost = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
+tokio-stream = "*"
 tonic = "*"
 tower = "*"

--- a/oak_containers_syslogd/Cargo.toml
+++ b/oak_containers_syslogd/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "oak_containers_syslogd"
+version = "0.1.0"
+authors = ["Andri Saar <andrisaar@google.com>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "*"
+clap = { version = "*", features = ["derive"] }
+oak_containers_orchestrator_client = { workspace = true }
+systemd = "*"
+tokio = { version = "*", features = [
+  "rt-multi-thread",
+  "macros",
+  "sync",
+  "fs",
+  "process",
+  "net",
+] }
+
+[build-dependencies]
+oak_grpc_utils = { workspace = true }

--- a/oak_containers_syslogd/Cargo.toml
+++ b/oak_containers_syslogd/Cargo.toml
@@ -7,9 +7,10 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "*"
+bitflags = "*"
 clap = { version = "*", features = ["derive"] }
 oak_containers_orchestrator_client = { workspace = true }
-systemd = "*"
+nix = "*"
 tokio = { version = "*", features = [
   "rt-multi-thread",
   "macros",
@@ -18,6 +19,7 @@ tokio = { version = "*", features = [
   "process",
   "net",
 ] }
+tokio-stream = "*"
 
 [build-dependencies]
 oak_grpc_utils = { workspace = true }

--- a/oak_containers_syslogd/README.md
+++ b/oak_containers_syslogd/README.md
@@ -1,0 +1,13 @@
+<!-- Oak Logo Start -->
+<!-- An HTML element is intentionally used since GitHub recommends this approach to handle different images in dark/light modes. Ref: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to -->
+<!-- markdownlint-disable-next-line MD033 -->
+<h1><picture><source media="(prefers-color-scheme: dark)" srcset="/docs/oak-logo/svgs/oak-containers-negative-colour.svg?sanitize=true"><source media="(prefers-color-scheme: light)" srcset="/docs/oak-logo/svgs/oak-containers.svg?sanitize=true"><img alt="Project Oak Containers Logo" src="/docs/oak-logo/svgs/oak-containers.svg?sanitize=true"></picture></h1>
+<!-- Oak Logo End -->
+
+# Oak Containers Syslog Forwarder
+
+This is a simple daemon that reads the systemd journal and forwards all logs to
+the launcher.
+
+Although the crate name contains `syslogd`, we use the native systemd APIs to
+read the journal, not the legacy syslog interface.

--- a/oak_containers_syslogd/build.rs
+++ b/oak_containers_syslogd/build.rs
@@ -1,0 +1,32 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Generate gRPC code for connecting to the launcher.
+    generate_grpc_code(
+        "../",
+        &[
+            "oak_containers/proto/interfaces.proto",
+            "oak_crypto/proto/v1/crypto.proto",
+            "oak_remote_attestation/proto/v1/messages.proto",
+        ],
+        CodegenOptions::default(),
+    )?;
+
+    Ok(())
+}

--- a/oak_containers_syslogd/src/log_relay.rs
+++ b/oak_containers_syslogd/src/log_relay.rs
@@ -1,0 +1,64 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use oak_containers_orchestrator_client::LauncherClient;
+use systemd::journal;
+
+pub async fn run(launcher_client: LauncherClient) -> Result<()> {
+    let mut journal = journal::OpenOptions::default()
+        .all_namespaces(true)
+        .open()?;
+    journal.seek_head()?;
+
+    loop {
+        // Read all entries we can.
+        let mut entries = Vec::new();
+        while let Some(entry) = journal.next_entry()? {
+            // DEBUG will contain _tons_ of garbage; if you need that level of detail, you can
+            // enable debug mode and log in directly. If
+            if entry
+                .get("PRIORITY")
+                .map(String::as_str)
+                .unwrap_or_default()
+                .parse()
+                .map(|prio: i32| prio > 6)
+                .unwrap_or_default()
+            {
+                continue;
+            }
+
+            // Newer versions of tokio can be
+            // configured to use BTreeMap directly, but we can't switch to that version
+            // due to dependencies being a mess
+            entries.push({
+                let mut fields = HashMap::new();
+                fields.extend(entry);
+                fields
+            });
+        }
+
+        launcher_client
+            .log(entries)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to send log entries: {}", err))?;
+
+        // Out of data to read. Wait for something to appear.
+        journal.wait(None)?;
+    }
+}

--- a/oak_containers_syslogd/src/main.rs
+++ b/oak_containers_syslogd/src/main.rs
@@ -1,0 +1,40 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+mod log_relay;
+
+use anyhow::anyhow;
+use clap::Parser;
+use oak_containers_orchestrator_client::LauncherClient;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(default_value = "http://10.0.2.100:8080")]
+    launcher_addr: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let launcher_client = LauncherClient::create(args.launcher_addr.parse()?)
+        .await
+        .map_err(|error| anyhow!("couldn't create client: {:?}", error))?;
+
+    tokio::try_join!(log_relay::run(launcher_client))?;
+
+    Ok(())
+}

--- a/oak_containers_syslogd/src/main.rs
+++ b/oak_containers_syslogd/src/main.rs
@@ -14,7 +14,10 @@
 // limitations under the License.
 //
 
+#![feature(c_size_t)]
+
 mod log_relay;
+mod systemd_journal;
 
 use anyhow::anyhow;
 use clap::Parser;

--- a/oak_containers_syslogd/src/systemd_journal.rs
+++ b/oak_containers_syslogd/src/systemd_journal.rs
@@ -1,0 +1,188 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use self::systemd_sys::*;
+use core::ffi::c_size_t;
+use nix::errno::Errno;
+use std::{
+    cmp::Ordering,
+    collections::HashMap,
+    ffi::{c_int, c_void},
+};
+
+mod systemd_sys {
+    use core::ffi::c_size_t;
+    use std::{
+        ffi::{c_int, c_void},
+        marker::{PhantomData, PhantomPinned},
+    };
+
+    /// Opaque type representing the systemd journal obtained via the systemd C API.
+    ///
+    /// See <https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs> that describes this trick.
+    #[repr(C)]
+    pub struct sd_journal {
+        _data: [u8; 0],
+        _marker: PhantomData<(*mut u8, PhantomPinned)>,
+    }
+
+    #[link(name = "systemd")]
+    extern "C" {
+        // https://www.freedesktop.org/software/systemd/man/sd_journal_open.html
+        pub fn sd_journal_open(ret: *mut *mut sd_journal, flags: c_int) -> c_int;
+        pub fn sd_journal_close(j: *mut sd_journal);
+
+        // https://www.freedesktop.org/software/systemd/man/sd_journal_seek_head.html
+        pub fn sd_journal_seek_head(j: *mut sd_journal) -> c_int;
+
+        // https://www.freedesktop.org/software/systemd/man/sd_journal_next.html
+        pub fn sd_journal_next(j: *mut sd_journal) -> c_int;
+
+        // https://www.freedesktop.org/software/systemd/man/sd_journal_get_data.html
+        pub fn sd_journal_enumerate_data(
+            j: *mut sd_journal,
+            data: *mut *mut c_void,
+            len: *mut c_size_t,
+        ) -> c_int;
+
+        // https://www.freedesktop.org/software/systemd/man/sd_journal_wait.html
+        pub fn sd_journal_wait(j: *mut sd_journal, timeout_usec: u64) -> c_int;
+    }
+}
+
+bitflags::bitflags! {
+    pub struct JournalOpenFlags: c_int {
+        const LOCAL_ONLY                = 1 << 0;
+        const RUNTIME_ONLY              = 1 << 1;
+        const SYSTEM                    = 1 << 2;
+        const CURRENT_USER              = 1 << 3;
+        const OS_ROOT                   = 1 << 4;
+        const ALL_NAMESPACES            = 1 << 5;
+        const INCLUDE_DEFAULT_NAMESPACE = 1 << 6;
+        const TAKE_DIRECTORY_FD         = 1 << 7;
+    }
+}
+
+/// Simple wrapper around libsystemd for reading entries from the systemd journal.
+pub struct Journal {
+    journal: *mut sd_journal,
+}
+
+impl Journal {
+    pub fn new(flags: JournalOpenFlags) -> Result<Self, Errno> {
+        let mut journal = std::ptr::null_mut();
+        // Safety: we pass in a valid pointer (to the pointer). The returned journal value is opaque
+        // and we never directly access it.
+        let ret = unsafe { sd_journal_open(&mut journal, flags.bits()) };
+        if ret == 0 {
+            Ok(Self { journal })
+        } else {
+            Err(nix::errno::from_i32(ret))
+        }
+    }
+
+    /// Moves the cursor to before the first record in the journal.
+    pub fn seek_head(&mut self) -> Result<(), Errno> {
+        // Safety: `self.journal` must be valid because of Journal::new().
+        let ret = unsafe { sd_journal_seek_head(self.journal) };
+
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(nix::errno::from_i32(ret))
+        }
+    }
+
+    // The slice will be valid until the next call to `next()` or `next_data()`, hence this is
+    // private.
+    fn next_data(&mut self) -> Result<Option<&[u8]>, Errno> {
+        let mut data: *mut c_void = std::ptr::null_mut();
+        let mut len: c_size_t = 0;
+        // Safety: `self.journal` must be valid because of `Journal::new()`; we pass in pointers to
+        // valid data structures. Any value is valid for both `data` and `len`.
+        let ret = unsafe {
+            sd_journal_enumerate_data(self.journal, &mut data as *mut *mut c_void, &mut len)
+        };
+
+        match ret.cmp(&0) {
+            Ordering::Less => Err(nix::errno::from_i32(ret)),
+            Ordering::Equal => Ok(None),
+            // Safety: we trust systemd didn't lie to us when giving back the pointer and length.
+            Ordering::Greater => Ok(Some(unsafe {
+                std::slice::from_raw_parts(data as *const u8, len)
+            })),
+        }
+    }
+
+    /// Reads the next entry from the journal; returns None if there is no next entry.
+    pub fn next(&mut self) -> Result<Option<HashMap<String, String>>, Errno> {
+        // Safety: `self.journal` must be valid as the only way how to instantiate this is via
+        // `Journal::new()`.
+        let ret = unsafe { sd_journal_next(self.journal) };
+
+        match ret.cmp(&0) {
+            Ordering::Less => Err(nix::errno::from_i32(ret)),
+            Ordering::Equal => Ok(None),
+            Ordering::Greater => Ok({
+                let mut fields: HashMap<String, String> = HashMap::new();
+
+                // Iterate over journal fields; split at '='.
+                while let Some(field) = self.next_data()? {
+                    let (name, value) =
+                        field.split_at(field.iter().position(|x| *x == b'=').unwrap_or(0));
+                    fields.insert(
+                        std::str::from_utf8(name).unwrap().to_string(),
+                        std::str::from_utf8(&value[1..]).unwrap().to_string(),
+                    );
+                }
+
+                Some(fields)
+            }),
+        }
+    }
+
+    /// Blocks until something is added to the
+    pub fn wait(&mut self) -> Result<(), Errno> {
+        // Safety: `self.journal` must be valid as the only way how to instantiate this is via
+        // `Journal::new()`.
+        let ret = unsafe { sd_journal_wait(self.journal, 0) };
+        if ret < 0 {
+            return Err(nix::errno::from_i32(ret));
+        };
+        Ok(())
+    }
+}
+
+impl Drop for Journal {
+    fn drop(&mut self) {
+        // Safety: `self.journal` must be valid as the only way how to instantiate this is via
+        // `Journal::new()`.
+        unsafe { sd_journal_close(self.journal) };
+    }
+}
+
+impl Iterator for Journal {
+    type Item = Result<HashMap<String, String>, Errno>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(result) = self.next().transpose() {
+                return Some(result);
+            }
+            self.wait().unwrap();
+        }
+    }
+}

--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -24,6 +24,10 @@ RUN chmod 644 /etc/systemd/system/oak-orchestrator.service
 # Start the orchestartor at boot
 RUN systemctl enable oak-orchestrator
 
+COPY ./target/oak_containers_syslogd /usr/bin
+COPY oak-syslogd.service /etc/systemd/system
+RUN systemctl enable oak-syslogd
+
 # Override the default journald configuration
 COPY journald.conf /etc/systemd/journald.conf.d/clear.conf
 

--- a/oak_containers_system_image/build.sh
+++ b/oak_containers_system_image/build.sh
@@ -5,6 +5,8 @@ mkdir -p target
 
 # build the orchestrator binary
 cargo build --package="oak_containers_orchestrator" --release --target="x86_64-unknown-linux-musl" -Z unstable-options --out-dir="./target"
+cargo build --package="oak_containers_syslogd" --release -Z unstable-options --out-dir="./target"
+patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 ./target/oak_containers_syslogd
 
 docker build . --tag oak-containers-system-image
 # We need to actually create a container, otherwise we won't be able to use `docker export` that gives us a filesystem image.

--- a/oak_containers_system_image/build.sh
+++ b/oak_containers_system_image/build.sh
@@ -6,6 +6,8 @@ mkdir -p target
 # build the orchestrator binary
 cargo build --package="oak_containers_orchestrator" --release --target="x86_64-unknown-linux-musl" -Z unstable-options --out-dir="./target"
 cargo build --package="oak_containers_syslogd" --release -Z unstable-options --out-dir="./target"
+# When built under nix the interpreter points to some Nix-specific location that doesn't exist on a regular Linux host, therefore
+# we need to manually patch the binary to set it back to the normal regular location.
 patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 ./target/oak_containers_syslogd
 
 docker build . --tag oak-containers-system-image

--- a/oak_containers_system_image/journald.conf
+++ b/oak_containers_system_image/journald.conf
@@ -1,4 +1,6 @@
 [Journal]
 Storage=volatile
+# Log everything with ERROR and above to the console, as we can't trust anything else to be
+# available in degraded conditions.
 ForwardToConsole=yes
-MaxLevelConsole=info
+MaxLevelConsole=err

--- a/oak_containers_system_image/oak-syslogd.service
+++ b/oak_containers_system_image/oak-syslogd.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Oak Containers Log Forwarder
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/oak_containers_syslogd
+# If the log forwarder outputs something, print it directly to the emergency serial console. After
+# all, this is the tool that is supposed to make logs available to the launcher; if it fails, there
+# is no point in it writing to the log as the log will never be exported.
+StandardOutput=tty
+StandardError=tty
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
As we've discussed, we don't really want to log over the (relatively slow) serial console for anything but truly critical situations where we can't rely on any other channel being available.

To that end, this PR creates a simple journal reader that will send logs to the launcher via gRPC.

In particular:
  * The log entries themselves are just key-value pairs of strings. This follows what systemd (and syslog) do.
  * I've built the log forwarder (or extractor, or whatever you want to call it) as a separate binary. The main reason for it is that I'm using the native systemd journal API, and that requires you to dynamically link against `libsystemd`. As the orchestrator itself is statically linked and uses musl, we can't rely on `libsystemd` there.
  * On that note, nix is leaking. I had to use `patchelf` to replace the interpreter value to get the dynamically linked binary to work.
  * I tried using the oldschool syslog API ("read from a socket"), but couldn't get it to work -- and honestly the systemd journal API is much cleaner anyway.

There's some more work to be done here, like making it more resilient toward long-running RPCs and making the output of the launcher nicer, but that can be done later.