### PR TITLE
Send DICE evidence and endorsements in Hostlibs

### DIFF
--- a/oak_containers/proto/interfaces.proto
+++ b/oak_containers/proto/interfaces.proto
@@ -20,6 +20,7 @@ package oak.containers;
 
 import "google/protobuf/empty.proto";
 import "oak_crypto/proto/v1/crypto.proto";
+import "proto/attestation/endorsement.proto";
 import "proto/attestation/evidence.proto";
 import "proto/session/messages.proto";
 

--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -224,7 +224,8 @@ impl Launcher {
             let endorsed_attestation_evidence = AttestationBundle {
                 attestation_evidence: Some(evidence),
                 attestation_endorsement: Some(self.attestation_endorsement.clone()),
-                dice_evidence: None,
+                evidence: None,
+                endorsements: None,
             };
             self.endorsed_attestation_evidence
                 .replace(endorsed_attestation_evidence);

--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -41,6 +41,9 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use anyhow::Context;
 use clap::Parser;
+use oak_attestation::proto::oak::attestation::v1::{
+    endorsements, Endorsements, Evidence, OakRestrictedKernelEndorsements,
+};
 use tokio::{
     net::TcpListener,
     sync::oneshot::{channel, Receiver, Sender},
@@ -121,7 +124,7 @@ pub struct Launcher {
     // Orchestrator) and Attestation Endorsement (initialized by the Launcher).
     endorsed_attestation_evidence: Option<AttestationBundle>,
     // Receiver that is used to get the Attestation Evidence from the server implementation.
-    attestation_evidence_receiver: Option<Receiver<AttestationEvidence>>,
+    attestation_evidence_receiver: Option<Receiver<(AttestationEvidence, Evidence)>>,
     app_ready_notifier: Option<Receiver<()>>,
     trusted_app_address: Option<SocketAddr>,
     shutdown: Option<Sender<()>>,
@@ -136,7 +139,7 @@ impl Launcher {
         let port = listener.local_addr()?.port();
         log::info!("Launcher service listening on port {port}");
         let (attestation_evidence_sender, attestation_evidence_receiver) =
-            channel::<AttestationEvidence>();
+            channel::<(AttestationEvidence, Evidence)>();
         let (shutdown_sender, shutdown_receiver) = channel::<()>();
         let (app_notifier_sender, app_notifier_receiver) = channel::<()>();
         let server = tokio::spawn(server::new(
@@ -216,16 +219,31 @@ impl Launcher {
         #[allow(deprecated)]
         if let Some(receiver) = self.attestation_evidence_receiver.take() {
             // Set a timeout since we don't want to wait forever if the VM didn't start properly.
-            let evidence = timeout(Duration::from_secs(VM_START_TIMEOUT), receiver)
-                .await
-                .context("couldn't get attestation evidence before timeout")?
-                .context("no attestation evidence available")?;
+            let (deprecated_evidence, evidence) =
+                timeout(Duration::from_secs(VM_START_TIMEOUT), receiver)
+                    .await
+                    .context("couldn't get attestation evidence before timeout")?
+                    .context("no attestation evidence available")?;
+
+            // Initialize attestation endorsements.
+            // TODO(#4074): Add layer endorsements.
+            let oak_restricted_kernel_endoesements = OakRestrictedKernelEndorsements {
+                root_layer: None,
+                kernel_layer: None,
+                application_layer: None,
+            };
+            let endorsements = Endorsements {
+                r#type: Some(endorsements::Type::OakRestrictedKernel(
+                    oak_restricted_kernel_endoesements,
+                )),
+            };
+
             #[allow(deprecated)]
             let endorsed_attestation_evidence = AttestationBundle {
-                attestation_evidence: Some(evidence),
+                attestation_evidence: Some(deprecated_evidence),
                 attestation_endorsement: Some(self.attestation_endorsement.clone()),
-                evidence: None,
-                endorsements: None,
+                evidence: Some(evidence),
+                endorsements: Some(endorsements),
             };
             self.endorsed_attestation_evidence
                 .replace(endorsed_attestation_evidence);

--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -227,14 +227,14 @@ impl Launcher {
 
             // Initialize attestation endorsements.
             // TODO(#4074): Add layer endorsements.
-            let oak_restricted_kernel_endoesements = OakRestrictedKernelEndorsements {
+            let oak_restricted_kernel_endorsements = OakRestrictedKernelEndorsements {
                 root_layer: None,
                 kernel_layer: None,
                 application_layer: None,
             };
             let endorsements = Endorsements {
                 r#type: Some(endorsements::Type::OakRestrictedKernel(
-                    oak_restricted_kernel_endoesements,
+                    oak_restricted_kernel_endorsements,
                 )),
             };
 

--- a/oak_containers_launcher/src/server.rs
+++ b/oak_containers_launcher/src/server.rs
@@ -169,7 +169,9 @@ impl Launcher for LauncherServerImplementation {
         // TODO(#4627): Remove old `AttestationEvidence` message.
         #[allow(deprecated)]
         let deprecated_evidence = request.evidence.ok_or_else(|| {
-            tonic::Status::internal("send_attestation_evidence_request doesn't have evidence")
+            tonic::Status::internal(
+                "send_attestation_evidence_request doesn't have deprecated evidence",
+            )
         })?;
 
         self.attestation_evidence_sender

--- a/oak_containers_launcher/src/server.rs
+++ b/oak_containers_launcher/src/server.rs
@@ -20,6 +20,7 @@ use std::{
 
 use anyhow::anyhow;
 use futures::{FutureExt, Stream};
+use oak_attestation::proto::oak::attestation::v1::Evidence;
 use opentelemetry_proto::tonic::{
     collector::{
         logs::v1::{
@@ -67,7 +68,8 @@ struct LauncherServerImplementation {
     container_bundle: std::path::PathBuf,
     application_config: Option<std::path::PathBuf>,
     // Will be used to send the Attestation Evidence to the Launcher.
-    attestation_evidence_sender: Mutex<Option<Sender<AttestationEvidence>>>,
+    // TODO(#4627): Remove old `AttestationEvidence` message.
+    attestation_evidence_sender: Mutex<Option<Sender<(AttestationEvidence, Evidence)>>>,
     // Will be used to notify the untrusted application that the trusted application is ready and
     // listening on a socket address.
     app_ready_notifier: Mutex<Option<Sender<()>>>,
@@ -160,7 +162,16 @@ impl Launcher for LauncherServerImplementation {
         &self,
         request: Request<SendAttestationEvidenceRequest>,
     ) -> Result<Response<()>, tonic::Status> {
+        let request = request.into_inner();
+        let evidence = request.dice_evidence.ok_or_else(|| {
+            tonic::Status::internal("send_attestation_evidence_request doesn't have evidence")
+        })?;
+        // TODO(#4627): Remove old `AttestationEvidence` message.
         #[allow(deprecated)]
+        let deprecated_evidence = request.evidence.ok_or_else(|| {
+            tonic::Status::internal("send_attestation_evidence_request doesn't have evidence")
+        })?;
+
         self.attestation_evidence_sender
             .lock()
             .map_err(|err| {
@@ -172,7 +183,7 @@ impl Launcher for LauncherServerImplementation {
             .ok_or_else(|| {
                 tonic::Status::invalid_argument("app has already sent an attestation evidence")
             })?
-            .send(request.into_inner().evidence.unwrap_or_default())
+            .send((deprecated_evidence, evidence))
             .map_err(|_err| {
                 tonic::Status::internal("couldn't send attestation evidence".to_string())
             })?;
@@ -285,7 +296,7 @@ pub async fn new(
     system_image: std::path::PathBuf,
     container_bundle: std::path::PathBuf,
     application_config: Option<std::path::PathBuf>,
-    attestation_evidence_sender: Sender<AttestationEvidence>,
+    attestation_evidence_sender: Sender<(AttestationEvidence, Evidence)>,
     app_ready_notifier: Sender<()>,
     shutdown: Receiver<()>,
 ) -> Result<(), anyhow::Error> {

--- a/oak_functions_containers_launcher/src/server.rs
+++ b/oak_functions_containers_launcher/src/server.rs
@@ -65,7 +65,8 @@ impl StreamingSession for SessionProxy {
         let attestation_bundle = AttestationBundle {
             attestation_evidence: Some(attestation_evidence),
             attestation_endorsement: Some(attestation_endorsement),
-            dice_evidence: None,
+            evidence: None,
+            endorsements: None,
         };
 
         let mut connector_handle = self.connector_handle.clone();

--- a/oak_functions_launcher/src/main.rs
+++ b/oak_functions_launcher/src/main.rs
@@ -67,14 +67,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize attestation endorsements.
     // TODO(#4074): Add layer endorsements.
-    let oak_restricted_kernel_endoesements = OakRestrictedKernelEndorsements {
+    let oak_restricted_kernel_endorsements = OakRestrictedKernelEndorsements {
         root_layer: None,
         kernel_layer: None,
         application_layer: None,
     };
     let endorsements = Endorsements {
         r#type: Some(endorsements::Type::OakRestrictedKernel(
-            oak_restricted_kernel_endoesements,
+            oak_restricted_kernel_endorsements,
         )),
     };
 

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -17,6 +17,7 @@
 use std::{net::SocketAddr, pin::Pin};
 
 use futures::{Future, Stream, StreamExt};
+use oak_attestation::proto::oak::attestation::v1::{Endorsements, Evidence};
 use tonic::{transport::Server, Request, Response, Status, Streaming};
 
 use crate::{
@@ -34,6 +35,8 @@ use crate::{
 
 pub struct SessionProxy {
     connector_handle: ConnectorHandle,
+    evidence: Evidence,
+    endorsements: Endorsements,
     encryption_public_key: Vec<u8>,
     attestation: Vec<u8>,
 }
@@ -65,8 +68,8 @@ impl StreamingSession for SessionProxy {
         let attestation_bundle = AttestationBundle {
             attestation_evidence: Some(attestation_evidence),
             attestation_endorsement: Some(attestation_endorsement),
-            evidence: None,
-            endorsements: None,
+            evidence: Some(self.evidence.clone()),
+            endorsements: Some(self.endorsements.clone()),
         };
 
         let connector_handle = self.connector_handle.clone();
@@ -124,11 +127,15 @@ impl StreamingSession for SessionProxy {
 pub fn new(
     addr: SocketAddr,
     connector_handle: ConnectorHandle,
+    evidence: Evidence,
+    endorsements: Endorsements,
     encryption_public_key: Vec<u8>,
     attestation: Vec<u8>,
 ) -> impl Future<Output = Result<(), tonic::transport::Error>> {
     let server_impl = SessionProxy {
         connector_handle,
+        evidence,
+        endorsements,
         encryption_public_key,
         attestation,
     };

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -65,7 +65,8 @@ impl StreamingSession for SessionProxy {
         let attestation_bundle = AttestationBundle {
             attestation_evidence: Some(attestation_evidence),
             attestation_endorsement: Some(attestation_endorsement),
-            dice_evidence: None,
+            evidence: None,
+            endorsements: None,
         };
 
         let connector_handle = self.connector_handle.clone();

--- a/proto/session/BUILD
+++ b/proto/session/BUILD
@@ -31,6 +31,7 @@ proto_library(
     srcs = ["messages.proto"],
     deps = [
         "//oak_crypto/proto/v1:crypto_proto",
+        "//proto/attestation:endorsement_proto",
         "//proto/attestation:evidence_proto",
     ],
 )

--- a/proto/session/messages.proto
+++ b/proto/session/messages.proto
@@ -19,6 +19,7 @@ syntax = "proto3";
 package oak.session.v1;
 
 import "oak_crypto/proto/v1/crypto.proto";
+import "proto/attestation/endorsement.proto";
 import "proto/attestation/evidence.proto";
 
 option java_multiple_files = true;
@@ -54,10 +55,13 @@ message AttestationBundle {
   AttestationEvidence attestation_evidence = 1 [deprecated = true];
 
   // Supporting evidence required for verifying the integrity of attestation evidence.
-  AttestationEndorsement attestation_endorsement = 2;
+  AttestationEndorsement attestation_endorsement = 2 [deprecated = true];
 
   // The DICE attestation evidence.
-  oak.attestation.v1.Evidence dice_evidence = 3;
+  oak.attestation.v1.Evidence evidence = 3;
+
+  // Thea attestation endorsements.
+  oak.attestation.v1.Endorsements endorsements = 4;
 }
 
 // AttestationEndorsement contains statements that some entity (e.g., a hardware provider) vouches


### PR DESCRIPTION
This PR makes Hostlibs accept and send DICE evidence and endorsements as part of the `AttestationBundle`

Ref https://github.com/project-oak/oak/issues/4074
Ref https://github.com/project-oak/oak/issues/4627