### PR TITLE
Add unimplemented signing method for the orchestrator

### DIFF
--- a/oak_containers_orchestrator/src/crypto.rs
+++ b/oak_containers_orchestrator/src/crypto.rs
@@ -23,7 +23,7 @@ use tonic::{Request, Response};
 use crate::proto::oak::{
     containers::v1::{
         orchestrator_crypto_server::OrchestratorCrypto, DeriveSessionKeysRequest,
-        DeriveSessionKeysResponse, KeyOrigin,
+        DeriveSessionKeysResponse, KeyOrigin, SignRequest, SignResponse,
     },
     key_provisioning::v1::GroupKeys,
 };
@@ -154,5 +154,13 @@ impl OrchestratorCrypto for CryptoService {
         Ok(tonic::Response::new(DeriveSessionKeysResponse {
             session_keys: Some(session_keys),
         }))
+    }
+
+    async fn sign(
+        &self,
+        _request: Request<SignRequest>,
+    ) -> Result<Response<SignResponse>, tonic::Status> {
+        // TODO(#4074): Implement once the DICE signing key is available in the orchestrator.
+        Err(tonic::Status::unimplemented("not yet implemented"))
     }
 }

--- a/proto/containers/orchestrator_crypto.proto
+++ b/proto/containers/orchestrator_crypto.proto
@@ -39,6 +39,15 @@ message DeriveSessionKeysResponse {
   oak.crypto.v1.SessionKeys session_keys = 1;
 }
 
+message SignRequest {
+  KeyOrigin key_origin = 1;
+  bytes message = 2;
+}
+
+message SignResponse {
+  oak.crypto.v1.Signature signature = 1;
+}
+
 // RPC service that is exposed to an enclave application and allows it to:
 // - Encrypt/decrypt messages
 // - Sign arbitrary data
@@ -46,4 +55,6 @@ message DeriveSessionKeysResponse {
 service OrchestratorCrypto {
   // Derives session keys for decrypting client requests and encrypting enclave responses.
   rpc DeriveSessionKeys(DeriveSessionKeysRequest) returns (DeriveSessionKeysResponse) {}
+  // Signs the provided message using the hardware rooted signing key.
+  rpc Sign(SignRequest) returns (SignResponse) {}
 }


### PR DESCRIPTION
Adds a placeholder signing method. To be implemented once the orchestrator reads the hardware rooted attestation attestation evidence & keys. 


Alternatively we could gen a placeholder signing key here similar to the encryption key, but not sure that temporary workaround is better than finishing the dice implementation by reading the layers & secrets provisioned by stage1.