### PR TITLE
Use crypto nonces from proto messages in C++ and Java

### DIFF
--- a/cc/crypto/client_encryptor.cc
+++ b/cc/crypto/client_encryptor.cc
@@ -17,6 +17,7 @@
 #include "cc/crypto/client_encryptor.h"
 
 #include <memory>
+#include <vector>
 #include <utility>
 
 #include "absl/status/statusor.h"
@@ -69,8 +70,13 @@ absl::StatusOr<EncryptedRequest> ClientEncryptor::Encrypt(absl::string_view plai
 
 absl::StatusOr<DecryptionResult> ClientEncryptor::Decrypt(EncryptedResponse encrypted_response) {
   // Decrypt response.
+  const std::vector<uint8_t> nonce(
+      encrypted_response.encrypted_message().nonce().begin(),
+      encrypted_response.encrypted_message().nonce().end()
+  );
   absl::StatusOr<std::string> plaintext =
-      sender_context_->Open(encrypted_response.encrypted_message().ciphertext(),
+      sender_context_->Open(nonce,
+                            encrypted_response.encrypted_message().ciphertext(),
                             encrypted_response.encrypted_message().associated_data());
   if (!plaintext.ok()) {
     return plaintext.status();

--- a/cc/crypto/client_encryptor.cc
+++ b/cc/crypto/client_encryptor.cc
@@ -17,8 +17,8 @@
 #include "cc/crypto/client_encryptor.h"
 
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "absl/status/statusor.h"
 #include "cc/crypto/common.h"
@@ -70,13 +70,10 @@ absl::StatusOr<EncryptedRequest> ClientEncryptor::Encrypt(absl::string_view plai
 
 absl::StatusOr<DecryptionResult> ClientEncryptor::Decrypt(EncryptedResponse encrypted_response) {
   // Decrypt response.
-  const std::vector<uint8_t> nonce(
-      encrypted_response.encrypted_message().nonce().begin(),
-      encrypted_response.encrypted_message().nonce().end()
-  );
+  const std::vector<uint8_t> nonce(encrypted_response.encrypted_message().nonce().begin(),
+                                   encrypted_response.encrypted_message().nonce().end());
   absl::StatusOr<std::string> plaintext =
-      sender_context_->Open(nonce,
-                            encrypted_response.encrypted_message().ciphertext(),
+      sender_context_->Open(nonce, encrypted_response.encrypted_message().ciphertext(),
                             encrypted_response.encrypted_message().associated_data());
   if (!plaintext.ok()) {
     return plaintext.status();

--- a/cc/crypto/hpke/jni/com_google_oak_crypto_hpke_RecipientContext.h
+++ b/cc/crypto/hpke/jni/com_google_oak_crypto_hpke_RecipientContext.h
@@ -18,10 +18,10 @@ JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_RecipientContext_na
 /*
  * Class:     com_google_oak_crypto_hpke_RecipientContext
  * Method:    nativeOpen
- * Signature: ([B[B)[B
+ * Signature: ([B[B[B)[B
  */
 JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_RecipientContext_nativeOpen
-  (JNIEnv *, jobject, jbyteArray, jbyteArray);
+  (JNIEnv *, jobject, jbyteArray, jbyteArray, jbyteArray);
 
 /*
  * Class:     com_google_oak_crypto_hpke_RecipientContext

--- a/cc/crypto/hpke/jni/com_google_oak_crypto_hpke_SenderContext.h
+++ b/cc/crypto/hpke/jni/com_google_oak_crypto_hpke_SenderContext.h
@@ -26,10 +26,10 @@ JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_SenderContext_nativ
 /*
  * Class:     com_google_oak_crypto_hpke_SenderContext
  * Method:    nativeOpen
- * Signature: ([B[B)[B
+ * Signature: ([B[B[B)[B
  */
 JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_SenderContext_nativeOpen
-  (JNIEnv *, jobject, jbyteArray, jbyteArray);
+  (JNIEnv *, jobject, jbyteArray, jbyteArray, jbyteArray);
 
 /*
  * Class:     com_google_oak_crypto_hpke_SenderContext

--- a/cc/crypto/hpke/jni/context_jni.cc
+++ b/cc/crypto/hpke/jni/context_jni.cc
@@ -70,11 +70,12 @@ JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_SenderContext_nativ
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_SenderContext_nativeOpen(
-    JNIEnv* env, jobject obj, jbyteArray ciphertext, jbyteArray associated_data) {
+    JNIEnv* env, jobject obj, jbyteArray nonce, jbyteArray ciphertext, jbyteArray associated_data) {
   if (ciphertext == NULL || associated_data == NULL) {
     return {};
   }
 
+  std::string nonce_str = convert_jbytearray_to_string(env, nonce);
   std::string ciphertext_str = convert_jbytearray_to_string(env, ciphertext);
   std::string associated_data_str = convert_jbytearray_to_string(env, associated_data);
 
@@ -86,7 +87,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_SenderContext_nativ
     return {};
   }
 
-  absl::StatusOr<std::string> result = sender_context->Open(ciphertext_str, associated_data_str);
+  const std::vector<uint8_t> nonce_bytes(nonce_str.begin(), nonce_str.end());
+  absl::StatusOr<std::string> result = sender_context->Open(nonce_bytes, ciphertext_str, associated_data_str);
   if (!result.ok()) {
     return {};
   }
@@ -115,11 +117,12 @@ Java_com_google_oak_crypto_hpke_RecipientContext_nativeGenerateNonce(JNIEnv* env
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_RecipientContext_nativeOpen(
-    JNIEnv* env, jobject obj, jbyteArray ciphertext, jbyteArray associated_data) {
+    JNIEnv* env, jobject obj, jbyteArray nonce, jbyteArray ciphertext, jbyteArray associated_data) {
   if (ciphertext == NULL || associated_data == NULL) {
     return {};
   }
 
+  std::string nonce_str = convert_jbytearray_to_string(env, nonce);
   std::string ciphertext_str = convert_jbytearray_to_string(env, ciphertext);
   std::string associated_data_str = convert_jbytearray_to_string(env, associated_data);
 
@@ -131,7 +134,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_RecipientContext_na
     return {};
   }
 
-  absl::StatusOr<std::string> result = recipient_context->Open(ciphertext_str, associated_data_str);
+  const std::vector<uint8_t> nonce_bytes(nonce_str.begin(), nonce_str.end());
+  absl::StatusOr<std::string> result = recipient_context->Open(nonce_bytes, ciphertext_str, associated_data_str);
   if (!result.ok()) {
     return {};
   }

--- a/cc/crypto/hpke/jni/context_jni.cc
+++ b/cc/crypto/hpke/jni/context_jni.cc
@@ -88,7 +88,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_SenderContext_nativ
   }
 
   const std::vector<uint8_t> nonce_bytes(nonce_str.begin(), nonce_str.end());
-  absl::StatusOr<std::string> result = sender_context->Open(nonce_bytes, ciphertext_str, associated_data_str);
+  absl::StatusOr<std::string> result =
+      sender_context->Open(nonce_bytes, ciphertext_str, associated_data_str);
   if (!result.ok()) {
     return {};
   }
@@ -135,7 +136,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_google_oak_crypto_hpke_RecipientContext_na
   }
 
   const std::vector<uint8_t> nonce_bytes(nonce_str.begin(), nonce_str.end());
-  absl::StatusOr<std::string> result = recipient_context->Open(nonce_bytes, ciphertext_str, associated_data_str);
+  absl::StatusOr<std::string> result =
+      recipient_context->Open(nonce_bytes, ciphertext_str, associated_data_str);
   if (!result.ok()) {
     return {};
   }

--- a/cc/crypto/hpke/recipient_context.cc
+++ b/cc/crypto/hpke/recipient_context.cc
@@ -118,14 +118,14 @@ std::vector<uint8_t> RecipientContext::GenerateNonce() {
   return nonce;
 }
 
-absl::StatusOr<std::string> RecipientContext::Open(absl::string_view ciphertext,
+absl::StatusOr<std::string> RecipientContext::Open(const std::vector<uint8_t>& nonce,
+                                                   absl::string_view ciphertext,
                                                    absl::string_view associated_data) {
   /// Maximum sequence number which can fit in kAeadNonceSizeBytes bytes.
   /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
   if (request_sequence_number_ == UINT64_MAX) {
     return absl::OutOfRangeError("Maximum sequence number reached");
   }
-  std::vector<uint8_t> nonce = CalculateNonce(request_base_nonce_, request_sequence_number_);
 
   absl::StatusOr<std::string> plaintext =
       AeadOpen(request_aead_context_.get(), nonce, ciphertext, associated_data);

--- a/cc/crypto/hpke/recipient_context.h
+++ b/cc/crypto/hpke/recipient_context.h
@@ -56,7 +56,7 @@ class RecipientContext {
 
   // Decrypts message and validates associated data using AEAD.
   // <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
-  absl::StatusOr<std::string> Open(absl::string_view ciphertext, absl::string_view associated_data);
+  absl::StatusOr<std::string> Open(const std::vector<uint8_t>& nonce, absl::string_view ciphertext, absl::string_view associated_data);
 
   // Encrypts response message with associated data using AEAD as part of bidirectional
   // communication.

--- a/cc/crypto/hpke/recipient_context.h
+++ b/cc/crypto/hpke/recipient_context.h
@@ -56,7 +56,8 @@ class RecipientContext {
 
   // Decrypts message and validates associated data using AEAD.
   // <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
-  absl::StatusOr<std::string> Open(const std::vector<uint8_t>& nonce, absl::string_view ciphertext, absl::string_view associated_data);
+  absl::StatusOr<std::string> Open(const std::vector<uint8_t>& nonce, absl::string_view ciphertext,
+                                   absl::string_view associated_data);
 
   // Encrypts response message with associated data using AEAD as part of bidirectional
   // communication.

--- a/cc/crypto/hpke/recipient_context_test.cc
+++ b/cc/crypto/hpke/recipient_context_test.cc
@@ -133,7 +133,7 @@ TEST_F(RecipientContextTest, RecipientContextOpenSuccess) {
   std::string encap_public_key = (*sender_context)->GetSerializedEncapsulatedPublicKey();
   auto recipient_context = SetupBaseRecipient(encap_public_key, recipient_key_pair_, info_string_);
   ASSERT_TRUE(recipient_context.ok());
-  auto received_plaintext = (*recipient_context)->Open(*ciphertext, associated_data_request_);
+  auto received_plaintext = (*recipient_context)->Open(nonce, *ciphertext, associated_data_request_);
   ASSERT_TRUE(received_plaintext.ok());
 
   EXPECT_THAT(*received_plaintext, StrEq(plaintext));
@@ -156,7 +156,7 @@ TEST_F(RecipientContextTest, RecipientRequestContextOpenFailure) {
   auto recipient_context = SetupBaseRecipient(encap_public_key, recipient_key_pair_, info_string_);
   ASSERT_TRUE(recipient_context.ok());
 
-  auto received_plaintext = (*recipient_context)->Open(edited_ciphertext, associated_data_request_);
+  auto received_plaintext = (*recipient_context)->Open(nonce, edited_ciphertext, associated_data_request_);
   EXPECT_FALSE(received_plaintext.ok());
   EXPECT_EQ(received_plaintext.status().code(), absl::StatusCode::kAborted);
 }

--- a/cc/crypto/hpke/recipient_context_test.cc
+++ b/cc/crypto/hpke/recipient_context_test.cc
@@ -133,7 +133,8 @@ TEST_F(RecipientContextTest, RecipientContextOpenSuccess) {
   std::string encap_public_key = (*sender_context)->GetSerializedEncapsulatedPublicKey();
   auto recipient_context = SetupBaseRecipient(encap_public_key, recipient_key_pair_, info_string_);
   ASSERT_TRUE(recipient_context.ok());
-  auto received_plaintext = (*recipient_context)->Open(nonce, *ciphertext, associated_data_request_);
+  auto received_plaintext =
+      (*recipient_context)->Open(nonce, *ciphertext, associated_data_request_);
   ASSERT_TRUE(received_plaintext.ok());
 
   EXPECT_THAT(*received_plaintext, StrEq(plaintext));
@@ -156,7 +157,8 @@ TEST_F(RecipientContextTest, RecipientRequestContextOpenFailure) {
   auto recipient_context = SetupBaseRecipient(encap_public_key, recipient_key_pair_, info_string_);
   ASSERT_TRUE(recipient_context.ok());
 
-  auto received_plaintext = (*recipient_context)->Open(nonce, edited_ciphertext, associated_data_request_);
+  auto received_plaintext =
+      (*recipient_context)->Open(nonce, edited_ciphertext, associated_data_request_);
   EXPECT_FALSE(received_plaintext.ok());
   EXPECT_EQ(received_plaintext.status().code(), absl::StatusCode::kAborted);
 }

--- a/cc/crypto/hpke/sender_context.cc
+++ b/cc/crypto/hpke/sender_context.cc
@@ -56,14 +56,14 @@ absl::StatusOr<std::string> SenderContext::Seal(const std::vector<uint8_t>& nonc
   return ciphertext;
 }
 
-absl::StatusOr<std::string> SenderContext::Open(absl::string_view ciphertext,
+absl::StatusOr<std::string> SenderContext::Open(const std::vector<uint8_t>& nonce,
+                                                absl::string_view ciphertext,
                                                 absl::string_view associated_data) {
   /// Maximum sequence number which can fit in kAeadNonceSizeBytes bytes.
   /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
   if (response_sequence_number_ == UINT64_MAX) {
     return absl::OutOfRangeError("Maximum sequence number reached");
   }
-  std::vector<uint8_t> nonce = CalculateNonce(response_base_nonce_, response_sequence_number_);
 
   absl::StatusOr<std::string> plaintext =
       AeadOpen(response_aead_context_.get(), nonce, ciphertext, associated_data);

--- a/cc/crypto/hpke/sender_context.h
+++ b/cc/crypto/hpke/sender_context.h
@@ -60,7 +60,7 @@ class SenderContext {
   // Decrypts response message and validates associated data using AEAD as part of
   // bidirectional communication.
   // <https://www.rfc-editor.org/rfc/rfc9180.html#name-bidirectional-encryption>
-  absl::StatusOr<std::string> Open(absl::string_view ciphertext, absl::string_view associated_data);
+  absl::StatusOr<std::string> Open(const std::vector<uint8_t>& nonce, absl::string_view ciphertext, absl::string_view associated_data);
 
   ~SenderContext();
 

--- a/cc/crypto/hpke/sender_context.h
+++ b/cc/crypto/hpke/sender_context.h
@@ -60,7 +60,8 @@ class SenderContext {
   // Decrypts response message and validates associated data using AEAD as part of
   // bidirectional communication.
   // <https://www.rfc-editor.org/rfc/rfc9180.html#name-bidirectional-encryption>
-  absl::StatusOr<std::string> Open(const std::vector<uint8_t>& nonce, absl::string_view ciphertext, absl::string_view associated_data);
+  absl::StatusOr<std::string> Open(const std::vector<uint8_t>& nonce, absl::string_view ciphertext,
+                                   absl::string_view associated_data);
 
   ~SenderContext();
 

--- a/cc/crypto/hpke/sender_context_test.cc
+++ b/cc/crypto/hpke/sender_context_test.cc
@@ -140,7 +140,7 @@ TEST_F(SenderContextTest, SenderOpensEncryptedMessageSuccess) {
   std::string ciphertext(ciphertext_bytes.begin(), ciphertext_bytes.end());
 
   // Successfully open encrypted message and get back original plaintext.
-  auto decyphered_message = sender_context.Open(ciphertext, associated_data_response_);
+  auto decyphered_message = sender_context.Open(default_nonce_bytes_, ciphertext, associated_data_response_);
   EXPECT_TRUE(decyphered_message.ok());
 
   // Cleanup the lingering context.
@@ -192,7 +192,7 @@ TEST_F(SenderContextTest, SenderOpensEncryptedMessageFailureNoncesNotAligned) {
   std::string ciphertext(ciphertext_bytes.begin(), ciphertext_bytes.end());
 
   // Attempt to open the encrypted message. This should fail.
-  auto decyphered_message = sender_context.Open(ciphertext, associated_data_response_);
+  auto decyphered_message = sender_context.Open(default_nonce_bytes_, ciphertext, associated_data_response_);
   EXPECT_FALSE(decyphered_message.ok());
   EXPECT_EQ(decyphered_message.status().code(), absl::StatusCode::kAborted);
 
@@ -243,7 +243,7 @@ TEST_F(SenderContextTest, SenderOpensEncryptedMessageFailureAssociatedDataNotAli
 
   // Attempt to open the encrypted message using different associated data. This should fail.
   std::string different_associated_data = "Different response associated data";
-  auto decyphered_message = sender_context.Open(ciphertext, different_associated_data);
+  auto decyphered_message = sender_context.Open(default_nonce_bytes_, ciphertext, different_associated_data);
   EXPECT_FALSE(decyphered_message.ok());
   EXPECT_EQ(decyphered_message.status().code(), absl::StatusCode::kAborted);
 
@@ -268,7 +268,7 @@ TEST_F(SenderContextTest, SenderOpensEmptyEncryptedMessageFailure) {
 
   // We use an empty ciphertext.
   std::string ciphertext = "";
-  auto decyphered_message = sender_context.Open(ciphertext, associated_data_response_);
+  auto decyphered_message = sender_context.Open(default_nonce_bytes_, ciphertext, associated_data_response_);
   EXPECT_FALSE(decyphered_message.ok());
   EXPECT_EQ(decyphered_message.status().code(), absl::StatusCode::kInvalidArgument);
 }

--- a/cc/crypto/hpke/sender_context_test.cc
+++ b/cc/crypto/hpke/sender_context_test.cc
@@ -140,7 +140,8 @@ TEST_F(SenderContextTest, SenderOpensEncryptedMessageSuccess) {
   std::string ciphertext(ciphertext_bytes.begin(), ciphertext_bytes.end());
 
   // Successfully open encrypted message and get back original plaintext.
-  auto decyphered_message = sender_context.Open(default_nonce_bytes_, ciphertext, associated_data_response_);
+  auto decyphered_message =
+      sender_context.Open(default_nonce_bytes_, ciphertext, associated_data_response_);
   EXPECT_TRUE(decyphered_message.ok());
 
   // Cleanup the lingering context.
@@ -192,7 +193,8 @@ TEST_F(SenderContextTest, SenderOpensEncryptedMessageFailureNoncesNotAligned) {
   std::string ciphertext(ciphertext_bytes.begin(), ciphertext_bytes.end());
 
   // Attempt to open the encrypted message. This should fail.
-  auto decyphered_message = sender_context.Open(default_nonce_bytes_, ciphertext, associated_data_response_);
+  auto decyphered_message =
+      sender_context.Open(default_nonce_bytes_, ciphertext, associated_data_response_);
   EXPECT_FALSE(decyphered_message.ok());
   EXPECT_EQ(decyphered_message.status().code(), absl::StatusCode::kAborted);
 
@@ -243,7 +245,8 @@ TEST_F(SenderContextTest, SenderOpensEncryptedMessageFailureAssociatedDataNotAli
 
   // Attempt to open the encrypted message using different associated data. This should fail.
   std::string different_associated_data = "Different response associated data";
-  auto decyphered_message = sender_context.Open(default_nonce_bytes_, ciphertext, different_associated_data);
+  auto decyphered_message =
+      sender_context.Open(default_nonce_bytes_, ciphertext, different_associated_data);
   EXPECT_FALSE(decyphered_message.ok());
   EXPECT_EQ(decyphered_message.status().code(), absl::StatusCode::kAborted);
 
@@ -268,7 +271,8 @@ TEST_F(SenderContextTest, SenderOpensEmptyEncryptedMessageFailure) {
 
   // We use an empty ciphertext.
   std::string ciphertext = "";
-  auto decyphered_message = sender_context.Open(default_nonce_bytes_, ciphertext, associated_data_response_);
+  auto decyphered_message =
+      sender_context.Open(default_nonce_bytes_, ciphertext, associated_data_response_);
   EXPECT_FALSE(decyphered_message.ok());
   EXPECT_EQ(decyphered_message.status().code(), absl::StatusCode::kInvalidArgument);
 }

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 #include <utility>
 
 #include "absl/status/status.h"
@@ -44,8 +45,13 @@ absl::StatusOr<DecryptionResult> ServerEncryptor::Decrypt(EncryptedRequest encry
   }
 
   // Decrypt request.
+  const std::vector<uint8_t> nonce(
+      encrypted_request.encrypted_message().nonce().begin(),
+      encrypted_request.encrypted_message().nonce().end()
+  );
   absl::StatusOr<std::string> plaintext =
-      recipient_context_->Open(encrypted_request.encrypted_message().ciphertext(),
+      recipient_context_->Open(nonce,
+                               encrypted_request.encrypted_message().ciphertext(),
                                encrypted_request.encrypted_message().associated_data());
   if (!plaintext.ok()) {
     return plaintext.status();

--- a/cc/crypto/server_encryptor.cc
+++ b/cc/crypto/server_encryptor.cc
@@ -18,8 +18,8 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -45,13 +45,10 @@ absl::StatusOr<DecryptionResult> ServerEncryptor::Decrypt(EncryptedRequest encry
   }
 
   // Decrypt request.
-  const std::vector<uint8_t> nonce(
-      encrypted_request.encrypted_message().nonce().begin(),
-      encrypted_request.encrypted_message().nonce().end()
-  );
+  const std::vector<uint8_t> nonce(encrypted_request.encrypted_message().nonce().begin(),
+                                   encrypted_request.encrypted_message().nonce().end());
   absl::StatusOr<std::string> plaintext =
-      recipient_context_->Open(nonce,
-                               encrypted_request.encrypted_message().ciphertext(),
+      recipient_context_->Open(nonce, encrypted_request.encrypted_message().ciphertext(),
                                encrypted_request.encrypted_message().associated_data());
   if (!plaintext.ok()) {
     return plaintext.status();

--- a/java/src/main/java/com/google/oak/crypto/ClientEncryptor.java
+++ b/java/src/main/java/com/google/oak/crypto/ClientEncryptor.java
@@ -114,11 +114,12 @@ public class ClientEncryptor implements AutoCloseable {
   public final Result<DecryptionResult, Exception> decrypt(
       final EncryptedResponse encryptedResponse) {
     AeadEncryptedMessage aeadEncryptedMessage = encryptedResponse.getEncryptedMessage();
+    byte[] nonce = aeadEncryptedMessage.getNonce().toByteArray();
     byte[] ciphertext = aeadEncryptedMessage.getCiphertext().toByteArray();
     byte[] associatedData = aeadEncryptedMessage.getAssociatedData().toByteArray();
 
     // Decrypt response.
-    return senderContext.open(ciphertext, associatedData)
+    return senderContext.open(nonce, ciphertext, associatedData)
         .map(plaintext -> new DecryptionResult(plaintext, associatedData));
   }
 }

--- a/java/src/main/java/com/google/oak/crypto/ServerEncryptor.java
+++ b/java/src/main/java/com/google/oak/crypto/ServerEncryptor.java
@@ -78,6 +78,7 @@ public class ServerEncryptor implements AutoCloseable {
   public final Result<DecryptionResult, Exception> decrypt(
       final EncryptedRequest encryptedRequest) {
     AeadEncryptedMessage aeadEncryptedMessage = encryptedRequest.getEncryptedMessage();
+    byte[] nonce = aeadEncryptedMessage.getNonce().toByteArray();
     byte[] ciphertext = aeadEncryptedMessage.getCiphertext().toByteArray();
     byte[] associatedData = aeadEncryptedMessage.getAssociatedData().toByteArray();
 
@@ -100,7 +101,7 @@ public class ServerEncryptor implements AutoCloseable {
 
     // Decrypt request.
     return recipientContext.get()
-        .open(ciphertext, associatedData)
+        .open(nonce, ciphertext, associatedData)
         .map(plaintext -> new DecryptionResult(plaintext, associatedData));
   }
 

--- a/java/src/main/java/com/google/oak/crypto/hpke/RecipientContext.java
+++ b/java/src/main/java/com/google/oak/crypto/hpke/RecipientContext.java
@@ -28,7 +28,7 @@ public final class RecipientContext implements AutoCloseable {
   }
 
   private native byte[] nativeGenerateNonce();
-  private native byte[] nativeOpen(final byte[] ciphertext, final byte[] associatedData);
+  private native byte[] nativeOpen(final byte[] nonce, final byte[] ciphertext, final byte[] associatedData);
   private native byte[] nativeSeal(
       final byte[] nonce, final byte[] plaintext, final byte[] associatedData);
   private native void nativeDestroy();
@@ -50,8 +50,8 @@ public final class RecipientContext implements AutoCloseable {
    * <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
    */
   public final Result<byte[], Exception> open(
-      final byte[] ciphertext, final byte[] associatedData) {
-    byte[] nativeResult = nativeOpen(ciphertext, associatedData);
+      final byte[] nonce, final byte[] ciphertext, final byte[] associatedData) {
+    byte[] nativeResult = nativeOpen(nonce, ciphertext, associatedData);
     if (nativeResult == null) {
       return Result.error(new Exception("RecipientContext open failed"));
     }

--- a/java/src/main/java/com/google/oak/crypto/hpke/RecipientContext.java
+++ b/java/src/main/java/com/google/oak/crypto/hpke/RecipientContext.java
@@ -28,7 +28,8 @@ public final class RecipientContext implements AutoCloseable {
   }
 
   private native byte[] nativeGenerateNonce();
-  private native byte[] nativeOpen(final byte[] nonce, final byte[] ciphertext, final byte[] associatedData);
+  private native byte[] nativeOpen(
+      final byte[] nonce, final byte[] ciphertext, final byte[] associatedData);
   private native byte[] nativeSeal(
       final byte[] nonce, final byte[] plaintext, final byte[] associatedData);
   private native void nativeDestroy();

--- a/java/src/main/java/com/google/oak/crypto/hpke/SenderContext.java
+++ b/java/src/main/java/com/google/oak/crypto/hpke/SenderContext.java
@@ -33,7 +33,7 @@ public final class SenderContext implements AutoCloseable {
   private native byte[] nativeGenerateNonce();
   private native byte[] nativeSeal(
       final byte[] nonce, final byte[] plaintext, final byte[] associatedData);
-  private native byte[] nativeOpen(final byte[] ciphertext, final byte[] associatedData);
+  private native byte[] nativeOpen(final byte[] nonce, final byte[] ciphertext, final byte[] associatedData);
   private native void nativeDestroy();
 
   public final byte[] getSerializedEncapsulatedPublicKey() {
@@ -70,8 +70,8 @@ public final class SenderContext implements AutoCloseable {
    * communication. <https://www.rfc-editor.org/rfc/rfc9180.html#name-bidirectional-encryption>
    */
   public final Result<byte[], Exception> open(
-      final byte[] ciphertext, final byte[] associatedData) {
-    byte[] nativeResult = nativeOpen(ciphertext, associatedData);
+      final byte[] nonce, final byte[] ciphertext, final byte[] associatedData) {
+    byte[] nativeResult = nativeOpen(nonce, ciphertext, associatedData);
     if (nativeResult == null) {
       return Result.error(new Exception("SenderContext open failed"));
     }

--- a/java/src/main/java/com/google/oak/crypto/hpke/SenderContext.java
+++ b/java/src/main/java/com/google/oak/crypto/hpke/SenderContext.java
@@ -33,7 +33,8 @@ public final class SenderContext implements AutoCloseable {
   private native byte[] nativeGenerateNonce();
   private native byte[] nativeSeal(
       final byte[] nonce, final byte[] plaintext, final byte[] associatedData);
-  private native byte[] nativeOpen(final byte[] nonce, final byte[] ciphertext, final byte[] associatedData);
+  private native byte[] nativeOpen(
+      final byte[] nonce, final byte[] ciphertext, final byte[] associatedData);
   private native void nativeDestroy();
 
   public final byte[] getSerializedEncapsulatedPublicKey() {


### PR DESCRIPTION
This PR makes C++ and Java crypto code to use nonces provided by Proto messages.

Ref https://github.com/project-oak/oak/issues/4507