### PR TITLE
Add GetEndorsedEvidence RPC

### DIFF
--- a/oak_functions_containers_launcher/src/server.rs
+++ b/oak_functions_containers_launcher/src/server.rs
@@ -25,6 +25,7 @@ use oak_functions_launcher::proto::oak::session::v1::{
     request_wrapper, response_wrapper,
     streaming_session_server::{StreamingSession, StreamingSessionServer},
     AttestationBundle, AttestationEndorsement, AttestationEvidence, GetPublicKeyResponse,
+    EndorsedEvidence, GetEndorsedEvidenceResponse,
     InvokeResponse, RequestWrapper, ResponseWrapper,
 };
 use tonic::{transport::Server, Request, Response, Status, Streaming};
@@ -71,6 +72,10 @@ impl StreamingSession for SessionProxy {
             evidence: Some(self.evidence.clone()),
             endorsements: Some(self.endorsements.clone()),
         };
+        let endorsed_evidence = EndorsedEvidence {
+            evidence: Some(self.evidence.clone()),
+            endorsements: Some(self.endorsements.clone()),
+        };
 
         let mut connector_handle = self.connector_handle.clone();
 
@@ -85,9 +90,13 @@ impl StreamingSession for SessionProxy {
 
                 let response = match request {
                     request_wrapper::Request::GetPublicKeyRequest(_) => {
-
                         response_wrapper::Response::GetPublicKeyResponse(GetPublicKeyResponse {
                             attestation_bundle: Some(attestation_bundle.clone()),
+                        })
+                    }
+                    request_wrapper::Request::GetEndorsedEvidenceRequest(_) => {
+                        response_wrapper::Response::GetEndorsedEvidenceResponse(GetEndorsedEvidenceResponse {
+                            endorsed_evidence: Some(endorsed_evidence.clone()),
                         })
                     }
                     request_wrapper::Request::InvokeRequest(invoke_request) => {

--- a/oak_functions_containers_launcher/src/server.rs
+++ b/oak_functions_containers_launcher/src/server.rs
@@ -24,9 +24,9 @@ use oak_attestation::proto::oak::attestation::v1::{Endorsements, Evidence};
 use oak_functions_launcher::proto::oak::session::v1::{
     request_wrapper, response_wrapper,
     streaming_session_server::{StreamingSession, StreamingSessionServer},
-    AttestationBundle, AttestationEndorsement, AttestationEvidence, GetPublicKeyResponse,
-    EndorsedEvidence, GetEndorsedEvidenceResponse,
-    InvokeResponse, RequestWrapper, ResponseWrapper,
+    AttestationBundle, AttestationEndorsement, AttestationEvidence, EndorsedEvidence,
+    GetEndorsedEvidenceResponse, GetPublicKeyResponse, InvokeResponse, RequestWrapper,
+    ResponseWrapper,
 };
 use tonic::{transport::Server, Request, Response, Status, Streaming};
 

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -27,9 +27,9 @@ use crate::{
         session::v1::{
             request_wrapper, response_wrapper,
             streaming_session_server::{StreamingSession, StreamingSessionServer},
-            AttestationBundle, AttestationEndorsement, AttestationEvidence, GetPublicKeyResponse,
-            EndorsedEvidence, GetEndorsedEvidenceResponse,
-            InvokeResponse, RequestWrapper, ResponseWrapper,
+            AttestationBundle, AttestationEndorsement, AttestationEvidence, EndorsedEvidence,
+            GetEndorsedEvidenceResponse, GetPublicKeyResponse, InvokeResponse, RequestWrapper,
+            ResponseWrapper,
         },
     },
 };

--- a/oak_functions_launcher/src/server.rs
+++ b/oak_functions_launcher/src/server.rs
@@ -28,6 +28,7 @@ use crate::{
             request_wrapper, response_wrapper,
             streaming_session_server::{StreamingSession, StreamingSessionServer},
             AttestationBundle, AttestationEndorsement, AttestationEvidence, GetPublicKeyResponse,
+            EndorsedEvidence, GetEndorsedEvidenceResponse,
             InvokeResponse, RequestWrapper, ResponseWrapper,
         },
     },
@@ -71,6 +72,10 @@ impl StreamingSession for SessionProxy {
             evidence: Some(self.evidence.clone()),
             endorsements: Some(self.endorsements.clone()),
         };
+        let endorsed_evidence = EndorsedEvidence {
+            evidence: Some(self.evidence.clone()),
+            endorsements: Some(self.endorsements.clone()),
+        };
 
         let connector_handle = self.connector_handle.clone();
 
@@ -85,9 +90,13 @@ impl StreamingSession for SessionProxy {
 
                 let response = match request {
                     request_wrapper::Request::GetPublicKeyRequest(_) => {
-
                         response_wrapper::Response::GetPublicKeyResponse(GetPublicKeyResponse {
                             attestation_bundle: Some(attestation_bundle.clone()),
+                        })
+                    }
+                    request_wrapper::Request::GetEndorsedEvidenceRequest(_) => {
+                        response_wrapper::Response::GetEndorsedEvidenceResponse(GetEndorsedEvidenceResponse {
+                            endorsed_evidence: Some(endorsed_evidence.clone()),
                         })
                     }
                     request_wrapper::Request::InvokeRequest(invoke_request) => {

--- a/proto/session/messages.proto
+++ b/proto/session/messages.proto
@@ -96,6 +96,19 @@ message GetPublicKeyResponse {
   AttestationBundle attestation_bundle = 1;
 }
 
+// Endorsed evidence contains an attestation evidence provided by the enclave and the corresponding
+// attestation endorsements provided by the hostlib.
+message EndorsedEvidence {
+  oak.attestation.v1.Evidence evidence = 1;
+  oak.attestation.v1.Endorsements endorsements = 2;
+}
+
+message GetEndorsedEvidenceRequest {}
+
+message GetEndorsedEvidenceResponse {
+  EndorsedEvidence endorsed_evidence = 1;
+}
+
 message InvokeRequest {
   // Body of the request, encrypted using Hybrid Public Key Encryption (HPKE).
   // <https://www.rfc-editor.org/rfc/rfc9180.html>

--- a/proto/session/service_streaming.proto
+++ b/proto/session/service_streaming.proto
@@ -27,6 +27,7 @@ message RequestWrapper {
   oneof request {
     GetPublicKeyRequest get_public_key_request = 1;
     InvokeRequest invoke_request = 2;
+    GetEndorsedEvidenceRequest get_endorsed_evidence_request = 3;
   }
 }
 
@@ -34,6 +35,7 @@ message ResponseWrapper {
   oneof response {
     GetPublicKeyResponse get_public_key_response = 1;
     InvokeResponse invoke_response = 2;
+    GetEndorsedEvidenceResponse get_endorsed_evidence_response = 3;
   }
 }
 

--- a/proto/session/service_unary.proto
+++ b/proto/session/service_unary.proto
@@ -28,6 +28,9 @@ service UnarySession {
   // Gets encryption key of sealed encironment.
   rpc GetPublicKey(GetPublicKeyRequest) returns (GetPublicKeyResponse);
 
+  // Gets a attestation evidence and endorsements.
+  rpc GetEndorsedEvidence(GetEndorsedEvidenceRequest) returns (GetEndorsedEvidenceResponse);
+
   // Performs lookup for a list of encrypted keys. The keys should be encrypted
   // using the Public key provided by the enclave. The response is encrypted
   // using the response key (supplied by the client).


### PR DESCRIPTION
This PR adds a new `GetEndorsedEvidence` RPC call and a corresponding `EndorsedEvidence` message. Also updates the Rust client code to use the new RPC.

Ref https://github.com/project-oak/oak/issues/4417