### PR TITLE
zero out DiceData after reading it and keep state

### DIFF
--- a/oak_restricted_kernel/src/syscall/dice_data.rs
+++ b/oak_restricted_kernel/src/syscall/dice_data.rs
@@ -35,9 +35,10 @@ impl FileDescriptor for DiceDataDescriptor {
     fn read(&mut self, buf: &mut [u8]) -> Result<isize, oak_restricted_kernel_interface::Errno> {
         let data_as_bytes = <DiceData as zerocopy::AsBytes>::as_bytes_mut(&mut self.data);
         let length = min(data_as_bytes.len() - self.index, buf.len());
-        let slice_to_read = &mut data_as_bytes[self.index..length];
+        let end_index = min(self.index + length, data_as_bytes.len());
+        let slice_to_read = &mut data_as_bytes[self.index..end_index];
         buf.copy_from_slice(slice_to_read);
-        self.index += length;
+        self.index += end_index;
         // destroy the data that was read, to ensure that it can only be read once
         slice_to_read.fill(0);
         Ok(length as isize)

--- a/oak_restricted_kernel/src/syscall/dice_data.rs
+++ b/oak_restricted_kernel/src/syscall/dice_data.rs
@@ -38,7 +38,7 @@ impl FileDescriptor for DiceDataDescriptor {
         let end_index = min(self.index + length, data_as_bytes.len());
         let slice_to_read = &mut data_as_bytes[self.index..end_index];
         buf.copy_from_slice(slice_to_read);
-        self.index += end_index;
+        self.index = end_index;
         // destroy the data that was read, to ensure that it can only be read once
         slice_to_read.fill(0);
         Ok(length as isize)


### PR DESCRIPTION
addresses https://github.com/project-oak/oak/pull/4377#discussion_r1361345702

I'm unsure if this is the right way.

Pro: I think zeroing out the private key is a good idea, and I think it should be done automatically once its been read.

Con: The stateful behavior of this descriptor is different from all other ones. They're stateless and always read from 0