### PR TITLE
Add Oak Containers SDK for encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,7 +1908,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "async-trait",
  "bytes",
  "oak_containers_sdk",
  "oak_crypto",
@@ -2189,7 +2188,6 @@ name = "oak_functions_containers_app"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "http",
  "micro_rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,12 +2194,8 @@ dependencies = [
  "clap",
  "http",
  "micro_rpc",
-<<<<<<< HEAD
  "oak_containers_orchestrator",
-=======
- "oak_containers_orchestrator_client",
  "oak_containers_sdk",
->>>>>>> fae2326ec (Add Oak Containers SDK for encryption)
  "oak_crypto",
  "oak_functions_service",
  "oak_functions_test_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,7 +2008,6 @@ dependencies = [
  "async-trait",
  "oak_crypto",
  "oak_grpc_utils",
- "oak_remote_attestation",
  "prost",
  "prost-types",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
+ "oak_containers_sdk",
  "oak_crypto",
  "oak_grpc_utils",
  "oak_remote_attestation",
@@ -1996,6 +1997,24 @@ dependencies = [
  "tokio-util",
  "tonic",
  "walkdir",
+]
+
+[[package]]
+name = "oak_containers_sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "oak_crypto",
+ "oak_grpc_utils",
+ "oak_remote_attestation",
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tower",
 ]
 
 [[package]]
@@ -2175,7 +2194,12 @@ dependencies = [
  "clap",
  "http",
  "micro_rpc",
+<<<<<<< HEAD
  "oak_containers_orchestrator",
+=======
+ "oak_containers_orchestrator_client",
+ "oak_containers_sdk",
+>>>>>>> fae2326ec (Add Oak Containers SDK for encryption)
  "oak_crypto",
  "oak_functions_service",
  "oak_functions_test_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "oak_containers_hello_world_untrusted_app",
   "oak_containers_launcher",
   "oak_containers_orchestrator",
+  "oak_containers_sdk",
   "oak_containers_stage1",
   "oak_containers_syslogd",
   "oak_core",
@@ -83,6 +84,7 @@ oak_channel = { path = "./oak_channel" }
 oak_client = { path = "./oak_client" }
 oak_containers_orchestrator = { path = "./oak_containers_orchestrator" }
 oak_containers_launcher = { path = "./oak_containers_launcher" }
+oak_containers_sdk = { path = "./oak_containers_sdk" }
 oak_core = { path = "./oak_core" }
 oak_crypto = { path = "./oak_crypto" }
 oak_dice = { path = "./oak_dice" }

--- a/oak_containers_hello_world_trusted_app/Cargo.toml
+++ b/oak_containers_hello_world_trusted_app/Cargo.toml
@@ -10,7 +10,6 @@ oak_grpc_utils = { workspace = true }
 
 [dependencies]
 anyhow = "*"
-async-trait = { version = "*", default-features = false }
 oak_containers_sdk = { workspace = true }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }

--- a/oak_containers_hello_world_trusted_app/src/app_service.rs
+++ b/oak_containers_hello_world_trusted_app/src/app_service.rs
@@ -18,7 +18,7 @@ use crate::proto::oak::containers::example::{
     HelloRequest, HelloResponse,
 };
 use anyhow::anyhow;
-use oak_containers_sdk::EncryptionKeyHandle;
+use oak_containers_sdk::InstanceEncryptionKeyHandle;
 use oak_crypto::encryptor::AsyncServerEncryptor;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -27,11 +27,14 @@ const EMPTY_ASSOCIATED_DATA: &[u8] = b"";
 
 struct TrustedApplicationImplementation {
     application_config: Vec<u8>,
-    encryption_key_handle: EncryptionKeyHandle,
+    encryption_key_handle: InstanceEncryptionKeyHandle,
 }
 
 impl TrustedApplicationImplementation {
-    pub fn new(application_config: Vec<u8>, encryption_key_handle: EncryptionKeyHandle) -> Self {
+    pub fn new(
+        application_config: Vec<u8>,
+        encryption_key_handle: InstanceEncryptionKeyHandle,
+    ) -> Self {
         Self {
             application_config,
             encryption_key_handle,
@@ -79,7 +82,7 @@ impl TrustedApplication for TrustedApplicationImplementation {
 pub async fn create(
     listener: TcpListener,
     application_config: Vec<u8>,
-    encryption_key_handle: EncryptionKeyHandle,
+    encryption_key_handle: InstanceEncryptionKeyHandle,
 ) -> Result<(), anyhow::Error> {
     tonic::transport::Server::builder()
         .add_service(TrustedApplicationServer::new(

--- a/oak_containers_hello_world_trusted_app/src/main.rs
+++ b/oak_containers_hello_world_trusted_app/src/main.rs
@@ -15,6 +15,7 @@
 
 use anyhow::anyhow;
 use oak_containers_hello_world_trusted_app::orchestrator_client::OrchestratorClient;
+use oak_containers_sdk::EncryptionKeyHandle;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio::net::TcpListener;
 
@@ -26,12 +27,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .map_err(|error| anyhow!("couldn't create Orchestrator client: {:?}", error))?;
     let application_config = client.clone().get_application_config().await?;
+    let encryption_key_handle = EncryptionKeyHandle::create()
+        .await
+        .map_err(|error| anyhow!("couldn't create encryption key handle: {:?}", error))?;
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), TRUSTED_APP_PORT);
     let listener = TcpListener::bind(addr).await?;
     let join_handle = tokio::spawn(oak_containers_hello_world_trusted_app::app_service::create(
         listener,
-        client.clone(),
         application_config,
+        encryption_key_handle,
     ));
     client.notify_app_ready().await?;
     join_handle.await??;

--- a/oak_containers_hello_world_trusted_app/src/main.rs
+++ b/oak_containers_hello_world_trusted_app/src/main.rs
@@ -15,7 +15,7 @@
 
 use anyhow::anyhow;
 use oak_containers_hello_world_trusted_app::orchestrator_client::OrchestratorClient;
-use oak_containers_sdk::EncryptionKeyHandle;
+use oak_containers_sdk::InstanceEncryptionKeyHandle;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio::net::TcpListener;
 
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .map_err(|error| anyhow!("couldn't create Orchestrator client: {:?}", error))?;
     let application_config = client.clone().get_application_config().await?;
-    let encryption_key_handle = EncryptionKeyHandle::create()
+    let encryption_key_handle = InstanceEncryptionKeyHandle::create()
         .await
         .map_err(|error| anyhow!("couldn't create encryption key handle: {:?}", error))?;
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), TRUSTED_APP_PORT);

--- a/oak_containers_hello_world_trusted_app/src/orchestrator_client.rs
+++ b/oak_containers_hello_world_trusted_app/src/orchestrator_client.rs
@@ -13,15 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto::oak::containers::{
-    orchestrator_client::OrchestratorClient as GrpcOrchestratorClient, GetCryptoContextRequest,
-};
+use crate::proto::oak::containers::orchestrator_client::OrchestratorClient as GrpcOrchestratorClient;
 use anyhow::Context;
-use async_trait::async_trait;
-use oak_crypto::{
-    encryptor::AsyncRecipientContextGenerator, hpke::RecipientContext,
-    proto::oak::crypto::v1::CryptoContext,
-};
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 
@@ -69,50 +62,8 @@ impl OrchestratorClient {
         Ok(config)
     }
 
-    pub async fn get_crypto_context(
-        &self,
-        serialized_encapsulated_public_key: &[u8],
-    ) -> Result<CryptoContext, Box<dyn std::error::Error>> {
-        let context = self
-            .inner
-            // TODO(#4477): Remove unnecessary copies of the Orchestrator client.
-            .clone()
-            .get_crypto_context(GetCryptoContextRequest {
-                serialized_encapsulated_public_key: serialized_encapsulated_public_key.to_vec(),
-            })
-            .await?
-            .into_inner()
-            // Crypto context.
-            .context
-            .context("crypto context wasn't provided")?;
-        Ok(context)
-    }
-
     pub async fn notify_app_ready(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         self.inner.notify_app_ready(tonic::Request::new(())).await?;
         Ok(())
-    }
-}
-
-#[async_trait]
-impl AsyncRecipientContextGenerator for OrchestratorClient {
-    async fn generate_recipient_context(
-        &self,
-        encapsulated_public_key: &[u8],
-    ) -> anyhow::Result<RecipientContext> {
-        let serialized_crypto_context = self
-            .get_crypto_context(encapsulated_public_key)
-            .await
-            .map_err(|error| {
-                tonic::Status::internal(format!(
-                    "couldn't get crypto context from the Orchestrator: {:?}",
-                    error
-                ))
-            })?;
-        let crypto_context =
-            RecipientContext::deserialize(serialized_crypto_context).map_err(|error| {
-                tonic::Status::internal(format!("couldn't deserialize crypto context: {:?}", error))
-            })?;
-        Ok(crypto_context)
     }
 }

--- a/oak_containers_sdk/Cargo.toml
+++ b/oak_containers_sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "oak_containers_hello_world_trusted_app"
+name = "oak_containers_sdk"
 version = "0.1.0"
-authors = ["Juliette Pretot <julsh@google.com>"]
+authors = ["Ivan Petrov <ivanpetrov@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
@@ -11,7 +11,6 @@ oak_grpc_utils = { workspace = true }
 [dependencies]
 anyhow = "*"
 async-trait = { version = "*", default-features = false }
-oak_containers_sdk = { workspace = true }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
 prost = "*"
@@ -20,5 +19,4 @@ tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tokio-stream = { version = "*", features = ["net"] }
 tonic = { workspace = true }
 async-stream = "*"
-bytes = "*"
 tower = "*"

--- a/oak_containers_sdk/Cargo.toml
+++ b/oak_containers_sdk/Cargo.toml
@@ -12,7 +12,6 @@ oak_grpc_utils = { workspace = true }
 anyhow = "*"
 async-trait = { version = "*", default-features = false }
 oak_crypto = { workspace = true }
-oak_remote_attestation = { workspace = true }
 prost = "*"
 prost-types = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }

--- a/oak_containers_sdk/README.md
+++ b/oak_containers_sdk/README.md
@@ -1,0 +1,9 @@
+<!-- Oak Logo Start -->
+<!-- An HTML element is intentionally used since GitHub recommends this approach to handle different images in dark/light modes. Ref: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to -->
+<!-- markdownlint-disable-next-line MD033 -->
+<h1><picture><source media="(prefers-color-scheme: dark)" srcset="/docs/oak-logo/svgs/oak-containers-negative-colour.svg?sanitize=true"><source media="(prefers-color-scheme: light)" srcset="/docs/oak-logo/svgs/oak-containers.svg?sanitize=true"><img alt="Project Oak Containers Logo" src="/docs/oak-logo/svgs/oak-containers.svg?sanitize=true"></picture></h1>
+<!-- Oak Logo End -->
+
+# Orchestrator SDK
+
+SDK library for implementing enclave applications on Oak Containers.

--- a/oak_containers_sdk/build.rs
+++ b/oak_containers_sdk/build.rs
@@ -1,0 +1,30 @@
+//
+// Copyright 2024 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Generate gRPC code for connecting to the Orchestrator.
+    generate_grpc_code(
+        "../",
+        &["proto/containers/orchestrator_crypto.proto"],
+        CodegenOptions {
+            build_client: true,
+            ..Default::default()
+        },
+    )?;
+
+    Ok(())
+}

--- a/oak_containers_sdk/build.rs
+++ b/oak_containers_sdk/build.rs
@@ -18,8 +18,8 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the Orchestrator.
     generate_grpc_code(
-        "../",
         &["proto/containers/orchestrator_crypto.proto"],
+        "..",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_sdk/src/crypto.rs
+++ b/oak_containers_sdk/src/crypto.rs
@@ -87,7 +87,7 @@ where
         &self,
         encapsulated_public_key: &[u8],
     ) -> anyhow::Result<RecipientContext> {
-        self.generate_recipient_context(encapsulated_public_key)
+        self.generate_recipient_context(encapsulated_public_key).await
     }
 }
 

--- a/oak_containers_sdk/src/crypto.rs
+++ b/oak_containers_sdk/src/crypto.rs
@@ -71,11 +71,31 @@ impl OrchestratorCryptoClient {
     }
 }
 
-pub struct EncryptionKeyHandle {
+pub trait EncryptionKeyHandle {
+    async fn derive_session_keys(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext>;
+}
+
+#[async_trait]
+impl<T> EncryptionKeyHandle for T
+where
+    T: AsyncRecipientContextGenerator,
+{
+    async fn derive_session_keys(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext> {
+        self.generate_recipient_context(encapsulated_public_key)
+    }
+}
+
+pub struct InstanceEncryptionKeyHandle {
     orchestrator_crypto_client: OrchestratorCryptoClient,
 }
 
-impl EncryptionKeyHandle {
+impl InstanceEncryptionKeyHandle {
     pub async fn create() -> anyhow::Result<Self> {
         Ok(Self {
             orchestrator_crypto_client: OrchestratorCryptoClient::create()
@@ -86,7 +106,7 @@ impl EncryptionKeyHandle {
 }
 
 #[async_trait]
-impl AsyncRecipientContextGenerator for EncryptionKeyHandle {
+impl AsyncRecipientContextGenerator for InstanceEncryptionKeyHandle {
     async fn generate_recipient_context(
         &self,
         encapsulated_public_key: &[u8],

--- a/oak_containers_sdk/src/crypto.rs
+++ b/oak_containers_sdk/src/crypto.rs
@@ -71,6 +71,7 @@ impl OrchestratorCryptoClient {
     }
 }
 
+#[async_trait(?Send)]
 pub trait EncryptionKeyHandle {
     async fn derive_session_keys(
         &self,
@@ -78,7 +79,7 @@ pub trait EncryptionKeyHandle {
     ) -> anyhow::Result<RecipientContext>;
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<T> EncryptionKeyHandle for T
 where
     T: AsyncRecipientContextGenerator,
@@ -87,7 +88,8 @@ where
         &self,
         encapsulated_public_key: &[u8],
     ) -> anyhow::Result<RecipientContext> {
-        self.generate_recipient_context(encapsulated_public_key).await
+        self.generate_recipient_context(encapsulated_public_key)
+            .await
     }
 }
 

--- a/oak_containers_sdk/src/crypto.rs
+++ b/oak_containers_sdk/src/crypto.rs
@@ -1,0 +1,110 @@
+//
+// Copyright 2024 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    proto::oak::containers::v1::{
+        orchestrator_crypto_client::OrchestratorCryptoClient as GrpcOrchestratorCryptoClient,
+        DeriveSessionKeysRequest, KeyOrigin,
+    },
+    IGNORED_ENDPOINT_URI, ORCHESTRATOR_IPC_SOCKET,
+};
+use anyhow::Context;
+use async_trait::async_trait;
+use oak_crypto::{
+    encryptor::AsyncRecipientContextGenerator, hpke::RecipientContext,
+    proto::oak::crypto::v1::CryptoContext,
+};
+use tonic::transport::{Endpoint, Uri};
+use tower::service_fn;
+
+struct OrchestratorCryptoClient {
+    inner: GrpcOrchestratorCryptoClient<tonic::transport::channel::Channel>,
+}
+
+impl OrchestratorCryptoClient {
+    async fn create() -> anyhow::Result<Self> {
+        let inner: GrpcOrchestratorCryptoClient<tonic::transport::channel::Channel> = {
+            let channel = Endpoint::try_from(IGNORED_ENDPOINT_URI)
+                .context("couldn't form endpoint")?
+                .connect_with_connector(service_fn(move |_: Uri| {
+                    tokio::net::UnixStream::connect(ORCHESTRATOR_IPC_SOCKET)
+                }))
+                .await
+                .context("couldn't connect to UDS socket")?;
+
+            GrpcOrchestratorCryptoClient::new(channel)
+        };
+        Ok(Self { inner })
+    }
+
+    async fn derive_session_keys(
+        &self,
+        key_origin: KeyOrigin,
+        serialized_encapsulated_public_key: &[u8],
+    ) -> Result<CryptoContext, Box<dyn std::error::Error>> {
+        let context = self
+            .inner
+            // TODO(#4477): Remove unnecessary copies of the Orchestrator client.
+            .clone()
+            .derive_session_keys(DeriveSessionKeysRequest {
+                key_origin: key_origin.into(),
+                serialized_encapsulated_public_key: serialized_encapsulated_public_key.to_vec(),
+            })
+            .await?
+            .into_inner()
+            // Crypto context.
+            .context
+            .context("crypto context wasn't provided by the Orchestrator")?;
+        Ok(context)
+    }
+}
+
+pub struct EncryptionKeyHandle {
+    orchestrator_crypto_client: OrchestratorCryptoClient,
+}
+
+impl EncryptionKeyHandle {
+    pub async fn create() -> anyhow::Result<Self> {
+        Ok(Self {
+            orchestrator_crypto_client: OrchestratorCryptoClient::create()
+                .await
+                .context("couldn't create Orchestrator crypto client")?,
+        })
+    }
+}
+
+#[async_trait]
+impl AsyncRecipientContextGenerator for EncryptionKeyHandle {
+    async fn generate_recipient_context(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext> {
+        let serialized_crypto_context = self
+            .orchestrator_crypto_client
+            .derive_session_keys(KeyOrigin::Instance, encapsulated_public_key)
+            .await
+            .map_err(|error| {
+                tonic::Status::internal(format!(
+                    "couldn't get crypto context from the Orchestrator: {:?}",
+                    error
+                ))
+            })?;
+        let crypto_context =
+            RecipientContext::deserialize(serialized_crypto_context).map_err(|error| {
+                tonic::Status::internal(format!("couldn't deserialize crypto context: {:?}", error))
+            })?;
+        Ok(crypto_context)
+    }
+}

--- a/oak_containers_sdk/src/lib.rs
+++ b/oak_containers_sdk/src/lib.rs
@@ -39,4 +39,4 @@ static IGNORED_ENDPOINT_URI: &str = "file://[::]:0";
 const ORCHESTRATOR_IPC_SOCKET: &str = "/oak_utils/orchestrator_ipc";
 
 // Re-export structs so that they are available at the top level of the SDK.
-pub use crypto::EncryptionKeyHandle;
+pub use crypto::{EncryptionKeyHandle, InstanceEncryptionKeyHandle};

--- a/oak_containers_sdk/src/lib.rs
+++ b/oak_containers_sdk/src/lib.rs
@@ -1,0 +1,42 @@
+//
+// Copyright 2024 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod proto {
+    pub mod oak {
+        pub mod containers {
+            pub mod v1 {
+                #![allow(clippy::return_self_not_must_use)]
+                tonic::include_proto!("oak.containers.v1");
+            }
+        }
+        pub use oak_crypto::proto::oak::crypto;
+    }
+}
+
+pub mod crypto;
+
+// Unix Domain Sockets do not use URIs, hence this URI will never be used.
+// It is defined purely since in order to create a channel, since a URI has to
+// be supplied to create an `Endpoint`. Even though in this case the endpoint
+// is technically a file, tonic expects us to provide our own connector, and
+// this ignored endpoint. :(
+static IGNORED_ENDPOINT_URI: &str = "file://[::]:0";
+
+// Path used to facilitate inter-process communication between the orchestrator
+// and the trusted application.
+const ORCHESTRATOR_IPC_SOCKET: &str = "/oak_utils/orchestrator_ipc";
+
+// Re-export structs so that they are available at the top level of the SDK.
+pub use crypto::EncryptionKeyHandle;

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = { version = "*", default-features = false }
 clap = { version = "*", features = ["derive"] }
 http = "*"
 oak_containers_orchestrator = { workspace = true }
+oak_containers_sdk = { workspace = true }
 oak_functions_service = { workspace = true, features = ["std"] }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -9,7 +9,6 @@ oak_grpc_utils = { workspace = true }
 
 [dependencies]
 anyhow = "*"
-async-trait = { version = "*", default-features = false }
 clap = { version = "*", features = ["derive"] }
 http = "*"
 oak_containers_orchestrator = { workspace = true }

--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -16,7 +16,7 @@
 
 use crate::proto::oak::functions::oak_functions_server::{OakFunctions, OakFunctionsServer};
 use anyhow::Context;
-use oak_containers_sdk::EncryptionKeyHandle;
+use oak_crypto::encryptor::AsyncRecipientContextGenerator;
 use oak_functions_service::{
     instance::OakFunctionsInstance,
     proto::oak::functions::{
@@ -61,15 +61,15 @@ pub mod proto {
 pub mod orchestrator_client;
 
 // Instance of the OakFunctions service for Oak Containers.
-pub struct OakFunctionsContainersService {
+pub struct OakFunctionsContainersService<G: AsyncRecipientContextGenerator + Send + Sync> {
     instance: OnceLock<OakFunctionsInstance>,
-    encryption_key_handle: Arc<dyn EncryptionKeyHandle>,
+    encryption_key_handle: Arc<G>,
     observer: Option<Arc<dyn Observer + Send + Sync>>,
 }
 
-impl OakFunctionsContainersService {
+impl<G: AsyncRecipientContextGenerator + Send + Sync> OakFunctionsContainersService<G> {
     pub fn new(
-        encryption_key_handle: Arc<dyn EncryptionKeyHandle>,
+        encryption_key_handle: Arc<G>,
         observer: Option<Arc<dyn Observer + Send + Sync>>,
     ) -> Self {
         Self {
@@ -110,7 +110,9 @@ fn map_status(status: micro_rpc::Status) -> tonic::Status {
 }
 
 #[tonic::async_trait]
-impl OakFunctions for OakFunctionsContainersService {
+impl<G: AsyncRecipientContextGenerator + Send + Sync + 'static> OakFunctions
+    for OakFunctionsContainersService<G>
+{
     async fn initialize(
         &self,
         request: tonic::Request<InitializeRequest>,
@@ -373,9 +375,9 @@ static GRPC_SUCCESS: http::header::HeaderValue = http::header::HeaderValue::from
 const GRPC_STATUS_HEADER_CODE: &str = "grpc-status";
 
 // Starts up and serves an OakFunctionsContainersService instance from the provided TCP listener.
-pub async fn serve<P: MeterProvider>(
+pub async fn serve<G: AsyncRecipientContextGenerator + Send + Sync + 'static, P: MeterProvider>(
     listener: TcpListener,
-    encryption_key_handle: Arc<dyn EncryptionKeyHandle>,
+    encryption_key_handle: Arc<G>,
     provider: P,
 ) -> anyhow::Result<()> {
     let meter = provider.meter("oak_functions_containers_app");

--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -16,7 +16,7 @@
 
 use crate::proto::oak::functions::oak_functions_server::{OakFunctions, OakFunctionsServer};
 use anyhow::Context;
-use oak_crypto::encryptor::AsyncRecipientContextGenerator;
+use oak_containers_sdk::EncryptionKeyHandle;
 use oak_functions_service::{
     instance::OakFunctionsInstance,
     proto::oak::functions::{
@@ -61,20 +61,20 @@ pub mod proto {
 pub mod orchestrator_client;
 
 // Instance of the OakFunctions service for Oak Containers.
-pub struct OakFunctionsContainersService<G: AsyncRecipientContextGenerator + Send + Sync> {
+pub struct OakFunctionsContainersService {
     instance: OnceLock<OakFunctionsInstance>,
-    encryption_context: Arc<G>,
+    encryption_key_handle: Arc<EncryptionKeyHandle>,
     observer: Option<Arc<dyn Observer + Send + Sync>>,
 }
 
-impl<G: AsyncRecipientContextGenerator + Send + Sync> OakFunctionsContainersService<G> {
+impl OakFunctionsContainersService {
     pub fn new(
-        encryption_context: Arc<G>,
+        encryption_key_handle: EncryptionKeyHandle,
         observer: Option<Arc<dyn Observer + Send + Sync>>,
     ) -> Self {
         Self {
             instance: OnceLock::new(),
-            encryption_context,
+            encryption_key_handle: Arc::new(encryption_key_handle),
             observer,
         }
     }
@@ -110,9 +110,7 @@ fn map_status(status: micro_rpc::Status) -> tonic::Status {
 }
 
 #[tonic::async_trait]
-impl<G: AsyncRecipientContextGenerator + Send + Sync + 'static> OakFunctions
-    for OakFunctionsContainersService<G>
-{
+impl OakFunctions for OakFunctionsContainersService {
     async fn initialize(
         &self,
         request: tonic::Request<InitializeRequest>,
@@ -135,7 +133,6 @@ impl<G: AsyncRecipientContextGenerator + Send + Sync + 'static> OakFunctions
         &self,
         request: tonic::Request<InvokeRequest>,
     ) -> tonic::Result<tonic::Response<InvokeResponse>> {
-        let encryption_key_provider = self.encryption_context.clone();
         let instance = self.get_instance()?;
 
         let encrypted_request = request.into_inner().encrypted_request.ok_or_else(|| {
@@ -144,7 +141,7 @@ impl<G: AsyncRecipientContextGenerator + Send + Sync + 'static> OakFunctions
             )
         })?;
 
-        AsyncEncryptionHandler::create(encryption_key_provider, |r| async {
+        AsyncEncryptionHandler::create(self.encryption_key_handle.clone(), |r| async {
             // Wrap the invocation result (which may be an Error) into a micro RPC Response
             // wrapper protobuf, and encode that as bytes.
             let response_result: Result<Vec<u8>, micro_rpc::Status> =
@@ -376,9 +373,9 @@ static GRPC_SUCCESS: http::header::HeaderValue = http::header::HeaderValue::from
 const GRPC_STATUS_HEADER_CODE: &str = "grpc-status";
 
 // Starts up and serves an OakFunctionsContainersService instance from the provided TCP listener.
-pub async fn serve<G: AsyncRecipientContextGenerator + Send + Sync + 'static, P: MeterProvider>(
+pub async fn serve<P: MeterProvider>(
     listener: TcpListener,
-    encryption_context: Arc<G>,
+    encryption_key_handle: EncryptionKeyHandle,
     provider: P,
 ) -> anyhow::Result<()> {
     let meter = provider.meter("oak_functions_containers_app");
@@ -401,7 +398,7 @@ pub async fn serve<G: AsyncRecipientContextGenerator + Send + Sync + 'static, P:
         .layer(tower::load_shed::LoadShedLayer::new())
         .layer(MonitoringLayer::new(meter.clone()))
         .add_service(OakFunctionsServer::new(OakFunctionsContainersService::new(
-            encryption_context,
+            encryption_key_handle,
             Some(Arc::new(OtelObserver::new(meter))),
         )))
         .serve_with_incoming(TcpListenerStream::new(listener))

--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -63,18 +63,18 @@ pub mod orchestrator_client;
 // Instance of the OakFunctions service for Oak Containers.
 pub struct OakFunctionsContainersService {
     instance: OnceLock<OakFunctionsInstance>,
-    encryption_key_handle: Arc<EncryptionKeyHandle>,
+    encryption_key_handle: Arc<dyn EncryptionKeyHandle>,
     observer: Option<Arc<dyn Observer + Send + Sync>>,
 }
 
 impl OakFunctionsContainersService {
     pub fn new(
-        encryption_key_handle: EncryptionKeyHandle,
+        encryption_key_handle: Arc<dyn EncryptionKeyHandle>,
         observer: Option<Arc<dyn Observer + Send + Sync>>,
     ) -> Self {
         Self {
             instance: OnceLock::new(),
-            encryption_key_handle: Arc::new(encryption_key_handle),
+            encryption_key_handle,
             observer,
         }
     }
@@ -375,7 +375,7 @@ const GRPC_STATUS_HEADER_CODE: &str = "grpc-status";
 // Starts up and serves an OakFunctionsContainersService instance from the provided TCP listener.
 pub async fn serve<P: MeterProvider>(
     listener: TcpListener,
-    encryption_key_handle: EncryptionKeyHandle,
+    encryption_key_handle: Arc<dyn EncryptionKeyHandle>,
     provider: P,
 ) -> anyhow::Result<()> {
     let meter = provider.meter("oak_functions_containers_app");

--- a/oak_functions_containers_app/src/main.rs
+++ b/oak_functions_containers_app/src/main.rs
@@ -16,7 +16,7 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use oak_containers_orchestrator::launcher_client::LauncherClient;
-use oak_containers_sdk::EncryptionKeyHandle;
+use oak_containers_sdk::InstanceEncryptionKeyHandle;
 use oak_functions_containers_app::{orchestrator_client::OrchestratorClient, serve};
 use opentelemetry_api::global::set_error_handler;
 use std::{
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = OrchestratorClient::create()
         .await
         .context("couldn't create Orchestrator client")?;
-    let encryption_key_handle = EncryptionKeyHandle::create()
+    let encryption_key_handle = InstanceEncryptionKeyHandle::create()
         .await
         .map_err(|error| anyhow!("couldn't create encryption key handle: {:?}", error))?;
 
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         OAK_FUNCTIONS_CONTAINERS_APP_PORT,
     );
     let listener = TcpListener::bind(addr).await?;
-    let server_handle = tokio::spawn(serve(listener, encryption_key_handle, metrics));
+    let server_handle = tokio::spawn(serve(listener, Arc::new(encryption_key_handle), metrics));
 
     eprintln!("Running Oak Functions on Oak Containers at address: {addr}");
     client.notify_app_ready().await?;

--- a/oak_functions_containers_app/tests/integration_test.rs
+++ b/oak_functions_containers_app/tests/integration_test.rs
@@ -23,13 +23,14 @@ pub mod proto {
 }
 
 use crate::proto::oak::functions::oak_functions_client::OakFunctionsClient;
-use oak_containers_sdk::crypto::EncryptionKeyHandle;
+use oak_crypto::encryptor::EncryptionKeyProvider;
 use oak_functions_containers_app::serve;
 use oak_functions_service::proto::oak::functions::InitializeRequest;
 use opentelemetry_api::metrics::noop::NoopMeterProvider;
 use std::{
     fs,
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
     time::Duration,
 };
 use tokio::net::TcpListener;
@@ -44,13 +45,9 @@ async fn test_lookup() {
     let listener = TcpListener::bind(addr).await.unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let encryption_key_handle = EncryptionKeyHandle::create()
-        .await
-        .expect("couldn't create encryption key handle");
-
     let server_handle = tokio::spawn(serve(
         listener,
-        encryption_key_handle,
+        Arc::new(EncryptionKeyProvider::generate()),
         NoopMeterProvider::new(),
     ));
 

--- a/oak_functions_containers_app/tests/integration_test.rs
+++ b/oak_functions_containers_app/tests/integration_test.rs
@@ -23,14 +23,13 @@ pub mod proto {
 }
 
 use crate::proto::oak::functions::oak_functions_client::OakFunctionsClient;
-use oak_crypto::encryptor::EncryptionKeyProvider;
+use oak_containers_sdk::crypto::EncryptionKeyHandle;
 use oak_functions_containers_app::serve;
 use oak_functions_service::proto::oak::functions::InitializeRequest;
 use opentelemetry_api::metrics::noop::NoopMeterProvider;
 use std::{
     fs,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
     time::Duration,
 };
 use tokio::net::TcpListener;
@@ -45,9 +44,13 @@ async fn test_lookup() {
     let listener = TcpListener::bind(addr).await.unwrap();
     let addr = listener.local_addr().unwrap();
 
+    let encryption_key_handle = EncryptionKeyHandle::create()
+        .await
+        .expect("couldn't create encryption key handle");
+
     let server_handle = tokio::spawn(serve(
         listener,
-        Arc::new(EncryptionKeyProvider::generate()),
+        encryption_key_handle,
         NoopMeterProvider::new(),
     ));
 


### PR DESCRIPTION
This PR adds a `oak_containers_sdk` crate for implementing enclave applications.

It also adds an SDK implementation for encryption: the new gRPC client connects to the Orchestrator Crypto service.

Ref https://github.com/project-oak/oak/issues/4490
Ref https://github.com/project-oak/oak/issues/4442