### PR TITLE
Enable a pty for runc so that trusted application stdout isn't dropped

### DIFF
--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::Context;
+use nix::unistd::{Gid, Uid};
+use oci_spec::runtime::{LinuxIdMapping, LinuxIdMappingBuilder, Mount, Spec};
 use std::{
     os::unix::fs::lchown,
     path::{Path, PathBuf},
 };
-
-use anyhow::Context;
-use nix::unistd::{Gid, Uid};
-use oci_spec::runtime::{LinuxIdMapping, LinuxIdMappingBuilder, Mount, Spec};
 use tokio::sync::oneshot::Sender;
 
 pub async fn run(
@@ -49,7 +48,7 @@ pub async fn run(
     log::info!("Setting up container");
 
     let spec_path = container_dir.join("config.json");
-    let mut spec = Spec::load(spec_path.clone()).context("error reading OCI spec")?;
+    let mut spec = Spec::load(&spec_path).context("error reading OCI spec")?;
     let mut mounts = spec.mounts().as_ref().cloned().unwrap_or_default();
     mounts.push({
         let mut mount = Mount::default();
@@ -97,21 +96,17 @@ pub async fn run(
             .try_into()
             .expect("invalid container path");
         cmd.args([
-            "--service-type=forking",
             "--property=RuntimeDirectory=oakc",
-            // PIDFile is relative to `/run`, but unfortunately can't reference `RuntimeDirectory`.
-            "--property=PIDFile=oakc/oakc.pid",
             "--property=ProtectSystem=strict",
             format!("--property=ReadWritePaths={}", container_dir).as_str(),
             format!("--uid={}", runtime_uid).as_str(),
             format!("--gid={}", runtime_gid).as_str(),
+            "--pty",
             "--wait",
             "--collect",
             "/bin/runc",
             "--root=${RUNTIME_DIRECTORY}/runc",
             "run",
-            "--detach",
-            "--pid-file=${PIDFILE}",
             format!("--bundle={}", container_dir).as_str(),
             "oakc",
         ]);

--- a/scripts/export_container_bundle
+++ b/scripts/export_container_bundle
@@ -65,10 +65,6 @@ umoci unpack \
     --image="${OCI_IMAGE_DIR}" \
     "${OCI_BUNDLE_DIR}"
 
-# Apply transformations which hopefully we can get rid of in the future.
-jq '.process.terminal = false' < "${OCI_BUNDLE_DIR}"/config.json > "${WORK_DIR}"/config.new.json
-mv --force "${WORK_DIR}"/config.new.json "${OCI_BUNDLE_DIR}"/config.json
-
 # Bundle just the files and directories that constitute the deterministically
 # generated OCI bundle.
 tar --create --file="${OUTPUT_OCI_BUNDLE_TAR}" --directory="${OCI_BUNDLE_DIR}" ./rootfs ./config.json


### PR DESCRIPTION
This is a bit less than ideal -- the correct answer here would be to route the console over a unix socket -- but has the benefit of being simple and it works.