### PR TITLE
Port basic integration tests to Oak Functions Containers launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,7 +971,7 @@ checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "windows-sys 0.48.0",
 ]
 
@@ -2183,12 +2183,15 @@ dependencies = [
  "oak_containers_launcher",
  "oak_crypto",
  "oak_functions_abi",
+ "oak_functions_client",
  "oak_functions_launcher",
+ "oak_functions_test_utils",
  "oak_grpc_utils",
  "prost",
  "tokio",
  "tonic",
  "ubyte",
+ "xtask",
 ]
 
 [[package]]
@@ -2688,6 +2691,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "smallvec",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,6 +3054,15 @@ name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -3739,7 +3774,7 @@ checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "rustix",
  "windows-sys 0.42.0",
 ]
@@ -3815,6 +3850,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/kokoro/run_tests.sh
+++ b/kokoro/run_tests.sh
@@ -15,7 +15,7 @@ export XDG_RUNTIME_DIR=/var/run
 cd "$(dirname "$0")/.."
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#ci --command just kokoro_run_tests
+./scripts/docker_run nix develop .#default --command just kokoro_run_tests
 
 mkdir -p "$KOKORO_ARTIFACTS_DIR/test_logs/"
 cp ./target/nextest/default/*.xml "$KOKORO_ARTIFACTS_DIR/test_logs/" || true

--- a/oak_functions_containers_launcher/Cargo.toml
+++ b/oak_functions_containers_launcher/Cargo.toml
@@ -22,3 +22,8 @@ prost = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tonic = { workspace = true }
 ubyte = "*"
+
+[dev-dependencies]
+oak_functions_client = { workspace = true }
+oak_functions_test_utils = { workspace = true }
+xtask = { workspace = true }

--- a/oak_functions_containers_launcher/src/main.rs
+++ b/oak_functions_containers_launcher/src/main.rs
@@ -39,8 +39,8 @@ async fn main() -> Result<(), anyhow::Error> {
         lookup_data_path: args.functions_args.lookup_data,
         // Hard-coded because we are not sure whether we want to configure the update interval.
         update_interval: Some(std::time::Duration::from_secs(60 * 10)),
-        // Fix the maximum size of a chunk to the proto limit size of 2 GiB.
-        max_chunk_size: ByteUnit::Gibibyte(2),
+        // gRPC messages are limited to 4 MiB.
+        max_chunk_size: ByteUnit::Mebibyte(4),
     };
 
     let mut untrusted_app =

--- a/oak_functions_containers_launcher/tests/integration_test.rs
+++ b/oak_functions_containers_launcher/tests/integration_test.rs
@@ -1,0 +1,151 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the Oak Functions Launcher.
+
+use oak_functions_client::OakFunctionsClient;
+use std::time::Duration;
+use xtask::{launcher::MOCK_LOOKUP_DATA_PATH, workspace_path};
+
+// Allow enough worker threads to collect output from background tasks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_launcher_key_value_lookup() {
+    if xtask::testing::skip_test() {
+        log::info!("skipping test");
+        return;
+    }
+
+    let wasm_path = oak_functions_test_utils::build_rust_crate_wasm("key_value_lookup")
+        .expect("Failed to build Wasm module");
+
+    let (mut _background, port) = xtask::containers::run_oak_functions_example_in_background(
+        &wasm_path,
+        MOCK_LOOKUP_DATA_PATH.to_str().unwrap(),
+    )
+    .await;
+
+    // Wait for the server to start up.
+    tokio::time::sleep(Duration::from_secs(60)).await;
+
+    let mut client = OakFunctionsClient::new(&format!("http://localhost:{port}"))
+        .await
+        .expect("failed to create client");
+
+    let response = client.invoke(b"test_key").await.expect("failed to invoke");
+    assert_eq!(response, b"test_value");
+}
+
+// Allow enough worker threads to collect output from background tasks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_launcher_echo() {
+    if xtask::testing::skip_test() {
+        log::info!("skipping test");
+        return;
+    }
+
+    let wasm_path = oak_functions_test_utils::build_rust_crate_wasm("echo")
+        .expect("Failed to build Wasm module");
+
+    let (_background, port) = xtask::containers::run_oak_functions_example_in_background(
+        &wasm_path,
+        MOCK_LOOKUP_DATA_PATH.to_str().unwrap(),
+    )
+    .await;
+
+    // Wait for the server to start up.
+    tokio::time::sleep(Duration::from_secs(60)).await;
+
+    let mut client = OakFunctionsClient::new(&format!("http://localhost:{port}"))
+        .await
+        .expect("failed to create client");
+
+    let response = client.invoke(b"xxxyyyzzz").await.expect("failed to invoke");
+    assert_eq!(std::str::from_utf8(&response).unwrap(), "xxxyyyzzz");
+}
+
+// Allow enough worker threads to collect output from background tasks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_launcher_weather_lookup() {
+    if xtask::testing::skip_test() {
+        log::info!("skipping test");
+        return;
+    }
+
+    let wasm_path = oak_functions_test_utils::build_rust_crate_wasm("weather_lookup")
+        .expect("Failed to build Wasm module");
+
+    let (_background, port) = xtask::containers::run_oak_functions_example_in_background(
+        &wasm_path,
+        workspace_path(&[
+            "oak_functions",
+            "examples",
+            "weather_lookup",
+            "testdata",
+            "lookup_data_weather_sparse_s2",
+        ])
+        .to_str()
+        .unwrap(),
+    )
+    .await;
+
+    // Wait for the server to start up.
+    tokio::time::sleep(Duration::from_secs(120)).await;
+
+    let mut client = OakFunctionsClient::new(&format!("http://localhost:{port}"))
+        .await
+        .expect("failed to create client");
+
+    let response = client
+        .invoke(br#"{"lat":0,"lng":0}"#)
+        .await
+        .expect("failed to invoke");
+    assert_eq!(
+        std::str::from_utf8(&response).unwrap(),
+        r#"{"temperature_degrees_celsius":29}"#
+    );
+
+    // TODO(#4177): Check response in the integration test.
+    // Run Java client via Bazel.
+    let status = tokio::process::Command::new("bazel")
+        .arg("run")
+        .arg("//java/src/main/java/com/google/oak/client/weather_lookup_client")
+        .arg("--")
+        .arg(format!("http://localhost:{port}"))
+        .current_dir(workspace_path(&[]))
+        .spawn()
+        .expect("failed to spawn bazel")
+        .wait()
+        .await
+        .expect("failed to wait for bazel");
+    eprintln!("bazel status: {:?}", status);
+    assert!(status.success());
+
+    // TODO(#4177): Check response in the integration test.
+    // Run C++ client via Bazel.
+    let status = tokio::process::Command::new("bazel")
+        .arg("run")
+        .arg("//cc/client:cli")
+        .arg("--")
+        .arg(format!("--address=localhost:{port}"))
+        .arg("--request={\"lat\":0,\"lng\":0}")
+        .current_dir(workspace_path(&[]))
+        .spawn()
+        .expect("failed to spawn bazel")
+        .wait()
+        .await
+        .expect("failed to wait for bazel");
+    eprintln!("bazel status: {:?}", status);
+    assert!(status.success());
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "*", features = [
   "fs",
   "io-util",
   "macros",
+  "parking_lot",
   "process",
   "rt-multi-thread",
   "signal",

--- a/xtask/src/containers.rs
+++ b/xtask/src/containers.rs
@@ -1,0 +1,167 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::{
+    internal::{Cmd, Runnable, Step},
+    workspace_path,
+};
+
+fn build_kernel() -> Step {
+    Step::Single {
+        name: "build kernel".to_string(),
+        command: Cmd::new("just", vec!["oak_containers_kernel"]),
+    }
+}
+
+fn build_stage1() -> Step {
+    Step::Single {
+        name: "build stage1".to_string(),
+        command: Cmd::new("just", vec!["stage1_cpio"]),
+    }
+}
+
+fn build_system_image() -> Step {
+    Step::Single {
+        name: "build system image".to_string(),
+        command: Cmd::new("just", vec!["oak_containers_system_image"]),
+    }
+}
+
+fn build_oak_functions_bundle() -> Step {
+    Step::Single {
+        name: "build Oak Functions bundle".to_string(),
+        command: Cmd::new(
+            "just",
+            vec!["oak_functions_containers_container_bundle_tar"],
+        ),
+    }
+}
+
+fn build_oak_functions_launcher() -> Step {
+    Step::Single {
+        name: "build Oak Functions bundle".to_string(),
+        command: Cmd::new("just", vec!["oak_functions_containers_launcher"]),
+    }
+}
+
+async fn build_prerequisites() {
+    // `just` steps can clash with each other, so ensure that we're not trying to build things like
+    // the system image concurrently.
+    static BUILD: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+    BUILD
+        .get_or_init(async || {
+            tokio::join!(
+                crate::testing::run_step(crate::launcher::build_stage0()),
+                crate::testing::run_step(build_kernel()),
+                crate::testing::run_step(build_stage1()),
+                crate::testing::run_step(build_system_image()),
+                crate::testing::run_step(build_oak_functions_bundle()),
+                crate::testing::run_step(build_oak_functions_launcher())
+            );
+        })
+        .await;
+}
+
+pub fn run_oak_functions_launcher_example_with_lookup_data(
+    wasm_path: &str,
+    port: u16,
+    lookup_data_path: &str,
+) -> Box<dyn Runnable> {
+    let args = vec![
+        format!(
+            "--vmm-binary={}",
+            which::which("qemu-system-x86_64")
+                .unwrap()
+                .to_str()
+                .unwrap()
+        ),
+        format!(
+            "--stage0-binary={}",
+            workspace_path(&[
+                "stage0_bin",
+                "target",
+                "x86_64-unknown-none",
+                "release",
+                "oak_stage0.bin",
+            ])
+            .to_str()
+            .unwrap()
+        ),
+        format!(
+            "--kernel={}",
+            workspace_path(&["oak_containers_kernel", "target", "bzImage"])
+                .to_str()
+                .unwrap()
+        ),
+        format!(
+            "--initrd={}",
+            workspace_path(&["target", "stage1.cpio"]).to_str().unwrap()
+        ),
+        format!(
+            "--system-image={}",
+            workspace_path(&["oak_containers_system_image", "target", "image.tar.xz"])
+                .to_str()
+                .unwrap()
+        ),
+        format!(
+            "--container-bundle={}",
+            workspace_path(&[
+                "oak_functions_containers_container",
+                "target",
+                "oak_functions_container_oci_filesystem_bundle.tar",
+            ])
+            .to_str()
+            .unwrap()
+        ),
+        format!("--ramdrive-size={}", "1000000"), // 1 GiB in KiB
+        format!("--memory-size={}", "2G"),
+        format!("--wasm={}", wasm_path),
+        format!("--port={}", port),
+        format!("--lookup-data={}", lookup_data_path),
+    ];
+    Cmd::new(
+        workspace_path(&[
+            "target",
+            "x86_64-unknown-linux-gnu",
+            "release",
+            "oak_functions_containers_launcher",
+        ])
+        .to_str()
+        .unwrap(),
+        args,
+    )
+}
+
+/// Runs the specified example as a background task. Returns a reference to the running server and
+/// the port on which the server is listening.
+pub async fn run_oak_functions_example_in_background(
+    wasm_path: &str,
+    lookup_data_path: &str,
+) -> (crate::testing::BackgroundStep, u16) {
+    build_prerequisites().await;
+
+    eprintln!("using Wasm module {}", wasm_path);
+
+    let port = portpicker::pick_unused_port().expect("failed to pick a port");
+    eprintln!("using port {}", port);
+
+    let background = crate::testing::run_background(
+        run_oak_functions_launcher_example_with_lookup_data(wasm_path, port, lookup_data_path),
+    )
+    .await;
+
+    (background, port)
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -15,6 +15,7 @@
 //
 
 #![feature(const_fmt_arguments_new)]
+#![feature(async_closure)]
 
 use once_cell::sync::Lazy;
 use std::{path::PathBuf, sync::Mutex};
@@ -22,6 +23,7 @@ use std::{path::PathBuf, sync::Mutex};
 pub mod check_build_licenses;
 pub mod check_license;
 pub mod check_todo;
+pub mod containers;
 pub mod diffs;
 pub mod examples;
 pub mod files;


### PR DESCRIPTION
We now run the basic end-to-end tests that we do with plain Oak Functions with Oak Functions on Oak Containers as well.

As always, this could use a ton of cleaning up, but... the tests are there, and more importantly, they pass!

Ref #4409 