### PR TITLE
Export basic network metrics (bytes/packets/errors sent/received)

### DIFF
--- a/oak_containers_orchestrator/src/metrics.rs
+++ b/oak_containers_orchestrator/src/metrics.rs
@@ -30,6 +30,14 @@ pub struct SystemMetrics {
     forks_total: ObservableCounter<u64>,
     procs_blocked: ObservableGauge<u64>,
     procs_running: ObservableGauge<u64>,
+
+    // Network-related metrics
+    net_recv_bytes: ObservableCounter<u64>,
+    net_recv_packets: ObservableCounter<u64>,
+    net_recv_errs: ObservableCounter<u64>,
+    net_sent_bytes: ObservableCounter<u64>,
+    net_sent_packets: ObservableCounter<u64>,
+    net_sent_errs: ObservableCounter<u64>,
 }
 
 impl SystemMetrics {
@@ -55,6 +63,32 @@ impl SystemMetrics {
             procs_running: meter
                 .u64_observable_gauge("procs_running")
                 .with_callback(Self::procs_running)
+                .try_init()?,
+            net_recv_bytes: meter
+                .u64_observable_counter("network_receive_bytes")
+                .with_unit(Unit::new("bytes"))
+                .with_callback(Self::net_recv_bytes)
+                .try_init()?,
+            net_recv_packets: meter
+                .u64_observable_counter("network_receive_packets")
+                .with_callback(Self::net_recv_packets)
+                .try_init()?,
+            net_recv_errs: meter
+                .u64_observable_counter("network_receive_errors")
+                .with_callback(Self::net_recv_errs)
+                .try_init()?,
+            net_sent_bytes: meter
+                .u64_observable_counter("network_transmit_bytes")
+                .with_unit(Unit::new("bytes"))
+                .with_callback(Self::net_sent_bytes)
+                .try_init()?,
+            net_sent_packets: meter
+                .u64_observable_counter("network_transmit_packets")
+                .with_callback(Self::net_sent_packets)
+                .try_init()?,
+            net_sent_errs: meter
+                .u64_observable_counter("network_transmit_errors")
+                .with_callback(Self::net_sent_errs)
                 .try_init()?,
         })
     }
@@ -110,6 +144,54 @@ impl SystemMetrics {
         let stats = procfs::KernelStats::new().unwrap();
         if let Some(procs_running) = stats.procs_running {
             gauge.observe(procs_running.into(), &[]);
+        }
+    }
+
+    fn net_recv_bytes(counter: &dyn AsyncInstrument<u64>) {
+        let stats = procfs::net::dev_status().unwrap();
+
+        for (interface, stats) in stats {
+            counter.observe(stats.recv_bytes, &[KeyValue::new("device", interface)]);
+        }
+    }
+
+    fn net_recv_packets(counter: &dyn AsyncInstrument<u64>) {
+        let stats = procfs::net::dev_status().unwrap();
+
+        for (interface, stats) in stats {
+            counter.observe(stats.recv_packets, &[KeyValue::new("device", interface)]);
+        }
+    }
+
+    fn net_recv_errs(counter: &dyn AsyncInstrument<u64>) {
+        let stats = procfs::net::dev_status().unwrap();
+
+        for (interface, stats) in stats {
+            counter.observe(stats.recv_errs, &[KeyValue::new("device", interface)]);
+        }
+    }
+
+    fn net_sent_bytes(counter: &dyn AsyncInstrument<u64>) {
+        let stats = procfs::net::dev_status().unwrap();
+
+        for (interface, stats) in stats {
+            counter.observe(stats.sent_bytes, &[KeyValue::new("device", interface)]);
+        }
+    }
+
+    fn net_sent_packets(counter: &dyn AsyncInstrument<u64>) {
+        let stats = procfs::net::dev_status().unwrap();
+
+        for (interface, stats) in stats {
+            counter.observe(stats.sent_packets, &[KeyValue::new("device", interface)]);
+        }
+    }
+
+    fn net_sent_errs(counter: &dyn AsyncInstrument<u64>) {
+        let stats = procfs::net::dev_status().unwrap();
+
+        for (interface, stats) in stats {
+            counter.observe(stats.sent_errs, &[KeyValue::new("device", interface)]);
         }
     }
 }


### PR DESCRIPTION
Include basic networking stats in the system metrics we export.

Right now all of these system metrics are collected inside the orchestrator; I'm thinking all of this metrics collection should really be broken out into a separate binary, much like the syslog proxy is in a separate binary.