### PR TITLE
Use jemalloc in the `oak_containers_orchestrator` as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,6 +2146,7 @@ dependencies = [
  "sha2",
  "syslog",
  "tar",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/oak_containers_orchestrator/Cargo.toml
+++ b/oak_containers_orchestrator/Cargo.toml
@@ -41,6 +41,7 @@ rand_core = { version = "*", default-features = false, features = [
 sha2 = { version = "*", default-features = false }
 syslog = "*"
 tar = "*"
+tikv-jemallocator = "*"
 tokio = { version = "*", features = [
   "rt-multi-thread",
   "macros",

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -25,6 +25,9 @@ use oak_containers_orchestrator::{
 use oak_dice::cert::generate_ecdsa_key_pair;
 use tokio_util::sync::CancellationToken;
 
+#[global_allocator]
+static ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(default_value = "http://10.0.2.100:8080")]

--- a/oak_containers_system_image/build.sh
+++ b/oak_containers_system_image/build.sh
@@ -8,7 +8,7 @@ set -o pipefail
 mkdir --parent target
 
 # build the orchestrator binary
-cargo build --package=oak_containers_orchestrator --release --target=x86_64-unknown-linux-musl -Z unstable-options --out-dir=./target
+cargo build --package=oak_containers_orchestrator --profile=release-lto --target=x86_64-unknown-linux-musl -Z unstable-options --out-dir=./target
 cargo build --package=oak_containers_syslogd --release -Z unstable-options --out-dir=./target
 
 # We need to patch the binary to set the interpreter to the correct location, but we can't do it in-place, as that would


### PR DESCRIPTION
Switching to jemalloc _drastically_ improved multithread performance of Oak Functions itself. As the orchestrator can also use multiple threads, let's use jemalloc there was well.

Clearly the default musl allocator is not that good in concurrent situations. I'm not expecting miracles here, but hey, every little helps.

And while I'm in here build the orchestrator with `release-lto` as well. This is likely to have even more miniscule effect, but might as well do it while I'm in here.