### PR TITLE
Remove unnecessary `&mut`-s and use `OnceCell` in `oak_functions_service`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,6 +2257,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "micro_rpc_build",
+ "oak_core",
  "oak_crypto",
  "oak_functions_abi",
  "oak_functions_sdk",

--- a/oak_functions_service/Cargo.toml
+++ b/oak_functions_service/Cargo.toml
@@ -16,6 +16,7 @@ byteorder = { version = "*", default-features = false }
 hashbrown = "*"
 log = "*"
 micro_rpc = { workspace = true }
+oak_core = { workspace = true }
 oak_crypto = { workspace = true }
 oak_functions_abi = { workspace = true }
 oak_functions_sdk = { workspace = true }

--- a/oak_functions_service/src/instance.rs
+++ b/oak_functions_service/src/instance.rs
@@ -53,7 +53,7 @@ impl OakFunctionsInstance {
         })
     }
     /// See [`crate::proto::oak::functions::OakFunctions::handle_user_request`].
-    pub fn handle_user_request(&mut self, request: &[u8]) -> Result<Vec<u8>, micro_rpc::Status> {
+    pub fn handle_user_request(&self, request: &[u8]) -> Result<Vec<u8>, micro_rpc::Status> {
         // TODO(#3442): Implement constant response size policy.
         self.wasm_handler
             .handle_invoke(Request {
@@ -63,7 +63,7 @@ impl OakFunctionsInstance {
     }
     /// See [`crate::proto::oak::functions::OakFunctions::extend_next_lookup_data`].
     pub fn extend_next_lookup_data(
-        &mut self,
+        &self,
         request: ExtendNextLookupDataRequest,
     ) -> Result<ExtendNextLookupDataResponse, micro_rpc::Status> {
         self.lookup_data_manager
@@ -72,7 +72,7 @@ impl OakFunctionsInstance {
     }
     /// See [`crate::proto::oak::functions::OakFunctions::finish_next_lookup_data`].
     pub fn finish_next_lookup_data(
-        &mut self,
+        &self,
         _request: FinishNextLookupDataRequest,
     ) -> Result<FinishNextLookupDataResponse, micro_rpc::Status> {
         self.lookup_data_manager.finish_next_lookup_data();
@@ -80,7 +80,7 @@ impl OakFunctionsInstance {
     }
     /// See [`crate::proto::oak::functions::OakFunctions::abort_next_lookup_data`].
     pub fn abort_next_lookup_data(
-        &mut self,
+        &self,
         _request: Empty,
     ) -> Result<AbortNextLookupDataResponse, Status> {
         self.lookup_data_manager.abort_next_lookup_data();


### PR DESCRIPTION
This might actually be everything that's needed to make `OakFunctionServce` thread-safe.

The `LookupDataManager` uses locking internally to guarantee safety (and thus doesn't require `&mut self), and `WasmHandler` just clones a lot of stuff and as long as `wasm_api_factory` is thread-safe, it should be golden there as well.

The only potential race condition is when `initialize` is called concurrently; to avoid that, I've used `oak_core::sync::OnceCell` to ensure that the initialization is guaranteed to happen once.

Ref #4409