### PR TITLE
Send Stage 0 DICE Data address to the next stage

### DIFF
--- a/oak_containers_stage1/src/main.rs
+++ b/oak_containers_stage1/src/main.rs
@@ -37,11 +37,14 @@ use tokio::process::Command;
 
 #[derive(Parser, Debug)]
 struct Args {
-    #[arg(default_value = "http://10.0.2.100:8080")]
+    #[arg(long, default_value = "http://10.0.2.100:8080")]
     launcher_addr: String,
 
-    #[arg(default_value = "/sbin/init")]
+    #[arg(long, default_value = "/sbin/init")]
     init: String,
+
+    #[arg(long = "oak-dice")]
+    dice_addr: String,
 }
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -88,6 +91,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .context("failed to move /rootfs to /")?;
     chroot(".").context("failed to chroot to .")?;
     chdir("/").context("failed to chdir to /")?;
+
+    println!("DICE address: {}", args.dice_addr);
 
     let mut client = LauncherClient::new(args.launcher_addr.parse()?)
         .await

--- a/oak_dice/src/evidence.rs
+++ b/oak_dice/src/evidence.rs
@@ -32,6 +32,13 @@ pub const PUBLIC_KEY_SIZE: usize = 256;
 /// The maximum size of a serialized CWT certificate.
 pub const CERTIFICATE_SIZE: usize = 1024;
 
+/// The name of the kernel command-line parameter that is used to send the physical address of the
+/// Stage 0 DICE data struct.
+pub const DICE_DATA_CMDLINE_PARAM: &str = "oak-dice";
+
+/// The magic number used to identify the Stage 0 DICE data in memory.
+pub const STAGE0_MAGIC: u64 = u64::from_le_bytes(*b"oak.dice");
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Display, FromRepr)]
 #[repr(u64)]
 /// The hardware platform providing the Trusted Execution Environment.
@@ -95,12 +102,15 @@ static_assertions::assert_eq_size!([u8; PRIVATE_KEY_SIZE], CertificateAuthority)
 #[derive(AsBytes, FromBytes)]
 #[repr(C, align(4096))]
 pub struct Stage0DiceData {
+    /// Magic number that is expected to always be set to the value of `STAGE0_MAGIC`.
+    pub magic: u64,
+    _padding_0: u64,
     /// The evidence about Stage 0 and the initial state of the VM.
     pub root_layer_evidence: RootLayerEvidence,
     /// The evidence about the next layer.
     pub layer_1_evidence: LayerEvidence,
     pub layer_1_certificate_authority: CertificateAuthority,
-    _padding: [u8; 688],
+    _padding_1: [u8; 672],
 }
 
 static_assertions::assert_eq_size!([u8; 4096], Stage0DiceData);

--- a/stage0/src/dice_attestation.rs
+++ b/stage0/src/dice_attestation.rs
@@ -23,7 +23,7 @@ use oak_dice::{
         KERNEL_COMMANDLINE_MEASUREMENT_ID, KERNEL_MEASUREMENT_ID, MEMORY_MAP_MEASUREMENT_ID,
         SETUP_DATA_MEASUREMENT_ID,
     },
-    evidence::{Stage0DiceData, TeePlatform},
+    evidence::{Stage0DiceData, TeePlatform, STAGE0_MAGIC},
 };
 use oak_sev_guest::guest::AttestationReport;
 use p256::ecdsa::SigningKey;
@@ -120,6 +120,7 @@ pub fn generate_dice_data(measurements: &Measurements) -> &'static Stage0DiceDat
     let report = get_attestation(report_data).expect("couldn't get attestation report.");
     let report_bytes = report.as_bytes();
 
+    result.magic = STAGE0_MAGIC;
     result.root_layer_evidence.tee_platform = TeePlatform::AmdSevSnp as u64;
     result.root_layer_evidence.remote_attestation_report[..report_bytes.len()]
         .copy_from_slice(report_bytes);

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -311,17 +311,17 @@ pub fn rust64_start(encrypted: u64) -> ! {
         E820EntryType::DiceData,
     ));
 
-    let extra = format!(
-        "--{}={:#018x}",
-        DICE_DATA_CMDLINE_PARAM,
-        dice_data.as_bytes().as_ptr() as usize
-    );
+    // Append the DICE data address to the kernel command-line.
+    let extra = format!("--{DICE_DATA_CMDLINE_PARAM}={dice_data:p}");
     let cmdline = if cmdline.is_empty() {
         extra
-    } else {
+    } else if cmdline.contains("--") {
         format!("{} {}", cmdline, extra)
+    } else {
+        format!("{} -- {}", cmdline, extra)
     };
     zero_page.set_cmdline(cmdline);
+
     log::info!("jumping to kernel at {:#018x}", entry.as_u64());
 
     // Clean-ups we need to do just before we jump to the kernel proper: clean up the early GHCB and

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -22,9 +22,10 @@
 extern crate alloc;
 
 use crate::{sev::GHCB_WRAPPER, smp::AP_JUMP_TABLE};
-use alloc::boxed::Box;
+use alloc::{boxed::Box, format};
 use core::{arch::asm, ffi::c_void, mem::MaybeUninit, panic::PanicInfo};
 use linked_list_allocator::LockedHeap;
+use oak_dice::evidence::DICE_DATA_CMDLINE_PARAM;
 use oak_linux_boot_params::{BootE820Entry, E820EntryType};
 use oak_sev_guest::{io::PortFactoryWrapper, msr::SevStatus};
 use sha2::{Digest, Sha256};
@@ -217,12 +218,8 @@ pub fn rust64_start(encrypted: u64) -> ! {
         zero_page.add_setup_data(setup_data);
     }
 
-    let cmdline_measurement = kernel::try_load_cmdline(&mut fwcfg)
-        .map(|cmdline| {
-            zero_page.set_cmdline(cmdline);
-            measure_byte_slice(cmdline.to_bytes())
-        })
-        .unwrap_or_default();
+    let cmdline = kernel::try_load_cmdline(&mut fwcfg).unwrap_or_default();
+    let cmdline_measurement = measure_byte_slice(cmdline.as_bytes());
 
     let kernel_info = kernel::try_load_kernel_image(&mut fwcfg, zero_page.e820_table())
         .unwrap_or(kernel::KernelInfo::default());
@@ -314,6 +311,17 @@ pub fn rust64_start(encrypted: u64) -> ! {
         E820EntryType::DiceData,
     ));
 
+    let extra = format!(
+        "--{}={:#018x}",
+        DICE_DATA_CMDLINE_PARAM,
+        dice_data.as_bytes().as_ptr() as usize
+    );
+    let cmdline = if cmdline.is_empty() {
+        extra
+    } else {
+        format!("{} {}", cmdline, extra)
+    };
+    zero_page.set_cmdline(cmdline);
     log::info!("jumping to kernel at {:#018x}", entry.as_u64());
 
     // Clean-ups we need to do just before we jump to the kernel proper: clean up the early GHCB and


### PR DESCRIPTION
To make sure we can find the DICE data from Stage 0 in the next boot stage this change adds two features:

- The address of the DICE data is appended as a kernel command-line argument
  - The restricted kernel can read this parameter directly
  - The Linux kernel will ignore this parameter, and pass it as a command-line parameter to the init process (Stage1 in Oak Containers)
- A magic number at the start of the `Stage0DiceData` struct so that the next stage can check that the address points to an expected data structure
