### PR TITLE
Add load shedding to Oak Functions

### DIFF
--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -34,7 +34,7 @@ prost = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tokio-stream = { version = "*", features = ["net"] }
 tonic = { workspace = true }
-tower = "*"
+tower = { version = "*", features = ["load-shed"] }
 tower-http = { version = "*", features = ["trace"] }
 tracing = "*"
 

--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -398,6 +398,7 @@ pub async fn serve<G: AsyncRecipientContextGenerator + Send + Sync + 'static, P:
                     span.record("rpc.grpc.status_code", code);
                 }),
         )
+        .layer(tower::load_shed::LoadShedLayer::new())
         .layer(MonitoringLayer::new(meter.clone()))
         .add_service(OakFunctionsServer::new(OakFunctionsContainersService::new(
             encryption_context,


### PR DESCRIPTION
What we've observed is that when we increase load to Oak Functions, at some point we'll start getting 100% RPC error rates with the RPCs timing out.

Remember that the number of threads in tokio is the same as the number of cores on the machine, so you will not be able to serve more requests in parallel than the number of worker threads. I assume there's a queue where the requests start building up, waiting for a worker thread to be available to execute.

My current theory is that we're hitting that limit: we have some requests that take a long time to execute, and thus are hogging all the worker threads. More RPCs are piling in into the queue, only to stay in the queue long enough to time out, which means we start serving timeout errors.

The hope is that after we've got enough parallel requests to saturate all threads going on, instead of building up a queue of RPCs, this will make the server start rejecting them (load shedding).

The question of deadlines themselves is a separate question: for example, if the RPC deadline is 10 seconds, then we should just kill the wasm sandbox once we get to that mark. But that'll be a separate thing to track, as I don't think there's a way to asynchronously kill the wasm interpreter right now.