### PR TITLE
Make grpc_streaming_test use a compatiable time for deadline

### DIFF
--- a/cc/transport/BUILD
+++ b/cc/transport/BUILD
@@ -53,7 +53,14 @@ cc_test(
     srcs = ["grpc_streaming_transport_test.cc"],
     deps = [
         ":grpc_streaming_transport",
+        "//oak_crypto/proto/v1:crypto_cc_proto",
+        "//oak_remote_attestation/proto/v1:messages_cc_proto",
+        "//oak_remote_attestation/proto/v1:service_streaming_cc_grpc",
+        "//oak_remote_attestation/proto/v1:service_streaming_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:absl_check",
+        "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/cc/transport/grpc_streaming_transport_test.cc
+++ b/cc/transport/grpc_streaming_transport_test.cc
@@ -16,16 +16,16 @@
 
 #include "cc/transport/grpc_streaming_transport.h"
 
-#include <gmock/gmock.h>
-#include <grpcpp/server_builder.h>
-#include <gtest/gtest.h>
-
 #include <chrono>
 #include <thread>
 
 #include "absl/log/absl_check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "gmock/gmock.h"
+#include "grpcpp/server_builder.h"
+#include "grpcpp/support/time.h"
+#include "gtest/gtest.h"
 #include "oak_crypto/proto/v1/crypto.pb.h"
 #include "oak_remote_attestation/proto/v1/messages.pb.h"
 #include "oak_remote_attestation/proto/v1/service_streaming.grpc.pb.h"
@@ -60,8 +60,9 @@ class GrpcStreamingTransportTest : public ::testing::Test {
     channel_ = server_->InProcessChannel({});
     stub_ = oak::session::v1::StreamingSession::NewStub(channel_);
 
-    std::chrono::time_point deadline =
-        std::chrono::system_clock::now() + std::chrono::milliseconds(5000);
+    absl::Time absl_deadline = absl::Now() + absl::Seconds(10);
+    gpr_timespec deadline;
+    deadline.tv_sec = absl::ToInt64Seconds(absl::time_internal::ToUnixDuration(absl_deadline));
     context_.set_deadline(deadline);
   }
 


### PR DESCRIPTION
And use "" style imports for grpc and test deps, for consistency.