### PR TITLE
Add explicit crypto proto messages to Oak services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,7 @@ dependencies = [
  "env_logger",
  "log",
  "oak_containers_launcher",
+ "oak_crypto",
  "oak_grpc_utils",
  "prost",
  "tokio",

--- a/oak_client/src/lib.rs
+++ b/oak_client/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod proto {
     pub mod oak {
+        pub use oak_crypto::proto::oak::crypto;
         pub mod session {
             pub mod v1 {
                 #![allow(clippy::return_self_not_must_use)]

--- a/oak_client/src/transport.rs
+++ b/oak_client/src/transport.rs
@@ -57,7 +57,10 @@ impl Transport for GrpcStreamingTransport {
             .rpc_client
             .stream(futures_util::stream::iter(vec![RequestWrapper {
                 request: Some(request_wrapper::Request::InvokeRequest(InvokeRequest {
+                    // TODO(#4037): Remove once explicit protos are used end-to-end.
                     encrypted_body: serialized_request,
+                    // TODO(#4037): Use explicit crypto protos.
+                    encrypted_request: None,
                 })),
             }]))
             .await

--- a/oak_functions_containers_app/build.rs
+++ b/oak_functions_containers_app/build.rs
@@ -21,8 +21,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
         "../",
         &[
-            "oak_functions_service/proto/oak_functions.proto",
             "oak_crypto/proto/v1/crypto.proto",
+            "oak_functions_service/proto/oak_functions.proto",
         ],
         CodegenOptions {
             build_server: true,

--- a/oak_functions_containers_launcher/Cargo.toml
+++ b/oak_functions_containers_launcher/Cargo.toml
@@ -16,3 +16,4 @@ prost = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tonic = { workspace = true }
 oak_containers_launcher = { workspace = true }
+oak_crypto = { workspace = true }

--- a/oak_functions_containers_launcher/build.rs
+++ b/oak_functions_containers_launcher/build.rs
@@ -20,7 +20,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
     generate_grpc_code(
         "../",
-        &["oak_functions_service/proto/oak_functions.proto"],
+        &[
+            "oak_crypto/proto/v1/crypto.proto",
+            "oak_functions_service/proto/oak_functions.proto",
+        ],
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_functions_containers_launcher/src/lib.rs
+++ b/oak_functions_containers_launcher/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod proto {
     pub mod oak {
+        pub use oak_crypto::proto::oak::crypto;
         pub mod functions {
             tonic::include_proto!("oak.functions");
         }

--- a/oak_functions_launcher/Cargo.toml
+++ b/oak_functions_launcher/Cargo.toml
@@ -31,6 +31,7 @@ oak_functions_abi = { workspace = true }
 oak_launcher_utils = { workspace = true }
 micro_rpc = { workspace = true }
 oak_channel = { workspace = true, features = ["client"] }
+oak_crypto = { workspace = true }
 hashbrown = "*"
 ubyte = "*"
 

--- a/oak_functions_launcher/benches/integration_benches.rs
+++ b/oak_functions_launcher/benches/integration_benches.rs
@@ -115,7 +115,10 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
         .encrypt(&config.request, &[])
         .expect("could not encrypt request");
     let invoke_request = InvokeRequest {
+        // TODO(#4037): Remove once explicit protos are used end-to-end.
         body: encrypted_request.encode_to_vec(),
+        // TODO(#4037): Use explicit crypto protos.
+        encrypted_request: None,
     };
 
     // Invoke the function once outside of the benchmark loop to make sure it's ready.

--- a/oak_functions_launcher/build.rs
+++ b/oak_functions_launcher/build.rs
@@ -36,10 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "{}oak_functions_service/proto/oak_functions.proto",
             env!("WORKSPACE_ROOT")
         )],
-        &[format!(
-            "{}oak_functions_service/proto",
-            env!("WORKSPACE_ROOT")
-        )],
+        &[env!("WORKSPACE_ROOT")],
         Default::default(),
     );
 

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -23,6 +23,7 @@ pub mod server;
 
 pub mod proto {
     pub mod oak {
+        pub use oak_crypto::proto::oak::crypto;
         pub mod functions {
             #![allow(dead_code)]
             use prost::Message;

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -85,7 +85,10 @@ impl StreamingSession for SessionProxy {
                     }
                     request_wrapper::Request::InvokeRequest(invoke_request) => {
                         let enclave_invoke_request = functions::InvokeRequest {
+                            // TODO(#4037): Remove once explicit protos are used end-to-end.
                             body: invoke_request.encrypted_body,
+                            // TODO(#4037): Use explicit crypto protos.
+                            encrypted_request: None,
                         };
                         let mut enclave_client =
                             functions::OakFunctionsAsyncClient::new(connector_handle.clone());
@@ -97,7 +100,10 @@ impl StreamingSession for SessionProxy {
                                 tonic::Status::internal(format!("error handling client request: {:?}", err))
                             })?;
                         response_wrapper::Response::InvokeResponse(InvokeResponse {
+                            // TODO(#4037): Remove once explicit protos are used end-to-end.
                             encrypted_body: enclave_invoke_response.body,
+                            // TODO(#4037): Use explicit crypto protos.
+                            encrypted_response: None,
                         })
                     }
                 };

--- a/oak_functions_service/build.rs
+++ b/oak_functions_service/build.rs
@@ -22,10 +22,7 @@ fn main() {
             "{}oak_functions_service/proto/oak_functions.proto",
             env!("WORKSPACE_ROOT")
         )],
-        &[format!(
-            "{}oak_functions_service/proto",
-            env!("WORKSPACE_ROOT")
-        )],
+        &[env!("WORKSPACE_ROOT")],
         micro_rpc_build::CompileOptions {
             receiver_type: ReceiverType::RefSelf,
         },

--- a/oak_functions_service/proto/oak_functions.proto
+++ b/oak_functions_service/proto/oak_functions.proto
@@ -18,6 +18,8 @@ syntax = "proto3";
 
 package oak.functions;
 
+import "oak_crypto/proto/v1/crypto.proto";
+
 service OakFunctions {
   // Initializes the service and remote attestation keys.
   //
@@ -66,11 +68,13 @@ message PublicKeyInfo {
 message InvokeRequest {
   // TODO(#3843): Use explicit `oak_crypto` messages.
   bytes body = 1;
+  oak.crypto.v1.EncryptedRequest encrypted_request = 2;
 }
 
 message InvokeResponse {
   // TODO(#3843): Use explicit `oak_crypto` messages.
   bytes body = 1;
+  oak.crypto.v1.EncryptedResponse encrypted_response = 2;
 }
 
 message LookupDataEntry {

--- a/oak_functions_service/src/lib.rs
+++ b/oak_functions_service/src/lib.rs
@@ -25,6 +25,7 @@ extern crate std;
 
 pub mod proto {
     pub mod oak {
+        pub use oak_crypto::proto::oak::crypto;
         pub mod functions {
             #![allow(dead_code)]
             use prost::Message;
@@ -136,7 +137,11 @@ impl OakFunctions for OakFunctionsService {
             response.encode_to_vec()
         })
         .invoke(&request.body)
-        .map(|response| InvokeResponse { body: response })
+        // TODO(#4037): Use explicit crypto protos.
+        .map(|response| InvokeResponse {
+            body: response,
+            encrypted_response: None,
+        })
         .map_err(|err| {
             micro_rpc::Status::new_with_message(
                 micro_rpc::StatusCode::Internal,

--- a/oak_functions_service/tests/integration_test.rs
+++ b/oak_functions_service/tests/integration_test.rs
@@ -53,7 +53,10 @@ fn it_should_not_handle_user_requests_before_initialization() {
     let mut client = OakFunctionsClient::new(OakFunctionsServer::new(service));
 
     let request = InvokeRequest {
+        // TODO(#4037): Remove once explicit protos are used end-to-end.
         body: vec![1, 2, 3],
+        // TODO(#4037): Use explicit crypto protos.
+        encrypted_request: None,
     };
     let result = client.handle_user_request(&request).into_ok();
 
@@ -100,7 +103,10 @@ fn it_should_handle_user_requests_after_initialization() {
 
     // Send invoke request.
     let invoke_request = InvokeRequest {
+        // TODO(#4037): Remove once explicit protos are used end-to-end.
         body: serialized_request,
+        // TODO(#4037): Use explicit crypto protos.
+        encrypted_request: None,
     };
     let result = client.handle_user_request(&invoke_request).into_ok();
     assert!(result.is_ok());
@@ -168,7 +174,10 @@ async fn it_should_error_on_invalid_wasm_module() {
     // Send invoke request.
     let lookup_response = client
         .handle_user_request(&InvokeRequest {
+            // TODO(#4037): Remove once explicit protos are used end-to-end.
             body: serialized_request,
+            // TODO(#4037): Use explicit crypto protos.
+            encrypted_request: None,
         })
         .expect("couldn't receive response");
     assert!(lookup_response.is_ok());
@@ -259,7 +268,10 @@ async fn it_should_support_lookup_data() {
     // Send invoke request.
     let lookup_response = client
         .handle_user_request(&InvokeRequest {
+            // TODO(#4037): Remove once explicit protos are used end-to-end.
             body: serialized_request,
+            // TODO(#4037): Use explicit crypto protos.
+            encrypted_request: None,
         })
         .expect("couldn't receive response");
     assert!(lookup_response.is_ok());
@@ -335,7 +347,10 @@ async fn it_should_handle_wasm_panic() {
     // Send invoke request.
     let lookup_response = client
         .handle_user_request(&InvokeRequest {
+            // TODO(#4037): Remove once explicit protos are used end-to-end.
             body: serialized_request,
+            // TODO(#4037): Use explicit crypto protos.
+            encrypted_request: None,
         })
         .expect("couldn't receive response");
     assert!(lookup_response.is_ok());

--- a/oak_remote_attestation/build.rs
+++ b/oak_remote_attestation/build.rs
@@ -16,8 +16,11 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     micro_rpc_build::compile(
-        &["proto/v1/messages.proto"],
-        &["proto/v1"],
+        &[&format!(
+            "{}oak_remote_attestation/proto/v1/messages.proto",
+            env!("WORKSPACE_ROOT")
+        )],
+        &[env!("WORKSPACE_ROOT")],
         Default::default(),
     );
 

--- a/oak_remote_attestation/proto/v1/messages.proto
+++ b/oak_remote_attestation/proto/v1/messages.proto
@@ -18,6 +18,8 @@ syntax = "proto3";
 
 package oak.session.v1;
 
+import "oak_crypto/proto/v1/crypto.proto";
+
 option java_multiple_files = true;
 option java_package = "com.google.oak.session.v1";
 
@@ -103,6 +105,9 @@ message InvokeRequest {
   // needs to be at least authenticated by the client, if not encrypted within this field.
   // TODO(#3843): Use explicit `oak_crypto` messages.
   bytes encrypted_body = 1;
+  // Body of the request, encrypted using Hybrid Public Key Encryption (HPKE).
+  // <https://www.rfc-editor.org/rfc/rfc9180.html>
+  oak.crypto.v1.EncryptedRequest encrypted_request = 2;
 }
 
 message InvokeResponse {
@@ -110,6 +115,9 @@ message InvokeResponse {
   // TODO(#3442): Specify encryption format.
   // TODO(#3843): Use explicit `oak_crypto` messages.
   bytes encrypted_body = 1;
+  // Body of the request, encrypted using Hybrid Public Key Encryption (HPKE).
+  // <https://www.rfc-editor.org/rfc/rfc9180.html>
+  oak.crypto.v1.EncryptedResponse encrypted_response = 2;
 }
 
 message GetEncryptionKeyRequest {

--- a/oak_remote_attestation/src/lib.rs
+++ b/oak_remote_attestation/src/lib.rs
@@ -20,6 +20,7 @@ extern crate alloc;
 
 pub mod proto {
     pub mod oak {
+        pub use oak_crypto::proto::oak::crypto;
         pub mod session {
             pub mod v1 {
                 #![allow(dead_code)]


### PR DESCRIPTION
This PR adds explicit `oak_crypto` messages to `oak_functions.proto` and `messages.proto` but doesn't remove the old serialized fields yet.

This PR is split from the original PR: https://github.com/project-oak/oak/pull/4386

Ref https://github.com/project-oak/oak/issues/4037