### PR TITLE
Use `bytes::Bytes` instead of `Vec<u8>` in lookup data map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,6 +2313,7 @@ dependencies = [
  "async-trait",
  "benchmark",
  "byteorder",
+ "bytes",
  "env_logger",
  "hashbrown 0.13.2",
  "log",

--- a/micro_rpc_build/src/lib.rs
+++ b/micro_rpc_build/src/lib.rs
@@ -41,10 +41,13 @@ impl ReceiverType {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct CompileOptions {
     /// Specifies the receiver type in generated server code.
     pub receiver_type: ReceiverType,
+
+    /// List of `bytes` fields that will use `bytes::Bytes` instead of `Vec<u8>`
+    pub bytes: Vec<String>,
 }
 
 /// Compile Rust server code from the services in the provided protobuf file.
@@ -77,10 +80,13 @@ pub fn compile(
         )
     });
     let mut config = prost_build::Config::new();
-    config.service_generator(Box::new(ServiceGenerator { options }));
+    config.service_generator(Box::new(ServiceGenerator {
+        options: options.clone(),
+    }));
     config
         // Use BTreeMap to allow using this function in no-std crates.
         .btree_map(["."])
+        .bytes(options.bytes)
         .compile_protos(protos, includes)
         .expect("couldn't compile protobuffer schema");
 }

--- a/oak_functions_sdk/tests/integration_test.rs
+++ b/oak_functions_sdk/tests/integration_test.rs
@@ -125,7 +125,10 @@ async fn test_write_log() {
 
 #[tokio::test]
 async fn test_storage_get_item() {
-    let entries = HashMap::from_iter([(b"StorageGet".to_vec(), b"StorageGetResponse".to_vec())]);
+    let entries = HashMap::from_iter([(
+        b"StorageGet".to_vec().into(),
+        b"StorageGetResponse".to_vec().into(),
+    )]);
 
     let logger = StandaloneLogger {};
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(entries, logger.clone()));
@@ -170,7 +173,7 @@ async fn test_storage_get_item_not_found() {
 #[ignore]
 async fn test_storage_get_item_huge_key() {
     let bytes: Vec<u8> = vec![42u8; 1 << 20];
-    let entries = HashMap::from_iter([(bytes.clone(), bytes.clone())]);
+    let entries = HashMap::from_iter([(bytes.clone().into(), bytes.clone().into())]);
 
     let logger = StandaloneLogger {};
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(entries, logger.clone()));

--- a/oak_functions_service/Cargo.toml
+++ b/oak_functions_service/Cargo.toml
@@ -13,6 +13,7 @@ deny_sensitive_logging = []
 [dependencies]
 anyhow = { version = "*", default-features = false }
 byteorder = { version = "*", default-features = false }
+bytes = { version = "*", default-features = false }
 hashbrown = "*"
 log = "*"
 micro_rpc = { workspace = true }

--- a/oak_functions_service/build.rs
+++ b/oak_functions_service/build.rs
@@ -25,6 +25,7 @@ fn main() {
         &[env!("WORKSPACE_ROOT")],
         micro_rpc_build::CompileOptions {
             receiver_type: ReceiverType::RefSelf,
+            bytes: vec![".oak.functions.LookupDataEntry".to_string()],
         },
     );
 }

--- a/oak_functions_service/src/instance.rs
+++ b/oak_functions_service/src/instance.rs
@@ -25,6 +25,7 @@ use crate::{
     wasm,
 };
 use alloc::{format, sync::Arc};
+use bytes::Bytes;
 use micro_rpc::{Status, Vec};
 use oak_functions_abi::Request;
 
@@ -92,7 +93,7 @@ impl OakFunctionsInstance {
 }
 
 // Helper function to convert [`LookupDataChunk`] to [`Data`].
-fn to_data(chunk: LookupDataChunk) -> impl Iterator<Item = (Vec<u8>, Vec<u8>)> {
+fn to_data(chunk: LookupDataChunk) -> impl Iterator<Item = (Bytes, Bytes)> {
     chunk
         .items
         .into_iter()

--- a/oak_functions_service/tests/integration_test.rs
+++ b/oak_functions_service/tests/integration_test.rs
@@ -236,8 +236,8 @@ async fn it_should_support_lookup_data() {
 
     let chunk = LookupDataChunk {
         items: vec![LookupDataEntry {
-            key: LOOKUP_TEST_KEY.to_vec(),
-            value: LOOKUP_TEST_VALUE.to_vec(),
+            key: LOOKUP_TEST_KEY.into(),
+            value: LOOKUP_TEST_VALUE.into(),
         }],
     };
 


### PR DESCRIPTION
`Bytes` is a data structure that is cheap to copy, as it effectively is an `Arc` to a buffer in memory, and thus you don't actually need to clone the data.

This is, again, in quest of efficiency: experimentation suggests up to 15% increase in performance.