### PR TITLE
Add Key Provisioning logic for requesting group keys from Hostlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "ciborium",
  "clap",
  "coset",
+ "hpke",
  "log",
  "nix 0.26.2",
  "oak_containers_orchestrator_client",

--- a/java/src/main/java/com/google/oak/verification/RekorLogEntry.java
+++ b/java/src/main/java/com/google/oak/verification/RekorLogEntry.java
@@ -96,7 +96,9 @@ public final class RekorLogEntry {
    * Based on
    * <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L179.>
    */
-  static class Data { Hash hash; }
+  static class Data {
+    Hash hash;
+  }
 
   /**
    * Represents a hash digest.

--- a/java/src/main/java/com/google/oak/verification/RekorLogEntry.java
+++ b/java/src/main/java/com/google/oak/verification/RekorLogEntry.java
@@ -96,9 +96,7 @@ public final class RekorLogEntry {
    * Based on
    * <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L179.>
    */
-  static class Data {
-    Hash hash;
-  }
+  static class Data { Hash hash; }
 
   /**
    * Represents a hash digest.

--- a/oak_containers_launcher/build.rs
+++ b/oak_containers_launcher/build.rs
@@ -23,6 +23,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "oak_containers/proto/interfaces.proto",
             "oak_crypto/proto/v1/crypto.proto",
             "oak_remote_attestation/proto/v1/messages.proto",
+            "proto/key_provisioning/key_provisioning.proto",
+            "proto/containers/hostlib_key_provisioning.proto",
         ],
         CodegenOptions {
             build_server: true,

--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -18,9 +18,19 @@ pub mod proto {
         pub mod containers {
             #![allow(clippy::return_self_not_must_use)]
             tonic::include_proto!("oak.containers");
+            pub mod v1 {
+                #![allow(clippy::return_self_not_must_use)]
+                tonic::include_proto!("oak.containers.v1");
+            }
         }
         pub use oak_crypto::proto::oak::crypto;
         pub use oak_remote_attestation::proto::oak::{attestation, session};
+        pub mod key_provisioning {
+            pub mod v1 {
+                #![allow(clippy::return_self_not_must_use)]
+                tonic::include_proto!("oak.key_provisioning.v1");
+            }
+        }
     }
 }
 

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -10,6 +10,10 @@ anyhow = "*"
 ciborium = { version = "*", default-features = false }
 clap = { version = "*", features = ["derive"] }
 coset = { version = "*", features = ["std"] }
+hpke = { version = "*", default-features = false, features = [
+  "alloc",
+  "x25519"
+] }
 log = "*"
 nix = "*"
 oak_containers_orchestrator_client = { workspace = true }

--- a/oak_containers_orchestrator/src/logging.rs
+++ b/oak_containers_orchestrator/src/logging.rs
@@ -15,11 +15,12 @@
 
 extern crate log;
 
+use anyhow::anyhow;
 use log::LevelFilter;
 use syslog::{BasicLogger, Facility, Formatter3164};
 
 /// Setup logging to syslog.
-pub fn setup() -> Result<(), Box<dyn std::error::Error>> {
+pub fn setup() -> anyhow::Result<()> {
     // Based on syslog's example of integrating with the log crate.
     // Ref: https://docs.rs/syslog/6.1.0/syslog/
 
@@ -31,11 +32,11 @@ pub fn setup() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let logger =
-        syslog::unix(formatter).map_err(|e| format!("impossible to connect to syslog: {:?}", e))?;
+        syslog::unix(formatter).map_err(|e| anyhow!("impossible to connect to syslog: {:?}", e))?;
 
     log::set_boxed_logger(Box::new(BasicLogger::new(logger)))
         .map(|()| log::set_max_level(LevelFilter::Debug))
-        .map_err(|e| format!("failed to set logger: {:?}", e))?;
+        .map_err(|e| anyhow!("failed to set logger: {:?}", e))?;
 
     Ok(())
 }

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -77,6 +77,7 @@ impl TryFrom<&oak_dice::evidence::RestrictedKernelDiceData> for EncryptionKeyPro
     }
 }
 
+// TODO(#4513): Merge `EncryptionKeyProvider` and `hpke::KeyPair` into `EncryptionKey`.
 impl EncryptionKeyProvider {
     /// Creates a crypto provider with a newly generated key pair.
     pub fn generate() -> Self {
@@ -92,6 +93,7 @@ impl EncryptionKeyProvider {
     }
 
     pub fn get_private_key(&self) -> Vec<u8> {
+        // TODO(#4513): Implement Rust protections for the private key.
         self.key_pair.get_private_key()
     }
 


### PR DESCRIPTION
This PR adds the Orchestrator logic for requesting the Hostlib with:
- Key Provisioning role request (whether it's a Leader or a Dependant)
- Requesting group keys for a Dependant role

Ref https://github.com/project-oak/oak/issues/4442