### PR TITLE
Change the default CPU target to `x86-64-v3`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,8 @@
 rustflags = [
   "-C",
   "link-args=-Xlinker --build-id=none",
+  "-C",
+  "target-cpu=x86-64-v3",
   # Enable `tokio_unstable` so that we can access the Tokio runtime metrics.
   "--cfg",
   "tokio_unstable"
@@ -23,6 +25,8 @@ rustflags = [
 rustflags = [
   "-C",
   "link-args=-Xlinker --build-id=none",
+  "-C",
+  "target-cpu=x86-64-v3",
   # Enable `tokio_unstable` so that we can access the Tokio runtime metrics.
   "--cfg",
   "tokio_unstable"

--- a/enclave_apps/.cargo/config.toml
+++ b/enclave_apps/.cargo/config.toml
@@ -2,4 +2,4 @@
 target = "x86_64-unknown-none"
 
 [target.x86_64-unknown-none]
-rustflags = "-C relocation-model=static -C code-model=small -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,+rdrand,-soft-float"
+rustflags = "-C relocation-model=static -C code-model=small -C target-feature=+sse,+sse2,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,+rdrand,-soft-float -C target-cpu=x86-64-v3"


### PR DESCRIPTION
The default target CPU is `x86-64`, which is fairly conservative; this will change the default target to `x86-64-v3`, which is roughly the feature set of Nehalem (which in itself is 10 years old by now).

It would obviously be even better to compile for the particular CPU you're going to run on, but we can't reliably predict which CPU we're going to run the binary on, so we'll have to choose something generic.

What features does v3 enable?
```
+target_feature="avx"
+target_feature="avx2"
+target_feature="bmi1"
+target_feature="bmi2"
+target_feature="cmpxchg16b"
+target_feature="f16c"
+target_feature="fma"
+target_feature="lzcnt"
+target_feature="movbe"
+target_feature="popcnt"
+target_feature="sse3"
+target_feature="sse4.1"
+target_feature="sse4.2"
+target_feature="ssse3"
+target_feature="xsave"
```

Simply enabling newer SSE flavours and AVX should make many operations faster, for free.