### PR TITLE
Use crypto nonces from proto messages in Rust

### DIFF
--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -20,8 +20,8 @@
 
 use crate::{
     hpke::{
-        aead::AEAD_NONCE_SIZE_BYTES, setup_base_recipient, setup_base_sender, KeyPair, PrivateKey,
-        PublicKey, RecipientContext, SenderContext,
+        deserialize_nonce, setup_base_recipient, setup_base_sender, KeyPair, PrivateKey, PublicKey,
+        RecipientContext, SenderContext,
     },
     proto::oak::crypto::v1::{AeadEncryptedMessage, EncryptedRequest, EncryptedResponse},
 };
@@ -204,13 +204,8 @@ impl ClientEncryptor {
             .encrypted_message
             .as_ref()
             .context("response doesn't contain encrypted message")?;
-        let nonce = encrypted_message.nonce.clone().try_into().map_err(|_| {
-            anyhow!(
-                "incorrect nonce size, expected {}, found {}",
-                AEAD_NONCE_SIZE_BYTES,
-                encrypted_message.nonce.len()
-            )
-        })?;
+        let nonce =
+            deserialize_nonce(&encrypted_message.nonce).context("couldn't deserialize nonce")?;
 
         let plaintext = self
             .sender_context
@@ -260,13 +255,8 @@ impl ServerEncryptor {
             .encrypted_message
             .as_ref()
             .context("request doesn't contain encrypted message")?;
-        let nonce = encrypted_message.nonce.clone().try_into().map_err(|_| {
-            anyhow!(
-                "incorrect nonce size, expected {}, found {}",
-                AEAD_NONCE_SIZE_BYTES,
-                encrypted_message.nonce.len()
-            )
-        })?;
+        let nonce =
+            deserialize_nonce(&encrypted_message.nonce).context("couldn't deserialize nonce")?;
 
         let plaintext = self
             .recipient_context

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -20,8 +20,8 @@
 
 use crate::{
     hpke::{
-        setup_base_recipient, setup_base_sender, KeyPair, PrivateKey, PublicKey, RecipientContext,
-        SenderContext, aead::AEAD_NONCE_SIZE_BYTES,
+        aead::AEAD_NONCE_SIZE_BYTES, setup_base_recipient, setup_base_sender, KeyPair, PrivateKey,
+        PublicKey, RecipientContext, SenderContext,
     },
     proto::oak::crypto::v1::{AeadEncryptedMessage, EncryptedRequest, EncryptedResponse},
 };
@@ -204,11 +204,13 @@ impl ClientEncryptor {
             .encrypted_message
             .as_ref()
             .context("response doesn't contain encrypted message")?;
-        let nonce = encrypted_message
-            .nonce
-            .clone()
-            .try_into()
-            .map_err(|_| anyhow!("incorrect nonce size, expected {}, found {}", AEAD_NONCE_SIZE_BYTES, encrypted_message.nonce.len()))?;
+        let nonce = encrypted_message.nonce.clone().try_into().map_err(|_| {
+            anyhow!(
+                "incorrect nonce size, expected {}, found {}",
+                AEAD_NONCE_SIZE_BYTES,
+                encrypted_message.nonce.len()
+            )
+        })?;
 
         let plaintext = self
             .sender_context
@@ -258,11 +260,13 @@ impl ServerEncryptor {
             .encrypted_message
             .as_ref()
             .context("request doesn't contain encrypted message")?;
-        let nonce = encrypted_message
-            .nonce
-            .clone()
-            .try_into()
-            .map_err(|_| anyhow!("incorrect nonce size, expected {}, found {}", AEAD_NONCE_SIZE_BYTES, encrypted_message.nonce.len()))?;
+        let nonce = encrypted_message.nonce.clone().try_into().map_err(|_| {
+            anyhow!(
+                "incorrect nonce size, expected {}, found {}",
+                AEAD_NONCE_SIZE_BYTES,
+                encrypted_message.nonce.len()
+            )
+        })?;
 
         let plaintext = self
             .recipient_context

--- a/oak_crypto/src/hpke/mod.rs
+++ b/oak_crypto/src/hpke/mod.rs
@@ -370,3 +370,13 @@ fn increment_sequence_number(sequence_number: &mut u128) -> anyhow::Result<()> {
         .context("couldn't increment sequence number")?;
     Ok(())
 }
+
+pub(crate) fn deserialize_nonce(nonce: &[u8]) -> anyhow::Result<AeadNonce> {
+    nonce.try_into().map_err(|_| {
+        anyhow!(
+            "incorrect nonce size, expected {}, found {}",
+            AEAD_NONCE_SIZE_BYTES,
+            nonce.len()
+        )
+    })
+}

--- a/oak_crypto/src/tests.rs
+++ b/oak_crypto/src/tests.rs
@@ -107,7 +107,11 @@ fn test_hpke() {
         // Check that the message was encrypted.
         assert_ne!(test_request_message, encrypted_request);
         let decrypted_request = recipient_context
-            .open(&encrypted_request, &test_request_associated_data)
+            .open(
+                &test_request_nonce,
+                &encrypted_request,
+                &test_request_associated_data,
+            )
             .expect("recipient context couldn't open request");
         assert_eq!(test_request_message, decrypted_request);
 
@@ -121,7 +125,11 @@ fn test_hpke() {
         // Check that the message was encrypted.
         assert_ne!(test_response_message, encrypted_response);
         let decrypted_response = sender_context
-            .open(&encrypted_response, &test_response_associated_data)
+            .open(
+                &test_response_nonce,
+                &encrypted_response,
+                &test_response_associated_data,
+            )
             .expect("sender couldn't open response");
         assert_eq!(test_response_message, decrypted_response);
     }


### PR DESCRIPTION
This PR makes `oak_crypto` use crypto nonces provided by the incoming message. This is one of the steps for implementing random nonces and sending them inside encrypted messages.

Ref https://github.com/project-oak/oak/issues/4507