### PR TITLE
Rename InitLayerEndorsements and the binary field

### DIFF
--- a/java/src/main/java/com/google/oak/verification/MainVerifier.java
+++ b/java/src/main/java/com/google/oak/verification/MainVerifier.java
@@ -22,8 +22,6 @@ import com.google.oak.attestation.v1.ContainerLayerReferenceValues;
 import com.google.oak.attestation.v1.EndorsementReferenceValue;
 import com.google.oak.attestation.v1.Endorsements;
 import com.google.oak.attestation.v1.Evidence;
-import com.google.oak.attestation.v1.InitLayerEndorsements;
-import com.google.oak.attestation.v1.InitLayerReferenceValues;
 import com.google.oak.attestation.v1.KernelLayerEndorsements;
 import com.google.oak.attestation.v1.KernelLayerReferenceValues;
 import com.google.oak.attestation.v1.OakContainersEndorsements;
@@ -31,6 +29,8 @@ import com.google.oak.attestation.v1.OakContainersReferenceValues;
 import com.google.oak.attestation.v1.ReferenceValues;
 import com.google.oak.attestation.v1.RootLayerEndorsements;
 import com.google.oak.attestation.v1.RootLayerReferenceValues;
+import com.google.oak.attestation.v1.SystemLayerReferenceValues;
+import com.google.oak.attestation.v1.SystemLayerEndorsements;
 import com.google.oak.attestation.v1.TransparentReleaseEndorsement;
 import java.util.Optional;
 
@@ -56,11 +56,11 @@ public class MainVerifier {
     return Optional.empty();
   }
 
-  Optional<Failure> verifyInitLayer(
-      InitLayerEndorsements endorsements, InitLayerReferenceValues values) {
-    BinaryReferenceValue binaryValue = values.getBinary();
-    if (binaryValue.hasEndorsement()) {
-      Optional<Failure> r = verifyLogEntry(endorsements.getBinary(), binaryValue.getEndorsement());
+  Optional<Failure> verifySystemLayer(
+      SystemLayerEndorsements endorsements, SystemLayerReferenceValues values) {
+    BinaryReferenceValue systemImageValue = values.getSystemImage();
+    if (systemImageValue.hasEndorsement()) {
+      Optional<Failure> r = verifyLogEntry(endorsements.getSystemImage(), systemImageValue.getEndorsement());
       if (r.isPresent()) {
         return r;
       }
@@ -91,7 +91,7 @@ public class MainVerifier {
     if (r.isPresent()) {
       return r;
     }
-    r = verifyInitLayer(endorsements.getInitLayer(), values.getInitLayer());
+    r = verifySystemLayer(endorsements.getSystemLayer(), values.getSystemLayer());
     if (r.isPresent()) {
       return r;
     }

--- a/java/src/main/java/com/google/oak/verification/MainVerifier.java
+++ b/java/src/main/java/com/google/oak/verification/MainVerifier.java
@@ -29,8 +29,8 @@ import com.google.oak.attestation.v1.OakContainersReferenceValues;
 import com.google.oak.attestation.v1.ReferenceValues;
 import com.google.oak.attestation.v1.RootLayerEndorsements;
 import com.google.oak.attestation.v1.RootLayerReferenceValues;
-import com.google.oak.attestation.v1.SystemLayerReferenceValues;
 import com.google.oak.attestation.v1.SystemLayerEndorsements;
+import com.google.oak.attestation.v1.SystemLayerReferenceValues;
 import com.google.oak.attestation.v1.TransparentReleaseEndorsement;
 import java.util.Optional;
 
@@ -60,7 +60,8 @@ public class MainVerifier {
       SystemLayerEndorsements endorsements, SystemLayerReferenceValues values) {
     BinaryReferenceValue systemImageValue = values.getSystemImage();
     if (systemImageValue.hasEndorsement()) {
-      Optional<Failure> r = verifyLogEntry(endorsements.getSystemImage(), systemImageValue.getEndorsement());
+      Optional<Failure> r =
+          verifyLogEntry(endorsements.getSystemImage(), systemImageValue.getEndorsement());
       if (r.isPresent()) {
         return r;
       }

--- a/java/src/test/java/com/google/oak/verification/MainVerifierTest.java
+++ b/java/src/test/java/com/google/oak/verification/MainVerifierTest.java
@@ -22,8 +22,6 @@ import com.google.oak.attestation.v1.ContainerLayerReferenceValues;
 import com.google.oak.attestation.v1.EndorsementReferenceValue;
 import com.google.oak.attestation.v1.Endorsements;
 import com.google.oak.attestation.v1.Evidence;
-import com.google.oak.attestation.v1.SystemLayerEndorsements;
-import com.google.oak.attestation.v1.SystemLayerReferenceValues;
 import com.google.oak.attestation.v1.KernelLayerEndorsements;
 import com.google.oak.attestation.v1.KernelLayerReferenceValues;
 import com.google.oak.attestation.v1.LayerEvidence;
@@ -33,6 +31,8 @@ import com.google.oak.attestation.v1.ReferenceValues;
 import com.google.oak.attestation.v1.RootLayerEndorsements;
 import com.google.oak.attestation.v1.RootLayerEvidence;
 import com.google.oak.attestation.v1.RootLayerReferenceValues;
+import com.google.oak.attestation.v1.SystemLayerEndorsements;
+import com.google.oak.attestation.v1.SystemLayerReferenceValues;
 import com.google.oak.attestation.v1.TeePlatform;
 import com.google.oak.attestation.v1.TransparentReleaseEndorsement;
 import com.google.protobuf.ByteString;
@@ -99,7 +99,8 @@ public class MainVerifierTest {
                 .setRootLayer(RootLayerEndorsements.newBuilder().setStage0(createTREndorsement()))
                 .setKernelLayer(
                     KernelLayerEndorsements.newBuilder().setKernelImage(createTREndorsement()))
-                .setSystemLayer(SystemLayerEndorsements.newBuilder().setSystemImage(createTREndorsement()))
+                .setSystemLayer(
+                    SystemLayerEndorsements.newBuilder().setSystemImage(createTREndorsement()))
                 .setContainerLayer(
                     ContainerLayerEndorsements.newBuilder().setBinary(createTREndorsement())))
         .build();

--- a/java/src/test/java/com/google/oak/verification/MainVerifierTest.java
+++ b/java/src/test/java/com/google/oak/verification/MainVerifierTest.java
@@ -22,8 +22,8 @@ import com.google.oak.attestation.v1.ContainerLayerReferenceValues;
 import com.google.oak.attestation.v1.EndorsementReferenceValue;
 import com.google.oak.attestation.v1.Endorsements;
 import com.google.oak.attestation.v1.Evidence;
-import com.google.oak.attestation.v1.InitLayerEndorsements;
-import com.google.oak.attestation.v1.InitLayerReferenceValues;
+import com.google.oak.attestation.v1.SystemLayerEndorsements;
+import com.google.oak.attestation.v1.SystemLayerReferenceValues;
 import com.google.oak.attestation.v1.KernelLayerEndorsements;
 import com.google.oak.attestation.v1.KernelLayerReferenceValues;
 import com.google.oak.attestation.v1.LayerEvidence;
@@ -99,7 +99,7 @@ public class MainVerifierTest {
                 .setRootLayer(RootLayerEndorsements.newBuilder().setStage0(createTREndorsement()))
                 .setKernelLayer(
                     KernelLayerEndorsements.newBuilder().setKernelImage(createTREndorsement()))
-                .setInitLayer(InitLayerEndorsements.newBuilder().setBinary(createTREndorsement()))
+                .setSystemLayer(SystemLayerEndorsements.newBuilder().setSystemImage(createTREndorsement()))
                 .setContainerLayer(
                     ContainerLayerEndorsements.newBuilder().setBinary(createTREndorsement())))
         .build();
@@ -114,7 +114,7 @@ public class MainVerifierTest {
             OakContainersReferenceValues.newBuilder()
                 .setRootLayer(RootLayerReferenceValues.newBuilder())
                 .setKernelLayer(KernelLayerReferenceValues.newBuilder())
-                .setInitLayer(InitLayerReferenceValues.newBuilder().setBinary(
+                .setSystemLayer(SystemLayerReferenceValues.newBuilder().setSystemImage(
                     BinaryReferenceValue.newBuilder().setEndorsement(
                         EndorsementReferenceValue.newBuilder()
                             .setEndorserPublicKey(endorserPublicKey)

--- a/proto/attestation/endorsement.proto
+++ b/proto/attestation/endorsement.proto
@@ -55,8 +55,8 @@ message KernelLayerEndorsements {
   TransparentReleaseEndorsement init_ram_fs = 3;
 }
 
-message InitLayerEndorsements {
-  TransparentReleaseEndorsement binary = 1;
+message SystemLayerEndorsements {
+  TransparentReleaseEndorsement system_image = 1;
 }
 
 message ApplicationLayerEndorsements {
@@ -76,7 +76,7 @@ message OakRestrictedKernelEndorsements {
 message OakContainersEndorsements {
   RootLayerEndorsements root_layer = 1;
   KernelLayerEndorsements kernel_layer = 2;
-  InitLayerEndorsements init_layer = 3;
+  SystemLayerEndorsements system_layer = 3;
   ContainerLayerEndorsements container_layer = 4;
 }
 

--- a/proto/attestation/reference_value.proto
+++ b/proto/attestation/reference_value.proto
@@ -107,9 +107,9 @@ message KernelLayerReferenceValues {
   BinaryReferenceValue acpi = 6;
 }
 
-message InitLayerReferenceValues {
-  // Verifies the binary based on endorsement.
-  BinaryReferenceValue binary = 1;
+message SystemLayerReferenceValues {
+  // Verifies the system image binary based on endorsement.
+  BinaryReferenceValue system_image = 1;
 
   // Configuration measurements.
   BinaryReferenceValue configuration = 2;
@@ -141,7 +141,7 @@ message OakRestrictedKernelReferenceValues {
 message OakContainersReferenceValues {
   RootLayerReferenceValues root_layer = 1;
   KernelLayerReferenceValues kernel_layer = 2;
-  InitLayerReferenceValues init_layer = 3;
+  SystemLayerReferenceValues system_layer = 3;
   ContainerLayerReferenceValues container_layer = 4;
 }
 


### PR DESCRIPTION
InitLayerEndorsements doesn't reflect well which components the endorsements refer to, and the binary field is too generic. Renaming to more descriptive names