### PR TITLE
Update `self_cell` to resolve `cargo-deny` error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c309e515543e67811222dbc9e3dd7e1056279b782e1dacffe4242b718734fb6"
+checksum = "e388332cd64eb80cd595a00941baf513caffae8dce9cfd0467fc9c66397dade6"
 
 [[package]]
 name = "semver"

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c309e515543e67811222dbc9e3dd7e1056279b782e1dacffe4242b718734fb6"
+checksum = "e388332cd64eb80cd595a00941baf513caffae8dce9cfd0467fc9c66397dade6"
 
 [[package]]
 name = "serde"


### PR DESCRIPTION
The version of `self_cell` that we have been using has been yanked, so updating it to resolve a new `cargo-deny` failure.