### PR TITLE
Do a release build of oak_functions_containers_app

### DIFF
--- a/oak_functions_containers_container/build_container_bundle
+++ b/oak_functions_containers_container/build_container_bundle
@@ -17,6 +17,7 @@ mkdir --parents ./target
 cargo build \
     --package=oak_functions_containers_app \
     --target=x86_64-unknown-linux-musl \
+    --release \
     -Zunstable-options \
     --out-dir=./target/
 


### PR DESCRIPTION
Simply by doing a `--release` build we've significantly improved allocation performance. The code is still inefficient, but at least it's now better at that.