### PR TITLE
Generate the DICE data struct in Stage 0

### DIFF
--- a/linux_boot_params/src/lib.rs
+++ b/linux_boot_params/src/lib.rs
@@ -45,6 +45,9 @@ pub enum E820EntryType {
     DISABLED = 6,
     /// Persistent memory: must be handled distinct from conventional volatile memory.
     PMEM = 7,
+    /// Custom implementation-defined value indicating that the memory region is used to pass
+    /// DICE-related information from Stage 0 to the next DICE stage.
+    DiceData = 0xFF000001,
 }
 
 bitflags! {

--- a/oak_dice/src/evidence.rs
+++ b/oak_dice/src/evidence.rs
@@ -99,7 +99,7 @@ pub struct Stage0DiceData {
     pub root_layer_evidence: RootLayerEvidence,
     /// The evidence about the next layer.
     pub layer_1_evidence: LayerEvidence,
-    pub layer_1_certifcate_authority: CertificateAuthority,
+    pub layer_1_certificate_authority: CertificateAuthority,
     _padding: [u8; 688],
 }
 

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -97,6 +97,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +166,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,12 +203,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
+name = "coset"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c214bbc5c8b4518856d79cae4d323feaa881ecf3e31b5af6572bb5313c11d5"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -198,12 +259,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -215,10 +287,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "errno"
@@ -251,6 +354,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +383,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -305,6 +419,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +446,12 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -479,6 +616,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_dice"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.3.3",
+ "coset",
+ "hex",
+ "hkdf",
+ "p256",
+ "rand_core",
+ "sha2",
+ "static_assertions",
+ "strum",
+ "zerocopy",
+]
+
+[[package]]
 name = "oak_linux_boot_params"
 version = "0.1.0"
 dependencies = [
@@ -506,6 +659,7 @@ dependencies = [
  "log",
  "oak_channel",
  "oak_core",
+ "oak_dice",
  "oak_linux_boot_params",
  "oak_restricted_kernel_interface",
  "oak_sev_guest",
@@ -589,6 +743,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +790,15 @@ checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2fcef82c0ec6eefcc179b978446c399b3cdf73c392c35604e399eee6df1ee3"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -706,6 +881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +912,16 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
 
 [[package]]
 name = "rsdp"
@@ -795,10 +989,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c309e515543e67811222dbc9e3dd7e1056279b782e1dacffe4242b718734fb6"
+
+[[package]]
+name = "serde"
+version = "1.0.156"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.156"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sev_serial"
@@ -817,6 +1044,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1131,3 +1368,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -16,7 +16,7 @@ linked_list_allocator = "*"
 oak_core = { path = "../oak_core", default-features = false }
 oak_dice = { workspace = true }
 oak_linux_boot_params = { path = "../linux_boot_params" }
-oak_sev_guest = { path = "../oak_sev_guest", default-features = false }
+oak_sev_guest = { workspace = true }
 p256 = { version = "*", default-features = false, features = ["ecdsa"] }
 rand_core = { version = "*", default-features = false, features = [
   "getrandom",

--- a/stage0/src/dice_attestation.rs
+++ b/stage0/src/dice_attestation.rs
@@ -14,14 +14,23 @@
 // limitations under the License.
 //
 
-use alloc::{string::String, vec, vec::Vec};
-use coset::{cbor::value::Value, cwt::ClaimName, CoseError, CoseSign1};
-use oak_dice::cert::{
-    derive_public_key_id, generate_eca_certificate, generate_ecdsa_key_pair, ACPI_MEASUREMENT_ID,
-    INITRD_MEASUREMENT_ID, KERNEL_COMMANDLINE_MEASUREMENT_ID, KERNEL_MEASUREMENT_ID,
-    MEMORY_MAP_MEASUREMENT_ID, SETUP_DATA_MEASUREMENT_ID,
+use alloc::{boxed::Box, string::String, vec, vec::Vec};
+use coset::{cbor::value::Value, cwt::ClaimName, CborSerializable, CoseSign1};
+use oak_dice::{
+    cert::{
+        derive_public_key_id, generate_eca_certificate, generate_ecdsa_key_pair,
+        public_key_to_cose_key, ACPI_MEASUREMENT_ID, INITRD_MEASUREMENT_ID,
+        KERNEL_COMMANDLINE_MEASUREMENT_ID, KERNEL_MEASUREMENT_ID, MEMORY_MAP_MEASUREMENT_ID,
+        SETUP_DATA_MEASUREMENT_ID,
+    },
+    evidence::{Stage0DiceData, TeePlatform},
 };
+use oak_sev_guest::guest::AttestationReport;
 use p256::ecdsa::SigningKey;
+use zerocopy::{AsBytes, FromBytes};
+
+// The number of custom bytes that can be included in the attestation report.
+const REPORT_DATA_SIZE: usize = 64;
 
 /// Measurements of various components in Stage1.
 pub struct Measurements {
@@ -44,64 +53,96 @@ fn generate_stage1_certificate(
     stage0_eca_key: &SigningKey,
     stage0_cert_issuer: String,
     measurements: &Measurements,
-) -> Result<(CoseSign1, SigningKey), CoseError> {
+) -> (CoseSign1, SigningKey) {
     // Generate additional claims to cover the measurements.
 
     let additional_claims = vec![
         (
             ClaimName::PrivateUse(KERNEL_MEASUREMENT_ID),
-            Value::Bytes(Vec::from(measurements.kernel_measurement)),
+            Value::Bytes(measurements.kernel_measurement.into()),
         ),
         (
             ClaimName::PrivateUse(KERNEL_COMMANDLINE_MEASUREMENT_ID),
-            Value::Bytes(Vec::from(measurements.cmdline_measurement)),
+            Value::Bytes(measurements.cmdline_measurement.into()),
         ),
         (
             ClaimName::PrivateUse(SETUP_DATA_MEASUREMENT_ID),
-            Value::Bytes(Vec::from(measurements.setup_data_measurement)),
+            Value::Bytes(measurements.setup_data_measurement.into()),
         ),
         (
             ClaimName::PrivateUse(INITRD_MEASUREMENT_ID),
-            Value::Bytes(Vec::from(measurements.ram_disk_measurement)),
+            Value::Bytes(measurements.ram_disk_measurement.into()),
         ),
         (
             ClaimName::PrivateUse(MEMORY_MAP_MEASUREMENT_ID),
-            Value::Bytes(Vec::from(measurements.memory_map_measurement)),
+            Value::Bytes(measurements.memory_map_measurement.into()),
         ),
         (
             ClaimName::PrivateUse(ACPI_MEASUREMENT_ID),
-            Value::Bytes(Vec::from(measurements.acpi_measurement)),
+            Value::Bytes(measurements.acpi_measurement.into()),
         ),
     ];
     generate_eca_certificate(stage0_eca_key, stage0_cert_issuer, additional_claims)
+        .expect("couldn't generate ECA certificate")
 }
 
-/// Generates signed attestation for the 'measurements' of all Stage 1 components.
-pub fn generate_stage1_attestation(measurements: &Measurements) {
-    // Generate Stage0 keys. This key will be used to sign Stage1
-    // measurement+config and the stage1_ca_key.
+/// Generates attestation evidence for the 'measurements' of all Stage 1 components.
+pub fn generate_dice_data(measurements: &Measurements) -> &'static Stage0DiceData {
+    let result = Box::leak(Box::new_in(
+        Stage0DiceData::new_zeroed(),
+        &crate::BOOT_ALLOC,
+    ));
+
+    // Generate ECA Stage0 key pair. This key will be used to sign Stage1 ECA certificate.
     let (stage0_eca_key, stage0_eca_verifying_key) = generate_ecdsa_key_pair();
 
-    // Call generate_attestation_report() to get 'stage0_ca_verifying_key' added to attestation
-    // report.
-    log::debug!(
-        "Stage0 Verification key: {}",
-        hex::encode(stage0_eca_verifying_key.to_encoded_point(false).as_bytes())
-    );
-
-    // Generate Stage1 CWT.
-    let stage1_eca = generate_stage1_certificate(
+    let (stage1_eca_cert, stage1_eca_signing_key) = generate_stage1_certificate(
         &stage0_eca_key,
         hex::encode(derive_public_key_id(&stage0_eca_verifying_key)),
         measurements,
     );
-    if stage1_eca.is_ok() {
-        // Call code that transmits the following to Stage1.
-        // 1. stage0_eca_verifying_key
-        // 2. stage1_eca.0 (the Stage 1 evidence)
-        // 3. stage1_eca.1 (the Stage 1 ECA private key)
-        log::debug!("Signing was successful..");
-        return;
-    }
-    log::debug!("Error in signing: {}", stage1_eca.unwrap_err())
+
+    let stage0_eca_verifying_key = public_key_to_cose_key(&stage0_eca_verifying_key)
+        .to_vec()
+        .expect("couldn't serialize the ECA public key");
+
+    let stage1_eca_cert = stage1_eca_cert
+        .to_vec()
+        .expect("couldn't serialize stage 1 ECA certificate");
+
+    let stage1_eca_signing_key: Vec<u8> = stage1_eca_signing_key.to_bytes().as_slice().into();
+
+    // Use the SHA2-256 digest of the serialized ECA verifying key as the report data.
+    let eca_measurement = crate::measure_byte_slice(&stage0_eca_verifying_key);
+    let mut report_data = [0u8; REPORT_DATA_SIZE];
+    report_data[..eca_measurement.len()].copy_from_slice(&eca_measurement[..]);
+
+    let report = get_attestation(report_data).expect("couldn't get attestation report.");
+    let report_bytes = report.as_bytes();
+
+    result.root_layer_evidence.tee_platform = TeePlatform::AmdSevSnp as u64;
+    result.root_layer_evidence.remote_attestation_report[..report_bytes.len()]
+        .copy_from_slice(report_bytes);
+    result.root_layer_evidence.eca_public_key[..stage0_eca_verifying_key.len()]
+        .copy_from_slice(&stage0_eca_verifying_key);
+    result.layer_1_evidence.eca_certificate[..stage1_eca_cert.len()]
+        .copy_from_slice(&stage1_eca_cert);
+    result.layer_1_certificate_authority.eca_private_key[..stage1_eca_signing_key.len()]
+        .copy_from_slice(&stage1_eca_signing_key);
+    result
+}
+
+/// Returns an attestation report.
+///
+/// # Arguments
+///
+/// * `report_data` - The custom data that must be included in the report. This is typically used to
+///   bind information (such as the hash of a public key) to the report.
+pub fn get_attestation(
+    report_data: [u8; REPORT_DATA_SIZE],
+) -> Result<AttestationReport, &'static str> {
+    // For now we just generate a fake report and set the report data.
+    let mut report = AttestationReport::new_zeroed();
+    report.data.report_data = report_data;
+    Ok(report)
 }

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -305,7 +305,7 @@ pub fn rust64_start(encrypted: u64) -> ! {
         memory_map_measurement,
     };
 
-    dice_attestation::generate_stage1_attestation(&measurements);
+    let _dice_data = dice_attestation::generate_dice_data(&measurements);
 
     log::info!("jumping to kernel at {:#018x}", entry.as_u64());
 

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -132,7 +132,7 @@ impl ZeroPage {
         // Construct the "real" E820 table, carving out a chunk of memory out for the ACPI area and
         // reserved memory just below 1 MiB.
         for entry in &e820_table[0..e820_entries] {
-            if entry.addr() < 0x8_0000 && entry.addr() + entry.size() >= 0x10_0000 {
+            if entry.addr() <= 0x8_0000 && entry.addr() + entry.size() >= 0x10_0000 {
                 // any memory before our hole?
                 let low_size = if entry.addr() < 0x8_0000 {
                     let size = 0x8_0000 - entry.addr();

--- a/stage0_bin/build.rs
+++ b/stage0_bin/build.rs
@@ -23,6 +23,6 @@ fn main() {
     if env::var("PROFILE").unwrap() == "release" {
         println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=256K");
     } else {
-        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=1024K");
+        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=2048K");
     }
 }


### PR DESCRIPTION
This PR is a step towards propagating the DICE data from Stage 0 to the next stage. The following features will be added in follow-up PRs:

- Marking the memory range of the Stage0 DICE data as a special reserved region in the E820 table so the the next stage can find the data
- Actually generating a real attestation report when running on AMD SEV-SNP
- Adding support for sealing key derivation
