### PR TITLE
Micro-optimization: elide one copy of data when loading lookup data

### DIFF
--- a/oak_functions_service/src/lookup.rs
+++ b/oak_functions_service/src/lookup.rs
@@ -54,7 +54,7 @@ impl DataBuilder {
     ///
     /// Note, if new data contains a key already present in the existing data, calling extend
     /// overwrites the value.
-    fn extend(&mut self, new_data: Data) {
+    fn extend<T: IntoIterator<Item = (Vec<u8>, Vec<u8>)>>(&mut self, new_data: T) {
         self.state = BuilderState::Extending;
         self.data.extend(new_data);
     }
@@ -104,7 +104,7 @@ where
         test_manager
     }
 
-    pub fn extend_next_lookup_data(&self, new_data: Data) {
+    pub fn extend_next_lookup_data<T: IntoIterator<Item = (Vec<u8>, Vec<u8>)>>(&self, new_data: T) {
         info!("Start extending next lookup data");
         {
             let mut data_builder = self.data_builder.lock();


### PR DESCRIPTION
1. We start with the proto, iterate over field values in there, turn the result into a `HashMap` (via `collect()`)... only to then iterate over the same `HashMap` to merge data into the main hashmap inside `LookupDataManager`. This optimizes away the extra `HashMap` by just passing iterators around.
2. Get rid of the `unwrap()` in the `to_data()` function that can cause a crash, and instead return a proper RPC error if something is wrong.