### PR TITLE
Hook `oak_functions_servce` into `oak_functions_containers_app`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,9 @@ name = "oak_functions_containers_app"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "micro_rpc",
  "oak_crypto",
+ "oak_functions_service",
  "oak_grpc_utils",
  "oak_remote_attestation",
  "prost",

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -9,8 +9,10 @@ oak_grpc_utils = { workspace = true }
 
 [dependencies]
 anyhow = "*"
+oak_functions_service = { workspace = true }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
+micro_rpc = { workspace = true }
 prost = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tokio-stream = { version = "*", features = ["net"] }

--- a/oak_functions_containers_app/build.rs
+++ b/oak_functions_containers_app/build.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
+use oak_grpc_utils::{generate_grpc_code, CodegenOptions, ExternPath};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
@@ -26,6 +26,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ],
         CodegenOptions {
             build_server: true,
+            extern_paths: vec![ExternPath::new(
+                ".oak.functions",
+                "::oak_functions_service::proto::oak::functions",
+            )],
             ..Default::default()
         },
     )?;

--- a/oak_functions_containers_app/src/main.rs
+++ b/oak_functions_containers_app/src/main.rs
@@ -18,16 +18,27 @@ use oak_functions_containers_app::{
     orchestrator_client::OrchestratorClient,
     proto::oak::functions::oak_functions_server::OakFunctionsServer, OakFunctionsContainersService,
 };
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use oak_remote_attestation::attester::{
+    AttestationReportGenerator, EmptyAttestationReportGenerator,
+};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 
 const OAK_FUNCTIONS_CONTAINERS_APP_PORT: u16 = 8080;
 
 // Starts up and serves an OakFunctionsContainersService instance from the provided TCP listener.
-pub async fn serve(listener: TcpListener) -> Result<(), anyhow::Error> {
+pub async fn serve(
+    listener: TcpListener,
+    attestation_report_generator: Arc<dyn AttestationReportGenerator>,
+) -> Result<(), anyhow::Error> {
     tonic::transport::Server::builder()
-        .add_service(OakFunctionsServer::new(OakFunctionsContainersService {}))
+        .add_service(OakFunctionsServer::new(OakFunctionsContainersService::new(
+            attestation_report_generator,
+        )))
         .serve_with_incoming(TcpListenerStream::new(listener))
         .await
         .map_err(|error| anyhow!("starting up the service failed with error: {:?}", error))
@@ -40,13 +51,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|error| anyhow!("couldn't create Orchestrator client: {:?}", error))?;
     // To be used when connecting trusted app to orchestrator.
     let _application_config = client.clone().get_application_config().await?;
+    let attestation_report_generator = Arc::new(EmptyAttestationReportGenerator);
 
     let addr = SocketAddr::new(
         IpAddr::V4(Ipv4Addr::UNSPECIFIED),
         OAK_FUNCTIONS_CONTAINERS_APP_PORT,
     );
     let listener = TcpListener::bind(addr).await?;
-    let server_handle = tokio::spawn(serve(listener));
+    let server_handle = tokio::spawn(serve(listener, attestation_report_generator));
 
     eprintln!("Running Oak Functions on Oak Containers at address: {addr}");
     client.notify_app_ready().await?;

--- a/oak_functions_service/src/wasm/mod.rs
+++ b/oak_functions_service/src/wasm/mod.rs
@@ -421,7 +421,7 @@ where
 #[derive(Clone)]
 pub struct WasmHandler<L: OakLogger> {
     wasm_module: Arc<wasmi::Module>,
-    wasm_api_factory: Arc<dyn WasmApiFactory<L>>,
+    wasm_api_factory: Arc<dyn WasmApiFactory<L> + Send + Sync>,
     logger: L,
 }
 
@@ -451,7 +451,7 @@ where
 {
     pub fn create(
         wasm_module_bytes: &[u8],
-        wasm_api_factory: Arc<dyn WasmApiFactory<L>>,
+        wasm_api_factory: Arc<dyn WasmApiFactory<L> + Send + Sync>,
         logger: L,
     ) -> anyhow::Result<Self> {
         let engine = wasmi::Engine::default();


### PR DESCRIPTION
This is to be the first step in a longer process, but it compiles!

There are _many_ issues here:
  - the `OakFunctionsServce` is wrapped in a mutex, which precludes any kind of concurrency we may want to exploit
  - `oak_functions_service` has logic and `micro_rpc`-specifics mixed together, so either (a) use of `micro_rpc` needs to be excised from there and banished to the Restricted Kernel-specific crate, (b) gRPC needs to be an optional dependency of `oak_functions_service`, or (c) the crate needs to be split into two (three?) crates: one with core functionality, one with `micro_rpc` specifics, and one with gRPC specifics.
  - obviously the attestation, it does nothing!
  - tests

Ref #4409 