### PR TITLE
Use explicit crypto protos in Rust client library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,6 @@ dependencies = [
  "async-trait",
  "futures-util",
  "log",
- "micro_rpc",
  "oak_crypto",
  "oak_grpc_utils",
  "prost",

--- a/oak_client/Cargo.toml
+++ b/oak_client/Cargo.toml
@@ -10,7 +10,6 @@ anyhow = "*"
 async-trait = "*"
 futures-util = "*"
 log = "*"
-micro_rpc = { workspace = true }
 oak_crypto = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }


### PR DESCRIPTION
This PR makes the Rust client library use explicit `oak_crypto` messages.

This PR is split from the original PR: https://github.com/project-oak/oak/pull/4386

Ref https://github.com/project-oak/oak/issues/4037