### PR TITLE
Segregate `runc` into its own runtime directory

### DIFF
--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -31,9 +31,6 @@ struct Args {
 
     #[arg(long, default_value = "/oak_utils/orchestrator_ipc")]
     ipc_socket_path: PathBuf,
-
-    #[arg(long, default_value = "/run/oakc.pid")]
-    container_pid: PathBuf,
 }
 
 #[tokio::main]
@@ -92,7 +89,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         oak_containers_orchestrator::container_runtime::run(
             &container_bundle,
             &args.container_dir,
-            &args.container_pid,
             &args.ipc_socket_path,
             exit_notification_sender
         ),

--- a/oak_containers_system_image/files/etc/systemd/system/oak-orchestrator.service
+++ b/oak_containers_system_image/files/etc/systemd/system/oak-orchestrator.service
@@ -7,7 +7,7 @@ SuccessAction=poweroff-force
 
 [Service]
 Type=simple
-ExecStart=/bin/oak_containers_orchestrator --container-dir ${RUNTIME_DIRECTORY}/oak_container --ipc-socket-path ${RUNTIME_DIRECTORY}/oak_utils/orchestrator_ipc --container-pid ${RUNTIME_DIRECTORY}/oakc.pid
+ExecStart=/bin/oak_containers_orchestrator --container-dir ${RUNTIME_DIRECTORY}/oak_container --ipc-socket-path ${RUNTIME_DIRECTORY}/oak_utils/orchestrator_ipc
 ProtectSystem=strict
 RuntimeDirectory=oak_containers_orchestrator
 


### PR DESCRIPTION
Preliminary steps toward setting `ProtectSystem=strict` on for `runc` as well: much like in the orchestrator unit file, use the systemd magic to generate a directory under `/var/run` for `runc` to store things in.

As a side effect, we no longer need to store the PID file in the (dynamically allocated) orchestrator runtime directory, which means we can remove code related to that.