### PR TITLE
Refactor java endorsement verification.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Free disk space
         run: |
           df --human-readable
-          sudo apt-get remove --yes '^dotnet-.*' '^llvm-.*' 'php.*' azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell
+          sudo apt-get remove --yes '^dotnet-.*' '^llvm-.*' 'php.*' azure-cli google-cloud-cli hhvm google-chrome-stable firefox powershell
           df --human-readable
           sudo apt-get autoremove --yes
           df --human-readable

--- a/java/README.md
+++ b/java/README.md
@@ -1,3 +1,8 @@
 # Java Code
 
 Top-level directory for all Java code.
+
+```bash
+apt get bazel
+bazel test java/...
+```

--- a/java/README.md
+++ b/java/README.md
@@ -3,6 +3,5 @@
 Top-level directory for all Java code. To build and test:
 
 ```bash
-nix develop
 bazel test java/...
 ```

--- a/java/README.md
+++ b/java/README.md
@@ -3,6 +3,6 @@
 Top-level directory for all Java code. To build and test:
 
 ```bash
-sudo apt-get install bazel
+nix develop
 bazel test java/...
 ```

--- a/java/README.md
+++ b/java/README.md
@@ -1,8 +1,8 @@
 # Java Code
 
-Top-level directory for all Java code.
+Top-level directory for all Java code. To build and test:
 
 ```bash
-apt get bazel
+sudo apt-get install bazel
 bazel test java/...
 ```

--- a/java/src/main/java/com/google/oak/transparency/BUILD
+++ b/java/src/main/java/com/google/oak/transparency/BUILD
@@ -22,8 +22,16 @@ package(
 )
 
 java_binary(
-    name = "endorsement_verifier",
-    main_class = "com.google.oak.transparency.EndorsementVerifier",
+    name = "log_entry_verifier",
+    main_class = "com.google.oak.transparency.LogEntryVerifier",
+    runtime_deps = [
+        ":transparency",
+    ],
+)
+
+java_binary(
+    name = "signature_verifier",
+    main_class = "com.google.oak.transparency.SignatureVerifier",
     runtime_deps = [
         ":transparency",
     ],

--- a/java/src/main/java/com/google/oak/transparency/BUILD
+++ b/java/src/main/java/com/google/oak/transparency/BUILD
@@ -14,19 +14,25 @@
 # limitations under the License.
 #
 
-load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )
 
+java_binary(
+    name = "endorsement_verifier",
+    main_class = "com.google.oak.transparency.EndorsementVerifier",
+    runtime_deps = [
+        ":transparency",
+    ],
+)
+
 java_library(
-    name = "rekor",
+    name = "transparency",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/google/oak/util",
-        "//oak_remote_attestation/proto/v1:messages_java_proto",
         "@com_google_code_gson_gson",
     ],
 )

--- a/java/src/main/java/com/google/oak/transparency/EndorsementVerifier.java
+++ b/java/src/main/java/com/google/oak/transparency/EndorsementVerifier.java
@@ -57,17 +57,10 @@ public class EndorsementVerifier {
   public static Optional<String> verifyRekorLogEntry(
       RekorLogEntry logEntry, byte[] publicKeyBytes, byte[] endorsementBytes) {
     Optional<String> rekorSigVer = verifyRekorSignature(logEntry, publicKeyBytes);
-    logger.warning("HEYJA ");
     if (rekorSigVer.isPresent()) {
-      logger.warning("HEY " + rekorSigVer.get());
       return rekorSigVer;
     }
-    logger.warning("DIG " + sha256Hex(endorsementBytes));
-    Optional<String> b = verifyRekorBody(logEntry.getBody(), endorsementBytes);
-    if (b.isPresent()) {
-      logger.warning("HUU " + b.get());
-    }
-    return b;
+    return verifyRekorBody(logEntry.getBody(), endorsementBytes);
   }
 
   /**

--- a/java/src/main/java/com/google/oak/transparency/EndorsementVerifier.java
+++ b/java/src/main/java/com/google/oak/transparency/EndorsementVerifier.java
@@ -55,16 +55,11 @@ public class EndorsementVerifier {
   /**
    * Verifies a Rekor LogEntry.
    *
-   * Verifies the following items:
-   * <ul>
-   * <li>The signature in {@code signedEntryTimestamp} (retrieved from
-   * {@code logEntryBytes}), using Rekor's public key ({@code publicKeyBytes}).
-   * <li>The signature in {@code body.RekordObj.signature} (retrieved
-   * from {@code logEntryBytes}), using the endorser's public key (also retrieved
-   * from {@code logEntryBytes}).
-   * <li>Equality of the content of the body (retrieved from
-   * {@code logEntryBytes}) and the input {@code endorsementBytes}.
-   * </ul>
+   * Verifies the signature of {@code logEntry.verification.signedEntryTimestamp}
+   * using the provided public key, the signature in
+   * {@code logEntry.body.RekordObj.signature} using the endorser's public key
+   * {@code logEntry.body.spec.signature.publicKey}, as well as digest equality of
+   * {@code logEntry.body.spec.data.hash} and the endorsement statement.
    *
    * @param logEntry         The Rekor log entry
    * @param publicKeyBytes   The PEM-encoded public key from Rekor

--- a/java/src/main/java/com/google/oak/transparency/Failure.java
+++ b/java/src/main/java/com/google/oak/transparency/Failure.java
@@ -1,0 +1,31 @@
+
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.transparency;
+
+/** Signals verification failure and provides a human-readable cause. */
+public class Failure {
+    public Failure(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    private final String message;
+}

--- a/java/src/main/java/com/google/oak/transparency/RekorLogEntry.java
+++ b/java/src/main/java/com/google/oak/transparency/RekorLogEntry.java
@@ -18,6 +18,7 @@ package com.google.oak.transparency;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import com.google.oak.util.Result;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
@@ -169,7 +170,8 @@ public final class RekorLogEntry {
   public static RekorLogEntry createFromJson(String json) {
     // Use a default Gson instance to parse JSON strings into Java objects.
     Gson gson = new GsonBuilder().create();
-    Map<String, Object> entryMap = gson.fromJson(json, Map.class);
+    Map<String, Object> entryMap = gson.fromJson(json, new TypeToken<Map<String, Object>>() {
+    }.getType());
 
     if (entryMap.size() != 1) {
       throw new IllegalArgumentException(

--- a/java/src/main/java/com/google/oak/transparency/RekorLogEntry.java
+++ b/java/src/main/java/com/google/oak/transparency/RekorLogEntry.java
@@ -19,12 +19,9 @@ package com.google.oak.transparency;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
-import com.google.oak.util.Result;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
 import java.util.Base64;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Represents a Rekor LogEntry as defined in

--- a/java/src/main/java/com/google/oak/transparency/RekorSignatureBundle.java
+++ b/java/src/main/java/com/google/oak/transparency/RekorSignatureBundle.java
@@ -39,9 +39,7 @@ public class RekorSignatureBundle {
    */
   private final String canonicalized;
 
-  /**
-   * Base64-encoded signature over the canonicalized JSON document.
-   */
+  /** Base64-encoded signature over the canonicalized JSON document. */
   private final String base64Signature;
 
   public RekorSignatureBundle(String canonicalized, String base64Signature) {
@@ -57,31 +55,17 @@ public class RekorSignatureBundle {
     return this.canonicalized.getBytes(StandardCharsets.UTF_8);
   }
 
-  /**
-   * Create a RekorSignatureBundle from the given LogEntry.
-   *
-   * @param entry
-   * @return
-   */
-  public static Result<RekorSignatureBundle, Exception> fromRekorLogEntry(RekorLogEntry entry) {
-    // Create a copy of the LogEntry, but skip the verification.
+  /** Creates a bundle from the given log entry. */
+  public static RekorSignatureBundle create(RekorLogEntry entry) {
     RekorLogEntry.LogEntry entrySubset = new RekorLogEntry.LogEntry();
     entrySubset.body = entry.logEntry.body;
     entrySubset.integratedTime = entry.logEntry.integratedTime;
     entrySubset.logId = entry.logEntry.logId;
     entrySubset.logIndex = entry.logEntry.logIndex;
 
-    // Canonicalized JSON document that is signed. Canonicalization should follow
-    // the RFC 8785 rules.
     Gson gson = new GsonBuilder().create();
     String canonicalized = gson.toJson(entrySubset);
 
-    if (entry.logEntry.verification == null) {
-      return Result.error(
-          new IllegalArgumentException("no verification in the log entry"));
-    }
-
-    return Result.success(
-        new RekorSignatureBundle(canonicalized, entry.logEntry.verification.signedEntryTimestamp));
+    return new RekorSignatureBundle(canonicalized, entry.logEntry.verification.signedEntryTimestamp);
   }
 }

--- a/java/src/main/java/com/google/oak/transparency/RekorSignatureBundle.java
+++ b/java/src/main/java/com/google/oak/transparency/RekorSignatureBundle.java
@@ -18,7 +18,6 @@ package com.google.oak.transparency;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.oak.util.Result;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 

--- a/java/src/main/java/com/google/oak/transparency/SignatureVerifier.java
+++ b/java/src/main/java/com/google/oak/transparency/SignatureVerifier.java
@@ -1,0 +1,74 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.oak.transparency;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/** Verifies a signature based on a public key. */
+public class SignatureVerifier {
+    /**
+     * Needs three paths as command line arguments, corresponding to the arguments
+     * of {@code #verify()}. Verification failure is signalled via exit code.
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length != 3) {
+            System.exit(2);
+        }
+
+        String signature = Files.readString(Path.of(args[0]));
+        byte[] publicKeyBytes = Files.readAllBytes(Path.of(args[1]));
+        byte[] contentBytes = Files.readAllBytes(Path.of(args[2]));
+
+        Optional<Failure> failure = verify(signature, publicKeyBytes, contentBytes);
+        if (failure.isPresent()) {
+            System.err.println("Verification failed: " + failure.get().getMessage());
+            System.exit(1);
+        }
+    }
+
+    private static Optional<Failure> failure(String message) {
+        return Optional.of(new Failure(message));
+    }
+
+    /**
+     * Verifies the signature over content bytes using a public key.
+     *
+     * @param signature      The base64-encoded signature
+     * @param publicKeyBytes The PEM-encoded public key
+     * @param contentBytes   The serialized content
+     * @return Empty if the verification succeeds, or a failure otherwise
+     */
+    public static Optional<Failure> verify(
+            String signature, byte[] publicKeyBytes, byte[] contentBytes) {
+        if (signature == null || signature.length() == 0) {
+            return failure("empty signature");
+        }
+        if (contentBytes == null || contentBytes.length == 0) {
+            return failure("empty content");
+        }
+        if (publicKeyBytes == null || publicKeyBytes.length == 0) {
+            return failure("empty public key");
+        }
+        // TODO(#2854): verify the signature
+        return Optional.empty();
+    }
+
+    private SignatureVerifier() {
+    }
+}

--- a/java/src/test/java/com/google/oak/transparency/BUILD
+++ b/java/src/test/java/com/google/oak/transparency/BUILD
@@ -26,7 +26,7 @@ java_test(
     data = ["//oak_remote_attestation_verification/testdata:logentry.json"],
     test_class = "com.google.oak.transparency.RekorLogEntryTest",
     deps = [
-        "//java/src/main/java/com/google/oak/transparency:rekor",
+        "//java/src/main/java/com/google/oak/transparency",
     ],
 )
 
@@ -40,7 +40,6 @@ java_test(
     ],
     test_class = "com.google.oak.transparency.EndorsementVerifierTest",
     deps = [
-        "//java/src/main/java/com/google/oak/transparency:rekor",
-        "//java/src/main/java/com/google/oak/util",
+        "//java/src/main/java/com/google/oak/transparency",
     ],
 )

--- a/java/src/test/java/com/google/oak/transparency/BUILD
+++ b/java/src/test/java/com/google/oak/transparency/BUILD
@@ -31,14 +31,14 @@ java_test(
 )
 
 java_test(
-    name = "endorsement_verifier_test",
-    srcs = ["EndorsementVerifierTest.java"],
+    name = "log_entry_verifier_test",
+    srcs = ["LogEntryVerifierTest.java"],
     data = [
         "//oak_remote_attestation_verification/testdata:endorsement.json",
         "//oak_remote_attestation_verification/testdata:logentry.json",
         "//oak_remote_attestation_verification/testdata:rekor_public_key.pem",
     ],
-    test_class = "com.google.oak.transparency.EndorsementVerifierTest",
+    test_class = "com.google.oak.transparency.LogEntryVerifierTest",
     deps = [
         "//java/src/main/java/com/google/oak/transparency",
     ],

--- a/java/src/test/java/com/google/oak/transparency/EndorsementVerifierTest.java
+++ b/java/src/test/java/com/google/oak/transparency/EndorsementVerifierTest.java
@@ -19,6 +19,8 @@ package com.google.oak.transparency;
 import com.google.oak.util.Result;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,17 +28,20 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class EndorsementVerifierTest {
+  private static final String LOG_ENTRY_PATH = "oak_remote_attestation_verification/testdata/logentry.json";
+  private static final String ENDORSEMENT_PATH = "oak_remote_attestation_verification/testdata/endorsement.json";
+  private static final String REKOR_PUBLIC_KEY_PATH = "oak_remote_attestation_verification/testdata/rekor_public_key.pem";
+
   @Test
   public void testVerifyRekorLogEntry() throws Exception {
-    String logEntryPath = "oak_remote_attestation_verification/testdata/logentry.json";
-    String endorsementPath = "oak_remote_attestation_verification/testdata/endorsement.json";
-    String rekorPubkeyPath = "oak_remote_attestation_verification/testdata/rekor_public_key.pem";
+    byte[] logEntryBytes = Files.readAllBytes(Path.of(LOG_ENTRY_PATH));
+    byte[] endorsementBytes = Files.readAllBytes(Path.of(REKOR_PUBLIC_KEY_PATH));
+    byte[] rekorPublicKeyBytes = Files.readAllBytes(Path.of(REKOR_PUBLIC_KEY_PATH));
 
-    byte[] logEntryBytes = Files.readAllBytes(Path.of(logEntryPath));
-    byte[] endorsementBytes = Files.readAllBytes(Path.of(endorsementPath));
-    byte[] rekorPublicKeyBytes = Files.readAllBytes(Path.of(rekorPubkeyPath));
-    Result<Boolean, Exception> result = new EndorsementVerifier().verifyRekorLogEntry(
-        logEntryBytes, rekorPublicKeyBytes, endorsementBytes);
-    Assert.assertTrue(result.isSuccess());
+    RekorLogEntry logEntry = RekorLogEntry.createFromJson(logEntryBytes);
+    Optional<String> error = EndorsementVerifier.verifyRekorLogEntry(
+        logEntry, rekorPublicKeyBytes, endorsementBytes);
+
+    Assert.assertFalse(error.isPresent());
   }
 }

--- a/java/src/test/java/com/google/oak/transparency/EndorsementVerifierTest.java
+++ b/java/src/test/java/com/google/oak/transparency/EndorsementVerifierTest.java
@@ -39,9 +39,9 @@ public class EndorsementVerifierTest {
     byte[] rekorPublicKeyBytes = Files.readAllBytes(Path.of(REKOR_PUBLIC_KEY_PATH));
 
     RekorLogEntry logEntry = RekorLogEntry.createFromJson(logEntryBytes);
-    Optional<String> error = EndorsementVerifier.verifyRekorLogEntry(
+    Optional<EndorsementVerifier.Failure> failure = EndorsementVerifier.verifyRekorLogEntry(
         logEntry, rekorPublicKeyBytes, endorsementBytes);
 
-    Assert.assertFalse(error.isPresent());
+    Assert.assertFalse(failure.isPresent());
   }
 }

--- a/java/src/test/java/com/google/oak/transparency/EndorsementVerifierTest.java
+++ b/java/src/test/java/com/google/oak/transparency/EndorsementVerifierTest.java
@@ -16,11 +16,9 @@
 
 package com.google.oak.transparency;
 
-import com.google.oak.util.Result;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,14 +27,14 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class EndorsementVerifierTest {
   private static final String LOG_ENTRY_PATH = "oak_remote_attestation_verification/testdata/logentry.json";
-  private static final String ENDORSEMENT_PATH = "oak_remote_attestation_verification/testdata/endorsement.json";
   private static final String REKOR_PUBLIC_KEY_PATH = "oak_remote_attestation_verification/testdata/rekor_public_key.pem";
+  private static final String ENDORSEMENT_PATH = "oak_remote_attestation_verification/testdata/endorsement.json";
 
   @Test
   public void testVerifyRekorLogEntry() throws Exception {
     byte[] logEntryBytes = Files.readAllBytes(Path.of(LOG_ENTRY_PATH));
-    byte[] endorsementBytes = Files.readAllBytes(Path.of(ENDORSEMENT_PATH));
     byte[] rekorPublicKeyBytes = Files.readAllBytes(Path.of(REKOR_PUBLIC_KEY_PATH));
+    byte[] endorsementBytes = Files.readAllBytes(Path.of(ENDORSEMENT_PATH));
 
     RekorLogEntry logEntry = RekorLogEntry.createFromJson(logEntryBytes);
     Optional<EndorsementVerifier.Failure> failure = EndorsementVerifier.verifyRekorLogEntry(

--- a/java/src/test/java/com/google/oak/transparency/EndorsementVerifierTest.java
+++ b/java/src/test/java/com/google/oak/transparency/EndorsementVerifierTest.java
@@ -35,7 +35,7 @@ public class EndorsementVerifierTest {
   @Test
   public void testVerifyRekorLogEntry() throws Exception {
     byte[] logEntryBytes = Files.readAllBytes(Path.of(LOG_ENTRY_PATH));
-    byte[] endorsementBytes = Files.readAllBytes(Path.of(REKOR_PUBLIC_KEY_PATH));
+    byte[] endorsementBytes = Files.readAllBytes(Path.of(ENDORSEMENT_PATH));
     byte[] rekorPublicKeyBytes = Files.readAllBytes(Path.of(REKOR_PUBLIC_KEY_PATH));
 
     RekorLogEntry logEntry = RekorLogEntry.createFromJson(logEntryBytes);

--- a/java/src/test/java/com/google/oak/transparency/LogEntryVerifierTest.java
+++ b/java/src/test/java/com/google/oak/transparency/LogEntryVerifierTest.java
@@ -25,19 +25,19 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class EndorsementVerifierTest {
+public class LogEntryVerifierTest {
   private static final String LOG_ENTRY_PATH = "oak_remote_attestation_verification/testdata/logentry.json";
   private static final String REKOR_PUBLIC_KEY_PATH = "oak_remote_attestation_verification/testdata/rekor_public_key.pem";
   private static final String ENDORSEMENT_PATH = "oak_remote_attestation_verification/testdata/endorsement.json";
 
   @Test
-  public void testVerifyRekorLogEntry() throws Exception {
+  public void testVerifySucceeds() throws Exception {
     byte[] logEntryBytes = Files.readAllBytes(Path.of(LOG_ENTRY_PATH));
     byte[] rekorPublicKeyBytes = Files.readAllBytes(Path.of(REKOR_PUBLIC_KEY_PATH));
     byte[] endorsementBytes = Files.readAllBytes(Path.of(ENDORSEMENT_PATH));
 
     RekorLogEntry logEntry = RekorLogEntry.createFromJson(logEntryBytes);
-    Optional<EndorsementVerifier.Failure> failure = EndorsementVerifier.verifyRekorLogEntry(
+    Optional<Failure> failure = LogEntryVerifier.verify(
         logEntry, rekorPublicKeyBytes, endorsementBytes);
 
     Assert.assertFalse(failure.isPresent());

--- a/java/src/test/java/com/google/oak/transparency/RekorLogEntryTest.java
+++ b/java/src/test/java/com/google/oak/transparency/RekorLogEntryTest.java
@@ -25,17 +25,17 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class RekorLogEntryTest {
-  @Test
-  public void testUnmarshalRekorLogEntry() throws Exception {
-    String logEntryPath = "oak_remote_attestation_verification/testdata/logentry.json";
+  private static final String LOG_ENTRY_PATH = "oak_remote_attestation_verification/testdata/logentry.json";
 
-    String json = Files.readString(Path.of(logEntryPath));
-    RekorLogEntry.LogEntry entry = RekorLogEntry.unmarshalLogEntry(json).logEntry;
-    Assert.assertTrue(entry.body.length() > 0);
-    Assert.assertEquals(entry.logIndex, 30891523);
-    Assert.assertEquals(entry.bodyObject.kind, "rekord");
-    Assert.assertEquals(entry.bodyObject.spec.data.hash.algorithm, "sha256");
-    Assert.assertEquals(entry.bodyObject.spec.signature.format, "x509");
-    Assert.assertNotNull(entry.verification);
+  @Test
+  public void testCreate() throws Exception {
+    String json = Files.readString(Path.of(LOG_ENTRY_PATH));
+    RekorLogEntry r = RekorLogEntry.createFromJson(json);
+    Assert.assertTrue(r.hasVerification());
+    Assert.assertTrue(r.logEntry.body.length() > 0);
+    Assert.assertEquals(r.logEntry.logIndex, 30891523);
+    Assert.assertEquals(r.logEntry.bodyObject.kind, "rekord");
+    Assert.assertEquals(r.logEntry.bodyObject.spec.data.hash.algorithm, "sha256");
+    Assert.assertEquals(r.logEntry.bodyObject.spec.signature.format, "x509");
   }
 }


### PR DESCRIPTION
- Split and renamed EndorsementVerifier class and added main() functions so they can be called from the command line
- Use `Optional<Failure>`  rather than `Result<Boolean, Exception>`
- Improved error handling during creation
- Fix a build breakage on copybara import
- Fix breakage in xtask Free disk space check
- Don't parse RekorLogEntry more than once
- Shortening in general
- Actual signature verification still not implemented