### PR TITLE
Add explicit crypto proto messages to Oak Clients

### DIFF
--- a/cc/transport/grpc_streaming_transport.cc
+++ b/cc/transport/grpc_streaming_transport.cc
@@ -69,7 +69,8 @@ absl::StatusOr<EncryptedResponse> GrpcStreamingTransport::Invoke(
     const EncryptedRequest& encrypted_request) {
   // Create request.
   RequestWrapper request;
-  // TODO(#4037): Use explicit crypto protos.
+  *request.mutable_invoke_request()->mutable_encrypted_request() = encrypted_request;
+  // TODO(#4037): Remove once explicit crypto protos are implemented.
   std::string encrypted_body;
   if (!encrypted_request.SerializeToString(&encrypted_body)) {
     return absl::InternalError("couldn't serialize encrypted request");

--- a/java/src/main/java/com/google/oak/server/EncryptedStreamObserver.java
+++ b/java/src/main/java/com/google/oak/server/EncryptedStreamObserver.java
@@ -150,11 +150,13 @@ public final class EncryptedStreamObserver<I, O> implements StreamObserver<Reque
       Result<EncryptedResponse, Exception> encryptedResponse =
           encryptor.encrypt(connectionAdapter.serialize(response), decrypted.associatedData);
 
-      // TODO(#4037): Use explicit crypto protos.
       return encryptedResponse.map(encrypted -> {
         InvokeResponse invokeResponse =
-            InvokeResponse.newBuilder()
+            InvokeResponse
+                .newBuilder()
+                // TODO(#4037): Remove once explicit crypto protos are implemented.
                 .setEncryptedBody(ByteString.copyFrom(encrypted.toByteArray()))
+                .setEncryptedResponse(encrypted)
                 .build();
         return ResponseWrapper.newBuilder().setInvokeResponse(invokeResponse).build();
       });

--- a/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
+++ b/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
@@ -100,11 +100,14 @@ public class GrpcStreamingTransport implements EvidenceProvider, Transport {
    */
   @Override
   public Result<EncryptedResponse, String> invoke(EncryptedRequest encryptedRequest) {
-    // TODO(#4037): Use explicit crypto protos.
     RequestWrapper requestWrapper =
         RequestWrapper.newBuilder()
-            .setInvokeRequest(InvokeRequest.newBuilder().setEncryptedBody(
-                ByteString.copyFrom(encryptedRequest.toByteArray())))
+            .setInvokeRequest(
+                InvokeRequest
+                    .newBuilder()
+                    // TODO(#4037): Remove once explicit crypto protos are implemented.
+                    .setEncryptedBody(ByteString.copyFrom(encryptedRequest.toByteArray()))
+                    .setEncryptedRequest(encryptedRequest))
             .build();
     logger.log(Level.INFO, "sending invoke request: " + requestWrapper);
     this.requestObserver.onNext(requestWrapper);

--- a/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
+++ b/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
@@ -66,11 +66,15 @@ public class GrpcStreamingTransportTest {
           responseObserver.onNext(responseWrapper);
           break;
         case INVOKE_REQUEST:
-          // TODO(#4037): Use explicit crypto protos.
-          responseWrapper = ResponseWrapper.newBuilder()
-                                .setInvokeResponse(InvokeResponse.newBuilder().setEncryptedBody(
-                                    ByteString.copyFrom(new byte[0])))
-                                .build();
+          responseWrapper =
+              ResponseWrapper.newBuilder()
+                  .setInvokeResponse(
+                      InvokeResponse
+                          .newBuilder()
+                          // TODO(#4037): Remove once explicit crypto protos are implemented.
+                          .setEncryptedBody(ByteString.copyFrom(new byte[0]))
+                          .setEncryptedResponse(EncryptedResponse.getDefaultInstance()))
+                  .build();
           responseObserver.onNext(responseWrapper);
           break;
         case REQUEST_NOT_SET:

--- a/oak_client/src/transport.rs
+++ b/oak_client/src/transport.rs
@@ -47,7 +47,7 @@ impl Transport for GrpcStreamingTransport {
         &mut self,
         encrypted_request: &EncryptedRequest,
     ) -> anyhow::Result<EncryptedResponse> {
-        // TODO(#4037): Use explicit crypto protos.
+        // TODO(#4037): Remove once explicit crypto protos are implemented.
         let mut serialized_request = vec![];
         encrypted_request
             .encode(&mut serialized_request)
@@ -57,10 +57,9 @@ impl Transport for GrpcStreamingTransport {
             .rpc_client
             .stream(futures_util::stream::iter(vec![RequestWrapper {
                 request: Some(request_wrapper::Request::InvokeRequest(InvokeRequest {
-                    // TODO(#4037): Remove once explicit protos are used end-to-end.
+                    // TODO(#4037): Remove once explicit crypto protos are implemented.
                     encrypted_body: serialized_request,
-                    // TODO(#4037): Use explicit crypto protos.
-                    encrypted_request: None,
+                    encrypted_request: Some(encrypted_request.clone()),
                 })),
             }]))
             .await


### PR DESCRIPTION
This PR adds explicit `oak_crypto` messages to Oak Rust, C++ and Java clients.

This PR is split from the original PR: https://github.com/project-oak/oak/pull/4386

Ref https://github.com/project-oak/oak/issues/4037