### PR TITLE
SDK: Only define global alloc in code output by entrypoint macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ oak_containers_sdk = { path = "./oak_containers_sdk" }
 oak_core = { path = "./oak_core" }
 oak_crypto = { path = "./oak_crypto" }
 oak_dice = { path = "./oak_dice" }
-oak_enclave_runtime_support = { path = "./oak_enclave_runtime_support" }
+oak_enclave_runtime_support = { path = "./oak_enclave_runtime_support", default-features = false }
 oak_functions_abi = { path = "./oak_functions_abi" }
 oak_functions_client = { path = "./oak_functions_client" }
 oak_functions_launcher = { path = "./oak_functions_launcher" }

--- a/oak_enclave_runtime_support/Cargo.toml
+++ b/oak_enclave_runtime_support/Cargo.toml
@@ -5,10 +5,6 @@ authors = ["Andri Saar <andrisaar@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
-[features]
-default = ["global_allocator"]
-global_allocator = []
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 libm = "*"

--- a/oak_enclave_runtime_support/Cargo.toml
+++ b/oak_enclave_runtime_support/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Andri Saar <andrisaar@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = ["global_allocator"]
+global_allocator = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 libm = "*"

--- a/oak_enclave_runtime_support/README.md
+++ b/oak_enclave_runtime_support/README.md
@@ -6,4 +6,4 @@
 
 Runtime support library for applications built for Oak Restricted Kernel.
 
-For now, the runtime support library only sets up the global heap allocator.
+For now, the runtime support library provides a global heap allocator.

--- a/oak_enclave_runtime_support/src/heap.rs
+++ b/oak_enclave_runtime_support/src/heap.rs
@@ -79,11 +79,6 @@ impl GrowableHeap {
         }
     }
 
-    /// # Safety
-    ///
-    /// Upheld by caller.
-    pub unsafe fn init(&mut self) {}
-
     #[allow(clippy::result_unit_err)]
     pub fn allocate(&mut self, layout: Layout) -> Result<NonNull<u8>, ()> {
         self.heap

--- a/oak_enclave_runtime_support/src/heap.rs
+++ b/oak_enclave_runtime_support/src/heap.rs
@@ -79,14 +79,23 @@ impl GrowableHeap {
         }
     }
 
+    /// # Safety
+    ///
+    /// Upheld by caller.
     pub unsafe fn init(&mut self) {}
 
+    #[allow(clippy::result_unit_err)]
     pub fn allocate(&mut self, layout: Layout) -> Result<NonNull<u8>, ()> {
         self.heap
             .allocate(layout)
             .ok_or_else(|| log::error!("failed to allocate memory with layout: {:?}", layout))
     }
 
+    /// # Safety
+    ///
+    ///  - `ptr` must denote a memory block previously allocated via `self`.
+    ///  - The memory block must have been allocated with the same alignment ([`Layout::align`]) as
+    ///    `align`.
     pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, align: usize) {
         self.heap.deallocate(ptr, align)
     }

--- a/oak_enclave_runtime_support/src/lib.rs
+++ b/oak_enclave_runtime_support/src/lib.rs
@@ -21,7 +21,7 @@ use heap::LockedGrowableHeap;
 mod heap;
 mod libm;
 
-#[cfg_attr(not(test), global_allocator)]
+#[cfg_attr(all(not(test), feature = "global_allocator"), global_allocator)]
 static ALLOCATOR: LockedGrowableHeap = LockedGrowableHeap::empty();
 
 pub fn init() {

--- a/oak_enclave_runtime_support/src/lib.rs
+++ b/oak_enclave_runtime_support/src/lib.rs
@@ -16,16 +16,7 @@
 
 #![no_std]
 
-use heap::LockedGrowableHeap;
+pub use heap::LockedGrowableHeap;
 
 mod heap;
 mod libm;
-
-#[cfg_attr(not(test), global_allocator)]
-static ALLOCATOR: LockedGrowableHeap = LockedGrowableHeap::empty();
-
-pub fn init() {
-    unsafe {
-        ALLOCATOR.lock().init();
-    }
-}

--- a/oak_enclave_runtime_support/src/lib.rs
+++ b/oak_enclave_runtime_support/src/lib.rs
@@ -16,7 +16,16 @@
 
 #![no_std]
 
-pub use heap::LockedGrowableHeap;
+use heap::LockedGrowableHeap;
 
 mod heap;
 mod libm;
+
+#[cfg_attr(all(not(test), feature = "global_allocator"), global_allocator)]
+static ALLOCATOR: LockedGrowableHeap = LockedGrowableHeap::empty();
+
+pub fn init() {
+    unsafe {
+        ALLOCATOR.lock().init();
+    }
+}

--- a/oak_enclave_runtime_support/src/lib.rs
+++ b/oak_enclave_runtime_support/src/lib.rs
@@ -21,7 +21,7 @@ use heap::LockedGrowableHeap;
 mod heap;
 mod libm;
 
-#[cfg_attr(all(not(test), feature = "global_allocator"), global_allocator)]
+#[cfg_attr(not(test), global_allocator)]
 static ALLOCATOR: LockedGrowableHeap = LockedGrowableHeap::empty();
 
 pub fn init() {

--- a/oak_enclave_runtime_support/src/lib.rs
+++ b/oak_enclave_runtime_support/src/lib.rs
@@ -18,7 +18,7 @@
 
 use heap::LockedGrowableHeap;
 
-mod heap;
+pub mod heap;
 mod libm;
 
 #[cfg_attr(all(not(test), feature = "global_allocator"), global_allocator)]

--- a/oak_enclave_runtime_support/src/lib.rs
+++ b/oak_enclave_runtime_support/src/lib.rs
@@ -21,11 +21,9 @@ use heap::LockedGrowableHeap;
 pub mod heap;
 mod libm;
 
-#[cfg_attr(all(not(test), feature = "global_allocator"), global_allocator)]
+#[cfg(feature = "global_allocator")]
+#[global_allocator]
 static ALLOCATOR: LockedGrowableHeap = LockedGrowableHeap::empty();
 
-pub fn init() {
-    unsafe {
-        ALLOCATOR.lock().init();
-    }
-}
+#[deprecated(note = "please make use of `oak_restricted_kernel_sdk::entrypoint` instead.")]
+pub fn init() {}

--- a/oak_functions_enclave_service/Cargo.toml
+++ b/oak_functions_enclave_service/Cargo.toml
@@ -27,6 +27,6 @@ log = "*"
 env_logger = { version = "*", default-features = false }
 oak_attestation = { workspace = true }
 oak_functions_test_utils = { workspace = true }
-oak_restricted_kernel_sdk = { workspace = true, features = [
+oak_restricted_kernel_sdk = { workspace = true, default-features = false, features = [
   "mock_attestation"
 ] }

--- a/oak_functions_enclave_service/Cargo.toml
+++ b/oak_functions_enclave_service/Cargo.toml
@@ -27,6 +27,6 @@ log = "*"
 env_logger = { version = "*", default-features = false }
 oak_attestation = { workspace = true }
 oak_functions_test_utils = { workspace = true }
-oak_restricted_kernel_sdk = { workspace = true, default-features = false, features = [
+oak_restricted_kernel_sdk = { workspace = true, features = [
   "mock_attestation"
 ] }

--- a/oak_restricted_kernel_sdk/Cargo.toml
+++ b/oak_restricted_kernel_sdk/Cargo.toml
@@ -17,7 +17,7 @@ oak_crypto = { workspace = true }
 oak_core = { workspace = true }
 oak_dice = { workspace = true }
 oak_restricted_kernel_interface = { workspace = true }
-oak_enclave_runtime_support = { workspace = true }
+oak_enclave_runtime_support = { default-features = false, workspace = true }
 oak_restricted_kernel_sdk_proc_macro = { workspace = true }
 oak_restricted_kernel_dice = { workspace = true, optional = true }
 oak_stage0_dice = { workspace = true, optional = true }

--- a/oak_restricted_kernel_sdk/Cargo.toml
+++ b/oak_restricted_kernel_sdk/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
+default = ["global_allocator"]
+global_allocator = ["oak_enclave_runtime_support/global_allocator"]
 # Functionality to create and use mock attestations. Helpful for tests.
 mock_attestation = ["oak_stage0_dice", "oak_restricted_kernel_dice"]
 
@@ -16,7 +18,7 @@ oak_channel = { workspace = true }
 oak_crypto = { workspace = true }
 oak_dice = { workspace = true }
 oak_restricted_kernel_interface = { workspace = true }
-oak_enclave_runtime_support = { workspace = true }
+oak_enclave_runtime_support = { workspace = true, optional = true }
 oak_restricted_kernel_sdk_proc_macro = { workspace = true }
 oak_restricted_kernel_dice = { workspace = true, optional = true }
 oak_stage0_dice = { workspace = true, optional = true }

--- a/oak_restricted_kernel_sdk/Cargo.toml
+++ b/oak_restricted_kernel_sdk/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-default = ["global_allocator"]
-global_allocator = ["oak_enclave_runtime_support/global_allocator"]
 # Functionality to create and use mock attestations. Helpful for tests.
 mock_attestation = ["oak_stage0_dice", "oak_restricted_kernel_dice"]
 
@@ -18,7 +16,7 @@ oak_channel = { workspace = true }
 oak_crypto = { workspace = true }
 oak_dice = { workspace = true }
 oak_restricted_kernel_interface = { workspace = true }
-oak_enclave_runtime_support = { workspace = true, optional = true }
+oak_enclave_runtime_support = { workspace = true }
 oak_restricted_kernel_sdk_proc_macro = { workspace = true }
 oak_restricted_kernel_dice = { workspace = true, optional = true }
 oak_stage0_dice = { workspace = true, optional = true }

--- a/oak_restricted_kernel_sdk/src/lib.rs
+++ b/oak_restricted_kernel_sdk/src/lib.rs
@@ -25,15 +25,7 @@ mod logging;
 pub use channel::*;
 pub use dice::*;
 pub use logging::StderrLogger;
-use logging::STDERR_LOGGER;
 pub use oak_restricted_kernel_sdk_proc_macro::entrypoint;
-
-/// Initialization function that sets up the allocator and logger.
-pub fn init(log_level: log::LevelFilter) {
-    log::set_logger(&STDERR_LOGGER).expect("failed to set logger");
-    log::set_max_level(log_level);
-    oak_enclave_runtime_support::init();
-}
 
 pub fn alloc_error_handler(layout: ::core::alloc::Layout) -> ! {
     panic!("error allocating memory: {:#?}", layout);

--- a/oak_restricted_kernel_sdk/src/lib.rs
+++ b/oak_restricted_kernel_sdk/src/lib.rs
@@ -22,10 +22,14 @@ mod channel;
 mod dice;
 mod logging;
 
+pub mod utils {
+    pub use oak_core::*;
+    pub use oak_enclave_runtime_support::heap;
+}
+
 pub use channel::*;
 pub use dice::*;
 pub use logging::StderrLogger;
-pub use oak_core as utils;
 pub use oak_restricted_kernel_sdk_proc_macro::entrypoint;
 
 pub fn alloc_error_handler(layout: ::core::alloc::Layout) -> ! {

--- a/oak_restricted_kernel_sdk/src/logging.rs
+++ b/oak_restricted_kernel_sdk/src/logging.rs
@@ -18,8 +18,6 @@ use core::fmt::Write;
 
 use oak_restricted_kernel_interface::syscall::{fsync, write};
 
-pub static STDERR_LOGGER: StderrLogger = StderrLogger {};
-
 struct Stderr {}
 
 impl Stderr {

--- a/oak_restricted_kernel_sdk_proc_macro/src/lib.rs
+++ b/oak_restricted_kernel_sdk_proc_macro/src/lib.rs
@@ -63,7 +63,7 @@ fn process_entry_fn(entry_fn: ItemFn) -> TokenStream {
         #entry_fn
 
         #[global_allocator]
-        static ALLOCATOR: LockedGrowableHeap = LockedGrowableHeap::empty();
+        static ALLOCATOR: oak_restricted_kernel_sdk::utils::LockedGrowableHeap = oak_restricted_kernel_sdk::utils::LockedGrowableHeap::empty();
 
         static LOGGER: oak_restricted_kernel_sdk::StderrLogger = oak_restricted_kernel_sdk::StderrLogger {};
 

--- a/oak_restricted_kernel_sdk_proc_macro/src/lib.rs
+++ b/oak_restricted_kernel_sdk_proc_macro/src/lib.rs
@@ -69,9 +69,6 @@ fn process_entry_fn(entry_fn: ItemFn) -> TokenStream {
 
         #[no_mangle]
         fn _start() -> ! {
-            unsafe {
-                ALLOCATOR.lock().init();
-            }
             log::set_logger(&LOGGER).expect("failed to set logger");
             log::set_max_level(log::LevelFilter::Debug);
             log::info!("In main!");

--- a/oak_restricted_kernel_sdk_proc_macro/src/lib.rs
+++ b/oak_restricted_kernel_sdk_proc_macro/src/lib.rs
@@ -62,11 +62,18 @@ fn process_entry_fn(entry_fn: ItemFn) -> TokenStream {
     let generated = quote! {
         #entry_fn
 
+        #[global_allocator]
+        static ALLOCATOR: LockedGrowableHeap = LockedGrowableHeap::empty();
+
         static LOGGER: oak_restricted_kernel_sdk::StderrLogger = oak_restricted_kernel_sdk::StderrLogger {};
 
         #[no_mangle]
         fn _start() -> ! {
-            oak_restricted_kernel_sdk::init(log::LevelFilter::Debug);
+            unsafe {
+                ALLOCATOR.lock().init();
+            }
+            log::set_logger(&STDERR_LOGGER).expect("failed to set logger");
+            log::set_max_level(log::LevelFilter::Debug);
             log::info!("In main!");
             #entry_fn_name();
         }

--- a/oak_restricted_kernel_sdk_proc_macro/src/lib.rs
+++ b/oak_restricted_kernel_sdk_proc_macro/src/lib.rs
@@ -63,7 +63,7 @@ fn process_entry_fn(entry_fn: ItemFn) -> TokenStream {
         #entry_fn
 
         #[global_allocator]
-        static ALLOCATOR: oak_restricted_kernel_sdk::utils::LockedGrowableHeap = oak_restricted_kernel_sdk::utils::LockedGrowableHeap::empty();
+        static ALLOCATOR: oak_restricted_kernel_sdk::utils::heap::LockedGrowableHeap = oak_restricted_kernel_sdk::utils::heap::LockedGrowableHeap::empty();
 
         static LOGGER: oak_restricted_kernel_sdk::StderrLogger = oak_restricted_kernel_sdk::StderrLogger {};
 
@@ -72,7 +72,7 @@ fn process_entry_fn(entry_fn: ItemFn) -> TokenStream {
             unsafe {
                 ALLOCATOR.lock().init();
             }
-            log::set_logger(&STDERR_LOGGER).expect("failed to set logger");
+            log::set_logger(&LOGGER).expect("failed to set logger");
             log::set_max_level(log::LevelFilter::Debug);
             log::info!("In main!");
             #entry_fn_name();


### PR DESCRIPTION
It's inconvenient to inadvertently declare a global alloc when importing the sdk for crate for unit tests. Hence this makes sure it only happens for enclave binaries.