### PR TITLE
Make oak_restricted_kernel_wrapper configurable

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,11 +22,14 @@ oak_functions_insecure_enclave_app:
 oak_restricted_kernel_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --bin=oak_restricted_kernel_bin
 
+oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
+    env --chdir=oak_restricted_kernel_wrapper cargo objcopy --release --features=oak_restricted_kernel_bin -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
+
 oak_restricted_kernel_simple_io_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
 
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
-    env --chdir=oak_restricted_kernel_wrapper cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
+    env --chdir=oak_restricted_kernel_wrapper cargo objcopy --release --features=oak_restricted_kernel_simple_io_bin -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
 
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ oak_restricted_kernel_simple_io_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
 
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
-    env --chdir=oak_restricted_kernel_wrapper cargo objcopy --release --features=oak_restricted_kernel_simple_io_bin -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
+    env --chdir=oak_restricted_kernel_wrapper cargo objcopy --release --no-default-features --features=oak_restricted_kernel_simple_io_bin -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
 
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin

--- a/oak_restricted_kernel_wrapper/Cargo.toml
+++ b/oak_restricted_kernel_wrapper/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-default = []
+default = ["oak_restricted_kernel_bin"]
 oak_restricted_kernel_simple_io_bin = []
 oak_restricted_kernel_bin = []
 

--- a/oak_restricted_kernel_wrapper/Cargo.toml
+++ b/oak_restricted_kernel_wrapper/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Conrad Grobler <grobler@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = []
+oak_restricted_kernel_simple_io_bin = []
+oak_restricted_kernel_bin = []
+
 [workspace]
 resolver = "2"
 members = ["."]

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -24,7 +24,18 @@ fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rustc-link-arg=--script=layout.ld");
     let kernel_directory = "oak_restricted_kernel_bin";
-    let file_name = "oak_restricted_kernel_simple_io_bin";
+    let file_name = match (cfg!(feature = "oak_restricted_kernel_bin"), cfg!(feature = "oak_restricted_kernel_simple_io_bin")) {
+        (true, false) => "oak_restricted_kernel_bin",
+        (false, true) => "oak_restricted_kernel_simple_io_bin",
+        (true, true) => panic!("oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin cannot be enabled at the same time. Only either version can be built."),
+        (false, false) => panic!("One of oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin must be enabled.")
+    };
+
+    if cfg!(feature = "oak_restricted_kernel_simple_io_bin") {
+        "oak_restricted_kernel_simple_io_bin"
+    } else {
+        "oak_restricted_kernel_bin"
+    };
 
     // The source file is the output from building "../oak_restricted_kernel_bin" in release mode.
     let mut source_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -20,7 +20,7 @@ use std::{
     path::PathBuf,
 };
 
-// returns source_path if it can be constructed and if points to a valid file
+// returns source_path if it can be constructed and if it points to a valid file
 fn try_source_path() -> Result<PathBuf, &'static str> {
     let kernel_directory = "oak_restricted_kernel_bin";
     let file_name = match (cfg!(feature = "oak_restricted_kernel_bin"), cfg!(feature = "oak_restricted_kernel_simple_io_bin")) {

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -20,16 +20,15 @@ use std::{
     path::PathBuf,
 };
 
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rustc-link-arg=--script=layout.ld");
+// returns source_path if it can be constructed and if points to a valid file
+fn try_source_path() -> Result<PathBuf, &'static str> {
     let kernel_directory = "oak_restricted_kernel_bin";
     let file_name = match (cfg!(feature = "oak_restricted_kernel_bin"), cfg!(feature = "oak_restricted_kernel_simple_io_bin")) {
-        (true, false) => "oak_restricted_kernel_bin",
-        (false, true) => "oak_restricted_kernel_simple_io_bin",
-        (true, true) => panic!("Feature oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin cannot be enabled at the same time. Only either version can be built."),
-        (false, false) => panic!("One of feature oak_restricted_kernel_simple_io_bin or feature oak_restricted_kernel_bin must be enabled.")
-    };
+        (true, false) => Ok("oak_restricted_kernel_bin"),
+        (false, true) => Ok("oak_restricted_kernel_simple_io_bin"),
+        (true, true) => Err("Feature oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin cannot be enabled at the same time. Only either version can be built."),
+        (false, false) => Err("One of feature oak_restricted_kernel_simple_io_bin or feature oak_restricted_kernel_bin must be enabled.")
+    }?;
 
     // The source file is the output from building "../oak_restricted_kernel_bin" in release mode.
     let mut source_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -37,16 +36,34 @@ fn main() {
     source_path.push(kernel_directory);
     source_path.push("target/x86_64-unknown-none/release");
     source_path.push(file_name);
+    match source_path.exists() {
+        true => Ok(source_path),
+        false => Err("contructed source_path does not exist"),
+    }
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rustc-link-arg=--script=layout.ld");
     let mut destination_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    destination_path.push(file_name);
-    if source_path.exists() {
-        copy(&source_path, &destination_path).unwrap();
-    } else {
-        // Create a fake file so cargo clippy doesn't break if the kernel was not built.
-        File::create(&destination_path)
-            .unwrap()
-            .write_all(b"invalid")
-            .unwrap();
+    match try_source_path() {
+        Ok(source_path) => {
+            destination_path.push(source_path.file_name().unwrap());
+            copy(&source_path, &destination_path).unwrap();
+        }
+        Err(msg) => {
+            let msg = format!(
+                "Kernel could not be built! An error occured when building: {}",
+                msg
+            );
+            println!("cargo:warning={}", msg.as_str());
+            // Create a fake file so cargo clippy doesn't break if the kernel was not built.
+            destination_path.push("invalid_build");
+            File::create(&destination_path)
+                .unwrap()
+                .write_all(msg.as_bytes())
+                .unwrap();
+        }
     }
 
     println!(

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -27,8 +27,8 @@ fn main() {
     let file_name = match (cfg!(feature = "oak_restricted_kernel_bin"), cfg!(feature = "oak_restricted_kernel_simple_io_bin")) {
         (true, false) => "oak_restricted_kernel_bin",
         (false, true) => "oak_restricted_kernel_simple_io_bin",
-        (true, true) => panic!("oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin cannot be enabled at the same time. Only either version can be built."),
-        (false, false) => panic!("One of oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin must be enabled.")
+        (true, true) => panic!("feature oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin cannot be enabled at the same time. Only either version can be built."),
+        (false, false) => panic!("One of feature oak_restricted_kernel_simple_io_bin or feature oak_restricted_kernel_bin must be enabled.")
     };
 
     if cfg!(feature = "oak_restricted_kernel_simple_io_bin") {

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -31,12 +31,6 @@ fn main() {
         (false, false) => panic!("One of feature oak_restricted_kernel_simple_io_bin or feature oak_restricted_kernel_bin must be enabled.")
     };
 
-    if cfg!(feature = "oak_restricted_kernel_simple_io_bin") {
-        "oak_restricted_kernel_simple_io_bin"
-    } else {
-        "oak_restricted_kernel_bin"
-    };
-
     // The source file is the output from building "../oak_restricted_kernel_bin" in release mode.
     let mut source_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     source_path.pop();

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -27,7 +27,7 @@ fn main() {
     let file_name = match (cfg!(feature = "oak_restricted_kernel_bin"), cfg!(feature = "oak_restricted_kernel_simple_io_bin")) {
         (true, false) => "oak_restricted_kernel_bin",
         (false, true) => "oak_restricted_kernel_simple_io_bin",
-        (true, true) => panic!("feature oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin cannot be enabled at the same time. Only either version can be built."),
+        (true, true) => panic!("Feature oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin cannot be enabled at the same time. Only either version can be built."),
         (false, false) => panic!("One of feature oak_restricted_kernel_simple_io_bin or feature oak_restricted_kernel_bin must be enabled.")
     };
 


### PR DESCRIPTION
One can now specify which kernel binary should be wrapped using feature flags.