### PR TITLE
Log less in the orchestrator

### DIFF
--- a/oak_containers_orchestrator/src/logging.rs
+++ b/oak_containers_orchestrator/src/logging.rs
@@ -34,7 +34,7 @@ pub fn setup() -> Result<(), Box<dyn std::error::Error>> {
         syslog::unix(formatter).map_err(|e| format!("impossible to connect to syslog: {:?}", e))?;
 
     log::set_boxed_logger(Box::new(BasicLogger::new(logger)))
-        .map(|()| log::set_max_level(LevelFilter::Trace))
+        .map(|()| log::set_max_level(LevelFilter::Debug))
         .map_err(|e| format!("failed to set logger: {:?}", e))?;
 
     Ok(())


### PR DESCRIPTION
As it stands, the orchestrator is duly sending _all_ of its log entries to syslog. That is fine.

Unfortunately tonic likes to be really verbose on the trace level; we don't need all of that.

Case in point, you often see journald complaining about the verbosity of the orchestrator:
```
Suppressed 529629 messages from oak-orchestrator.service
```

I'm not sure we want ~half a million log entries every time we do a couple of RPCs.