### PR TITLE
Add `/etc/hosts` to sysimage by hand.

### DIFF
--- a/oak_containers_system_image/build.sh
+++ b/oak_containers_system_image/build.sh
@@ -17,6 +17,8 @@ readonly NEW_DOCKER_CONTAINER_ID="$(docker create oak-containers-system-image:la
 
 docker export "$NEW_DOCKER_CONTAINER_ID" > target/image.tar
 ls -lah target/image.tar
+# Hack, as Docker doesn't give us a `/etc/hosts` which means `localhost` won't resovle.
+tar --append --file=target/image.tar --directory=files etc/hosts
 xz --force target/image.tar
 
 docker rm "$NEW_DOCKER_CONTAINER_ID"

--- a/oak_containers_system_image/files/etc/hosts
+++ b/oak_containers_system_image/files/etc/hosts
@@ -1,0 +1,7 @@
+127.0.0.1	localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1	localhost ip6-localhost ip6-loopback
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+ff02::3	ip6-allhosts


### PR DESCRIPTION
We build the sysimage from the Docker container, which assumes `/etc/hosts` will be bind-mounted from the host. But we're not using it as a container, we're using it as a proper host image.

The "correct" solution here would be _not_ to use Docker at all, as there may be other surprises lurking in there, but rather use something like `debootstrap` to create the system image as that tool is designed for installing Debian properly. However, switching to debootstrap is not an easy task, especially if you want to do it in a rootless environment.

Hence, for now, let's add a hack.