### PR TITLE
Remove some pinned crate versions from `Cargo.toml` files

### DIFF
--- a/oak_launcher_utils/Cargo.toml
+++ b/oak_launcher_utils/Cargo.toml
@@ -12,7 +12,7 @@ bmrng = "*"
 clap = { version = "*", features = ["derive"] }
 command-fds = { version = "*", features = ["tokio"] }
 log = "*"
-prost = "0.11.2"
+prost = { workspace = true }
 tokio = { version = "*", features = [
   "rt-multi-thread",
   "macros",

--- a/quirk_echo_launcher/Cargo.toml
+++ b/quirk_echo_launcher/Cargo.toml
@@ -12,8 +12,8 @@ bmrng = "*"
 clap = { version = "*", features = ["derive"] }
 command-fds = { version = "*", features = ["tokio"] }
 log = "*"
-env_logger = "0.10.0"
-prost = "0.11.2"
+env_logger = "*"
+prost = { workspace = true }
 tokio = { version = "*", features = [
   "rt-multi-thread",
   "macros",


### PR DESCRIPTION
The hope is that perhaps Dependabot can now start updating some of these dependencies.
