### PR TITLE
Add histograms to track wasm sandbox setup and invocation times

### DIFF
--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> ! {
     )
     .expect("couldn't get evidence");
     let service =
-        oak_functions_service::OakFunctionsService::new(evidence, Arc::new(encryption_key));
+        oak_functions_service::OakFunctionsService::new(evidence, Arc::new(encryption_key), None);
     let server = oak_functions_service::proto::oak::functions::OakFunctionsServer::new(service);
     oak_channel::server::start_blocking_server(
         Box::<FileDescriptorChannel>::default(),

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = { version = "*", default-features = false }
 clap = { version = "*", features = ["derive"] }
 http = "*"
 oak_containers_orchestrator_client = { workspace = true }
-oak_functions_service = { workspace = true }
+oak_functions_service = { workspace = true, features = ["std"] }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
 micro_rpc = { workspace = true }

--- a/oak_functions_sdk/tests/integration_test.rs
+++ b/oak_functions_sdk/tests/integration_test.rs
@@ -55,9 +55,13 @@ async fn test_read_write() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &LOOKUP_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"ReadWrite".to_vec(),
@@ -74,9 +78,13 @@ async fn test_double_read() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &LOOKUP_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"DoubleRead".to_vec(),
@@ -93,9 +101,13 @@ async fn test_double_write() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &LOOKUP_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"DoubleWrite".to_vec(),
@@ -112,9 +124,13 @@ async fn test_write_log() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &LOOKUP_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"WriteLog".to_vec(),
@@ -136,9 +152,13 @@ async fn test_storage_get_item() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &LOOKUP_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"StorageGet".to_vec(),
@@ -158,9 +178,13 @@ async fn test_storage_get_item_not_found() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &LOOKUP_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"StorageGetItemNotFound".to_vec(),
@@ -181,9 +205,13 @@ async fn test_storage_get_item_huge_key() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&LOOKUP_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &LOOKUP_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: b"LargeKey".to_vec(),
@@ -204,9 +232,13 @@ async fn test_echo() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&TESTING_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &TESTING_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: message_to_echo.as_bytes().to_vec(),
@@ -230,9 +262,13 @@ async fn test_blackhole() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&TESTING_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &TESTING_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: message_to_blackhole.as_bytes().to_vec(),
@@ -256,9 +292,13 @@ async fn test_huge_response() {
         lookup_data_manager,
     };
 
-    let wasm_handler =
-        WasmHandler::create(&TESTING_WASM_MODULE_BYTES, Arc::new(api_factory), logger)
-            .expect("couldn't instantiate WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &TESTING_WASM_MODULE_BYTES,
+        Arc::new(api_factory),
+        logger,
+        None,
+    )
+    .expect("couldn't instantiate WasmHandler");
 
     let request = Request {
         body: "HUGE_RESPONSE".as_bytes().to_vec(),

--- a/oak_functions_service/Cargo.toml
+++ b/oak_functions_service/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 default = ["deny_sensitive_logging"]
 # Disable sensitive logging.
 deny_sensitive_logging = []
+std = ["anyhow/std", "wasmi/std"]
 
 [dependencies]
 anyhow = { version = "*", default-features = false }

--- a/oak_functions_service/src/wasm/tests.rs
+++ b/oak_functions_service/src/wasm/tests.rs
@@ -139,8 +139,13 @@ fn create_test_state() -> TestState {
     let wasm_module_path = oak_functions_test_utils::build_rust_crate_wasm("echo").unwrap();
     let wasm_module_bytes = std::fs::read(wasm_module_path).unwrap();
 
-    let wasm_handler = WasmHandler::create(&wasm_module_bytes, api_factory.clone(), logger.clone())
-        .expect("couldn't create WasmHandler");
+    let wasm_handler = WasmHandler::create(
+        &wasm_module_bytes,
+        api_factory.clone(),
+        logger.clone(),
+        None,
+    )
+    .expect("couldn't create WasmHandler");
 
     let request = Vec::new();
     let response = Arc::new(Spinlock::new(Vec::new()));

--- a/oak_functions_service/tests/integration_test.rs
+++ b/oak_functions_service/tests/integration_test.rs
@@ -53,6 +53,7 @@ fn new_service_for_testing() -> OakFunctionsService {
     OakFunctionsService::new(
         Evidence::default(),
         Arc::new(EncryptionKeyProvider::generate()),
+        None,
     )
 }
 


### PR DESCRIPTION
The main goal for these metrics is to help us find out where the time is going: for example, if we know (from the outside) that a RPC took 5 seconds, was the time spent executing wasm code or lost somewhere else?

I added two metrics: one for the initialization work (linking the module etc), and one for the actual invocation of `main`.

These statistics are collected unconditionally for every request. Privacy-wise, I argue that this is fine, because (a) we expect the wasm code to be called to we're not leaking any information based on the fact that we're calling wasm, and (b) in an ideal case the externally-observable RPC latency will be the wasm invocation time + some constant-ish overhead for the sandbox setup, so we're not leaking any new information there either.

Now, I would really like to instrument the wasm API side as well (lookup calls), but there could be an argument there about the number of lookup calls you do leaking some information.

As only Oak Containers supports tracking metrics (no timers in Restricted Kernel), I've plumbed an `Optional<Arc<dyn Observer>>` through all the parts of the system, for now.

And because `Instant` is only available in `std`, I added a bunch of conditionals to make `no_std` an optional feature (opt-out, though) and while I was in there propagated the `std` flag to some crates like anyhow and wasmi where we disabled it by default. Now if you're running on linux where std is available even wasmi can make use of it, if it wants.