### PR TITLE
Expose basic `/proc/stat` metrics over the new API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +859,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1505,6 +1530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1809,7 @@ dependencies = [
  "oak_crypto",
  "oak_grpc_utils",
  "oak_remote_attestation",
+ "procfs",
  "prost",
  "prost-types",
  "serde",
@@ -1828,9 +1863,9 @@ name = "oak_containers_syslogd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "clap",
- "nix 0.22.3",
+ "nix 0.26.2",
  "oak_containers_orchestrator_client",
  "oak_grpc_utils",
  "tokio",
@@ -2528,6 +2563,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "rustix",
 ]
 
 [[package]]

--- a/oak_containers_launcher/src/server.rs
+++ b/oak_containers_launcher/src/server.rs
@@ -198,8 +198,10 @@ impl Launcher for LauncherServerImplementation {
 
     async fn push_metrics(
         &self,
-        _request: tonic::Request<MetricSet>,
+        request: tonic::Request<MetricSet>,
     ) -> Result<Response<()>, tonic::Status> {
+        let metrics = request.into_inner();
+        log::debug!("metrics: {:?}", metrics);
         Ok(tonic::Response::new(()))
     }
 }

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -15,6 +15,7 @@ oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
 prost = "*"
 prost-types = "*"
+procfs = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = "*"
 syslog = "*"

--- a/oak_containers_orchestrator/src/ipc_server.rs
+++ b/oak_containers_orchestrator/src/ipc_server.rs
@@ -32,7 +32,7 @@ pub struct ServiceImplementation {
     attester: Attester,
     encryption_key_provider: Arc<EncryptionKeyProvider>,
     application_config: Vec<u8>,
-    launcher_client: LauncherClient,
+    launcher_client: Arc<LauncherClient>,
 }
 
 #[tonic::async_trait]
@@ -92,7 +92,7 @@ pub async fn create<P>(
     encryption_key_provider: Arc<EncryptionKeyProvider>,
     attester: Attester,
     application_config: Vec<u8>,
-    launcher_client: LauncherClient,
+    launcher_client: Arc<LauncherClient>,
     shutdown_receiver: Receiver<()>,
 ) -> Result<(), anyhow::Error>
 where

--- a/oak_containers_orchestrator/src/lib.rs
+++ b/oak_containers_orchestrator/src/lib.rs
@@ -31,6 +31,7 @@ mod proto {
 pub mod container_runtime;
 pub mod ipc_server;
 pub mod logging;
+pub mod metrics;
 
 // Utility directory that is shared between the orchestrator & container
 pub const UTIL_DIR: &str = "oak_utils";

--- a/oak_containers_orchestrator/src/metrics.rs
+++ b/oak_containers_orchestrator/src/metrics.rs
@@ -1,0 +1,166 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use anyhow::Result;
+use oak_containers_orchestrator_client::{
+    proto::openmetrics::{
+        self, counter_value::Total, CounterValue, GaugeValue, Label, Metric, MetricFamily,
+        MetricPoint, MetricType,
+    },
+    LauncherClient,
+};
+use std::{sync::Arc, time::Duration};
+
+fn gauge(name: String, unit: String, help: String, value: i64) -> MetricFamily {
+    MetricFamily {
+        name,
+        r#type: MetricType::Gauge.into(),
+        unit,
+        help,
+        metrics: vec![Metric {
+            labels: Vec::new(),
+            metric_points: vec![MetricPoint {
+                timestamp: None,
+                value: Some(openmetrics::metric_point::Value::GaugeValue(GaugeValue {
+                    value: Some(openmetrics::gauge_value::Value::IntValue(value)),
+                })),
+            }],
+        }],
+    }
+}
+
+fn counter(name: String, unit: String, help: String, value: u64) -> MetricFamily {
+    MetricFamily {
+        name,
+        r#type: MetricType::Counter.into(),
+        unit,
+        help,
+        metrics: vec![Metric {
+            labels: Vec::new(),
+            metric_points: vec![MetricPoint {
+                timestamp: None,
+                value: Some(openmetrics::metric_point::Value::CounterValue(
+                    CounterValue {
+                        created: None,
+                        exemplar: None,
+                        total: Some(Total::IntValue(value)),
+                    },
+                )),
+            }],
+        }],
+    }
+}
+
+fn collect_proc_stat() -> Result<Vec<MetricFamily>> {
+    let stats = procfs::KernelStats::new()?;
+
+    let mut metrics = Vec::new();
+
+    let create_cpu_metric = |cpu: usize, mode: &'static str, value: u64| Metric {
+        labels: vec![
+            Label {
+                name: "cpu".to_string(),
+                value: cpu.to_string(),
+            },
+            Label {
+                name: "mode".to_string(),
+                value: mode.to_string(),
+            },
+        ],
+        metric_points: vec![MetricPoint {
+            value: Some(openmetrics::metric_point::Value::CounterValue(
+                CounterValue {
+                    created: None,
+                    exemplar: None,
+                    total: Some(Total::IntValue(value)),
+                },
+            )),
+            timestamp: None,
+        }],
+    };
+
+    let mut cpu_seconds = Vec::new();
+    for (cpu, stats) in stats.cpu_time.iter().enumerate() {
+        cpu_seconds.push(create_cpu_metric(cpu, "user", stats.user));
+        cpu_seconds.push(create_cpu_metric(cpu, "idle", stats.idle));
+        cpu_seconds.push(create_cpu_metric(cpu, "nice", stats.nice));
+        cpu_seconds.push(create_cpu_metric(cpu, "system", stats.system));
+        if let Some(iowait) = stats.iowait {
+            cpu_seconds.push(create_cpu_metric(cpu, "iowait", iowait));
+        }
+        if let Some(irq) = stats.irq {
+            cpu_seconds.push(create_cpu_metric(cpu, "irq", irq));
+        }
+        if let Some(softirq) = stats.irq {
+            cpu_seconds.push(create_cpu_metric(cpu, "softirq", softirq));
+        }
+        if let Some(steal) = stats.steal {
+            cpu_seconds.push(create_cpu_metric(cpu, "steal", steal));
+        }
+    }
+    metrics.push(MetricFamily {
+        name: "cpu_seconds_total".to_string(),
+        r#type: MetricType::Counter.into(),
+        unit: "seconds".to_string(),
+        help: "Seconds the CPUs spent in each mode.".to_string(),
+        metrics: cpu_seconds,
+    });
+
+    metrics.push(counter(
+        "context_switches_total".to_string(),
+        String::new(),
+        "Total number of context switches.".to_string(),
+        stats.ctxt,
+    ));
+    metrics.push(counter(
+        "forks_total".to_string(),
+        String::new(),
+        "Total number of forks.".to_string(),
+        stats.processes,
+    ));
+    if let Some(blocked) = stats.procs_blocked {
+        gauge(
+            "procs_blocked".to_string(),
+            String::new(),
+            "Number of processes blocked waiting for I/O to complete.".to_string(),
+            blocked.into(),
+        );
+    }
+    if let Some(running) = stats.procs_running {
+        metrics.push(gauge(
+            "procs_running".to_string(),
+            String::new(),
+            "Number of processes in runnable state.".to_string(),
+            running.into(),
+        ));
+    }
+
+    Ok(metrics)
+}
+
+pub async fn run(launcher_client: Arc<LauncherClient>) -> Result<()> {
+    let mut interval = tokio::time::interval(Duration::from_secs(60));
+
+    loop {
+        interval.tick().await;
+        let mut metric_families = Vec::new();
+        metric_families.append(&mut collect_proc_stat()?);
+        launcher_client
+            .push_metrics(metric_families)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to push metrics: {}", err))?;
+    }
+}


### PR DESCRIPTION
Follow-up to #4347 that added said API: start sending some metrics over the API.

The Rust API to build the protos is rather cumbersome as the openmetrics proto supports far more stuff than we need; creating a nicer Rusty wrapper to build the proto will have to wait for a future PR.

The one-minute sleep period is chosen arbitrarily.

The metric names, labels and types themselves are inspired by the Prometheus node exporter (https://github.com/prometheus/node_exporter) -- yet again, let's use something that's well-known in the open source realm instead of inventing our own.

Here's an example of the metrics proto:
```
MetricSet { metric_families: [
  MetricFamily {
    name: "cpu_seconds_total",
    r#type: Counter,
    unit: "seconds",
    help: "Seconds the CPUs spent in each mode.",
    metrics: [
      Metric {
        labels: [Label { name: "cpu", value: "0" }, Label { name: "mode", value: "user" }],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(4420)) })) }]
      }, Metric {
        labels: [Label { name: "cpu", value: "0" }, Label { name: "mode", value: "idle" }],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(546)) })) }]
      }, Metric {
        labels: [Label { name: "cpu", value: "0" }, Label { name: "mode", value: "nice" }],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(0)) })) }]
      }, Metric {
        labels: [Label { name: "cpu", value: "0" }, Label { name: "mode", value: "system" }],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(3487)) })) }]
      }, Metric {
        labels: [Label { name: "cpu", value: "0" }, Label { name: "mode", value: "iowait" }],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(0)) })) }]
      }, Metric {
        labels: [Label { name: "cpu", value: "0" }, Label { name: "mode", value: "irq" }],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(0)) })) }]
      }, Metric {
        labels: [Label { name: "cpu", value: "0" }, Label { name: "mode", value: "softirq" }],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(0)) })) }]
      }, Metric {
        labels: [Label { name: "cpu", value: "0" }, Label { name: "mode", value: "steal" }],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(1)) })) }]
     }]
  }, MetricFamily {
    name: "context_switches_total",
    r#type: Counter,
    unit: "",
    help: "Total number of context switches.",
    metrics: [
      Metric {
        labels: [],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(42853)) })) }]
    }] 
  }, MetricFamily {
    name: "forks_total",
    r#type: Counter,
    unit: "",
    help: "Total number of forks.",
    metrics: [
      Metric {
        labels: [],
        metric_points: [MetricPoint { timestamp: None, value: Some(CounterValue(CounterValue { created: None, exemplar: None, total: Some(IntValue(199)) })) }]
    }]
  }, MetricFamily {
     name: "procs_running",
     r#type: Gauge,
     unit: "",
     help: "Number of processes in runnable state.",
    metrics: [
    Metric {
      labels: [],
      metric_points: [MetricPoint { timestamp: None, value: Some(GaugeValue(GaugeValue { value: Some(IntValue(3)) })) }]
    }] 
  }
]}
```