### PR TITLE
Add missing request wrapper case in Java tests

### DIFF
--- a/java/src/test/java/com/google/oak/transport/BUILD
+++ b/java/src/test/java/com/google/oak/transport/BUILD
@@ -27,6 +27,8 @@ java_test(
     deps = [
         "//java/src/main/java/com/google/oak/transport:grpc_streaming_transport",
         "//java/src/main/java/com/google/oak/util",
+        "//proto/attestation:endorsement_java_proto",
+        "//proto/attestation:evidence_java_proto",
         "//proto/crypto:crypto_java_proto",
         "//proto/session:messages_java_proto",
         "//proto/session:service_streaming_java_grpc",

--- a/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
+++ b/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
@@ -19,9 +19,13 @@ package com.google.oak.transport;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 
+import com.google.oak.attestation.v1.Endorsements;
+import com.google.oak.attestation.v1.Evidence;
 import com.google.oak.crypto.v1.EncryptedRequest;
 import com.google.oak.crypto.v1.EncryptedResponse;
 import com.google.oak.session.v1.AttestationBundle;
+import com.google.oak.session.v1.EndorsedEvidence;
+import com.google.oak.session.v1.GetEndorsedEvidenceResponse;
 import com.google.oak.session.v1.GetPublicKeyResponse;
 import com.google.oak.session.v1.InvokeResponse;
 import com.google.oak.session.v1.RequestWrapper;
@@ -29,7 +33,6 @@ import com.google.oak.session.v1.ResponseWrapper;
 import com.google.oak.session.v1.StreamingSessionGrpc;
 import com.google.oak.transport.GrpcStreamingTransport;
 import com.google.oak.util.Result;
-import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
@@ -62,6 +65,20 @@ public class GrpcStreamingTransportTest {
               ResponseWrapper.newBuilder()
                   .setGetPublicKeyResponse(GetPublicKeyResponse.newBuilder().setAttestationBundle(
                       AttestationBundle.getDefaultInstance()))
+                  .build();
+          responseObserver.onNext(responseWrapper);
+          break;
+        case GET_ENDORSED_EVIDENCE_REQUEST:
+          responseWrapper =
+              ResponseWrapper.newBuilder()
+                  .setGetEndorsedEvidenceResponse(
+                      GetEndorsedEvidenceResponse
+                          .newBuilder()
+                          .setEndorsedEvidence(
+                              EndorsedEvidence
+                              .newBuilder()
+                              .setEvidence(Evidence.getDefaultInstance())
+                              .setEndorsements(Endorsements.getDefaultInstance())))
                   .build();
           responseObserver.onNext(responseWrapper);
           break;

--- a/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
+++ b/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
@@ -69,17 +69,13 @@ public class GrpcStreamingTransportTest {
           responseObserver.onNext(responseWrapper);
           break;
         case GET_ENDORSED_EVIDENCE_REQUEST:
-          responseWrapper =
-              ResponseWrapper.newBuilder()
-                  .setGetEndorsedEvidenceResponse(
-                      GetEndorsedEvidenceResponse
-                          .newBuilder()
-                          .setEndorsedEvidence(
-                              EndorsedEvidence
-                              .newBuilder()
-                              .setEvidence(Evidence.getDefaultInstance())
-                              .setEndorsements(Endorsements.getDefaultInstance())))
-                  .build();
+          responseWrapper = ResponseWrapper.newBuilder()
+                                .setGetEndorsedEvidenceResponse(
+                                    GetEndorsedEvidenceResponse.newBuilder().setEndorsedEvidence(
+                                        EndorsedEvidence.newBuilder()
+                                            .setEvidence(Evidence.getDefaultInstance())
+                                            .setEndorsements(Endorsements.getDefaultInstance())))
+                                .build();
           responseObserver.onNext(responseWrapper);
           break;
         case INVOKE_REQUEST:


### PR DESCRIPTION
This PR adds a `GET_ENDORSED_EVIDENCE_REQUEST` case to Java tests.

Ref https://github.com/project-oak/oak/issues/4417