### PR TITLE
Remove nonces from the serialized RecipientContext

### DIFF
--- a/cc/crypto/hpke/recipient_context.cc
+++ b/cc/crypto/hpke/recipient_context.cc
@@ -32,7 +32,7 @@
 namespace oak::crypto {
 
 namespace {
-using ::oak::crypto::v1::CryptoContext;
+using ::oak::crypto::v1::SessionKeys;
 
 // Validates that the public and private key pairing is valid for HPKE. If the public and private
 // keys are valid, the recipient_keys argument will be an initialized HPKE_KEY.
@@ -76,11 +76,11 @@ absl::Status ValidateKeys(std::vector<uint8_t>& public_key_bytes,
 }  // namespace
 
 absl::StatusOr<std::unique_ptr<RecipientContext>> RecipientContext::Deserialize(
-    CryptoContext serialized_recipient_context) {
+    SessionKeys session_keys) {
   std::unique_ptr<EVP_AEAD_CTX> request_aead_context(EVP_AEAD_CTX_new(
       /* aead= */ EVP_HPKE_AEAD_aead(EVP_hpke_aes_256_gcm()),
-      /* key= */ (uint8_t*)serialized_recipient_context.request_key().data(),
-      /* key_len= */ serialized_recipient_context.request_key().size(),
+      /* key= */ (uint8_t*)session_keys.request_key().data(),
+      /* key_len= */ session_keys.request_key().size(),
       /* tag_len= */ 0));
   if (request_aead_context == nullptr) {
     return absl::AbortedError("Unable to deserialize request AEAD context");
@@ -88,8 +88,8 @@ absl::StatusOr<std::unique_ptr<RecipientContext>> RecipientContext::Deserialize(
 
   std::unique_ptr<EVP_AEAD_CTX> response_aead_context(EVP_AEAD_CTX_new(
       /* aead= */ EVP_HPKE_AEAD_aead(EVP_hpke_aes_256_gcm()),
-      /* key= */ (uint8_t*)serialized_recipient_context.response_key().data(),
-      /* key_len= */ serialized_recipient_context.response_key().size(),
+      /* key= */ (uint8_t*)session_keys.response_key().data(),
+      /* key_len= */ session_keys.response_key().size(),
       /* tag_len= */ 0));
   if (response_aead_context == nullptr) {
     return absl::AbortedError("Unable to deserialize response AEAD context");

--- a/cc/crypto/hpke/recipient_context.h
+++ b/cc/crypto/hpke/recipient_context.h
@@ -45,7 +45,7 @@ class RecipientContext {
         response_aead_context_(std::move(response_aead_context)) {}
 
   static absl::StatusOr<std::unique_ptr<RecipientContext>> Deserialize(
-      ::oak::crypto::v1::CryptoContext serialized_recipient_context);
+      ::oak::crypto::v1::SessionKeys session_keys);
 
   // Decrypts message and validates associated data using AEAD.
   // <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>

--- a/cc/crypto/hpke/recipient_context_test.cc
+++ b/cc/crypto/hpke/recipient_context_test.cc
@@ -31,7 +31,7 @@
 namespace oak::crypto {
 namespace {
 
-using ::oak::crypto::v1::CryptoContext;
+using ::oak::crypto::v1::SessionKeys;
 using ::testing::StrEq;
 using ::testing::StrNe;
 
@@ -80,7 +80,7 @@ class RecipientContextTest : public testing::Test {
   std::string info_string_;
   std::string associated_data_response_;
   std::string associated_data_request_;
-  CryptoContext crypto_context_;
+  SessionKeys crypto_context_;
 };
 
 TEST_F(RecipientContextTest, SetupBaseRecipientEmptyEncapKeyReturnsFailure) {

--- a/oak_containers_orchestrator/src/crypto.rs
+++ b/oak_containers_orchestrator/src/crypto.rs
@@ -144,7 +144,7 @@ impl OrchestratorCrypto for CryptoService {
             KeyOrigin::Group => &self.key_store.group_encryption_key,
         };
 
-        let context = encryption_key
+        let session_keys = encryption_key
             .generate_recipient_context(&request.serialized_encapsulated_public_key)
             .map_err(|err| tonic::Status::internal(format!("couldn't derive session keys: {err}")))?
             .serialize()
@@ -152,7 +152,7 @@ impl OrchestratorCrypto for CryptoService {
                 tonic::Status::internal(format!("couldn't serialize session keys: {err}"))
             })?;
         Ok(tonic::Response::new(DeriveSessionKeysResponse {
-            context: Some(context),
+            session_keys: Some(session_keys),
         }))
     }
 }

--- a/oak_containers_sdk/src/crypto.rs
+++ b/oak_containers_sdk/src/crypto.rs
@@ -17,7 +17,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use oak_crypto::{
     encryptor::AsyncRecipientContextGenerator, hpke::RecipientContext,
-    proto::oak::crypto::v1::CryptoContext,
+    proto::oak::crypto::v1::SessionKeys,
 };
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
@@ -54,7 +54,7 @@ impl OrchestratorCryptoClient {
         &self,
         key_origin: KeyOrigin,
         serialized_encapsulated_public_key: &[u8],
-    ) -> Result<CryptoContext, Box<dyn std::error::Error>> {
+    ) -> Result<SessionKeys, Box<dyn std::error::Error>> {
         let context = self
             .inner
             // TODO(#4477): Remove unnecessary copies of the Orchestrator client.

--- a/oak_containers_sdk/src/crypto.rs
+++ b/oak_containers_sdk/src/crypto.rs
@@ -65,9 +65,8 @@ impl OrchestratorCryptoClient {
             })
             .await?
             .into_inner()
-            // Crypto context.
-            .context
-            .context("crypto context wasn't provided by the Orchestrator")?;
+            .session_keys
+            .context("session keys weren't provided by the Orchestrator")?;
         Ok(context)
     }
 }

--- a/oak_crypto/proto/v1/crypto.proto
+++ b/oak_crypto/proto/v1/crypto.proto
@@ -46,24 +46,17 @@ message EncryptedResponse {
 message AeadEncryptedMessage {
   bytes ciphertext = 1;
   bytes associated_data = 2;
-  // TODO(#4507): Nonce is currently not used by the crypto library. We need to make a non-breaking
-  // change, where we first make the library send and use deterministic nonces in the Proto, and
-  // then replace it with a rendom nonce.
   bytes nonce = 3;
 }
 
 // Envelope containing session keys required to encrypt/decrypt messages within a secure session.
 // Needed to serialize contexts in order to send them over an RPC.
-message CryptoContext {
-  // AEAD key and nonce for encrypting/decrypting client requests.
+message SessionKeys {
+  // AEAD key for encrypting/decrypting client requests.
   bytes request_key = 1;
-  bytes request_base_nonce = 2;
-  uint64 request_sequence_number = 3;
 
-  // Symmetric key and nonce for encrypting/decrypting enclave responses.
-  bytes response_key = 4;
-  bytes response_base_nonce = 5;
-  uint64 response_sequence_number = 6;
+  // AEAD key for encrypting/decrypting enclave responses.
+  bytes response_key = 2;
 }
 
 message Signature {

--- a/oak_crypto/proto/v1/crypto.proto
+++ b/oak_crypto/proto/v1/crypto.proto
@@ -55,7 +55,7 @@ message SessionKeys {
   // AEAD key for encrypting/decrypting client requests.
   bytes request_key = 1;
   // AEAD key for encrypting/decrypting enclave responses.
-  bytes response_key = 2;
+  bytes response_key = 4;
 }
 
 message Signature {

--- a/oak_crypto/proto/v1/crypto.proto
+++ b/oak_crypto/proto/v1/crypto.proto
@@ -54,7 +54,6 @@ message AeadEncryptedMessage {
 message SessionKeys {
   // AEAD key for encrypting/decrypting client requests.
   bytes request_key = 1;
-
   // AEAD key for encrypting/decrypting enclave responses.
   bytes response_key = 2;
 }

--- a/oak_crypto/src/hpke/mod.rs
+++ b/oak_crypto/src/hpke/mod.rs
@@ -16,17 +16,19 @@
 
 pub(crate) mod aead;
 
-use crate::{
-    hpke::aead::{AeadKey, AeadNonce, AEAD_ALGORITHM_KEY_SIZE_BYTES, AEAD_NONCE_SIZE_BYTES},
-    proto::oak::crypto::v1::CryptoContext,
-};
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
+
 use anyhow::{anyhow, Context};
 use hpke::{
     aead::AesGcm256, kdf::HkdfSha256, kem::X25519HkdfSha256, Kem as KemTrait, OpModeR, OpModeS,
 };
 pub use hpke::{Deserializable, Serializable};
 use rand_core::{OsRng, RngCore};
+
+use crate::{
+    hpke::aead::{AeadKey, AeadNonce, AEAD_ALGORITHM_KEY_SIZE_BYTES, AEAD_NONCE_SIZE_BYTES},
+    proto::oak::crypto::v1::SessionKeys,
+};
 
 type Aead = AesGcm256;
 type Kdf = HkdfSha256;

--- a/proto/containers/orchestrator_crypto.proto
+++ b/proto/containers/orchestrator_crypto.proto
@@ -36,7 +36,7 @@ message DeriveSessionKeysRequest {
 
 message DeriveSessionKeysResponse {
   // Session keys for decrypting client requests and encrypting enclave responses.
-  oak.crypto.v1.CryptoContext context = 1;
+  oak.crypto.v1.SessionKeys session_keys = 1;
 }
 
 // RPC service that is exposed to an enclave application and allows it to:


### PR DESCRIPTION
This PR removes predetermined nonces from the serialized proto for the `RecipientContext`, because we are currently using randomly generated nonces.

Ref https://github.com/project-oak/oak/issues/4507