### PR TITLE
Attempt to export some Tokio-related metrics from Oak Functions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,13 @@
 # process is deterministic.
 #
 # See https://linux.die.net/man/1/ld (--build-id flag).
-rustflags = ["-C", "link-args=-Xlinker --build-id=none"]
+rustflags = [
+  "-C",
+  "link-args=-Xlinker --build-id=none",
+  # Enable `tokio_unstable` so that we can access the Tokio runtime metrics.
+  "--cfg",
+  "tokio_unstable"
+]
 
 [target.x86_64-unknown-linux-musl]
 # Make NT_GNU_BUILD_ID header generation deterministic.
@@ -14,7 +20,13 @@ rustflags = ["-C", "link-args=-Xlinker --build-id=none"]
 # process is deterministic.
 #
 # See https://linux.die.net/man/1/ld (--build-id flag).
-rustflags = ["-C", "link-args=-Xlinker --build-id=none"]
+rustflags = [
+  "-C",
+  "link-args=-Xlinker --build-id=none",
+  # Enable `tokio_unstable` so that we can access the Tokio runtime metrics.
+  "--cfg",
+  "tokio_unstable"
+]
 
 # Workaround for 'unable to find __addtf3, __multf3 and __subtf3'
 # Related issue: https://github.com/rust-lang/compiler-builtins/issues/201

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +237,21 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -1137,6 +1161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "goblin"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,7 +1368,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -1497,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libm"
@@ -1685,14 +1715,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2595,6 +2624,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oci-spec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -3196,6 +3234,12 @@ dependencies = [
  "log",
  "x86_64",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
@@ -3617,6 +3661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3867,22 +3921,21 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.5",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3897,13 +3950,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.41",
 ]
 
 [[package]]

--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -29,7 +29,7 @@ use oak_functions_service::{
 };
 use oak_remote_attestation::handler::AsyncEncryptionHandler;
 use opentelemetry_api::{
-    metrics::{Histogram, Meter, MeterProvider, Unit},
+    metrics::{Histogram, Meter, Unit},
     KeyValue,
 };
 use prost::Message;
@@ -375,12 +375,11 @@ static GRPC_SUCCESS: http::header::HeaderValue = http::header::HeaderValue::from
 const GRPC_STATUS_HEADER_CODE: &str = "grpc-status";
 
 // Starts up and serves an OakFunctionsContainersService instance from the provided TCP listener.
-pub async fn serve<G: AsyncRecipientContextGenerator + Send + Sync + 'static, P: MeterProvider>(
+pub async fn serve<G: AsyncRecipientContextGenerator + Send + Sync + 'static>(
     listener: TcpListener,
     encryption_key_handle: Arc<G>,
-    provider: P,
+    meter: Meter,
 ) -> anyhow::Result<()> {
-    let meter = provider.meter("oak_functions_containers_app");
     tonic::transport::Server::builder()
         .layer(
             tower_http::trace::TraceLayer::new_for_grpc()

--- a/oak_functions_containers_app/tests/integration_test.rs
+++ b/oak_functions_containers_app/tests/integration_test.rs
@@ -26,7 +26,7 @@ use crate::proto::oak::functions::oak_functions_client::OakFunctionsClient;
 use oak_crypto::encryptor::EncryptionKeyProvider;
 use oak_functions_containers_app::serve;
 use oak_functions_service::proto::oak::functions::InitializeRequest;
-use opentelemetry_api::metrics::noop::NoopMeterProvider;
+use opentelemetry_api::metrics::{noop::NoopMeterProvider, MeterProvider};
 use std::{
     fs,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -48,7 +48,7 @@ async fn test_lookup() {
     let server_handle = tokio::spawn(serve(
         listener,
         Arc::new(EncryptionKeyProvider::generate()),
-        NoopMeterProvider::new(),
+        NoopMeterProvider::new().meter(""),
     ));
 
     let mut oak_functions_client: OakFunctionsClient<tonic::transport::channel::Channel> = {


### PR DESCRIPTION
This will be somewhat contentious as while Tokio has a facility to expose some runtime metrics, they're gated behind `tokio_unstable` -- and even worse, it's not a simple feature you can just throw into `Cargo.toml`, you need a compiler flag for it.

However, enabling this should give us a bit more visibility into what the runtime is doing: namely, how many threads are there, and how many tasks we have queued in the system.

There are other metrics that can be exposed -- see https://docs.rs/tokio/latest/tokio/runtime/struct.RuntimeMetrics.html -- but we can add them later if these work and prove useful.