### PR TITLE
Merge Rust EncryptionKeyProvider and KeyPair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,12 +2154,12 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
- "oak_dice",
  "p256",
  "prost",
  "rand_core",
  "sha2",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -718,11 +718,11 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
- "oak_dice",
  "p256",
  "prost",
  "rand_core",
  "sha2",
+ "zeroize",
 ]
 
 [[package]]

--- a/micro_rpc_workspace_test/Cargo.lock
+++ b/micro_rpc_workspace_test/Cargo.lock
@@ -257,33 +257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,16 +272,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "coset"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c214bbc5c8b4518856d79cae4d323feaa881ecf3e31b5af6572bb5313c11d5"
-dependencies = [
- "ciborium",
- "ciborium-io",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -596,12 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,12 +575,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -888,28 +839,10 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
- "oak_dice",
  "p256",
  "prost",
  "rand_core",
  "sha2",
-]
-
-[[package]]
-name = "oak_dice"
-version = "0.1.0"
-dependencies = [
- "bitflags 2.4.1",
- "ciborium",
- "coset",
- "hex",
- "hkdf",
- "p256",
- "rand_core",
- "sha2",
- "static_assertions",
- "strum",
- "zerocopy",
  "zeroize",
 ]
 
@@ -1343,34 +1276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,27 +1665,6 @@ checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
  "curve25519-dalek",
  "rand_core",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/oak_attestation/src/attester.rs
+++ b/oak_attestation/src/attester.rs
@@ -17,7 +17,7 @@
 use alloc::{sync::Arc, vec::Vec};
 
 use anyhow::Context;
-use oak_crypto::encryptor::EncryptionKeyProvider;
+use oak_crypto::encryption_key::EncryptionKey;
 
 use crate::proto::oak::session::v1::AttestationEvidence;
 
@@ -47,24 +47,24 @@ impl AttestationReportGenerator for EmptyAttestationReportGenerator {
 /// <https://www.rfc-editor.org/rfc/rfc9334.html#name-attester>
 pub struct Attester {
     attestation_report_generator: Arc<dyn AttestationReportGenerator>,
-    encryption_key_provider: Arc<EncryptionKeyProvider>,
+    encryption_key: Arc<EncryptionKey>,
 }
 
 impl Attester {
     pub fn new(
         attestation_report_generator: Arc<dyn AttestationReportGenerator>,
-        encryption_key_provider: Arc<EncryptionKeyProvider>,
+        encryption_key: Arc<EncryptionKey>,
     ) -> Self {
         Self {
             attestation_report_generator,
-            encryption_key_provider,
+            encryption_key,
         }
     }
 
     /// Generate an attestation evidence containing a remote attestation report and ensuring that
     /// `attested_data` is cryptographically bound to the result (e.g. via a signature).
     pub fn generate_attestation_evidence(&self) -> anyhow::Result<AttestationEvidence> {
-        let encryption_public_key = self.encryption_key_provider.get_serialized_public_key();
+        let encryption_public_key = self.encryption_key.get_serialized_public_key();
         let attestation_report = self
             .attestation_report_generator
             .generate_attestation_report(&encryption_public_key)

--- a/oak_attestation/src/attester.rs
+++ b/oak_attestation/src/attester.rs
@@ -17,7 +17,6 @@
 use alloc::{sync::Arc, vec::Vec};
 
 use anyhow::Context;
-use oak_crypto::encryption_key::EncryptionKey;
 
 use crate::proto::oak::session::v1::AttestationEvidence;
 
@@ -47,31 +46,30 @@ impl AttestationReportGenerator for EmptyAttestationReportGenerator {
 /// <https://www.rfc-editor.org/rfc/rfc9334.html#name-attester>
 pub struct Attester {
     attestation_report_generator: Arc<dyn AttestationReportGenerator>,
-    encryption_key: Arc<EncryptionKey>,
+    encryption_public_key: Vec<u8>,
 }
 
 impl Attester {
     pub fn new(
         attestation_report_generator: Arc<dyn AttestationReportGenerator>,
-        encryption_key: Arc<EncryptionKey>,
+        encryption_public_key: &[u8],
     ) -> Self {
         Self {
             attestation_report_generator,
-            encryption_key,
+            encryption_public_key: encryption_public_key.to_vec(),
         }
     }
 
     /// Generate an attestation evidence containing a remote attestation report and ensuring that
     /// `attested_data` is cryptographically bound to the result (e.g. via a signature).
     pub fn generate_attestation_evidence(&self) -> anyhow::Result<AttestationEvidence> {
-        let encryption_public_key = self.encryption_key.get_serialized_public_key();
         let attestation_report = self
             .attestation_report_generator
-            .generate_attestation_report(&encryption_public_key)
+            .generate_attestation_report(&self.encryption_public_key)
             .context("couldn't generate attestation report")?;
         Ok(AttestationEvidence {
             attestation: attestation_report,
-            encryption_public_key,
+            encryption_public_key: self.encryption_public_key.to_vec(),
             // TODO(#3836): Implement signature generation and add the signing key.
             signing_public_key: Vec::new(),
             // TODO(#3640): Sign application data.

--- a/oak_attestation/src/handler.rs
+++ b/oak_attestation/src/handler.rs
@@ -19,11 +19,11 @@ use core::future::Future;
 
 use anyhow::Context;
 use oak_crypto::{
-    encryptor::{AsyncEncryptionKeyHandle, EncryptionKeyHandle, ServerEncryptor},
+    encryption_key::{AsyncEncryptionKeyHandle, EncryptionKeyHandle},
+    encryptor::ServerEncryptor,
     proto::oak::crypto::v1::{EncryptedRequest, EncryptedResponse},
+    EMPTY_ASSOCIATED_DATA,
 };
-
-const EMPTY_ASSOCIATED_DATA: &[u8] = b"";
 
 /// Information about a public key.
 #[derive(Debug, Clone)]

--- a/oak_containers_orchestrator/src/crypto.rs
+++ b/oak_containers_orchestrator/src/crypto.rs
@@ -81,8 +81,9 @@ impl InstanceKeys {
             ServerEncryptor::decrypt(&encrypted_encryption_private_key, &self.encryption_key)
                 .context("couldn't decrypt the encryption private key")?;
 
-        let group_encryption_key = EncryptionKey::deserialize(&mut decrypted_encryption_private_key)
-            .context("couldn't deserialize private key")?;
+        let group_encryption_key =
+            EncryptionKey::deserialize(&mut decrypted_encryption_private_key)
+                .context("couldn't deserialize private key")?;
 
         Ok(GroupKeys {
             encryption_key: group_encryption_key,

--- a/oak_containers_orchestrator/src/crypto.rs
+++ b/oak_containers_orchestrator/src/crypto.rs
@@ -23,7 +23,6 @@ use oak_crypto::{
 };
 use oak_dice::cert::generate_ecdsa_key_pair;
 use tonic::{Request, Response};
-use zeroize::Zeroizing;
 
 use crate::proto::oak::{
     containers::v1::{
@@ -78,12 +77,11 @@ impl InstanceKeys {
             .context("encrypted encryption key wasn't provided")?;
 
         // Decrypt group keys.
-        let (_, decrypted_encryption_private_key, _) =
+        let (_, mut decrypted_encryption_private_key, _) =
             ServerEncryptor::decrypt(&encrypted_encryption_private_key, &self.encryption_key)
                 .context("couldn't decrypt the encryption private key")?;
-        let decrypted_encryption_private_key = Zeroizing::new(decrypted_encryption_private_key);
 
-        let group_encryption_key = EncryptionKey::deserialize(&decrypted_encryption_private_key)
+        let group_encryption_key = EncryptionKey::deserialize(&mut decrypted_encryption_private_key)
             .context("couldn't deserialize private key")?;
 
         Ok(GroupKeys {

--- a/oak_containers_orchestrator/src/crypto.rs
+++ b/oak_containers_orchestrator/src/crypto.rs
@@ -15,126 +15,112 @@
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context};
-use hpke::{kem::X25519HkdfSha256, Deserializable, Kem};
+use anyhow::Context;
 use oak_crypto::{
-    encryption_key::{EncryptionKey, EncryptionKeyHandle},
-    encryptor::{ClientEncryptor, ServerEncryptor},
+    encryption_key::{generate_encryption_key_pair, EncryptionKey, EncryptionKeyHandle},
+    encryptor::ServerEncryptor,
     proto::oak::crypto::v1::EncryptedRequest,
-    EMPTY_ASSOCIATED_DATA,
 };
+use oak_dice::cert::generate_ecdsa_key_pair;
 use tonic::{Request, Response};
+use zeroize::Zeroizing;
 
 use crate::proto::oak::{
     containers::v1::{
         orchestrator_crypto_server::OrchestratorCrypto, DeriveSessionKeysRequest,
         DeriveSessionKeysResponse, KeyOrigin, SignRequest, SignResponse,
     },
-    key_provisioning::v1::GroupKeys,
+    key_provisioning::v1::GroupKeys as GroupKeysProto,
 };
 
-/// An implementation of the Key Store without group keys.
-pub struct InstanceKeyStore {
-    // TODO(#4507): Remove `Arc` once the key is no longer required by the `Attester`.
-    instance_encryption_key: Arc<EncryptionKey>,
-    instance_signing_key: p256::ecdsa::SigningKey,
+pub fn generate_instance_keys() -> (InstanceKeys, InstancePublicKeys) {
+    let (encryption_key, encryption_public_key) = generate_encryption_key_pair();
+    let (signing_key, signing_public_key) = generate_ecdsa_key_pair();
+    (
+        InstanceKeys {
+            encryption_key,
+            signing_key,
+        },
+        InstancePublicKeys {
+            encryption_public_key,
+            signing_public_key,
+        },
+    )
 }
 
-impl InstanceKeyStore {
-    pub fn new(instance_signing_key: p256::ecdsa::SigningKey) -> Self {
-        Self {
-            instance_encryption_key: Arc::new(EncryptionKey::generate()),
-            instance_signing_key,
-        }
+pub struct InstanceKeys {
+    encryption_key: EncryptionKey,
+    signing_key: p256::ecdsa::SigningKey,
+}
+
+pub struct InstancePublicKeys {
+    pub encryption_public_key: Vec<u8>,
+    pub signing_public_key: p256::ecdsa::VerifyingKey,
+}
+
+impl InstanceKeys {
+    pub fn generate_group_keys(&self) -> (GroupKeys, GroupPublicKeys) {
+        let (group_encryption_key, group_encryption_public_key) = generate_encryption_key_pair();
+        (
+            GroupKeys {
+                encryption_key: group_encryption_key,
+            },
+            GroupPublicKeys {
+                encryption_public_key: group_encryption_public_key,
+            },
+        )
     }
 
-    pub fn instance_encryption_key(&self) -> Arc<EncryptionKey> {
-        // TODO(#4442): Currently we have to give the encryption key to the `ipc_server`.
-        // Once we move all enclave apps to the new crypto service and update the `Attester` to not
-        // have the private key - this function should be removed.
-        self.instance_encryption_key.clone()
-    }
-
-    pub fn instance_encryption_public_key(&self) -> Vec<u8> {
-        self.instance_encryption_key.get_serialized_public_key()
-    }
-
-    pub fn generate_group_keys(self) -> KeyStore {
-        KeyStore {
-            instance_encryption_key: self.instance_encryption_key,
-            group_encryption_key: EncryptionKey::generate(),
-            instance_signing_key: self.instance_signing_key,
-        }
-    }
-
-    pub fn provide_group_keys(self, group_keys: GroupKeys) -> anyhow::Result<KeyStore> {
+    pub fn provide_group_keys(&self, group_keys: GroupKeysProto) -> anyhow::Result<GroupKeys> {
         // Create server encryptor for decrypting the group keys received from the leader enclave.
         let encrypted_encryption_private_key = group_keys
             .encrypted_encryption_private_key
             .context("encrypted encryption key wasn't provided")?;
 
         // Decrypt group keys.
-        let (_, decrypted_encryption_private_key, _) = ServerEncryptor::decrypt(
-            &encrypted_encryption_private_key,
-            self.instance_encryption_key.as_ref(),
-        )
-        .context("couldn't decrypt the encryption private key")?;
+        let (_, decrypted_encryption_private_key, _) =
+            ServerEncryptor::decrypt(&encrypted_encryption_private_key, &self.encryption_key)
+                .context("couldn't decrypt the encryption private key")?;
+        let decrypted_encryption_private_key = Zeroizing::new(decrypted_encryption_private_key);
 
-        // Parse private key and derive public key.
-        // TODO(#4513): We shouldn't store the public key, only the private key.
-        let encryption_private_key =
-            <X25519HkdfSha256 as Kem>::PrivateKey::from_bytes(&decrypted_encryption_private_key)
-                .map_err(|err| anyhow!("couldn't deserialize private key: {:?}", err))?;
-        let encryption_public_key = X25519HkdfSha256::sk_to_pk(&encryption_private_key);
-        let group_encryption_key =
-            EncryptionKey::new(encryption_private_key, encryption_public_key);
+        let group_encryption_key = EncryptionKey::deserialize(&decrypted_encryption_private_key)
+            .context("couldn't deserialize private key")?;
 
-        // Add group keys to the Orchestrator key store.
-        Ok(KeyStore {
-            instance_encryption_key: self.instance_encryption_key,
-            instance_signing_key: self.instance_signing_key,
-            group_encryption_key,
+        Ok(GroupKeys {
+            encryption_key: group_encryption_key,
         })
     }
 }
 
-/// An implementation of the Key Store with initialized group keys.
-pub struct KeyStore {
-    // TODO(#4507): Remove `Arc` once the key is no longer required by the `Attester`.
-    instance_encryption_key: Arc<EncryptionKey>,
-    instance_signing_key: p256::ecdsa::SigningKey,
-    group_encryption_key: EncryptionKey,
+pub struct GroupKeys {
+    encryption_key: EncryptionKey,
 }
 
-impl KeyStore {
-    pub fn instance_encryption_key(&self) -> Arc<EncryptionKey> {
-        // TODO(#4442): Currently we have to give the encryption key to the `ipc_server`.
-        // Once we move all enclave apps to the new crypto service and update the `Attester` to not
-        // have the private key - this function should be removed.
-        self.instance_encryption_key.clone()
-    }
+pub struct GroupPublicKeys {
+    pub encryption_public_key: Vec<u8>,
+}
 
+impl GroupKeys {
     /// Returns group encryption private key which was encrypted with the `peer_public_key`.
     pub fn encrypted_group_encryption_key(
         &self,
         peer_public_key: &[u8],
     ) -> anyhow::Result<EncryptedRequest> {
-        let mut client_encryptor =
-            ClientEncryptor::create(peer_public_key).context("couldn't create client encryptor")?;
-        client_encryptor.encrypt(
-            &self.group_encryption_key.get_private_key(),
-            EMPTY_ASSOCIATED_DATA,
-        )
+        self.encryption_key.encrypted_private_key(peer_public_key)
     }
 }
 
 pub(crate) struct CryptoService {
-    key_store: Arc<KeyStore>,
+    instance_keys: InstanceKeys,
+    group_keys: Arc<GroupKeys>,
 }
 
 impl CryptoService {
-    pub(crate) fn new(key_store: Arc<KeyStore>) -> Self {
-        Self { key_store }
+    pub(crate) fn new(instance_keys: InstanceKeys, group_keys: Arc<GroupKeys>) -> Self {
+        Self {
+            instance_keys,
+            group_keys,
+        }
     }
 
     fn signing_key(
@@ -145,7 +131,7 @@ impl CryptoService {
             KeyOrigin::Unspecified => {
                 Err(tonic::Status::invalid_argument("unspecified key origin"))?
             }
-            KeyOrigin::Instance => Ok(&self.key_store.instance_signing_key),
+            KeyOrigin::Instance => Ok(&self.instance_keys.signing_key),
             KeyOrigin::Group =>
             // TODO(#4442): Implement with key provisioning.
             {
@@ -169,8 +155,8 @@ impl OrchestratorCrypto for CryptoService {
             KeyOrigin::Unspecified => {
                 Err(tonic::Status::invalid_argument("unspecified key origin"))?
             }
-            KeyOrigin::Instance => &self.key_store.instance_encryption_key,
-            KeyOrigin::Group => &self.key_store.group_encryption_key,
+            KeyOrigin::Instance => &self.instance_keys.encryption_key,
+            KeyOrigin::Group => &self.group_keys.encryption_key,
         };
 
         let session_keys = encryption_key

--- a/oak_containers_orchestrator/src/ipc_server.rs
+++ b/oak_containers_orchestrator/src/ipc_server.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::{transport::Server, Request, Response};
 
 use crate::{
-    crypto::{CryptoService, KeyStore},
+    crypto::{CryptoService, GroupKeys, InstanceKeys},
     launcher_client::LauncherClient,
     proto::oak::containers::{
         orchestrator_server::{Orchestrator, OrchestratorServer},
@@ -58,7 +58,8 @@ impl Orchestrator for ServiceImplementation {
 
 pub async fn create<P>(
     socket_address: P,
-    key_store: Arc<KeyStore>,
+    instance_keys: InstanceKeys,
+    group_keys: Arc<GroupKeys>,
     application_config: Vec<u8>,
     launcher_client: Arc<LauncherClient>,
     cancellation_token: CancellationToken,
@@ -71,7 +72,7 @@ where
         application_config,
         launcher_client,
     };
-    let crypto_service_instance = CryptoService::new(key_store);
+    let crypto_service_instance = CryptoService::new(instance_keys, group_keys);
 
     let uds = UnixListener::bind(socket_address.clone())
         .context("could not bind to the supplied address")?;

--- a/oak_containers_sdk/src/crypto.rs
+++ b/oak_containers_sdk/src/crypto.rs
@@ -16,7 +16,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use oak_crypto::{
-    encryptor::AsyncEncryptionKeyHandle, hpke::RecipientContext,
+    encryption_key::AsyncEncryptionKeyHandle, hpke::RecipientContext,
     proto::oak::crypto::v1::SessionKeys,
 };
 use tonic::transport::{Endpoint, Uri};

--- a/oak_crypto/Cargo.toml
+++ b/oak_crypto/Cargo.toml
@@ -27,7 +27,7 @@ rand_core = { version = "*", default-features = false, features = [
   "getrandom"
 ] }
 sha2 = { version = "*", default-features = false }
-oak_dice = { workspace = true }
+zeroize = "*"
 
 [build-dependencies]
 micro_rpc_build = { workspace = true }

--- a/oak_crypto/src/encryption_key.rs
+++ b/oak_crypto/src/encryption_key.rs
@@ -1,0 +1,113 @@
+//
+// Copyright 2024 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use alloc::{boxed::Box, vec::Vec};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use zeroize::Zeroizing;
+
+use crate::{
+    encryptor::ClientEncryptor,
+    hpke::{
+        generate_kem_keypair, setup_base_recipient, Deserializable, PrivateKey, RecipientContext,
+        Serializable, OAK_HPKE_INFO,
+    },
+    proto::oak::crypto::v1::EncryptedRequest,
+    EMPTY_ASSOCIATED_DATA,
+};
+
+/// Generates a random encryption key pair and returns an instance of the `EncryptionKey` and a
+/// NIST P-256 SEC1 encoded point public key.
+/// <https://secg.org/sec1-v2.pdf>
+pub fn generate_encryption_key_pair() -> (EncryptionKey, Vec<u8>) {
+    let (private_key, public_key) = generate_kem_keypair();
+    (
+        EncryptionKey::new(private_key),
+        public_key.to_bytes().to_vec(),
+    )
+}
+
+// TODO(#4513): Implement `Zeroize` for `EncryptionKey`.
+pub struct EncryptionKey {
+    private_key: PrivateKey,
+}
+
+impl EncryptionKey {
+    pub fn new(private_key: PrivateKey) -> Self {
+        Self { private_key }
+    }
+
+    pub fn serialize(self) -> Vec<u8> {
+        self.private_key.to_bytes().to_vec()
+    }
+
+    pub fn deserialize(serialized_private_key: &[u8]) -> anyhow::Result<Self> {
+        let private_key = PrivateKey::from_bytes(serialized_private_key)
+            .map_err(|error| anyhow::anyhow!("couldn't deserialize private key: {}", error))?;
+        Ok(Self { private_key })
+    }
+
+    /// Returns the private key encrypted with the `peer_public_key`.
+    pub fn encrypted_private_key(
+        &self,
+        peer_public_key: &[u8],
+    ) -> anyhow::Result<EncryptedRequest> {
+        let mut client_encryptor =
+            ClientEncryptor::create(peer_public_key).context("couldn't create client encryptor")?;
+        client_encryptor.encrypt(
+            &Zeroizing::new(self.private_key.to_bytes()),
+            EMPTY_ASSOCIATED_DATA,
+        )
+    }
+}
+
+/// Exposes the ability to derive a session key from the provided encapsulated private key,
+/// using a private key that has been endorsed in the Attestation Evidence.
+pub trait EncryptionKeyHandle {
+    fn generate_recipient_context(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext>;
+}
+
+impl EncryptionKeyHandle for EncryptionKey {
+    fn generate_recipient_context(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext> {
+        setup_base_recipient(encapsulated_public_key, &self.private_key, OAK_HPKE_INFO)
+            .context("couldn't generate recipient crypto context")
+    }
+}
+
+#[async_trait]
+pub trait AsyncEncryptionKeyHandle {
+    async fn generate_recipient_context(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext>;
+}
+
+#[async_trait]
+impl AsyncEncryptionKeyHandle for EncryptionKey {
+    async fn generate_recipient_context(
+        &self,
+        encapsulated_public_key: &[u8],
+    ) -> anyhow::Result<RecipientContext> {
+        (self as &dyn EncryptionKeyHandle).generate_recipient_context(encapsulated_public_key)
+    }
+}

--- a/oak_crypto/src/encryption_key.rs
+++ b/oak_crypto/src/encryption_key.rs
@@ -23,7 +23,7 @@ use zeroize::Zeroizing;
 use crate::{
     encryptor::ClientEncryptor,
     hpke::{
-        generate_kem_keypair, setup_base_recipient, Deserializable, PrivateKey, RecipientContext,
+        generate_kem_key_pair, setup_base_recipient, Deserializable, PrivateKey, RecipientContext,
         Serializable, OAK_HPKE_INFO,
     },
     proto::oak::crypto::v1::EncryptedRequest,
@@ -34,7 +34,7 @@ use crate::{
 /// NIST P-256 SEC1 encoded point public key.
 /// <https://secg.org/sec1-v2.pdf>
 pub fn generate_encryption_key_pair() -> (EncryptionKey, Vec<u8>) {
-    let (private_key, public_key) = generate_kem_keypair();
+    let (private_key, public_key) = generate_kem_key_pair();
     (
         EncryptionKey::new(private_key),
         public_key.to_bytes().to_vec(),

--- a/oak_crypto/src/encryption_key.rs
+++ b/oak_crypto/src/encryption_key.rs
@@ -18,7 +18,7 @@ use alloc::{boxed::Box, vec::Vec};
 
 use anyhow::Context;
 use async_trait::async_trait;
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
     encryptor::ClientEncryptor,
@@ -41,7 +41,6 @@ pub fn generate_encryption_key_pair() -> (EncryptionKey, Vec<u8>) {
     )
 }
 
-// TODO(#4513): Implement `Zeroize` for `EncryptionKey`.
 pub struct EncryptionKey {
     private_key: PrivateKey,
 }
@@ -55,9 +54,10 @@ impl EncryptionKey {
         self.private_key.to_bytes().to_vec()
     }
 
-    pub fn deserialize(serialized_private_key: &[u8]) -> anyhow::Result<Self> {
+    pub fn deserialize(serialized_private_key: &mut [u8]) -> anyhow::Result<Self> {
         let private_key = PrivateKey::from_bytes(serialized_private_key)
             .map_err(|error| anyhow::anyhow!("couldn't deserialize private key: {}", error))?;
+        serialized_private_key.zeroize();
         Ok(Self { private_key })
     }
 

--- a/oak_crypto/src/hpke/mod.rs
+++ b/oak_crypto/src/hpke/mod.rs
@@ -32,46 +32,16 @@ use crate::{
 
 type Aead = AesGcm256;
 type Kdf = HkdfSha256;
-type Kem = X25519HkdfSha256;
+pub type Kem = X25519HkdfSha256;
 pub type PrivateKey = <Kem as KemTrait>::PrivateKey;
 pub type PublicKey = <Kem as KemTrait>::PublicKey;
 pub(crate) type EncappedKey = <Kem as KemTrait>::EncappedKey;
 
-pub fn gen_kem_keypair() -> (PrivateKey, PublicKey) {
+/// Info string used by Hybrid Public Key Encryption;
+pub(crate) const OAK_HPKE_INFO: &[u8] = b"Oak Hybrid Public Key Encryption v1";
+
+pub(crate) fn generate_kem_keypair() -> (PrivateKey, PublicKey) {
     Kem::gen_keypair(&mut OsRng)
-}
-
-pub struct KeyPair {
-    pub(crate) private_key: PrivateKey,
-    pub(crate) public_key: PublicKey,
-}
-
-impl KeyPair {
-    /// Randomly generates a key pair.
-    pub fn generate() -> Self {
-        let (private_key, public_key) = gen_kem_keypair();
-        Self {
-            private_key,
-            public_key,
-        }
-    }
-
-    pub fn new(private_key: PrivateKey, public_key: PublicKey) -> Self {
-        Self {
-            private_key,
-            public_key,
-        }
-    }
-
-    pub fn get_private_key(&self) -> Vec<u8> {
-        self.private_key.to_bytes().to_vec()
-    }
-
-    /// Returns a NIST P-256 SEC1 encoded point public key.
-    /// <https://secg.org/sec1-v2.pdf>
-    pub fn get_serialized_public_key(&self) -> Vec<u8> {
-        self.public_key.to_bytes().to_vec()
-    }
 }
 
 /// Sets up an HPKE sender by generating an ephemeral keypair (and serializing the corresponding
@@ -122,7 +92,7 @@ pub(crate) fn setup_base_sender(
 /// <https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-to-a-public-key>
 pub(crate) fn setup_base_recipient(
     serialized_encapsulated_public_key: &[u8],
-    recipient_key_pair: &KeyPair,
+    recipient_private_key: &PrivateKey,
     info: &[u8],
 ) -> anyhow::Result<RecipientContext> {
     let encapsulated_public_key = EncappedKey::from_bytes(serialized_encapsulated_public_key)
@@ -135,7 +105,7 @@ pub(crate) fn setup_base_recipient(
 
     let recipient_context = hpke::setup_receiver::<Aead, Kdf, Kem>(
         &OpModeR::Base,
-        &recipient_key_pair.private_key,
+        recipient_private_key,
         &encapsulated_public_key,
         info,
     )

--- a/oak_crypto/src/hpke/mod.rs
+++ b/oak_crypto/src/hpke/mod.rs
@@ -40,7 +40,7 @@ pub(crate) type EncappedKey = <Kem as KemTrait>::EncappedKey;
 /// Info string used by Hybrid Public Key Encryption;
 pub(crate) const OAK_HPKE_INFO: &[u8] = b"Oak Hybrid Public Key Encryption v1";
 
-pub(crate) fn generate_kem_keypair() -> (PrivateKey, PublicKey) {
+pub(crate) fn generate_kem_key_pair() -> (PrivateKey, PublicKey) {
     Kem::gen_keypair(&mut OsRng)
 }
 

--- a/oak_crypto/src/lib.rs
+++ b/oak_crypto/src/lib.rs
@@ -32,9 +32,12 @@ pub mod proto {
     }
 }
 
+pub mod encryption_key;
 pub mod encryptor;
 pub mod hpke;
 pub mod signer;
 #[cfg(test)]
 mod tests;
 pub mod verifier;
+
+pub const EMPTY_ASSOCIATED_DATA: &[u8] = b"";

--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
 
 use anyhow::Context;
 use oak_attestation::handler::AsyncEncryptionHandler;
-use oak_crypto::encryptor::AsyncEncryptionKeyHandle;
+use oak_crypto::encryption_key::AsyncEncryptionKeyHandle;
 use oak_functions_service::{
     instance::OakFunctionsInstance,
     proto::oak::functions::{

--- a/oak_functions_containers_app/tests/integration_test.rs
+++ b/oak_functions_containers_app/tests/integration_test.rs
@@ -29,7 +29,7 @@ use std::{
     time::Duration,
 };
 
-use oak_crypto::encryptor::EncryptionKeyProvider;
+use oak_crypto::encryption_key::generate_encryption_key_pair;
 use oak_functions_containers_app::serve;
 use oak_functions_service::proto::oak::functions::InitializeRequest;
 use opentelemetry::metrics::{noop::NoopMeterProvider, MeterProvider};
@@ -47,9 +47,11 @@ async fn test_lookup() {
     let listener = TcpListener::bind(addr).await.unwrap();
     let addr = listener.local_addr().unwrap();
 
+    let (encryption_key, _) = generate_encryption_key_pair();
+
     let server_handle = tokio::spawn(serve(
         listener,
-        Arc::new(EncryptionKeyProvider::generate()),
+        Arc::new(encryption_key),
         NoopMeterProvider::new().meter(""),
     ));
 

--- a/oak_functions_enclave_service/src/lib.rs
+++ b/oak_functions_enclave_service/src/lib.rs
@@ -22,7 +22,7 @@ use alloc::{format, string::ToString, sync::Arc, vec::Vec};
 
 use oak_attestation::{dice::evidence_to_proto, handler::EncryptionHandler};
 use oak_core::sync::OnceCell;
-use oak_crypto::encryptor::EncryptionKeyHandle;
+use oak_crypto::encryption_key::EncryptionKeyHandle;
 pub use oak_functions_service::proto;
 use oak_functions_service::{
     instance::OakFunctionsInstance,

--- a/oak_restricted_kernel_bin/Cargo.lock
+++ b/oak_restricted_kernel_bin/Cargo.lock
@@ -677,11 +677,11 @@ dependencies = [
  "hkdf",
  "hpke",
  "micro_rpc_build",
- "oak_dice",
  "p256",
  "prost",
  "rand_core",
  "sha2",
+ "zeroize",
 ]
 
 [[package]]

--- a/oak_restricted_kernel_sdk/src/instance_attestation.rs
+++ b/oak_restricted_kernel_sdk/src/instance_attestation.rs
@@ -48,9 +48,9 @@ fn get_restricted_kernel_dice_data() -> anyhow::Result<RestrictedKernelDiceData>
 
 impl TryFrom<RestrictedKernelDiceData> for DiceWrapper {
     type Error = anyhow::Error;
-    fn try_from(dice_data: RestrictedKernelDiceData) -> Result<Self, Self::Error> {
+    fn try_from(mut dice_data: RestrictedKernelDiceData) -> Result<Self, Self::Error> {
         let encryption_key = EncryptionKey::deserialize(
-            &dice_data.application_private_keys.encryption_private_key
+            &mut dice_data.application_private_keys.encryption_private_key
                 [..oak_dice::evidence::X25519_PRIVATE_KEY_SIZE],
         )?;
         let signing_key = SigningKey::from_slice(

--- a/oak_restricted_kernel_sdk/src/instance_attestation.rs
+++ b/oak_restricted_kernel_sdk/src/instance_attestation.rs
@@ -18,7 +18,7 @@
 
 use anyhow::Ok;
 use oak_crypto::{
-    encryptor::{EncryptionKeyHandle, EncryptionKeyProvider},
+    encryption_key::{EncryptionKey, EncryptionKeyHandle},
     hpke::RecipientContext,
 };
 use oak_dice::evidence::{Evidence, RestrictedKernelDiceData, P256_PRIVATE_KEY_SIZE};
@@ -49,7 +49,10 @@ fn get_restricted_kernel_dice_data() -> anyhow::Result<RestrictedKernelDiceData>
 impl TryFrom<RestrictedKernelDiceData> for DiceWrapper {
     type Error = anyhow::Error;
     fn try_from(dice_data: RestrictedKernelDiceData) -> Result<Self, Self::Error> {
-        let encryption_key = EncryptionKeyProvider::try_from(&dice_data)?;
+        let encryption_key = EncryptionKey::deserialize(
+            &dice_data.application_private_keys.encryption_private_key
+                [..oak_dice::evidence::X25519_PRIVATE_KEY_SIZE],
+        )?;
         let signing_key = SigningKey::from_slice(
             &dice_data.application_private_keys.signing_private_key[..P256_PRIVATE_KEY_SIZE],
         )
@@ -94,7 +97,7 @@ impl Signer for InstanceSigner {
 /// private keys.
 #[derive(Clone)]
 pub struct InstanceEncryptionKeyHandle {
-    key: &'static EncryptionKeyProvider,
+    key: &'static EncryptionKey,
 }
 
 impl InstanceEncryptionKeyHandle {

--- a/oak_restricted_kernel_sdk/src/lib.rs
+++ b/oak_restricted_kernel_sdk/src/lib.rs
@@ -27,8 +27,8 @@ pub mod instance_attestation;
 #[doc(cfg(feature = "mock_attestation"))]
 pub mod mock_attestation;
 pub mod utils;
-pub use oak_crypto::encryptor::EncryptionKeyHandle;
-use oak_crypto::encryptor::EncryptionKeyProvider;
+use oak_crypto::encryption_key::EncryptionKey;
+pub use oak_crypto::encryption_key::EncryptionKeyHandle;
 use oak_dice::evidence::Evidence;
 /// Marks a function as the entrypoint to an enclave app and sets up an conviences such an
 /// allocator, logger, panic handler.
@@ -80,6 +80,6 @@ pub trait EvidenceProvider {
 /// Wrapper for DICE evidence and application private keys.
 pub(crate) struct DiceWrapper {
     pub evidence: Evidence,
-    pub encryption_key: EncryptionKeyProvider,
+    pub encryption_key: EncryptionKey,
     pub signing_key: p256::ecdsa::SigningKey,
 }

--- a/oak_restricted_kernel_sdk/src/mock_attestation.rs
+++ b/oak_restricted_kernel_sdk/src/mock_attestation.rs
@@ -18,7 +18,7 @@
 //! TEE may not be available.
 
 use oak_crypto::{
-    encryptor::{EncryptionKeyHandle, EncryptionKeyProvider},
+    encryption_key::{EncryptionKey, EncryptionKeyHandle},
     hpke::RecipientContext,
 };
 use oak_dice::evidence::{Evidence, RestrictedKernelDiceData};
@@ -77,7 +77,7 @@ impl Signer for MockSigner {
 /// private keys.
 #[derive(Clone)]
 pub struct MockEncryptionKeyHandle {
-    key: &'static EncryptionKeyProvider,
+    key: &'static EncryptionKey,
 }
 
 impl MockEncryptionKeyHandle {


### PR DESCRIPTION
This PR:
- Merges `oak_crypto::encryptor::EncryptionKeyProvider` and `oak_crypto::hpke::KeyPair` into `oak_crypto::encryption_key::EncryptionKey`
- Implements serialization/deserialization
- Implements encryping the private key for Key Provisioning.
- Removes public keys from `EncryptionKey` struct (it's only used to be put into the evidence)

Ref https://github.com/project-oak/oak/issues/4513