### PR TITLE
Add Orchestrator encryption key generation in Oak Functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,7 @@ name = "oak_functions_containers_app"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "micro_rpc",
  "oak_crypto",
  "oak_functions_service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,6 +1888,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
+ "async-trait",
  "bytes",
  "oak_crypto",
  "oak_grpc_utils",

--- a/oak_containers_hello_world_trusted_app/Cargo.toml
+++ b/oak_containers_hello_world_trusted_app/Cargo.toml
@@ -10,6 +10,7 @@ oak_grpc_utils = { workspace = true }
 
 [dependencies]
 anyhow = "*"
+async-trait = { version = "*", default-features = false }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
 prost = "*"

--- a/oak_containers_hello_world_trusted_app/src/app_service.rs
+++ b/oak_containers_hello_world_trusted_app/src/app_service.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 use anyhow::anyhow;
-use oak_crypto::{encryptor::ServerEncryptor, hpke::RecipientContext};
+use oak_crypto::{encryptor::AsyncServerEncryptor, hpke::RecipientContext};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 
@@ -52,32 +52,12 @@ impl TrustedApplication for TrustedApplicationImplementation {
             .encrypted_request
             .ok_or(tonic::Status::internal("encrypted request wasn't provided"))?;
 
-        // Initialize server encryptor.
-        let serialized_encapsulated_public_key = encrypted_request
-            .serialized_encapsulated_public_key
-            .as_ref()
-            .ok_or(tonic::Status::invalid_argument(
-                "initial request message doesn't contain encapsulated public key",
-            ))?;
-        let serialized_crypto_context = self
-            .orchestrator_client
-            .get_crypto_context(serialized_encapsulated_public_key)
-            .await
-            .map_err(|error| {
-                tonic::Status::internal(format!(
-                    "couldn't get crypto context from the Orchestrator: {:?}",
-                    error
-                ))
-            })?;
-        let crypto_context =
-            RecipientContext::deserialize(serialized_crypto_context).map_err(|error| {
-                tonic::Status::internal(format!("couldn't deserialize crypto context: {:?}", error))
-            })?;
-        let mut server_encryptor = ServerEncryptor::new(crypto_context);
+        let mut server_encryptor = AsyncServerEncryptor::new(&self.orchestrator_client);
 
         // Associated data is ignored.
         let (name_bytes, _) = server_encryptor
             .decrypt(&encrypted_request)
+            .await
             .map_err(|error| {
                 tonic::Status::internal(format!("couldn't decrypt request: {:?}", error))
             })?;

--- a/oak_containers_hello_world_trusted_app/src/app_service.rs
+++ b/oak_containers_hello_world_trusted_app/src/app_service.rs
@@ -57,12 +57,13 @@ impl TrustedApplication for TrustedApplicationImplementation {
         let mut server_encryptor = AsyncServerEncryptor::new(&orchestrator_client);
 
         // Associated data is ignored.
-        let (name_bytes, _) = server_encryptor
-            .decrypt(&encrypted_request)
-            .await
-            .map_err(|error| {
-                tonic::Status::internal(format!("couldn't decrypt request: {:?}", error))
-            })?;
+        let (name_bytes, _) =
+            server_encryptor
+                .decrypt(&encrypted_request)
+                .await
+                .map_err(|error| {
+                    tonic::Status::internal(format!("couldn't decrypt request: {:?}", error))
+                })?;
 
         let name = String::from_utf8(name_bytes)
             .map_err(|error| tonic::Status::internal(format!("name is not UTF-8: {:?}", error)))?;

--- a/oak_containers_hello_world_trusted_app/src/app_service.rs
+++ b/oak_containers_hello_world_trusted_app/src/app_service.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 use anyhow::anyhow;
-use oak_crypto::{encryptor::AsyncServerEncryptor, hpke::RecipientContext};
+use oak_crypto::encryptor::AsyncServerEncryptor;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 
@@ -52,7 +52,9 @@ impl TrustedApplication for TrustedApplicationImplementation {
             .encrypted_request
             .ok_or(tonic::Status::internal("encrypted request wasn't provided"))?;
 
-        let mut server_encryptor = AsyncServerEncryptor::new(&self.orchestrator_client);
+        // TODO(#4477): Remove unnecessary copies of the Orchestrator client.
+        let orchestrator_client = self.orchestrator_client.clone();
+        let mut server_encryptor = AsyncServerEncryptor::new(&orchestrator_client);
 
         // Associated data is ignored.
         let (name_bytes, _) = server_encryptor

--- a/oak_containers_hello_world_trusted_app/src/app_service.rs
+++ b/oak_containers_hello_world_trusted_app/src/app_service.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use oak_crypto::{encryptor::ServerEncryptor, hpke::RecipientContext};
+use oak_remote_attestation::handler::AsyncEncryptionHandler;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 

--- a/oak_containers_hello_world_trusted_app/src/app_service.rs
+++ b/oak_containers_hello_world_trusted_app/src/app_service.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 use anyhow::anyhow;
 use oak_crypto::{encryptor::ServerEncryptor, hpke::RecipientContext};
-use oak_remote_attestation::handler::AsyncEncryptionHandler;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 

--- a/oak_containers_hello_world_trusted_app/src/orchestrator_client.rs
+++ b/oak_containers_hello_world_trusted_app/src/orchestrator_client.rs
@@ -93,8 +93,9 @@ impl OrchestratorClient {
 }
 
 impl AsyncRecipientContextGenerator for OrchestratorClient {
-    async fn generate_recipient_context(&mut self, encapsulated_public_key: &[u8]) -> anyhow::Result<RecipientContext> {
+    async fn generate_recipient_context(&self, encapsulated_public_key: &[u8]) -> anyhow::Result<RecipientContext> {
         let serialized_crypto_context = self
+            .clone()
             .get_crypto_context(encapsulated_public_key)
             .await
             .map_err(|error| {

--- a/oak_containers_hello_world_trusted_app/src/orchestrator_client.rs
+++ b/oak_containers_hello_world_trusted_app/src/orchestrator_client.rs
@@ -42,6 +42,7 @@ pub struct OrchestratorClient {
     inner: GrpcOrchestratorClient<tonic::transport::channel::Channel>,
 }
 
+// TODO(#4478): Reuse Orchestrator client in all Oak Containers examples.
 impl OrchestratorClient {
     pub async fn create() -> Result<Self, Box<dyn std::error::Error>> {
         let inner: GrpcOrchestratorClient<tonic::transport::channel::Channel> = {
@@ -74,6 +75,7 @@ impl OrchestratorClient {
     ) -> Result<CryptoContext, Box<dyn std::error::Error>> {
         let context = self
             .inner
+            // TODO(#4477): Remove unnecessary copies of the Orchestrator client.
             .clone()
             .get_crypto_context(GetCryptoContextRequest {
                 serialized_encapsulated_public_key: serialized_encapsulated_public_key.to_vec(),

--- a/oak_containers_hello_world_trusted_app/src/orchestrator_client.rs
+++ b/oak_containers_hello_world_trusted_app/src/orchestrator_client.rs
@@ -17,9 +17,9 @@ use crate::proto::oak::containers::{
     orchestrator_client::OrchestratorClient as GrpcOrchestratorClient, GetCryptoContextRequest,
 };
 use anyhow::Context;
+use async_trait::async_trait;
 use oak_crypto::{
-    encryptor::AsyncRecipientContextGenerator,
-    hpke::RecipientContext,
+    encryptor::AsyncRecipientContextGenerator, hpke::RecipientContext,
     proto::oak::crypto::v1::CryptoContext,
 };
 use tonic::transport::{Endpoint, Uri};
@@ -92,10 +92,13 @@ impl OrchestratorClient {
     }
 }
 
+#[async_trait]
 impl AsyncRecipientContextGenerator for OrchestratorClient {
-    async fn generate_recipient_context(&self, encapsulated_public_key: &[u8]) -> anyhow::Result<RecipientContext> {
+    async fn generate_recipient_context(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext> {
         let serialized_crypto_context = self
-            .clone()
             .get_crypto_context(encapsulated_public_key)
             .await
             .map_err(|error| {

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -231,12 +231,14 @@ impl ServerEncryptor {
 // TODO(#4311): Merge `AsyncServerEncryptor` and `ServerEncryptor` once there is `async` support in
 // the Restricted Kernel.
 pub struct AsyncServerEncryptor<'a> {
-    recipient_context_generator: &'a(dyn AsyncRecipientContextGenerator + Send + Sync),
+    recipient_context_generator: &'a (dyn AsyncRecipientContextGenerator + Send + Sync),
     inner: Option<ServerEncryptor>,
 }
 
 impl<'a> AsyncServerEncryptor<'a> {
-    pub fn new(recipient_context_generator: &'a(dyn AsyncRecipientContextGenerator + Send + Sync)) -> Self {
+    pub fn new(
+        recipient_context_generator: &'a (dyn AsyncRecipientContextGenerator + Send + Sync),
+    ) -> Self {
         Self {
             recipient_context_generator,
             inner: None,

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -231,12 +231,12 @@ impl ServerEncryptor {
 // TODO(#4311): Merge `AsyncServerEncryptor` and `ServerEncryptor` once there is `async` support in
 // the Restricted Kernel.
 pub struct AsyncServerEncryptor<'a> {
-    recipient_context_generator: &'a dyn AsyncRecipientContextGenerator,
+    recipient_context_generator: &'a(dyn AsyncRecipientContextGenerator + Send + Sync),
     inner: Option<ServerEncryptor>,
 }
 
 impl<'a> AsyncServerEncryptor<'a> {
-    pub fn new(recipient_context_generator: &'a dyn AsyncRecipientContextGenerator) -> Self {
+    pub fn new(recipient_context_generator: &'a(dyn AsyncRecipientContextGenerator + Send + Sync)) -> Self {
         Self {
             recipient_context_generator,
             inner: None,

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -230,13 +230,13 @@ impl ServerEncryptor {
 /// be multiple responses per request and multiple requests per response.
 // TODO(#4311): Merge `AsyncServerEncryptor` and `ServerEncryptor` once there is `async` support in
 // the Restricted Kernel.
-pub struct AsyncServerEncryptor {
-    recipient_context_generator: Arc<dyn AsyncRecipientContextGenerator>,
+pub struct AsyncServerEncryptor<'a> {
+    recipient_context_generator: &'a dyn AsyncRecipientContextGenerator,
     inner: Option<ServerEncryptor>,
 }
 
-impl AsyncServerEncryptor {
-    pub fn new(recipient_context_generator: Arc<dyn AsyncRecipientContextGenerator>) -> Self {
+impl<'a> AsyncServerEncryptor<'a> {
+    pub fn new(recipient_context_generator: &'a dyn AsyncRecipientContextGenerator) -> Self {
         Self {
             recipient_context_generator,
             inner: None,

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -75,7 +75,7 @@ impl RecipientContextGenerator for EncryptionKeyProvider {
 #[async_trait]
 pub trait AsyncRecipientContextGenerator {
     async fn generate_recipient_context(
-        &mut self,
+        &self,
         encapsulated_public_key: &[u8],
     ) -> anyhow::Result<RecipientContext>;
 }

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -75,7 +75,7 @@ impl RecipientContextGenerator for EncryptionKeyProvider {
 #[async_trait]
 pub trait AsyncRecipientContextGenerator {
     async fn generate_recipient_context(
-        &self,
+        &mut self,
         encapsulated_public_key: &[u8],
     ) -> anyhow::Result<RecipientContext>;
 }

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -230,15 +230,19 @@ impl ServerEncryptor {
 /// be multiple responses per request and multiple requests per response.
 // TODO(#4311): Merge `AsyncServerEncryptor` and `ServerEncryptor` once there is `async` support in
 // the Restricted Kernel.
-pub struct AsyncServerEncryptor<'a> {
-    recipient_context_generator: &'a (dyn AsyncRecipientContextGenerator + Send + Sync),
+pub struct AsyncServerEncryptor<'a, G>
+where
+    G: AsyncRecipientContextGenerator + Send + Sync,
+{
+    recipient_context_generator: &'a G,
     inner: Option<ServerEncryptor>,
 }
 
-impl<'a> AsyncServerEncryptor<'a> {
-    pub fn new(
-        recipient_context_generator: &'a (dyn AsyncRecipientContextGenerator + Send + Sync),
-    ) -> Self {
+impl<'a, G> AsyncServerEncryptor<'a, G>
+where
+    G: AsyncRecipientContextGenerator + Send + Sync,
+{
+    pub fn new(recipient_context_generator: &'a G) -> Self {
         Self {
             recipient_context_generator,
             inner: None,

--- a/oak_crypto/src/tests.rs
+++ b/oak_crypto/src/tests.rs
@@ -217,12 +217,12 @@ impl AsyncRecipientContextGenerator for TestEncryptionKeyProvider {
 
 #[tokio::test]
 async fn test_async_encryptor() {
-    let key_provider = Arc::new(TestEncryptionKeyProvider::new());
+    let key_provider = TestEncryptionKeyProvider::new();
     let serialized_server_public_key = key_provider.get_serialized_public_key();
 
     let mut client_encryptor = ClientEncryptor::create(&serialized_server_public_key)
         .expect("couldn't create client encryptor");
-    let mut server_encryptor = AsyncServerEncryptor::new(key_provider);
+    let mut server_encryptor = AsyncServerEncryptor::new(&key_provider);
 
     for i in 0..TEST_SESSION_SIZE {
         let test_request_message = [TEST_REQUEST_MESSAGE, &[i as u8]].concat();

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -9,6 +9,7 @@ oak_grpc_utils = { workspace = true }
 
 [dependencies]
 anyhow = "*"
+async-trait = { version = "*", default-features = false }
 oak_functions_service = { workspace = true }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }

--- a/oak_functions_containers_app/src/orchestrator_client.rs
+++ b/oak_functions_containers_app/src/orchestrator_client.rs
@@ -13,8 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto::oak::containers::orchestrator_client::OrchestratorClient as GrpcOrchestratorClient;
+use crate::proto::oak::containers::{
+    orchestrator_client::OrchestratorClient as GrpcOrchestratorClient, GetCryptoContextRequest,
+};
 use anyhow::Context;
+use async_trait::async_trait;
+use oak_crypto::{
+    encryptor::AsyncRecipientContextGenerator, hpke::RecipientContext,
+    proto::oak::crypto::v1::CryptoContext,
+};
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 
@@ -35,6 +42,7 @@ pub struct OrchestratorClient {
     inner: GrpcOrchestratorClient<tonic::transport::channel::Channel>,
 }
 
+// TODO(#4478): Reuse Orchestrator client in all Oak Containers examples.
 impl OrchestratorClient {
     pub async fn create() -> Result<Self, Box<dyn std::error::Error>> {
         let inner: GrpcOrchestratorClient<tonic::transport::channel::Channel> = {
@@ -61,8 +69,50 @@ impl OrchestratorClient {
         Ok(config)
     }
 
+    pub async fn get_crypto_context(
+        &self,
+        serialized_encapsulated_public_key: &[u8],
+    ) -> Result<CryptoContext, Box<dyn std::error::Error>> {
+        let context = self
+            .inner
+            // TODO(#4477): Remove unnecessary copies of the Orchestrator client.
+            .clone()
+            .get_crypto_context(GetCryptoContextRequest {
+                serialized_encapsulated_public_key: serialized_encapsulated_public_key.to_vec(),
+            })
+            .await?
+            .into_inner()
+            // Crypto context.
+            .context
+            .context("crypto context wasn't provided")?;
+        Ok(context)
+    }
+
     pub async fn notify_app_ready(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         self.inner.notify_app_ready(tonic::Request::new(())).await?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl AsyncRecipientContextGenerator for OrchestratorClient {
+    async fn generate_recipient_context(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext> {
+        let serialized_crypto_context = self
+            .get_crypto_context(encapsulated_public_key)
+            .await
+            .map_err(|error| {
+                tonic::Status::internal(format!(
+                    "couldn't get crypto context from the Orchestrator: {:?}",
+                    error
+                ))
+            })?;
+        let crypto_context =
+            RecipientContext::deserialize(serialized_crypto_context).map_err(|error| {
+                tonic::Status::internal(format!("couldn't deserialize crypto context: {:?}", error))
+            })?;
+        Ok(crypto_context)
     }
 }

--- a/oak_remote_attestation/src/handler.rs
+++ b/oak_remote_attestation/src/handler.rs
@@ -75,7 +75,7 @@ impl<H: FnOnce(Vec<u8>) -> Vec<u8>> EncryptionHandler<H> {
         let response = (self.request_handler)(request);
 
         // Encrypt and serialize response.
-        // The resulting decryptor for consequent requests is discarded because we don't expect
+        // The resulting decryptor for subsequent requests is discarded because we don't expect
         // another message from the stream.
         server_encryptor
             .encrypt(&response, EMPTY_ASSOCIATED_DATA)
@@ -85,7 +85,7 @@ impl<H: FnOnce(Vec<u8>) -> Vec<u8>> EncryptionHandler<H> {
 
 /// Wraps a closure to an underlying function with request encryption and response decryption logic,
 /// based on the provided encryption key.
-/// `AsyncEncryptionHandler` can be used when the `AsyncRecipientContextGenerator` is needed.
+/// [`AsyncEncryptionHandler`] can be used when an [`AsyncRecipientContextGenerator`] is needed.
 pub struct AsyncEncryptionHandler<H: FnOnce(Vec<u8>) -> Vec<u8>> {
     // TODO(#3442): Use attester to attest to the public key.
     recipient_context_generator: Arc<dyn AsyncRecipientContextGenerator + Send + Sync>,
@@ -114,7 +114,7 @@ impl<H: FnOnce(Vec<u8>) -> Vec<u8>> AsyncEncryptionHandler<H> {
             AsyncServerEncryptor::new(self.recipient_context_generator.as_ref());
 
         // Decrypt request.
-        let (request, _) = server_encryptor
+        let (request, _associated_data) = server_encryptor
             .decrypt(encrypted_request)
             .await
             .context("couldn't decrypt request")?;

--- a/oak_remote_attestation/src/handler.rs
+++ b/oak_remote_attestation/src/handler.rs
@@ -88,13 +88,13 @@ impl<H: FnOnce(Vec<u8>) -> Vec<u8>> EncryptionHandler<H> {
 /// `AsyncEncryptionHandler` can be used when the `AsyncRecipientContextGenerator` is needed.
 pub struct AsyncEncryptionHandler<H: FnOnce(Vec<u8>) -> Vec<u8>> {
     // TODO(#3442): Use attester to attest to the public key.
-    recipient_context_generator: Arc<dyn AsyncRecipientContextGenerator>,
+    recipient_context_generator: Arc<dyn AsyncRecipientContextGenerator + Send + Sync>,
     request_handler: H,
 }
 
 impl<H: FnOnce(Vec<u8>) -> Vec<u8>> AsyncEncryptionHandler<H> {
     pub fn create(
-        recipient_context_generator: Arc<dyn AsyncRecipientContextGenerator>,
+        recipient_context_generator: Arc<dyn AsyncRecipientContextGenerator + Send + Sync>,
         request_handler: H,
     ) -> Self {
         Self {

--- a/oak_remote_attestation/src/handler.rs
+++ b/oak_remote_attestation/src/handler.rs
@@ -17,7 +17,10 @@
 use alloc::{sync::Arc, vec::Vec};
 use anyhow::{anyhow, Context};
 use oak_crypto::{
-    encryptor::{AsyncServerEncryptor, EncryptionKeyProvider, RecipientContextGenerator, AsyncRecipientContextGenerator, ServerEncryptor},
+    encryptor::{
+        AsyncRecipientContextGenerator, AsyncServerEncryptor, EncryptionKeyProvider,
+        ServerEncryptor,
+    },
     proto::oak::crypto::v1::{EncryptedRequest, EncryptedResponse},
 };
 
@@ -90,7 +93,10 @@ pub struct AsyncEncryptionHandler<H: FnOnce(Vec<u8>) -> Vec<u8>> {
 }
 
 impl<H: FnOnce(Vec<u8>) -> Vec<u8>> AsyncEncryptionHandler<H> {
-    pub fn create(recipient_context_generator: Arc<dyn AsyncRecipientContextGenerator>, request_handler: H) -> Self {
+    pub fn create(
+        recipient_context_generator: Arc<dyn AsyncRecipientContextGenerator>,
+        request_handler: H,
+    ) -> Self {
         Self {
             recipient_context_generator,
             request_handler,
@@ -99,11 +105,13 @@ impl<H: FnOnce(Vec<u8>) -> Vec<u8>> AsyncEncryptionHandler<H> {
 }
 
 impl<H: FnOnce(Vec<u8>) -> Vec<u8>> AsyncEncryptionHandler<H> {
-    pub async fn invoke(self, encrypted_request: &EncryptedRequest) -> anyhow::Result<EncryptedResponse> {
+    pub async fn invoke(
+        self,
+        encrypted_request: &EncryptedRequest,
+    ) -> anyhow::Result<EncryptedResponse> {
         // Initialize server encryptor.
-        let mut server_encryptor = AsyncServerEncryptor::new(
-            self.recipient_context_generator.clone(),
-        );
+        let mut server_encryptor =
+            AsyncServerEncryptor::new(self.recipient_context_generator.as_ref());
 
         // Decrypt request.
         let (request, _) = server_encryptor


### PR DESCRIPTION
This PR adds:
- `AsyncEncryptionHandler` to be used in Oak Containers in conjunction with the Orchestrator client
- Logic for requesting the session key from the Orchestrator to Oak Functions Containers

Though we will still need to add this to Oak Functions Service. And because of how Rust works, we cannot have the same version that works for both sync and async. So we might need to reimplement Oak Functions Service in an async fashion.