### PR TITLE
Fix git diff check

### DIFF
--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -580,8 +580,8 @@ dependencies = [
  "micro_rpc",
  "oak_channel",
  "oak_enclave_runtime_support",
- "oak_restricted_kernel_sdk",
  "oak_restricted_kernel_interface",
+ "oak_restricted_kernel_sdk",
  "static_assertions",
 ]
 
@@ -758,8 +758,8 @@ version = "0.1.0"
 dependencies = [
  "libm",
  "log",
- "oak_restricted_kernel_sdk",
  "oak_restricted_kernel_interface",
+ "oak_restricted_kernel_sdk",
  "rlsf",
  "spinning_top",
 ]
@@ -839,6 +839,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_restricted_kernel_interface"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.4.0",
+ "strum",
+]
+
+[[package]]
 name = "oak_restricted_kernel_sdk"
 version = "0.1.0"
 dependencies = [
@@ -852,14 +860,6 @@ dependencies = [
  "p256",
  "strum",
  "zerocopy",
-]
-
-[[package]]
-name = "oak_restricted_kernel_interface"
-version = "0.1.0"
-dependencies = [
- "bitflags 2.4.0",
- "strum",
 ]
 
 [[package]]

--- a/scripts/common
+++ b/scripts/common
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034  # Unused variables OK as this script is `source`d.
 
+set -o xtrace
 set -o errexit
 set -o nounset
-set -o xtrace
 set -o pipefail
 
 # Set the default Rust log level to info if unset.

--- a/scripts/git_check_diff
+++ b/scripts/git_check_diff
@@ -4,6 +4,13 @@ readonly SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=scripts/common
 source "$SCRIPTS_DIR/common"
 
+# Solves the following error when running on GitHub Actions:
+#
+# fatal: detected dubious ownership in repository at '/workspace'
+#   To add an exception for this directory, call:
+#   git config --global --add safe.directory /workspace
+git config --global --add safe.directory /workspace
+
 # Check that any generated files match those that are checked in.
 if [[ $(git status --short) ]]; then
     echo "Some files are either modified or newly generated, please commit them and try again."


### PR DESCRIPTION
The fix is to add the repo to the list of safe folders.

Also reorder bash common options to start with `xtrace` so they all logged
correctly.

Ref #4538