### PR TITLE
Opentelemetrification, vol 2: use the opentelemetry log APIs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,6 +2019,9 @@ dependencies = [
  "nix 0.26.2",
  "oak_containers_orchestrator_client",
  "oak_grpc_utils",
+ "opentelemetry-otlp",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "tokio",
  "tokio-stream",
 ]

--- a/oak_containers_launcher/Cargo.toml
+++ b/oak_containers_launcher/Cargo.toml
@@ -21,7 +21,8 @@ oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
 opentelemetry-proto = { version = "*", default-features = false, features = [
   "gen-tonic",
-  "metrics"
+  "logs",
+  "metrics",
 ] }
 prost = "*"
 prost-types = "*"

--- a/oak_containers_orchestrator_client/Cargo.toml
+++ b/oak_containers_orchestrator_client/Cargo.toml
@@ -12,10 +12,9 @@ oak_grpc_utils = { workspace = true }
 anyhow = "*"
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
-# opentelemetry = { version = "*", default-features = false, features = ["metrics"]}
-# opentelemetry-proto = { version = "*", features = ["metrics", "gen-tonic", "gen-tonic-messages"]}
 opentelemetry-otlp = { version = "*", default-features = false, features = [
   "grpc-tonic",
+  "logs",
   "metrics"
 ] }
 prost = "*"

--- a/oak_containers_syslogd/Cargo.toml
+++ b/oak_containers_syslogd/Cargo.toml
@@ -10,6 +10,16 @@ anyhow = "*"
 bitflags = "*"
 clap = { version = "*", features = ["derive"] }
 oak_containers_orchestrator_client = { workspace = true }
+opentelemetry_api = { version = "*", default-features = false, features = [
+  "logs"
+] }
+opentelemetry_sdk = { version = "*", default-features = false, features = [
+  "logs",
+  "rt-tokio"
+] }
+opentelemetry-otlp = { version = "*", default-features = false, features = [
+  "logs"
+] }
 nix = "*"
 tokio = { version = "*", features = [
   "rt-multi-thread",

--- a/oak_containers_syslogd/src/log_relay.rs
+++ b/oak_containers_syslogd/src/log_relay.rs
@@ -17,13 +17,14 @@
 use crate::systemd_journal::{Journal, JournalOpenFlags};
 use anyhow::{Context, Result};
 use oak_containers_orchestrator_client::LauncherClient;
+use opentelemetry_api::logs::{AnyValue, LogRecord, Logger, Severity};
+use std::time::{Duration, SystemTime};
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
 
 pub async fn run(launcher_client: LauncherClient) -> Result<()> {
     // Journal is not Send, because the underlying systemd journal can't be shared between threads
     // (even with locking). Thus, let's wrap things in a channel.
-    let (send, recv) = mpsc::unbounded_channel();
+    let (send, mut recv) = mpsc::unbounded_channel();
 
     let reader = async move {
         // Iterating over the journal can block (synchronously), so we need to wrap this in a
@@ -52,11 +53,53 @@ pub async fn run(launcher_client: LauncherClient) -> Result<()> {
         });
         x.await?
     };
+    let logger = opentelemetry_otlp::new_pipeline()
+        .logging()
+        .with_exporter(launcher_client.openmetrics_builder())
+        .install_batch(opentelemetry_sdk::runtime::Tokio)
+        .context("could not create OTLP logger")?;
     let sender = async {
-        launcher_client
-            .log(UnboundedReceiverStream::new(recv))
-            .await
-            .map_err(|err| anyhow::anyhow!("error writing logs to launcher: {}", err))
+        while let Some(mut msg) = recv.recv().await {
+            let mut builder = LogRecord::builder();
+            // PRIORITY
+            if let Some(val) = msg.remove("PRIORITY") {
+                builder = builder.with_severity_number(match val.parse()? {
+                    // EMERGENCY
+                    0 => Severity::Error4,
+                    // ALERT
+                    1 => Severity::Error3,
+                    // CRITICAL
+                    2 => Severity::Error2,
+                    // ERROR
+                    3 => Severity::Error,
+                    // WARNING
+                    4 => Severity::Warn,
+                    // NOTICE
+                    5 => Severity::Info2,
+                    // INFORMATIONAL
+                    6 => Severity::Info,
+                    // DEBUG
+                    7 => Severity::Debug,
+                    // lower priorities
+                    _ => Severity::Trace,
+                });
+            }
+            if let Some(val) = msg.remove("_SOURCE_REALTIME_TIMESTAMP") {
+                builder = builder
+                    .with_timestamp(SystemTime::UNIX_EPOCH + Duration::from_secs(val.parse()?));
+            }
+            if let Some(val) = msg.remove("MESSAGE") {
+                builder = builder.with_body(AnyValue::String(val.into()));
+            }
+            builder = builder.with_attributes(
+                msg.into_iter()
+                    .map(|(k, v)| (k.into(), AnyValue::String(v.into())))
+                    .collect(),
+            );
+            logger.emit(builder.build());
+        }
+        Ok(())
     };
+
     tokio::try_join!(reader, sender).map(|((), ())| ())
 }


### PR DESCRIPTION
We use the opentelemetry APIs for metrics already, but it has other facilities, like logging (and tracing -- but that will need more thought).

This PR migrates the Github bits from the method in the Launcher interface to opentelemetry APIs.

The end goal is to provide a more standardised interface to the enclave: opentelemetry comes with client libraries (and integrations!) in several languages, hopefully lowering the barrier to adoption.