### PR TITLE
Add explicit crypto proto messages to Oak Enclaves

### DIFF
--- a/oak_functions_containers_launcher/src/server.rs
+++ b/oak_functions_containers_launcher/src/server.rs
@@ -86,8 +86,7 @@ impl StreamingSession for SessionProxy {
                         let enclave_invoke_request = InvokeRequest {
                             // TODO(#4037): Remove once explicit protos are used end-to-end.
                             body: invoke_request.encrypted_body,
-                            // TODO(#4037): Use explicit crypto protos.
-                            encrypted_request: None,
+                            encrypted_request: invoke_request.encrypted_request,
                         };
                         let enclave_invoke_response = connector_handle
                             .handle_user_request(enclave_invoke_request)
@@ -98,8 +97,7 @@ impl StreamingSession for SessionProxy {
                         response_wrapper::Response::InvokeResponse(InvokeResponse {
                             // TODO(#4037): Remove once explicit protos are used end-to-end.
                             encrypted_body: enclave_invoke_response.body,
-                            // TODO(#4037): Use explicit crypto protos.
-                            encrypted_response: None,
+                            encrypted_response: enclave_invoke_response.encrypted_response,
                         })
                     }
                 };

--- a/oak_functions_launcher/benches/integration_benches.rs
+++ b/oak_functions_launcher/benches/integration_benches.rs
@@ -117,7 +117,7 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
     let invoke_request = InvokeRequest {
         // TODO(#4037): Remove once explicit protos are used end-to-end.
         body: encrypted_request.encode_to_vec(),
-        encrypted_request,
+        encrypted_request: Some(encrypted_request),
     };
 
     // Invoke the function once outside of the benchmark loop to make sure it's ready.

--- a/oak_functions_launcher/benches/integration_benches.rs
+++ b/oak_functions_launcher/benches/integration_benches.rs
@@ -130,8 +130,7 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
         assert!(response.is_ok());
 
         // Only check this outside of the benchmark loop.
-        let encrypted_response =
-            EncryptedResponse::decode(response.unwrap().body.as_ref()).unwrap();
+        let encrypted_response = response.unwrap().encrypted_response.unwrap();
         let (decrypted_response, _authenticated_data) = client_encryptor
             .decrypt(&encrypted_response)
             .expect("could not decrypt response");

--- a/oak_functions_launcher/benches/integration_benches.rs
+++ b/oak_functions_launcher/benches/integration_benches.rs
@@ -19,7 +19,7 @@
 
 extern crate test;
 
-use oak_crypto::{encryptor::ClientEncryptor, proto::oak::crypto::v1::EncryptedResponse};
+use oak_crypto::encryptor::ClientEncryptor;
 use oak_functions_launcher::{
     proto::oak::functions::{InvokeRequest, OakFunctionsAsyncClient},
     LookupDataConfig,

--- a/oak_functions_launcher/benches/integration_benches.rs
+++ b/oak_functions_launcher/benches/integration_benches.rs
@@ -117,8 +117,7 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
     let invoke_request = InvokeRequest {
         // TODO(#4037): Remove once explicit protos are used end-to-end.
         body: encrypted_request.encode_to_vec(),
-        // TODO(#4037): Use explicit crypto protos.
-        encrypted_request: None,
+        encrypted_request,
     };
 
     // Invoke the function once outside of the benchmark loop to make sure it's ready.

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -86,8 +86,7 @@ impl StreamingSession for SessionProxy {
                         let enclave_invoke_request = functions::InvokeRequest {
                             // TODO(#4037): Remove once explicit protos are used end-to-end.
                             body: invoke_request.encrypted_body,
-                            // TODO(#4037): Use explicit crypto protos.
-                            encrypted_request: None,
+                            encrypted_request: invoke_request.encrypted_request,
                         };
                         let mut enclave_client =
                             functions::OakFunctionsAsyncClient::new(connector_handle.clone());
@@ -101,8 +100,7 @@ impl StreamingSession for SessionProxy {
                         response_wrapper::Response::InvokeResponse(InvokeResponse {
                             // TODO(#4037): Remove once explicit protos are used end-to-end.
                             encrypted_body: enclave_invoke_response.body,
-                            // TODO(#4037): Use explicit crypto protos.
-                            encrypted_response: None,
+                            encrypted_response: enclave_invoke_response.encrypted_response,
                         })
                     }
                 };

--- a/oak_functions_service/tests/integration_test.rs
+++ b/oak_functions_service/tests/integration_test.rs
@@ -21,7 +21,7 @@ extern crate alloc;
 
 use benchmark::proto::{benchmark_request::Action, BenchmarkRequest, EchoAndPanicTest};
 use core::assert_matches::assert_matches;
-use oak_crypto::{encryptor::ClientEncryptor, proto::oak::crypto::v1::EncryptedResponse};
+use oak_crypto::{encryptor::ClientEncryptor, proto::oak::crypto::v1::EncryptedRequest};
 use oak_functions_service::{
     proto::oak::functions::{
         ExtendNextLookupDataRequest, FinishNextLookupDataRequest, InitializeRequest, InvokeRequest,
@@ -54,9 +54,8 @@ fn it_should_not_handle_user_requests_before_initialization() {
 
     let request = InvokeRequest {
         // TODO(#4037): Remove once explicit protos are used end-to-end.
-        body: vec![1, 2, 3],
-        // TODO(#4037): Use explicit crypto protos.
-        encrypted_request: None,
+        body: vec![],
+        encrypted_request: Some(EncryptedRequest::default()),
     };
     let result = client.handle_user_request(&request).into_ok();
 
@@ -95,6 +94,7 @@ fn it_should_handle_user_requests_after_initialization() {
         .encrypt(&[1, 2, 3], EMPTY_ASSOCIATED_DATA)
         .expect("couldn't encrypt request");
 
+    // TODO(#4037): Remove once explicit protos are used end-to-end.
     // Serialize request.
     let mut serialized_request = vec![];
     encrypted_request
@@ -105,8 +105,7 @@ fn it_should_handle_user_requests_after_initialization() {
     let invoke_request = InvokeRequest {
         // TODO(#4037): Remove once explicit protos are used end-to-end.
         body: serialized_request,
-        // TODO(#4037): Use explicit crypto protos.
-        encrypted_request: None,
+        encrypted_request: Some(encrypted_request),
     };
     let result = client.handle_user_request(&invoke_request).into_ok();
     assert!(result.is_ok());
@@ -165,6 +164,7 @@ async fn it_should_error_on_invalid_wasm_module() {
         .encrypt(LOOKUP_TEST_KEY, EMPTY_ASSOCIATED_DATA)
         .expect("couldn't encrypt request");
 
+    // TODO(#4037): Remove once explicit protos are used end-to-end.
     // Serialize request.
     let mut serialized_request = vec![];
     encrypted_request
@@ -176,16 +176,14 @@ async fn it_should_error_on_invalid_wasm_module() {
         .handle_user_request(&InvokeRequest {
             // TODO(#4037): Remove once explicit protos are used end-to-end.
             body: serialized_request,
-            // TODO(#4037): Use explicit crypto protos.
-            encrypted_request: None,
+            encrypted_request: Some(encrypted_request),
         })
         .expect("couldn't receive response");
     assert!(lookup_response.is_ok());
-    let serialized_response = lookup_response.unwrap().body;
-
-    // Deserialize response.
-    let encrypted_response = EncryptedResponse::decode(serialized_response.as_ref())
-        .expect("couldn't deserialize response");
+    let encrypted_response = lookup_response
+        .unwrap()
+        .encrypted_response
+        .expect("no encrypted response provided");
 
     // Decrypt response.
     let (response_bytes, _) = client_encryptor
@@ -259,6 +257,7 @@ async fn it_should_support_lookup_data() {
         .encrypt(LOOKUP_TEST_KEY, EMPTY_ASSOCIATED_DATA)
         .expect("couldn't encrypt request");
 
+    // TODO(#4037): Remove once explicit protos are used end-to-end.
     // Serialize request.
     let mut serialized_request = vec![];
     encrypted_request
@@ -270,16 +269,14 @@ async fn it_should_support_lookup_data() {
         .handle_user_request(&InvokeRequest {
             // TODO(#4037): Remove once explicit protos are used end-to-end.
             body: serialized_request,
-            // TODO(#4037): Use explicit crypto protos.
-            encrypted_request: None,
+            encrypted_request: Some(encrypted_request),
         })
         .expect("couldn't receive response");
     assert!(lookup_response.is_ok());
-    let serialized_response = lookup_response.unwrap().body;
-
-    // Deserialize response.
-    let encrypted_response = EncryptedResponse::decode(serialized_response.as_ref())
-        .expect("couldn't deserialize response");
+    let encrypted_response = lookup_response
+        .unwrap()
+        .encrypted_response
+        .expect("no encrypted response provided");
 
     // Decrypt response.
     let (response_bytes, _) = client_encryptor
@@ -338,6 +335,7 @@ async fn it_should_handle_wasm_panic() {
         .encrypt(&request.encode_to_vec(), EMPTY_ASSOCIATED_DATA)
         .expect("couldn't encrypt request");
 
+    // TODO(#4037): Remove once explicit protos are used end-to-end.
     // Serialize request.
     let mut serialized_request = vec![];
     encrypted_request
@@ -349,16 +347,14 @@ async fn it_should_handle_wasm_panic() {
         .handle_user_request(&InvokeRequest {
             // TODO(#4037): Remove once explicit protos are used end-to-end.
             body: serialized_request,
-            // TODO(#4037): Use explicit crypto protos.
-            encrypted_request: None,
+            encrypted_request: Some(encrypted_request),
         })
         .expect("couldn't receive response");
     assert!(lookup_response.is_ok());
-    let serialized_response = lookup_response.unwrap().body;
-
-    // Deserialize response.
-    let encrypted_response = EncryptedResponse::decode(serialized_response.as_ref())
-        .expect("couldn't deserialize response");
+    let encrypted_response = lookup_response
+        .unwrap()
+        .encrypted_response
+        .expect("no encrypted response provided");
 
     // Decrypt response.
     let (response_bytes, _) = client_encryptor


### PR DESCRIPTION
This PR adds explicit `oak_crypto` messages to Oak Rust enclaves.

This PR is split from the original PR: https://github.com/project-oak/oak/pull/4386

Ref https://github.com/project-oak/oak/issues/4037