### PR TITLE
Remove oak_attestation_verification dependency on std.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,7 +1880,6 @@ dependencies = [
  "prost",
  "prost-build",
  "serde",
- "serde_canonical_json",
  "serde_json",
  "sha2",
  "time",
@@ -3411,18 +3410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_canonical_json"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef94ee2661f3ce924fa936258393d02155fa22c5a81125016a24069e23a0465"
-dependencies = [
- "itoa",
- "lazy_static",
- "regex",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ dependencies = [
  "base64 0.21.7",
  "coset",
  "ecdsa",
+ "getrandom",
  "hex",
  "oak_dice",
  "oak_sev_guest",

--- a/justfile
+++ b/justfile
@@ -66,8 +66,7 @@ all_oak_functions_containers_binaries: stage0_bin stage1_cpio oak_containers_ker
 ensure_no_std package:
     cargo check --target=x86_64-unknown-none --package='{{package}}'
 
-# TODO(#4682): Add "oak_attestation_verification" when it is no_std compatible
-all_ensure_no_std: (ensure_no_std "micro_rpc")
+all_ensure_no_std: (ensure_no_std "micro_rpc") (ensure_no_std "oak_attestation_verification") (ensure_no_std "oak_restricted_kernel_sdk")
 
 # Entry points for Kokoro CI.
 

--- a/oak_attestation_verification/Cargo.toml
+++ b/oak_attestation_verification/Cargo.toml
@@ -7,20 +7,27 @@ license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "*"
-base64 = "0.21"
+anyhow = { version = "*", default-features = false }
+base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 coset = { version = "*", default-features = false }
 ecdsa = { version = "*", features = ["pkcs8", "pem"] }
-hex = "*"
+hex = { version = "*", default-features = false }
 oak_dice = { workspace = true }
 oak_sev_guest = { workspace = true }
 prost = { workspace = true }
-p256 = { version = "*", features = ["ecdsa-core", "ecdsa", "pem"] }
-serde = { version = "*", features = ["derive"] }
-serde_canonical_json = "*"
-serde_json = "*"
+p256 = { version = "*", default-features = false, features = [
+  "alloc",
+  "ecdsa-core",
+  "ecdsa",
+  "pem"
+] }
+serde = { version = "*", default-features = false, features = ["derive"] }
+serde_json = { version = "*", default-features = false, features = ["alloc"] }
 sha2 = { version = "*", default-features = false }
-time = { version = "0.3.28", features = ["serde", "parsing", "formatting"] }
+time = { version = "0.3.28", default-features = false, features = [
+  "serde",
+  "parsing"
+] }
 zerocopy = "*"
 
 [build-dependencies]

--- a/oak_attestation_verification/Cargo.toml
+++ b/oak_attestation_verification/Cargo.toml
@@ -14,6 +14,10 @@ anyhow = { version = "*", default-features = false }
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 coset = { version = "*", default-features = false }
 ecdsa = { version = "*", features = ["pkcs8", "pem"] }
+getrandom = { version = "*", features = [
+  # While getrandom isn't used directly, rdrand is required to support x64_64-unknown-none.
+  "rdrand"
+] }
 hex = { version = "*", default-features = false }
 oak_dice = { workspace = true }
 oak_sev_guest = { workspace = true }

--- a/oak_attestation_verification/Cargo.toml
+++ b/oak_attestation_verification/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Razieh Behjati <razieh@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+serialize = ["time/formatting"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anyhow = { version = "*", default-features = false }

--- a/oak_attestation_verification/src/claims.rs
+++ b/oak_attestation_verification/src/claims.rs
@@ -23,7 +23,6 @@ extern crate alloc;
 
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
-use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
@@ -70,7 +69,7 @@ pub enum InvalidClaimData {
 }
 
 /// Detailed content of a claim.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct ClaimPredicate<S> {
     /// URI indicating the type of the claim. It determines the meaning of
     /// `claimSpec` and `evidence`.
@@ -95,7 +94,7 @@ pub struct ClaimPredicate<S> {
 }
 
 /// Validity time range of an issued claim.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct ClaimValidity {
     /// The timestamp (encoded as an Epoch time) from which the claim is
     /// effective.
@@ -128,7 +127,8 @@ pub type EndorsementStatement = Statement<ClaimPredicate<Claimless>>;
 
 /// Converts the given byte array into an endorsement statement.
 pub fn parse_endorsement_statement(bytes: &[u8]) -> anyhow::Result<EndorsementStatement> {
-    serde_json::from_slice(bytes).context("parsing endorsement bytes")
+    serde_json::from_slice(bytes)
+        .map_err(|error| anyhow::anyhow!("parsing endorsement bytes: {}", error))
 }
 
 /// Checks that the given statement is a valid claim:

--- a/oak_attestation_verification/src/claims.rs
+++ b/oak_attestation_verification/src/claims.rs
@@ -23,7 +23,9 @@ extern crate alloc;
 
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+#[cfg(feature = "serialize")]
+use serde::Serialize;
 use time::OffsetDateTime;
 
 use crate::proto::oak::HexDigest;
@@ -44,14 +46,16 @@ pub const STATEMENT_INTOTO_V01: &str = "https://in-toto.io/Statement/v0.1";
 pub type DigestSet = BTreeMap<String, String>;
 
 /// A software artifact identified by its name and a set of artifacts.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct Subject {
     pub name: String,
     pub digest: DigestSet,
 }
 
 /// Represents a generic statement that binds a predicate to a subject.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct Statement<P> {
     pub _type: String,
     #[serde(rename = "predicateType")]
@@ -70,6 +74,7 @@ pub enum InvalidClaimData {
 
 /// Detailed content of a claim.
 #[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct ClaimPredicate<S> {
     /// URI indicating the type of the claim. It determines the meaning of
     /// `claimSpec` and `evidence`.
@@ -95,6 +100,7 @@ pub struct ClaimPredicate<S> {
 
 /// Validity time range of an issued claim.
 #[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct ClaimValidity {
     /// The timestamp (encoded as an Epoch time) from which the claim is
     /// effective.
@@ -109,7 +115,8 @@ pub struct ClaimValidity {
 }
 
 /// Metadata about an artifact that serves as the evidence for the truth of a claim.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct ClaimEvidence {
     /// Optional field specifying the role of this evidence within the claim.
     pub role: Option<String>,
@@ -120,7 +127,8 @@ pub struct ClaimEvidence {
 }
 
 /// Inner type for a simple claim with no further fields.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct Claimless {}
 
 pub type EndorsementStatement = Statement<ClaimPredicate<Claimless>>;

--- a/oak_attestation_verification/src/rekor.rs
+++ b/oak_attestation_verification/src/rekor.rs
@@ -21,13 +21,16 @@ use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
 
 use anyhow::Context;
 use base64::{prelude::BASE64_STANDARD, Engine as _};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+#[cfg(feature = "serialize")]
+use serde::Serialize;
 
 use crate::util::{convert_pem_to_raw, hash_sha2_256, verify_signature_raw};
 
 /// Struct representing a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/log_entry.go#L89.>
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct LogEntry {
     /// We cannot directly use the type `Body` here, since body is Base64-encoded.
     #[serde(rename = "body")]
@@ -53,7 +56,8 @@ pub struct LogEntry {
 }
 
 /// Struct representing the body in a Rekor LogEntry.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct Body {
     #[serde(rename = "apiVersion")]
     pub api_version: String,
@@ -63,7 +67,8 @@ pub struct Body {
 
 /// Struct representing the `spec` in the body of a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L39.>
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct Spec {
     pub data: Data,
     pub signature: GenericSignature,
@@ -71,14 +76,16 @@ pub struct Spec {
 
 /// Struct representing the hashed data in the body of a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L179.>
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct Data {
     pub hash: Hash,
 }
 
 /// Struct representing a hash digest.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L273.>
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct Hash {
     pub algorithm: String,
     pub value: String,
@@ -86,7 +93,8 @@ pub struct Hash {
 
 /// Struct representing a signature in the body of a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L383>
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct GenericSignature {
     /// Base64 content that is signed.
     pub content: String,
@@ -97,7 +105,8 @@ pub struct GenericSignature {
 
 /// Struct representing a public key included in the body of a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L551.>
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct PublicKey {
     /// Base64 content of a public key.
     pub content: String,
@@ -106,7 +115,8 @@ pub struct PublicKey {
 /// Struct representing a verification object in a Rekor LogEntry. The verification object in Rekor
 /// also contains an inclusion proof. Since we currently don't verify the inclusion proof in the
 /// client, it is omitted from this struct.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct LogEntryVerification {
     // Base64-encoded signature over the body, integratedTime, logID, and logIndex.
     #[serde(rename = "signedEntryTimestamp")]

--- a/oak_attestation_verification/src/util.rs
+++ b/oak_attestation_verification/src/util.rs
@@ -17,7 +17,6 @@
 use alloc::{string::String, vec::Vec};
 use core::{cmp::Ordering, str::FromStr};
 
-use anyhow::Context;
 use base64::{prelude::BASE64_STANDARD, Engine as _};
 use ecdsa::{signature::Verifier, Signature};
 use p256::ecdsa::VerifyingKey;
@@ -44,7 +43,9 @@ pub fn convert_pem_to_raw(public_key_pem: &str) -> anyhow::Result<Vec<u8>> {
         .expect("could not find expected footer");
     let remove_newlines = stripped.replace('\n', "");
 
-    Ok(BASE64_STANDARD.decode(remove_newlines)?)
+    BASE64_STANDARD
+        .decode(remove_newlines)
+        .map_err(|error| anyhow::anyhow!(error))
 }
 
 /// Converts a raw public key to PEM format.
@@ -64,8 +65,12 @@ pub fn convert_raw_to_pem(public_key: &[u8]) -> String {
 
 /// Converts a PEM-encoded x509/PKIX public key to a verifying key.
 pub fn convert_pem_to_verifying_key(public_key_pem: &str) -> anyhow::Result<VerifyingKey> {
-    VerifyingKey::from_str(public_key_pem)
-        .context("couldn't parse pem as a p256::ecdsa::VerifyingKey")
+    VerifyingKey::from_str(public_key_pem).map_err(|error| {
+        anyhow::anyhow!(
+            "couldn't parse pem as a p256::ecdsa::VerifyingKey: {}",
+            error
+        )
+    })
 }
 
 /// Converts a raw public key to a verifying key.
@@ -90,11 +95,12 @@ pub fn verify_signature_raw(
     contents: &[u8],
     public_key: &[u8],
 ) -> anyhow::Result<()> {
-    let sig = Signature::from_der(signature).context("invalid ASN.1 signature")?;
+    let sig = Signature::from_der(signature)
+        .map_err(|error| anyhow::anyhow!("invalid ASN.1 signature: {}", error))?;
     let key = convert_raw_to_verifying_key(public_key)?;
 
     key.verify(contents, &sig)
-        .context("couldn't verify signature")
+        .map_err(|error| anyhow::anyhow!("couldn't verify signature: {}", error))
 }
 
 pub fn hash_sha2_256(input: &[u8]) -> [u8; 32] {
@@ -199,15 +205,24 @@ pub fn raw_to_hex_digest(r: &RawDigest) -> HexDigest {
 /// Converts hex digest to raw digest.
 pub fn hex_to_raw_digest(h: &HexDigest) -> anyhow::Result<RawDigest> {
     let raw = RawDigest {
-        psha2: hex::decode(&h.psha2).context("could not decode field psha2")?,
-        sha1: hex::decode(&h.sha1).context("could not decode field sha1")?,
-        sha2_256: hex::decode(&h.sha2_256).context("could not decode field sha2_256")?,
-        sha2_512: hex::decode(&h.sha2_512).context("could not decode field sha2_512")?,
-        sha3_512: hex::decode(&h.sha3_512).context("could not decode field sha3_512")?,
-        sha3_384: hex::decode(&h.sha3_384).context("could not decode field sha3_384")?,
-        sha3_256: hex::decode(&h.sha3_256).context("could not decode field sha3_256")?,
-        sha3_224: hex::decode(&h.sha3_224).context("could not decode field sha3_224")?,
-        sha2_384: hex::decode(&h.sha2_384).context("could not decode field sha2_384")?,
+        psha2: hex::decode(&h.psha2)
+            .map_err(|error| anyhow::anyhow!("could not decode field psha2: {}", error))?,
+        sha1: hex::decode(&h.sha1)
+            .map_err(|error| anyhow::anyhow!("could not decode field sha1: {}", error))?,
+        sha2_256: hex::decode(&h.sha2_256)
+            .map_err(|error| anyhow::anyhow!("could not decode field sha2_256: {}", error))?,
+        sha2_512: hex::decode(&h.sha2_512)
+            .map_err(|error| anyhow::anyhow!("could not decode field sha2_512: {}", error))?,
+        sha3_512: hex::decode(&h.sha3_512)
+            .map_err(|error| anyhow::anyhow!("could not decode field sha3_512: {}", error))?,
+        sha3_384: hex::decode(&h.sha3_384)
+            .map_err(|error| anyhow::anyhow!("could not decode field sha3_384: {}", error))?,
+        sha3_256: hex::decode(&h.sha3_256)
+            .map_err(|error| anyhow::anyhow!("could not decode field sha3_256: {}", error))?,
+        sha3_224: hex::decode(&h.sha3_224)
+            .map_err(|error| anyhow::anyhow!("could not decode field sha3_224: {}", error))?,
+        sha2_384: hex::decode(&h.sha2_384)
+            .map_err(|error| anyhow::anyhow!("could not decode field sha2_384: {}", error))?,
     };
 
     Ok(raw)

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -136,7 +136,8 @@ pub fn verify_dice_chain(evidence: &Evidence) -> anyhow::Result<DiceChainResult>
         cert.verify_signature(ADDITIONAL_DATA, |signature, contents| {
             let sig = Signature::from_slice(signature)?;
             verifying_key.verify(contents, &sig)
-        })?;
+        })
+        .map_err(|error| anyhow::anyhow!(error))?;
         let payload = cert
             .payload
             .ok_or_else(|| anyhow::anyhow!("no cert payload"))?;
@@ -158,10 +159,12 @@ pub fn verify_dice_chain(evidence: &Evidence) -> anyhow::Result<DiceChainResult>
     let encryption_cert =
         coset::CoseSign1::from_slice(&appl_keys.encryption_public_key_certificate)
             .map_err(|_cose_err| anyhow::anyhow!("could not parse encryption certificate"))?;
-    encryption_cert.verify_signature(ADDITIONAL_DATA, |signature, contents| {
-        let sig = Signature::from_slice(signature)?;
-        verifying_key.verify(contents, &sig)
-    })?;
+    encryption_cert
+        .verify_signature(ADDITIONAL_DATA, |signature, contents| {
+            let sig = Signature::from_slice(signature)?;
+            verifying_key.verify(contents, &sig)
+        })
+        .map_err(|error| anyhow::anyhow!(error))?;
     let encryption_payload = encryption_cert
         .payload
         .ok_or_else(|| anyhow::anyhow!("no encryption cert payload"))?;
@@ -175,10 +178,12 @@ pub fn verify_dice_chain(evidence: &Evidence) -> anyhow::Result<DiceChainResult>
     // Process signing certificate.
     let signing_cert = coset::CoseSign1::from_slice(&appl_keys.signing_public_key_certificate)
         .map_err(|_cose_err| anyhow::anyhow!("could not parse encryption certificate"))?;
-    signing_cert.verify_signature(ADDITIONAL_DATA, |signature, contents| {
-        let sig = Signature::from_slice(signature)?;
-        verifying_key.verify(contents, &sig)
-    })?;
+    signing_cert
+        .verify_signature(ADDITIONAL_DATA, |signature, contents| {
+            let sig = Signature::from_slice(signature)?;
+            verifying_key.verify(contents, &sig)
+        })
+        .map_err(|error| anyhow::anyhow!(error))?;
     let signing_payload = signing_cert
         .payload
         .ok_or_else(|| anyhow::anyhow!("no signing cert payload"))?;

--- a/oak_ml_transparency/runner/Cargo.lock
+++ b/oak_ml_transparency/runner/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "base64",
  "coset",
  "ecdsa",
+ "getrandom",
  "hex",
  "oak_dice",
  "oak_sev_guest",

--- a/oak_ml_transparency/runner/Cargo.lock
+++ b/oak_ml_transparency/runner/Cargo.lock
@@ -511,12 +511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,7 +565,6 @@ dependencies = [
  "prost",
  "prost-build",
  "serde",
- "serde_canonical_json",
  "serde_json",
  "sha2",
  "time",
@@ -879,18 +872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_canonical_json"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef94ee2661f3ce924fa936258393d02155fa22c5a81125016a24069e23a0465"
-dependencies = [
- "itoa",
- "lazy_static",
- "regex",
- "serde_json",
 ]
 
 [[package]]

--- a/oak_ml_transparency/runner/Cargo.toml
+++ b/oak_ml_transparency/runner/Cargo.toml
@@ -10,7 +10,9 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anyhow = "*"
-oak_attestation_verification = { path = "../../oak_attestation_verification" }
+oak_attestation_verification = { path = "../../oak_attestation_verification", features = [
+  "serialize"
+] }
 clap = { version = "*", features = ["derive"] }
 env_logger = "*"
 hex = "*"


### PR DESCRIPTION
The crate itself already set no_std, but it relied on a lot of std-only features in its dependencies, such as anyhow::Context and serde json serialization.

Since all canonical serde json serialization libraries require std, it's necessary to manually serialize one structure. But since the structure doesn't have optional fields, nesting, or complex types, the serialization logic is straightforward.

Fixes #4682