### PR TITLE
Extract reusable components from Stage0 DICE code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,6 +2051,13 @@ dependencies = [
 name = "oak_dice"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.3.3",
+ "coset",
+ "hex",
+ "hkdf",
+ "p384",
+ "rand_core 0.6.4",
+ "sha2",
  "static_assertions",
  "strum",
  "zerocopy",
@@ -2453,6 +2460,7 @@ dependencies = [
  "linked_list_allocator",
  "log",
  "oak_core",
+ "oak_dice",
  "oak_linux_boot_params",
  "oak_sev_guest",
  "p384",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,7 +2055,7 @@ dependencies = [
  "coset",
  "hex",
  "hkdf",
- "p384",
+ "p256",
  "rand_core 0.6.4",
  "sha2",
  "static_assertions",
@@ -2463,7 +2463,7 @@ dependencies = [
  "oak_dice",
  "oak_linux_boot_params",
  "oak_sev_guest",
- "p384",
+ "p256",
  "rand_core 0.6.4",
  "sev_serial",
  "sha2",
@@ -2671,18 +2671,6 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/oak_dice/Cargo.toml
+++ b/oak_dice/Cargo.toml
@@ -6,6 +6,15 @@ authors = ["Conrad Grobler <grobler@google.com>"]
 license = "Apache-2.0"
 
 [dependencies]
+bitflags = "*"
+coset = { version = "*", default-features = false }
+hex = { version = "*", default-features = false, features = ["alloc"] }
+hkdf = { version = "*", default-features = false }
+p384 = { version = "*", default-features = false, features = ["ecdsa"] }
+rand_core = { version = "*", default-features = false, features = [
+    "getrandom",
+] }
+sha2 = { version = "*", default-features = false }
 static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
 zerocopy = "*"

--- a/oak_dice/Cargo.toml
+++ b/oak_dice/Cargo.toml
@@ -10,7 +10,7 @@ bitflags = "*"
 coset = { version = "*", default-features = false }
 hex = { version = "*", default-features = false, features = ["alloc"] }
 hkdf = { version = "*", default-features = false }
-p384 = { version = "*", default-features = false, features = ["ecdsa"] }
+p256 = { version = "*", default-features = false, features = ["ecdsa"] }
 rand_core = { version = "*", default-features = false, features = [
   "getrandom",
 ] }

--- a/oak_dice/Cargo.toml
+++ b/oak_dice/Cargo.toml
@@ -12,7 +12,7 @@ hex = { version = "*", default-features = false, features = ["alloc"] }
 hkdf = { version = "*", default-features = false }
 p384 = { version = "*", default-features = false, features = ["ecdsa"] }
 rand_core = { version = "*", default-features = false, features = [
-    "getrandom",
+  "getrandom",
 ] }
 sha2 = { version = "*", default-features = false }
 static_assertions = "*"

--- a/oak_dice/src/cert.rs
+++ b/oak_dice/src/cert.rs
@@ -1,0 +1,177 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Constants and helper functions to work with CWT-based DICE certificates.
+
+use alloc::{string::String, vec, vec::Vec};
+use coset::{
+    cbor::value::Value,
+    cwt::{ClaimName, ClaimsSetBuilder},
+    iana, Algorithm, CborSerializable, CoseError, CoseKey, CoseSign1, KeyOperation, KeyType, Label,
+};
+use hkdf::Hkdf;
+use p384::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
+use rand_core::OsRng;
+use sha2::Sha256;
+
+/// Length of the unique ID for ECDSA keys generated.
+pub const KEY_ID_LENGTH: usize = 20;
+/// ID for the CWT private claim corresponding to the Subject of the CWT.
+pub const SUBJECT_PUBLIC_KEY_ID: i64 = -4670552;
+/// ID for the bitstring used to describe the intended usage for the key represented by the
+/// certificate.
+pub const KEY_USAGE_ID: i64 = -4670553;
+/// ID for the CWT private claim ID corresponding to the VM kernel measurement.
+pub const KERNEL_MEASUREMENT_ID: i64 = -4670555;
+/// ID for the CWT private claim ID corresponding to the VM kernel commandline measurement.
+pub const KERNEL_COMMANDLINE_MEASUREMENT_ID: i64 = -4670556;
+/// ID for the CWT private claim ID corresponding to the VM kernel setup data measurement.
+pub const SETUP_DATA_MEASUREMENT_ID: i64 = -4670557;
+/// ID for the CWT private claim ID corresponding to the initial RAM disk measurement.
+pub const INITRD_MEASUREMENT_ID: i64 = -4670558;
+/// ID for the CWT private claim ID corresponding to the physical memory map (e820 table).
+pub const MEMORY_MAP_MEASUREMENT_ID: i64 = -4670559;
+/// ID for the CWT private claim ID corresponding to the hash of the commands for building the ACPI
+/// tables.
+pub const ACPI_MEASUREMENT_ID: i64 = -4670560;
+
+/// String to be used as salt for generating Key IDs.
+const ID_SALT: &[u8] = b"DICE_ID_SALT";
+/// Info string for HKDF generator.
+const INFO_STR: &[u8] = b"ID";
+/// Empty additional data.
+const EMPTY_ADDITIONAL_DATA: &[u8] = b"";
+
+bitflags::bitflags! {
+    /// Intended usage of a key.
+    ///
+    /// See: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3 for more details.
+    #[derive(Clone, Copy, Debug)]
+    pub struct KeyUsage: u16 {
+        const DIGITAL_SIGNATURE = 1 << 0;
+        const CONTENT_COMMITMENT = 1 << 1;
+        const KEY_ENCIPHERMENT = 1 << 2;
+        const DATA_ENCIPHERMENT = 1 << 3;
+        const KEY_AGREEMENT = 1 << 4;
+        const KEY_CERT_SIGN = 1<< 5;
+        const CRL_SIGN = 1 << 6;
+        const ENCIPHER_ONLY = 1 << 7;
+        const DECIPHER_ONLY = 1 << 8;
+    }
+}
+
+/// Derives an ID from a public key.
+pub fn derive_public_key_id(public_key: &VerifyingKey) -> [u8; KEY_ID_LENGTH] {
+    let ikm = public_key.to_encoded_point(false);
+    let hkdf = Hkdf::<Sha256>::new(Some(ID_SALT), ikm.as_bytes());
+    let mut result = [0u8; KEY_ID_LENGTH];
+    hkdf.expand(INFO_STR, &mut result)
+        .expect("invalid length for HKDF output");
+    result
+}
+
+/// Generates private/public ECDSA key pair.
+pub fn generate_ecdsa_keys() -> (SigningKey, VerifyingKey) {
+    let private_key = SigningKey::random(&mut OsRng);
+    let public_key = VerifyingKey::from(&private_key);
+    (private_key, public_key)
+}
+
+/// Converts an ECDSA verifying key to a COSE_Key representation.
+pub fn public_key_to_cose_key(public_key: &VerifyingKey) -> CoseKey {
+    let encoded_point = public_key.to_encoded_point(false);
+    CoseKey {
+        kty: KeyType::Assigned(iana::KeyType::EC2),
+        key_id: Vec::from(derive_public_key_id(public_key)),
+        alg: Some(Algorithm::Assigned(iana::Algorithm::ES384)),
+        key_ops: vec![KeyOperation::Assigned(iana::KeyOperation::Verify)]
+            .into_iter()
+            .collect(),
+        params: vec![
+            (
+                Label::Int(iana::Ec2KeyParameter::Crv as i64),
+                Value::from(iana::EllipticCurve::P_384 as u64),
+            ),
+            (
+                Label::Int(iana::Ec2KeyParameter::X as i64),
+                Value::Bytes(encoded_point.x().unwrap().to_vec()),
+            ),
+            (
+                Label::Int(iana::Ec2KeyParameter::Y as i64),
+                Value::Bytes(encoded_point.y().unwrap().to_vec()),
+            ),
+        ],
+        ..Default::default()
+    }
+}
+
+/// Generates a CWT certificate representing an embedded certificate authority (ECA) with its
+/// private key.
+///
+///  # Arguments
+///
+/// * `issuer_eca_key` - The private key that the issuer uses to sign issued certificates.
+/// * `issuer_id` - A string identifying the key used by the issuer. This would typically be the hex
+///   encoding of the output from calling `derive_public_key_id` using the issuer's public key.
+/// * `additional_claims` - Any additional claims that must be included in the certificate. This is
+///   typically used to provide measurements of the components in the layer associated with th
+///   certificate.
+pub fn generate_eca_certificate(
+    issuer_eca_key: &SigningKey,
+    issuer_id: String,
+    additional_claims: Vec<(ClaimName, Value)>,
+) -> Result<(CoseSign1, SigningKey), CoseError> {
+    let (signing_key, verifying_key) = generate_ecdsa_keys();
+    let verifying_key_id = hex::encode(derive_public_key_id(&verifying_key));
+    let mut claim_builder = ClaimsSetBuilder::new()
+        .issuer(issuer_id)
+        .subject(verifying_key_id)
+        .private_claim(
+            SUBJECT_PUBLIC_KEY_ID,
+            Value::Bytes(public_key_to_cose_key(&verifying_key).to_vec().unwrap()),
+        )
+        .private_claim(
+            KEY_USAGE_ID,
+            Value::Bytes(KeyUsage::KEY_CERT_SIGN.bits().to_le_bytes().into()),
+        );
+
+    for (claim_name, value) in additional_claims.into_iter() {
+        claim_builder = match claim_name {
+            ClaimName::PrivateUse(id) => claim_builder.private_claim(id, value),
+            ClaimName::Assigned(assigned_name) => claim_builder.claim(assigned_name, value),
+            ClaimName::Text(name) => claim_builder.text_claim(name, value),
+        }
+    }
+
+    let protected = coset::HeaderBuilder::new()
+        .algorithm(iana::Algorithm::ES384)
+        .build();
+    let unprotected = coset::HeaderBuilder::new()
+        .key_id((*b"AsymmetricECDSA384").into())
+        .build();
+    Ok((
+        coset::CoseSign1Builder::new()
+            .protected(protected)
+            .unprotected(unprotected)
+            .payload(claim_builder.build().to_vec()?)
+            .create_signature(EMPTY_ADDITIONAL_DATA, |data| {
+                let signature: Signature = issuer_eca_key.sign(data);
+                signature.to_bytes().as_slice().into()
+            })
+            .build(),
+        signing_key,
+    ))
+}

--- a/oak_dice/src/cert.rs
+++ b/oak_dice/src/cert.rs
@@ -23,7 +23,7 @@ use coset::{
     iana, Algorithm, CborSerializable, CoseError, CoseKey, CoseSign1, KeyOperation, KeyType, Label,
 };
 use hkdf::Hkdf;
-use p384::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
+use p256::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
 use rand_core::OsRng;
 use sha2::Sha256;
 
@@ -36,7 +36,7 @@ pub const SUBJECT_PUBLIC_KEY_ID: i64 = -4670552;
 pub const KEY_USAGE_ID: i64 = -4670553;
 /// ID for the CWT private claim ID corresponding to the VM kernel measurement.
 pub const KERNEL_MEASUREMENT_ID: i64 = -4670555;
-/// ID for the CWT private claim ID corresponding to the VM kernel commandline measurement.
+/// ID for the CWT private claim ID corresponding to the VM kernel command-line measurement.
 pub const KERNEL_COMMANDLINE_MEASUREMENT_ID: i64 = -4670556;
 /// ID for the CWT private claim ID corresponding to the VM kernel setup data measurement.
 pub const SETUP_DATA_MEASUREMENT_ID: i64 = -4670557;
@@ -84,7 +84,7 @@ pub fn derive_public_key_id(public_key: &VerifyingKey) -> [u8; KEY_ID_LENGTH] {
 }
 
 /// Generates private/public ECDSA key pair.
-pub fn generate_ecdsa_keys() -> (SigningKey, VerifyingKey) {
+pub fn generate_ecdsa_key_pair() -> (SigningKey, VerifyingKey) {
     let private_key = SigningKey::random(&mut OsRng);
     let public_key = VerifyingKey::from(&private_key);
     (private_key, public_key)
@@ -134,7 +134,7 @@ pub fn generate_eca_certificate(
     issuer_id: String,
     additional_claims: Vec<(ClaimName, Value)>,
 ) -> Result<(CoseSign1, SigningKey), CoseError> {
-    let (signing_key, verifying_key) = generate_ecdsa_keys();
+    let (signing_key, verifying_key) = generate_ecdsa_key_pair();
     let verifying_key_id = hex::encode(derive_public_key_id(&verifying_key));
     let mut claim_builder = ClaimsSetBuilder::new()
         .issuer(issuer_id)

--- a/oak_dice/src/lib.rs
+++ b/oak_dice/src/lib.rs
@@ -18,4 +18,7 @@
 
 //! Structs and helpers for implementing DICE-based attestation.
 
+extern crate alloc;
+
+pub mod cert;
 pub mod evidence;

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -17,7 +17,7 @@ oak_core = { path = "../oak_core", default-features = false }
 oak_dice = { workspace = true }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 oak_sev_guest = { path = "../oak_sev_guest", default-features = false }
-p384 = { version = "*", default-features = false, features = ["ecdsa"] }
+p256 = { version = "*", default-features = false, features = ["ecdsa"] }
 rand_core = { version = "*", default-features = false, features = [
   "getrandom",
 ] }

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -7,12 +7,20 @@ license = "Apache-2.0"
 
 [dependencies]
 bitflags = "*"
+coset = { version = "*", default-features = false }
 elf = { version = "*", default-features = false }
+hex = { version = "*", default-features = false, features = ["alloc"] }
+hkdf = { version = "*", default-features = false }
 log = "*"
 linked_list_allocator = "*"
 oak_core = { path = "../oak_core", default-features = false }
+oak_dice = { workspace = true }
 oak_linux_boot_params = { path = "../linux_boot_params" }
 oak_sev_guest = { path = "../oak_sev_guest", default-features = false }
+p384 = { version = "*", default-features = false, features = ["ecdsa"] }
+rand_core = { version = "*", default-features = false, features = [
+  "getrandom",
+] }
 sev_serial = { path = "../sev_serial" }
 sha2 = { version = "*", default-features = false, features = ["force-soft"] }
 spinning_top = "*"
@@ -20,10 +28,3 @@ static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
 x86_64 = "*"
 zerocopy = "*"
-p384 = { version = "*", default-features = false, features = ["ecdsa"] }
-hkdf = { version = "*", default-features = false }
-rand_core = { version = "*", default-features = false, features = [
-  "getrandom"
-] }
-hex = { version = "*", default-features = false, features = ["alloc"] }
-coset = { version = "*", default-features = false }

--- a/stage0/src/dice_attestation.rs
+++ b/stage0/src/dice_attestation.rs
@@ -17,11 +17,11 @@
 use alloc::{string::String, vec, vec::Vec};
 use coset::{cbor::value::Value, cwt::ClaimName, CoseError, CoseSign1};
 use oak_dice::cert::{
-    derive_public_key_id, generate_eca_certificate, generate_ecdsa_keys, ACPI_MEASUREMENT_ID,
+    derive_public_key_id, generate_eca_certificate, generate_ecdsa_key_pair, ACPI_MEASUREMENT_ID,
     INITRD_MEASUREMENT_ID, KERNEL_COMMANDLINE_MEASUREMENT_ID, KERNEL_MEASUREMENT_ID,
     MEMORY_MAP_MEASUREMENT_ID, SETUP_DATA_MEASUREMENT_ID,
 };
-use p384::ecdsa::SigningKey;
+use p256::ecdsa::SigningKey;
 
 /// Measurements of various components in Stage1.
 pub struct Measurements {
@@ -80,7 +80,7 @@ fn generate_stage1_certificate(
 pub fn generate_stage1_attestation(measurements: &Measurements) {
     // Generate Stage0 keys. This key will be used to sign Stage1
     // measurement+config and the stage1_ca_key.
-    let (stage0_eca_key, stage0_eca_verifying_key) = generate_ecdsa_keys();
+    let (stage0_eca_key, stage0_eca_verifying_key) = generate_ecdsa_key_pair();
 
     // Call generate_attestation_report() to get 'stage0_ca_verifying_key' added to attestation
     // report.

--- a/stage0/src/dice_attestation.rs
+++ b/stage0/src/dice_attestation.rs
@@ -14,189 +14,73 @@
 // limitations under the License.
 //
 
-extern crate alloc;
-
 use alloc::{string::String, vec, vec::Vec};
-use coset::{
-    cbor::value::Value, cwt, iana, Algorithm, CborSerializable, CoseError, CoseKey, KeyOperation,
-    KeyType, Label,
+use coset::{cbor::value::Value, cwt::ClaimName, CoseError, CoseSign1};
+use oak_dice::cert::{
+    derive_public_key_id, generate_eca_certificate, generate_ecdsa_keys, ACPI_MEASUREMENT_ID,
+    INITRD_MEASUREMENT_ID, KERNEL_COMMANDLINE_MEASUREMENT_ID, KERNEL_MEASUREMENT_ID,
+    MEMORY_MAP_MEASUREMENT_ID, SETUP_DATA_MEASUREMENT_ID,
 };
-use hkdf::Hkdf;
-use p384::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
-use rand_core::OsRng;
-use sha2::Sha256;
+use p384::ecdsa::SigningKey;
 
-/// String to be used as salt for generating Key IDs.
-pub const ID_SALT: &str = "DICE_ID_SALT";
-/// ID for the CWT private claim corresponding to the Subject of the CWT.
-pub const SUBJECT_PUBLIC_KEY_ID: i64 = -4670552;
-/// ID for bitstring used to describe the intended usage for the key represented by the certificate.
-pub const KEY_USAGE_ID: i64 = -4670553;
-/// ID for the CWT private claim corresponding to the VM kernel measurement.
-pub const KERNEL_MEASUREMENT_ID: i64 = -4670555;
-/// ID for the CWT private claim corresponding to the VM kernel commandline measurement.
-pub const KERNEL_COMMANDLINE_MEASUREMENT_ID: i64 = -4670556;
-/// ID for the CWT private claim corresponding to the VM kernel setup data measurement.
-pub const SETUP_DATA_MEASUREMENT_ID: i64 = -4670557;
-/// ID for the CWT private claim corresponding to the initial ramdisk measurement.
-pub const INITRD_MEASUREMENT_ID: i64 = -4670558;
-/// ID for the CWT private claim corresponding to the physical memory map (e820 table).
-pub const MEMORY_MAP_MEASUREMENT_ID: i64 = -4670559;
-/// ID for the CWT private claim corresponding to the hash of the commands for building the ACPI
-/// tables.
-pub const ACPI_MEASUREMENT_ID: i64 = -4670560;
-/// Length of the unique ID for ECDSA keys generated.
-pub const KEY_ID_LENGTH: usize = 20;
-/// Info string for HKDF generator.
-pub const INFO_STR: &str = "ID";
-
-/// Attestation related functions.
-///
-/// Returns Signed Stage1 key and measurments.
-struct Stage0Signer {
-    signing_key: SigningKey,
-}
 /// Measurements of various components in Stage1.
 pub struct Measurements {
+    /// The measurement of the kernel image.
     pub kernel_measurement: [u8; 32],
+    /// The measurement of the kernel command-line.
     pub cmdline_measurement: [u8; 32],
+    /// The measurement of the kernel setup data.
     pub setup_data_measurement: [u8; 32],
+    /// The measurement of the initial RAM disk.
     pub ram_disk_measurement: [u8; 32],
+    /// The measurement of the physical memory map.
     pub memory_map_measurement: [u8; 32],
+    /// The concatenated measurement of the command used for building the ACPI tables.
     pub acpi_measurement: [u8; 32],
 }
 
-/// Signer implementation.
-impl Stage0Signer {
-    fn sign(&self, data: &[u8]) -> Vec<u8> {
-        let signed_stage1_ca_verifying_key: Signature = self.signing_key.sign(data);
-        Vec::from(signed_stage1_ca_verifying_key.to_bytes().as_slice())
-    }
-}
-
-fn derive_id(ikm: &[u8], info: Option<&[u8]>) -> [u8; KEY_ID_LENGTH] {
-    let hkdf = Hkdf::<Sha256>::new(Some(ID_SALT.as_bytes()), ikm);
-    let mut okm: [u8; KEY_ID_LENGTH] = [0u8; KEY_ID_LENGTH];
-    hkdf.expand(info.unwrap_or(&[]), &mut okm)
-        .expect("invalid length for HKDF output");
-
-    okm
-}
-
-fn generate_ecdsa_keys(info: &str) -> (SigningKey, [u8; KEY_ID_LENGTH]) {
-    let key = SigningKey::random(&mut OsRng);
-    let public_key = VerifyingKey::from(&key);
-    let key_id = derive_id(
-        public_key.to_encoded_point(false).as_bytes(),
-        Some(info.as_bytes()),
-    );
-    (key, key_id)
-}
-///
-/// Generates Stage1 attestation evidence and ECA
+/// Generates an ECA certificate for use by the next boot stage (Stage 1).
 fn generate_stage1_certificate(
-    stage0_eca_key: SigningKey,
+    stage0_eca_key: &SigningKey,
     stage0_cert_issuer: String,
     measurements: &Measurements,
-) -> Result<Vec<u8>, CoseError> {
-    // Generate Stage 1 keys and Signer.
-    let stage1_eca_key = generate_ecdsa_keys(INFO_STR);
-    let stage1_eca_verifying_key = VerifyingKey::from(&stage1_eca_key.0);
-    let stage0_signer = Stage0Signer {
-        signing_key: stage0_eca_key,
-    };
+) -> Result<(CoseSign1, SigningKey), CoseError> {
+    // Generate additional claims to cover the measurements.
 
-    let encoded_point = stage1_eca_verifying_key.to_encoded_point(false);
-    let x = encoded_point.x();
-    let y = encoded_point.y();
-
-    let stage1_eca_verifying_cose_key = CoseKey {
-        kty: KeyType::Assigned(iana::KeyType::EC2),
-        key_id: Vec::from(stage1_eca_key.1),
-        alg: Some(Algorithm::Assigned(iana::Algorithm::ES384)),
-        key_ops: vec![KeyOperation::Assigned(iana::KeyOperation::Verify)]
-            .into_iter()
-            .collect(),
-        params: vec![
-            (
-                Label::Int(iana::Ec2KeyParameter::Crv as i64),
-                Value::from(iana::EllipticCurve::P_384 as u64),
-            ),
-            (
-                Label::Int(iana::Ec2KeyParameter::X as i64),
-                Value::Bytes(x.unwrap().to_vec()),
-            ),
-            (
-                Label::Int(iana::Ec2KeyParameter::Y as i64),
-                Value::Bytes(y.unwrap().to_vec()),
-            ),
-        ],
-        ..Default::default()
-    };
-
-    // Setting bit 5 in little-endian order to 1 for keyCertSign usage. For more details
-    // refer: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3
-    let key_usage: [u8; 2] = [0x20, 0x00];
-    // Generate claims and add the Stage1 CA key.
-    let claims = cwt::ClaimsSetBuilder::new()
-        .issuer(stage0_cert_issuer)
-        .subject(hex::encode(stage1_eca_key.1))
-        // Add additional private-use claim.
-        .private_claim(
-            SUBJECT_PUBLIC_KEY_ID,
-            Value::Bytes(stage1_eca_verifying_cose_key.to_vec().unwrap()),
-        )
-        .private_claim(KEY_USAGE_ID, Value::Bytes(Vec::from(key_usage)))
-        .private_claim(
-            KERNEL_MEASUREMENT_ID,
+    let additional_claims = vec![
+        (
+            ClaimName::PrivateUse(KERNEL_MEASUREMENT_ID),
             Value::Bytes(Vec::from(measurements.kernel_measurement)),
-        )
-        .private_claim(
-            KERNEL_COMMANDLINE_MEASUREMENT_ID,
+        ),
+        (
+            ClaimName::PrivateUse(KERNEL_COMMANDLINE_MEASUREMENT_ID),
             Value::Bytes(Vec::from(measurements.cmdline_measurement)),
-        )
-        .private_claim(
-            SETUP_DATA_MEASUREMENT_ID,
+        ),
+        (
+            ClaimName::PrivateUse(SETUP_DATA_MEASUREMENT_ID),
             Value::Bytes(Vec::from(measurements.setup_data_measurement)),
-        )
-        .private_claim(
-            INITRD_MEASUREMENT_ID,
+        ),
+        (
+            ClaimName::PrivateUse(INITRD_MEASUREMENT_ID),
             Value::Bytes(Vec::from(measurements.ram_disk_measurement)),
-        )
-        .private_claim(
-            MEMORY_MAP_MEASUREMENT_ID,
+        ),
+        (
+            ClaimName::PrivateUse(MEMORY_MAP_MEASUREMENT_ID),
             Value::Bytes(Vec::from(measurements.memory_map_measurement)),
-        )
-        .private_claim(
-            ACPI_MEASUREMENT_ID,
+        ),
+        (
+            ClaimName::PrivateUse(ACPI_MEASUREMENT_ID),
             Value::Bytes(Vec::from(measurements.acpi_measurement)),
-        )
-        .build();
-
-    let aad = b"";
-
-    // Build a `CoseSign1` object.
-    let protected = coset::HeaderBuilder::new()
-        .algorithm(iana::Algorithm::ES384)
-        .build();
-    let unprotected = coset::HeaderBuilder::new()
-        .key_id((*b"AsymmetricECDSA384").into())
-        .build();
-    let sign1 = coset::CoseSign1Builder::new()
-        .protected(protected)
-        .unprotected(unprotected)
-        .payload(claims.clone().to_vec()?)
-        .create_signature(aad, |data| stage0_signer.sign(data))
-        .build();
-    sign1.to_vec()
+        ),
+    ];
+    generate_eca_certificate(stage0_eca_key, stage0_cert_issuer, additional_claims)
 }
 
-/// Generate signed attestation for the 'measurements' of all Stage 1 components.
+/// Generates signed attestation for the 'measurements' of all Stage 1 components.
 pub fn generate_stage1_attestation(measurements: &Measurements) {
     // Generate Stage0 keys. This key will be used to sign Stage1
     // measurement+config and the stage1_ca_key.
-    let stage0_eca_key = generate_ecdsa_keys(INFO_STR);
-    let stage0_eca_verifying_key = VerifyingKey::from(&stage0_eca_key.0);
+    let (stage0_eca_key, stage0_eca_verifying_key) = generate_ecdsa_keys();
 
     // Call generate_attestation_report() to get 'stage0_ca_verifying_key' added to attestation
     // report.
@@ -207,8 +91,8 @@ pub fn generate_stage1_attestation(measurements: &Measurements) {
 
     // Generate Stage1 CWT.
     let stage1_eca = generate_stage1_certificate(
-        stage0_eca_key.0,
-        hex::encode(stage0_eca_key.1),
+        &stage0_eca_key,
+        hex::encode(derive_public_key_id(&stage0_eca_verifying_key)),
         measurements,
     );
     if stage1_eca.is_ok() {

--- a/stage0_bin/Cargo.lock
+++ b/stage0_bin/Cargo.lock
@@ -314,6 +314,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_dice"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.4.0",
+ "coset",
+ "hex",
+ "hkdf",
+ "p384",
+ "rand_core",
+ "sha2",
+ "static_assertions",
+ "strum",
+ "zerocopy",
+]
+
+[[package]]
 name = "oak_linux_boot_params"
 version = "0.1.0"
 dependencies = [
@@ -349,6 +365,7 @@ dependencies = [
  "linked_list_allocator",
  "log",
  "oak_core",
+ "oak_dice",
  "oak_linux_boot_params",
  "oak_sev_guest",
  "p384",

--- a/stage0_bin/Cargo.lock
+++ b/stage0_bin/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
  "coset",
  "hex",
  "hkdf",
- "p384",
+ "p256",
  "rand_core",
  "sha2",
  "static_assertions",
@@ -368,7 +368,7 @@ dependencies = [
  "oak_dice",
  "oak_linux_boot_params",
  "oak_sev_guest",
- "p384",
+ "p256",
  "rand_core",
  "sev_serial",
  "sha2",
@@ -387,10 +387,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "p384"
-version = "0.13.0"
+name = "p256"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/stage0_bin/build.rs
+++ b/stage0_bin/build.rs
@@ -21,8 +21,8 @@ fn main() {
     println!("cargo:rustc-link-arg=--script=layout.ld");
 
     if env::var("PROFILE").unwrap() == "release" {
-        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=384K");
+        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=256K");
     } else {
-        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=512K");
+        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=1024K");
     }
 }


### PR DESCRIPTION
Many parts of the existing Stage 0 DICE certificate generation code can be reused for other boot stages. This change refactors the code so that the reusable parts can be moved to a shared crate (oak_dice).