### PR TITLE
Remove some seemingly unnecessary `mut`-s in the crypto code

### DIFF
--- a/oak_attestation/src/handler.rs
+++ b/oak_attestation/src/handler.rs
@@ -61,7 +61,7 @@ impl<H: FnOnce(Vec<u8>) -> Vec<u8>> EncryptionHandler<H> {
             .serialized_encapsulated_public_key
             .as_ref()
             .context("initial request message doesn't contain encapsulated public key")?;
-        let mut server_encryptor = ServerEncryptor::create(
+        let server_encryptor = ServerEncryptor::create(
             serialized_encapsulated_public_key,
             self.encryption_key_handle.clone(),
         )

--- a/oak_containers_orchestrator/src/crypto.rs
+++ b/oak_containers_orchestrator/src/crypto.rs
@@ -71,7 +71,7 @@ impl InstanceKeyStore {
             .serialized_encapsulated_public_key
             .as_ref()
             .context("encapsulated public key wasn't provided")?;
-        let mut server_encryptor = ServerEncryptor::create(
+        let server_encryptor = ServerEncryptor::create(
             encapsulated_public_key,
             self.instance_encryption_key.clone(),
         )

--- a/oak_crypto/src/encryptor.rs
+++ b/oak_crypto/src/encryptor.rs
@@ -197,7 +197,7 @@ impl ClientEncryptor {
     /// Returns a response message plaintext and associated data.
     /// <https://datatracker.ietf.org/doc/html/rfc5116>
     pub fn decrypt(
-        &mut self,
+        &self,
         encrypted_response: &EncryptedResponse,
     ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
         let encrypted_message = encrypted_response
@@ -248,7 +248,7 @@ impl ServerEncryptor {
     /// Returns a response message plaintext and associated data.
     /// <https://datatracker.ietf.org/doc/html/rfc5116>
     pub fn decrypt(
-        &mut self,
+        &self,
         encrypted_request: &EncryptedRequest,
     ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
         let encrypted_message = encrypted_request
@@ -273,7 +273,7 @@ impl ServerEncryptor {
     /// Returns a [`EncryptedResponse`] proto message.
     /// <https://datatracker.ietf.org/doc/html/rfc5116>
     pub fn encrypt(
-        &mut self,
+        &self,
         plaintext: &[u8],
         associated_data: &[u8],
     ) -> anyhow::Result<EncryptedResponse> {
@@ -329,7 +329,7 @@ where
         &mut self,
         encrypted_request: &EncryptedRequest,
     ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
-        match &mut self.inner {
+        match &self.inner {
             Some(inner) => inner.decrypt(encrypted_request),
             None => {
                 let serialized_encapsulated_public_key = encrypted_request
@@ -341,7 +341,7 @@ where
                     .generate_recipient_context(serialized_encapsulated_public_key)
                     .await
                     .context("couldn't generate recipient crypto context")?;
-                let mut inner = ServerEncryptor::new(recipient_context);
+                let inner = ServerEncryptor::new(recipient_context);
                 let (plaintext, associated_data) = inner.decrypt(encrypted_request)?;
                 self.inner = Some(inner);
                 Ok((plaintext, associated_data))

--- a/oak_crypto/src/hpke/mod.rs
+++ b/oak_crypto/src/hpke/mod.rs
@@ -173,7 +173,7 @@ impl SenderContext {
     /// Encrypts request message with associated data using AEAD.
     /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
     pub(crate) fn seal(
-        &mut self,
+        &self,
         nonce: &AeadNonce,
         plaintext: &[u8],
         associated_data: &[u8],
@@ -188,7 +188,7 @@ impl SenderContext {
     /// communication.
     /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-bidirectional-encryption>
     pub(crate) fn open(
-        &mut self,
+        &self,
         nonce: &AeadNonce,
         ciphertext: &[u8],
         associated_data: &[u8],
@@ -209,7 +209,7 @@ impl RecipientContext {
     /// Decrypts request message and validates associated data using AEAD.
     /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption>
     pub(crate) fn open(
-        &mut self,
+        &self,
         nonce: &AeadNonce,
         ciphertext: &[u8],
         associated_data: &[u8],
@@ -224,7 +224,7 @@ impl RecipientContext {
     /// communication.
     /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-bidirectional-encryption>
     pub(crate) fn seal(
-        &mut self,
+        &self,
         nonce: &AeadNonce,
         plaintext: &[u8],
         associated_data: &[u8],

--- a/oak_crypto/src/tests.rs
+++ b/oak_crypto/src/tests.rs
@@ -71,12 +71,12 @@ fn test_aead() {
 #[test]
 fn test_hpke() {
     let recipient_key_pair = KeyPair::generate();
-    let (serialized_encapsulated_public_key, mut sender_context) = setup_base_sender(
+    let (serialized_encapsulated_public_key, sender_context) = setup_base_sender(
         &recipient_key_pair.get_serialized_public_key(),
         TEST_HPKE_INFO,
     )
     .expect("couldn't setup base sender");
-    let mut recipient_context = setup_base_recipient(
+    let recipient_context = setup_base_recipient(
         &serialized_encapsulated_public_key,
         &recipient_key_pair,
         TEST_HPKE_INFO,


### PR DESCRIPTION
As far as I can see these `mut`-s are not necessary as the code doesn't actually try to mutate anything and is stateless.

However, I believe there were some API design questions that might mandate the `mut`-s, so I'll defer to you whether this is just cruft that can be cleaned up or something we want to retain.