### PR TITLE
Run Orchestrator Crypto service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,7 @@ dependencies = [
  "tar",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "walkdir",
 ]

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { version = "*", features = [
   "net",
 ] }
 tokio-stream = { version = "*", features = ["net"] }
+tokio-util = { version = "*", default-features = false }
 tonic = { workspace = true }
 walkdir = "*"
 

--- a/oak_containers_orchestrator/src/container_runtime.rs
+++ b/oak_containers_orchestrator/src/container_runtime.rs
@@ -21,6 +21,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use tokio::sync::oneshot::Sender;
+use tokio_util::sync::CancellationToken;
 
 pub async fn run(
     container_bundle: &[u8],
@@ -29,6 +30,7 @@ pub async fn run(
     runtime_gid: Gid,
     ipc_socket_path: &Path,
     exit_notification_sender: Sender<()>,
+    cancellation_token: CancellationToken,
 ) -> Result<(), anyhow::Error> {
     tokio::fs::create_dir_all(container_dir).await?;
     log::info!("Unpacking container bundle");
@@ -118,6 +120,7 @@ pub async fn run(
     ))?;
     log::info!("Container exited with status {status:?}");
 
-    let _ = exit_notification_sender.send(());
+    // let _ = exit_notification_sender.send(());
+    cancellation_token.cancel();
     Ok(())
 }

--- a/oak_containers_orchestrator/src/crypto.rs
+++ b/oak_containers_orchestrator/src/crypto.rs
@@ -19,6 +19,7 @@ use crate::proto::oak::containers::v1::{
 };
 use oak_crypto::encryptor::{EncryptionKeyProvider, RecipientContextGenerator};
 use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 use tonic::{Request, Response};
 
 pub struct KeyStore {

--- a/oak_containers_orchestrator/src/ipc_server.rs
+++ b/oak_containers_orchestrator/src/ipc_server.rs
@@ -28,6 +28,7 @@ use oak_crypto::encryptor::{EncryptionKeyProvider, RecipientContextGenerator};
 use std::{fs::Permissions, os::unix::prelude::PermissionsExt, sync::Arc};
 use tokio::{fs::set_permissions, net::UnixListener, sync::oneshot::Receiver};
 use tokio_stream::wrappers::UnixListenerStream;
+use tokio_util::sync::CancellationToken;
 use tonic::{transport::Server, Request, Response};
 
 pub struct ServiceImplementation {
@@ -82,6 +83,7 @@ pub async fn create<P>(
     application_config: Vec<u8>,
     launcher_client: Arc<LauncherClient>,
     shutdown_receiver: Receiver<()>,
+    cancellation_token: CancellationToken,
 ) -> Result<(), anyhow::Error>
 where
     P: AsRef<std::path::Path> + Clone,
@@ -104,7 +106,7 @@ where
     Server::builder()
         .add_service(OrchestratorServer::new(service_instance))
         .add_service(OrchestratorCryptoServer::new(crypto_service_instance))
-        .serve_with_incoming_shutdown(uds_stream, shutdown_receiver.map(|_| ()))
+        .serve_with_incoming_shutdown(uds_stream, cancellation_token.cancelled())
         .await?;
 
     Ok(())


### PR DESCRIPTION
This PR:
- Makes Orchestrator start a separate Crypto service
- Uses [`tokio_util::sync::CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html#) to shutdown services in the Orchestrator

Ref https://github.com/project-oak/oak/issues/4507