### PR TITLE
Clean up some of the error handling code in Oak Functions

### DIFF
--- a/oak_functions_containers_app/src/main.rs
+++ b/oak_functions_containers_app/src/main.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::anyhow;
+use anyhow::Context;
 use oak_functions_containers_app::{orchestrator_client::OrchestratorClient, serve};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -27,7 +27,8 @@ const OAK_FUNCTIONS_CONTAINERS_APP_PORT: u16 = 8080;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = OrchestratorClient::create()
         .await
-        .map_err(|error| anyhow!("couldn't create Orchestrator client: {:?}", error))?;
+        .context("couldn't create Orchestrator client")?;
+
     // To be used when connecting trusted app to orchestrator.
     let _application_config = client.get_application_config().await?;
 

--- a/oak_remote_attestation/src/handler.rs
+++ b/oak_remote_attestation/src/handler.rs
@@ -15,7 +15,7 @@
 //
 
 use alloc::{sync::Arc, vec::Vec};
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use oak_crypto::{
     encryptor::{
         AsyncRecipientContextGenerator, AsyncServerEncryptor, RecipientContextGenerator,
@@ -62,12 +62,12 @@ impl<H: FnOnce(Vec<u8>) -> Vec<u8>> EncryptionHandler<H> {
         let serialized_encapsulated_public_key = encrypted_request
             .serialized_encapsulated_public_key
             .as_ref()
-            .expect("initial request message doesn't contain encapsulated public key");
+            .context("initial request message doesn't contain encapsulated public key")?;
         let mut server_encryptor = ServerEncryptor::create(
             serialized_encapsulated_public_key,
             self.encryption_key_provider.clone(),
         )
-        .map_err(|error| anyhow!("couldn't create server encryptor: {:?}", error))?;
+        .context("couldn't create server encryptor")?;
 
         // Decrypt request.
         let (request, _) = server_encryptor


### PR DESCRIPTION
Mostly just more efficient use of `anyhow` (instead of formatting bazillions of strings), but also one meaningful change:

The `EncryptionHandler::invoke` had an `expect()` in it, which means that if someone sends an RPC with no public key, the server will promptly crash.
The server should _never_ panic on invalid user input, otherwise this provides a way how to DoS the server. This replaces the `expect` with proper error propagation, which should fail the RPC (but keep the server alive for other requests).