### PR TITLE
Modifications to oak_containers_launcher for external use

### DIFF
--- a/oak_containers_hello_world_untrusted_app/tests/integration_test.rs
+++ b/oak_containers_hello_world_untrusted_app/tests/integration_test.rs
@@ -58,7 +58,7 @@ async fn run_hello_world_test(container_bundle: std::path::PathBuf) {
 
     let app_args = Args {
         container_bundle,
-        ..Args::default_for_test()
+        ..Args::default_for_root(env!("WORKSPACE_ROOT"))
     };
     let mut untrusted_app =
         oak_containers_hello_world_untrusted_app::UntrustedApp::create(app_args)
@@ -97,7 +97,7 @@ async fn run_hello_world_test(container_bundle: std::path::PathBuf) {
 }
 
 async fn hello_world() {
-    run_hello_world_test(Args::default_for_test().container_bundle).await;
+    run_hello_world_test(Args::default_for_root(env!("WORKSPACE_ROOT")).container_bundle).await;
 }
 
 async fn cc_hello_world() {

--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -44,6 +44,7 @@ use clap::Parser;
 use oak_attestation::proto::oak::attestation::v1::{
     endorsements, Endorsements, Evidence, OakRestrictedKernelEndorsements,
 };
+pub use qemu::Params as QemuParams;
 use tokio::{
     net::TcpListener,
     sync::oneshot::{channel, Receiver, Sender},
@@ -84,21 +85,16 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn default_for_test() -> Self {
-        let system_image = format!(
-            "{}oak_containers_system_image/target/image.tar.xz",
-            env!("WORKSPACE_ROOT")
-        )
-        .into();
+    pub fn default_for_root(root: &str) -> Self {
+        let system_image = format!("{root}oak_containers_system_image/target/image.tar.xz",).into();
         let container_bundle = format!(
-            "{}oak_containers_hello_world_container/target/oak_container_example_oci_filesystem_bundle.tar",
-            env!("WORKSPACE_ROOT")
+            "{root}oak_containers_hello_world_container/target/oak_container_example_oci_filesystem_bundle.tar",
         ).into();
         Self {
             system_image,
             container_bundle,
             application_config: None,
-            qemu_params: qemu::Params::default_for_test(),
+            qemu_params: qemu::Params::default_for_root(root),
         }
     }
 }

--- a/oak_containers_launcher/src/qemu.rs
+++ b/oak_containers_launcher/src/qemu.rs
@@ -67,19 +67,12 @@ pub struct Params {
 }
 
 impl Params {
-    pub fn default_for_test() -> Self {
+    pub fn default_for_root(root: &str) -> Self {
         let vmm_binary = which::which("qemu-system-x86_64").expect("could not find qemu path");
-        let stage0_binary = format!(
-            "{}stage0_bin/target/x86_64-unknown-none/release/stage0_bin",
-            env!("WORKSPACE_ROOT")
-        )
-        .into();
-        let kernel = format!(
-            "{}oak_containers_kernel/target/bzImage",
-            env!("WORKSPACE_ROOT")
-        )
-        .into();
-        let initrd = format!("{}/target/stage1.cpio", env!("WORKSPACE_ROOT")).into();
+        let stage0_binary =
+            format!("{root}stage0_bin/target/x86_64-unknown-none/release/stage0_bin",).into();
+        let kernel = format!("{root}oak_containers_kernel/target/bzImage",).into();
+        let initrd = format!("{root}/target/stage1.cpio").into();
         Self {
             vmm_binary,
             stage0_binary,


### PR DESCRIPTION
* Hide the default constructor functions behind a feature flag, since they use WORKSPACE_ROOT.
* Expose the Qemu params struct
* Make the Args fields public