### PR TITLE
Stop exposing dice related structs in the SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,6 +2082,7 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
+ "oak_dice",
  "p256",
  "prost",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,7 +2486,6 @@ dependencies = [
  "oak_channel",
  "oak_crypto",
  "oak_dice",
- "oak_remote_attestation",
  "oak_restricted_kernel_interface",
  "os_pipe",
  "p256",

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -701,6 +701,7 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
+ "oak_dice",
  "p256",
  "prost",
  "rand_core",
@@ -792,11 +793,15 @@ dependencies = [
  "micro_rpc",
  "oak_channel",
  "oak_core",
+ "oak_crypto",
+ "oak_dice",
  "oak_enclave_runtime_support",
  "oak_functions_service",
  "oak_remote_attestation",
+ "oak_restricted_kernel_interface",
  "oak_restricted_kernel_sdk",
  "static_assertions",
+ "zerocopy",
 ]
 
 [[package]]

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -869,7 +869,6 @@ dependencies = [
  "oak_channel",
  "oak_crypto",
  "oak_dice",
- "oak_remote_attestation",
  "oak_restricted_kernel_interface",
  "p256",
  "strum",

--- a/enclave_apps/Cargo.toml
+++ b/enclave_apps/Cargo.toml
@@ -12,6 +12,8 @@ micro_rpc = { path = "../micro_rpc" }
 oak_enclave_runtime_support = { path = "../oak_enclave_runtime_support" }
 oak_channel = { path = "../oak_channel" }
 oak_core = { path = "../oak_core" }
+oak_crypto = { path = "../oak_crypto" }
+oak_dice = { path = "../oak_dice" }
 oak_restricted_kernel_sdk = { path = "../oak_restricted_kernel_sdk" }
 oak_restricted_kernel_interface = { path = "../oak_restricted_kernel_interface" }
 oak_remote_attestation = { path = "../oak_remote_attestation" }

--- a/enclave_apps/oak_functions_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_functions_enclave_app/Cargo.toml
@@ -20,9 +20,13 @@ micro_rpc = { workspace = true }
 oak_enclave_runtime_support = { workspace = true }
 oak_core = { workspace = true }
 oak_channel = { workspace = true }
+oak_crypto = { workspace = true }
+oak_dice = { workspace = true }
 oak_remote_attestation = { workspace = true }
 oak_restricted_kernel_sdk = { workspace = true }
+oak_restricted_kernel_interface = { workspace = true }
 static_assertions = "*"
+zerocopy = "*"
 
 [[bin]]
 name = "oak_functions_enclave_app"

--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -25,6 +25,7 @@ use core::panic::PanicInfo;
 use log::info;
 use oak_core::samplestore::StaticSampleStore;
 use oak_restricted_kernel_sdk::{FileDescriptorChannel, StderrLogger};
+use zerocopy::{AsBytes, FromZeroes};
 
 static LOGGER: StderrLogger = StderrLogger {};
 
@@ -45,12 +46,29 @@ fn main() -> ! {
         log::set_max_level(log::LevelFilter::Warn);
     }
     let mut invocation_stats = StaticSampleStore::<1000>::new().unwrap();
-    let dice_data =
-        oak_restricted_kernel_sdk::DiceWrapper::try_create().expect("couldn't get DICE data");
-    let service = oak_functions_service::OakFunctionsService::new(
-        dice_data.evidence,
-        Arc::new(dice_data.encryption_key),
-    );
+
+    let restricted_kernel_dice_data = {
+        let mut result = oak_dice::evidence::RestrictedKernelDiceData::new_zeroed();
+        let buffer = result.as_bytes_mut();
+        let len = oak_restricted_kernel_sdk::syscall::read(
+            oak_restricted_kernel_interface::DICE_DATA_FD,
+            buffer,
+        )
+        .expect("couldn't read DICE data");
+        if len != buffer.len() {
+            panic!("invalid dice data size");
+        }
+        result
+    };
+    let encryption_key =
+        oak_crypto::encryptor::EncryptionKeyProvider::try_from(&restricted_kernel_dice_data)
+            .expect("couldn't get encryption key");
+    let evidence = oak_remote_attestation::proto::oak::attestation::v1::Evidence::try_from(
+        restricted_kernel_dice_data.evidence,
+    )
+    .expect("couldn't get evidence");
+    let service =
+        oak_functions_service::OakFunctionsService::new(evidence, Arc::new(encryption_key));
     let server = oak_functions_service::proto::oak::functions::OakFunctionsServer::new(service);
     oak_channel::server::start_blocking_server(
         Box::<FileDescriptorChannel>::default(),

--- a/oak_crypto/Cargo.toml
+++ b/oak_crypto/Cargo.toml
@@ -27,6 +27,7 @@ rand_core = { version = "*", default-features = false, features = [
   "getrandom"
 ] }
 sha2 = { version = "*", default-features = false }
+oak_dice = { workspace = true }
 
 [build-dependencies]
 micro_rpc_build = { workspace = true }

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -28,6 +28,7 @@ use crate::{
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
+use hpke::Deserializable;
 
 /// Info string used by Hybrid Public Key Encryption;
 pub(crate) const OAK_HPKE_INFO: &[u8] = b"Oak Hybrid Public Key Encryption v1";
@@ -39,6 +40,42 @@ pub struct EncryptionKeyProvider {
 impl Default for EncryptionKeyProvider {
     fn default() -> Self {
         Self::generate()
+    }
+}
+
+impl TryFrom<&oak_dice::evidence::RestrictedKernelDiceData> for EncryptionKeyProvider {
+    type Error = anyhow::Error;
+    fn try_from(
+        dice_data: &oak_dice::evidence::RestrictedKernelDiceData,
+    ) -> Result<Self, Self::Error> {
+        let claims = oak_dice::cert::get_claims_set_from_certificate_bytes(
+            &dice_data
+                .evidence
+                .application_keys
+                .encryption_public_key_certificate,
+        )
+        .map_err(|err| {
+            anyhow::anyhow!("couldn't parse encryption public key certificate: {err}")
+        })?;
+        let private_key = PrivateKey::from_bytes(
+            &dice_data.application_private_keys.encryption_private_key
+                [..oak_dice::evidence::X25519_PRIVATE_KEY_SIZE],
+        )
+        .map_err(|error| anyhow::anyhow!("couldn't deserialize private key: {}", error))?;
+        let public_key = {
+            let cose_key =
+                oak_dice::cert::get_public_key_from_claims_set(&claims).map_err(|err| {
+                    anyhow::anyhow!("couldn't get public key from certificate: {err}")
+                })?;
+            oak_dice::cert::cose_key_to_hpke_public_key(&cose_key)
+                .map_err(|err| anyhow::anyhow!("couldn't extract public key: {err}"))?
+        };
+        let encryption_key_provider = EncryptionKeyProvider::new(
+            private_key,
+            PublicKey::from_bytes(&public_key)
+                .map_err(|err| anyhow::anyhow!("couldn't decode public key: {err}"))?,
+        );
+        Ok(encryption_key_provider)
     }
 }
 

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
+ "oak_dice",
  "p256",
  "prost",
  "rand_core 0.6.4",

--- a/oak_restricted_kernel_sdk/Cargo.toml
+++ b/oak_restricted_kernel_sdk/Cargo.toml
@@ -11,7 +11,6 @@ log = "*"
 oak_channel = { workspace = true }
 oak_crypto = { workspace = true }
 oak_dice = { workspace = true }
-oak_remote_attestation = { workspace = true }
 oak_restricted_kernel_interface = { workspace = true }
 p256 = { version = "*", default-features = false, features = ["ecdsa"] }
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/oak_restricted_kernel_sdk/src/dice.rs
+++ b/oak_restricted_kernel_sdk/src/dice.rs
@@ -15,74 +15,34 @@
 //
 
 use crate::syscall::read;
-use oak_crypto::{
-    encryptor::EncryptionKeyProvider,
-    hpke::{Deserializable, PrivateKey, PublicKey},
-};
-use oak_dice::{
-    cert::{
-        cose_key_to_hpke_public_key, get_claims_set_from_certificate_bytes,
-        get_public_key_from_claims_set,
-    },
-    evidence::{RestrictedKernelDiceData, P256_PRIVATE_KEY_SIZE, X25519_PRIVATE_KEY_SIZE},
-};
-use oak_remote_attestation::proto::oak::attestation::v1::Evidence;
+use anyhow::Ok;
+use oak_crypto::encryptor::EncryptionKeyProvider;
+use oak_dice::evidence::{Evidence, RestrictedKernelDiceData, P256_PRIVATE_KEY_SIZE};
 use oak_restricted_kernel_interface::DICE_DATA_FD;
 use p256::ecdsa::SigningKey;
 use zerocopy::{AsBytes, FromZeroes};
 
 /// Wrapper for DICE evidence and application private keys.
-pub struct DiceWrapper {
+#[allow(dead_code)]
+struct DiceWrapper {
     pub evidence: Evidence,
     pub encryption_key: EncryptionKeyProvider,
     pub signer: Signer,
 }
 
+#[allow(dead_code)]
 impl DiceWrapper {
     pub fn try_create() -> anyhow::Result<Self> {
-        get_dice_evidence_and_keys()
+        let restricted_kernel_dice_data = get_restricted_kernel_dice_data()?;
+        let encryption_key = EncryptionKeyProvider::try_from(&restricted_kernel_dice_data)?;
+        let signer = Signer::try_from(&restricted_kernel_dice_data)?;
+        let evidence = restricted_kernel_dice_data.evidence;
+        Ok(Self {
+            evidence,
+            encryption_key,
+            signer,
+        })
     }
-}
-
-/// Get the DICE evidence and application private keys from the Restricted Kernel
-fn get_dice_evidence_and_keys() -> anyhow::Result<DiceWrapper> {
-    let dice_data = get_restricted_kernel_dice_data()?;
-    let evidence: Evidence = dice_data.evidence.try_into()?;
-    let private_key = PrivateKey::from_bytes(
-        &dice_data.application_private_keys.encryption_private_key[..X25519_PRIVATE_KEY_SIZE],
-    )
-    .map_err(|error| anyhow::anyhow!("couldn't deserialize private key: {}", error))?;
-    let application_keys = evidence
-        .application_keys
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("no application keys"))?;
-    let claims =
-        get_claims_set_from_certificate_bytes(application_keys.encryption_public_key_certificate())
-            .map_err(|err| {
-                anyhow::anyhow!("couldn't parse encryption public key certificate: {err}")
-            })?;
-    let public_key = get_public_key_from_claims_set(&claims)
-        .map_err(|err| anyhow::anyhow!("couldn't get public key from certificate: {err}"))?;
-    let public_key = cose_key_to_hpke_public_key(&public_key)
-        .map_err(|err| anyhow::anyhow!("couldn't extract public key: {err}"))?;
-    let encryption_key = EncryptionKeyProvider::new(
-        private_key,
-        PublicKey::from_bytes(&public_key)
-            .map_err(|err| anyhow::anyhow!("couldn't decode public key: {err}"))?,
-    );
-    let signer = {
-        let key = SigningKey::from_slice(
-            &dice_data.application_private_keys.signing_private_key[..P256_PRIVATE_KEY_SIZE],
-        )
-        .map_err(|error| anyhow::anyhow!("couldn't deserialize signing key: {}", error))?;
-        Signer { key }
-    };
-
-    Ok(DiceWrapper {
-        evidence,
-        encryption_key,
-        signer,
-    })
 }
 
 fn get_restricted_kernel_dice_data() -> anyhow::Result<RestrictedKernelDiceData> {
@@ -102,5 +62,18 @@ pub struct Signer {
 impl Signer {
     pub fn sign(&self, message: &[u8]) -> oak_crypto::signer::Signature {
         <SigningKey as oak_crypto::signer::Signer>::sign(&self.key, message)
+    }
+}
+
+impl TryFrom<&oak_dice::evidence::RestrictedKernelDiceData> for Signer {
+    type Error = anyhow::Error;
+    fn try_from(
+        dice_data: &oak_dice::evidence::RestrictedKernelDiceData,
+    ) -> Result<Self, Self::Error> {
+        let key = SigningKey::from_slice(
+            &dice_data.application_private_keys.signing_private_key[..P256_PRIVATE_KEY_SIZE],
+        )
+        .map_err(|error| anyhow::anyhow!("couldn't deserialize signing key: {}", error))?;
+        Ok(Signer { key })
     }
 }

--- a/oak_restricted_kernel_sdk/src/lib.rs
+++ b/oak_restricted_kernel_sdk/src/lib.rs
@@ -26,5 +26,5 @@ mod raw_syscall;
 pub mod syscall;
 
 pub use channel::FileDescriptorChannel;
-pub use dice::{DiceWrapper, Signer};
+pub use dice::Signer;
 pub use logging::StderrLogger;


### PR DESCRIPTION
The SDK should be agnostic about which underlying attesation method is used. Hence dice related structs are removed. oak functions still depends on them, so the relevant code has been moved to continue supporting it. In the future it should be refactored to use the SDK.