### PR TITLE
Change `AsyncEncryptionHandler` callback to be async

### DIFF
--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -144,7 +144,7 @@ impl<G: AsyncRecipientContextGenerator + Send + Sync + 'static> OakFunctions
             )
         })?;
 
-        AsyncEncryptionHandler::create(encryption_key_provider, |r| {
+        AsyncEncryptionHandler::create(encryption_key_provider, |r| async {
             // Wrap the invocation result (which may be an Error) into a micro RPC Response
             // wrapper protobuf, and encode that as bytes.
             let response_result: Result<Vec<u8>, micro_rpc::Status> =


### PR DESCRIPTION
On its own, this PR doesn't do much interesting, but it will allow us to call `await` in the request handler callback.