### PR TITLE
Create a fake EFI System Table in stage0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +2728,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.4.1",
  "coset",
+ "crc",
  "elf",
  "hex",
  "hkdf",

--- a/stage0/Cargo.toml
+++ b/stage0/Cargo.toml
@@ -5,8 +5,13 @@ authors = ["Andri Saar <andrisaar@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = ["efi"]
+efi = ["dep:crc"]
+
 [dependencies]
 bitflags = "*"
+crc = { version = "*", optional = true }
 coset = { version = "*", default-features = false }
 elf = { version = "*", default-features = false }
 hex = { version = "*", default-features = false, features = ["alloc"] }

--- a/stage0/src/efi.rs
+++ b/stage0/src/efi.rs
@@ -1,0 +1,139 @@
+//
+// Copyright 2023 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Basic data structures for EFI.
+//!
+//! IMPORTANT: We do not claim any compatibility with EFI. These data structures are here just in
+//! hopes that we'll be able to fool Linux enough not to scan a non-validated range of memory for
+//! DMI data when booting under SEV-SNP.
+//!
+//! We do not plan to support any EFI services in stage0.
+
+use alloc::boxed::Box;
+use core::mem;
+
+use zerocopy::AsBytes;
+
+use crate::{BootAllocator, BOOT_ALLOC};
+
+type EfiHandle = usize;
+
+/// EFI table header.
+///
+/// See Section 4.2.1. EFI_TABLE_HEADER in the UEFI Specification 2.10 for more details.
+#[repr(C)]
+#[derive(AsBytes, Default)]
+pub struct EfiTableHeader {
+    /// Identifies the type of table that follows.
+    pub signature: u64,
+
+    /// Revsion of the EFI Specification to which this table conforms.
+    pub revision: u32,
+
+    /// The size, in bytes, of the entire table, including the header.
+    pub header_size: u32,
+
+    /// 32-bit CRC of the entire table.
+    pub crc32: u32,
+
+    /// Reserved, must be zero.
+    pub reserved: u32,
+}
+
+impl EfiTableHeader {
+    const EFI_2_100_SYSTEM_TABLE_REVISION: u32 = ((2 << 16) | (100));
+}
+
+/// EFI System Table.
+///
+/// See Section 4.3.1. EFI_SYSTEM_TABLE in the UEFI Specification 2.10 for more details.
+#[repr(C)]
+#[derive(AsBytes)]
+pub struct EfiSystemTable {
+    /// Table header for the EFI System Table.
+    pub header: EfiTableHeader,
+
+    /// Pointer to a null-terminated string that identifies the vendor of the firmware.
+    pub firmware_vendor: usize,
+
+    /// Vendor-specific value that identifies the revision of the firmware.
+    pub firmware_revision: u32,
+
+    // Padding to placate `zerocopy::AsBytes.` This does not change the size of the data structure,
+    // as we're `repr(C)` and the padding would be added implicitly anyway. (Verified by the static
+    // assertion just after the data structure.)
+    _pad: u32,
+
+    pub console_in_handle: EfiHandle,
+    pub con_in: usize,
+    pub console_out_handle: EfiHandle,
+    pub con_out: usize,
+    pub std_err_handle: EfiHandle,
+    pub std_err: usize,
+    pub runtime_services: usize,
+    pub boot_services: usize,
+
+    /// Number of system configuration tables in the `config_table`.
+    pub num_entries: usize,
+
+    /// Pointer to the system configuration tables.
+    pub config_table: usize,
+}
+static_assertions::assert_eq_size!(EfiSystemTable, [u8; 120usize]);
+
+impl EfiSystemTable {
+    const SIGNATURE: u64 = 0x5453595320494249;
+
+    const CCITT32_CRC: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_CKSUM);
+
+    pub fn checksum(&self) -> u32 {
+        Self::CCITT32_CRC.checksum(self.as_bytes())
+    }
+}
+
+impl Default for EfiSystemTable {
+    fn default() -> Self {
+        let mut table = Self {
+            header: EfiTableHeader {
+                signature: Self::SIGNATURE,
+                revision: EfiTableHeader::EFI_2_100_SYSTEM_TABLE_REVISION,
+                header_size: mem::size_of::<Self>().try_into().unwrap(),
+                ..EfiTableHeader::default()
+            },
+            firmware_vendor: 0,
+            firmware_revision: 0,
+            _pad: 0,
+            console_in_handle: 0,
+            con_in: 0,
+            console_out_handle: 0,
+            con_out: 0,
+            std_err_handle: 0,
+            std_err: 0,
+            runtime_services: 0,
+            boot_services: 0,
+            num_entries: 0,
+            config_table: 0,
+        };
+        table.header.crc32 = table.checksum();
+        table
+    }
+}
+
+/// Create a fake placeholder EFI System Table and put a pointer to that in the zero page.
+pub fn create_efi_skeleton() -> Box<EfiSystemTable, &'static BootAllocator> {
+    // We don't set anything in the table itself. As said, it's a fake table.
+    Box::new_in(EfiSystemTable::default(), &BOOT_ALLOC)
+}

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -50,6 +50,8 @@ mod allocator;
 mod apic;
 mod cmos;
 mod dice_attestation;
+#[cfg(feature = "efi")]
+mod efi;
 mod fw_cfg;
 mod initramfs;
 mod kernel;
@@ -362,6 +364,14 @@ pub fn rust64_start(encrypted: u64) -> ! {
         format!("{} -- {}", cmdline, extra)
     };
     zero_page.set_cmdline(cmdline);
+
+    // If required, create a fake EFI system table.
+    if cfg!(feature = "efi") {
+        let system_table = efi::create_efi_skeleton();
+        zero_page.set_efi_system_table(PhysAddr::new(
+            VirtAddr::from_ptr(Box::leak(system_table)).as_u64(),
+        ))
+    }
 
     log::info!("jumping to kernel at {:#018x}", entry.as_u64());
 

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -300,6 +300,12 @@ impl ZeroPage {
         // of RAM.
         self.inner.hdr.ramdisk_size = ram_disk.len() as u32;
     }
+
+    /// Sets the address of the EFI system table.
+    pub fn set_efi_system_table(&mut self, efi_info: PhysAddr) {
+        self.inner.efi_info.efi_systab = efi_info.as_u64() as u32;
+        self.inner.efi_info.efi_systab_hi = (efi_info.as_u64() >> 32) as u32;
+    }
 }
 
 /// Builds an E820 table by reading the low and high memory amount from CMOS.

--- a/stage0_bin/Cargo.lock
+++ b/stage0_bin/Cargo.lock
@@ -151,6 +151,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +461,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.4.0",
  "coset",
+ "crc",
  "elf",
  "hex",
  "hkdf",


### PR DESCRIPTION
This might not be enough to convince Linux that it should read the EFI tables, but I think this should be the first attempt (and let's see whether it's palatable or it throws errors at us).

If this doesn't work, then the next step would be to set `zero_page.efi_info.efi_loader_signature` to `EL64` which should make Linux think it's booting under EFI -- but this may have other adverse effects as we're not setting anything up in the table itself.

I have my doubts whether this approach is feasible at all, therefore I've gated the whole thing behind a feature.