### PR TITLE
Remove WORKSPACE_ROOT from oak_attestation_verification.

### DIFF
--- a/oak_attestation_verification/build.rs
+++ b/oak_attestation_verification/build.rs
@@ -26,12 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Tell cargo to rerun this build script if the proto file has changed.
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
     for proto_path in proto_paths.iter() {
-        let file_path = std::path::Path::new(proto_path);
-        println!(
-            "cargo:rerun-if-changed={}{}",
-            env!("WORKSPACE_ROOT"),
-            file_path.display()
-        );
+        println!("cargo:rerun-if-changed=../{}", proto_path);
     }
 
     Ok(())

--- a/oak_attestation_verification/build.rs
+++ b/oak_attestation_verification/build.rs
@@ -16,17 +16,17 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proto_paths = [
-        "proto/attestation/endorsement.proto",
-        "proto/attestation/evidence.proto",
-        "proto/attestation/reference_value.proto",
-        "proto/attestation/verification.proto",
+        "../proto/attestation/endorsement.proto",
+        "../proto/attestation/evidence.proto",
+        "../proto/attestation/reference_value.proto",
+        "../proto/attestation/verification.proto",
     ];
     prost_build::compile_protos(&proto_paths, &[".."]).expect("proto compilation failed");
 
     // Tell cargo to rerun this build script if the proto file has changed.
     // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath
     for proto_path in proto_paths.iter() {
-        println!("cargo:rerun-if-changed=../{}", proto_path);
+        println!("cargo:rerun-if-changed={}", proto_path);
     }
 
     Ok(())


### PR DESCRIPTION
`WORKSPACE_ROOT` makes a crate incompatible with use from another repository because there's no way for it to be set relative to the root of the oak repository. `cargo:rerun-if-change` supports relative paths, however, which solve this problem.