### PR TITLE
Copy crypto protos into the global proto directory

### DIFF
--- a/oak_crypto/proto/v1/crypto.proto
+++ b/oak_crypto/proto/v1/crypto.proto
@@ -16,6 +16,8 @@
 
 syntax = "proto3";
 
+// TODO(#4392): Currently in the process of moving to `/proto` directory.
+// DO NOT MODIFY THOSE FILES WHILE THEY ARE BEING MOVED.
 package oak.crypto.v1;
 
 option java_multiple_files = true;

--- a/proto/crypto/BUILD
+++ b/proto/crypto/BUILD
@@ -1,0 +1,55 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_java//java:defs.bzl", "java_lite_proto_library", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+proto_library(
+    name = "crypto_proto",
+    srcs = ["crypto.proto"],
+)
+
+cc_proto_library(
+    name = "crypto_cc_proto",
+    deps = [":crypto_proto"],
+)
+
+java_proto_library(
+    name = "crypto_java_proto",
+    deps = [":crypto_proto"],
+)
+
+java_lite_proto_library(
+    name = "crypto_java_proto_lite",
+    deps = [":crypto_proto"],
+)
+
+build_test(
+    name = "build_test",
+    targets = [
+        ":crypto_proto",
+        ":crypto_cc_proto",
+        ":crypto_java_proto",
+        ":crypto_java_proto_lite",
+    ],
+)

--- a/proto/crypto/crypto.proto
+++ b/proto/crypto/crypto.proto
@@ -1,0 +1,63 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.crypto.v1;
+
+option java_multiple_files = true;
+option java_package = "com.google.oak.crypto.v1";
+
+// Request message encrypted using Hybrid Public Key Encryption (HPKE).
+// <https://www.rfc-editor.org/rfc/rfc9180.html>
+message EncryptedRequest {
+  // Message encrypted with Authenticated Encryption with Associated Data (AEAD)
+  // using the derived session key.
+  AeadEncryptedMessage encrypted_message = 1;
+  // Ephemeral Diffie-Hellman client public key that is needed to derive a session key.
+  // Only sent in the first message of the secure session.
+  optional bytes serialized_encapsulated_public_key = 2;
+}
+
+// Response message encrypted Hybrid Public Key Encryption (HPKE), which uses a
+// response key generated as part of bidirectional encryption.
+// <https://www.rfc-editor.org/rfc/rfc9180.html#name-bidirectional-encryption>
+message EncryptedResponse {
+  // Message encrypted with Authenticated Encryption with Associated Data (AEAD)
+  // using the derived session key.
+  AeadEncryptedMessage encrypted_message = 1;
+}
+
+// Message encrypted with Authenticated Encryption with Associated Data (AEAD).
+// <https://datatracker.ietf.org/doc/html/rfc5116>
+message AeadEncryptedMessage {
+  bytes ciphertext = 1;
+  bytes associated_data = 2;
+  bytes nonce = 3;
+}
+
+// Envelope containing session keys required to encrypt/decrypt messages within a secure session.
+// Needed to serialize contexts in order to send them over an RPC.
+message SessionKeys {
+  // AEAD key for encrypting/decrypting client requests.
+  bytes request_key = 1;
+  // AEAD key for encrypting/decrypting enclave responses.
+  bytes response_key = 4;
+}
+
+message Signature {
+  bytes signature = 1;
+}

--- a/proto/crypto/crypto.proto
+++ b/proto/crypto/crypto.proto
@@ -16,6 +16,8 @@
 
 syntax = "proto3";
 
+// TODO(#4392): Currently in the process of moving to `/proto` directory.
+// DO NOT MODIFY THOSE FILES WHILE THEY ARE BEING MOVED.
 package oak.crypto.v1;
 
 option java_multiple_files = true;


### PR DESCRIPTION
This PR copies Crypto proto files into the `proto` directory. We need this step to first update internal dependencies to use the new proto directory.

Ref https://github.com/project-oak/oak/issues/4392