### PR TITLE
Use logging rather than System.err.

### DIFF
--- a/java/src/main/java/com/google/oak/transparency/LogEntryVerifier.java
+++ b/java/src/main/java/com/google/oak/transparency/LogEntryVerifier.java
@@ -50,7 +50,7 @@ public class LogEntryVerifier {
     RekorLogEntry logEntry = RekorLogEntry.createFromJson(logEntryBytes);
     Optional<Failure> failure = verify(logEntry, publicKeyBytes, endorsementBytes);
     if (failure.isPresent()) {
-      System.err.println("Verification failed: " + failure.get().getMessage());
+      logger.warning("Verification failed: " + failure.get().getMessage());
       System.exit(1);
     }
   }

--- a/java/src/main/java/com/google/oak/transparency/SignatureVerifier.java
+++ b/java/src/main/java/com/google/oak/transparency/SignatureVerifier.java
@@ -25,98 +25,101 @@ import java.security.Signature;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 /** Verifies a signature based on a public key. */
 public class SignatureVerifier {
-    /**
-     * Needs three paths as command line arguments, corresponding to the arguments
-     * of {@code #verify()}. Verification failure is signalled via exit code.
-     */
-    public static void main(String[] args) throws Exception {
-        if (args.length != 3) {
-            System.exit(2);
-        }
-
-        byte[] signatureBytes = Files.readAllBytes(Path.of(args[0]));
-        byte[] publicKeyBytes = Files.readAllBytes(Path.of(args[1]));
-        byte[] contentBytes = Files.readAllBytes(Path.of(args[2]));
-
-        // Auto-detect PEM format of public key.
-        String publicKeyString = new String(publicKeyBytes, StandardCharsets.UTF_8);
-        if (looksLikePem(publicKeyString)) {
-            publicKeyBytes = convertPemToRaw(publicKeyString);
-        }
-
-        Optional<Failure> failure = verify(signatureBytes, publicKeyBytes, contentBytes);
-        if (failure.isPresent()) {
-            System.err.println("Verification failed: " + failure.get().getMessage());
-            System.exit(1);
-        }
+  /**
+   * Needs three paths as command line arguments, corresponding to the arguments
+   * of {@code #verify()}. Verification failure is signalled via exit code.
+   */
+  public static void main(String[] args) throws Exception {
+    if (args.length != 3) {
+      System.exit(2);
     }
 
-    private static Optional<Failure> failure(String message) {
-        return Optional.of(new Failure(message));
+    byte[] signatureBytes = Files.readAllBytes(Path.of(args[0]));
+    byte[] publicKeyBytes = Files.readAllBytes(Path.of(args[1]));
+    byte[] contentBytes = Files.readAllBytes(Path.of(args[2]));
+
+    // Auto-detect PEM format of public key.
+    String publicKeyString = new String(publicKeyBytes, StandardCharsets.UTF_8);
+    if (looksLikePem(publicKeyString)) {
+      publicKeyBytes = convertPemToRaw(publicKeyString);
     }
 
-    /**
-     * Verifies the signature over content bytes using a public key.
-     *
-     * @param signatureBytes the raw ECDSA signature, likely 71 bytes long
-     * @param publicKeyBytes the raw public key
-     * @param contentBytes   the serialized content
-     * @return empty if the verification succeeds, or a failure otherwise
-     */
-    public static Optional<Failure> verify(
-            byte[] signatureBytes, byte[] publicKeyBytes, byte[] contentBytes) {
-        if (signatureBytes == null || signatureBytes.length == 0) {
-            return failure("empty signature");
-        }
-        if (publicKeyBytes == null || publicKeyBytes.length == 0) {
-            return failure("empty public key");
-        }
-        if (contentBytes == null || contentBytes.length == 0) {
-            return failure("empty content");
-        }
+    Optional<Failure> failure = verify(signatureBytes, publicKeyBytes, contentBytes);
+    if (failure.isPresent()) {
+      logger.warning("Verification failed: " + failure.get().getMessage());
+      System.exit(1);
+    }
+  }
 
-        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(publicKeyBytes);
-        Exception exception = null;
-        boolean success = false;
-        try {
-            KeyFactory keyFactory = KeyFactory.getInstance("EC");
-            PublicKey publicKey = keyFactory.generatePublic(keySpec);
-            Signature s = Signature.getInstance("SHA256withECDSA");
-            s.initVerify(publicKey);
-            s.update(contentBytes);
-            success = s.verify(signatureBytes);
-        } catch (Exception e) {
-            exception = e;
-        }
+  private static final Logger logger = Logger.getLogger(SignatureVerifier.class.getName());
 
-        return success ? Optional.empty()
-                : failure(exception != null
-                        ? String.format("%s: %s", exception.getClass().getName(), exception.getMessage())
-                        : "Signature verification failed");
+  private static Optional<Failure> failure(String message) {
+    return Optional.of(new Failure(message));
+  }
+
+  /**
+   * Verifies the signature over content bytes using a public key.
+   *
+   * @param signatureBytes the raw ECDSA signature, likely 71 bytes long
+   * @param publicKeyBytes the raw public key
+   * @param contentBytes   the serialized content
+   * @return empty if the verification succeeds, or a failure otherwise
+   */
+  public static Optional<Failure> verify(
+      byte[] signatureBytes, byte[] publicKeyBytes, byte[] contentBytes) {
+    if (signatureBytes == null || signatureBytes.length == 0) {
+      return failure("empty signature");
+    }
+    if (publicKeyBytes == null || publicKeyBytes.length == 0) {
+      return failure("empty public key");
+    }
+    if (contentBytes == null || contentBytes.length == 0) {
+      return failure("empty content");
     }
 
-    private static final String PEM_HEADER = "-----BEGIN PUBLIC KEY-----";
-    private static final String PEM_FOOTER = "-----END PUBLIC KEY-----";
-
-    /** Makes a plausible guess whether the public key is in PEM format. */
-    static boolean looksLikePem(String maybePem) {
-        String p = maybePem.trim();
-        return p.startsWith(PEM_HEADER) && p.endsWith(PEM_FOOTER);
+    X509EncodedKeySpec keySpec = new X509EncodedKeySpec(publicKeyBytes);
+    Exception exception = null;
+    boolean success = false;
+    try {
+      KeyFactory keyFactory = KeyFactory.getInstance("EC");
+      PublicKey publicKey = keyFactory.generatePublic(keySpec);
+      Signature s = Signature.getInstance("SHA256withECDSA");
+      s.initVerify(publicKey);
+      s.update(contentBytes);
+      success = s.verify(signatureBytes);
+    } catch (Exception e) {
+      exception = e;
     }
 
-    /** Converts a public key from PEM (on disk format) to raw binary format. */
-    static byte[] convertPemToRaw(String pem) {
-        String trimmed = pem
-                .replace(PEM_HEADER, "")
-                .replace(PEM_FOOTER, "")
-                .replace("\n", "")
-                .trim();
-        return Base64.getDecoder().decode(trimmed);
-    }
+    return success ? Optional.empty()
+        : failure(exception != null
+            ? String.format("%s: %s", exception.getClass().getName(), exception.getMessage())
+            : "Signature verification failed");
+  }
 
-    private SignatureVerifier() {
-    }
+  private static final String PEM_HEADER = "-----BEGIN PUBLIC KEY-----";
+  private static final String PEM_FOOTER = "-----END PUBLIC KEY-----";
+
+  /** Makes a plausible guess whether the public key is in PEM format. */
+  static boolean looksLikePem(String maybePem) {
+    String p = maybePem.trim();
+    return p.startsWith(PEM_HEADER) && p.endsWith(PEM_FOOTER);
+  }
+
+  /** Converts a public key from PEM (on disk format) to raw binary format. */
+  static byte[] convertPemToRaw(String pem) {
+    String trimmed = pem
+        .replace(PEM_HEADER, "")
+        .replace(PEM_FOOTER, "")
+        .replace("\n", "")
+        .trim();
+    return Base64.getDecoder().decode(trimmed);
+  }
+
+  private SignatureVerifier() {
+  }
 }


### PR DESCRIPTION
This is required so the reason why verification failed appears in the internal test log.