### PR TITLE
Fix file permissions in the generated system image

### DIFF
--- a/oak_containers_system_image/build.sh
+++ b/oak_containers_system_image/build.sh
@@ -10,6 +10,10 @@ cargo build --package="oak_containers_syslogd" --release -Z unstable-options --o
 # we need to manually patch the binary to set it back to the normal regular location.
 patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 ./target/oak_containers_syslogd
 
+# Fix the file permissions that will be loaded into the system image, as Git doesn't track them.
+# Unfortunately we can't do it in Dockerfile (with `COPY --chown`), as that requires BuildKit.
+chmod --recursive a+rX files/
+
 docker build . --tag oak-containers-system-image
 # We need to actually create a container, otherwise we won't be able to use `docker export` that gives us a filesystem image.
 # (`docker save` creates a tarball which has all the layers separate, which is _not_ what we want.)


### PR DESCRIPTION
I broke the permissions in #4367 partly intentionally (I fixed the permissions and expected git to track them) and partly inadvertently (git doesn't.)

Building the system image worked for me until I started jumping around branches, at which point the permissions broke and `/etc/` ended up world-unreadable, with surprisingly little consequences -- apart from the network not coming up as expected.