### PR TITLE
Remove the `Launcher::Log` RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,7 +1983,6 @@ dependencies = [
  "prost",
  "prost-types",
  "tokio",
- "tokio-stream",
  "tonic 0.9.2",
  "tower",
 ]

--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -53,14 +53,6 @@ message GetCryptoContextResponse {
   oak.crypto.v1.CryptoContext context = 1;
 }
 
-// One log entry; a key-value map of strings.
-//
-// Log entries should use the (semi-standard) systemd journal field definitions:
-// https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
-message LogEntry {
-  map<string, string> fields = 1;
-}
-
 // Defines the service exposed by the launcher, that can be invoked by the stage1 and the
 // orchestrator.
 service Launcher {
@@ -85,9 +77,6 @@ service Launcher {
   // Notifies the launcher that the trusted app is ready to serve requests and listening on the
   // pre-arranged port (8080).
   rpc NotifyAppReady(google.protobuf.Empty) returns (google.protobuf.Empty) {}
-
-  // Logs a set of log entries from the guest.
-  rpc Log(stream LogEntry) returns (google.protobuf.Empty) {}
 }
 
 // Defines the service exposed by the orchestrator, that can be invoked by the application.

--- a/oak_containers_launcher/src/server.rs
+++ b/oak_containers_launcher/src/server.rs
@@ -16,12 +16,12 @@
 use crate::proto::oak::{
     containers::{
         launcher_server::{Launcher, LauncherServer},
-        GetApplicationConfigResponse, GetImageResponse, LogEntry, SendAttestationEvidenceRequest,
+        GetApplicationConfigResponse, GetImageResponse, SendAttestationEvidenceRequest,
     },
     session::v1::AttestationEvidence,
 };
 use anyhow::anyhow;
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{FutureExt, Stream};
 use opentelemetry_proto::tonic::{
     collector::{
         logs::v1::{
@@ -184,27 +184,6 @@ impl Launcher for LauncherServerImplementation {
             })?
             .send(())
             .map_err(|_err| tonic::Status::internal(format!("couldn't send notification")))?;
-        Ok(tonic::Response::new(()))
-    }
-
-    async fn log(
-        &self,
-        request: Request<tonic::Streaming<LogEntry>>,
-    ) -> Result<Response<()>, tonic::Status> {
-        let mut stream = request.into_inner();
-        while let Some(message) = stream.next().await {
-            let message = message?;
-
-            let unit = message
-                .fields
-                .get("_SYSTEMD_UNIT")
-                .map_or("", |unit| unit.as_str());
-            let message = message
-                .fields
-                .get("MESSAGE")
-                .map_or("", |message| message.as_str());
-            println!("{}: {}", unit, message);
-        }
         Ok(tonic::Response::new(()))
     }
 }

--- a/oak_containers_orchestrator_client/Cargo.toml
+++ b/oak_containers_orchestrator_client/Cargo.toml
@@ -20,6 +20,5 @@ opentelemetry-otlp = { version = "*", default-features = false, features = [
 prost = "*"
 prost-types = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
-tokio-stream = "*"
 tonic = "*"
 tower = "*"

--- a/oak_containers_orchestrator_client/src/lib.rs
+++ b/oak_containers_orchestrator_client/src/lib.rs
@@ -28,9 +28,7 @@ use self::proto::oak::{
 };
 use anyhow::Context;
 use opentelemetry_otlp::{TonicExporterBuilder, WithExportConfig};
-use proto::oak::containers::{launcher_client::LauncherClient as GrpcLauncherClient, LogEntry};
-use std::collections::HashMap;
-use tokio_stream::{Stream, StreamExt};
+use proto::oak::containers::launcher_client::LauncherClient as GrpcLauncherClient;
 use tonic::transport::Channel;
 
 /// Utility struct used to interface with the launcher
@@ -103,19 +101,6 @@ impl LauncherClient {
             .notify_app_ready(request)
             .await
             .context("couldn't send notification")?;
-        Ok(())
-    }
-
-    pub async fn log<I>(&self, entry: I) -> Result<(), Box<dyn std::error::Error>>
-    where
-        I: Stream<Item = HashMap<String, String>> + Send + 'static,
-    {
-        let request = tonic::Request::new(entry.map(|fields| LogEntry { fields }));
-        self.inner
-            .clone()
-            .log(request)
-            .await
-            .context("couldn't stream log messages")?;
         Ok(())
     }
 


### PR DESCRIPTION
We've moved to the opentelemetry APIs, so this is now unused.