### PR TITLE
Add Orchestrator Key Provisioning service definition

### DIFF
--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -43,22 +43,22 @@ message GetAttestationEvidenceResponse {
   oak.session.v1.AttestationEvidence evidence = 1;
 }
 
-message GetEncryptionKeyRequest {
+message GetProvisionSecretsRequest {
   // Endorsed evidence of the enclave that requests a new encryption key using Key Provisioning.
   // TODO(#4074): Replace with `oak.attestation.v1.EndorsedEvidence` once DICE is implemented.
   oak.session.v1.AttestationBundle endorsed_evidence = 1;
 }
 
-message GetEncryptionKeyResponse {
+message GetProvisionSecretsResponse {
   // Encryption private key that was encrypted with HPKE using the encryption public key provided
   // in the endorsed evidence.
-  bytes encrypted_encryption_key = 1;
+  oak.crypto.v1.EncryptedRequest encrypted_encryption_key = 1;
 }
 
-message SendEncryptionKeyRequest {
-  // New encryption private key that was encrypted with HPKE using enclave's old encryption key.
-  // The new encryption key will replace the old one.
-  bytes encrypted_encryption_key = 1;
+message SendProvisionSecretsRequest {
+  // Enclave group encryption private key that was encrypted with HPKE using enclave's encryption
+  // key.
+  oak.crypto.v1.EncryptedRequest encrypted_encryption_key = 1;
 }
 
 message GetCryptoContextRequest {
@@ -98,12 +98,12 @@ service Launcher {
 }
 
 // Defines the service exposed by the orchestrator, that can be invoked by the application.
-service ControlPlane {
-  // Request a new enclave encryption key as part of Key Provisioning.
-  rpc GetEncryptionKey(GetEncryptionKeyRequest) returns (GetEncryptionKeyResponse) {}
+service KeyProvisioning {
+  // Request provision secrets from for other enclaves as part of Key Provisioning.
+  rpc GetProvisionSecrets(GetProvisionSecretsRequest) returns (GetProvisionSecretsResponse) {}
 
-  // Replace old enclave encryption key with a new one as part of Key Provisioning.
-  rpc SendEncryptionKey(SendEncryptionKeyRequest) returns (google.protobuf.Empty) {}
+  // Send provision secrets to the enclave as part of Key Provisioning.
+  rpc SendProvisionSecrets(SendProvisionSecretsRequest) returns (google.protobuf.Empty) {}
 }
 
 // Defines the service exposed by the orchestrator, that can be invoked by the application.

--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -43,6 +43,24 @@ message GetAttestationEvidenceResponse {
   oak.session.v1.AttestationEvidence evidence = 1;
 }
 
+message GetEncryptionKeyRequest {
+  // Endorsed evidence of the enclave that requests a new encryption key using Key Provisioning.
+  // TODO(#4074): Replace with `oak.attestation.v1.EndorsedEvidence` once DICE is implemented.
+  oak.session.v1.AttestationBundle endorsed_evidence = 1;
+}
+
+message GetEncryptionKeyResponse {
+  // Encryption private key that was encrypted with HPKE using the encryption public key provided
+  // in the endorsed evidence.
+  bytes encrypted_encryption_key = 1;
+}
+
+message SendEncryptionKeyRequest {
+  // New encryption private key that was encrypted with HPKE using enclave's old encryption key.
+  // The new encryption key will replace the old one.
+  bytes encrypted_encryption_key = 1;
+}
+
 message GetCryptoContextRequest {
   // Ephemeral Diffie-Hellman client public key that is needed to derive a session key.
   bytes serialized_encapsulated_public_key = 1;
@@ -77,6 +95,15 @@ service Launcher {
   // Notifies the launcher that the trusted app is ready to serve requests and listening on the
   // pre-arranged port (8080).
   rpc NotifyAppReady(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+}
+
+// Defines the service exposed by the orchestrator, that can be invoked by the application.
+service ControlPlane {
+  // Request a new enclave encryption key as part of Key Provisioning.
+  rpc GetEncryptionKey(GetEncryptionKeyRequest) returns (GetEncryptionKeyResponse) {}
+
+  // Replace old enclave encryption key with a new one as part of Key Provisioning.
+  rpc SendEncryptionKey(SendEncryptionKeyRequest) returns (google.protobuf.Empty) {}
 }
 
 // Defines the service exposed by the orchestrator, that can be invoked by the application.

--- a/oak_containers_orchestrator/src/control_plane.rs
+++ b/oak_containers_orchestrator/src/control_plane.rs
@@ -1,0 +1,41 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::proto::oak::containers::{
+    control_plane_server::ControlPlane, GetEncryptionKeyRequest, GetEncryptionKeyResponse,
+    SendEncryptionKeyRequest,
+};
+use tonic::{Request, Response};
+
+struct ControlPlaneImplementation {}
+
+#[tonic::async_trait]
+impl ControlPlane for ControlPlaneImplementation {
+    async fn get_encryption_key(
+        &self,
+        _request: Request<GetEncryptionKeyRequest>,
+    ) -> Result<Response<GetEncryptionKeyResponse>, tonic::Status> {
+        Ok(tonic::Response::new(GetEncryptionKeyResponse {
+            encrypted_encryption_key: vec![],
+        }))
+    }
+
+    async fn send_encryption_key(
+        &self,
+        _request: Request<SendEncryptionKeyRequest>,
+    ) -> Result<Response<()>, tonic::Status> {
+        Ok(tonic::Response::new(()))
+    }
+}

--- a/oak_containers_orchestrator/src/key_provisioning.rs
+++ b/oak_containers_orchestrator/src/key_provisioning.rs
@@ -14,27 +14,27 @@
 // limitations under the License.
 
 use crate::proto::oak::containers::{
-    control_plane_server::ControlPlane, GetEncryptionKeyRequest, GetEncryptionKeyResponse,
-    SendEncryptionKeyRequest,
+    key_provisioning_server::KeyProvisioning, GetProvisionSecretsRequest,
+    GetProvisionSecretsResponse, SendProvisionSecretsRequest,
 };
 use tonic::{Request, Response};
 
-struct ControlPlaneImplementation {}
+struct KeyProvisioningService {}
 
 #[tonic::async_trait]
-impl ControlPlane for ControlPlaneImplementation {
-    async fn get_encryption_key(
+impl KeyProvisioning for KeyProvisioningService {
+    async fn get_provision_secrets(
         &self,
-        _request: Request<GetEncryptionKeyRequest>,
-    ) -> Result<Response<GetEncryptionKeyResponse>, tonic::Status> {
-        Ok(tonic::Response::new(GetEncryptionKeyResponse {
-            encrypted_encryption_key: vec![],
+        _request: Request<GetProvisionSecretsRequest>,
+    ) -> Result<Response<GetProvisionSecretsResponse>, tonic::Status> {
+        Ok(tonic::Response::new(GetProvisionSecretsResponse {
+            encrypted_encryption_key: None,
         }))
     }
 
-    async fn send_encryption_key(
+    async fn send_provision_secrets(
         &self,
-        _request: Request<SendEncryptionKeyRequest>,
+        _request: Request<SendProvisionSecretsRequest>,
     ) -> Result<Response<()>, tonic::Status> {
         Ok(tonic::Response::new(()))
     }

--- a/oak_containers_orchestrator/src/lib.rs
+++ b/oak_containers_orchestrator/src/lib.rs
@@ -25,7 +25,7 @@ mod proto {
 }
 
 pub mod container_runtime;
-pub mod control_plane;
 pub mod ipc_server;
+pub mod key_provisioning;
 pub mod logging;
 pub mod metrics;

--- a/oak_containers_orchestrator/src/lib.rs
+++ b/oak_containers_orchestrator/src/lib.rs
@@ -25,6 +25,7 @@ mod proto {
 }
 
 pub mod container_runtime;
+pub mod control_plane;
 pub mod ipc_server;
 pub mod logging;
 pub mod metrics;


### PR DESCRIPTION
This PR adds a Key Provisioning service definition for communication from the Hostlib to the Orchestrator.

Ref https://github.com/project-oak/oak/issues/4442