### PR TITLE
Stop rebuilding Oak Containers SDK

### DIFF
--- a/oak_containers_sdk/build.rs
+++ b/oak_containers_sdk/build.rs
@@ -19,10 +19,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate gRPC code for connecting to the Orchestrator.
     generate_grpc_code(
         &[
-            "oak_containers/proto/interfaces.proto",
-            "oak_crypto/proto/v1/crypto.proto",
-            "proto/session/messages.proto",
-            "proto/containers/orchestrator_crypto.proto",
+            "../oak_containers/proto/interfaces.proto",
+            "../oak_crypto/proto/v1/crypto.proto",
+            "../proto/session/messages.proto",
+            "../proto/containers/orchestrator_crypto.proto",
         ],
         "..",
         CodegenOptions {


### PR DESCRIPTION
The change detection logic was not working correctly because of the proto paths, and this crate (and its dependants) were constantly rebuilt instead of being cached.