### PR TITLE
Improve shutdown behaviour in oak_functions_containers_launcher

### DIFF
--- a/oak_containers_launcher/src/qemu.rs
+++ b/oak_containers_launcher/src/qemu.rs
@@ -99,7 +99,7 @@ impl Qemu {
     pub fn start(params: Params, launcher_service_port: u16, host_proxy_port: u16) -> Result<Self> {
         let mut cmd = tokio::process::Command::new(params.vmm_binary);
         let (guest_socket, host_socket) = UnixStream::pair()?;
-
+        cmd.kill_on_drop(true);
         cmd.stderr(Stdio::inherit());
         cmd.stdin(Stdio::null());
         cmd.stdout(Stdio::inherit());

--- a/oak_containers_syslogd/src/main.rs
+++ b/oak_containers_syslogd/src/main.rs
@@ -22,6 +22,7 @@ mod systemd_journal;
 use anyhow::anyhow;
 use clap::Parser;
 use oak_containers_orchestrator_client::LauncherClient;
+use opentelemetry_api::global::set_error_handler;
 use signal_hook::consts::signal::SIGTERM;
 use signal_hook_tokio::Signals;
 use std::sync::Arc;
@@ -51,6 +52,8 @@ async fn signal_handler(mut signals: Signals, term: Arc<OnceCell<()>>) {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
+
+    set_error_handler(|err| eprintln!("oak-syslogd: OTLP error: {}", err))?;
 
     let term = Arc::new(OnceCell::new());
     let launcher_client = LauncherClient::create(args.launcher_addr.parse()?)

--- a/oak_functions_containers_launcher/src/lib.rs
+++ b/oak_functions_containers_launcher/src/lib.rs
@@ -32,8 +32,8 @@ use tokio::time::Duration;
 use tonic::transport::Endpoint;
 
 pub struct UntrustedApp {
-    launcher: Launcher,
     oak_functions_client: GrpcOakFunctionsClient<tonic::transport::channel::Channel>,
+    launcher: Launcher,
 }
 
 impl UntrustedApp {


### PR DESCRIPTION
If there's ever a fault, right now the `oak_functions_containers_launcher` can hang, with the only symptom that something is going wrong being that the code in the enclave will complain that it can't send logs to the launcher.

This is because of the following sequence of events:

1. Something fails, like `untrusted.app_initialize_enclave()?` in the launcher
2. Because of the `?`, the control flow wants to return, which means in turn it starts cleaning up the stack, which means dropping the `untrusted_app` itself
3. In the `untrusted_app`, it starts dropping the launcher
4. In the launcher, the gRPC server is successfully shut down (and dropped), but dropping `qemu` fails as it's still running.

Net result: the launcher gRPC server is down, so nothing in the enclave can talk to the launcher, but the launcher is still alive as qemu hasn't terminated, which means we never see the error _why_ the launcher started to be torn down in the first place.

Here we try to alleviate it in several ways:

1. When the `Qemu` struct is dropped, just kill the qemu process itself. We know it won't terminate by itself.
2. In `oak_containers_syslogd`, if the OTLP RPC fails, say that the message is coming from syslogd to aid in debugging.
3. Shut down the client before trying to shut down the launcher.

Ref #4409 