### PR TITLE
Rename oak_attestation_verification "serialize" feature to "std".

### DIFF
--- a/oak_attestation_verification/Cargo.toml
+++ b/oak_attestation_verification/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-serialize = ["time/formatting"]
+std = ["time/formatting"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/oak_attestation_verification/src/claims.rs
+++ b/oak_attestation_verification/src/claims.rs
@@ -24,7 +24,7 @@ extern crate alloc;
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
 use serde::Deserialize;
-#[cfg(feature = "serialize")]
+#[cfg(feature = "std")]
 use serde::Serialize;
 use time::OffsetDateTime;
 
@@ -47,7 +47,7 @@ pub type DigestSet = BTreeMap<String, String>;
 
 /// A software artifact identified by its name and a set of artifacts.
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct Subject {
     pub name: String,
     pub digest: DigestSet,
@@ -55,7 +55,7 @@ pub struct Subject {
 
 /// Represents a generic statement that binds a predicate to a subject.
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct Statement<P> {
     pub _type: String,
     #[serde(rename = "predicateType")]
@@ -74,7 +74,7 @@ pub enum InvalidClaimData {
 
 /// Detailed content of a claim.
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct ClaimPredicate<S> {
     /// URI indicating the type of the claim. It determines the meaning of
     /// `claimSpec` and `evidence`.
@@ -100,7 +100,7 @@ pub struct ClaimPredicate<S> {
 
 /// Validity time range of an issued claim.
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct ClaimValidity {
     /// The timestamp (encoded as an Epoch time) from which the claim is
     /// effective.
@@ -116,7 +116,7 @@ pub struct ClaimValidity {
 
 /// Metadata about an artifact that serves as the evidence for the truth of a claim.
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct ClaimEvidence {
     /// Optional field specifying the role of this evidence within the claim.
     pub role: Option<String>,
@@ -128,7 +128,7 @@ pub struct ClaimEvidence {
 
 /// Inner type for a simple claim with no further fields.
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct Claimless {}
 
 pub type EndorsementStatement = Statement<ClaimPredicate<Claimless>>;

--- a/oak_attestation_verification/src/rekor.rs
+++ b/oak_attestation_verification/src/rekor.rs
@@ -22,7 +22,7 @@ use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
 use anyhow::Context;
 use base64::{prelude::BASE64_STANDARD, Engine as _};
 use serde::Deserialize;
-#[cfg(feature = "serialize")]
+#[cfg(feature = "std")]
 use serde::Serialize;
 
 use crate::util::{convert_pem_to_raw, hash_sha2_256, verify_signature_raw};
@@ -30,7 +30,7 @@ use crate::util::{convert_pem_to_raw, hash_sha2_256, verify_signature_raw};
 /// Struct representing a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/log_entry.go#L89.>
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct LogEntry {
     /// We cannot directly use the type `Body` here, since body is Base64-encoded.
     #[serde(rename = "body")]
@@ -57,7 +57,7 @@ pub struct LogEntry {
 
 /// Struct representing the body in a Rekor LogEntry.
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct Body {
     #[serde(rename = "apiVersion")]
     pub api_version: String,
@@ -68,7 +68,7 @@ pub struct Body {
 /// Struct representing the `spec` in the body of a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L39.>
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct Spec {
     pub data: Data,
     pub signature: GenericSignature,
@@ -77,7 +77,7 @@ pub struct Spec {
 /// Struct representing the hashed data in the body of a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L179.>
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct Data {
     pub hash: Hash,
 }
@@ -85,7 +85,7 @@ pub struct Data {
 /// Struct representing a hash digest.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L273.>
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct Hash {
     pub algorithm: String,
     pub value: String,
@@ -94,7 +94,7 @@ pub struct Hash {
 /// Struct representing a signature in the body of a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L383>
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct GenericSignature {
     /// Base64 content that is signed.
     pub content: String,
@@ -106,7 +106,7 @@ pub struct GenericSignature {
 /// Struct representing a public key included in the body of a Rekor LogEntry.
 /// Based on <https://github.com/sigstore/rekor/blob/2978cdc26fdf8f5bfede8459afd9735f0f231a2a/pkg/generated/models/rekord_v001_schema.go#L551.>
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct PublicKey {
     /// Base64 content of a public key.
     pub content: String,
@@ -116,7 +116,7 @@ pub struct PublicKey {
 /// also contains an inclusion proof. Since we currently don't verify the inclusion proof in the
 /// client, it is omitted from this struct.
 #[derive(Debug, Deserialize, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub struct LogEntryVerification {
     // Base64-encoded signature over the body, integratedTime, logID, and logIndex.
     #[serde(rename = "signedEntryTimestamp")]

--- a/oak_ml_transparency/runner/Cargo.toml
+++ b/oak_ml_transparency/runner/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "*"
 oak_attestation_verification = { path = "../../oak_attestation_verification", features = [
-  "serialize"
+  "std"
 ] }
 clap = { version = "*", features = ["derive"] }
 env_logger = "*"


### PR DESCRIPTION
The new name was requested in
https://github.com/project-oak/oak/pull/4685#discussion_r1459674232.