### PR TITLE
Patch the Oak Container kernels to enable DMA with virtio <1.0

### DIFF
--- a/oak_containers_kernel/Makefile
+++ b/oak_containers_kernel/Makefile
@@ -12,3 +12,4 @@ target/linux-6.1.33:
 	mkdir -p target
 	curl -O -L --output-dir target https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.33.tar.xz
 	tar -C target -Jxf target/linux-6.1.33.tar.xz
+	patch -p1 -d target/linux-6.1.33 < patches/virtio-dma.patch

--- a/oak_containers_kernel/patches/virtio-dma.patch
+++ b/oak_containers_kernel/patches/virtio-dma.patch
@@ -1,0 +1,29 @@
+diff '--color=auto' -u -r linux-6.1.33-orig/drivers/virtio/virtio.c linux-6.1.33/drivers/virtio/virtio.c
+--- linux-6.1.33-orig/drivers/virtio/virtio.c	2023-06-09 08:34:30.000000000 +0000
++++ linux-6.1.33/drivers/virtio/virtio.c	2024-02-01 18:55:31.105888971 +0000
+@@ -177,11 +177,8 @@
+ 	if (virtio_check_mem_acc_cb(dev)) {
+ 		if (!virtio_has_feature(dev, VIRTIO_F_VERSION_1)) {
+ 			dev_warn(&dev->dev,
+-				 "device must provide VIRTIO_F_VERSION_1\n");
+-			return -ENODEV;
+-		}
+-
+-		if (!virtio_has_feature(dev, VIRTIO_F_ACCESS_PLATFORM)) {
++				"device does not provide VIRTIO_F_VERSION_1 while restricted memory access is enabled!.\n");
++		} else if (!virtio_has_feature(dev, VIRTIO_F_ACCESS_PLATFORM)) {
+ 			dev_warn(&dev->dev,
+ 				 "device must provide VIRTIO_F_ACCESS_PLATFORM\n");
+ 			return -ENODEV;
+diff '--color=auto' -u -r linux-6.1.33-orig/include/linux/virtio_config.h linux-6.1.33/include/linux/virtio_config.h
+--- linux-6.1.33-orig/include/linux/virtio_config.h	2023-06-09 08:34:30.000000000 +0000
++++ linux-6.1.33/include/linux/virtio_config.h	2024-02-01 19:02:29.526141223 +0000
+@@ -201,6 +201,9 @@
+ 	 * Note the reverse polarity of the quirk feature (compared to most
+ 	 * other features), this is for compatibility with legacy systems.
+ 	 */
++	if (!virtio_has_feature(vdev, VIRTIO_F_VERSION_1))
++		return false;
++
+ 	return !virtio_has_feature(vdev, VIRTIO_F_ACCESS_PLATFORM);
+ }


### PR DESCRIPTION
As we're dealing with VMMs that only support old virtio standards, this is unfortunately required (for now).

This is inspired by the patch proposed in https://lore.kernel.org/all/20211027232828.2043569-1-erdemaktas@google.com/T/ except that a lot of things have changed in the intervening years, and I've taken the lazy option of just returning false instead of making sure we're in confidential mode.

Not meant for upstreaming or consumption outside our project, really. Hopefully we can modernize said VMM a bit in the future and drop this patch altogether.