### PR TITLE
Rename GetPublicKey to GetEndorsedEvidence

### DIFF
--- a/cc/client/client.cc
+++ b/cc/client/client.cc
@@ -34,7 +34,7 @@ using ::oak::crypto::DecryptionResult;
 using ::oak::crypto::v1::EncryptedRequest;
 using ::oak::crypto::v1::EncryptedResponse;
 using ::oak::remote_attestation::AttestationVerifier;
-using ::oak::session::v1::AttestationBundle;
+using ::oak::session::v1::EndorsedEvidence;
 using ::oak::transport::TransportWrapper;
 }  // namespace
 
@@ -42,7 +42,7 @@ constexpr absl::string_view kEmptyAssociatedData = "";
 
 absl::StatusOr<std::unique_ptr<OakClient>> OakClient::Create(
     std::unique_ptr<TransportWrapper> transport, AttestationVerifier& verifier) {
-  absl::StatusOr<AttestationBundle> endorsed_evidence = transport->GetEvidence();
+  absl::StatusOr<EndorsedEvidence> endorsed_evidence = transport->GetEvidence();
   if (!endorsed_evidence.ok()) {
     return endorsed_evidence.status();
   }

--- a/cc/client/client_test.cc
+++ b/cc/client/client_test.cc
@@ -39,7 +39,7 @@ using ::oak::crypto::ServerEncryptor;
 using ::oak::crypto::v1::EncryptedRequest;
 using ::oak::crypto::v1::EncryptedResponse;
 using ::oak::remote_attestation::InsecureAttestationVerifier;
-using ::oak::session::v1::AttestationBundle;
+using ::oak::session::v1::EndorsedEvidence;
 using ::oak::transport::TransportWrapper;
 using ::testing::StrEq;
 
@@ -64,8 +64,8 @@ class TestTransport : public TransportWrapper {
   explicit TestTransport(EncryptionKeyProvider encryption_key_provider)
       : encryption_key_provider_(encryption_key_provider) {}
 
-  absl::StatusOr<AttestationBundle> GetEvidence() override {
-    AttestationBundle endorsed_evidence;
+  absl::StatusOr<EndorsedEvidence> GetEvidence() override {
+    EndorsedEvidence endorsed_evidence;
     endorsed_evidence.mutable_attestation_evidence()->set_encryption_public_key(
         encryption_key_provider_.GetSerializedPublicKey());
     return endorsed_evidence;

--- a/cc/transport/grpc_streaming_transport.cc
+++ b/cc/transport/grpc_streaming_transport.cc
@@ -34,14 +34,14 @@ namespace oak::transport {
 namespace {
 using ::oak::crypto::v1::EncryptedRequest;
 using ::oak::crypto::v1::EncryptedResponse;
-using ::oak::session::v1::AttestationBundle;
+using ::oak::session::v1::EndorsedEvidence;
 using ::oak::session::v1::GetPublicKeyRequest;
 using ::oak::session::v1::InvokeRequest;
 using ::oak::session::v1::RequestWrapper;
 using ::oak::session::v1::ResponseWrapper;
 }  // namespace
 
-absl::StatusOr<AttestationBundle> GrpcStreamingTransport::GetEvidence() {
+absl::StatusOr<EndorsedEvidence> GrpcStreamingTransport::GetEvidence() {
   // Create request.
   RequestWrapper request;
   GetPublicKeyRequest get_public_key_request;

--- a/cc/transport/grpc_streaming_transport.cc
+++ b/cc/transport/grpc_streaming_transport.cc
@@ -35,7 +35,7 @@ namespace {
 using ::oak::crypto::v1::EncryptedRequest;
 using ::oak::crypto::v1::EncryptedResponse;
 using ::oak::session::v1::EndorsedEvidence;
-using ::oak::session::v1::GetPublicKeyRequest;
+using ::oak::session::v1::GetEndorsedEvidenceRequest;
 using ::oak::session::v1::InvokeRequest;
 using ::oak::session::v1::RequestWrapper;
 using ::oak::session::v1::ResponseWrapper;
@@ -44,8 +44,8 @@ using ::oak::session::v1::ResponseWrapper;
 absl::StatusOr<EndorsedEvidence> GrpcStreamingTransport::GetEvidence() {
   // Create request.
   RequestWrapper request;
-  GetPublicKeyRequest get_public_key_request;
-  *request.mutable_get_public_key_request() = get_public_key_request;
+  GetEndorsedEvidenceRequest get_endorsed_evidence_request;
+  *request.mutable_get_endorsed_evidence_request() = get_endorsed_evidence_request;
 
   // Send request.
   auto response = Send(request);
@@ -55,10 +55,10 @@ absl::StatusOr<EndorsedEvidence> GrpcStreamingTransport::GetEvidence() {
 
   // Process response.
   switch (response->response_case()) {
-    case ResponseWrapper::kGetPublicKeyResponseFieldNumber:
-      return response->get_public_key_response().attestation_bundle();
+    case ResponseWrapper::kGetEndorsedEvidenceResponseFieldNumber:
+      return response->get_endorsed_evidence_response().attestation_bundle();
     case ResponseWrapper::kInvokeResponseFieldNumber:
-      return absl::InternalError("received InvokeResponse instead of GetPublicKeyResponse");
+      return absl::InternalError("received InvokeResponse instead of GetEndorsedEvidenceResponse");
     case ResponseWrapper::RESPONSE_NOT_SET:
     default:
       return absl::InternalError("received unsupported response: " + response->DebugString());
@@ -84,8 +84,8 @@ absl::StatusOr<EncryptedResponse> GrpcStreamingTransport::Invoke(
 
   // Process response.
   switch (response->response_case()) {
-    case ResponseWrapper::kGetPublicKeyResponseFieldNumber:
-      return absl::InternalError("received GetPublicKeyResponse instead of InvokeResponse");
+    case ResponseWrapper::kGetEndorsedEvidenceResponseFieldNumber:
+      return absl::InternalError("received GetEndorsedEvidenceResponse instead of InvokeResponse");
     case ResponseWrapper::kInvokeResponseFieldNumber: {
       // TODO(#4037): Use explicit crypto protos.
       EncryptedResponse encrypted_response;

--- a/cc/transport/grpc_streaming_transport.h
+++ b/cc/transport/grpc_streaming_transport.h
@@ -38,7 +38,7 @@ class GrpcStreamingTransport : public TransportWrapper {
           channel_reader_writer)
       : channel_reader_writer_(std::move(channel_reader_writer)) {}
 
-  absl::StatusOr<::oak::session::v1::AttestationBundle> GetEvidence() override;
+  absl::StatusOr<::oak::session::v1::EndorsedEvidence> GetEvidence() override;
   absl::StatusOr<::oak::crypto::v1::EncryptedResponse> Invoke(
       const oak::crypto::v1::EncryptedRequest& encrypted_request) override;
 

--- a/cc/transport/transport.h
+++ b/cc/transport/transport.h
@@ -32,7 +32,7 @@ class EvidenceProvider {
   virtual ~EvidenceProvider() = default;
 
   // Returns evidence about the trustworthiness of a remote server.
-  virtual absl::StatusOr<::oak::session::v1::AttestationBundle> GetEvidence() = 0;
+  virtual absl::StatusOr<::oak::session::v1::EndorsedEvidence> GetEvidence() = 0;
 };
 
 // Abstract class for sending messages to the enclave.

--- a/docs/remote-attestation.md
+++ b/docs/remote-attestation.md
@@ -44,9 +44,9 @@ deactivate T
 
 Note over C,P: Fetch Enclave Public Key
 
-C->>U: GetPublicKeyRequest
+C->>U: GetEndorsedEvidenceRequest
 activate U
-U->>C: GetPublicKeyResponse<br>With Additional Evidence<br>EPK,AR,Ev
+U->>C: GetEndorsedEvidenceResponse<br>With Additional Evidence<br>EPK,AR,Ev
 deactivate U
 C-->>C: Verify AttestationReport and Enclave Public Key<br>With Additional Evidence
 

--- a/java/src/main/java/com/google/oak/server/EncryptedStreamObserver.java
+++ b/java/src/main/java/com/google/oak/server/EncryptedStreamObserver.java
@@ -19,7 +19,7 @@ package com.google.oak.server;
 import com.google.oak.crypto.Encryptor;
 import com.google.oak.crypto.ServerEncryptor;
 import com.google.oak.crypto.hpke.KeyPair;
-import com.google.oak.session.v1.AttestationBundle;
+import com.google.oak.session.v1.EndorsedEvidence;
 import com.google.oak.session.v1.AttestationEndorsement;
 import com.google.oak.session.v1.AttestationEvidence;
 import com.google.oak.session.v1.GetPublicKeyResponse;
@@ -121,11 +121,11 @@ public final class EncryptedStreamObserver<I, O> implements StreamObserver<Reque
             .build();
     // TODO(#3640): Fill out the details of the attestation.
     AttestationEndorsement attestationEndorsement = AttestationEndorsement.getDefaultInstance();
-    AttestationBundle attestationBundle = AttestationBundle.newBuilder()
+    EndorsedEvidence EndorsedEvidence = EndorsedEvidence.newBuilder()
                                               .setAttestationEvidence(attestationEvidence)
                                               .setAttestationEndorsement(attestationEndorsement)
                                               .build();
-    return GetPublicKeyResponse.newBuilder().setAttestationBundle(attestationBundle).build();
+    return GetPublicKeyResponse.newBuilder().setEndorsedEvidence(EndorsedEvidence).build();
   }
 
   private Result<ResponseWrapper, Exception> processMessage(Encryptor.DecryptionResult decrypted) {

--- a/java/src/main/java/com/google/oak/server/EncryptedStreamObserver.java
+++ b/java/src/main/java/com/google/oak/server/EncryptedStreamObserver.java
@@ -22,7 +22,7 @@ import com.google.oak.crypto.hpke.KeyPair;
 import com.google.oak.session.v1.EndorsedEvidence;
 import com.google.oak.session.v1.AttestationEndorsement;
 import com.google.oak.session.v1.AttestationEvidence;
-import com.google.oak.session.v1.GetPublicKeyResponse;
+import com.google.oak.session.v1.GetEndorsedEvidenceResponse;
 import com.google.oak.session.v1.InvokeResponse;
 import com.google.oak.session.v1.RequestWrapper;
 import com.google.oak.session.v1.ResponseWrapper;
@@ -80,11 +80,11 @@ public final class EncryptedStreamObserver<I, O> implements StreamObserver<Reque
 
   @Override
   public void onNext(RequestWrapper message) {
-    if (message.hasGetPublicKeyRequest()) {
-      logger.log(Level.INFO, "Received GetPublicKeyRequest request");
+    if (message.hasGetEndorsedEvidenceRequest()) {
+      logger.log(Level.INFO, "Received GetEndorsedEvidenceRequest request");
       ResponseWrapper response =
-          ResponseWrapper.newBuilder().setGetPublicKeyResponse(createPublicKeyResponse()).build();
-      logger.log(Level.INFO, "Sending GetPublicKeyResponse response");
+          ResponseWrapper.newBuilder().setGetEndorsedEvidenceResponse(createPublicKeyResponse()).build();
+      logger.log(Level.INFO, "Sending GetEndorsedEvidenceResponse response");
       outboundObserver.onNext(response);
     } else if (message.hasInvokeRequest()) {
       logger.log(Level.INFO, "Received InvokeRequest request");
@@ -99,7 +99,7 @@ public final class EncryptedStreamObserver<I, O> implements StreamObserver<Reque
     } else {
       onError(new InvalidProtocolBufferException(
           "Got unexpected RequestWrapper that is neither an InvokeRequest nor a"
-          + " GetPublicKeyRequest."));
+          + " GetEndorsedEvidenceRequest."));
     }
   }
 
@@ -114,7 +114,7 @@ public final class EncryptedStreamObserver<I, O> implements StreamObserver<Reque
     outboundObserver.onCompleted();
   }
 
-  private GetPublicKeyResponse createPublicKeyResponse() {
+  private GetEndorsedEvidenceResponse createPublicKeyResponse() {
     AttestationEvidence attestationEvidence =
         AttestationEvidence.newBuilder()
             .setEncryptionPublicKey(ByteString.copyFrom(this.publicKey))
@@ -125,7 +125,7 @@ public final class EncryptedStreamObserver<I, O> implements StreamObserver<Reque
                                               .setAttestationEvidence(attestationEvidence)
                                               .setAttestationEndorsement(attestationEndorsement)
                                               .build();
-    return GetPublicKeyResponse.newBuilder().setEndorsedEvidence(EndorsedEvidence).build();
+    return GetEndorsedEvidenceResponse.newBuilder().setEndorsedEvidence(EndorsedEvidence).build();
   }
 
   private Result<ResponseWrapper, Exception> processMessage(Encryptor.DecryptionResult decrypted) {

--- a/java/src/main/java/com/google/oak/transport/EvidenceProvider.java
+++ b/java/src/main/java/com/google/oak/transport/EvidenceProvider.java
@@ -16,7 +16,7 @@
 
 package com.google.oak.transport;
 
-import com.google.oak.session.v1.AttestationBundle;
+import com.google.oak.session.v1.EndorsedEvidence;
 import com.google.oak.util.Result;
 
 /** An interface for providing an enclave evidence. */
@@ -24,7 +24,7 @@ public interface EvidenceProvider {
   /**
    * Returns evidence about the trustworthiness of a remote server.
    *
-   * @return {@code AttestationBundle} wrapped in a {@code Result}
+   * @return {@code EndorsedEvidence} wrapped in a {@code Result}
    */
-  abstract Result<AttestationBundle, String> getEvidence();
+  abstract Result<EndorsedEvidence, String> getEvidence();
 }

--- a/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
+++ b/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
@@ -17,8 +17,8 @@
 package com.google.oak.transport;
 
 import com.google.oak.session.v1.EndorsedEvidence;
-import com.google.oak.session.v1.GetPublicKeyRequest;
-import com.google.oak.session.v1.GetPublicKeyResponse;
+import com.google.oak.session.v1.GetEndorsedEvidenceRequest;
+import com.google.oak.session.v1.GetEndorsedEvidenceResponse;
 import com.google.oak.session.v1.InvokeRequest;
 import com.google.oak.session.v1.InvokeResponse;
 import com.google.oak.session.v1.RequestWrapper;
@@ -65,7 +65,7 @@ public class GrpcStreamingTransport implements EvidenceProvider, Transport {
   @Override
   public Result<EndorsedEvidence, String> getEvidence() {
     RequestWrapper requestWrapper = RequestWrapper.newBuilder()
-                                        .setGetPublicKeyRequest(GetPublicKeyRequest.newBuilder())
+                                        .setGetEndorsedEvidenceRequest(GetEndorsedEvidenceRequest.newBuilder())
                                         .build();
     logger.log(Level.INFO, "sending get public key request: " + requestWrapper);
     this.requestObserver.onNext(requestWrapper);
@@ -83,7 +83,7 @@ public class GrpcStreamingTransport implements EvidenceProvider, Transport {
     }
 
     logger.log(Level.INFO, "received get public key response: " + responseWrapper);
-    GetPublicKeyResponse response = responseWrapper.getGetPublicKeyResponse();
+    GetEndorsedEvidenceResponse response = responseWrapper.getGetEndorsedEvidenceResponse();
 
     return Result.success(response.getEndorsedEvidence());
   }

--- a/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
+++ b/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
@@ -16,7 +16,7 @@
 
 package com.google.oak.transport;
 
-import com.google.oak.session.v1.AttestationBundle;
+import com.google.oak.session.v1.EndorsedEvidence;
 import com.google.oak.session.v1.GetPublicKeyRequest;
 import com.google.oak.session.v1.GetPublicKeyResponse;
 import com.google.oak.session.v1.InvokeRequest;
@@ -60,10 +60,10 @@ public class GrpcStreamingTransport implements EvidenceProvider, Transport {
   /**
    * Returns evidence about the trustworthiness of a remote server.
    *
-   * @return {@code AttestationBundle} wrapped in a {@code Result}
+   * @return {@code EndorsedEvidence} wrapped in a {@code Result}
    */
   @Override
-  public Result<AttestationBundle, String> getEvidence() {
+  public Result<EndorsedEvidence, String> getEvidence() {
     RequestWrapper requestWrapper = RequestWrapper.newBuilder()
                                         .setGetPublicKeyRequest(GetPublicKeyRequest.newBuilder())
                                         .build();
@@ -85,7 +85,7 @@ public class GrpcStreamingTransport implements EvidenceProvider, Transport {
     logger.log(Level.INFO, "received get public key response: " + responseWrapper);
     GetPublicKeyResponse response = responseWrapper.getGetPublicKeyResponse();
 
-    return Result.success(response.getAttestationBundle());
+    return Result.success(response.getEndorsedEvidence());
   }
 
   /**

--- a/java/src/test/java/com/google/oak/client/OakClientTest.java
+++ b/java/src/test/java/com/google/oak/client/OakClientTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.oak.crypto.ServerEncryptor;
 import com.google.oak.crypto.hpke.KeyPair;
 import com.google.oak.remote_attestation.InsecureAttestationVerifier;
-import com.google.oak.session.v1.AttestationBundle;
+import com.google.oak.session.v1.EndorsedEvidence;
 import com.google.oak.session.v1.AttestationEndorsement;
 import com.google.oak.session.v1.AttestationEvidence;
 import com.google.oak.transport.EvidenceProvider;
@@ -55,18 +55,18 @@ public class OakClientTest {
     }
 
     @Override
-    public Result<AttestationBundle, String> getEvidence() {
+    public Result<EndorsedEvidence, String> getEvidence() {
       AttestationEvidence attestationEvidence =
           AttestationEvidence.newBuilder()
               .setEncryptionPublicKey(ByteString.copyFrom(keyPair.publicKey))
               .build();
       AttestationEndorsement attestationEndorsement = AttestationEndorsement.getDefaultInstance();
-      AttestationBundle attestationBundle = AttestationBundle.newBuilder()
+      EndorsedEvidence EndorsedEvidence = EndorsedEvidence.newBuilder()
                                                 .setAttestationEvidence(attestationEvidence)
                                                 .setAttestationEndorsement(attestationEndorsement)
                                                 .build();
 
-      return Result.success(attestationBundle);
+      return Result.success(EndorsedEvidence);
     }
 
     @Override

--- a/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
+++ b/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
@@ -20,8 +20,8 @@ import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 
 import com.google.oak.session.v1.EndorsedEvidence;
-import com.google.oak.session.v1.GetPublicKeyRequest;
-import com.google.oak.session.v1.GetPublicKeyResponse;
+import com.google.oak.session.v1.GetEndorsedEvidenceRequest;
+import com.google.oak.session.v1.GetEndorsedEvidenceResponse;
 import com.google.oak.session.v1.InvokeRequest;
 import com.google.oak.session.v1.InvokeResponse;
 import com.google.oak.session.v1.RequestWrapper;
@@ -66,10 +66,10 @@ public class GrpcStreamingTransportTest {
       ResponseWrapper responseWrapper;
       RequestWrapper.RequestCase requestCase = request.getRequestCase();
       switch (requestCase) {
-        case GET_PUBLIC_KEY_REQUEST:
+        case GET_ENDORSED_EVIDENCE_REQUEST:
           responseWrapper =
               ResponseWrapper.newBuilder()
-                  .setGetPublicKeyResponse(GetPublicKeyResponse.newBuilder().setEndorsedEvidence(
+                  .setGetEndorsedEvidenceResponse(GetEndorsedEvidenceResponse.newBuilder().setEndorsedEvidence(
                       EndorsedEvidence.getDefaultInstance()))
                   .build();
           responseObserver.onNext(responseWrapper);

--- a/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
+++ b/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
@@ -19,7 +19,7 @@ package com.google.oak.transport;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 
-import com.google.oak.session.v1.AttestationBundle;
+import com.google.oak.session.v1.EndorsedEvidence;
 import com.google.oak.session.v1.GetPublicKeyRequest;
 import com.google.oak.session.v1.GetPublicKeyResponse;
 import com.google.oak.session.v1.InvokeRequest;
@@ -69,8 +69,8 @@ public class GrpcStreamingTransportTest {
         case GET_PUBLIC_KEY_REQUEST:
           responseWrapper =
               ResponseWrapper.newBuilder()
-                  .setGetPublicKeyResponse(GetPublicKeyResponse.newBuilder().setAttestationBundle(
-                      AttestationBundle.getDefaultInstance()))
+                  .setGetPublicKeyResponse(GetPublicKeyResponse.newBuilder().setEndorsedEvidence(
+                      EndorsedEvidence.getDefaultInstance()))
                   .build();
           responseObserver.onNext(responseWrapper);
           break;
@@ -141,7 +141,7 @@ public class GrpcStreamingTransportTest {
   public void testGrpcStreamingTransport() throws Exception {
     GrpcStreamingTransport transport = new GrpcStreamingTransport(client::stream);
 
-    Result<AttestationBundle, String> getEvidenceResult = transport.getEvidence();
+    Result<EndorsedEvidence, String> getEvidenceResult = transport.getEvidence();
     Assert.assertTrue(getEvidenceResult.isSuccess());
 
     Result<byte[], String> invokeResult = transport.invoke(TEST_REQUEST);

--- a/oak_client/src/transport.rs
+++ b/oak_client/src/transport.rs
@@ -16,7 +16,7 @@
 
 use crate::proto::oak::session::v1::{
     request_wrapper, response_wrapper, streaming_session_client::StreamingSessionClient,
-    AttestationEvidence, GetPublicKeyRequest, InvokeRequest, RequestWrapper,
+    AttestationEvidence, GetEndorsedEvidenceRequest, InvokeRequest, RequestWrapper,
 };
 use anyhow::{anyhow, Context};
 use oak_crypto::proto::oak::crypto::v1::{EncryptedRequest, EncryptedResponse};
@@ -99,8 +99,8 @@ impl EvidenceProvider for GrpcStreamingTransport {
             .rpc_client
             .stream(futures_util::stream::iter(vec![RequestWrapper {
                 // TODO(#3641): Rename the corresponding message to `GetEvidence`.
-                request: Some(request_wrapper::Request::GetPublicKeyRequest(
-                    GetPublicKeyRequest {},
+                request: Some(request_wrapper::Request::GetEndorsedEvidenceRequest(
+                    GetEndorsedEvidenceRequest {},
                 )),
             }]))
             .await
@@ -114,7 +114,7 @@ impl EvidenceProvider for GrpcStreamingTransport {
             .context("gRPC server error when requesting attestation evidence")?
             .context("received empty response stream")?;
 
-        let Some(response_wrapper::Response::GetPublicKeyResponse(get_evidence_response)) =
+        let Some(response_wrapper::Response::GetEndorsedEvidenceResponse(get_evidence_response)) =
             response_wrapper.response
         else {
             return Err(anyhow::anyhow!(

--- a/oak_containers_hello_world_untrusted_app/src/lib.rs
+++ b/oak_containers_hello_world_untrusted_app/src/lib.rs
@@ -27,7 +27,7 @@ mod proto {
 mod app_client;
 
 use crate::proto::oak::crypto::v1::{EncryptedRequest, EncryptedResponse};
-use oak_containers_launcher::{proto::oak::session::v1::AttestationBundle, Launcher};
+use oak_containers_launcher::{proto::oak::session::v1::EndorsedEvidence, Launcher};
 
 pub struct UntrustedApp {
     launcher: Launcher,
@@ -49,7 +49,7 @@ impl UntrustedApp {
         })
     }
 
-    pub async fn get_endorsed_evidence(&mut self) -> anyhow::Result<AttestationBundle> {
+    pub async fn get_endorsed_evidence(&mut self) -> anyhow::Result<EndorsedEvidence> {
         self.launcher.get_endorsed_evidence().await
     }
 

--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -28,7 +28,7 @@ mod qemu;
 mod server;
 
 use crate::proto::oak::session::v1::{
-    AttestationBundle, AttestationEndorsement, AttestationEvidence, BinaryAttestation,
+    EndorsedEvidence, AttestationEndorsement, AttestationEvidence, BinaryAttestation,
 };
 use anyhow::Context;
 use clap::Parser;
@@ -103,7 +103,7 @@ pub struct Launcher {
     attestation_endorsement: AttestationEndorsement,
     // Endorsed Attestation Evidence consists of Attestation Evidence (initialized by the
     // Orchestrator) and Attestation Endorsement (initialized by the Launcher).
-    endorsed_attestation_evidence: Option<AttestationBundle>,
+    endorsed_attestation_evidence: Option<EndorsedEvidence>,
     // Receiver that is used to get the Attestation Evidence from the server implementation.
     attestation_evidence_receiver: Option<Receiver<AttestationEvidence>>,
     app_ready_notifier: Option<Receiver<()>>,
@@ -188,7 +188,7 @@ impl Launcher {
 
     /// Gets the endorsed attestation evidence that the untrusted application can send to remote
     /// clients, which will verify it before connecting.
-    pub async fn get_endorsed_evidence(&mut self) -> anyhow::Result<AttestationBundle> {
+    pub async fn get_endorsed_evidence(&mut self) -> anyhow::Result<EndorsedEvidence> {
         // If we haven't received an attestation evidence, wait for it.
         if let Some(receiver) = self.attestation_evidence_receiver.take() {
             // Set a timeout since we don't want to wait forever if the VM didn't start properly.
@@ -196,7 +196,7 @@ impl Launcher {
                 .await
                 .context("couldn't get attestation evidence before timeout")?
                 .context("no attestation evidence available")?;
-            let endorsed_attestation_evidence = AttestationBundle {
+            let endorsed_attestation_evidence = EndorsedEvidence {
                 attestation_evidence: Some(evidence),
                 attestation_endorsement: Some(self.attestation_endorsement.clone()),
             };

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -21,7 +21,7 @@ use crate::{
         session::v1::{
             request_wrapper, response_wrapper,
             streaming_session_server::{StreamingSession, StreamingSessionServer},
-            EndorsedEvidence, AttestationEndorsement, AttestationEvidence, GetPublicKeyResponse,
+            EndorsedEvidence, AttestationEndorsement, AttestationEvidence, GetEndorsedEvidenceResponse,
             InvokeResponse, RequestWrapper, ResponseWrapper,
         },
     },
@@ -77,9 +77,9 @@ impl StreamingSession for SessionProxy {
                     .ok_or_else(|| tonic::Status::invalid_argument("empty request message"))?;
 
                 let response = match request {
-                    request_wrapper::Request::GetPublicKeyRequest(_) => {
+                    request_wrapper::Request::GetEndorsedEvidenceRequest(_) => {
 
-                        response_wrapper::Response::GetPublicKeyResponse(GetPublicKeyResponse {
+                        response_wrapper::Response::GetEndorsedEvidenceResponse(GetEndorsedEvidenceResponse {
                             attestation_bundle: Some(attestation_bundle.clone()),
                         })
                     }

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -21,7 +21,7 @@ use crate::{
         session::v1::{
             request_wrapper, response_wrapper,
             streaming_session_server::{StreamingSession, StreamingSessionServer},
-            AttestationBundle, AttestationEndorsement, AttestationEvidence, GetPublicKeyResponse,
+            EndorsedEvidence, AttestationEndorsement, AttestationEvidence, GetPublicKeyResponse,
             InvokeResponse, RequestWrapper, ResponseWrapper,
         },
     },
@@ -60,7 +60,7 @@ impl StreamingSession for SessionProxy {
             binary_attestation: None,
             application_data: None,
         };
-        let attestation_bundle = AttestationBundle {
+        let attestation_bundle = EndorsedEvidence {
             attestation_evidence: Some(attestation_evidence),
             attestation_endorsement: Some(attestation_endorsement),
         };

--- a/oak_grpc_unary_attestation/proto/unary_server.proto
+++ b/oak_grpc_unary_attestation/proto/unary_server.proto
@@ -70,5 +70,5 @@ service UnarySession {
 
   // Gets the public key and the attestation report that binds the public key to a specific instance
   // of the code running in a TEE.
-  rpc GetPublicKeyInfo(google.protobuf.Empty) returns (PublicKeyInfo);
+  rpc GetEndorsedEvidenceInfo(google.protobuf.Empty) returns (PublicKeyInfo);
 }

--- a/oak_remote_attestation/proto/v1/messages.proto
+++ b/oak_remote_attestation/proto/v1/messages.proto
@@ -43,9 +43,9 @@ message AttestationEvidence {
   bytes signed_application_data = 4;
 }
 
-// AttestationBundle contains the information that the untrusted launcher provides to the client
+// EndorsedEvidence contains the information that the untrusted launcher provides to the client
 // in response to its request for the enclave's public key(s).
-message AttestationBundle {
+message EndorsedEvidence {
   // Attestation evidence from the enclave.
   AttestationEvidence attestation_evidence = 1;
 
@@ -93,7 +93,7 @@ message GetPublicKeyRequest {}
 
 message GetPublicKeyResponse {
   // The enclave's signing and encryption public keys and attestation evidence about them.
-  AttestationBundle attestation_bundle = 1;
+  EndorsedEvidence attestation_bundle = 1;
 }
 
 message InvokeRequest {
@@ -119,7 +119,7 @@ message GetEncryptionKeyRequest {
 
 message GetEncryptionKeyResponse {
   // Attestation evidence and public key.
-  AttestationBundle endorsed_evidence = 1;
+  EndorsedEvidence endorsed_evidence = 1;
 
   // Encrypted private key of the leader enclave.
   bytes encrypted_encryption_key = 2;

--- a/oak_remote_attestation/proto/v1/messages.proto
+++ b/oak_remote_attestation/proto/v1/messages.proto
@@ -89,9 +89,9 @@ message ApplicationData {
   bytes config = 2;
 }
 
-message GetPublicKeyRequest {}
+message GetEndorsedEvidenceRequest {}
 
-message GetPublicKeyResponse {
+message GetEndorsedEvidenceResponse {
   // The enclave's signing and encryption public keys and attestation evidence about them.
   EndorsedEvidence attestation_bundle = 1;
 }

--- a/oak_remote_attestation/proto/v1/service_streaming.proto
+++ b/oak_remote_attestation/proto/v1/service_streaming.proto
@@ -25,14 +25,14 @@ option java_package = "com.google.oak.session.v1";
 
 message RequestWrapper {
   oneof request {
-    GetPublicKeyRequest get_public_key_request = 1;
+    GetEndorsedEvidenceRequest get_endorsed_evidence_request = 1;
     InvokeRequest invoke_request = 2;
   }
 }
 
 message ResponseWrapper {
   oneof response {
-    GetPublicKeyResponse get_public_key_response = 1;
+    GetEndorsedEvidenceResponse get_endorsed_evidence_response = 1;
     InvokeResponse invoke_response = 2;
   }
 }
@@ -46,7 +46,7 @@ service StreamingSession {
   // messages exchanged by client and server, giving it a minimal amount of structure and type
   // safety.
   //
-  // The expected message sequence starts with the client sending a `GetPublicKeyRequest` message
+  // The expected message sequence starts with the client sending a `GetEndorsedEvidenceRequest` message
   // in order to fetch the public key of the enclave. This method may be handled by the untrusted
   // launcher or by the enclave, depending on the server implementation.
   //

--- a/oak_remote_attestation/proto/v1/service_unary.proto
+++ b/oak_remote_attestation/proto/v1/service_unary.proto
@@ -26,7 +26,7 @@ option java_package = "com.google.oak.session.v1";
 // Service definition for unary communication with Oak server.
 service UnarySession {
   // Gets encryption key of sealed encironment.
-  rpc GetPublicKey(GetPublicKeyRequest) returns (GetPublicKeyResponse);
+  rpc GetEndorsedEvidence(GetEndorsedEvidenceRequest) returns (GetEndorsedEvidenceResponse);
 
   // Performs lookup for a list of encrypted keys. The keys should be encrypted
   // using the Public key provided by the enclave. The response is encrypted


### PR DESCRIPTION
This PR resolves #4417.
`AttestationBundle` renamed to `EndorsedEvidence`
`GetPublicKey` renamed to `GetEndorsedEvidence` including arguments and variables

These names conflict with the DICE Attestation #4074, therefore the renaming is necessary.