### PR TITLE
Add a method to pre-reserve space for the lookup data entries

### DIFF
--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -796,6 +796,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
+ "bytes",
  "hashbrown 0.14.2",
  "log",
  "micro_rpc",

--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -23,6 +23,7 @@ use oak_functions_service::{
         AbortNextLookupDataResponse, Empty, ExtendNextLookupDataRequest,
         ExtendNextLookupDataResponse, FinishNextLookupDataRequest, FinishNextLookupDataResponse,
         InitializeRequest, InitializeResponse, InvokeRequest, InvokeResponse, LookupDataChunk,
+        ReserveRequest, ReserveResponse,
     },
 };
 use oak_remote_attestation::handler::AsyncEncryptionHandler;
@@ -195,6 +196,17 @@ impl<G: AsyncRecipientContextGenerator + Send + Sync + 'static> OakFunctions
         }
         instance
             .finish_next_lookup_data(FinishNextLookupDataRequest {})
+            .map(tonic::Response::new)
+            .map_err(map_status)
+    }
+
+    async fn reserve(
+        &self,
+        request: tonic::Request<ReserveRequest>,
+    ) -> tonic::Result<tonic::Response<ReserveResponse>> {
+        let request = request.into_inner();
+        self.get_instance()?
+            .reserve(request)
             .map(tonic::Response::new)
             .map_err(map_status)
     }

--- a/oak_functions_service/src/instance.rs
+++ b/oak_functions_service/src/instance.rs
@@ -20,7 +20,7 @@ use crate::{
     proto::oak::functions::{
         AbortNextLookupDataResponse, Empty, ExtendNextLookupDataRequest,
         ExtendNextLookupDataResponse, FinishNextLookupDataRequest, FinishNextLookupDataResponse,
-        InitializeRequest, LookupDataChunk,
+        InitializeRequest, LookupDataChunk, ReserveRequest, ReserveResponse,
     },
     wasm,
 };
@@ -95,6 +95,18 @@ impl OakFunctionsInstance {
     ) -> Result<AbortNextLookupDataResponse, Status> {
         self.lookup_data_manager.abort_next_lookup_data();
         Ok(AbortNextLookupDataResponse {})
+    }
+
+    pub fn reserve(&self, request: ReserveRequest) -> Result<ReserveResponse, Status> {
+        self.lookup_data_manager
+            .reserve(request.additional_entries)
+            .map(|()| ReserveResponse {})
+            .map_err(|err| {
+                micro_rpc::Status::new_with_message(
+                    micro_rpc::StatusCode::ResourceExhausted,
+                    format!("failed to reserve memory: {:?}", err),
+                )
+            })
     }
 }
 

--- a/oak_functions_service/src/lib.rs
+++ b/oak_functions_service/src/lib.rs
@@ -50,7 +50,7 @@ use proto::oak::functions::{
     AbortNextLookupDataResponse, Empty, ExtendNextLookupDataRequest, ExtendNextLookupDataResponse,
     FinishNextLookupDataRequest, FinishNextLookupDataResponse, InitializeRequest,
     InitializeResponse, InvokeRequest, InvokeResponse, LookupDataChunk, OakFunctions,
-    PublicKeyInfo,
+    PublicKeyInfo, ReserveRequest, ReserveResponse,
 };
 
 pub struct OakFunctionsService {
@@ -184,5 +184,9 @@ impl OakFunctions for OakFunctionsService {
         let instance = self.get_instance()?;
         instance.extend_lookup_data_chunk(request);
         instance.finish_next_lookup_data(FinishNextLookupDataRequest {})
+    }
+
+    fn reserve(&self, request: ReserveRequest) -> Result<ReserveResponse, micro_rpc::Status> {
+        self.get_instance()?.reserve(request)
     }
 }

--- a/proto/oak_functions/service/oak_functions.proto
+++ b/proto/oak_functions/service/oak_functions.proto
@@ -57,6 +57,14 @@ service OakFunctions {
   //
   // method_id: 5
   rpc StreamLookupData(stream LookupDataChunk) returns (FinishNextLookupDataResponse);
+
+  // Reserves additional capacity for entries in the lookup table.
+  //
+  // It should be called before `ExtendNextLookupData`/`StreamLookupData` to reduce the
+  // number of memory allocations, but it's not mandatory to call this RPC.
+  //
+  // method_id: 6
+  rpc Reserve(ReserveRequest) returns (ReserveResponse);
 }
 
 message InitializeRequest {
@@ -107,3 +115,9 @@ message FinishNextLookupDataResponse {}
 message AbortNextLookupDataResponse {}
 
 message Empty {}
+
+message ReserveRequest {
+  uint64 additional_entries = 1;
+}
+
+message ReserveResponse {}


### PR DESCRIPTION
Evidence suggests that reserving space in the map before streaming in the entries can shave ~10% off the runtime, presumably because the `HashMap` doesn't have to keep re-allocating more space as entries are added to it.

It's totally optional to call it though; the system will work just fine if you don't pre-allocate space.