### PR TITLE
Explode verification of transparent release endorsements to cover all cases.

### DIFF
--- a/proto/attestation/endorsement.proto
+++ b/proto/attestation/endorsement.proto
@@ -51,20 +51,26 @@ message RootLayerEndorsements {
 
 message KernelLayerEndorsements {
   TransparentReleaseEndorsement kernel_image = 1;
-  TransparentReleaseEndorsement kernel_setup_data = 2;
-  TransparentReleaseEndorsement init_ram_fs = 3;
+  TransparentReleaseEndorsement kernel_cmd_line = 2;
+  TransparentReleaseEndorsement kernel_setup_data = 3;
+  TransparentReleaseEndorsement init_ram_fs = 4;
+  TransparentReleaseEndorsement memory_map = 5;
+  TransparentReleaseEndorsement acpi = 6;
 }
 
 message SystemLayerEndorsements {
   TransparentReleaseEndorsement system_image = 1;
+  TransparentReleaseEndorsement configuration = 2;
 }
 
 message ApplicationLayerEndorsements {
   TransparentReleaseEndorsement binary = 1;
+  TransparentReleaseEndorsement configuration = 2;
 }
 
 message ContainerLayerEndorsements {
   TransparentReleaseEndorsement binary = 1;
+  TransparentReleaseEndorsement configuration = 2;
 }
 
 message OakRestrictedKernelEndorsements {


### PR DESCRIPTION
- Extend endorsements and reference values so that they are in a 1:1 correspondence w.r.t. subfields