### PR TITLE
Reduce latency of Wasm invocations

### DIFF
--- a/oak_functions_service/src/lib.rs
+++ b/oak_functions_service/src/lib.rs
@@ -17,6 +17,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(never_type)]
 #![feature(unwrap_infallible)]
+// Required for enabling benchmark tests.
+#![feature(test)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Only create a single linker, and reuse that to create all subsequent instances.

Add benchmarks to measure it.

Before:

```
test wasm::tests::bench_invoke ... bench:     246,826 ns/iter (+/- 49,215)
```

After:

```
test wasm::tests::bench_invoke ... bench:      45,246 ns/iter (+/- 1,894)
```

Ref #3757