### PR TITLE
Deprecate AttestationEvidence, add DICE Evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,6 +1878,7 @@ dependencies = [
  "log",
  "oak_crypto",
  "oak_grpc_utils",
+ "oak_remote_attestation",
  "prost",
  "tonic",
 ]
@@ -2227,6 +2228,7 @@ dependencies = [
  "oak_functions_test_utils",
  "oak_grpc_utils",
  "oak_launcher_utils",
+ "oak_remote_attestation",
  "prost",
  "rand",
  "serde",

--- a/oak_client/Cargo.toml
+++ b/oak_client/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "*"
 futures-util = "*"
 log = "*"
 oak_crypto = { workspace = true }
+oak_remote_attestation = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }
 

--- a/oak_client/src/lib.rs
+++ b/oak_client/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod proto {
     pub mod oak {
         pub use oak_crypto::proto::oak::crypto;
+        pub use oak_remote_attestation::proto::oak::attestation;
         pub mod session {
             pub mod v1 {
                 #![allow(clippy::return_self_not_must_use)]

--- a/oak_client/src/transport.rs
+++ b/oak_client/src/transport.rs
@@ -114,6 +114,7 @@ impl EvidenceProvider for GrpcStreamingTransport {
             ));
         };
 
+        #[allow(deprecated)]
         get_evidence_response
             .attestation_bundle
             .context("get_evidence_response message doesn't contain an attestation bundle")?

--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -37,7 +37,6 @@ message GetApplicationConfigResponse {
 }
 
 message SendAttestationEvidenceRequest {
-  // TODO(#4488): Remove once this is no longer used.
   oak.session.v1.AttestationEvidence evidence = 1 [deprecated = true];
   oak.attestation.v1.Evidence dice_evidence = 2;
 }

--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -37,7 +37,8 @@ message GetApplicationConfigResponse {
 }
 
 message SendAttestationEvidenceRequest {
-  oak.session.v1.AttestationEvidence evidence = 1;
+  // TODO(#4488): Remove once this is no longer used.
+  oak.session.v1.AttestationEvidence evidence = 1 [deprecated = true];
   oak.attestation.v1.Evidence dice_evidence = 2;
 }
 

--- a/oak_containers_hello_world_untrusted_app/src/main.rs
+++ b/oak_containers_hello_world_untrusted_app/src/main.rs
@@ -32,6 +32,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .get_endorsed_evidence()
         .await
         .map_err(|error| anyhow::anyhow!("couldn't get endorsed evidence: {}", error))?;
+    #[allow(deprecated)]
     let encryption_public_key = endorsed_evidence
         .attestation_evidence
         .context("no attestation evidence provided")?

--- a/oak_containers_hello_world_untrusted_app/tests/integration_test.rs
+++ b/oak_containers_hello_world_untrusted_app/tests/integration_test.rs
@@ -50,6 +50,7 @@ async fn hello_world() {
     let get_endorsed_evidence_result = untrusted_app.get_endorsed_evidence().await;
     assert!(get_endorsed_evidence_result.is_ok());
     let endorsed_evidence = get_endorsed_evidence_result.unwrap();
+    #[allow(deprecated)]
     let encryption_public_key = endorsed_evidence
         .attestation_evidence
         .expect("no attestation evidence provided")

--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -186,15 +186,18 @@ impl Launcher {
     /// clients, which will verify it before connecting.
     pub async fn get_endorsed_evidence(&mut self) -> anyhow::Result<AttestationBundle> {
         // If we haven't received an attestation evidence, wait for it.
+        #[allow(deprecated)]
         if let Some(receiver) = self.attestation_evidence_receiver.take() {
             // Set a timeout since we don't want to wait forever if the VM didn't start properly.
             let evidence = timeout(Duration::from_secs(VM_START_TIMEOUT), receiver)
                 .await
                 .context("couldn't get attestation evidence before timeout")?
                 .context("no attestation evidence available")?;
+            #[allow(deprecated)]
             let endorsed_attestation_evidence = AttestationBundle {
                 attestation_evidence: Some(evidence),
                 attestation_endorsement: Some(self.attestation_endorsement.clone()),
+                dice_evidence: None,
             };
             self.endorsed_attestation_evidence
                 .replace(endorsed_attestation_evidence);

--- a/oak_containers_launcher/src/server.rs
+++ b/oak_containers_launcher/src/server.rs
@@ -152,6 +152,7 @@ impl Launcher for LauncherServerImplementation {
         &self,
         request: Request<SendAttestationEvidenceRequest>,
     ) -> Result<Response<()>, tonic::Status> {
+        #[allow(deprecated)]
         self.attestation_evidence_sender
             .lock()
             .map_err(|err| {

--- a/oak_containers_orchestrator_client/src/lib.rs
+++ b/oak_containers_orchestrator_client/src/lib.rs
@@ -84,6 +84,7 @@ impl LauncherClient {
         evidence: AttestationEvidence,
         dice_evidence: Evidence,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        #[allow(deprecated)]
         let request = tonic::Request::new(SendAttestationEvidenceRequest {
             evidence: Some(evidence),
             dice_evidence: Some(dice_evidence),

--- a/oak_functions_containers_launcher/src/server.rs
+++ b/oak_functions_containers_launcher/src/server.rs
@@ -59,9 +59,11 @@ impl StreamingSession for SessionProxy {
             tee_certificates: vec![],
             application_data: None,
         };
+        #[allow(deprecated)]
         let attestation_bundle = AttestationBundle {
             attestation_evidence: Some(attestation_evidence),
             attestation_endorsement: Some(attestation_endorsement),
+            dice_evidence: None,
         };
 
         let mut connector_handle = self.connector_handle.clone();

--- a/oak_functions_launcher/Cargo.toml
+++ b/oak_functions_launcher/Cargo.toml
@@ -29,6 +29,7 @@ tonic = "*"
 tonic-web = { version = "*", optional = true }
 oak_functions_abi = { workspace = true }
 oak_launcher_utils = { workspace = true }
+oak_remote_attestation = { workspace = true }
 micro_rpc = { workspace = true }
 oak_channel = { workspace = true, features = ["client"] }
 oak_crypto = { workspace = true }

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -24,6 +24,7 @@ pub mod server;
 pub mod proto {
     pub mod oak {
         pub use oak_crypto::proto::oak::crypto;
+        pub use oak_remote_attestation::proto::oak::attestation;
         pub mod functions {
             #![allow(dead_code)]
             use prost::Message;

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -59,9 +59,11 @@ impl StreamingSession for SessionProxy {
             tee_certificates: vec![],
             application_data: None,
         };
+        #[allow(deprecated)]
         let attestation_bundle = AttestationBundle {
             attestation_evidence: Some(attestation_evidence),
             attestation_endorsement: Some(attestation_endorsement),
+            dice_evidence: None,
         };
 
         let connector_handle = self.connector_handle.clone();

--- a/oak_remote_attestation/proto/v1/BUILD
+++ b/oak_remote_attestation/proto/v1/BUILD
@@ -29,8 +29,10 @@ package(
 proto_library(
     name = "messages_proto",
     srcs = ["messages.proto"],
-    deps = ["//oak_crypto/proto/v1:crypto_proto"],
-    deps = ["//proto/attestation:evidence_proto"],
+    deps = [
+        "//oak_crypto/proto/v1:crypto_proto",
+        "//proto/attestation:evidence_proto",
+    ],
 )
 
 cc_proto_library(

--- a/oak_remote_attestation/proto/v1/BUILD
+++ b/oak_remote_attestation/proto/v1/BUILD
@@ -30,6 +30,7 @@ proto_library(
     name = "messages_proto",
     srcs = ["messages.proto"],
     deps = ["//oak_crypto/proto/v1:crypto_proto"],
+    deps = ["//proto/attestation:evidence_proto"],
 )
 
 cc_proto_library(

--- a/oak_remote_attestation/proto/v1/messages.proto
+++ b/oak_remote_attestation/proto/v1/messages.proto
@@ -51,7 +51,6 @@ message AttestationEvidence {
 // in response to its request for the enclave's public key(s).
 message AttestationBundle {
   // Attestation evidence from the enclave.
-  // TODO(#4488): Remove once this is no longer used.
   AttestationEvidence attestation_evidence = 1 [deprecated = true];
 
   // Supporting evidence required for verifying the integrity of attestation evidence.

--- a/oak_remote_attestation/proto/v1/messages.proto
+++ b/oak_remote_attestation/proto/v1/messages.proto
@@ -58,7 +58,7 @@ message AttestationBundle {
   AttestationEndorsement attestation_endorsement = 2;
 
   // The DICE attestation evidence.
-  oak.attestation.v1.Evidence dice_evidence = 3;  
+  oak.attestation.v1.Evidence dice_evidence = 3;
 }
 
 // AttestationEndorsement contains statements that some entity (e.g., a hardware provider) vouches

--- a/oak_remote_attestation/proto/v1/messages.proto
+++ b/oak_remote_attestation/proto/v1/messages.proto
@@ -19,6 +19,7 @@ syntax = "proto3";
 package oak.session.v1;
 
 import "oak_crypto/proto/v1/crypto.proto";
+import "proto/attestation/evidence.proto";
 
 option java_multiple_files = true;
 option java_package = "com.google.oak.session.v1";
@@ -27,6 +28,7 @@ option java_package = "com.google.oak.session.v1";
 // claims about the Target Environment. The name is chosen to match the RATS terminology
 // (see https://www.rfc-editor.org/rfc/rfc9334.html#name-evidence).
 message AttestationEvidence {
+  option deprecated = true;
   // The serialized public key part of the enclave encryption key.
   // TODO(#3442): Specify key format.
   bytes encryption_public_key = 1;
@@ -49,10 +51,14 @@ message AttestationEvidence {
 // in response to its request for the enclave's public key(s).
 message AttestationBundle {
   // Attestation evidence from the enclave.
-  AttestationEvidence attestation_evidence = 1;
+  // TODO(#4488): Remove once this is no longer used.
+  AttestationEvidence attestation_evidence = 1 [deprecated = true];
 
   // Supporting evidence required for verifying the integrity of attestation evidence.
   AttestationEndorsement attestation_endorsement = 2;
+
+  // The DICE attestation evidence.
+  oak.attestation.v1.Evidence dice_evidence = 3;  
 }
 
 // AttestationEndorsement contains statements that some entity (e.g., a hardware provider) vouches

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -175,30 +175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chacha20"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
-dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,7 +209,6 @@ checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
  "crypto-common",
  "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -268,7 +243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -280,7 +255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -294,19 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,15 +275,6 @@ checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "zeroize",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -350,7 +302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -370,11 +322,11 @@ checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -416,7 +368,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -482,7 +434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -525,28 +477,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hpke"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf39e5461bfdc6ad0fbc97067519fcaf96a7a2e67f24cc0eb8a1e7c0c45af792"
-dependencies = [
- "aead",
- "aes-gcm",
- "byteorder",
- "chacha20poly1305",
- "digest 0.10.7",
- "generic-array",
- "hkdf",
- "hmac",
- "rand_core 0.6.4",
- "sha2",
- "subtle",
- "x25519-dalek",
- "zeroize",
+ "digest",
 ]
 
 [[package]]
@@ -700,22 +631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oak_crypto"
-version = "0.1.0"
-dependencies = [
- "aes-gcm",
- "anyhow",
- "async-trait",
- "bytes",
- "hkdf",
- "hpke",
- "micro_rpc_build",
- "prost",
- "rand_core 0.6.4",
- "sha2",
-]
-
-[[package]]
 name = "oak_dice"
 version = "0.1.0"
 dependencies = [
@@ -725,7 +640,7 @@ dependencies = [
  "hex",
  "hkdf",
  "p256",
- "rand_core 0.6.4",
+ "rand_core",
  "sha2",
  "static_assertions",
  "strum",
@@ -762,7 +677,6 @@ dependencies = [
  "log",
  "oak_channel",
  "oak_core",
- "oak_crypto",
  "oak_dice",
  "oak_linux_boot_params",
  "oak_restricted_kernel_interface",
@@ -876,17 +790,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
 name = "polyval"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,12 +898,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -1179,7 +1076,7 @@ checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1188,8 +1085,8 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1484,17 +1381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "x25519-dalek"
-version = "2.0.0-pre.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df"
-dependencies = [
- "curve25519-dalek",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "x86_64"
 version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,17 +1439,3 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]


### PR DESCRIPTION
Add `dice_evidence` to the `AttestationBundle` and deprecates `AttestationEvidence`.

This is an intermediate step to allow us to swith from `AttestationEvidence` to DICE `Evidence`. `AttestationEvidence` will be removed once nothing depends on it anymore.