### PR TITLE
Add endorsement signature to the transparent release endorsement.

### DIFF
--- a/proto/attestation/endorsement.proto
+++ b/proto/attestation/endorsement.proto
@@ -25,14 +25,16 @@ option java_package = "com.google.oak.attestation.v1";
 // Endorsement for binaries from the Transparent Release process.
 // <https://github.com/project-oak/oak/blob/main/docs/release.md>
 message TransparentReleaseEndorsement {
-  // The endorsement statement for the underlying binary.
+  // JSON string comtaining the endorsement statement for the underlying binary.
+  // The format is described here:
+  // https://github.com/project-oak/transparent-release/blob/main/docs/claim-transparency.md#the-claim-format
   bytes endorsement = 1;
 
-  // The log entry as proof of inclusion of the endorsement statement in Rekor.
-  bytes rekor_log_entry = 2;
-
   // The signature for the endorsement.
-  bytes endorsement_signature = 3;
+  bytes endorsement_signature = 2;
+
+  // The log entry as proof of inclusion of the endorsement statement in Rekor.
+  bytes rekor_log_entry = 3;
 }
 
 message RootLayerEndorsements {

--- a/proto/attestation/endorsement.proto
+++ b/proto/attestation/endorsement.proto
@@ -30,6 +30,9 @@ message TransparentReleaseEndorsement {
 
   // The log entry as proof of inclusion of the endorsement statement in Rekor.
   bytes rekor_log_entry = 2;
+
+  // The signature for the endorsement.
+  bytes endorsement_signature = 3;
 }
 
 message RootLayerEndorsements {


### PR DESCRIPTION
The transparent release endorsement message needs to include the signature for the endorsement of the underlying binary