### PR TITLE
Allow batching lookup data from Wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "key_value_lookup_multi"
+version = "0.1.0"
+dependencies = [
+ "oak_functions_sdk",
+ "oak_proto_rust",
+ "prost",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "oak_functions/examples/echo/module",
   "oak_functions/examples/invalid_module/module",
   "oak_functions/examples/key_value_lookup/module",
+  "oak_functions/examples/key_value_lookup_multi/module",
   "oak_functions/examples/weather_lookup/module",
   "oak_functions/load_test",
   "oak_functions/location_utils",

--- a/oak_functions/examples/key_value_lookup/module/Cargo.toml
+++ b/oak_functions/examples/key_value_lookup/module/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "key_value_lookup"
 version = "0.1.0"
-authors = ["Tiziano Santoro <tzn@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 

--- a/oak_functions/examples/key_value_lookup_multi/module/Cargo.toml
+++ b/oak_functions/examples/key_value_lookup_multi/module/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "key_value_lookup_multi"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+oak_functions_sdk = { workspace = true }
+oak_proto_rust = { workspace = true }
+prost = { workspace = true }

--- a/oak_functions/examples/key_value_lookup_multi/module/src/lib.rs
+++ b/oak_functions/examples/key_value_lookup_multi/module/src/lib.rs
@@ -1,0 +1,52 @@
+//
+// Copyright 2021 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Oak Functions key / value lookup example.
+
+use oak_proto_rust::oak::oak_functions::benchmark::{
+    lookup_request::Mode, LookupRequest, LookupResponse,
+};
+use prost::Message;
+
+#[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn main() {
+    let request_bytes = oak_functions_sdk::read_request().expect("couldn't read request body");
+    let request = LookupRequest::decode(request_bytes.as_ref()).expect("couldn't decode request");
+
+    // Implicitly convert not found entries to empty values.
+    let values: Vec<Vec<u8>> = match request.mode() {
+        // Look up individual keys one by one and collect the results.
+        Mode::Individual => request
+            .keys
+            .into_iter()
+            .map(|key| {
+                oak_functions_sdk::storage_get_item(&key)
+                    .expect("couldn't look up entry")
+                    .unwrap_or_default()
+            })
+            .collect(),
+        // Look up all keys in a batch.
+        Mode::Batch => oak_functions_sdk::storage_get_items(request.keys)
+            .expect("couldn't look up entries")
+            .into_iter()
+            .map(|v| v.unwrap_or_default())
+            .collect(),
+    };
+
+    let response = LookupResponse { values };
+    let response_bytes = response.encode_to_vec();
+    oak_functions_sdk::write_response(&response_bytes).expect("couldn't write response body");
+}

--- a/oak_functions_service/benches/wasm_benchmark.rs
+++ b/oak_functions_service/benches/wasm_benchmark.rs
@@ -25,7 +25,10 @@ use oak_functions_service::{
     lookup::{Data, LookupDataManager},
     wasm::WasmHandler,
 };
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use oak_proto_rust::oak::oak_functions::benchmark::{
+    lookup_request::Mode, LookupRequest, LookupResponse,
+};
+use prost::Message;
 
 fn bench_invoke_echo(c: &mut Criterion) {
     let test_state = create_test_state_with_wasm_module_name("echo");
@@ -53,19 +56,18 @@ fn bench_invoke_echo(c: &mut Criterion) {
 fn bench_invoke_lookup(c: &mut Criterion) {
     let test_state = create_test_state_with_wasm_module_name("key_value_lookup");
 
-    let max_data_size = 1000;
+    const MAX_DATA_SIZE: i32 = 1000;
+    const KEY_INDEX: i32 = 100;
 
-    let test_data = create_test_data(0, max_data_size);
+    let test_data = create_test_data(0, MAX_DATA_SIZE);
     test_state
         .lookup_data_manager
         .extend_next_lookup_data(test_data.clone());
     test_state.lookup_data_manager.finish_next_lookup_data();
 
     c.bench_function("lookup wasm", |b| {
-        let mut rng = SmallRng::seed_from_u64(0);
-        let i = rng.gen_range(0..max_data_size);
-        let request = format!("key{i}").into_bytes();
-        let expected_response = format!("value{i}").into_bytes();
+        let request = format!("key{KEY_INDEX}").into_bytes();
+        let expected_response = format!("value{KEY_INDEX}").into_bytes();
         b.iter(|| {
             let response = test_state
                 .wasm_handler
@@ -79,15 +81,69 @@ fn bench_invoke_lookup(c: &mut Criterion) {
 
     // Baseline for comparison.
     c.bench_function("lookup native", |b| {
-        let mut rng = SmallRng::seed_from_u64(0);
-        let i = rng.gen_range(0..max_data_size);
-        let request: Bytes = format!("key{i}").into_bytes().into();
-        let expected_response = format!("value{i}").into_bytes();
+        let request: Bytes = format!("key{KEY_INDEX}").into_bytes().into();
+        let expected_response = format!("value{KEY_INDEX}").into_bytes();
         b.iter(|| {
             let response = test_data.get(&request).unwrap();
             assert_eq!(response.as_ref(), expected_response);
         })
     });
+}
+
+fn bench_invoke_lookup_multi(c: &mut Criterion) {
+    let test_state = create_test_state_with_wasm_module_name("key_value_lookup_multi");
+
+    const MAX_DATA_SIZE: i32 = 1_000_000;
+    const START_KEY_INDEX: i32 = 100;
+
+    let test_data = create_test_data(0, MAX_DATA_SIZE);
+    test_state
+        .lookup_data_manager
+        .extend_next_lookup_data(test_data.clone());
+    test_state.lookup_data_manager.finish_next_lookup_data();
+
+    fn run_lookup_with_items(
+        b: &mut criterion::Bencher,
+        test_state: &TestState,
+        items: i32,
+        mode: Mode,
+    ) {
+        let lookup_request = LookupRequest {
+            keys: (START_KEY_INDEX..START_KEY_INDEX + items)
+                .map(|i| format!("key{}", i).into_bytes())
+                .collect(),
+            mode: mode.into(),
+        };
+        let request_bytes = lookup_request.encode_to_vec();
+
+        let expected_response = LookupResponse {
+            values: (START_KEY_INDEX..START_KEY_INDEX + items)
+                .map(|i| format!("value{}", i).into_bytes())
+                .collect(),
+        };
+        let expected_response_bytes = expected_response.encode_to_vec();
+
+        b.iter(|| {
+            let response = test_state
+                .wasm_handler
+                .handle_invoke(Request {
+                    body: request_bytes.clone(),
+                })
+                .unwrap();
+            assert_eq!(response.body, expected_response_bytes);
+        })
+    }
+
+    let mut group = c.benchmark_group("lookup_multi wasm");
+    for i in [1, 1000, 2000, 3000, 4000].iter() {
+        group.bench_with_input(BenchmarkId::new("Individual", i), i, |b, &i| {
+            run_lookup_with_items(b, &test_state, i, Mode::Individual);
+        });
+        group.bench_with_input(BenchmarkId::new("Batch", i), i, |b, &i| {
+            run_lookup_with_items(b, &test_state, i, Mode::Batch);
+        });
+    }
+    group.finish();
 }
 
 fn create_test_data(start: i32, end: i32) -> Data {
@@ -124,5 +180,10 @@ fn create_test_state_with_wasm_module_name(wasm_module_name: &str) -> TestState 
     }
 }
 
-criterion_group!(benches, bench_invoke_echo, bench_invoke_lookup);
+criterion_group!(
+    benches,
+    bench_invoke_echo,
+    bench_invoke_lookup,
+    bench_invoke_lookup_multi
+);
 criterion_main!(benches);

--- a/oak_functions_service/src/wasm/api.rs
+++ b/oak_functions_service/src/wasm/api.rs
@@ -18,9 +18,9 @@ use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 
 use log::Level;
 use oak_functions_sdk::proto::oak::functions::wasm::v1::{
-    LogRequest, LogResponse, LookupDataRequest, LookupDataResponse, ReadRequestRequest,
-    ReadRequestResponse, StdWasmApi, StdWasmApiServer, TestRequest, TestResponse,
-    WriteResponseRequest, WriteResponseResponse,
+    BytesValue, LogRequest, LogResponse, LookupDataMultiRequest, LookupDataMultiResponse,
+    LookupDataRequest, LookupDataResponse, ReadRequestRequest, ReadRequestResponse, StdWasmApi,
+    StdWasmApiServer, TestRequest, TestResponse, WriteResponseRequest, WriteResponseResponse,
 };
 use spinning_top::Spinlock;
 
@@ -98,14 +98,12 @@ impl StdWasmApi for StdWasmApiImpl {
         &mut self,
         request: LookupDataRequest,
     ) -> Result<LookupDataResponse, ::micro_rpc::Status> {
-        self.logger
-            .log_sensitive(Level::Debug, "invoked lookup_data");
         // The request is the key to lookup.
         let key = request.key;
         let key_to_log = limit(&key, 512);
         self.logger.log_sensitive(
             Level::Debug,
-            &format!("storage_get_item(): key: {}", format_bytes(key_to_log)),
+            &format!("lookup_data(): key: {}", format_bytes(key_to_log)),
         );
         let value = self.lookup_data.get(&key);
 
@@ -126,6 +124,35 @@ impl StdWasmApi for StdWasmApiImpl {
         );
 
         Ok(LookupDataResponse { value })
+    }
+
+    fn lookup_data_multi(
+        &mut self,
+        request: LookupDataMultiRequest,
+    ) -> Result<LookupDataMultiResponse, ::micro_rpc::Status> {
+        // The request contains the keys to lookup.
+        let keys = request.keys;
+
+        self.logger.log_sensitive(
+            Level::Debug,
+            &format!("lookup_data_multi(): {} keys", keys.len()),
+        );
+
+        let values: Vec<BytesValue> = keys
+            .iter()
+            .map(|key| match self.lookup_data.get(key) {
+                Some(value) => BytesValue {
+                    found: true,
+                    value: value.clone(),
+                },
+                None => BytesValue {
+                    found: false,
+                    value: Vec::new(),
+                },
+            })
+            .collect();
+
+        Ok(LookupDataMultiResponse { values })
     }
 
     fn test(&mut self, req: TestRequest) -> Result<TestResponse, micro_rpc::Status> {

--- a/proto/oak_functions/benchmark.proto
+++ b/proto/oak_functions/benchmark.proto
@@ -37,3 +37,16 @@ message LookupTest {
 message EchoAndPanicTest {
   bytes data = 1;
 }
+
+message LookupRequest {
+  repeated bytes keys = 1;
+  enum Mode {
+    INDIVIDUAL = 0;
+    BATCH = 1;
+  }
+  Mode mode = 2;
+}
+
+message LookupResponse {
+  repeated bytes values = 1;
+}

--- a/proto/oak_functions/sdk/oak_functions_wasm.proto
+++ b/proto/oak_functions/sdk/oak_functions_wasm.proto
@@ -54,6 +54,11 @@ service StdWasmApi {
   // method_id: 3
   rpc LookupData(LookupDataRequest) returns (LookupDataResponse) {}
 
+  // Looks up multiple items from the in-memory key/value lookup store.
+  //
+  // method_id: 4
+  rpc LookupDataMulti(LookupDataMultiRequest) returns (LookupDataMultiResponse) {}
+
   // Test method only.
   //
   // method_id: 128
@@ -86,6 +91,14 @@ message LookupDataResponse {
   google.protobuf.BytesValue value = 1;
 }
 
+message LookupDataMultiRequest {
+  repeated bytes keys = 1;
+}
+
+message LookupDataMultiResponse {
+  repeated BytesValue values = 1;
+}
+
 message TestRequest {
   bytes body = 1;
   // Whether to echo the message back. If false, the response will be empty.
@@ -94,4 +107,11 @@ message TestRequest {
 
 message TestResponse {
   bytes body = 1;
+}
+
+message BytesValue {
+  bytes value = 1;
+  // If true, the value was found in the store. This is useful to distinguish between a value that
+  // was not found and a value that was found and is empty.
+  bool found = 2;
 }


### PR DESCRIPTION
Adds a new microRPC method for multiple lookups. In the future the two may be easily unified, but at the moment I didn't want to risk breaking existing functionality.

Add a new Wasm module to perform multiple lookups. The difference from the existing one is that it deals with protos as input / output instead of just the raw value to look up, and also a parameter to determine how to do the lookups (to help with benchmarking).

Remove randomness in benchmark (it was not actually doing anything useful in the way it was written)