### PR TITLE
kernel wrapper: pass kernel file name via env

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,16 +23,16 @@ oak_functions_insecure_enclave_app:
 oak_restricted_kernel_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --bin=oak_restricted_kernel_bin
 
-oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
-    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_bin cargo build --release
-    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/oak_restricted_kernel_bin oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
+oak_restricted_kernel_wrapper kernel_file_name="oak_restricted_kernel_bin": oak_restricted_kernel_bin
+    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME={{kernel_file_name}} cargo build --release
+    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/{{kernel_file_name}} oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_file_name}}_bin
 
 oak_restricted_kernel_simple_io_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
 
-oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
-    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_simple_io_bin cargo build --release
-    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_bin oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
+oak_restricted_kernel_simple_io_wrapper kernel_file_name="oak_restricted_kernel_simple_io_bin": oak_restricted_kernel_simple_io_bin
+    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME={{kernel_file_name}} cargo build --release
+    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/{{kernel_file_name}} oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_file_name}}_bin
 
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin

--- a/justfile
+++ b/justfile
@@ -23,16 +23,18 @@ oak_functions_insecure_enclave_app:
 oak_restricted_kernel_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --bin=oak_restricted_kernel_bin
 
-oak_restricted_kernel_wrapper kernel_file_name="oak_restricted_kernel_bin": oak_restricted_kernel_bin
+_wrap_kernel kernel_file_name:
     env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME={{kernel_file_name}} cargo build --release
     rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/{{kernel_file_name}} oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_file_name}}_bin
+
+oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
+    just _wrap_kernel oak_restricted_kernel_bin
 
 oak_restricted_kernel_simple_io_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
 
-oak_restricted_kernel_simple_io_wrapper kernel_file_name="oak_restricted_kernel_simple_io_bin": oak_restricted_kernel_simple_io_bin
-    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME={{kernel_file_name}} cargo build --release
-    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/{{kernel_file_name}} oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_file_name}}_bin
+oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
+    just _wrap_kernel oak_restricted_kernel_simple_io_bin
 
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin

--- a/justfile
+++ b/justfile
@@ -35,8 +35,7 @@ oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
     env --chdir=oak_restricted_kernel_wrapper rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
 
 stage0_bin:
-    env --chdir=stage0_bin cargo build --release
-    rust-objcopy --output-target=binary target/x86_64-unknown-none/release/stage0_bin
+env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin
 
 stage1_cpio:
     env --chdir=oak_containers_stage1 make

--- a/justfile
+++ b/justfile
@@ -25,7 +25,7 @@ oak_restricted_kernel_bin:
 
 _wrap_kernel kernel_bin_prefix:
     env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME={{kernel_bin_prefix}}_bin cargo build --release
-    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/{{kernel_bin_prefix}}_bin oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_bin_prefix}}_wrapper_bin
+    rust-objcopy --output-target=binary oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_bin_prefix}}_wrapper_bin
 
 oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
     just _wrap_kernel oak_restricted_kernel

--- a/justfile
+++ b/justfile
@@ -24,13 +24,13 @@ oak_restricted_kernel_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --bin=oak_restricted_kernel_bin
 
 oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
-    env --chdir=oak_restricted_kernel_wrapper cargo objcopy --release --features=oak_restricted_kernel_bin -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
+    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
 
 oak_restricted_kernel_simple_io_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
 
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
-    env --chdir=oak_restricted_kernel_wrapper cargo objcopy --release --no-default-features --features=oak_restricted_kernel_simple_io_bin -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
+    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_simple_io_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
 
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
     env --chdir=oak_restricted_kernel_wrapper rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
 
 stage0_bin:
-env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin
+    env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin
 
 stage1_cpio:
     env --chdir=oak_containers_stage1 make

--- a/justfile
+++ b/justfile
@@ -25,14 +25,14 @@ oak_restricted_kernel_bin:
 
 oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
     env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_bin cargo build --release
-    env --chdir=oak_restricted_kernel_bin rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_bin target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
+    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/oak_restricted_kernel_bin oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
 
 oak_restricted_kernel_simple_io_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
 
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
     env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_simple_io_bin cargo build --release
-    env --chdir=oak_restricted_kernel_bin rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_bin target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
+    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_bin oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
 
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin

--- a/justfile
+++ b/justfile
@@ -25,14 +25,14 @@ oak_restricted_kernel_bin:
 
 oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
     env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_bin cargo build --release
-    env --chdir=oak_restricted_kernel_wrapper rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
+    env --chdir=oak_restricted_kernel_bin rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_bin target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
 
 oak_restricted_kernel_simple_io_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
 
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
     env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_simple_io_bin cargo build --release
-    env --chdir=oak_restricted_kernel_wrapper rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
+    env --chdir=oak_restricted_kernel_bin rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_bin target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
 
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin

--- a/justfile
+++ b/justfile
@@ -23,18 +23,18 @@ oak_functions_insecure_enclave_app:
 oak_restricted_kernel_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --bin=oak_restricted_kernel_bin
 
-_wrap_kernel kernel_file_name:
-    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME={{kernel_file_name}} cargo build --release
-    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/{{kernel_file_name}} oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_file_name}}_bin
+_wrap_kernel kernel_bin_prefix:
+    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME={{kernel_bin_prefix}}_bin cargo build --release
+    rust-objcopy --output-target=binary oak_restricted_kernel_bin/target/x86_64-unknown-none/release/{{kernel_bin_prefix}}_bin oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_bin_prefix}}_wrapper_bin
 
 oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
-    just _wrap_kernel oak_restricted_kernel_bin
+    just _wrap_kernel oak_restricted_kernel
 
 oak_restricted_kernel_simple_io_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
 
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
-    just _wrap_kernel oak_restricted_kernel_simple_io_bin
+    just _wrap_kernel oak_restricted_kernel_simple_io
 
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin

--- a/justfile
+++ b/justfile
@@ -24,16 +24,19 @@ oak_restricted_kernel_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --bin=oak_restricted_kernel_bin
 
 oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
-    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
+    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_bin cargo build --release
+    env --chdir=oak_restricted_kernel_wrapper rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin
 
 oak_restricted_kernel_simple_io_bin:
     env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
 
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
-    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_simple_io_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
+    env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME=oak_restricted_kernel_simple_io_bin cargo build --release
+    env --chdir=oak_restricted_kernel_wrapper rust-objcopy --output-target=binary target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
 
 stage0_bin:
-    env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin
+    env --chdir=stage0_bin cargo build --release
+    rust-objcopy --output-target=binary target/x86_64-unknown-none/release/stage0_bin
 
 stage1_cpio:
     env --chdir=oak_containers_stage1 make

--- a/oak_restricted_kernel_wrapper/Cargo.toml
+++ b/oak_restricted_kernel_wrapper/Cargo.toml
@@ -5,11 +5,6 @@ authors = ["Conrad Grobler <grobler@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
-[features]
-default = ["oak_restricted_kernel_bin"]
-oak_restricted_kernel_simple_io_bin = []
-oak_restricted_kernel_bin = []
-
 [workspace]
 resolver = "2"
 members = ["."]

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -20,15 +20,14 @@ use std::{
     path::PathBuf,
 };
 
+const ENV_FILE_NAME: &'static str = "OAK_RESTRICTED_KERNEL_FILE_NAME";
+
 // returns source_path if it can be constructed and if it points to a valid file
 fn try_source_path() -> Result<PathBuf, &'static str> {
     let kernel_directory = "oak_restricted_kernel_bin";
-    let file_name = match (cfg!(feature = "oak_restricted_kernel_bin"), cfg!(feature = "oak_restricted_kernel_simple_io_bin")) {
-        (true, false) => Ok("oak_restricted_kernel_bin"),
-        (false, true) => Ok("oak_restricted_kernel_simple_io_bin"),
-        (true, true) => Err("Feature oak_restricted_kernel_simple_io_bin and feature oak_restricted_kernel_bin cannot be enabled at the same time. Only either version can be built."),
-        (false, false) => Err("One of feature oak_restricted_kernel_simple_io_bin or feature oak_restricted_kernel_bin must be enabled.")
-    }?;
+    let file_name = std::env::var(ENV_FILE_NAME).map_err(|_| {
+            "the correct env variable must be set with the file name of the kernel build. See build file."
+    })?;
 
     // The source file is the output from building "../oak_restricted_kernel_bin" in release mode.
     let mut source_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -20,7 +20,7 @@ use std::{
     path::PathBuf,
 };
 
-const ENV_FILE_NAME: &'static str = "OAK_RESTRICTED_KERNEL_FILE_NAME";
+const ENV_FILE_NAME: &str = "OAK_RESTRICTED_KERNEL_FILE_NAME";
 
 // returns source_path if it can be constructed and if it points to a valid file
 fn try_source_path() -> Result<PathBuf, &'static str> {

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -20,13 +20,11 @@ use std::{
     path::PathBuf,
 };
 
-const ENV_FILE_NAME: &str = "OAK_RESTRICTED_KERNEL_FILE_NAME";
-
 // returns source_path if it can be constructed and if it points to a valid file
 fn try_source_path() -> Result<PathBuf, &'static str> {
     let kernel_directory = "oak_restricted_kernel_bin";
-    let file_name = std::env::var(ENV_FILE_NAME).map_err(|_| {
-            "the correct env variable must be set with the file name of the kernel build. See build file."
+    let file_name = std::env::var("OAK_RESTRICTED_KERNEL_FILE_NAME").map_err(|_| {
+            "the correct env variable OAK_RESTRICTED_KERNEL_FILE_NAME must be set with the file name of the kernel build."
     })?;
 
     // The source file is the output from building "../oak_restricted_kernel_bin" in release mode.
@@ -43,6 +41,7 @@ fn try_source_path() -> Result<PathBuf, &'static str> {
 }
 
 fn main() {
+    println!("cargo:rerun-if-changed=cargo:rerun-if-env-changed=OAK_RESTRICTED_KERNEL_FILE_NAME");
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rustc-link-arg=--script=layout.ld");
     let mut destination_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());


### PR DESCRIPTION
We'll need more versions given that the kernel now has compile time flags. It gets messy with that many features, this is easier.