### PR TITLE
Fix Stage 0 crashes on SEV-ES and SNP

### DIFF
--- a/stage0_bin/.cargo/config.toml
+++ b/stage0_bin/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
-rustflags = "-C relocation-model=static -C code-model=large"
+rustflags = "-C relocation-model=static -C code-model=large -C target-feature=+rdrand"
 
 [unstable]
 # We need to build std / core because of the code model. This may be removed if / when it's possible to build stage0 without it in the future.


### PR DESCRIPTION
Fixes #4460

It turns out the problem was with random number generation (generating a new dice key). If the `rdrand` compiler feature is not enabled it looks like the code does a CPUID call to check whether RDRAND is supported. Since we don't have a #VC handler in Stage 0 this crashes on SEV-ES and SEV-SNP.