### PR TITLE
Permit dice data to be written back to the kernel

### DIFF
--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -427,9 +427,9 @@ pub fn start_kernel(info: &BootParams) -> ! {
     syscall::enable_syscalls(
         channel,
         #[cfg(feature = "initrd")]
-        stage0_dice_data,
+        syscall::dice_data::DiceData::Layer0(Box::new(stage0_dice_data)),
         #[cfg(not(feature = "initrd"))]
-        restricted_kernel_dice_data,
+        syscall::dice_data::DiceData::Layer1(Box::new(restricted_kernel_dice_data)),
         #[cfg(not(feature = "initrd"))]
         derived_key,
     );

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -427,9 +427,9 @@ pub fn start_kernel(info: &BootParams) -> ! {
     syscall::enable_syscalls(
         channel,
         #[cfg(feature = "initrd")]
-        syscall::dice_data::DiceData::Layer0(Box::new(stage0_dice_data)),
+        syscall::dice_data::DiceLayer::Layer0(Box::new(stage0_dice_data)),
         #[cfg(not(feature = "initrd"))]
-        syscall::dice_data::DiceData::Layer1(Box::new(restricted_kernel_dice_data)),
+        syscall::dice_data::DiceLayer::Layer1(Box::new(restricted_kernel_dice_data)),
         #[cfg(not(feature = "initrd"))]
         derived_key,
     );

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -427,9 +427,9 @@ pub fn start_kernel(info: &BootParams) -> ! {
     syscall::enable_syscalls(
         channel,
         #[cfg(feature = "initrd")]
-        syscall::dice_data::DiceLayer::Layer0(Box::new(stage0_dice_data)),
+        syscall::dice_data::DiceData::Layer0(Box::new(stage0_dice_data)),
         #[cfg(not(feature = "initrd"))]
-        syscall::dice_data::DiceLayer::Layer1(Box::new(restricted_kernel_dice_data)),
+        syscall::dice_data::DiceData::Layer1(Box::new(restricted_kernel_dice_data)),
         #[cfg(not(feature = "initrd"))]
         derived_key,
     );

--- a/oak_restricted_kernel/src/syscall/dice_data.rs
+++ b/oak_restricted_kernel/src/syscall/dice_data.rs
@@ -106,15 +106,16 @@ impl FileDescriptor for DiceDataDescriptor {
                 let data_as_slice = <RestrictedKernelDiceData as zerocopy::AsBytes>::as_bytes_mut(
                     &mut write_state.data,
                 );
-                let length = copy_max_slice(buf, &mut data_as_slice[write_state.index..]);
 
-                write_state.index += length;
-
-                if write_state.index > data_as_slice.len() {
+                if buf.len() > data_as_slice[write_state.index..].len() {
                     // the dice data the app may write has a known size. If the app keeps writing to
                     // this FD after it has written all of it, it's doing something wrong.
                     return Err(Errno::EINVAL);
                 }
+
+                let length = copy_max_slice(buf, &mut data_as_slice[write_state.index..]);
+
+                write_state.index += length;
 
                 if write_state.index == data_as_slice.len() {
                     let read_data =

--- a/oak_restricted_kernel/src/syscall/dice_data.rs
+++ b/oak_restricted_kernel/src/syscall/dice_data.rs
@@ -124,7 +124,7 @@ impl FileDescriptor for DiceDataDescriptor {
                         self,
                         Self::Readable(Box::new(ReadState {
                             index: 0,
-                            data: DiceData::Layer1(Box::new(write_state.data)),
+                            data: DiceData::Layer1(Box::new(read_data)),
                         })),
                     );
                 }

--- a/oak_restricted_kernel/src/syscall/dice_data.rs
+++ b/oak_restricted_kernel/src/syscall/dice_data.rs
@@ -117,15 +117,11 @@ impl FileDescriptor for DiceDataDescriptor {
                 }
 
                 if write_state.index == data_as_slice.len() {
-                    let read_data =
-                        <RestrictedKernelDiceData as zerocopy::FromBytes>::read_from(data_as_slice)
-                            .unwrap();
-
                     let _ = core::mem::replace(
                         self,
                         Self::Readable(Box::new(ReadState {
                             index: 0,
-                            data: DiceData::Layer1(Box::new(read_data)),
+                            data: DiceData::Layer1(Box::new(write_state.data)),
                         })),
                     );
                 }
@@ -147,6 +143,7 @@ pub fn register(data: DiceData) {
         .expect("DiceDataDescriptor already registered");
 }
 
+#[cfg(feature = "initrd")]
 #[test]
 fn fd_permits_one_full_write() {
     let layer0 = <Stage0DiceData as zerocopy::FromZeroes>::new_zeroed();
@@ -179,6 +176,7 @@ fn fd_permits_one_full_write() {
         .is_err());
 }
 
+#[cfg(feature = "initrd")]
 #[test]
 fn fd_supports_partial_writes() {
     let layer0 = <Stage0DiceData as zerocopy::FromZeroes>::new_zeroed();

--- a/oak_restricted_kernel/src/syscall/dice_data.rs
+++ b/oak_restricted_kernel/src/syscall/dice_data.rs
@@ -117,6 +117,9 @@ impl FileDescriptor for DiceDataDescriptor {
                 }
 
                 if write_state.index == data_as_slice.len() {
+                    let read_data =
+                        <RestrictedKernelDiceData as zerocopy::FromBytes>::read_from(data_as_slice)
+                            .unwrap();
                     let _ = core::mem::replace(
                         self,
                         Self::Readable(Box::new(ReadState {

--- a/oak_restricted_kernel/src/syscall/dice_data.rs
+++ b/oak_restricted_kernel/src/syscall/dice_data.rs
@@ -22,20 +22,20 @@ use zeroize::Zeroize;
 
 use super::fd::{copy_max_slice, FileDescriptor};
 
-pub enum DiceData {
+pub enum DiceLayer {
     #[cfg(feature = "initrd")]
     Layer0(Box<Stage0DiceData>),
     Layer1(Box<RestrictedKernelDiceData>),
 }
 
-impl DiceData {
+impl DiceLayer {
     fn as_mut_slice(&mut self) -> &mut [u8] {
         match self {
             #[cfg(feature = "initrd")]
-            DiceData::Layer0(stage0_dice_data) => {
+            DiceLayer::Layer0(stage0_dice_data) => {
                 <Stage0DiceData as zerocopy::AsBytes>::as_bytes_mut(stage0_dice_data)
             }
-            DiceData::Layer1(stage1_dice_data) => {
+            DiceLayer::Layer1(stage1_dice_data) => {
                 <RestrictedKernelDiceData as zerocopy::AsBytes>::as_bytes_mut(stage1_dice_data)
             }
         }
@@ -43,7 +43,7 @@ impl DiceData {
 }
 
 struct ReadState {
-    data: DiceData,
+    data: DiceLayer,
     index: usize,
 }
 
@@ -59,7 +59,7 @@ enum DiceDataDescriptor {
 }
 
 impl DiceDataDescriptor {
-    fn new(data: DiceData) -> Self {
+    fn new(data: DiceLayer) -> Self {
         Self::Readable(Box::new(ReadState { index: 0, data }))
     }
 }
@@ -88,7 +88,7 @@ impl FileDescriptor for DiceDataDescriptor {
         match self {
             DiceDataDescriptor::Readable(read_state) => match &mut read_state.data {
                 #[cfg(feature = "initrd")]
-                DiceData::Layer0(stage0_dice_data) => {
+                DiceLayer::Layer0(stage0_dice_data) => {
                     <Stage0DiceData as zerocopy::AsBytes>::as_bytes_mut(stage0_dice_data).zeroize();
                     let _ = core::mem::replace(
                         self,
@@ -121,7 +121,7 @@ impl FileDescriptor for DiceDataDescriptor {
                         self,
                         Self::Readable(Box::new(ReadState {
                             index: 0,
-                            data: DiceData::Layer1(Box::new(write_state.data)),
+                            data: DiceLayer::Layer1(Box::new(write_state.data)),
                         })),
                     );
                 }
@@ -137,7 +137,7 @@ impl FileDescriptor for DiceDataDescriptor {
 }
 
 /// Registers a file descriptor for reading dice data
-pub fn register(data: DiceData) {
+pub fn register(data: DiceLayer) {
     super::fd::register(DICE_DATA_FD, Box::new(DiceDataDescriptor::new(data)))
         .map_err(|_| ()) // throw away the box
         .expect("DiceDataDescriptor already registered");
@@ -149,7 +149,7 @@ fn fd_permits_one_full_write() {
     let layer0 = <Stage0DiceData as zerocopy::FromZeroes>::new_zeroed();
     let layer1 = <RestrictedKernelDiceData as zerocopy::FromZeroes>::new_zeroed();
 
-    let mut fd = DiceDataDescriptor::new(DiceData::Layer0(Box::new(layer0)));
+    let mut fd = DiceDataDescriptor::new(DiceLayer::Layer0(Box::new(layer0)));
 
     {
         let mut buf: [u8; 1] = [5; 1];
@@ -182,7 +182,7 @@ fn fd_supports_partial_writes() {
     let layer0 = <Stage0DiceData as zerocopy::FromZeroes>::new_zeroed();
     let layer1 = <RestrictedKernelDiceData as zerocopy::FromZeroes>::new_zeroed();
 
-    let mut fd = DiceDataDescriptor::new(DiceData::Layer0(Box::new(layer0)));
+    let mut fd = DiceDataDescriptor::new(DiceLayer::Layer0(Box::new(layer0)));
 
     let layer1_bytes = <RestrictedKernelDiceData as zerocopy::AsBytes>::as_bytes(&layer1);
     let halfway_point = layer1_bytes.len() / 2;

--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -15,7 +15,7 @@
 //
 
 mod channel;
-mod dice_data;
+pub mod dice_data;
 mod fd;
 #[cfg(not(feature = "initrd"))]
 mod key;
@@ -30,10 +30,6 @@ use alloc::boxed::Box;
 use core::{arch::asm, ffi::c_void};
 
 use oak_channel::Channel;
-#[cfg(not(feature = "initrd"))]
-use oak_dice::evidence::RestrictedKernelDiceData as DiceData;
-#[cfg(feature = "initrd")]
-use oak_dice::evidence::Stage0DiceData as DiceData;
 #[cfg(not(feature = "initrd"))]
 use oak_restricted_kernel_dice::DerivedKey;
 use oak_restricted_kernel_interface::{Errno, Syscall};
@@ -73,7 +69,7 @@ struct GsData {
 
 pub fn enable_syscalls(
     channel: Box<dyn Channel>,
-    dice_data: DiceData,
+    dice_data: dice_data::DiceData,
     #[cfg(not(feature = "initrd"))] derived_key: DerivedKey,
 ) {
     channel::register(channel);

--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -69,7 +69,7 @@ struct GsData {
 
 pub fn enable_syscalls(
     channel: Box<dyn Channel>,
-    dice_data: dice_data::DiceData,
+    dice_data: dice_data::DiceLayer,
     #[cfg(not(feature = "initrd"))] derived_key: DerivedKey,
 ) {
     channel::register(channel);

--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -69,7 +69,7 @@ struct GsData {
 
 pub fn enable_syscalls(
     channel: Box<dyn Channel>,
-    dice_data: dice_data::DiceLayer,
+    dice_data: dice_data::DiceData,
     #[cfg(not(feature = "initrd"))] derived_key: DerivedKey,
 ) {
     channel::register(channel);


### PR DESCRIPTION
In v0 the orchestrator will use this mechanism to write dice data back to the kernel after it measures the application. Following this, it launches the application and exists.

Then, the application will load the dice data from the kernel as usual. 

This means we should be able to ship the orchestrator as a non breaking change, before context switching is implemented.