### PR TITLE
Re-export oak_core as utils in SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,6 +2684,7 @@ dependencies = [
  "lazy_static",
  "log",
  "oak_channel",
+ "oak_core",
  "oak_crypto",
  "oak_dice",
  "oak_enclave_runtime_support",

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -750,7 +750,6 @@ version = "0.1.0"
 dependencies = [
  "log",
  "micro_rpc",
- "oak_core",
  "oak_echo_service",
  "oak_restricted_kernel_sdk",
 ]
@@ -801,7 +800,6 @@ version = "0.1.0"
 dependencies = [
  "log",
  "micro_rpc",
- "oak_core",
  "oak_functions_enclave_service",
  "oak_restricted_kernel_sdk",
 ]
@@ -879,6 +877,7 @@ dependencies = [
  "lazy_static",
  "log",
  "oak_channel",
+ "oak_core",
  "oak_crypto",
  "oak_dice",
  "oak_enclave_runtime_support",

--- a/enclave_apps/Cargo.toml
+++ b/enclave_apps/Cargo.toml
@@ -11,4 +11,3 @@ members = [
 micro_rpc = { path = "../micro_rpc" }
 oak_restricted_kernel_sdk = { path = "../oak_restricted_kernel_sdk" }
 oak_restricted_kernel_interface = { path = "../oak_restricted_kernel_interface" }
-oak_core = { path = "../oak_core" }

--- a/enclave_apps/oak_echo_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_echo_enclave_app/Cargo.toml
@@ -10,7 +10,6 @@ oak_echo_service = { path = "../../testing/oak_echo_service" }
 log = "*"
 micro_rpc = { workspace = true }
 oak_restricted_kernel_sdk = { workspace = true }
-oak_core = { workspace = true }
 
 [[bin]]
 name = "oak_echo_enclave_app"

--- a/enclave_apps/oak_echo_enclave_app/src/main.rs
+++ b/enclave_apps/oak_echo_enclave_app/src/main.rs
@@ -22,8 +22,9 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 
-use oak_core::samplestore::StaticSampleStore;
-use oak_restricted_kernel_sdk::{entrypoint, start_blocking_server, FileDescriptorChannel};
+use oak_restricted_kernel_sdk::{
+    entrypoint, start_blocking_server, utils::samplestore::StaticSampleStore, FileDescriptorChannel,
+};
 
 // Starts an echo server that uses the Oak communication channel:
 // https://github.com/project-oak/oak/blob/main/oak_channel/SPEC.md

--- a/enclave_apps/oak_functions_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_functions_enclave_app/Cargo.toml
@@ -20,7 +20,6 @@ oak_functions_enclave_service = { path = "../../oak_functions_enclave_service", 
 log = "*"
 micro_rpc = { workspace = true }
 oak_restricted_kernel_sdk = { workspace = true }
-oak_core = { workspace = true }
 
 [[bin]]
 name = "oak_functions_enclave_app"

--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -22,8 +22,9 @@ extern crate alloc;
 
 use alloc::{boxed::Box, sync::Arc};
 
-use oak_core::samplestore::StaticSampleStore;
-use oak_restricted_kernel_sdk::{entrypoint, start_blocking_server, FileDescriptorChannel};
+use oak_restricted_kernel_sdk::{
+    entrypoint, start_blocking_server, utils::samplestore::StaticSampleStore, FileDescriptorChannel,
+};
 
 #[entrypoint]
 fn main() -> ! {

--- a/oak_restricted_kernel_sdk/Cargo.toml
+++ b/oak_restricted_kernel_sdk/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { version = "*", default-features = false }
 log = "*"
 oak_channel = { workspace = true }
 oak_crypto = { workspace = true }
+oak_core = { workspace = true }
 oak_dice = { workspace = true }
 oak_restricted_kernel_interface = { workspace = true }
 oak_enclave_runtime_support = { workspace = true }

--- a/oak_restricted_kernel_sdk/src/lib.rs
+++ b/oak_restricted_kernel_sdk/src/lib.rs
@@ -26,6 +26,7 @@ pub use channel::*;
 pub use dice::*;
 pub use logging::StderrLogger;
 use logging::STDERR_LOGGER;
+pub use oak_core as utils;
 pub use oak_restricted_kernel_sdk_proc_macro::entrypoint;
 
 /// Initialization function that sets up the allocator and logger.


### PR DESCRIPTION
oak_core datastructures are used in interfaces exposed by the SDK