### PR TITLE
Use correct paths for proto compilation

### DIFF
--- a/oak_client/build.rs
+++ b/oak_client/build.rs
@@ -19,10 +19,10 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
         &[
-            "oak_remote_attestation/proto/v1/messages.proto",
-            "oak_remote_attestation/proto/v1/service_streaming.proto",
+            "../oak_remote_attestation/proto/v1/messages.proto",
+            "../oak_remote_attestation/proto/v1/service_streaming.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_hello_world_trusted_app/build.rs
+++ b/oak_containers_hello_world_trusted_app/build.rs
@@ -18,10 +18,10 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
         &[
-            "oak_containers_hello_world_trusted_app/proto/interface.proto",
-            "oak_crypto/proto/v1/crypto.proto",
+            "../oak_containers_hello_world_trusted_app/proto/interface.proto",
+            "../oak_crypto/proto/v1/crypto.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_server: true,
             ..Default::default()
@@ -30,10 +30,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     generate_grpc_code(
         &[
-            "oak_containers/proto/interfaces.proto",
-            "oak_remote_attestation/proto/v1/messages.proto",
+            "../oak_containers/proto/interfaces.proto",
+            "../oak_remote_attestation/proto/v1/messages.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_hello_world_untrusted_app/build.rs
+++ b/oak_containers_hello_world_untrusted_app/build.rs
@@ -18,10 +18,10 @@ use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_grpc_code(
         &[
-            "oak_containers_hello_world_trusted_app/proto/interface.proto",
-            "oak_crypto/proto/v1/crypto.proto",
+            "../oak_containers_hello_world_trusted_app/proto/interface.proto",
+            "../oak_crypto/proto/v1/crypto.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_launcher/build.rs
+++ b/oak_containers_launcher/build.rs
@@ -19,13 +19,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the launcher.
     generate_grpc_code(
         &[
-            "oak_containers/proto/interfaces.proto",
-            "oak_crypto/proto/v1/crypto.proto",
-            "oak_remote_attestation/proto/v1/messages.proto",
-            "proto/key_provisioning/key_provisioning.proto",
-            "proto/containers/hostlib_key_provisioning.proto",
+            "../oak_containers/proto/interfaces.proto",
+            "../oak_crypto/proto/v1/crypto.proto",
+            "../oak_remote_attestation/proto/v1/messages.proto",
+            "../proto/key_provisioning/key_provisioning.proto",
+            "../proto/containers/hostlib_key_provisioning.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_server: true,
             ..Default::default()

--- a/oak_containers_orchestrator/build.rs
+++ b/oak_containers_orchestrator/build.rs
@@ -19,13 +19,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for Orchestrator services.
     generate_grpc_code(
         &[
-            "oak_remote_attestation/proto/v1/messages.proto",
-            "oak_containers/proto/interfaces.proto",
-            "proto/key_provisioning/key_provisioning.proto",
-            "proto/containers/orchestrator_crypto.proto",
-            "proto/containers/hostlib_key_provisioning.proto",
+            "../oak_remote_attestation/proto/v1/messages.proto",
+            "../oak_containers/proto/interfaces.proto",
+            "../proto/key_provisioning/key_provisioning.proto",
+            "../proto/containers/orchestrator_crypto.proto",
+            "../proto/containers/hostlib_key_provisioning.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_server: true,
             build_client: true,

--- a/oak_containers_stage1/build.rs
+++ b/oak_containers_stage1/build.rs
@@ -20,11 +20,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for loading the system image.
     generate_grpc_code(
         &[
-            "oak_containers/proto/interfaces.proto",
-            "oak_crypto/proto/v1/crypto.proto",
-            "oak_remote_attestation/proto/v1/messages.proto",
+            "../oak_containers/proto/interfaces.proto",
+            "../oak_crypto/proto/v1/crypto.proto",
+            "../oak_remote_attestation/proto/v1/messages.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_containers_syslogd/build.rs
+++ b/oak_containers_syslogd/build.rs
@@ -20,11 +20,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the launcher.
     generate_grpc_code(
         &[
-            "oak_containers/proto/interfaces.proto",
-            "oak_crypto/proto/v1/crypto.proto",
-            "oak_remote_attestation/proto/v1/messages.proto",
+            "../oak_containers/proto/interfaces.proto",
+            "../oak_crypto/proto/v1/crypto.proto",
+            "../oak_remote_attestation/proto/v1/messages.proto",
         ],
-        "../",
+        "..",
         CodegenOptions::default(),
     )?;
 

--- a/oak_functions_containers_app/build.rs
+++ b/oak_functions_containers_app/build.rs
@@ -20,11 +20,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
     generate_grpc_code(
         &[
-            "oak_crypto/proto/v1/crypto.proto",
-            "proto/attestation/evidence.proto",
-            "proto/oak_functions/service/oak_functions.proto",
+            "../oak_crypto/proto/v1/crypto.proto",
+            "../proto/attestation/evidence.proto",
+            "../proto/oak_functions/service/oak_functions.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_server: true,
             // The client is only used in the integration test.
@@ -38,10 +38,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     generate_grpc_code(
         &[
-            "oak_containers/proto/interfaces.proto",
-            "oak_remote_attestation/proto/v1/messages.proto",
+            "../oak_containers/proto/interfaces.proto",
+            "../oak_remote_attestation/proto/v1/messages.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_functions_containers_launcher/build.rs
+++ b/oak_functions_containers_launcher/build.rs
@@ -20,11 +20,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
     generate_grpc_code(
         &[
-            "oak_crypto/proto/v1/crypto.proto",
-            "proto/attestation/evidence.proto",
-            "proto/oak_functions/service/oak_functions.proto",
+            "../oak_crypto/proto/v1/crypto.proto",
+            "../proto/attestation/evidence.proto",
+            "../proto/oak_functions/service/oak_functions.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_client: true,
             ..Default::default()

--- a/oak_functions_launcher/build.rs
+++ b/oak_functions_launcher/build.rs
@@ -20,10 +20,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for exchanging messages with clients.
     generate_grpc_code(
         &[
-            "oak_remote_attestation/proto/v1/messages.proto",
-            "oak_remote_attestation/proto/v1/service_streaming.proto",
+            "../oak_remote_attestation/proto/v1/messages.proto",
+            "../oak_remote_attestation/proto/v1/service_streaming.proto",
         ],
-        "../",
+        "..",
         CodegenOptions {
             build_server: true,
             ..Default::default()
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Generate micro RPC code for exchanging messages with the enclave.
     micro_rpc_build::compile(
-        &["proto/oak_functions/service/oak_functions.proto"],
+        &["../proto/oak_functions/service/oak_functions.proto"],
         &[".."],
         Default::default(),
     );

--- a/oak_functions_sdk/build.rs
+++ b/oak_functions_sdk/build.rs
@@ -16,7 +16,7 @@
 
 fn main() {
     micro_rpc_build::compile(
-        &["proto/oak_functions/sdk/oak_functions_wasm.proto"],
+        &["../proto/oak_functions/sdk/oak_functions_wasm.proto"],
         &[".."],
         Default::default(),
     );

--- a/oak_functions_service/build.rs
+++ b/oak_functions_service/build.rs
@@ -18,7 +18,7 @@ use micro_rpc_build::ReceiverType;
 
 fn main() {
     micro_rpc_build::compile(
-        &["proto/oak_functions/service/oak_functions.proto"],
+        &["../proto/oak_functions/service/oak_functions.proto"],
         &[".."],
         micro_rpc_build::CompileOptions {
             receiver_type: ReceiverType::RefSelf,

--- a/oak_grpc_utils/src/lib.rs
+++ b/oak_grpc_utils/src/lib.rs
@@ -70,7 +70,7 @@ pub fn generate_grpc_code(
     protos.iter().for_each(|filename| {
         println!(
             "cargo:rerun-if-changed={}",
-            include.as_ref().join(filename).to_string_lossy()
+            filename.as_ref().as_os_str().to_string_lossy()
         )
     });
 

--- a/oak_remote_attestation/build.rs
+++ b/oak_remote_attestation/build.rs
@@ -17,10 +17,10 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     micro_rpc_build::compile(
         &[
-            "oak_remote_attestation/proto/v1/messages.proto",
-            "proto/attestation/dice.proto",
-            "proto/attestation/evidence.proto",
-            "proto/attestation/endorsement.proto",
+            "../oak_remote_attestation/proto/v1/messages.proto",
+            "../proto/attestation/dice.proto",
+            "../proto/attestation/evidence.proto",
+            "../proto/attestation/endorsement.proto",
         ],
         &[".."],
         Default::default(),


### PR DESCRIPTION
This makes `cargo build` idempotent again, which should noticeably reduce build and test time.

Ref #4608