### PR TITLE
Merge `AsyncServerEncryptor` into `ServerEncryptor` (mostly)

### DIFF
--- a/oak_attestation/src/handler.rs
+++ b/oak_attestation/src/handler.rs
@@ -19,9 +19,7 @@ use core::future::Future;
 
 use anyhow::Context;
 use oak_crypto::{
-    encryptor::{
-        AsyncEncryptionKeyHandle, AsyncServerEncryptor, EncryptionKeyHandle, ServerEncryptor,
-    },
+    encryptor::{AsyncEncryptionKeyHandle, EncryptionKeyHandle, ServerEncryptor},
     proto::oak::crypto::v1::{EncryptedRequest, EncryptedResponse},
 };
 
@@ -56,21 +54,10 @@ impl<H: FnOnce(Vec<u8>) -> Vec<u8>> EncryptionHandler<H> {
 
 impl<H: FnOnce(Vec<u8>) -> Vec<u8>> EncryptionHandler<H> {
     pub fn invoke(self, encrypted_request: &EncryptedRequest) -> anyhow::Result<EncryptedResponse> {
-        // Initialize server encryptor.
-        let serialized_encapsulated_public_key = encrypted_request
-            .serialized_encapsulated_public_key
-            .as_ref()
-            .context("initial request message doesn't contain encapsulated public key")?;
-        let server_encryptor = ServerEncryptor::create(
-            serialized_encapsulated_public_key,
-            self.encryption_key_handle.clone(),
-        )
-        .context("couldn't create server encryptor")?;
-
         // Decrypt request.
-        let (request, _) = server_encryptor
-            .decrypt(encrypted_request)
-            .context("couldn't decrypt request")?;
+        let (server_encryptor, request, _) =
+            ServerEncryptor::decrypt(encrypted_request, self.encryption_key_handle.as_ref())
+                .context("couldn't create server encryptor")?;
 
         // Handle request.
         let response = (self.request_handler)(request);
@@ -115,14 +102,11 @@ where
         self,
         encrypted_request: &EncryptedRequest,
     ) -> anyhow::Result<EncryptedResponse> {
-        // Initialize server encryptor.
-        let mut server_encryptor = AsyncServerEncryptor::new(self.encryption_key_handle.as_ref());
-
         // Decrypt request.
-        let (request, _associated_data) = server_encryptor
-            .decrypt(encrypted_request)
-            .await
-            .context("couldn't decrypt request")?;
+        let (server_encryptor, request, _associated_data) =
+            ServerEncryptor::decrypt_async(encrypted_request, self.encryption_key_handle.as_ref())
+                .await
+                .context("couldn't decrypt request")?;
 
         // Handle request.
         let response = (self.request_handler)(request).await;

--- a/oak_containers_orchestrator/src/crypto.rs
+++ b/oak_containers_orchestrator/src/crypto.rs
@@ -67,20 +67,13 @@ impl InstanceKeyStore {
         let encrypted_encryption_private_key = group_keys
             .encrypted_encryption_private_key
             .context("encrypted encryption key wasn't provided")?;
-        let encapsulated_public_key = encrypted_encryption_private_key
-            .serialized_encapsulated_public_key
-            .as_ref()
-            .context("encapsulated public key wasn't provided")?;
-        let server_encryptor = ServerEncryptor::create(
-            encapsulated_public_key,
-            self.instance_encryption_key.clone(),
-        )
-        .context("couldn't create server encryptor")?;
 
         // Decrypt group keys.
-        let (decrypted_encryption_private_key, _) = server_encryptor
-            .decrypt(&encrypted_encryption_private_key)
-            .context("couldn't decrypt the encryption private key")?;
+        let (_, decrypted_encryption_private_key, _) = ServerEncryptor::decrypt(
+            &encrypted_encryption_private_key,
+            self.instance_encryption_key.as_ref(),
+        )
+        .context("couldn't decrypt the encryption private key")?;
 
         // Parse private key and derive public key.
         // TODO(#4513): We shouldn't store the public key, only the private key.

--- a/oak_crypto/src/tests.rs
+++ b/oak_crypto/src/tests.rs
@@ -14,19 +14,13 @@
 // limitations under the License.
 //
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-
-use anyhow::Context;
-use async_trait::async_trait;
+use alloc::sync::Arc;
 
 use crate::{
-    encryptor::{
-        AsyncEncryptionKeyHandle, AsyncServerEncryptor, ClientEncryptor, EncryptionKeyProvider,
-        ServerEncryptor, OAK_HPKE_INFO,
-    },
+    encryptor::{ClientEncryptor, EncryptionKeyProvider, ServerEncryptor},
     hpke::{
         aead::{AEAD_ALGORITHM_KEY_SIZE_BYTES, AEAD_NONCE_SIZE_BYTES},
-        generate_random_nonce, setup_base_recipient, setup_base_sender, KeyPair, RecipientContext,
+        generate_random_nonce, setup_base_recipient, setup_base_sender, KeyPair,
     },
 };
 
@@ -130,7 +124,6 @@ fn test_encryptor() {
 
     let mut client_encryptor = ClientEncryptor::create(&serialized_server_public_key)
         .expect("couldn't create client encryptor");
-    let mut server_encryptor = None;
 
     let encrypted_request = client_encryptor
         .encrypt(TEST_REQUEST_MESSAGE, TEST_REQUEST_ASSOCIATED_DATA)
@@ -146,28 +139,13 @@ fn test_encryptor() {
     );
 
     // Initialize server encryptor.
-    if server_encryptor.is_none() {
-        let serialized_encapsulated_public_key = encrypted_request
-            .serialized_encapsulated_public_key
-            .as_ref()
-            .expect("initial request message doesn't contain encapsulated public key");
-        server_encryptor = Some(
-            ServerEncryptor::create(serialized_encapsulated_public_key, encryption_key.clone())
-                .expect("couldn't create server encryptor"),
-        );
-    }
-
-    let (decrypted_request, request_associated_data) = server_encryptor
-        .as_mut()
-        .expect("server encryptor is not initialized")
-        .decrypt(&encrypted_request)
-        .expect("server couldn't decrypt request");
+    let (server_encryptor, decrypted_request, request_associated_data) =
+        ServerEncryptor::decrypt(&encrypted_request, encryption_key.as_ref())
+            .expect("server couldn't decrypt request");
     assert_eq!(TEST_REQUEST_MESSAGE, decrypted_request);
     assert_eq!(TEST_REQUEST_ASSOCIATED_DATA, request_associated_data);
 
     let encrypted_response = server_encryptor
-        .as_mut()
-        .expect("server encryptor is not initialized")
         .encrypt(TEST_RESPONSE_MESSAGE, TEST_RESPONSE_ASSOCIATED_DATA)
         .expect("server couldn't encrypt response");
     // Check that the message was encrypted.
@@ -186,47 +164,13 @@ fn test_encryptor() {
     assert_eq!(TEST_RESPONSE_ASSOCIATED_DATA, response_associated_data);
 }
 
-struct TestEncryptionKey {
-    key_pair: KeyPair,
-}
-
-impl Default for TestEncryptionKey {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl TestEncryptionKey {
-    pub fn new() -> Self {
-        Self {
-            key_pair: KeyPair::generate(),
-        }
-    }
-
-    pub fn get_serialized_public_key(&self) -> Vec<u8> {
-        self.key_pair.get_serialized_public_key()
-    }
-}
-
-#[async_trait]
-impl AsyncEncryptionKeyHandle for TestEncryptionKey {
-    async fn generate_recipient_context(
-        &self,
-        encapsulated_public_key: &[u8],
-    ) -> anyhow::Result<RecipientContext> {
-        setup_base_recipient(encapsulated_public_key, &self.key_pair, OAK_HPKE_INFO)
-            .context("couldn't generate recipient crypto context")
-    }
-}
-
 #[tokio::test]
 async fn test_async_encryptor() {
-    let encryption_key = TestEncryptionKey::new();
+    let encryption_key = Arc::new(EncryptionKeyProvider::generate());
     let serialized_server_public_key = encryption_key.get_serialized_public_key();
 
     let mut client_encryptor = ClientEncryptor::create(&serialized_server_public_key)
         .expect("couldn't create client encryptor");
-    let mut server_encryptor = AsyncServerEncryptor::new(&encryption_key);
 
     let encrypted_request = client_encryptor
         .encrypt(TEST_REQUEST_MESSAGE, TEST_REQUEST_ASSOCIATED_DATA)
@@ -240,10 +184,12 @@ async fn test_async_encryptor() {
             .unwrap()
             .ciphertext
     );
-    let (decrypted_request, request_associated_data) = server_encryptor
-        .decrypt(&encrypted_request)
-        .await
-        .expect("server couldn't decrypt request");
+
+    // Initialize server encryptor.
+    let (server_encryptor, decrypted_request, request_associated_data) =
+        ServerEncryptor::decrypt_async(&encrypted_request, encryption_key.as_ref())
+            .await
+            .expect("server couldn't decrypt request");
     assert_eq!(TEST_REQUEST_MESSAGE, decrypted_request);
     assert_eq!(TEST_REQUEST_ASSOCIATED_DATA, request_associated_data);
 


### PR DESCRIPTION
What started up as an endeavour to get rid of the `mut`-s in `AsyncServerEncryptor` ended up with an unified `ServerEncryptor`, with just a slightly different `create` method -- until hopefully one day we can unify all of it.

And, remove some hard dependencies on `Arc`-s while I'm in there. If we're not keeping a reference around, then there is no need for things to be wrapped in a smart pointer.

Ref #4311