### PR TITLE
Elide an unnecessary copy in `OakFunctionsInstance`

### DIFF
--- a/oak_functions_service/src/instance.rs
+++ b/oak_functions_service/src/instance.rs
@@ -53,12 +53,10 @@ impl OakFunctionsInstance {
         })
     }
     /// See [`crate::proto::oak::functions::OakFunctions::handle_user_request`].
-    pub fn handle_user_request(&self, request: &[u8]) -> Result<Vec<u8>, micro_rpc::Status> {
+    pub fn handle_user_request(&self, request: Vec<u8>) -> Result<Vec<u8>, micro_rpc::Status> {
         // TODO(#3442): Implement constant response size policy.
         self.wasm_handler
-            .handle_invoke(Request {
-                body: request.to_vec(),
-            })
+            .handle_invoke(Request { body: request })
             .map(|response| response.body)
     }
     /// See [`crate::proto::oak::functions::OakFunctions::extend_next_lookup_data`].

--- a/oak_functions_service/src/lib.rs
+++ b/oak_functions_service/src/lib.rs
@@ -131,7 +131,7 @@ impl OakFunctions for OakFunctionsService {
             // Wrap the invocation result (which may be an Error) into a micro RPC Response
             // wrapper protobuf, and encode that as bytes.
             let response_result: Result<Vec<u8>, micro_rpc::Status> =
-                instance.handle_user_request(&r);
+                instance.handle_user_request(r);
             let response: micro_rpc::ResponseWrapper = response_result.into();
             response.encode_to_vec()
         })


### PR DESCRIPTION
We have a `Vec` that is used only once, but we pass it as a slice and create of the copy of the contents. It'll be more efficient to just move the vector itself around.