### PR TITLE
Run the container rootless under a nonprivileged user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "clap",
  "futures",
  "log",
+ "nix 0.22.3",
  "oak_containers_orchestrator_client",
  "oak_crypto",
  "oak_grpc_utils",
@@ -1967,6 +1968,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.9.2",
+ "walkdir",
 ]
 
 [[package]]

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "*"
 clap = { version = "*", features = ["derive"] }
 futures = "*"
 log = "*"
+nix = "*"
 oak_containers_orchestrator_client = { workspace = true }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
@@ -39,6 +40,7 @@ tokio = { version = "*", features = [
 ] }
 tokio-stream = { version = "*", features = ["net"] }
 tonic = { workspace = true }
+walkdir = "*"
 
 [build-dependencies]
 oak_grpc_utils = { workspace = true }

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -17,27 +17,44 @@
 //! containers in the form of an OCI filesystem bundle. However the runtime
 //! itself is not OCI spec compliant.
 
-use std::path::{Path, PathBuf};
+use std::{
+    os::unix::fs::lchown,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context;
-use oci_spec::runtime::{Mount, Spec};
+use nix::unistd::{Gid, Uid};
+use oci_spec::runtime::{LinuxIdMapping, LinuxIdMappingBuilder, Mount, Spec};
 use tokio::sync::oneshot::Sender;
 
 pub async fn run(
     container_bundle: &[u8],
     container_dir: &Path,
+    runtime_uid: Uid,
+    runtime_gid: Gid,
     ipc_socket_path: &Path,
     exit_notification_sender: Sender<()>,
 ) -> Result<(), anyhow::Error> {
     tokio::fs::create_dir_all(container_dir).await?;
     log::info!("Unpacking container bundle");
-    tar::Archive::new(container_bundle).unpack(container_dir)?;
+    let mut archive = tar::Archive::new(container_bundle);
+    archive.unpack(container_dir)?;
+
+    for entry in walkdir::WalkDir::new(container_dir) {
+        let entry = entry?;
+        lchown(
+            entry.path(),
+            Some(runtime_uid.into()),
+            Some(runtime_gid.into()),
+        )
+        .context(format!("failed to chown path {:?}", entry.path()))?;
+    }
 
     log::info!("Setting up container");
 
     let spec_path = container_dir.join("config.json");
     let mut spec = Spec::load(spec_path.clone()).context("error reading OCI spec")?;
-    let mut mounts = spec.mounts().as_ref().map_or(Vec::new(), |v| v.clone());
+    let mut mounts = spec.mounts().as_ref().cloned().unwrap_or_default();
     mounts.push({
         let mut mount = Mount::default();
         mount.set_source(Some(ipc_socket_path.into()));
@@ -47,6 +64,34 @@ pub async fn run(
         mount
     });
     spec.set_mounts(Some(mounts));
+    let mut linux = spec.linux().as_ref().cloned().unwrap_or_default();
+    let uid_mappings: Option<Vec<LinuxIdMapping>> = linux.uid_mappings().as_ref().map(|x| {
+        x.iter()
+            .map(|entry| {
+                LinuxIdMappingBuilder::default()
+                    .host_id(runtime_uid)
+                    .container_id(entry.container_id())
+                    .size(entry.size())
+                    .build()
+                    .unwrap()
+            })
+            .collect()
+    });
+    linux.set_uid_mappings(uid_mappings);
+    let gid_mappings: Option<Vec<LinuxIdMapping>> = linux.gid_mappings().as_ref().map(|x| {
+        x.iter()
+            .map(|entry| {
+                LinuxIdMappingBuilder::default()
+                    .host_id(runtime_gid)
+                    .container_id(entry.container_id())
+                    .size(entry.size())
+                    .build()
+                    .unwrap()
+            })
+            .collect()
+    });
+    linux.set_gid_mappings(gid_mappings);
+    spec.set_linux(Some(linux));
     spec.save(spec_path).context("error writing OCI spec")?;
 
     let mut start_trusted_app_cmd = {
@@ -62,10 +107,11 @@ pub async fn run(
             "--property=PIDFile=oakc/oakc.pid",
             "--property=ProtectSystem=strict",
             format!("--property=ReadWritePaths={}", container_dir).as_str(),
+            format!("--uid={}", runtime_uid).as_str(),
+            format!("--gid={}", runtime_gid).as_str(),
             "--wait",
             "--collect",
             "/bin/runc",
-            "--systemd-cgroup",
             "--root=${RUNTIME_DIRECTORY}/runc",
             "run",
             "--detach",

--- a/oak_containers_orchestrator/src/lib.rs
+++ b/oak_containers_orchestrator/src/lib.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(unix_chown)]
+
 mod proto {
     pub mod oak {
         pub mod containers {

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -77,6 +77,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let _metrics = oak_containers_orchestrator::metrics::run(launcher_client.clone())?;
 
+    let user = nix::unistd::User::from_name("oakc")
+        .expect("error resolving user `oakc`")
+        .expect("user `oakc` not found");
+
     tokio::try_join!(
         oak_containers_orchestrator::ipc_server::create(
             &args.ipc_socket_path,
@@ -89,6 +93,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         oak_containers_orchestrator::container_runtime::run(
             &container_bundle,
             &args.container_dir,
+            user.uid,
+            user.gid,
             &args.ipc_socket_path,
             exit_notification_sender
         ),

--- a/oak_containers_system_image/files/etc/sysusers.d/oak.conf
+++ b/oak_containers_system_image/files/etc/sysusers.d/oak.conf
@@ -1,0 +1,3 @@
+u oakc -
+g oakc -
+m oakc oakc

--- a/scripts/export_container_bundle
+++ b/scripts/export_container_bundle
@@ -66,7 +66,7 @@ umoci unpack \
     "${OCI_BUNDLE_DIR}"
 
 # Apply transformations which hopefully we can get rid of in the future.
-jq '.process.terminal = false | .linux.uidMappings[0].hostID = 0 | .linux.gidMappings[0].hostID = 0' < "${OCI_BUNDLE_DIR}"/config.json > "${WORK_DIR}"/config.new.json
+jq '.process.terminal = false' < "${OCI_BUNDLE_DIR}"/config.json > "${WORK_DIR}"/config.new.json
 mv --force "${WORK_DIR}"/config.new.json "${OCI_BUNDLE_DIR}"/config.json
 
 # Bundle just the files and directories that constitute the deterministically


### PR DESCRIPTION
This will create a new user, `oakc`, for the container and overrides all UID mappings to point to the newly created user.

It's a bit less than perfect as I had to remove `--systemd-cgroup` from runc which means the cgroups are not properly propagated to the systemd level, but there's some complexity around `dbus` I need to read up about and I wasn't able to get it to work right now.

However, for our current use, it's mostly cosmetic anyway.