### PR TITLE
Verify attestation in Rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "log",
+ "oak_attestation_verification",
  "oak_crypto",
  "oak_grpc_utils",
  "oak_remote_attestation",

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -54,8 +54,8 @@ use oak_dice::cert::{
 const ADDITIONAL_DATA: &[u8] = b"";
 
 pub struct DiceChainResult {
-    encryption_public_key: Vec<u8>,
-    signing_public_key: Vec<u8>,
+    pub encryption_public_key: Vec<u8>,
+    pub signing_public_key: Vec<u8>,
 }
 
 impl From<&anyhow::Result<DiceChainResult>> for AttestationResults {

--- a/oak_client/Cargo.toml
+++ b/oak_client/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "*"
 async-trait = "*"
 futures-util = "*"
 log = "*"
+oak_attestation_verification = { workspace = true }
 oak_crypto = { workspace = true }
 oak_remote_attestation = { workspace = true }
 prost = { workspace = true }

--- a/proto/session/BUILD
+++ b/proto/session/BUILD
@@ -31,6 +31,7 @@ proto_library(
     srcs = ["messages.proto"],
     deps = [
         "//oak_crypto/proto/v1:crypto_proto",
+        "//proto/attestation:endorsement_proto",
         "//proto/attestation:evidence_proto",
     ],
 )

--- a/proto/session/messages.proto
+++ b/proto/session/messages.proto
@@ -19,6 +19,7 @@ syntax = "proto3";
 package oak.session.v1;
 
 import "oak_crypto/proto/v1/crypto.proto";
+import "proto/attestation/endorsement.proto";
 import "proto/attestation/evidence.proto";
 
 option java_multiple_files = true;
@@ -57,7 +58,10 @@ message AttestationBundle {
   AttestationEndorsement attestation_endorsement = 2;
 
   // The DICE attestation evidence.
-  oak.attestation.v1.Evidence dice_evidence = 3;
+  oak.attestation.v1.Evidence evidence = 3;
+
+  // Thea attestation endorsements.
+  oak.attestation.v1.Endorsements endorsements = 4;
 }
 
 // AttestationEndorsement contains statements that some entity (e.g., a hardware provider) vouches


### PR DESCRIPTION
This PR makes Oak Rust client to use the attestation verification library and to verify DICE attestation evidence.

Ref https://github.com/project-oak/oak/issues/4074