### PR TITLE
Move logic for syscalls out of the restricted kernel sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,7 +2147,6 @@ dependencies = [
  "libm",
  "log",
  "oak_restricted_kernel_interface",
- "oak_restricted_kernel_sdk",
  "rlsf",
  "spinning_top",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,6 +2474,7 @@ name = "oak_restricted_kernel_interface"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.3.3",
+ "os_pipe",
  "strum",
 ]
 
@@ -2487,7 +2488,6 @@ dependencies = [
  "oak_crypto",
  "oak_dice",
  "oak_restricted_kernel_interface",
- "os_pipe",
  "p256",
  "strum",
  "zerocopy 0.7.3",

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
  "oak_core",
  "oak_echo_service",
  "oak_enclave_runtime_support",
+ "oak_restricted_kernel_interface",
  "oak_restricted_kernel_sdk",
  "static_assertions",
 ]
@@ -747,6 +748,7 @@ dependencies = [
  "micro_rpc",
  "oak_channel",
  "oak_enclave_runtime_support",
+ "oak_restricted_kernel_interface",
  "oak_restricted_kernel_sdk",
  "static_assertions",
 ]

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -771,7 +771,6 @@ dependencies = [
  "libm",
  "log",
  "oak_restricted_kernel_interface",
- "oak_restricted_kernel_sdk",
  "rlsf",
  "spinning_top",
 ]

--- a/enclave_apps/key_xor_test_app/src/main.rs
+++ b/enclave_apps/key_xor_test_app/src/main.rs
@@ -23,8 +23,8 @@ extern crate alloc;
 use core::panic::PanicInfo;
 use log::info;
 use oak_channel::{Read, Write};
-use oak_restricted_kernel_interface::DERIVED_KEY_FD;
-use oak_restricted_kernel_sdk::{syscall::read, FileDescriptorChannel, StderrLogger};
+use oak_restricted_kernel_interface::{syscall::read, DERIVED_KEY_FD};
+use oak_restricted_kernel_sdk::{FileDescriptorChannel, StderrLogger};
 
 static LOGGER: StderrLogger = StderrLogger {};
 
@@ -66,5 +66,5 @@ fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     log::error!("PANIC: {}", info);
-    oak_restricted_kernel_sdk::syscall::exit(-1);
+    oak_restricted_kernel_interface::syscall::exit(-1);
 }

--- a/enclave_apps/oak_echo_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_echo_enclave_app/Cargo.toml
@@ -13,6 +13,7 @@ oak_enclave_runtime_support = { workspace = true }
 oak_channel = { workspace = true }
 oak_core = { workspace = true }
 oak_restricted_kernel_sdk = { workspace = true }
+oak_restricted_kernel_interface = { workspace = true }
 static_assertions = "*"
 
 [[bin]]

--- a/enclave_apps/oak_echo_enclave_app/src/main.rs
+++ b/enclave_apps/oak_echo_enclave_app/src/main.rs
@@ -63,5 +63,5 @@ fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     log::error!("PANIC: {}", info);
-    oak_restricted_kernel_sdk::syscall::exit(-1);
+    oak_restricted_kernel_interface::syscall::exit(-1);
 }

--- a/enclave_apps/oak_echo_raw_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_echo_raw_enclave_app/Cargo.toml
@@ -11,6 +11,7 @@ micro_rpc = { workspace = true }
 oak_enclave_runtime_support = { workspace = true }
 oak_channel = { workspace = true }
 oak_restricted_kernel_sdk = { workspace = true }
+oak_restricted_kernel_interface = { workspace = true }
 static_assertions = "*"
 
 [[bin]]

--- a/enclave_apps/oak_echo_raw_enclave_app/src/main.rs
+++ b/enclave_apps/oak_echo_raw_enclave_app/src/main.rs
@@ -65,5 +65,5 @@ fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     log::error!("PANIC: {}", info);
-    oak_restricted_kernel_sdk::syscall::exit(-1);
+    oak_restricted_kernel_interface::syscall::exit(-1);
 }

--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> ! {
     let restricted_kernel_dice_data = {
         let mut result = oak_dice::evidence::RestrictedKernelDiceData::new_zeroed();
         let buffer = result.as_bytes_mut();
-        let len = oak_restricted_kernel_sdk::syscall::read(
+        let len = oak_restricted_kernel_interface::syscall::read(
             oak_restricted_kernel_interface::DICE_DATA_FD,
             buffer,
         )
@@ -86,5 +86,5 @@ fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     log::error!("PANIC: {}", info);
-    oak_restricted_kernel_sdk::syscall::exit(-1);
+    oak_restricted_kernel_interface::syscall::exit(-1);
 }

--- a/oak_enclave_runtime_support/Cargo.toml
+++ b/oak_enclave_runtime_support/Cargo.toml
@@ -10,6 +10,5 @@ license = "Apache-2.0"
 libm = "*"
 rlsf = "*"
 log = "*"
-oak_restricted_kernel_sdk = { workspace = true }
 oak_restricted_kernel_interface = { workspace = true }
 spinning_top = "*"

--- a/oak_enclave_runtime_support/src/heap.rs
+++ b/oak_enclave_runtime_support/src/heap.rs
@@ -39,7 +39,7 @@ unsafe impl FlexSource for Source {
             min_size
         };
 
-        oak_restricted_kernel_sdk::syscall::mmap(
+        oak_restricted_kernel_interface::syscall::mmap(
             // TODO(#3864): One we start compiling C++ applications internally using the Oak
             // Toolchain, we won't need to manually separate Rust and C++ heaps.
             Some(0x100_0000_0000 as *const core::ffi::c_void),

--- a/oak_restricted_kernel_interface/Cargo.toml
+++ b/oak_restricted_kernel_interface/Cargo.toml
@@ -8,3 +8,6 @@ license = "Apache-2.0"
 [dependencies]
 bitflags = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
+
+[dev-dependencies]
+os_pipe = "*"

--- a/oak_restricted_kernel_interface/src/lib.rs
+++ b/oak_restricted_kernel_interface/src/lib.rs
@@ -15,8 +15,11 @@
 //
 
 #![no_std]
+#![feature(c_size_t)]
 
 pub mod errno;
+mod raw_syscall;
+pub mod syscall;
 pub mod syscalls;
 
 pub use errno::Errno;

--- a/oak_restricted_kernel_interface/src/raw_syscall.rs
+++ b/oak_restricted_kernel_interface/src/raw_syscall.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
+use crate::Syscall;
 use core::arch::asm;
-use oak_restricted_kernel_interface::Syscall;
 
 /// Invoke system calls based on the Linux calling convention using `SYSCALL`.
 ///

--- a/oak_restricted_kernel_interface/src/syscall.rs
+++ b/oak_restricted_kernel_interface/src/syscall.rs
@@ -14,12 +14,12 @@
 // limitations under the License.
 //
 
-use crate::syscall;
-use core::ffi::{c_int, c_size_t, c_ssize_t, c_void};
-use oak_restricted_kernel_interface::{
+use crate::{
+    syscall,
     syscalls::{MmapFlags, MmapProtection},
     Errno, Syscall,
 };
+use core::ffi::{c_int, c_size_t, c_ssize_t, c_void};
 
 #[no_mangle]
 pub extern "C" fn sys_read(fd: c_int, buf: *mut c_void, count: c_size_t) -> c_ssize_t {

--- a/oak_restricted_kernel_sdk/Cargo.toml
+++ b/oak_restricted_kernel_sdk/Cargo.toml
@@ -15,6 +15,3 @@ oak_restricted_kernel_interface = { workspace = true }
 p256 = { version = "*", default-features = false, features = ["ecdsa"] }
 strum = { version = "*", default-features = false, features = ["derive"] }
 zerocopy = "*"
-
-[dev-dependencies]
-os_pipe = "*"

--- a/oak_restricted_kernel_sdk/src/channel.rs
+++ b/oak_restricted_kernel_sdk/src/channel.rs
@@ -43,8 +43,11 @@ impl Read for FileDescriptorChannel {
         let mut remaining = data.len();
 
         while remaining > 0 {
-            remaining -= crate::syscall::read(self.fd, &mut data[len - remaining..])
-                .map_err(|err| anyhow!("read failure: {}", err))?;
+            remaining -= oak_restricted_kernel_interface::syscall::read(
+                self.fd,
+                &mut data[len - remaining..],
+            )
+            .map_err(|err| anyhow!("read failure: {}", err))?;
         }
 
         Ok(())
@@ -57,14 +60,16 @@ impl Write for FileDescriptorChannel {
         let mut remaining = data.len();
 
         while remaining > 0 {
-            remaining -= crate::syscall::write(self.fd, &data[len - remaining..])
-                .map_err(|err| anyhow!("write failure: {}", err))?;
+            remaining -=
+                oak_restricted_kernel_interface::syscall::write(self.fd, &data[len - remaining..])
+                    .map_err(|err| anyhow!("write failure: {}", err))?;
         }
 
         Ok(())
     }
 
     fn flush(&mut self) -> anyhow::Result<()> {
-        crate::syscall::fsync(self.fd).map_err(|err| anyhow!("sync failure: {}", err))
+        oak_restricted_kernel_interface::syscall::fsync(self.fd)
+            .map_err(|err| anyhow!("sync failure: {}", err))
     }
 }

--- a/oak_restricted_kernel_sdk/src/dice.rs
+++ b/oak_restricted_kernel_sdk/src/dice.rs
@@ -14,11 +14,10 @@
 // limitations under the License.
 //
 
-use crate::syscall::read;
 use anyhow::Ok;
 use oak_crypto::encryptor::EncryptionKeyProvider;
 use oak_dice::evidence::{Evidence, RestrictedKernelDiceData, P256_PRIVATE_KEY_SIZE};
-use oak_restricted_kernel_interface::DICE_DATA_FD;
+use oak_restricted_kernel_interface::{syscall::read, DICE_DATA_FD};
 use p256::ecdsa::SigningKey;
 use zerocopy::{AsBytes, FromZeroes};
 

--- a/oak_restricted_kernel_sdk/src/lib.rs
+++ b/oak_restricted_kernel_sdk/src/lib.rs
@@ -15,15 +15,12 @@
 //
 
 #![cfg_attr(not(test), no_std)]
-#![feature(c_size_t)]
 
 extern crate alloc;
 
 mod channel;
 mod dice;
 mod logging;
-mod raw_syscall;
-pub mod syscall;
 
 pub use channel::FileDescriptorChannel;
 pub use dice::Signer;

--- a/oak_restricted_kernel_sdk/src/logging.rs
+++ b/oak_restricted_kernel_sdk/src/logging.rs
@@ -16,7 +16,7 @@
 
 use core::fmt::Write;
 
-use crate::syscall::{fsync, write};
+use oak_restricted_kernel_interface::syscall::{fsync, write};
 
 struct Stderr {}
 


### PR DESCRIPTION
This isn't part of the SDK as outlined in the design doc, so let's move it to a different crate. 