### PR TITLE
Support generating interfaces with non-mutable references with microrpc

### DIFF
--- a/micro_rpc/build.rs
+++ b/micro_rpc/build.rs
@@ -15,5 +15,5 @@
 //
 
 fn main() {
-    micro_rpc_build::compile(&["proto/messages.proto"], &["proto"]);
+    micro_rpc_build::compile(&["proto/messages.proto"], &["proto"], Default::default());
 }

--- a/micro_rpc_tests/build.rs
+++ b/micro_rpc_tests/build.rs
@@ -21,5 +21,6 @@ fn main() {
             env!("WORKSPACE_ROOT")
         )],
         &[format!("{}micro_rpc_tests/proto", env!("WORKSPACE_ROOT"))],
+        Default::default(),
     );
 }

--- a/oak_crypto/build.rs
+++ b/oak_crypto/build.rs
@@ -15,7 +15,7 @@
 //
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    micro_rpc_build::compile(&["proto/v1/crypto.proto"], &["proto"]);
+    micro_rpc_build::compile(&["proto/v1/crypto.proto"], &["proto"], Default::default());
 
     Ok(())
 }

--- a/oak_functions_launcher/build.rs
+++ b/oak_functions_launcher/build.rs
@@ -40,6 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "{}oak_functions_service/proto",
             env!("WORKSPACE_ROOT")
         )],
+        Default::default(),
     );
 
     Ok(())

--- a/oak_functions_sdk/build.rs
+++ b/oak_functions_sdk/build.rs
@@ -21,5 +21,6 @@ fn main() {
             env!("WORKSPACE_ROOT")
         )],
         &[format!("{}oak_functions_sdk/proto", env!("WORKSPACE_ROOT"))],
+        Default::default(),
     );
 }

--- a/oak_functions_service/build.rs
+++ b/oak_functions_service/build.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+use micro_rpc_build::ReceiverType;
+
 fn main() {
     micro_rpc_build::compile(
         &[format!(
@@ -24,5 +26,8 @@ fn main() {
             "{}oak_functions_service/proto",
             env!("WORKSPACE_ROOT")
         )],
+        micro_rpc_build::CompileOptions {
+            receiver_type: ReceiverType::RefSelf,
+        },
     );
 }

--- a/oak_functions_service/src/lib.rs
+++ b/oak_functions_service/src/lib.rs
@@ -67,7 +67,7 @@ impl OakFunctionsService {
             instance: OnceCell::new(),
         }
     }
-    fn get_instance(&mut self) -> Result<&OakFunctionsInstance, micro_rpc::Status> {
+    fn get_instance(&self) -> Result<&OakFunctionsInstance, micro_rpc::Status> {
         self.instance.get().ok_or_else(|| {
             micro_rpc::Status::new_with_message(
                 micro_rpc::StatusCode::FailedPrecondition,
@@ -79,14 +79,14 @@ impl OakFunctionsService {
 
 impl OakFunctions for OakFunctionsService {
     fn initialize(
-        &mut self,
+        &self,
         request: InitializeRequest,
     ) -> Result<InitializeResponse, micro_rpc::Status> {
         log::debug!(
             "called initialize (Wasm module size: {} bytes)",
             request.wasm_module.len()
         );
-        match &mut self.instance.get() {
+        match self.instance.get() {
             Some(_) => Err(micro_rpc::Status::new_with_message(
                 micro_rpc::StatusCode::FailedPrecondition,
                 "already initialized",
@@ -121,7 +121,7 @@ impl OakFunctions for OakFunctionsService {
     }
 
     fn handle_user_request(
-        &mut self,
+        &self,
         request: InvokeRequest,
     ) -> Result<InvokeResponse, micro_rpc::Status> {
         log::debug!("called handle_user_request");
@@ -146,7 +146,7 @@ impl OakFunctions for OakFunctionsService {
     }
 
     fn extend_next_lookup_data(
-        &mut self,
+        &self,
         request: ExtendNextLookupDataRequest,
     ) -> Result<ExtendNextLookupDataResponse, micro_rpc::Status> {
         log::debug!(
@@ -157,7 +157,7 @@ impl OakFunctions for OakFunctionsService {
     }
 
     fn finish_next_lookup_data(
-        &mut self,
+        &self,
         request: FinishNextLookupDataRequest,
     ) -> Result<FinishNextLookupDataResponse, micro_rpc::Status> {
         log::debug!("called finish_next_lookup_data");
@@ -165,7 +165,7 @@ impl OakFunctions for OakFunctionsService {
     }
 
     fn abort_next_lookup_data(
-        &mut self,
+        &self,
         request: Empty,
     ) -> Result<AbortNextLookupDataResponse, micro_rpc::Status> {
         log::debug!("called abort_next_lookup_data");

--- a/oak_iree_service/build.rs
+++ b/oak_iree_service/build.rs
@@ -35,6 +35,7 @@ fn main() {
             env!("WORKSPACE_ROOT")
         )],
         &[format!("{}oak_iree_service/proto", env!("WORKSPACE_ROOT"))],
+        Default::default(),
     );
 
     build_library();

--- a/oak_remote_attestation/build.rs
+++ b/oak_remote_attestation/build.rs
@@ -15,7 +15,11 @@
 //
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    micro_rpc_build::compile(&["proto/v1/messages.proto"], &["proto/v1"]);
+    micro_rpc_build::compile(
+        &["proto/v1/messages.proto"],
+        &["proto/v1"],
+        Default::default(),
+    );
 
     Ok(())
 }

--- a/oak_tensorflow_service/build.rs
+++ b/oak_tensorflow_service/build.rs
@@ -34,6 +34,7 @@ fn main() {
             "{}oak_tensorflow_service/proto",
             env!("WORKSPACE_ROOT")
         )],
+        Default::default(),
     );
 
     build_tflite();

--- a/quirk_echo_launcher/build.rs
+++ b/quirk_echo_launcher/build.rs
@@ -24,6 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "{}quirk_echo_service/proto",
             env!("WORKSPACE_ROOT")
         )],
+        Default::default(),
     );
 
     Ok(())

--- a/quirk_echo_service/build.rs
+++ b/quirk_echo_service/build.rs
@@ -15,5 +15,5 @@
 //
 
 fn main() {
-    micro_rpc_build::compile(&["proto/quirk_echo.proto"], &["."]);
+    micro_rpc_build::compile(&["proto/quirk_echo.proto"], &["."], Default::default());
 }

--- a/testing/oak_echo_service/build.rs
+++ b/testing/oak_echo_service/build.rs
@@ -15,5 +15,5 @@
 //
 
 fn main() {
-    micro_rpc_build::compile(&["proto/oak_echo.proto"], &["."]);
+    micro_rpc_build::compile(&["proto/oak_echo.proto"], &["."], Default::default());
 }


### PR DESCRIPTION
This will make it possible to call methods from a Tonic handler, as `&self` is all we get there and we want to get rid of the `Mutex` there.

Ref #4409 