### PR TITLE
Make all FD reads behave consistently & idiomatically

### DIFF
--- a/oak_restricted_kernel/src/syscall/dice_data.rs
+++ b/oak_restricted_kernel/src/syscall/dice_data.rs
@@ -35,9 +35,10 @@ impl FileDescriptor for DiceDataDescriptor {
     fn read(&mut self, buf: &mut [u8]) -> Result<isize, oak_restricted_kernel_interface::Errno> {
         let data_as_bytes = <DiceData as zerocopy::AsBytes>::as_bytes_mut(&mut self.data);
         let length = min(data_as_bytes.len() - self.index, buf.len());
-        let slice_to_read = &mut data_as_bytes[self.index..length];
+        let end_index = min(self.index + length, data_as_bytes.len());
+        let slice_to_read = &mut data_as_bytes[self.index..end_index];
         buf.copy_from_slice(slice_to_read);
-        self.index += length;
+        self.index += end_index;
         // destroy the data that was read, to ensure that it can only be read once
         slice_to_read.fill(0);
         Ok(length as isize)

--- a/oak_restricted_kernel/src/syscall/dice_data.rs
+++ b/oak_restricted_kernel/src/syscall/dice_data.rs
@@ -38,7 +38,7 @@ impl FileDescriptor for DiceDataDescriptor {
         let end_index = min(self.index + length, data_as_bytes.len());
         let slice_to_read = &mut data_as_bytes[self.index..end_index];
         buf.copy_from_slice(slice_to_read);
-        self.index += end_index;
+        self.index = end_index;
         // destroy the data that was read, to ensure that it can only be read once
         slice_to_read.fill(0);
         Ok(length as isize)

--- a/oak_restricted_kernel/src/syscall/fd.rs
+++ b/oak_restricted_kernel/src/syscall/fd.rs
@@ -38,8 +38,7 @@ type Fd = c_int;
 /// to a destination buffer.
 pub fn copy_max_slice(src_buf: &[u8], dst_buf: &mut [u8]) -> usize {
     let length: usize = min(src_buf.len(), dst_buf.len());
-    let slice_to_read = &src_buf[..length];
-    dst_buf.copy_from_slice(slice_to_read);
+    dst_buf[..length].copy_from_slice(&src_buf[..length]);
     length
 }
 

--- a/oak_restricted_kernel/src/syscall/fd.rs
+++ b/oak_restricted_kernel/src/syscall/fd.rs
@@ -38,8 +38,7 @@ type Fd = c_int;
 /// to a destination buffer.
 pub fn copy_max_slice(src_buf: &[u8], dst_buf: &mut [u8]) -> usize {
     let length: usize = min(src_buf.len(), dst_buf.len());
-    let end_index = min(length, src_buf.len());
-    let slice_to_read = &src_buf[..end_index];
+    let slice_to_read = &src_buf[..length];
     dst_buf.copy_from_slice(slice_to_read);
     length
 }

--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -22,6 +22,9 @@ pub mod mmap;
 mod process;
 mod stdio;
 
+#[cfg(test)]
+mod tests;
+
 use self::{
     fd::{syscall_fsync, syscall_read, syscall_write},
     mmap::syscall_mmap,

--- a/oak_restricted_kernel/src/syscall/tests.rs
+++ b/oak_restricted_kernel/src/syscall/tests.rs
@@ -1,0 +1,44 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use super::fd::copy_max_slice;
+
+#[test]
+fn shorter_dst_copy() {
+    let src: &[u8; 6] = &[0, 1, 2, 3, 4, 5];
+    let dst: &mut [u8; 5] = &mut [0; 5];
+    let length = copy_max_slice(src, dst);
+    assert_eq!(length, 5);
+    assert_eq!(dst, &[0, 1, 2, 3, 4])
+}
+
+#[test]
+fn longer_dst_copy() {
+    let src: &[u8; 6] = &[0, 1, 2, 3, 4, 5];
+    let dst: &mut [u8; 8] = &mut [0; 8];
+    let length = copy_max_slice(src, dst);
+    assert_eq!(length, 5);
+    assert_eq!(dst, &[0, 1, 2, 3, 4, 5, 0, 0])
+}
+
+#[test]
+fn empty_copy() {
+    let src: &[u8; 0] = &[];
+    let dst: &mut [u8; 5] = &mut [1; 5];
+    let length = copy_max_slice(src, dst);
+    assert_eq!(length, 0);
+    assert_eq!(dst, &[1; 5])
+}

--- a/oak_restricted_kernel/src/syscall/tests.rs
+++ b/oak_restricted_kernel/src/syscall/tests.rs
@@ -30,7 +30,7 @@ fn longer_dst_copy() {
     let src: &[u8; 6] = &[0, 1, 2, 3, 4, 5];
     let dst: &mut [u8; 8] = &mut [0; 8];
     let length = copy_max_slice(src, dst);
-    assert_eq!(length, 5);
+    assert_eq!(length, 6);
     assert_eq!(dst, &[0, 1, 2, 3, 4, 5, 0, 0])
 }
 


### PR DESCRIPTION
~Review once https://github.com/project-oak/oak/pull/4384 is merged.~

Now all FDs keep an inner state that tracks how much they've been read. Subsequent reads return the subequent bytes. If the FD has been read to end, no bytes are copied on subsequent reads.

If we want to permit mulitple reads in the future, we should add a seek method to permit the app manipulate the state of the FD.