### PR TITLE
stage0: use wrapping_sub for AddChecksum

### DIFF
--- a/stage0/src/acpi.rs
+++ b/stage0/src/acpi.rs
@@ -246,7 +246,8 @@ impl AddChecksum {
 
         let checksum =
             AddChecksum::checksum(&file[self.start as usize..(self.start + self.length) as usize]);
-        *file.get_mut(self.offset as usize).unwrap() -= checksum;
+        let val = file.get_mut(self.offset as usize).unwrap();
+        *val = val.wrapping_sub(checksum);
         Ok(())
     }
 


### PR DESCRIPTION
Numeric overflow is common in checksum calculation. We should use wrapping_sub to avoid overflow check by rust runtime. Without this patch panics are observed when stage0 is built with debug mode.