### PR TITLE
Wipe VMPCK0 after reading it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,6 +2555,7 @@ dependencies = [
  "strum",
  "x86_64",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -29,3 +29,4 @@ static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }
 x86_64 = "*"
 zerocopy = "*"
+zeroize = "*"

--- a/stage0_bin/Cargo.lock
+++ b/stage0_bin/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "strum",
  "x86_64",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]


### PR DESCRIPTION
The VM Platform Communication Key (VMPCK) for VM Protection Level (VMPL) 0 is used to request an attestation report and a sealing key that form the basis of the DICE attestation chain. We don't want later boot stages to be able to request updated attestation reports or sealing keys for VMPL0, as that would allow them to generate counterfeit DICE chains.

To stop that from happening we wipe VMPCK0 as soon as we have successfully read it and initialised the Guest Message Encryptor.