### PR TITLE
Forward host to Orchestrator port

### DIFF
--- a/oak_containers_launcher/src/qemu.rs
+++ b/oak_containers_launcher/src/qemu.rs
@@ -96,7 +96,12 @@ pub struct Qemu {
 }
 
 impl Qemu {
-    pub fn start(params: Params, launcher_service_port: u16, host_proxy_port: u16) -> Result<Self> {
+    pub fn start(
+        params: Params,
+        launcher_service_port: u16,
+        host_proxy_port: u16,
+        host_orchestrator_proxy_port: u16,
+    ) -> Result<Self> {
         let mut cmd = tokio::process::Command::new(params.vmm_binary);
         let (guest_socket, host_socket) = UnixStream::pair()?;
         cmd.kill_on_drop(true);
@@ -141,6 +146,7 @@ impl Qemu {
         // `efi-virtio.rom` file, as we're not using EFI anyway.
         let vm_address = crate::VM_LOCAL_ADDRESS;
         let vm_port = crate::VM_LOCAL_PORT;
+        let vm_orchestrator_port = crate::VM_ORCHESTRATOR_LOCAL_PORT;
         let host_address = Ipv4Addr::LOCALHOST;
         cmd.args([
             "-netdev",
@@ -151,6 +157,7 @@ impl Qemu {
                     "guestfwd=tcp:10.0.2.100:8080-cmd:nc {host_address} {launcher_service_port}"
                 ),
                 &format!("hostfwd=tcp:{host_address}:{host_proxy_port}-{vm_address}:{vm_port}"),
+                &format!("hostfwd=tcp:{host_address}:{host_orchestrator_proxy_port}-{vm_address}:{vm_orchestrator_port}"),
             ]
             .join(",")
             .as_str(),

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -27,6 +27,9 @@ struct Args {
     #[arg(default_value = "http://10.0.2.100:8080")]
     launcher_addr: String,
 
+    #[arg(default_value = "127.0.0.1:4000")]
+    orchestrator_addr: String,
+
     #[arg(long, default_value = "/oak_container")]
     container_dir: PathBuf,
 


### PR DESCRIPTION
This PR creates port forwarding from host to the VM in order to access the Orchestrator Key Provisioning service.

Ref https://github.com/project-oak/oak/issues/4442