### PR TITLE
no_std test: use cargo build (with flags) instead of cargo check

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ oak_functions_containers_launcher:
 all_oak_functions_containers_binaries: stage0_bin stage1_cpio oak_containers_kernel oak_containers_system_image oak_functions_containers_container_bundle_tar oak_functions_containers_launcher
 
 ensure_no_std package:
-    cargo check --target=x86_64-unknown-none --package='{{package}}'
+    RUSTFLAGS="-C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,+rdrand,-soft-float" cargo build --target=x86_64-unknown-none --package='{{package}}'
 
 all_ensure_no_std: (ensure_no_std "micro_rpc") (ensure_no_std "oak_attestation_verification") (ensure_no_std "oak_restricted_kernel_sdk")
 


### PR DESCRIPTION
Cargo check does not detect all failures. Running cargo build without extra flags exposes failures.