### PR TITLE
Reorder arguments for proto compilation

### DIFF
--- a/micro_rpc_workspace_test/build.rs
+++ b/micro_rpc_workspace_test/build.rs
@@ -18,8 +18,8 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions, ExternPath};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "proto",
         &["test.proto", "stubs.proto"],
+        "proto",
         CodegenOptions {
             extern_paths: vec![ExternPath::new(
                 ".oak.crypto.v1",

--- a/oak_client/build.rs
+++ b/oak_client/build.rs
@@ -18,11 +18,11 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../",
         &[
             "oak_remote_attestation/proto/v1/messages.proto",
             "oak_remote_attestation/proto/v1/service_streaming.proto",
         ],
+        "../",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_hello_world_trusted_app/build.rs
+++ b/oak_containers_hello_world_trusted_app/build.rs
@@ -17,11 +17,11 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../",
         &[
             "oak_containers_hello_world_trusted_app/proto/interface.proto",
             "oak_crypto/proto/v1/crypto.proto",
         ],
+        "../",
         CodegenOptions {
             build_server: true,
             ..Default::default()
@@ -29,11 +29,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     generate_grpc_code(
-        "../",
         &[
             "oak_containers/proto/interfaces.proto",
             "oak_remote_attestation/proto/v1/messages.proto",
         ],
+        "../",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_hello_world_untrusted_app/build.rs
+++ b/oak_containers_hello_world_untrusted_app/build.rs
@@ -17,11 +17,11 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
-        "../",
         &[
             "oak_containers_hello_world_trusted_app/proto/interface.proto",
             "oak_crypto/proto/v1/crypto.proto",
         ],
+        "../",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_launcher/build.rs
+++ b/oak_containers_launcher/build.rs
@@ -18,7 +18,6 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the launcher.
     generate_grpc_code(
-        "../",
         &[
             "oak_containers/proto/interfaces.proto",
             "oak_crypto/proto/v1/crypto.proto",
@@ -26,6 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/key_provisioning/key_provisioning.proto",
             "proto/containers/hostlib_key_provisioning.proto",
         ],
+        "../",
         CodegenOptions {
             build_server: true,
             ..Default::default()

--- a/oak_containers_orchestrator/build.rs
+++ b/oak_containers_orchestrator/build.rs
@@ -18,7 +18,6 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for Orchestrator services.
     generate_grpc_code(
-        "../",
         &[
             "oak_remote_attestation/proto/v1/messages.proto",
             "oak_containers/proto/interfaces.proto",
@@ -26,6 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/containers/orchestrator_crypto.proto",
             "proto/containers/hostlib_key_provisioning.proto",
         ],
+        "../",
         CodegenOptions {
             build_server: true,
             build_client: true,

--- a/oak_containers_stage1/build.rs
+++ b/oak_containers_stage1/build.rs
@@ -19,12 +19,12 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for loading the system image.
     generate_grpc_code(
-        "../",
         &[
             "oak_containers/proto/interfaces.proto",
             "oak_crypto/proto/v1/crypto.proto",
             "oak_remote_attestation/proto/v1/messages.proto",
         ],
+        "../",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_syslogd/build.rs
+++ b/oak_containers_syslogd/build.rs
@@ -19,12 +19,12 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the launcher.
     generate_grpc_code(
-        "../",
         &[
             "oak_containers/proto/interfaces.proto",
             "oak_crypto/proto/v1/crypto.proto",
             "oak_remote_attestation/proto/v1/messages.proto",
         ],
+        "../",
         CodegenOptions::default(),
     )?;
 

--- a/oak_functions_containers_app/build.rs
+++ b/oak_functions_containers_app/build.rs
@@ -19,12 +19,12 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions, ExternPath};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
     generate_grpc_code(
-        "../",
         &[
             "oak_crypto/proto/v1/crypto.proto",
             "proto/attestation/evidence.proto",
             "proto/oak_functions/service/oak_functions.proto",
         ],
+        "../",
         CodegenOptions {
             build_server: true,
             // The client is only used in the integration test.
@@ -37,11 +37,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     generate_grpc_code(
-        "../",
         &[
             "oak_containers/proto/interfaces.proto",
             "oak_remote_attestation/proto/v1/messages.proto",
         ],
+        "../",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_functions_containers_launcher/build.rs
+++ b/oak_functions_containers_launcher/build.rs
@@ -19,12 +19,12 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
     generate_grpc_code(
-        "../",
         &[
             "oak_crypto/proto/v1/crypto.proto",
             "proto/attestation/evidence.proto",
             "proto/oak_functions/service/oak_functions.proto",
         ],
+        "../",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_functions_launcher/build.rs
+++ b/oak_functions_launcher/build.rs
@@ -19,11 +19,11 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
     generate_grpc_code(
-        "../",
         &[
             "oak_remote_attestation/proto/v1/messages.proto",
             "oak_remote_attestation/proto/v1/service_streaming.proto",
         ],
+        "../",
         CodegenOptions {
             build_server: true,
             ..Default::default()

--- a/oak_grpc_utils/src/lib.rs
+++ b/oak_grpc_utils/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+use std::path::Path;
+
 /// Options for building gRPC code.
 #[derive(Default)]
 pub struct CodegenOptions {
@@ -45,21 +47,14 @@ impl ExternPath {
 /// The path to the root repository must be passed as `include`. All paths to `.proto` files
 /// must be specified relative to this path. Likewise, all imported paths in `.proto` files must
 /// be specified relative to this path.
-// TODO(#4588): Swap the include and protos arguments, so they match the order of the
-// corresponding arguments in the `tonic_build::configure()` function.
 pub fn generate_grpc_code(
-    include: &str,
-    protos: &[&str],
+    protos: &[impl AsRef<Path>],
+    include: impl AsRef<Path>,
     options: CodegenOptions,
 ) -> std::io::Result<()> {
     set_protoc_env_if_unset();
 
     // TODO(#1093): Move all proto generation to a common crate.
-    let include = std::path::Path::new(include);
-    let file_paths: Vec<std::path::PathBuf> = protos
-        .iter()
-        .map(|file_path| include.join(file_path))
-        .collect();
 
     // Generate the normal (non-Oak) server and client code for the gRPC service,
     // along with the Rust types corresponding to the message definitions.
@@ -72,17 +67,17 @@ pub fn generate_grpc_code(
     // every time. Instead, we specify the list of files to watch explicitly, even though that
     // may not have 100% recall, since some of the transitive includes may be missed.
     config = config.emit_rerun_if_changed(false);
-    file_paths.iter().for_each(|filename| {
+    protos.iter().for_each(|filename| {
         println!(
             "cargo:rerun-if-changed={}",
-            filename.as_os_str().to_string_lossy()
+            include.as_ref().join(filename).to_string_lossy()
         )
     });
 
     for extern_path in options.extern_paths {
         config = config.extern_path(extern_path.proto_path, extern_path.rust_path);
     }
-    config.compile(&file_paths, &[include])
+    config.compile(protos, &[include])
 }
 
 fn set_protoc_env_if_unset() {


### PR DESCRIPTION
Use same name, type and semantics as prost and tonic.

Simplify the change tracking logic.

Fix #4587