### PR TITLE
Create an API for Oak Functions handlers

### DIFF
--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "oak_functions_enclave_service",
+ "oak_functions_service",
  "oak_restricted_kernel_sdk",
 ]
 

--- a/enclave_apps/oak_functions_enclave_app/Cargo.toml
+++ b/enclave_apps/oak_functions_enclave_app/Cargo.toml
@@ -17,6 +17,7 @@ allow_sensitive_logging = []
 
 [dependencies]
 oak_functions_enclave_service = { path = "../../oak_functions_enclave_service", default-features = false }
+oak_functions_service = { path = "../../oak_functions_service", default-features = false }
 log = "*"
 micro_rpc = { workspace = true }
 oak_restricted_kernel_sdk = { workspace = true }

--- a/enclave_apps/oak_functions_enclave_app/src/main.rs
+++ b/enclave_apps/oak_functions_enclave_app/src/main.rs
@@ -22,6 +22,7 @@ extern crate alloc;
 
 use alloc::{boxed::Box, sync::Arc};
 
+use oak_functions_service::wasm::WasmHandler;
 use oak_restricted_kernel_sdk::{
     channel::{start_blocking_server, FileDescriptorChannel},
     entrypoint,
@@ -42,7 +43,7 @@ fn main() -> ! {
     let encryption_key_handle =
         InstanceEncryptionKeyHandle::create().expect("couldn't encryption key");
     let evidencer = InstanceEvidenceProvider::create().expect("couldn't get evidence");
-    let service = oak_functions_enclave_service::OakFunctionsService::new(
+    let service = oak_functions_enclave_service::OakFunctionsService::<_, _, WasmHandler>::new(
         evidencer,
         Arc::new(encryption_key_handle),
         None,

--- a/oak_functions_enclave_service/tests/integration_test.rs
+++ b/oak_functions_enclave_service/tests/integration_test.rs
@@ -50,6 +50,7 @@ fn init() {
 fn new_service_for_testing() -> OakFunctionsService<
     oak_restricted_kernel_sdk::mock_attestation::MockEncryptionKeyHandle,
     oak_restricted_kernel_sdk::mock_attestation::MockEvidenceProvider,
+    oak_functions_service::wasm::WasmHandler,
 > {
     OakFunctionsService::new(
         oak_restricted_kernel_sdk::mock_attestation::MockEvidenceProvider::create()
@@ -328,6 +329,7 @@ fn it_should_handle_wasm_panic() {
                 OakFunctionsService<
                     oak_restricted_kernel_sdk::mock_attestation::MockEncryptionKeyHandle,
                     oak_restricted_kernel_sdk::mock_attestation::MockEvidenceProvider,
+                    oak_functions_service::wasm::WasmHandler,
                 >,
             >,
         >,

--- a/oak_functions_sdk/tests/integration_test.rs
+++ b/oak_functions_sdk/tests/integration_test.rs
@@ -22,6 +22,7 @@ use oak_functions_service::{
     logger::StandaloneLogger,
     lookup::{Data, LookupDataManager},
     wasm::{api::StdWasmApiFactory, WasmHandler},
+    Handler,
 };
 
 lazy_static! {

--- a/oak_functions_service/benches/wasm_benchmark.rs
+++ b/oak_functions_service/benches/wasm_benchmark.rs
@@ -27,6 +27,7 @@ use oak_functions_service::{
     logger::StandaloneLogger,
     lookup::{Data, LookupDataManager},
     wasm::WasmHandler,
+    Handler,
 };
 use oak_proto_rust::oak::oak_functions::testing::{
     lookup_request::Mode, LookupRequest, LookupResponse, TestModuleClient,
@@ -182,7 +183,7 @@ fn create_test_state_with_wasm_module_name(wasm_module_name: &str) -> TestState 
         oak_functions_test_utils::build_rust_crate_wasm(wasm_module_name).unwrap();
     let wasm_module_bytes = std::fs::read(wasm_module_path).unwrap();
 
-    let wasm_handler = oak_functions_service::wasm::new_wasm_handler(
+    let wasm_handler = oak_functions_service::wasm::WasmHandler::new_handler(
         &wasm_module_bytes,
         lookup_data_manager.clone(),
         None,

--- a/oak_functions_service/src/instance.rs
+++ b/oak_functions_service/src/instance.rs
@@ -28,15 +28,15 @@ use crate::{
         ExtendNextLookupDataResponse, FinishNextLookupDataRequest, FinishNextLookupDataResponse,
         InitializeRequest, LookupDataChunk, ReserveRequest, ReserveResponse,
     },
-    wasm, Observer,
+    Handler, Observer,
 };
 
-pub struct OakFunctionsInstance {
+pub struct OakFunctionsInstance<H: Handler> {
     lookup_data_manager: Arc<LookupDataManager>,
-    wasm_handler: wasm::WasmHandler,
+    wasm_handler: H::HandlerType,
 }
 
-impl OakFunctionsInstance {
+impl<H: Handler> OakFunctionsInstance<H> {
     /// See [`crate::proto::oak::functions::OakFunctions::initialize`].
     pub fn new(
         request: &InitializeRequest,
@@ -45,13 +45,14 @@ impl OakFunctionsInstance {
         let lookup_data_manager =
             Arc::new(LookupDataManager::new_empty(Arc::new(StandaloneLogger)));
         let wasm_handler =
-            wasm::new_wasm_handler(&request.wasm_module, lookup_data_manager.clone(), observer)
-                .map_err(|err| {
+            H::new_handler(&request.wasm_module, lookup_data_manager.clone(), observer).map_err(
+                |err| {
                     micro_rpc::Status::new_with_message(
                         micro_rpc::StatusCode::Internal,
                         format!("couldn't initialize Wasm handler: {:?}", err),
                     )
-                })?;
+                },
+            )?;
         Ok(Self {
             lookup_data_manager,
             wasm_handler,

--- a/oak_functions_service/src/lib.rs
+++ b/oak_functions_service/src/lib.rs
@@ -20,6 +20,11 @@
 // Required for enabling benchmark tests.
 #![feature(test)]
 
+use alloc::sync::Arc;
+
+use lookup::LookupDataManager;
+use oak_functions_abi::{Request, Response};
+
 extern crate alloc;
 
 #[cfg(test)]
@@ -45,4 +50,18 @@ pub mod wasm;
 pub trait Observer {
     fn wasm_initialization(&self, duration: core::time::Duration);
     fn wasm_invocation(&self, duration: core::time::Duration);
+}
+
+pub trait Handler {
+    type HandlerType: Handler;
+
+    fn new_handler(
+        wasm_module_bytes: &[u8],
+        lookup_data_manager: Arc<LookupDataManager>,
+        observer: Option<Arc<dyn Observer + Send + Sync>>,
+    ) -> anyhow::Result<Self::HandlerType>;
+
+    /// Handles a call to invoke by getting the raw request bytes from the body of the request to
+    /// invoke and returns a reponse to invoke setting the raw bytes in the body of the response.
+    fn handle_invoke(&self, invoke_request: Request) -> Result<Response, micro_rpc::Status>;
 }

--- a/oak_functions_service/src/wasm/mod.rs
+++ b/oak_functions_service/src/wasm/mod.rs
@@ -37,7 +37,7 @@ use wasmi::Store;
 use crate::{
     logger::{OakLogger, StandaloneLogger},
     lookup::LookupDataManager,
-    Observer,
+    Handler, Observer,
 };
 
 /// Fixed name of the function to start a Wasm. Every Oak Wasm module must provide this function.
@@ -454,10 +454,25 @@ impl WasmHandler {
             observer,
         })
     }
+}
 
-    /// Handles a call to invoke by getting the raw request bytes from the body of the request to
-    /// invoke and returns a reponse to invoke setting the raw bytes in the body of the response.
-    pub fn handle_invoke(&self, invoke_request: Request) -> Result<Response, micro_rpc::Status> {
+impl Handler for WasmHandler {
+    type HandlerType = WasmHandler;
+
+    fn new_handler(
+        wasm_module_bytes: &[u8],
+        lookup_data_manager: Arc<LookupDataManager>,
+        observer: Option<Arc<dyn Observer + Send + Sync>>,
+    ) -> anyhow::Result<WasmHandler> {
+        let logger = Arc::new(StandaloneLogger);
+        let wasm_api_factory = Arc::new(StdWasmApiFactory {
+            lookup_data_manager,
+        });
+
+        Self::create(wasm_module_bytes, wasm_api_factory, logger, observer)
+    }
+
+    fn handle_invoke(&self, invoke_request: Request) -> Result<Response, micro_rpc::Status> {
         #[cfg(feature = "std")]
         let now = Instant::now();
         let module = self.wasm_module.clone();
@@ -521,22 +536,4 @@ impl WasmHandler {
 fn from_status_code(result: Result<(), StatusCode>) -> Result<i32, wasmi::core::Trap> {
     let status_code = result.err().unwrap_or(StatusCode::Ok);
     Ok(status_code as i32)
-}
-
-/// Creates a new `WasmHandler` instance.
-pub fn new_wasm_handler(
-    wasm_module_bytes: &[u8],
-    lookup_data_manager: Arc<LookupDataManager>,
-    observer: Option<Arc<dyn Observer + Send + Sync>>,
-) -> anyhow::Result<WasmHandler> {
-    let logger = Arc::new(StandaloneLogger);
-    let wasm_api_factory = StdWasmApiFactory {
-        lookup_data_manager,
-    };
-    WasmHandler::create(
-        wasm_module_bytes,
-        Arc::new(wasm_api_factory),
-        logger,
-        observer,
-    )
 }

--- a/oak_functions_service/src/wasm/tests.rs
+++ b/oak_functions_service/src/wasm/tests.rs
@@ -31,6 +31,7 @@ use crate::{
     logger::StandaloneLogger,
     lookup::LookupDataManager,
     wasm::{AbiPointer, AbiPointerOffset},
+    Handler,
 };
 
 #[test]


### PR DESCRIPTION
There is some clean-up to be done here, but the basic gist of it is that we now have a trait, `Handler`, for handling user invocations.

For now, we obviously only have the Wasm handler. But this is the hook that a native implementation could use.