### PR TITLE
Isolate orchestrator from system and use systemd `RuntimeDirectory`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "der"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +769,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1049,6 +1115,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1380,12 @@ dependencies = [
  "cxx",
  "cxx-build",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -1871,14 +1955,13 @@ dependencies = [
  "oak_crypto",
  "oak_grpc_utils",
  "oak_remote_attestation",
+ "oci-spec",
  "opentelemetry-otlp",
  "opentelemetry_api",
  "opentelemetry_sdk",
  "procfs",
  "prost",
  "prost-types",
- "serde",
- "serde_json",
  "syslog",
  "tar",
  "tokio",
@@ -2058,7 +2141,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
 ]
 
 [[package]]
@@ -2428,6 +2511,19 @@ dependencies = [
  "rust-hypervisor-firmware-virtio",
  "strum",
  "x86_64",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e7c5a234613dd98d240891270925718736701c2dbce9c5587567133cf8220f"
+dependencies = [
+ "derive_builder",
+ "getset",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -13,6 +13,7 @@ log = "*"
 oak_containers_orchestrator_client = { workspace = true }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
+oci-spec = "*"
 opentelemetry_api = { version = "*", default-features = false, features = [
   "metrics"
 ] }

--- a/oak_containers_orchestrator/src/lib.rs
+++ b/oak_containers_orchestrator/src/lib.rs
@@ -28,7 +28,3 @@ pub mod container_runtime;
 pub mod ipc_server;
 pub mod logging;
 pub mod metrics;
-
-// Utility directory that is shared between the orchestrator & container
-pub const UTIL_DIR: &str = "oak_utils";
-pub const IPC_SOCKET_FILE_NAME: &str = "orchestrator_ipc";

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -15,17 +15,25 @@
 
 use anyhow::anyhow;
 use clap::Parser;
-use oak_containers_orchestrator::{IPC_SOCKET_FILE_NAME, UTIL_DIR};
 use oak_containers_orchestrator_client::LauncherClient;
 use oak_crypto::encryptor::EncryptionKeyProvider;
 use oak_remote_attestation::attester::{Attester, EmptyAttestationReportGenerator};
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tokio::sync::oneshot::channel;
 
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(default_value = "http://10.0.2.100:8080")]
     launcher_addr: String,
+
+    #[arg(long, default_value = "/oak_container")]
+    container_dir: PathBuf,
+
+    #[arg(long, default_value = "/oak_utils/orchestrator_ipc")]
+    ipc_socket_path: PathBuf,
+
+    #[arg(long, default_value = "/run/oakc.pid")]
+    container_pid: PathBuf,
 }
 
 #[tokio::main]
@@ -64,20 +72,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .map_err(|error| anyhow!("couldn't send attestation evidence: {:?}", error))?;
 
-    let util_dir_absolute_path = std::path::Path::new("/").join(UTIL_DIR);
-    tokio::fs::create_dir_all(&util_dir_absolute_path).await?;
-    let ipc_path = {
-        let mut path = util_dir_absolute_path;
-        path.push(IPC_SOCKET_FILE_NAME);
-        path
-    };
+    if let Some(path) = args.ipc_socket_path.parent() {
+        tokio::fs::create_dir_all(path).await?;
+    }
+
     let (exit_notification_sender, shutdown_receiver) = channel::<()>();
 
     let _metrics = oak_containers_orchestrator::metrics::run(launcher_client.clone())?;
 
     tokio::try_join!(
         oak_containers_orchestrator::ipc_server::create(
-            ipc_path,
+            &args.ipc_socket_path,
             encryption_key_provider,
             attester,
             application_config,
@@ -86,6 +91,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ),
         oak_containers_orchestrator::container_runtime::run(
             &container_bundle,
+            &args.container_dir,
+            &args.container_pid,
+            &args.ipc_socket_path,
             exit_notification_sender
         ),
     )?;

--- a/oak_containers_system_image/files/etc/systemd/system/oak-orchestrator.service
+++ b/oak_containers_system_image/files/etc/systemd/system/oak-orchestrator.service
@@ -7,7 +7,9 @@ SuccessAction=poweroff-force
 
 [Service]
 Type=simple
-ExecStart=/bin/oak_containers_orchestrator
+ExecStart=/bin/oak_containers_orchestrator --container-dir ${RUNTIME_DIRECTORY}/oak_container --ipc-socket-path ${RUNTIME_DIRECTORY}/oak_utils/orchestrator_ipc --container-pid ${RUNTIME_DIRECTORY}/oakc.pid
+ProtectSystem=strict
+RuntimeDirectory=oak_containers_orchestrator
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/export_container_bundle
+++ b/scripts/export_container_bundle
@@ -66,7 +66,7 @@ umoci unpack \
     "${OCI_BUNDLE_DIR}"
 
 # Apply transformations which hopefully we can get rid of in the future.
-jq '.process.terminal = false | .linux.uidMappings[0].hostID = 0 | .linux.gidMappings[0].hostID = 0 | .mounts += [{"destination": "/oak_utils", "type": "bind", "source": "/oak_utils", "options": ["rbind"]}]' < "${OCI_BUNDLE_DIR}"/config.json > "${WORK_DIR}"/config.new.json
+jq '.process.terminal = false | .linux.uidMappings[0].hostID = 0 | .linux.gidMappings[0].hostID = 0' < "${OCI_BUNDLE_DIR}"/config.json > "${WORK_DIR}"/config.new.json
 mv --force "${WORK_DIR}"/config.new.json "${OCI_BUNDLE_DIR}"/config.json
 
 # Bundle just the files and directories that constitute the deterministically


### PR DESCRIPTION
First steps in hardening the system.

systemd offers this neat feature, [`ProtectSystem=strict`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ProtectSystem=), which makes the whole file system hierarchy read-only, meaning the orchestrator can't write random files.

However, we do need to write _some_ things to the filesystem: namely, the container image itself and the IPC socket. To achieve that, [`RuntimeDirectory`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#RuntimeDirectory=) to the rescue: it creates a directory under `/run` for us to use.

This PR plumbs a lot of that infrastructure through the orchestrator itself. The trusted application should see no change; this is one step in one day dropping the root privileges for both the container and the orchestrator.

Unfortunately this does mean that we need to alter `config.json` inside the container, as `${RUNTIME_DIRECTORY}` is fundamentally dynamic. I know @jul-sh doesn't like this, but unfortunately I think this is the cleanest answer here -- and if in the future we switch to dynamically allocated non-root users, we need to modify the spec ourselves anyway so that we could set up the UID mapping properly. This is but the first step in that direction.