### PR TITLE
Allow restricted kernel dice logic to be shared with orchestator

### DIFF
--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -27,7 +27,6 @@ goblin = { version = "*", default-features = false, features = [
   "endian_fd",
 ] }
 hex = { version = "*", default-features = false, features = ["alloc"] }
-hkdf = "*"
 linked_list_allocator = { version = "*", features = ["alloc_ref"] }
 log = "*"
 libm = "*"
@@ -45,7 +44,6 @@ oak_sev_guest = { workspace = true, features = ["rust-crypto"] }
 p256 = { version = "*", default-features = false, features = ["ecdsa"] }
 self_cell = "*"
 sev_serial = { workspace = true }
-sha2 = { version = "*", default-features = false }
 spinning_top = "*"
 static_assertions = "*"
 strum = { version = "*", default-features = false, features = ["derive"] }

--- a/oak_restricted_kernel/src/syscall/key.rs
+++ b/oak_restricted_kernel/src/syscall/key.rs
@@ -16,10 +16,10 @@
 
 use alloc::boxed::Box;
 
+use oak_restricted_kernel_dice::DerivedKey;
 use oak_restricted_kernel_interface::{Errno, DERIVED_KEY_FD};
 
 use super::fd::{copy_max_slice, FileDescriptor};
-use crate::DerivedKey;
 
 #[derive(Default)]
 struct DerivedKeyDescriptor {

--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -30,6 +30,7 @@ use core::{arch::asm, ffi::c_void};
 
 use oak_channel::Channel;
 use oak_dice::evidence::RestrictedKernelDiceData as DiceData;
+use oak_restricted_kernel_dice::DerivedKey;
 use oak_restricted_kernel_interface::{Errno, Syscall};
 use x86_64::{
     registers::{
@@ -44,7 +45,7 @@ use self::{
     mmap::syscall_mmap,
     process::syscall_exit,
 };
-use crate::{mm, DerivedKey};
+use crate::mm;
 
 /// State we need to track for system calls.
 ///

--- a/oak_restricted_kernel_dice/Cargo.toml
+++ b/oak_restricted_kernel_dice/Cargo.toml
@@ -10,3 +10,5 @@ p256 = { version = "*", default-features = false, features = ["ecdsa"] }
 coset = { version = "*", default-features = false }
 oak_crypto = { workspace = true }
 oak_dice = { workspace = true }
+sha2 = { version = "*", default-features = false }
+hkdf = "*"

--- a/oak_restricted_kernel_dice/src/lib.rs
+++ b/oak_restricted_kernel_dice/src/lib.rs
@@ -24,8 +24,43 @@
 extern crate alloc;
 
 use coset::{cbor::Value, cwt::ClaimName, CborSerializable};
+use hkdf::Hkdf;
 use oak_crypto::hpke::Serializable;
 use oak_dice::cert::{ENCLAVE_APPLICATION_LAYER_ID, LAYER_2_CODE_MEASUREMENT_ID, SHA2_256_ID};
+use sha2::{Digest, Sha256};
+
+/// A derived sealing key.
+pub type DerivedKey = [u8; 32];
+
+// Digest of an application.
+pub type AppDigest = [u8; 32];
+
+pub fn attest_application(
+    stage0_dice_data: oak_dice::evidence::Stage0DiceData,
+    app_bytes: &[u8],
+) -> (DerivedKey, oak_dice::evidence::RestrictedKernelDiceData) {
+    let app_digest = measure_app_digest(app_bytes);
+    (
+        generate_derived_key(&stage0_dice_data, &app_digest),
+        generate_dice_data(stage0_dice_data, &app_digest),
+    )
+}
+
+fn measure_app_digest(app_bytes: &[u8]) -> AppDigest {
+    Sha256::digest(&app_bytes[..]).into()
+}
+
+fn generate_derived_key(
+    stage0_dice_data: &oak_dice::evidence::Stage0DiceData,
+    app_digest: &AppDigest,
+) -> DerivedKey {
+    // Mix in the application digest when deriving CDI for Layer 2.
+    let hkdf = Hkdf::<Sha256>::new(Some(app_digest), &stage0_dice_data.layer_1_cdi.cdi[..]);
+    let mut derived_key = DerivedKey::default();
+    hkdf.expand(b"CDI_Seal", &mut derived_key)
+        .expect("invalid length for derived key");
+    derived_key
+}
 
 fn certificate_to_byte_array(cert: coset::CoseSign1) -> [u8; oak_dice::evidence::CERTIFICATE_SIZE] {
     let vec = cert.to_vec().expect("couldn't serialize certificate");
@@ -37,7 +72,7 @@ fn certificate_to_byte_array(cert: coset::CoseSign1) -> [u8; oak_dice::evidence:
 /// Generates attestation evidence for the 'measurement' of the application.
 pub fn generate_dice_data(
     stage0_dice_data: oak_dice::evidence::Stage0DiceData,
-    app_digest: &[u8],
+    app_digest: &AppDigest,
 ) -> oak_dice::evidence::RestrictedKernelDiceData {
     let (application_keys, application_private_keys): (
         oak_dice::evidence::ApplicationKeys,

--- a/oak_restricted_kernel_launcher/README.md
+++ b/oak_restricted_kernel_launcher/README.md
@@ -19,7 +19,7 @@ must be built.
 Stage0, the restricted kernel, and an enclave app may be built like so:
 
 ```shell
-just stage0_bin oak_restricted_kernel_wrapper oak_echo_raw_enclave_app
+just stage0_bin oak_restricted_kernel_wrapper oak_orchestrator oak_echo_raw_enclave_app
 ```
 
 After building dependencies, an enclave app may be run like so:
@@ -31,5 +31,6 @@ cargo run --package=oak_restricted_kernel_launcher -- \
 --vmm-binary=$(which qemu-system-x86_64) \
 --memory-size=8G \
 --bios-binary=stage0_bin/target/x86_64-unknown-none/release/stage0_bin \
+--initrd=enclave_apps/target/x86_64-unknown-none/release/oak_orchestrator \
 --app-binary=enclave_apps/target/x86_64-unknown-none/release/oak_echo_raw_enclave_app
 ```

--- a/oak_restricted_kernel_sdk/src/dice.rs
+++ b/oak_restricted_kernel_sdk/src/dice.rs
@@ -73,7 +73,10 @@ fn get_mock_dice_data() -> RestrictedKernelDiceData {
         oak_stage0_dice::mock_derived_key,
     );
 
-    oak_restricted_kernel_dice::generate_dice_data(stage0_dice_data, &[])
+    oak_restricted_kernel_dice::generate_dice_data(
+        stage0_dice_data,
+        &oak_restricted_kernel_dice::AppDigest::default(),
+    )
 }
 
 /// Wrapper for DICE evidence and application private keys.


### PR DESCRIPTION
By moving all remaining dice logic from `oak_restricted_kernel` to oak_restricted_kernel_dice