### PR TITLE
Increase timeout for oak functions tests

### DIFF
--- a/oak_functions/examples/key_value_lookup/module/src/tests.rs
+++ b/oak_functions/examples/key_value_lookup/module/src/tests.rs
@@ -47,7 +47,8 @@ async fn test_server() {
         .await;
 
     // Wait for the server to start up.
-    std::thread::sleep(Duration::from_secs(10));
+    // TODO(#4677): Reduce the wait time.
+    std::thread::sleep(Duration::from_secs(15));
 
     {
         // Lookup match.

--- a/oak_functions_containers_launcher/src/lib.rs
+++ b/oak_functions_containers_launcher/src/lib.rs
@@ -115,5 +115,9 @@ async fn update_lookup_data(
     config: &LookupDataConfig,
 ) -> anyhow::Result<()> {
     log::info!("updating lookup data");
-    lookup::update_lookup_data(client, &config.lookup_data_path, config.max_chunk_size).await
+    let start = std::time::Instant::now();
+    let result =
+        lookup::update_lookup_data(client, &config.lookup_data_path, config.max_chunk_size).await;
+    log::info!("updated lookup data in {}ms", start.elapsed().as_millis());
+    result
 }

--- a/oak_functions_launcher/src/lib.rs
+++ b/oak_functions_launcher/src/lib.rs
@@ -156,7 +156,11 @@ pub async fn update_lookup_data(
     config: &LookupDataConfig,
 ) -> anyhow::Result<()> {
     log::info!("updating lookup data");
-    lookup::update_lookup_data(client, &config.lookup_data_path, config.max_chunk_size).await
+    let start = std::time::Instant::now();
+    let result =
+        lookup::update_lookup_data(client, &config.lookup_data_path, config.max_chunk_size).await;
+    log::info!("updated lookup data in {}ms", start.elapsed().as_millis());
+    result
 }
 
 // Loads application config (including Wasm bytes) into the enclave and returns a remote attestation


### PR DESCRIPTION
We should find a better solution, but this at least lets us get past #4677