### PR TITLE
Create `tracing::Span` for each incoming RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "http",
  "micro_rpc",
  "oak_crypto",
  "oak_functions_service",
@@ -2198,6 +2199,8 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tower",
+ "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -4037,6 +4040,7 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -10,6 +10,7 @@ oak_grpc_utils = { workspace = true }
 [dependencies]
 anyhow = "*"
 async-trait = { version = "*", default-features = false }
+http = "*"
 oak_functions_service = { workspace = true }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
@@ -19,6 +20,8 @@ tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tokio-stream = { version = "*", features = ["net"] }
 tonic = { workspace = true }
 tower = "*"
+tower-http = { version = "*", features = ["trace"] }
+tracing = "*"
 
 [dev-dependencies]
 oak_functions_test_utils = { workspace = true }


### PR DESCRIPTION
Tracing: it's like logging, but more clever.

This modification doesn't do much right now as we don't log anything (for now), but it adds a `Span` that can hold extra context; for example, which RPC service and method is being invoked.

It'll allow for log messages to contain more context in the future, e.g.:
```
2023-12-05T21:25:00.173017Z  INFO request{rpc.method="StreamLookupData" rpc.service="oak.functions.OakFunctions" rpc.system="grpc" server.address="[::1]" server.port=48951}: oak_functions_service::lookup: Start replacing lookup data by next lookup data
2023-12-05T21:25:00.173356Z  INFO request{rpc.method="StreamLookupData" rpc.service="oak.functions.OakFunctions" rpc.system="grpc" server.address="[::1]" server.port=48951}: oak_functions_service::lookup: Finished replacing lookup data with len 0 by next lookup data with len 13615767
```

And, what's more important for my use case right now, I want to start keeping a histogram of how long a RPC invocation took. By creating (and filling in) a `Span`, I now know in `on_response` (a) what method was invoked (from the span), and (b) how long the invocation took (the `_latency` parameter), and (c) what the result was (success/failure).

Next step: creating a histogram of that data and pushing it to the launcher, via OpenTelemetry. (And maybe sending logs to the launcher directly as well, while we're in there.)