### PR TITLE
Minor fix and optimization to wasm API

### DIFF
--- a/oak_functions_service/src/lookup.rs
+++ b/oak_functions_service/src/lookup.rs
@@ -123,8 +123,8 @@ where
             let next_data = data_builder.build();
             next_data_len = next_data.len();
             let mut data = self.data.lock();
-            *data = Arc::new(next_data);
             data_len = data.len();
+            *data = Arc::new(next_data);
         }
         info!(
             "Finished replacing lookup data with len {} by next lookup data with len {}",
@@ -198,6 +198,11 @@ where
     pub fn log_debug(&self, message: &str) {
         self.logger.log_sensitive(Level::Debug, message)
     }
+}
+
+/// Returns a slice covering up to the first `limit` elements of the given slice.
+pub fn limit<T>(slice: &[T], limit: usize) -> &[T] {
+    &slice[..limit.min(slice.len())]
 }
 
 /// Converts a binary sequence to a string if it is a valid UTF-8 string, or formats it as a numeric

--- a/oak_functions_service/src/wasm/api.rs
+++ b/oak_functions_service/src/wasm/api.rs
@@ -17,7 +17,7 @@
 use super::{WasmApi, WasmApiFactory};
 use crate::{
     logger::{OakLogger, StandaloneLogger},
-    lookup::{format_bytes, LookupData, LookupDataManager},
+    lookup::{format_bytes, limit, LookupData, LookupDataManager},
 };
 use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use log::Level;
@@ -100,25 +100,25 @@ impl StdWasmApi for StdWasmApiImpl {
             .log_sensitive(Level::Debug, "invoked lookup_data");
         // The request is the key to lookup.
         let key = request.key;
-        let key_to_log = key.iter().take(512).cloned().collect::<Vec<_>>();
+        let key_to_log = limit(&key, 512);
         self.logger.log_sensitive(
             Level::Debug,
-            &format!("storage_get_item(): key: {}", format_bytes(&key_to_log)),
+            &format!("storage_get_item(): key: {}", format_bytes(key_to_log)),
         );
         let value = self.lookup_data.get(&key);
 
         // Log found value.
-        value.clone().map_or_else(
+        value.as_ref().map_or_else(
             || {
                 self.logger
                     .log_sensitive(Level::Debug, "storage_get_item(): value not found");
             },
             |value| {
                 // Truncate value for logging.
-                let value_to_log = value.into_iter().take(512).collect::<Vec<_>>();
+                let value_to_log = limit(value, 512);
                 self.logger.log_sensitive(
                     Level::Debug,
-                    &format!("storage_get_item(): value: {}", format_bytes(&value_to_log)),
+                    &format!("storage_get_item(): value: {}", format_bytes(value_to_log)),
                 );
             },
         );


### PR DESCRIPTION
1) I think the message we printed when loading lookup data is wrong: we set `next_data_len` to be the size of the new lookup data, then proceed to update `data` , and _after that_ look up the size and say it's the old size. I don't think it is what it says it is.

2) in the wasm api when we log the lookup key and value, we truncate them to 512 bytes. Doing it via slices is simpler and elides a copy (because of `.collect()`).

(Note: I'm not seeking out these minor things on purpose, but rather I'm trying to understand how all of it fits together and while I'm in that file anyway I might as well fix some minor issues I see.)