### PR TITLE
Mark the SMBIOS entry point table region as disabled

### DIFF
--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -497,18 +497,6 @@ pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
         .expect("failed to validate memory");
     }
 
-    // Also pvalidate the range from 0xF0000 to 0xFFFFF since the Linux Kernel will scan this range
-    // for the SMBIOS entry point table if CONFIG_DMI is enabled, even if the range is marked as
-    // reserved.
-    // See <https://github.com/torvalds/linux/blob/master/drivers/firmware/dmi_scan.c>
-    let range = PhysFrame::<Size4KiB>::range(
-        PhysFrame::from_start_address(PhysAddr::new(0xF0000)).unwrap(),
-        PhysFrame::from_start_address(PhysAddr::new(0x100000)).unwrap(),
-    );
-    range
-        .pvalidate(&mut validation_pt, encrypted)
-        .expect("failed to validate SMBIOS memory");
-
     page_tables.pd_0[1].set_unused();
     page_tables.pdpt[1].set_unused();
     tlb::flush_all();

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -133,11 +133,23 @@ impl ZeroPage {
         self.validate_e820_table();
 
         // Carve out a chunk of memory out for the ACPI area and reserved memory just below 1 MiB.
+        // The ACPI area is from 0x80000-0x9FFFF. We also reserve the region from 0xA0000-0xEFFFF
+        // since historically this contained hardware-related regions such as the VGA bios rom.
         self.insert_e820_entry(BootE820Entry::new(0x8_0000, 0x2_0000, E820EntryType::ACPI));
         self.insert_e820_entry(BootE820Entry::new(
             0xA_0000,
-            0x6_0000,
+            0x5_0000,
             E820EntryType::RESERVED,
+        ));
+        // Mark the memory range for the SMBIOS entry point table as disabled since we don't support
+        // DMI or SMBIOS tables. If this memory range is enabled (even it if is reserved) and the
+        // Linux kernel has CONFIG_DMI enabled it will try to scan this memory range to find the
+        // SMBIOS entry point table. On AMD SEV-SNP scanning of this memory range causes #VC
+        // exceptions, so we don't want the kernel to try to scan it.
+        self.insert_e820_entry(BootE820Entry::new(
+            0xF_0000,
+            0x1_0000,
+            E820EntryType::DISABLED,
         ));
 
         for entry in self.inner.e820_table() {

--- a/stage0_bin/README.md
+++ b/stage0_bin/README.md
@@ -143,6 +143,10 @@ memory just below the end of 4 GiB address space, like any other BIOS ROM.
                |          Restricted Kernel ELF Header          |
      0x20_0000 +------------------------------------------------+ 2MiB
                |                                                |
+     0x10_0000 +------------------------------------------------+ 1MiB
+               |                     Disabled                   |
+      0xF_0000 +------------------------------------------------+ 960KiB
+               |               Reserved BIOS Range              |
       0xA_0000 +------------------------------------------------+ 640KiB
                |     Extended BIOS Data Area (ACPI Tables)      |
       0x8_0000 +------------------------------------------------+ 512KiB
@@ -162,10 +166,6 @@ into the kernel (by calling the PVALIDATE instruction).
 The one difference is that the Linux kernel assumes that the firmware will not
 validate the VGA BIOS ROM range (0C0000-0xC7FFF), so we skip this range. For
 simplicity of the logic we actually skip a larger range (0xA0000-0xEFFFF).
-
-We explicitly PVALIDATE the SMBIOS entry table memory range (0xF0000-0xFFFFF)
-even though it is marked as reserved since the Linux kernel will scan this range
-looking for the table if CONFIG_DMI is enabled.
 
 We don't have to PVALIDATE the Stage 0 ROM image range, since that memory was
 already set in the appropriate validated state by the Secure Processor before


### PR DESCRIPTION
The change in #4640 caused the Linux kernel to fail earlier AMD SEV-SNP, even if DMI is not enabled. So, instead of PVALIDATing this range, let's try to mark the memory range as "disabled" so that the Linux kernel will not touch it at all.