### PR TITLE
Impl signing crypto oracle in the restricted kernel sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,6 +2082,7 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
+ "p256",
  "prost",
  "rand_core",
  "sha2",

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -91,6 +91,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +331,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -345,6 +352,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -693,6 +701,7 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
+ "p256",
  "prost",
  "rand_core",
  "sha2",
@@ -903,6 +912,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "platforms"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1129,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -1174,6 +1194,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
     }
     let mut invocation_stats = StaticSampleStore::<1000>::new().unwrap();
     let dice_data =
-        oak_restricted_kernel_sdk::dice::DiceWrapper::try_create().expect("couldn't get DICE data");
+        oak_restricted_kernel_sdk::DiceWrapper::try_create().expect("couldn't get DICE data");
     let service = oak_functions_service::OakFunctionsService::new(
         dice_data.evidence,
         Arc::new(dice_data.encryption_key),

--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -45,8 +45,8 @@ fn main() -> ! {
         log::set_max_level(log::LevelFilter::Warn);
     }
     let mut invocation_stats = StaticSampleStore::<1000>::new().unwrap();
-    let dice_data = oak_restricted_kernel_sdk::dice::get_dice_evidence_and_keys()
-        .expect("couldn't get DICE data");
+    let dice_data =
+        oak_restricted_kernel_sdk::dice::DiceWrapper::try_create().expect("couldn't get DICE data");
     let service = oak_functions_service::OakFunctionsService::new(
         dice_data.evidence,
         Arc::new(dice_data.encryption_key),

--- a/oak_crypto/Cargo.toml
+++ b/oak_crypto/Cargo.toml
@@ -18,6 +18,10 @@ hpke = { version = "*", default-features = false, features = [
   "alloc",
   "x25519"
 ] }
+p256 = { version = "*", default-features = false, features = [
+  "ecdsa",
+  "alloc"
+] }
 prost = { version = "*", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "*", default-features = false, features = [
   "getrandom"

--- a/oak_crypto/proto/v1/crypto.proto
+++ b/oak_crypto/proto/v1/crypto.proto
@@ -69,4 +69,3 @@ message CryptoContext {
 message Signature {
   bytes signature = 1;
 }
-

--- a/oak_crypto/proto/v1/crypto.proto
+++ b/oak_crypto/proto/v1/crypto.proto
@@ -65,3 +65,8 @@ message CryptoContext {
   bytes response_base_nonce = 5;
   uint64 response_sequence_number = 6;
 }
+
+message Signature {
+  bytes signature = 1;
+}
+

--- a/oak_crypto/src/signer.rs
+++ b/oak_crypto/src/signer.rs
@@ -15,15 +15,19 @@
 //
 
 pub use crate::proto::oak::crypto::v1::Signature;
-pub use p256::ecdsa::signature::{Error, Signer};
 
 // TODO(#3836): Implement signature verification.
 
-impl Signer<Signature> for p256::ecdsa::SigningKey {
-    fn try_sign(&self, message: &[u8]) -> Result<Signature, Error> {
-        let signature =
-            <p256::ecdsa::SigningKey as Signer<p256::ecdsa::Signature>>::try_sign(self, message)?
-                .to_vec();
-        Ok(Signature { signature })
+pub trait Signer {
+    fn sign(&self, message: &[u8]) -> Signature;
+}
+
+impl Signer for p256::ecdsa::SigningKey {
+    fn sign(&self, message: &[u8]) -> Signature {
+        let signature = <p256::ecdsa::SigningKey as p256::ecdsa::signature::Signer<
+            p256::ecdsa::Signature,
+        >>::sign(self, message)
+        .to_vec();
+        Signature { signature }
     }
 }

--- a/oak_crypto/src/signer.rs
+++ b/oak_crypto/src/signer.rs
@@ -14,5 +14,16 @@
 // limitations under the License.
 //
 
-// TODO(#3836): Implement signature generation and verification.
-pub struct Signer {}
+pub use crate::proto::oak::crypto::v1::Signature;
+pub use p256::ecdsa::signature::{Error, Signer};
+
+// TODO(#3836): Implement signature verification.
+
+impl Signer<Signature> for p256::ecdsa::SigningKey {
+    fn try_sign(&self, message: &[u8]) -> Result<Signature, Error> {
+        let signature =
+            <p256::ecdsa::SigningKey as Signer<p256::ecdsa::Signature>>::try_sign(self, message)?
+                .to_vec();
+        Ok(Signature { signature })
+    }
+}

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -112,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +360,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -374,6 +381,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -710,6 +718,7 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
+ "p256",
  "prost",
  "rand_core 0.6.4",
  "sha2",
@@ -868,6 +877,16 @@ checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -1134,6 +1153,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -1222,6 +1242,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/oak_restricted_kernel_sdk/src/dice.rs
+++ b/oak_restricted_kernel_sdk/src/dice.rs
@@ -35,7 +35,7 @@ use zerocopy::{AsBytes, FromZeroes};
 pub struct DiceWrapper {
     pub evidence: Evidence,
     pub encryption_key: EncryptionKeyProvider,
-    pub signer: SignerStruct,
+    pub signer: SigningOracle,
 }
 
 impl DiceWrapper {
@@ -75,7 +75,7 @@ fn get_dice_evidence_and_keys() -> anyhow::Result<DiceWrapper> {
             &dice_data.application_private_keys.signing_private_key[..P256_PRIVATE_KEY_SIZE],
         )
         .map_err(|error| anyhow::anyhow!("couldn't deserialize signing key: {}", error))?;
-        SignerStruct { key }
+        SigningOracle { key }
     };
 
     Ok(DiceWrapper {
@@ -95,11 +95,11 @@ fn get_restricted_kernel_dice_data() -> anyhow::Result<RestrictedKernelDiceData>
     Ok(result)
 }
 
-pub struct SignerStruct {
+pub struct SigningOracle {
     key: SigningKey,
 }
 
-impl oak_crypto::signer::Signer<oak_crypto::signer::Signature> for SignerStruct {
+impl oak_crypto::signer::Signer<oak_crypto::signer::Signature> for SigningOracle {
     fn try_sign(
         &self,
         message: &[u8],

--- a/oak_restricted_kernel_sdk/src/dice.rs
+++ b/oak_restricted_kernel_sdk/src/dice.rs
@@ -35,11 +35,17 @@ use zerocopy::{AsBytes, FromZeroes};
 pub struct DiceWrapper {
     pub evidence: Evidence,
     pub encryption_key: EncryptionKeyProvider,
-    pub signing_key: SigningKey,
+    pub signer: SignerStruct,
+}
+
+impl DiceWrapper {
+    pub fn try_create() -> anyhow::Result<Self> {
+        get_dice_evidence_and_keys()
+    }
 }
 
 /// Get the DICE evidence and application private keys from the Restricted Kernel
-pub fn get_dice_evidence_and_keys() -> anyhow::Result<DiceWrapper> {
+fn get_dice_evidence_and_keys() -> anyhow::Result<DiceWrapper> {
     let dice_data = get_restricted_kernel_dice_data()?;
     let evidence: Evidence = dice_data.evidence.try_into()?;
     let private_key = PrivateKey::from_bytes(
@@ -64,14 +70,18 @@ pub fn get_dice_evidence_and_keys() -> anyhow::Result<DiceWrapper> {
         PublicKey::from_bytes(&public_key)
             .map_err(|err| anyhow::anyhow!("couldn't decode public key: {err}"))?,
     );
-    let signing_key = SigningKey::from_slice(
-        &dice_data.application_private_keys.signing_private_key[..P256_PRIVATE_KEY_SIZE],
-    )
-    .map_err(|error| anyhow::anyhow!("couldn't deserialize signing key: {}", error))?;
+    let signer = {
+        let key = SigningKey::from_slice(
+            &dice_data.application_private_keys.signing_private_key[..P256_PRIVATE_KEY_SIZE],
+        )
+        .map_err(|error| anyhow::anyhow!("couldn't deserialize signing key: {}", error))?;
+        SignerStruct { key }
+    };
+
     Ok(DiceWrapper {
         evidence,
         encryption_key,
-        signing_key,
+        signer,
     })
 }
 
@@ -83,4 +93,17 @@ fn get_restricted_kernel_dice_data() -> anyhow::Result<RestrictedKernelDiceData>
         anyhow::bail!("invalid dice data size");
     }
     Ok(result)
+}
+
+pub struct SignerStruct {
+    key: SigningKey,
+}
+
+impl oak_crypto::signer::Signer<oak_crypto::signer::Signature> for SignerStruct {
+    fn try_sign(
+        &self,
+        message: &[u8],
+    ) -> Result<oak_crypto::signer::Signature, p256::ecdsa::signature::Error> {
+        self.key.try_sign(message)
+    }
 }

--- a/oak_restricted_kernel_sdk/src/lib.rs
+++ b/oak_restricted_kernel_sdk/src/lib.rs
@@ -20,10 +20,11 @@
 extern crate alloc;
 
 mod channel;
-pub mod dice;
+mod dice;
 mod logging;
 mod raw_syscall;
 pub mod syscall;
 
 pub use channel::FileDescriptorChannel;
+pub use dice::{DiceWrapper, Signer};
 pub use logging::StderrLogger;


### PR DESCRIPTION
Previously we would expose the signign key directly, now it's behind a struct whose only public method is a sign.

Tracking http://b/314749025 and http://b/312897453.

The implementation is slightly different from what is outlined in the bugs. Specifically the bug propsed implementing a create method directly Signer struct, which would call directly into the kernel to fetch the key.

This isn't feasible dice data can only be read from the restricted kernel once and only read at once. Hence a create method is used for the overarching DiceWrapper struct.

If we want to maintain the orginally proposed interface, we could store the dice data seperately in memory for the application, and read ot from there whenever a new struct is created. A perhaps more ergonimic but also more complex and magical solution. Hence why I didn't go with it. Thoughts otherwise are welcome in the comments

Ref https://github.com/project-oak/oak/issues/4490