### PR TITLE
Run the container properly using `runc` instead of just forking

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,7 @@
                 docker
                 elfutils
                 flex
+                jq
                 libelf
                 perl
                 glibc

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -26,8 +26,6 @@ opentelemetry-otlp = { version = "*", default-features = false, features = [
 prost = "*"
 prost-types = "*"
 procfs = "*"
-serde = { version = "*", features = ["derive"] }
-serde_json = "*"
 syslog = "*"
 tar = "*"
 tokio = { version = "*", features = [

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -18,61 +18,10 @@
 //! itself is not OCI spec compliant.
 
 use anyhow::Context;
-use std::path::PathBuf;
 use tokio::sync::oneshot::Sender;
-
-/// Representation of a minimal OCI filesystem bundle config, including just the required fields.
-/// Ref: <https://github.com/opencontainers/runtime-spec/blob/c4ee7d12c742ffe806cd9350b6af3b4b19faed6f/config.md>
-#[derive(serde::Deserialize)]
-struct OciFilesystemBundleConfig {
-    process: OciFilesystemBundleConfigProcess,
-    root: OciFilesystemBundleConfigRoot,
-}
-
-#[derive(serde::Deserialize)]
-struct OciFilesystemBundleConfigProcess {
-    args: Vec<String>,
-    #[serde(default)]
-    cwd: std::path::PathBuf,
-    #[serde(default)]
-    env: Vec<String>,
-    user: OciFilesystemBundleConfigProcessUser,
-}
-
-#[derive(serde::Deserialize)]
-struct OciFilesystemBundleConfigProcessUser {
-    uid: u32,
-    gid: u32,
-}
-
-#[derive(serde::Deserialize)]
-struct OciFilesystemBundleConfigRoot {
-    path: std::path::PathBuf,
-}
 
 // Directory at which the container OCI filesystem bundle will be unpacked.
 const CONTAINER_DIR: &str = "/oak_container";
-
-async fn rmount_dir(source: PathBuf, target: PathBuf) -> Result<(), anyhow::Error> {
-    if target.exists() {
-        tokio::fs::remove_dir_all(&target)
-            .await
-            .context("failed to removing existing directories at the target")?
-    }
-    tokio::fs::create_dir_all(&target)
-        .await
-        .context("failed to create a directory at the target")?;
-
-    tokio::process::Command::new("mount")
-        .current_dir(CONTAINER_DIR)
-        .arg("--rbind")
-        .arg(&source)
-        .arg(&target)
-        .status()
-        .await?;
-
-    Ok(())
-}
 
 pub async fn run(
     container_bundle: &[u8],
@@ -82,103 +31,31 @@ pub async fn run(
     log::info!("Unpacking container bundle");
     tar::Archive::new(container_bundle).unpack(CONTAINER_DIR)?;
 
-    let oci_filesystem_bundle_config: OciFilesystemBundleConfig = {
-        let file_path = {
-            let mut base = std::path::PathBuf::from(CONTAINER_DIR);
-            base.push("config.json");
-            base
-        };
-        let oci_filesystem_bundle_config_file = tokio::fs::read_to_string(file_path).await?;
-
-        serde_json::from_str(&oci_filesystem_bundle_config_file)?
-    };
-
     log::info!("Setting up container");
 
-    let container_rootfs_path = {
-        let mut base = std::path::PathBuf::from(CONTAINER_DIR);
-        base.push(oci_filesystem_bundle_config.root.path);
-        base
-    };
-
-    // mount the utility dir (includes the ipc socket) into the container
-    let container_dev_path = {
-        let mut base = container_rootfs_path.clone();
-        base.push(crate::UTIL_DIR);
-        base
-    };
-    rmount_dir(
-        std::path::Path::new("/").join(crate::UTIL_DIR),
-        container_dev_path,
-    )
-    .await?;
-
-    // mount host /dev into the container
-    let container_dev_path = {
-        let mut base = container_rootfs_path.clone();
-        base.push("dev");
-        base
-    };
-    rmount_dir(std::path::PathBuf::from("/dev"), container_dev_path).await?;
-
-    // mount host /sys into the container
-    let container_sys_path = {
-        let mut base = container_rootfs_path.clone();
-        base.push("sys");
-        base
-    };
-    rmount_dir(std::path::PathBuf::from("/sys"), container_sys_path).await?;
-
-    // mount host /proc into the container
-    let container_proc_path = {
-        let mut base = container_rootfs_path.clone();
-        base.push("proc");
-        base
-    };
-    rmount_dir(std::path::PathBuf::from("/proc"), container_proc_path).await?;
-
-    log::debug!(
-        "Startup command: {:?}",
-        oci_filesystem_bundle_config.process.args
-    );
     let mut start_trusted_app_cmd = {
-        let mut cmd =
-            tokio::process::Command::new(oci_filesystem_bundle_config.process.args[0].clone());
-        cmd.args(oci_filesystem_bundle_config.process.args.as_slice()[1..].to_vec())
-            .uid(oci_filesystem_bundle_config.process.user.uid)
-            .gid(oci_filesystem_bundle_config.process.user.gid);
-        for variable in oci_filesystem_bundle_config.process.env.clone() {
-            if let Some((key, value)) = variable.split_once('=') {
-                log::debug!("Setting environment variable: {key}={value}");
-                cmd.env(key, value);
-            }
-        }
+        let mut cmd = tokio::process::Command::new("/bin/systemd-run");
+        cmd.args([
+            "--service-type=forking",
+            "--property=PIDFile=/run/oakc.pid",
+            "--wait",
+            "--collect",
+            "/bin/runc",
+            "--systemd-cgroup",
+            "run",
+            "--detach",
+            "--pid-file",
+            "/run/oakc.pid",
+            "--bundle",
+            "/oak_container",
+            "oakc",
+        ]);
         cmd
     };
 
-    log::debug!(
-        "Setting working directory: {:?}",
-        oci_filesystem_bundle_config.process.cwd
-    );
-
-    let prep_trusted_app_process = move || {
-        // Run the trusted app in a chroot environment of the container.
-        std::os::unix::fs::chroot(container_rootfs_path.clone())?;
-        let cwd = oci_filesystem_bundle_config.process.cwd.clone();
-        if cwd.has_root() {
-            std::env::set_current_dir(cwd)?;
-        }
-        Ok(())
-    };
-    // Safety: this unsafe block exists solely we can call the unsafe `pre_exec`
-    // method, allowing us to use a closure to prep the newly forked child
-    // process. That closure runs in a special environment so it can behave a bit
-    // unexpectedly. For our case that's fine though, since we just use it to
-    // make chdir & chroot syscalls.
-    // Ref: https://docs.rs/tokio/latest/tokio/process/struct.Command.html#safety
-    let status = unsafe { start_trusted_app_cmd.pre_exec(prep_trusted_app_process) }
-        .status()
-        .await?;
+    let status = start_trusted_app_cmd.status().await.context(format!(
+        "failed to run trusted app, cmd: {start_trusted_app_cmd:?}"
+    ))?;
     log::info!("Container exited with status {status:?}");
 
     let _ = exit_notification_sender.send(());

--- a/oak_containers_system_image/Dockerfile
+++ b/oak_containers_system_image/Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get --yes update \
   && apt-get install --yes --no-install-recommends \
-  systemd systemd-sysv dbus udev\
+  systemd systemd-sysv dbus udev runc \
   # Cleanup
   && apt-get clean \
   && rm --recursive --force /var/lib/apt/lists/*

--- a/scripts/export_container_bundle
+++ b/scripts/export_container_bundle
@@ -65,6 +65,10 @@ umoci unpack \
     --image="${OCI_IMAGE_DIR}" \
     "${OCI_BUNDLE_DIR}"
 
+# Apply transformations which hopefully we can get rid of in the future.
+jq '.process.terminal = false | .linux.uidMappings[0].hostID = 0 | .linux.gidMappings[0].hostID = 0 | .mounts += [{"destination": "/oak_utils", "type": "bind", "source": "/oak_utils", "options": ["rbind"]}]' < "${OCI_BUNDLE_DIR}"/config.json > "${WORK_DIR}"/config.new.json
+mv --force "${WORK_DIR}"/config.new.json "${OCI_BUNDLE_DIR}"/config.json
+
 # Bundle just the files and directories that constitute the deterministically
 # generated OCI bundle.
 tar --create --file="${OUTPUT_OCI_BUNDLE_TAR}" --directory="${OCI_BUNDLE_DIR}" ./rootfs ./config.json


### PR DESCRIPTION
Well, I say "properly", but this PR comes with a list of caveats a mile long, for example the `jq` hacks in the `export_container_bundle` that we need to fix properly.

However, it works, and has the added benefit of creating a proper systemd unit and cgroup for the container!

```
# systemctl status
● 10.0.2.15
    State: running
    Units: 175 loaded (incl. loaded aliases)
     Jobs: 0 queued
   Failed: 0 units
    Since: Wed 2023-10-11 17:44:44 UTC; 37s ago
  systemd: 252.17-1~deb12u1
   CGroup: /
           ├─init.scope
           │ └─1 /init
           └─system.slice
             ├─dbus.service
             │ └─177 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
             ├─oak-orchestrator.service
             │ ├─195 /bin/oak_containers_orchestrator
             │ └─213 /bin/systemd-run --service-type=forking --property=PIDFile=/run/oakc.pid --wait --collect /bin/runc --systemd-cgroup run --detach --pid-file /run/oakc.pid --bundle /oak_container oakc
             ├─oak-syslogd.service
             │ └─197 /usr/bin/oak_containers_syslogd
             ├─runc-oakc.scope
             │ └─223 /bin/oak_containers_hello_world_trusted_app
             ├─system-serial\x2dgetty.slice
             │ └─serial-getty@ttyS0.service
             │   ├─194 /bin/login -p --
             │   ├─206 -bash
             │   ├─237 systemctl status
             │   └─238 "(pager)"
             ├─systemd-journald.service
             │ └─135 /lib/systemd/systemd-journald
             ├─systemd-logind.service
             │ └─182 /lib/systemd/systemd-logind
             ├─systemd-networkd.service
             │ └─176 /lib/systemd/systemd-networkd
             └─systemd-udevd.service
               └─udev
                 └─154 /lib/systemd/systemd-udevd

```