### PR TITLE
Send nonces in Rust Crypto

### DIFF
--- a/oak_crypto/proto/v1/crypto.proto
+++ b/oak_crypto/proto/v1/crypto.proto
@@ -46,6 +46,9 @@ message EncryptedResponse {
 message AeadEncryptedMessage {
   bytes ciphertext = 1;
   bytes associated_data = 2;
+  // TODO(#4507): Nonce is currently not used by the crypto library. We need to make a non-breaking
+  // change, where we first make the library send and use deterministic nonces in the Proto, and
+  // then replace it with a rendom nonce.
   bytes nonce = 3;
 }
 

--- a/oak_crypto/proto/v1/crypto.proto
+++ b/oak_crypto/proto/v1/crypto.proto
@@ -46,6 +46,7 @@ message EncryptedResponse {
 message AeadEncryptedMessage {
   bytes ciphertext = 1;
   bytes associated_data = 2;
+  bytes nonce = 3;
 }
 
 // Envelope containing session keys required to encrypt/decrypt messages within a secure session.

--- a/oak_crypto/src/hpke/mod.rs
+++ b/oak_crypto/src/hpke/mod.rs
@@ -72,6 +72,7 @@ impl KeyPair {
         self.public_key.to_bytes().to_vec()
     }
 }
+
 /// Sets up an HPKE sender by generating an ephemeral keypair (and serializing the corresponding
 /// public key) and creating a sender context.
 /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-to-a-public-key>
@@ -205,17 +206,22 @@ pub struct SenderContext {
 }
 
 impl SenderContext {
+    // TODO(#4507): Use random nonces for Hybrid Encryption.
+    pub(crate) fn generate_nonce(&mut self) -> anyhow::Result<AeadNonce> {
+        compute_nonce(self.request_sequence_number, &self.request_base_nonce)
+            .context("couldn't compute nonce")
+    }
+
     /// Encrypts request message with associated data using AEAD.
     /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
     pub(crate) fn seal(
         &mut self,
+        nonce: &AeadNonce,
         plaintext: &[u8],
         associated_data: &[u8],
     ) -> anyhow::Result<Vec<u8>> {
-        let nonce = compute_nonce(self.request_sequence_number, &self.request_base_nonce)
-            .context("couldn't compute nonce")?;
         let ciphertext =
-            crate::hpke::aead::encrypt(&self.request_key, &nonce, plaintext, associated_data)
+            crate::hpke::aead::encrypt(&self.request_key, nonce, plaintext, associated_data)
                 .context("couldn't encrypt request message")?;
         increment_sequence_number(&mut self.request_sequence_number)
             .context("couldn't increment sequence number")?;
@@ -256,6 +262,12 @@ pub struct RecipientContext {
 }
 
 impl RecipientContext {
+    // TODO(#4507): Use random nonces for Hybrid Encryption.
+    pub(crate) fn generate_nonce(&mut self) -> anyhow::Result<AeadNonce> {
+        compute_nonce(self.response_sequence_number, &self.response_base_nonce)
+            .context("couldn't compute nonce")
+    }
+
     /// Decrypts request message and validates associated data using AEAD.
     /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
     pub(crate) fn open(
@@ -278,13 +290,14 @@ impl RecipientContext {
     /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-bidirectional-encryption>
     pub(crate) fn seal(
         &mut self,
+        nonce: &AeadNonce,
         plaintext: &[u8],
         associated_data: &[u8],
     ) -> anyhow::Result<Vec<u8>> {
-        let nonce = compute_nonce(self.response_sequence_number, &self.response_base_nonce)
-            .context("couldn't compute nonce")?;
+        // let nonce = compute_nonce(self.response_sequence_number, &self.response_base_nonce)
+        //     .context("couldn't compute nonce")?;
         let ciphertext =
-            crate::hpke::aead::encrypt(&self.response_key, &nonce, plaintext, associated_data)
+            crate::hpke::aead::encrypt(&self.response_key, nonce, plaintext, associated_data)
                 .context("couldn't encrypt response message")?;
         increment_sequence_number(&mut self.response_sequence_number)
             .context("couldn't increment sequence number")?;

--- a/oak_crypto/src/hpke/mod.rs
+++ b/oak_crypto/src/hpke/mod.rs
@@ -294,8 +294,6 @@ impl RecipientContext {
         plaintext: &[u8],
         associated_data: &[u8],
     ) -> anyhow::Result<Vec<u8>> {
-        // let nonce = compute_nonce(self.response_sequence_number, &self.response_base_nonce)
-        //     .context("couldn't compute nonce")?;
         let ciphertext =
             crate::hpke::aead::encrypt(&self.response_key, nonce, plaintext, associated_data)
                 .context("couldn't encrypt response message")?;

--- a/oak_crypto/src/tests.rs
+++ b/oak_crypto/src/tests.rs
@@ -85,13 +85,24 @@ fn test_hpke() {
     .expect("couldn't setup base recipient");
 
     for i in 0..TEST_SESSION_SIZE {
+        let test_request_nonce = sender_context
+            .generate_nonce()
+            .expect("couldn't generate nonce");
         let test_request_message = [TEST_REQUEST_MESSAGE, &[i as u8]].concat();
         let test_request_associated_data = [TEST_REQUEST_ASSOCIATED_DATA, &[i as u8]].concat();
+
+        let test_response_nonce = recipient_context
+            .generate_nonce()
+            .expect("couldn't generate nonce");
         let test_response_message = [TEST_RESPONSE_MESSAGE, &[i as u8]].concat();
         let test_response_associated_data = [TEST_RESPONSE_ASSOCIATED_DATA, &[i as u8]].concat();
 
         let encrypted_request = sender_context
-            .seal(&test_request_message, &test_request_associated_data)
+            .seal(
+                &test_request_nonce,
+                &test_request_message,
+                &test_request_associated_data,
+            )
             .expect("sender context couldn't seal request");
         // Check that the message was encrypted.
         assert_ne!(test_request_message, encrypted_request);
@@ -101,7 +112,11 @@ fn test_hpke() {
         assert_eq!(test_request_message, decrypted_request);
 
         let encrypted_response = recipient_context
-            .seal(&test_response_message, &test_response_associated_data)
+            .seal(
+                &test_response_nonce,
+                &test_response_message,
+                &test_response_associated_data,
+            )
             .expect("recipient context couldn't seal response");
         // Check that the message was encrypted.
         assert_ne!(test_response_message, encrypted_response);


### PR DESCRIPTION
This PR makes Rust Crypto send nonces in Proto messages.

This PR is part of a non-breaking change aimed to implement random nonces for Hybrid Encryption.
Ref https://github.com/project-oak/oak/issues/4507

For now we send deterministic nonces, but once we make sure that code uses nonces from the proto instead of computing them, we can swap nonces for random ones.