### PR TITLE
Use DICE evidence in Oak Functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,6 +2216,7 @@ dependencies = [
  "oak_functions_launcher",
  "oak_functions_test_utils",
  "oak_grpc_utils",
+ "oak_remote_attestation",
  "prost",
  "tokio",
  "tonic",

--- a/oak_functions_containers_app/build.rs
+++ b/oak_functions_containers_app/build.rs
@@ -22,6 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "../",
         &[
             "oak_crypto/proto/v1/crypto.proto",
+            "proto/attestation/evidence.proto",
             "proto/oak_functions/service/oak_functions.proto",
         ],
         CodegenOptions {

--- a/oak_functions_containers_launcher/Cargo.toml
+++ b/oak_functions_containers_launcher/Cargo.toml
@@ -18,6 +18,7 @@ oak_containers_launcher = { workspace = true }
 oak_crypto = { workspace = true }
 oak_functions_abi = { workspace = true }
 oak_functions_launcher = { workspace = true }
+oak_remote_attestation = { workspace = true }
 prost = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tonic = { workspace = true }

--- a/oak_functions_containers_launcher/build.rs
+++ b/oak_functions_containers_launcher/build.rs
@@ -22,6 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "../",
         &[
             "oak_crypto/proto/v1/crypto.proto",
+            "proto/attestation/evidence.proto",
             "proto/oak_functions/service/oak_functions.proto",
         ],
         CodegenOptions {

--- a/oak_functions_containers_launcher/src/lib.rs
+++ b/oak_functions_containers_launcher/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod proto {
     pub mod oak {
         pub use oak_crypto::proto::oak::crypto;
+        pub use oak_remote_attestation::proto::oak::attestation;
         pub mod functions {
             tonic::include_proto!("oak.functions");
         }

--- a/oak_functions_launcher/benches/integration_benches.rs
+++ b/oak_functions_launcher/benches/integration_benches.rs
@@ -102,6 +102,7 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
         .expect("Failed to create launcher");
     log::info!("created launcher instance");
 
+    #[allow(deprecated)]
     let serialized_server_public_key = initialize_response
         .public_key_info
         .expect("initialize response doesn't have public key info")

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -57,6 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
+    #[allow(deprecated)]
     let public_key_info = initialize_response
         .public_key_info
         .expect("no public key info returned");

--- a/proto/oak_functions/service/oak_functions.proto
+++ b/proto/oak_functions/service/oak_functions.proto
@@ -19,6 +19,7 @@ syntax = "proto3";
 package oak.functions;
 
 import "oak_crypto/proto/v1/crypto.proto";
+import "proto/attestation/evidence.proto";
 
 service OakFunctions {
   // Initializes the service and remote attestation keys.
@@ -57,10 +58,12 @@ message InitializeRequest {
 }
 
 message InitializeResponse {
-  PublicKeyInfo public_key_info = 1;
+  PublicKeyInfo public_key_info = 1 [deprecated = true];
+  oak.attestation.v1.Evidence evidence = 2;
 }
 
 message PublicKeyInfo {
+  option deprecated = true;
   bytes public_key = 1;
   bytes attestation = 2;
 }


### PR DESCRIPTION
This change adds supports for using DICE evidence in the Restricted Kernel version of Oak Functions.

It also deprecates the `PublicKeyInfo` message, which is still needed untill we have a DICE verification library, but will be removed when clients no longer rely on direclty fetching the public key.