### PR TITLE
Revalidate pages after un-sharing

### DIFF
--- a/oak_sev_guest/src/instructions.rs
+++ b/oak_sev_guest/src/instructions.rs
@@ -41,7 +41,7 @@ pub enum PageSize {
 }
 
 /// The potential errors when calling the PVALIDATE or RMPADJUST instructions.
-#[derive(Debug, FromRepr)]
+#[derive(Debug, FromRepr, PartialEq)]
 #[repr(u32)]
 pub enum InstructionError {
     /// The input parameters were invalid.

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -187,8 +187,7 @@ pub fn share_page(page: Page<Size4KiB>) {
     {
         let mut page_tables = crate::paging::PAGE_TABLE_REFS.get().unwrap().lock();
         let pt = &mut page_tables.pt_0;
-        let idx = (page_start / Size4KiB::SIZE) as usize;
-        pt[idx].set_addr(
+        pt[page.p1_index()].set_addr(
             PhysAddr::new(page_start),
             PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
         );
@@ -209,7 +208,6 @@ pub fn unshare_page(page: Page<Size4KiB>) {
     // Only the first 2MiB is mapped as 4KiB pages, so make sure we fall in that range.
     assert!(page_start < Size2MiB::SIZE);
     if sev_status().contains(SevStatus::SNP_ACTIVE) {
-        let page_start = page.start_address().as_u64();
         let request = SnpPageStateChangeRequest::new(page_start as usize, PageAssignment::Private)
             .expect("invalid address for page location");
         change_snp_page_state(request).expect("couldn't change SNP state for page");
@@ -218,8 +216,7 @@ pub fn unshare_page(page: Page<Size4KiB>) {
     {
         let mut page_tables = crate::paging::PAGE_TABLE_REFS.get().unwrap().lock();
         let pt = &mut page_tables.pt_0;
-        let idx = (page_start / Size4KiB::SIZE) as usize;
-        pt[idx].set_addr(
+        pt[page.p1_index()].set_addr(
             PhysAddr::new(page_start | crate::ENCRYPTED.get().unwrap_or(&0)),
             PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
         );

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -205,11 +205,31 @@ pub fn share_page(page: Page<Size4KiB>) {
 
 /// Stops sharing a single 4KiB page with the hypervisor when running with AMD SEV-SNP enabled.
 pub fn unshare_page(page: Page<Size4KiB>) {
+    let page_start = page.start_address().as_u64();
+    // Only the first 2MiB is mapped as 4KiB pages, so make sure we fall in that range.
+    assert!(page_start < Size2MiB::SIZE);
     if sev_status().contains(SevStatus::SNP_ACTIVE) {
         let page_start = page.start_address().as_u64();
         let request = SnpPageStateChangeRequest::new(page_start as usize, PageAssignment::Private)
             .expect("invalid address for page location");
         change_snp_page_state(request).expect("couldn't change SNP state for page");
+    }
+    // Mark the page as encrypted.
+    {
+        let mut page_tables = crate::paging::PAGE_TABLE_REFS.get().unwrap().lock();
+        let pt = &mut page_tables.pt_0;
+        let idx = (page_start / Size4KiB::SIZE) as usize;
+        pt[idx].set_addr(
+            PhysAddr::new(page_start | crate::ENCRYPTED.get().unwrap_or(&0)),
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+        );
+    }
+    tlb::flush_all();
+    // We have to revalidate the page again after un-sharing it.
+    if let Err(err) = page.pvalidate() {
+        if err != InstructionError::ValidationStatusNotUpdated {
+            panic!("shared page revalidation failed");
+        }
     }
 }
 


### PR DESCRIPTION
This is a better fix for the unsharing issues I mentioned in #4503.

When sharing and unsharing pages we didn't run pvalidate on them again. This meant that the pages ended up in a non-validated state and the Linux kernel crashed when trying to reuse these pages. We perviously got away with it because the other pages we shared were in a range that the Linux kernel did not try to reuse.