### PR TITLE
Fix provenance generation.

### DIFF
--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -16,7 +16,8 @@ on:
       # The Ent API key is used to upload the binary and its provenance to Ent.
       ENT_API_KEY:
         required: true
-      # The Ent secret key is used to sign Ent tags, mapping the identifier of a binary to its provenance.
+      # The Ent secret key is used to sign Ent tags, mapping the identifier
+      # of a binary to its provenance.
       ENT_SECRET_KEY:
         required: true
 
@@ -36,18 +37,21 @@ jobs:
       - name: Get artifact path
         id: artifact-path
         run: |
-          echo "name=$(tail -1 ${{ inputs.build-config-path }} | grep -oP 'artifact_path = \K(.*)')" >> $GITHUB_OUTPUT
+          name="$(tail -1 ${{ inputs.build-config-path }} | grep -oP 'artifact_path = \K(.*)')"
+          echo "name=${name}" >> $GITHUB_OUTPUT
 
       - name: Get provenance name
         id: provenance-name
         run: |
-          echo "name=$(basename ${{ steps.artifact-path.outputs.name }}).intoto" >> $GITHUB_OUTPUT
+          name="$(basename ${{ steps.artifact-path.outputs.name }}).intoto"
+          echo "name=${name}" >> $GITHUB_OUTPUT
 
       - name: Get builder image info
         id: builder-digest
         run: |
           source ./scripts/common
-          echo "builder-digest=$(echo $DOCKER_IMAGE_REPO_DIGEST | cut -d'@' -f2)" >> $GITHUB_OUTPUT
+          digest="$(echo "${DOCKER_IMAGE_REPO_DIGEST}" | cut -d'@' -f2)"
+          echo "builder-digest=${digest}" >> $GITHUB_OUTPUT
 
       - name: Print values
         run: |
@@ -94,7 +98,7 @@ jobs:
           set -o nounset
           set -o xtrace
           set -o pipefail
-          curl --fail ${ENT_URL}/raw/sha2-256:${ENT_DIGEST_SHA_2_256} > /usr/local/bin/ent
+          curl --fail "${ENT_URL}/raw/sha2-256:${ENT_DIGEST_SHA_2_256}" > /usr/local/bin/ent
           echo "${ENT_DIGEST_SHA_2_256} /usr/local/bin/ent" | sha256sum --check
           chmod +x /usr/local/bin/ent
           ent
@@ -132,24 +136,27 @@ jobs:
           set -o nounset
           set -o xtrace
           set -o pipefail
-          echo "binary_digest=$(ent put --digest-format=human --porcelain ${{ needs.get_inputs.outputs.artifact-path }})" >> $GITHUB_OUTPUT
+          file="${{ needs.get_inputs.outputs.artifact-path }}"
+          digest="$(ent put --digest-format=human --porcelain "${file}")"
+          echo "binary_digest=${digest}" >> $GITHUB_OUTPUT
 
       - name: Upload provenance to Ent
         id: ent_upload_provenance
         working-directory: downloads
-        # The output on any trigger other than "pull_request" has an addition ".sigstore" suffix.
+        # The output on any trigger other than "pull_request" has an additional
+        # ".sigstore" suffix. However, that suffix appears to be "builder.slsa". 
         # See https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/docker#workflow-outputs
         run: |
           set -o errexit
           set -o nounset
           set -o xtrace
           set -o pipefail
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            PROVENANCE_FILENAME="${{ needs.get_inputs.outputs.provenance-name }}"
-          else
-            PROVENANCE_FILENAME="${{ needs.get_inputs.outputs.provenance-name }}.sigstore"
+          file="${{ needs.get_inputs.outputs.provenance-name }}"
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            file="${file}.builder.slsa"
           fi
-          echo "provenance_digest=$(ent put --digest-format=human --porcelain $PROVENANCE_FILENAME)" >> $GITHUB_OUTPUT
+          digest="$(ent put --digest-format=human --porcelain "${file}")"
+          echo "provenance_digest=${digest}" >> $GITHUB_OUTPUT
 
       - name: Upload signed tag to Ent
         run: |
@@ -157,17 +164,18 @@ jobs:
           set -o nounset
           set -o xtrace
           set -o pipefail
-          export BINARY_NAME="$(basename ${{ needs.get_inputs.outputs.artifact-path }})"
+          file="${{ needs.get_inputs.outputs.artifact-path }}"
+          binary_name="$(basename "${file}")"
           ent tag set --public-key=${{ inputs.ent-public-key }} \
-            --label="artifact_${GITHUB_SHA}_${BINARY_NAME}" \
+            --label="artifact_${GITHUB_SHA}_${binary_name}" \
             --target=${{ steps.ent_upload_binary.outputs.binary_digest }}
           ent tag set --public-key=${{ inputs.ent-public-key }} \
-            --label="provenance_${GITHUB_SHA}_${BINARY_NAME}" \
+            --label="provenance_${GITHUB_SHA}_${binary_name}" \
             --target=${{ steps.ent_upload_provenance.outputs.provenance_digest }}
 
-  # Debug step similar to `upload_provenance`, but runs on pull-request events. Differs from
-  # `upload_provenance` in that it does not publish the binary and its provenance into Ent and that
-  # it does not post a comment on the PR.
+  # Debug step similar to `upload_provenance`, but runs on pull-request events.
+  # Differs from `upload_provenance` in that it does not publish the binary
+  # and its provenance into Ent and that it does not post a comment on the PR.
   debug_provenance:
     if: github.event_name == 'pull_request'
     needs: [get_inputs, generate_provenance]

--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -144,7 +144,7 @@ jobs:
         id: ent_upload_provenance
         working-directory: downloads
         # The output on any trigger other than "pull_request" has an additional
-        # ".sigstore" suffix. However, that suffix appears to be "builder.slsa". 
+        # ".sigstore" suffix. However, that suffix appears to be "builder.slsa".
         # See https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/docker#workflow-outputs
         run: |
           set -o errexit

--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -37,18 +37,30 @@ jobs:
       - name: Get artifact path
         id: artifact-path
         run: |
+          set -o errexit
+          set -o nounset
+          set -o xtrace
+          set -o pipefail
           name="$(tail -1 ${{ inputs.build-config-path }} | grep -oP 'artifact_path = \K(.*)')"
           echo "name=${name}" >> $GITHUB_OUTPUT
 
       - name: Get provenance name
         id: provenance-name
         run: |
+          set -o errexit
+          set -o nounset
+          set -o xtrace
+          set -o pipefail
           name="$(basename ${{ steps.artifact-path.outputs.name }}).intoto"
           echo "name=${name}" >> $GITHUB_OUTPUT
 
       - name: Get builder image info
         id: builder-digest
         run: |
+          set -o errexit
+          set -o nounset
+          set -o xtrace
+          set -o pipefail
           source ./scripts/common
           digest="$(echo "${DOCKER_IMAGE_REPO_DIGEST}" | cut -d'@' -f2)"
           echo "builder-digest=${digest}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
* Bug fix: Change artifact suffix from .sigstore to .builder.slsa
* Bug fix: Don't put crucial commands inside an echo since failure will not trigger the `errexit` (if set). See https://github.com/project-oak/oak/actions/runs/7064214967/job/19231936581, where the step before the failing step contains the actual failure
* Better quoting
* Shorten long comment lines to 80 cols

Not 100% clear if this fixes the failure behind the link, but it is a promising attempt.