### PR TITLE
Change a `Spinlock` to `RwSpinlock`

### DIFF
--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -1228,9 +1228,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spinning_top"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]

--- a/oak_functions_service/src/lookup.rs
+++ b/oak_functions_service/src/lookup.rs
@@ -24,7 +24,7 @@ use alloc::{
 use bytes::Bytes;
 use hashbrown::HashMap;
 use log::{info, Level};
-use spinning_top::Spinlock;
+use spinning_top::{RwSpinlock, Spinlock};
 
 use crate::logger::OakLogger;
 
@@ -84,7 +84,7 @@ impl DataBuilder {
 ///
 /// In the future we may replace both the mutex and the hash map with something like RCU.
 pub struct LookupDataManager {
-    data: Spinlock<Arc<Data>>,
+    data: RwSpinlock<Arc<Data>>,
     // Behind a lock, because we have multiple references to LookupDataManager and need to mutate
     // data builder.
     data_builder: Spinlock<DataBuilder>,
@@ -95,7 +95,7 @@ impl LookupDataManager {
     /// Creates a new instance with empty backing data.
     pub fn new_empty(logger: Arc<dyn OakLogger>) -> Self {
         Self {
-            data: Spinlock::new(Arc::new(Data::new())),
+            data: RwSpinlock::new(Arc::new(Data::new())),
             // Incrementally builds the backing data that will be used by new `LookupData`
             // instances when finished.
             data_builder: Spinlock::new(DataBuilder::default()),
@@ -106,7 +106,7 @@ impl LookupDataManager {
     /// Creates an instance of LookupData populated with the given entries.
     pub fn for_test(data: Data, logger: Arc<dyn OakLogger>) -> Self {
         let test_manager = Self::new_empty(logger);
-        *test_manager.data.lock() = Arc::new(data);
+        *test_manager.data.write() = Arc::new(data);
         test_manager
     }
 
@@ -137,7 +137,7 @@ impl LookupDataManager {
             let mut data_builder = self.data_builder.lock();
             let next_data = data_builder.build();
             next_data_len = next_data.len();
-            let mut data = self.data.lock();
+            let mut data = self.data.write();
             data_len = data.len();
             *data = Arc::new(next_data);
         }
@@ -161,7 +161,7 @@ impl LookupDataManager {
     pub fn create_lookup_data(&self) -> LookupData {
         let keys;
         let data = {
-            let data = self.data.lock().clone();
+            let data = self.data.read().clone();
             keys = data.len();
             LookupData::new(data, self.logger.clone())
         };


### PR DESCRIPTION
There is no need to grab an exclusive lock when we're constructing new LookupData instances, as we only ever read.

My naive native lookup application went from 1.8k QPS to 7.2k QPS with just this one change.

This won't help Wasm code as much, as Wasm called `create_lookup_data()` once during sandbox creation; however, this will likely mean we can create more sandboxes in parallel as they don't have to synchronize here and we'll likely gain some marginal QPS for the simple use case.