### PR TITLE
Don't bother with in-place encryption in oak_crypto

### DIFF
--- a/oak_crypto/src/hpke/aead.rs
+++ b/oak_crypto/src/hpke/aead.rs
@@ -19,7 +19,10 @@
 
 use alloc::vec::Vec;
 
-use aes_gcm::{aead::AeadInPlace, Aes256Gcm, Key, KeyInit, Nonce};
+use aes_gcm::{
+    aead::{Aead, Payload},
+    Aes256Gcm, Key, KeyInit,
+};
 use anyhow::anyhow;
 
 /// Represents `N_k` from RFC9180.
@@ -44,11 +47,15 @@ pub(crate) fn encrypt(
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(secret_key));
 
     // Encrypt message.
-    let mut ciphertext = plaintext.to_vec();
     cipher
-        .encrypt_in_place(Nonce::from_slice(nonce), associated_data, &mut ciphertext)
-        .map_err(|error| anyhow!("couldn't encrypt data: {}", error))?;
-    Ok(ciphertext)
+        .encrypt(
+            nonce.into(),
+            Payload {
+                msg: plaintext,
+                aad: associated_data,
+            },
+        )
+        .map_err(|error| anyhow!("couldn't encrypt data: {}", error))
 }
 
 /// Decrypts `ciphertext` and authenticates `associated_data` using AES-GCM encryption scheme.
@@ -61,10 +68,13 @@ pub(crate) fn decrypt(
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(secret_key));
 
     // Decrypt message.
-    let mut plaintext = ciphertext.to_vec();
     cipher
-        .decrypt_in_place(Nonce::from_slice(nonce), associated_data, &mut plaintext)
-        .map_err(|error| anyhow!("couldn't decrypt data: {}", error))?;
-
-    Ok(plaintext)
+        .decrypt(
+            nonce.into(),
+            Payload {
+                msg: ciphertext,
+                aad: associated_data,
+            },
+        )
+        .map_err(|error| anyhow!("couldn't decrypt data: {}", error))
 }


### PR DESCRIPTION
Right now we take in a slice, turn it into a vector (which entails an allocation + copy), and then call `encrypt_in_place` which explicitly states in the documentation that the ciphertext will be larger than the original, therefore the `Vec` will be reallocated (and possibly copied) at least once more.

I don't think we need to bother with any of that. Just use `encrypt` and `decrypt`, which return Vec-s directly.