### PR TITLE
Add bazel build test for protocol buffers. Fix build.

### DIFF
--- a/oak_crypto/proto/v1/BUILD
+++ b/oak_crypto/proto/v1/BUILD
@@ -40,10 +40,10 @@ java_proto_library(
 )
 
 build_test(
-   name = "build_test",
-   targets = [
-     ":crypto_proto",
-     ":crypto_cc_proto",
-     ":crypto_java_proto",
-   ],
+    name = "build_test",
+    targets = [
+        ":crypto_proto",
+        ":crypto_cc_proto",
+        ":crypto_java_proto",
+    ],
 )

--- a/oak_crypto/proto/v1/BUILD
+++ b/oak_crypto/proto/v1/BUILD
@@ -17,6 +17,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -36,4 +37,13 @@ cc_proto_library(
 java_proto_library(
     name = "crypto_java_proto",
     deps = [":crypto_proto"],
+)
+
+build_test(
+   name = "build_test",
+   targets = [
+     ":crypto_proto",
+     ":crypto_cc_proto",
+     ":crypto_java_proto",
+   ],
 )

--- a/oak_remote_attestation/proto/v1/BUILD
+++ b/oak_remote_attestation/proto/v1/BUILD
@@ -19,6 +19,7 @@ load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -28,11 +29,13 @@ package(
 proto_library(
     name = "dice_proto",
     srcs = ["dice.proto"],
+    deps = [":evidence_proto"],
 )
 
 proto_library(
     name = "endorsement_proto",
     srcs = ["endorsement.proto"],
+    deps = [":evidence_proto"],
 )
 
 proto_library(
@@ -46,6 +49,16 @@ proto_library(
     deps = ["//oak_crypto/proto/v1:crypto_proto"],
 )
 
+cc_proto_library(
+    name = "messages_cc_proto",
+    deps = [":messages_proto"],
+)
+
+java_proto_library(
+    name = "messages_java_proto",
+    deps = [":messages_proto"],
+)
+
 proto_library(
     name = "service_streaming_proto",
     srcs = ["service_streaming.proto"],
@@ -55,11 +68,6 @@ proto_library(
 proto_library(
     name = "service_unary_proto",
     srcs = ["service_unary.proto"],
-    deps = [":messages_proto"],
-)
-
-cc_proto_library(
-    name = "messages_cc_proto",
     deps = [":messages_proto"],
 )
 
@@ -88,11 +96,6 @@ cc_grpc_library(
 )
 
 java_proto_library(
-    name = "messages_java_proto",
-    deps = [":messages_proto"],
-)
-
-java_proto_library(
     name = "service_streaming_java_proto",
     deps = [":service_streaming_proto"],
 )
@@ -112,4 +115,17 @@ java_grpc_library(
     name = "service_unary_java_grpc",
     srcs = [":service_unary_proto"],
     deps = [":service_unary_java_proto"],
+)
+
+build_test(
+   name = "build_test",
+   targets = [
+     ":dice_proto",
+     ":endorsement_proto",
+     ":messages_proto",
+     ":service_streaming_cc_grpc",
+     ":service_streaming_java_grpc",
+     ":service_unary_cc_grpc",
+     ":service_unary_java_grpc",
+   ],
 )

--- a/oak_remote_attestation/proto/v1/BUILD
+++ b/oak_remote_attestation/proto/v1/BUILD
@@ -118,14 +118,14 @@ java_grpc_library(
 )
 
 build_test(
-   name = "build_test",
-   targets = [
-     ":dice_proto",
-     ":endorsement_proto",
-     ":messages_proto",
-     ":service_streaming_cc_grpc",
-     ":service_streaming_java_grpc",
-     ":service_unary_cc_grpc",
-     ":service_unary_java_grpc",
-   ],
+    name = "build_test",
+    targets = [
+        ":dice_proto",
+        ":endorsement_proto",
+        ":messages_proto",
+        ":service_streaming_cc_grpc",
+        ":service_streaming_java_grpc",
+        ":service_unary_cc_grpc",
+        ":service_unary_java_grpc",
+    ],
 )

--- a/oak_remote_attestation/proto/v1/dice.proto
+++ b/oak_remote_attestation/proto/v1/dice.proto
@@ -18,6 +18,8 @@ syntax = "proto3";
 
 package oak.remote_attestation.v1;
 
+import "oak_remote_attestation/proto/v1/evidence.proto";
+
 option java_multiple_files = true;
 option java_package = "com.google.oak.remote_attestation.v1";
 

--- a/oak_remote_attestation/proto/v1/service_unary.proto
+++ b/oak_remote_attestation/proto/v1/service_unary.proto
@@ -26,14 +26,10 @@ option java_package = "com.google.oak.session.v1";
 // Service definition for unary communication with Oak server.
 service UnarySession {
   // Gets encryption key of sealed encironment.
-  rpc GetPublicKey(GetPublicKeyRequest) returns (GetPublicKeyResponse) {
-    option deadline = 10.0;
-  }
+  rpc GetPublicKey(GetPublicKeyRequest) returns (GetPublicKeyResponse);
 
   // Performs lookup for a list of encrypted keys. The keys should be encrypted
   // using the Public key provided by the enclave. The response is encrypted
   // using the response key (supplied by the client).
-  rpc Invoke(InvokeRequest) returns (InvokeResponse) {
-    option deadline = 10.0;
-  }
+  rpc Invoke(InvokeRequest) returns (InvokeResponse);
 }

--- a/oak_remote_attestation_verification/proto/v1/BUILD
+++ b/oak_remote_attestation_verification/proto/v1/BUILD
@@ -17,6 +17,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -36,4 +37,13 @@ cc_proto_library(
 java_proto_library(
     name = "verification_java_proto",
     deps = [":verification_proto"],
+)
+
+build_test(
+   name = "build_test",
+   targets = [
+     ":verification_proto",
+     ":verification_cc_proto",
+     ":verification_java_proto",
+   ],
 )

--- a/oak_remote_attestation_verification/proto/v1/BUILD
+++ b/oak_remote_attestation_verification/proto/v1/BUILD
@@ -40,10 +40,10 @@ java_proto_library(
 )
 
 build_test(
-   name = "build_test",
-   targets = [
-     ":verification_proto",
-     ":verification_cc_proto",
-     ":verification_java_proto",
-   ],
+    name = "build_test",
+    targets = [
+        ":verification_proto",
+        ":verification_cc_proto",
+        ":verification_java_proto",
+    ],
 )


### PR DESCRIPTION
This went undetected, even the copybara import did not flag this.

- Seems like the protoc compiler is happy, or the protos were not used yet
- TAP only considers *_binary and *_test targets (therefore we should have more tests, however trivial, just as the present build_test)