### PR TITLE
Add a integration test to `oak_functions_containers_app`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,6 +2155,7 @@ dependencies = [
  "micro_rpc",
  "oak_crypto",
  "oak_functions_service",
+ "oak_functions_test_utils",
  "oak_grpc_utils",
  "oak_remote_attestation",
  "prost",

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -18,3 +18,6 @@ tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tokio-stream = { version = "*", features = ["net"] }
 tonic = { workspace = true }
 tower = "*"
+
+[dev-dependencies]
+oak_functions_test_utils = { workspace = true }

--- a/oak_functions_containers_app/build.rs
+++ b/oak_functions_containers_app/build.rs
@@ -26,11 +26,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ],
         CodegenOptions {
             build_server: true,
+            // The client is only used in the integration test.
+            build_client: true,
             extern_paths: vec![ExternPath::new(
                 ".oak.functions",
                 "::oak_functions_service::proto::oak::functions",
             )],
-            ..Default::default()
         },
     )?;
 

--- a/oak_functions_containers_app/src/main.rs
+++ b/oak_functions_containers_app/src/main.rs
@@ -14,35 +14,15 @@
 // limitations under the License.
 
 use anyhow::anyhow;
-use oak_functions_containers_app::{
-    orchestrator_client::OrchestratorClient,
-    proto::oak::functions::oak_functions_server::OakFunctionsServer, OakFunctionsContainersService,
-};
-use oak_remote_attestation::attester::{
-    AttestationReportGenerator, EmptyAttestationReportGenerator,
-};
+use oak_functions_containers_app::{orchestrator_client::OrchestratorClient, serve};
+use oak_remote_attestation::attester::EmptyAttestationReportGenerator;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
 };
 use tokio::net::TcpListener;
-use tokio_stream::wrappers::TcpListenerStream;
 
 const OAK_FUNCTIONS_CONTAINERS_APP_PORT: u16 = 8080;
-
-// Starts up and serves an OakFunctionsContainersService instance from the provided TCP listener.
-pub async fn serve(
-    listener: TcpListener,
-    attestation_report_generator: Arc<dyn AttestationReportGenerator>,
-) -> Result<(), anyhow::Error> {
-    tonic::transport::Server::builder()
-        .add_service(OakFunctionsServer::new(OakFunctionsContainersService::new(
-            attestation_report_generator,
-        )))
-        .serve_with_incoming(TcpListenerStream::new(listener))
-        .await
-        .map_err(|error| anyhow!("starting up the service failed with error: {:?}", error))
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/oak_functions_containers_app/tests/integration_test.rs
+++ b/oak_functions_containers_app/tests/integration_test.rs
@@ -1,0 +1,70 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+pub mod proto {
+    pub mod oak {
+        pub mod functions {
+            tonic::include_proto!("oak.functions");
+        }
+    }
+}
+
+use crate::proto::oak::functions::oak_functions_client::OakFunctionsClient;
+use oak_functions_containers_app::serve;
+use oak_functions_service::proto::oak::functions::InitializeRequest;
+use oak_remote_attestation::attester::EmptyAttestationReportGenerator;
+use std::{
+    fs,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::net::TcpListener;
+use tonic::transport::Endpoint;
+
+#[tokio::test]
+async fn test_lookup() {
+    let wasm_path = oak_functions_test_utils::build_rust_crate_wasm("key_value_lookup")
+        .expect("Failed to build Wasm module");
+
+    let attestation_report_generator = Arc::new(EmptyAttestationReportGenerator);
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
+    let listener = TcpListener::bind(addr).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server_handle = tokio::spawn(serve(listener, attestation_report_generator));
+
+    let mut oak_functions_client: OakFunctionsClient<tonic::transport::channel::Channel> = {
+        let channel = Endpoint::from_shared(format!("http://{addr}"))
+            .expect("couldn't form channel")
+            .connect_timeout(Duration::from_secs(120))
+            .connect()
+            .await
+            .expect("couldn't connect to trusted app");
+        OakFunctionsClient::new(channel)
+    };
+
+    let _ = oak_functions_client
+        .initialize(InitializeRequest {
+            constant_response_size: 1000,
+            wasm_module: fs::read(wasm_path).expect("failed to read wasm module"),
+        })
+        .await
+        .expect("failed to initialize Oak Functions");
+
+    server_handle.abort();
+    let _ = server_handle.await;
+}


### PR DESCRIPTION
This is a really basic test that fires up the gRPC server and tries to initialize Oak Functions. Nothing too complicated.

Ref #4409 