### PR TITLE
Add a streaming RPC for uploading lookup data to Oak Functions

### DIFF
--- a/oak_functions_service/src/instance.rs
+++ b/oak_functions_service/src/instance.rs
@@ -73,6 +73,12 @@ impl OakFunctionsInstance {
             )?));
         Ok(ExtendNextLookupDataResponse {})
     }
+
+    pub fn extend_lookup_data_chunk(&self, chunk: LookupDataChunk) {
+        self.lookup_data_manager
+            .extend_next_lookup_data(to_data(chunk))
+    }
+
     /// See [`crate::proto::oak::functions::OakFunctions::finish_next_lookup_data`].
     pub fn finish_next_lookup_data(
         &self,

--- a/oak_functions_service/src/lib.rs
+++ b/oak_functions_service/src/lib.rs
@@ -49,7 +49,8 @@ use prost::Message;
 use proto::oak::functions::{
     AbortNextLookupDataResponse, Empty, ExtendNextLookupDataRequest, ExtendNextLookupDataResponse,
     FinishNextLookupDataRequest, FinishNextLookupDataResponse, InitializeRequest,
-    InitializeResponse, InvokeRequest, InvokeResponse, OakFunctions, PublicKeyInfo,
+    InitializeResponse, InvokeRequest, InvokeResponse, LookupDataChunk, OakFunctions,
+    PublicKeyInfo,
 };
 
 pub struct OakFunctionsService {
@@ -174,5 +175,14 @@ impl OakFunctions for OakFunctionsService {
     ) -> Result<AbortNextLookupDataResponse, micro_rpc::Status> {
         log::debug!("called abort_next_lookup_data");
         self.get_instance()?.abort_next_lookup_data(request)
+    }
+
+    fn stream_lookup_data(
+        &self,
+        request: LookupDataChunk,
+    ) -> Result<FinishNextLookupDataResponse, micro_rpc::Status> {
+        let instance = self.get_instance()?;
+        instance.extend_lookup_data_chunk(request);
+        instance.finish_next_lookup_data(FinishNextLookupDataRequest {})
     }
 }

--- a/proto/oak_functions/service/oak_functions.proto
+++ b/proto/oak_functions/service/oak_functions.proto
@@ -50,6 +50,13 @@ service OakFunctions {
   //
   // method_id: 4
   rpc AbortNextLookupData(Empty) returns (AbortNextLookupDataResponse);
+
+  // Streaming version combining `ExtendNextLookupData` and `FinishNextLookupData`.
+  //
+  // This is mainly for use with gRPC, as microRPC doesn't support streaming.
+  //
+  // method_id: 5
+  rpc StreamLookupData(stream LookupDataChunk) returns (FinishNextLookupDataResponse);
 }
 
 message InitializeRequest {


### PR DESCRIPTION
Instead of calling _n_ `ExtendNextLookupData` RPCs + a `FinishNextLookupData` RPC, this lets you do all of it in one streaming RPC.

This is slightly more efficient (my benchmarking shows around 10% increase in performance).

Unfortunately this is mostly of interest for gRPC only, as micro_rpc doesn't support streaming and just ignores the `stream` keyword. I guess for microRPC users it'd be an easy way to fling just one chunk of data in there and calling it a day.