### PR TITLE
Bridge the gap between sync and async universes in `OrchestratorClient`

### DIFF
--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -89,6 +89,16 @@ pub trait AsyncRecipientContextGenerator {
     ) -> anyhow::Result<RecipientContext>;
 }
 
+#[async_trait]
+impl AsyncRecipientContextGenerator for EncryptionKeyProvider {
+    async fn generate_recipient_context(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext> {
+        (self as &dyn RecipientContextGenerator).generate_recipient_context(encapsulated_public_key)
+    }
+}
+
 /// Encryptor object for encrypting client requests that will be sent to the server and decrypting
 /// server responses that are received by the client. Each Encryptor object corresponds to a single
 /// crypto session between the client and the server.

--- a/oak_functions_containers_app/src/main.rs
+++ b/oak_functions_containers_app/src/main.rs
@@ -38,7 +38,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         OAK_FUNCTIONS_CONTAINERS_APP_PORT,
     );
     let listener = TcpListener::bind(addr).await?;
-    let server_handle = tokio::spawn(serve(listener, attestation_report_generator));
+    let server_handle = tokio::spawn(serve(
+        listener,
+        attestation_report_generator,
+        Arc::new(client.clone()),
+    ));
 
     eprintln!("Running Oak Functions on Oak Containers at address: {addr}");
     client.notify_app_ready().await?;

--- a/oak_functions_containers_app/tests/integration_test.rs
+++ b/oak_functions_containers_app/tests/integration_test.rs
@@ -23,6 +23,7 @@ pub mod proto {
 }
 
 use crate::proto::oak::functions::oak_functions_client::OakFunctionsClient;
+use oak_crypto::encryptor::EncryptionKeyProvider;
 use oak_functions_containers_app::serve;
 use oak_functions_service::proto::oak::functions::InitializeRequest;
 use oak_remote_attestation::attester::EmptyAttestationReportGenerator;
@@ -45,7 +46,11 @@ async fn test_lookup() {
     let listener = TcpListener::bind(addr).await.unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let server_handle = tokio::spawn(serve(listener, attestation_report_generator));
+    let server_handle = tokio::spawn(serve(
+        listener,
+        attestation_report_generator,
+        Arc::new(EncryptionKeyProvider::generate()),
+    ));
 
     let mut oak_functions_client: OakFunctionsClient<tonic::transport::channel::Channel> = {
         let channel = Endpoint::from_shared(format!("http://{addr}"))

--- a/oak_remote_attestation/src/handler.rs
+++ b/oak_remote_attestation/src/handler.rs
@@ -18,7 +18,7 @@ use alloc::{sync::Arc, vec::Vec};
 use anyhow::{anyhow, Context};
 use oak_crypto::{
     encryptor::{
-        AsyncRecipientContextGenerator, AsyncServerEncryptor, EncryptionKeyProvider,
+        AsyncRecipientContextGenerator, AsyncServerEncryptor, RecipientContextGenerator,
         ServerEncryptor,
     },
     proto::oak::crypto::v1::{EncryptedRequest, EncryptedResponse},
@@ -40,12 +40,15 @@ pub struct PublicKeyInfo {
 /// based on the provided encryption key.
 pub struct EncryptionHandler<H: FnOnce(Vec<u8>) -> Vec<u8>> {
     // TODO(#3442): Use attester to attest to the public key.
-    encryption_key_provider: Arc<EncryptionKeyProvider>,
+    encryption_key_provider: Arc<dyn RecipientContextGenerator>,
     request_handler: H,
 }
 
 impl<H: FnOnce(Vec<u8>) -> Vec<u8>> EncryptionHandler<H> {
-    pub fn create(encryption_key_provider: Arc<EncryptionKeyProvider>, request_handler: H) -> Self {
+    pub fn create(
+        encryption_key_provider: Arc<dyn RecipientContextGenerator>,
+        request_handler: H,
+    ) -> Self {
         Self {
             encryption_key_provider,
             request_handler,


### PR DESCRIPTION
This _should_ allow the sync code the rely on async code. Emphasis on _should_, we'll see what the tests think of this.

I've left the existing `encryption_key_provider` as-is for now; it's only used in the `initialize` call. Per Conrad, the attestation report (and public key) we return there should be unused; I'll see about ripping that out (and returning an empty proto) in a follow-up PR.