### PR TITLE
Use the boot allocator for guest message buffers

### DIFF
--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -497,7 +497,7 @@ pub fn send_guest_message_request<
     encryptor: &mut GuestMessageEncryptor,
     request: Request,
 ) -> Result<Response, &'static str> {
-    let alloc = &crate::SHORT_TERM_ALLOC;
+    let alloc = &crate::BOOT_ALLOC;
     let mut request_message = Shared::new_in(GuestMessage::new(), alloc);
     encryptor.encrypt_message(request, request_message.as_mut())?;
     let response_message = Shared::new_in(GuestMessage::new(), alloc);


### PR DESCRIPTION
The Linux kernel didn't like us using the short-term allocator for shared buffers on AMD SEV-SNP. Since we don't pvalidate shared pages again when we unshare them they are in state that is unusable by the Linux kernel. The boot allocator uses a memory range that does not cause the Linux kernel to crash.

This is a temporary fix. These are not long-lived boot structures, so should not really be in the boot allocator. But since we don't yet have a short-term allocator that supports unsharing pages, this is the easiest approach for now.