### PR TITLE
PVALIDATE the SMBIOS entry point table range

### DIFF
--- a/stage0_bin/README.md
+++ b/stage0_bin/README.md
@@ -153,10 +153,42 @@ memory just below the end of 4 GiB address space, like any other BIOS ROM.
            0x0 +------------------------------------------------+
 ```
 
+### AMD SEV-SNP Memory validation
+
+The Linux kernel and the Oak restricted kernel both assume that the firmware
+will validate all (or at least most) of the guest-physical memory before jumping
+into the kernel (by calling the PVALIDATE instruction).
+
+The one difference is that the Linux kernel assumes that the firmware will not
+validate the VGA BIOS ROM range (0C0000-0xC7FFF), so we skip this range. For
+simplicity of the logic we actually skip a larger range (0xA0000-0xEFFFF).
+
+We explicitly PVALIDATE the SMBIOS entry table memory range (0xF0000-0xFFFFF)
+even though it is marked as reserved since the Linux kernel will scan this range
+looking for the table if CONFIG_DMI is enabled.
+
+We don't have to PVALIDATE the Stage 0 ROM image range, since that memory was
+already set in the appropriate validated state by the Secure Processor before
+launching the guest VM.
+
+```text
+               |     PVALIDATEd up to end of physical memory    |
+ 0x1_0000_0000 +------------------------------------------------+ 4GiB
+               |    Stage 0 ROM Image (PVALIDATE not needed)    |
+   0xFFFE_0000 +------------------------------------------------+ 4GiB - 128MiB
+               |                   PVALIDATEd                   |
+     0x10_0000 +------------------------------------------------+ 1MiB
+               |   PVALIDATEd SMBIOS entry point table memory   |
+      0xF_0000 +------------------------------------------------+ 960KiB
+               |                   Unvalidated                  |
+      0xA_0000 +------------------------------------------------+ 640KiB
+               |      PVALIDATEd by bootstrap assembly code     |
+           0x0 +------------------------------------------------+
+```
+
 ## Future work
 
 - Support for Intel TDX
-- Attest the loaded kernel
 
 ## Related projects
 


### PR DESCRIPTION
Stage 0 fails to boot the Linux kernel on AMD SEV-SNP is CONFIG_DMI is enabled in the kernel. This seems to be because the Linux kernel scans the range 0xF0000 to 0xFFFFF looking for the SMBIOS entry point table, even though this range is marked as reserved. If we don't PVALIDATE this memory page, the scan causes an unhandled #VC during early boot.