### PR TITLE
Remove non standard dice data type from E820 table

### DIFF
--- a/linux_boot_params/src/lib.rs
+++ b/linux_boot_params/src/lib.rs
@@ -46,9 +46,6 @@ pub enum E820EntryType {
     DISABLED = 6,
     /// Persistent memory: must be handled distinct from conventional volatile memory.
     PMEM = 7,
-    /// Custom implementation-defined value indicating that the memory region is used to pass
-    /// DICE-related information from Stage 0 to the next DICE stage.
-    DiceData = 0xFF000001,
 }
 
 bitflags! {

--- a/oak_containers_stage1/src/dice.rs
+++ b/oak_containers_stage1/src/dice.rs
@@ -95,7 +95,7 @@ fn read_stage0_dice_data(start: PhysAddr) -> anyhow::Result<Stage0DiceData> {
     let end = start + (length as u64 - 1);
     // Ensure that the memory range is in reserved memory.
     anyhow::ensure!(
-        !read_memory_ranges()?
+        read_memory_ranges()?
             .iter()
             .any(|range| range.type_description == RESERVED_E820_TYPE
                 && range.contains(&start)

--- a/oak_containers_stage1/src/dice.rs
+++ b/oak_containers_stage1/src/dice.rs
@@ -86,7 +86,7 @@ fn read_stage0_dice_data(start: PhysAddr) -> anyhow::Result<Stage0DiceData> {
     // Ensure that the memory range is in reserved memory.
     anyhow::ensure!(
         !read_memory_ranges()?.iter().any(|range| {
-            let dice_data_fully_contained_in_range = range.start <= start && range.end <= end;
+            let dice_data_fully_contained_in_range = range.start <= start && end <= range.end;
 
             range.type_description == RESERVED_E820_TYPE && dice_data_fully_contained_in_range
         }),

--- a/oak_containers_stage1/src/dice.rs
+++ b/oak_containers_stage1/src/dice.rs
@@ -32,12 +32,11 @@ use zeroize::Zeroize;
 
 use crate::try_parse_phys_addr;
 
-/// The expected string representation of the custom type for the reserved memory range that
-/// contains the DICE data.
+/// The expected string representation for reserved memory.
 ///
-/// Since we use a custom type the Linux Kernel does not recognize it. The text is defined in
+/// The text is defined in
 /// <https://github.com/torvalds/linux/blob/d88520ad73b79e71e3ddf08de335b8520ae41c5c/arch/x86/kernel/e820.c#L1086>.
-const EXPECTED_E820_TYPE: &str = "Unknown E820 type";
+const RESERVED_E820_TYPE: &str = "Reserved";
 
 /// The path for reading the memory map from the sysfs pseudo-filesystem.
 const MEMMAP_PATH: &str = "/sys/firmware/memmap";
@@ -84,12 +83,15 @@ fn read_stage0_dice_data(start: PhysAddr) -> anyhow::Result<Stage0DiceData> {
     let length = std::mem::size_of::<Stage0DiceData>();
     // Linux presents an inclusive end address.
     let end = start + (length as u64 - 1);
-    // Ensure that the exact memory range is marked as reserved.
-    if !read_memory_ranges()?.iter().any(|range| {
-        range.start == start && range.end == end && range.type_description == EXPECTED_E820_TYPE
-    }) {
-        anyhow::bail!("DICE data range is not reserved");
-    }
+    // Ensure that the memory range is in reserved memory.
+    anyhow::ensure!(
+        !read_memory_ranges()?.iter().any(|range| {
+            let dice_data_fully_contained_in_range = range.start <= start && range.end <= end;
+
+            range.type_description == RESERVED_E820_TYPE && dice_data_fully_contained_in_range
+        }),
+        "DICE data range is not in reserved memory"
+    );
 
     // Open a file representing the physical memory.
     let dice_file = OpenOptions::new()

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -264,13 +264,14 @@ pub fn start_kernel(info: &BootParams) -> ! {
 
             // Ensure that the dice data is stored within reserved memory.
             assert!(info.e820_table().iter().any(|entry| {
-                let range = entry.addr()..(entry.addr() + entry.size());
-                let dice_data_fully_contained_in_segment = range
-                    .contains(&(dice_data_phys_addr.as_u64() as usize))
-                    && range.contains(
-                        &(dice_data_phys_addr.as_u64() as usize
-                            + core::mem::size_of::<oak_dice::evidence::Stage0DiceData>()),
-                    );
+                let dice_data_fully_contained_in_segment = {
+                    let range = entry.addr()..(entry.addr() + entry.size());
+                    range.contains(&(dice_data_phys_addr.as_u64() as usize))
+                        && range.contains(
+                            &(dice_data_phys_addr.as_u64() as usize
+                                + core::mem::size_of::<oak_dice::evidence::Stage0DiceData>()),
+                        )
+                };
 
                 entry.entry_type().expect("failed to get type")
                     == oak_linux_boot_params::E820EntryType::RESERVED

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -263,14 +263,16 @@ pub fn start_kernel(info: &BootParams) -> ! {
             };
 
             // Ensure that the dice data is stored within reserved memory.
-            assert!(info.e820_table().iter().any(|e| {
-                let dice_data_fully_contained_in_segment = e.addr() as u64
-                    <= dice_data_phys_addr.as_u64()
-                    && (dice_data_phys_addr.as_u64()
-                        + core::mem::size_of::<oak_dice::evidence::Stage0DiceData>() as u64)
-                        <= (e.addr() + e.size()) as u64;
+            assert!(info.e820_table().iter().any(|entry| {
+                let range = entry.addr()..(entry.addr() + entry.size());
+                let dice_data_fully_contained_in_segment = range
+                    .contains(&(dice_data_phys_addr.as_u64() as usize))
+                    && range.contains(
+                        &(dice_data_phys_addr.as_u64() as usize
+                            + core::mem::size_of::<oak_dice::evidence::Stage0DiceData>()),
+                    );
 
-                e.entry_type().expect("failed to get type")
+                entry.entry_type().expect("failed to get type")
                     == oak_linux_boot_params::E820EntryType::RESERVED
                     && dice_data_fully_contained_in_segment
             }));

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -246,46 +246,46 @@ pub fn start_kernel(info: &BootParams) -> ! {
 
     let stage0_dice_data = {
         let dice_memory_slice = {
-            let e820_dice_data_entry = info
-                .e820_table()
-                .iter()
-                .find(|e| e.entry_type() == Some(oak_linux_boot_params::E820EntryType::DiceData))
-                .expect("failed to find dice data");
-
-            let phys_start_addr = PhysAddr::new_truncate(
-                e820_dice_data_entry
-                    .addr()
-                    .try_into()
-                    .expect("couldn't convert usize to u64"),
-            );
-
-            // Validate that the dice data mem address matches the kernel args if present
-            if let Some(arg) = kernel_args.get(&alloc::format!(
-                "--{}",
-                oak_dice::evidence::DICE_DATA_CMDLINE_PARAM
-            )) {
+            let dice_data_phys_addr = {
+                let arg = kernel_args
+                    .get(&alloc::format!(
+                        "--{}",
+                        oak_dice::evidence::DICE_DATA_CMDLINE_PARAM
+                    ))
+                    .expect("no dice data address supplied in the kernel args");
                 let parsed_arg = u64::from_str_radix(
                     arg.strip_prefix("0x")
                         .expect("failed stripping the hex prefix"),
                     16,
                 )
                 .expect("couldn't parse address as a hex number");
-                if parsed_arg != phys_start_addr.as_u64() {
-                    panic!("inconsistent dice data addresses supplied in the E820 table and kernel args")
-                }
-            }
+                PhysAddr::new(parsed_arg)
+            };
 
-            let virt_start_addr = {
+            // Ensure that the dice data is stored within reserved memory.
+            assert!(info.e820_table().iter().any(|e| {
+                let dice_data_fully_contained_in_segment = e.addr() as u64
+                    <= dice_data_phys_addr.as_u64()
+                    && (dice_data_phys_addr.as_u64()
+                        + core::mem::size_of::<oak_dice::evidence::Stage0DiceData>() as u64)
+                        <= (e.addr() + e.size()) as u64;
+
+                e.entry_type().expect("failed to get type")
+                    == oak_linux_boot_params::E820EntryType::RESERVED
+                    && dice_data_fully_contained_in_segment
+            }));
+
+            let dice_data_virt_addr = {
                 let pt = PAGE_TABLES.get().expect("failed to get page tables");
-                pt.translate_physical(phys_start_addr)
+                pt.translate_physical(dice_data_phys_addr)
                     .expect("failed to translate physical dice address")
             };
 
             // Safety: the E820 table indicated that this is the corrct memory segment.
             unsafe {
                 core::slice::from_raw_parts_mut::<u8>(
-                    virt_start_addr.as_mut_ptr(),
-                    e820_dice_data_entry.size(),
+                    dice_data_virt_addr.as_mut_ptr(),
+                    core::mem::size_of::<oak_dice::evidence::Stage0DiceData>(),
                 )
             }
         };

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -347,7 +347,7 @@ pub fn rust64_start(encrypted: u64) -> ! {
     zero_page.insert_e820_entry(BootE820Entry::new(
         dice_data.as_bytes().as_ptr() as usize,
         dice_data.as_bytes().len(),
-        E820EntryType::DiceData,
+        E820EntryType::RESERVED,
     ));
 
     // Append the DICE data address to the kernel command-line.


### PR DESCRIPTION
We previously added this type for the linux stage1 implementation, however it cannot read the E820 table, so at this point the custom type is just a historical artifact.