### PR TITLE
Use explicit crypto protos in C++ crypto library

### DIFF
--- a/cc/client/BUILD
+++ b/cc/client/BUILD
@@ -30,6 +30,7 @@ cc_library(
         "//cc/crypto:common",
         "//cc/remote_attestation:attestation_verifier",
         "//cc/transport",
+        "//oak_crypto/proto/v1:crypto_cc_proto",
         "//oak_remote_attestation/proto/v1:messages_cc_proto",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status:statusor",

--- a/cc/client/client.cc
+++ b/cc/client/client.cc
@@ -23,6 +23,7 @@
 #include "absl/strings/string_view.h"
 #include "cc/crypto/client_encryptor.h"
 #include "cc/crypto/common.h"
+#include "oak_crypto/proto/v1/crypto.pb.h"
 #include "oak_remote_attestation/proto/v1/messages.pb.h"
 
 namespace oak::client {
@@ -30,6 +31,8 @@ namespace oak::client {
 namespace {
 using ::oak::crypto::ClientEncryptor;
 using ::oak::crypto::DecryptionResult;
+using ::oak::crypto::v1::EncryptedRequest;
+using ::oak::crypto::v1::EncryptedResponse;
 using ::oak::remote_attestation::AttestationVerifier;
 using ::oak::session::v1::AttestationBundle;
 using ::oak::transport::TransportWrapper;
@@ -63,14 +66,14 @@ absl::StatusOr<std::string> OakClient::Invoke(absl::string_view request_body) {
   }
 
   // Encrypt request.
-  absl::StatusOr<std::string> encrypted_request =
+  absl::StatusOr<EncryptedRequest> encrypted_request =
       (*client_encryptor)->Encrypt(request_body, kEmptyAssociatedData);
   if (!encrypted_request.ok()) {
     return encrypted_request.status();
   }
 
   // Send request.
-  absl::StatusOr<std::string> encrypted_response = transport_->Invoke(*encrypted_request);
+  absl::StatusOr<EncryptedResponse> encrypted_response = transport_->Invoke(*encrypted_request);
   if (!encrypted_response.ok()) {
     return encrypted_response.status();
   }

--- a/cc/client/client_test.cc
+++ b/cc/client/client_test.cc
@@ -36,6 +36,8 @@ namespace {
 using ::oak::crypto::EncryptionKeyProvider;
 using ::oak::crypto::KeyPair;
 using ::oak::crypto::ServerEncryptor;
+using ::oak::crypto::v1::EncryptedRequest;
+using ::oak::crypto::v1::EncryptedResponse;
 using ::oak::remote_attestation::InsecureAttestationVerifier;
 using ::oak::session::v1::AttestationBundle;
 using ::oak::transport::TransportWrapper;
@@ -69,9 +71,9 @@ class TestTransport : public TransportWrapper {
     return endorsed_evidence;
   }
 
-  absl::StatusOr<std::string> Invoke(absl::string_view request_bytes) override {
+  absl::StatusOr<EncryptedResponse> Invoke(const EncryptedRequest& encrypted_request) override {
     ServerEncryptor server_encryptor = ServerEncryptor(encryption_key_provider_);
-    auto decrypted_request = server_encryptor.Decrypt(request_bytes);
+    auto decrypted_request = server_encryptor.Decrypt(encrypted_request);
     if (!decrypted_request.ok()) {
       return decrypted_request.status();
     }

--- a/cc/crypto/client_encryptor.h
+++ b/cc/crypto/client_encryptor.h
@@ -25,6 +25,7 @@
 #include "absl/strings/string_view.h"
 #include "cc/crypto/common.h"
 #include "cc/crypto/hpke/sender_context.h"
+#include "oak_crypto/proto/v1/crypto.pb.h"
 
 namespace oak::crypto {
 
@@ -54,18 +55,15 @@ class ClientEncryptor {
   // Encrypts `plaintext` and authenticates `associated_data` using AEAD.
   // <https://datatracker.ietf.org/doc/html/rfc5116>
   //
-  // Returns a serialized [`oak.crypto.EncryptedRequest`] message.
-  // TODO(#3843): Return unserialized proto messages once we have Java encryption without JNI.
-  absl::StatusOr<std::string> Encrypt(absl::string_view plaintext,
-                                      absl::string_view associated_data);
+  // Returns an [`oak.crypto.EncryptedRequest`] proto message.
+  absl::StatusOr<oak::crypto::v1::EncryptedRequest> Encrypt(absl::string_view plaintext,
+                                                            absl::string_view associated_data);
 
   // Decrypts a [`EncryptedResponse`] proto message using AEAD.
   // <https://datatracker.ietf.org/doc/html/rfc5116>
   //
-  // `encrypted_response` must be a serialized [`oak.crypto.EncryptedResponse`] message.
   // Returns a response message plaintext and associated data.
-  // TODO(#3843): Accept unserialized proto messages once we have Java encryption without JNI.
-  absl::StatusOr<DecryptionResult> Decrypt(absl::string_view encrypted_response);
+  absl::StatusOr<DecryptionResult> Decrypt(oak::crypto::v1::EncryptedResponse encrypted_response);
 
  private:
   // Encapsulated public key needed to establish a symmetric session key.

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -33,33 +33,28 @@ using ::oak::crypto::v1::EncryptedRequest;
 using ::oak::crypto::v1::EncryptedResponse;
 }  // namespace
 
-absl::StatusOr<DecryptionResult> ServerEncryptor::Decrypt(absl::string_view encrypted_request) {
-  // Deserialize request.
-  EncryptedRequest request;
-  if (!request.ParseFromString(encrypted_request)) {
-    return absl::InvalidArgumentError("couldn't deserialize request");
-  }
-
+absl::StatusOr<DecryptionResult> ServerEncryptor::Decrypt(EncryptedRequest encrypted_request) {
   // Get recipient context.
   if (!recipient_context_) {
-    absl::Status status = InitializeRecipientContexts(request);
+    absl::Status status = InitializeRecipientContexts(encrypted_request);
     if (!status.ok()) {
       return status;
     }
   }
 
   // Decrypt request.
-  absl::StatusOr<std::string> plaintext = recipient_context_->Open(
-      request.encrypted_message().ciphertext(), request.encrypted_message().associated_data());
+  absl::StatusOr<std::string> plaintext =
+      recipient_context_->Open(encrypted_request.encrypted_message().ciphertext(),
+                               encrypted_request.encrypted_message().associated_data());
   if (!plaintext.ok()) {
     return plaintext.status();
   }
 
-  return DecryptionResult{*plaintext, request.encrypted_message().associated_data()};
+  return DecryptionResult{*plaintext, encrypted_request.encrypted_message().associated_data()};
 }
 
-absl::StatusOr<std::string> ServerEncryptor::Encrypt(absl::string_view plaintext,
-                                                     absl::string_view associated_data) {
+absl::StatusOr<EncryptedResponse> ServerEncryptor::Encrypt(absl::string_view plaintext,
+                                                           absl::string_view associated_data) {
   // Get recipient context.
   if (!recipient_context_) {
     return absl::InternalError("server encryptor is not initialized");
@@ -72,16 +67,11 @@ absl::StatusOr<std::string> ServerEncryptor::Encrypt(absl::string_view plaintext
   }
 
   // Create response message.
-  EncryptedResponse response;
-  *response.mutable_encrypted_message()->mutable_ciphertext() = *ciphertext;
-  *response.mutable_encrypted_message()->mutable_associated_data() = associated_data;
+  EncryptedResponse encrypted_response;
+  *encrypted_response.mutable_encrypted_message()->mutable_ciphertext() = *ciphertext;
+  *encrypted_response.mutable_encrypted_message()->mutable_associated_data() = associated_data;
 
-  // Serialize response.
-  std::string serialized_response;
-  if (!response.SerializeToString(&serialized_response)) {
-    return absl::InternalError("couldn't serialize response");
-  }
-  return serialized_response;
+  return encrypted_response;
 }
 
 absl::Status ServerEncryptor::InitializeRecipientContexts(const EncryptedRequest& request) {

--- a/cc/crypto/server_encryptor.h
+++ b/cc/crypto/server_encryptor.h
@@ -48,18 +48,16 @@ class ServerEncryptor {
   // Decrypts a [`EncryptedRequest`] proto message using AEAD.
   // <https://datatracker.ietf.org/doc/html/rfc5116>
   //
-  // `encrypted_request` must be a serialized [`oak.crypto.EncryptedRequest`] message.
   // Returns a response message plaintext and associated data.
-  // TODO(#3843): Accept unserialized proto messages once we have Java encryption without JNI.
-  absl::StatusOr<DecryptionResult> Decrypt(absl::string_view encrypted_request);
+  absl::StatusOr<DecryptionResult> Decrypt(oak::crypto::v1::EncryptedRequest encrypted_request);
 
   // Encrypts `plaintext` and authenticates `associated_data` using AEAD.
   // <https://datatracker.ietf.org/doc/html/rfc5116>
   //
-  // Returns a serialized [`oak.crypto.EncryptedResponse`] message.
+  // Returns an [`oak.crypto.EncryptedResponse`] proto message.
   // TODO(#3843): Return unserialized proto messages once we have Java encryption without JNI.
-  absl::StatusOr<std::string> Encrypt(absl::string_view plaintext,
-                                      absl::string_view associated_data);
+  absl::StatusOr<oak::crypto::v1::EncryptedResponse> Encrypt(absl::string_view plaintext,
+                                                             absl::string_view associated_data);
 
  private:
   RecipientContextGenerator& recipient_context_generator_;

--- a/cc/transport/BUILD
+++ b/cc/transport/BUILD
@@ -23,6 +23,7 @@ cc_library(
     name = "transport",
     hdrs = ["transport.h"],
     deps = [
+        "//oak_crypto/proto/v1:crypto_cc_proto",
         "//oak_remote_attestation/proto/v1:messages_cc_proto",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -35,6 +36,7 @@ cc_library(
     hdrs = ["grpc_streaming_transport.h"],
     deps = [
         ":transport",
+        "//oak_crypto/proto/v1:crypto_cc_proto",
         "//oak_remote_attestation/proto/v1:messages_cc_proto",
         "//oak_remote_attestation/proto/v1:service_streaming_cc_grpc",
         "//oak_remote_attestation/proto/v1:service_streaming_cc_proto",

--- a/cc/transport/grpc_streaming_transport.cc
+++ b/cc/transport/grpc_streaming_transport.cc
@@ -24,10 +24,14 @@
 #include "grpcpp/client_context.h"
 #include "grpcpp/create_channel.h"
 #include "grpcpp/grpcpp.h"
+#include "oak_crypto/proto/v1/crypto.pb.h"
+#include "oak_remote_attestation/proto/v1/messages.pb.h"
 
 namespace oak::transport {
 
 namespace {
+using ::oak::crypto::v1::EncryptedRequest;
+using ::oak::crypto::v1::EncryptedResponse;
 using ::oak::session::v1::AttestationBundle;
 using ::oak::session::v1::GetPublicKeyRequest;
 using ::oak::session::v1::InvokeRequest;
@@ -59,11 +63,16 @@ absl::StatusOr<AttestationBundle> GrpcStreamingTransport::GetEvidence() {
   }
 }
 
-absl::StatusOr<std::string> GrpcStreamingTransport::Invoke(absl::string_view request_bytes) {
+absl::StatusOr<EncryptedResponse> GrpcStreamingTransport::Invoke(
+    const EncryptedRequest& encrypted_request) {
   // Create request.
   RequestWrapper request;
-  InvokeRequest* invoke_request = request.mutable_invoke_request();
-  invoke_request->set_encrypted_body(request_bytes);
+  // TODO(#4037): Use explicit crypto protos.
+  std::string encrypted_body;
+  if (!encrypted_request.SerializeToString(&encrypted_body)) {
+    return absl::InternalError("couldn't serialize encrypted request");
+  }
+  *request.mutable_invoke_request()->mutable_encrypted_body() = encrypted_body;
 
   // Send request.
   auto response = Send(request);
@@ -75,8 +84,14 @@ absl::StatusOr<std::string> GrpcStreamingTransport::Invoke(absl::string_view req
   switch (response->response_case()) {
     case ResponseWrapper::kGetPublicKeyResponseFieldNumber:
       return absl::InternalError("received GetPublicKeyResponse instead of InvokeResponse");
-    case ResponseWrapper::kInvokeResponseFieldNumber:
-      return response->invoke_response().encrypted_body();
+    case ResponseWrapper::kInvokeResponseFieldNumber: {
+      // TODO(#4037): Use explicit crypto protos.
+      EncryptedResponse encrypted_response;
+      if (!encrypted_response.ParseFromString(response->invoke_response().encrypted_body())) {
+        return absl::InvalidArgumentError("couldn't deserialize response");
+      }
+      return encrypted_response;
+    }
     case ResponseWrapper::RESPONSE_NOT_SET:
     default:
       return absl::InternalError("received unsupported response: " + response->DebugString());

--- a/cc/transport/grpc_streaming_transport.h
+++ b/cc/transport/grpc_streaming_transport.h
@@ -23,6 +23,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "cc/transport/transport.h"
+#include "oak_crypto/proto/v1/crypto.pb.h"
 #include "oak_remote_attestation/proto/v1/messages.pb.h"
 #include "oak_remote_attestation/proto/v1/service_streaming.grpc.pb.h"
 #include "oak_remote_attestation/proto/v1/service_streaming.pb.h"
@@ -38,7 +39,8 @@ class GrpcStreamingTransport : public TransportWrapper {
       : channel_reader_writer_(std::move(channel_reader_writer)) {}
 
   absl::StatusOr<::oak::session::v1::AttestationBundle> GetEvidence() override;
-  absl::StatusOr<std::string> Invoke(absl::string_view request_bytes) override;
+  absl::StatusOr<oak::crypto::v1::EncryptedResponse> Invoke(
+      const oak::crypto::v1::EncryptedRequest& encrypted_request) override;
 
   ~GrpcStreamingTransport() override;
 

--- a/cc/transport/transport.h
+++ b/cc/transport/transport.h
@@ -21,6 +21,7 @@
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "oak_crypto/proto/v1/crypto.pb.h"
 #include "oak_remote_attestation/proto/v1/messages.pb.h"
 
 namespace oak::transport {
@@ -40,7 +41,8 @@ class Transport {
   virtual ~Transport() = default;
 
   // Sends a request to the enclave and returns a response.
-  virtual absl::StatusOr<std::string> Invoke(absl::string_view request_bytes) = 0;
+  virtual absl::StatusOr<oak::crypto::v1::EncryptedResponse> Invoke(
+      const oak::crypto::v1::EncryptedRequest& encrypted_request) = 0;
 };
 
 // Wrapper for `EvidenceProvider` and `Transport` abstract classes.


### PR DESCRIPTION
This PR makes the C++ crypto library use explicit `oak_crypto` messages.

This PR is split from the original PR: https://github.com/project-oak/oak/pull/4386

Ref https://github.com/project-oak/oak/issues/4037