### PR TITLE
Add a fairly rudimentary `NativeHandler` to oak_functions_containers_app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,6 +2551,7 @@ dependencies = [
  "oak_containers_orchestrator",
  "oak_containers_sdk",
  "oak_crypto",
+ "oak_functions_abi",
  "oak_functions_service",
  "oak_functions_test_utils",
  "oak_grpc_utils",
@@ -2558,6 +2559,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "prost",
+ "strum 0.24.1",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
@@ -4220,6 +4222,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros 0.24.3",
+]
 
 [[package]]
 name = "strum"
@@ -4227,7 +4232,20 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5584,7 +5602,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "strum 0.24.1",
- "strum_macros",
+ "strum_macros 0.25.3",
  "tokio",
  "toml 0.8.8",
  "walkdir",

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -14,6 +14,7 @@ http = "*"
 oak_attestation = { workspace = true }
 oak_containers_orchestrator = { workspace = true }
 oak_containers_sdk = { workspace = true }
+oak_functions_abi = { workspace = true }
 oak_functions_service = { workspace = true, features = ["std"] }
 oak_crypto = { workspace = true }
 micro_rpc = { workspace = true }
@@ -31,6 +32,7 @@ opentelemetry-otlp = { version = "*", default-features = false, features = [
   "trace",
 ] }
 prost = "*"
+strum = { version = "*", features = ["derive"] }
 tikv-jemallocator = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tokio-stream = { version = "*", features = ["net"] }

--- a/oak_functions_containers_app/src/main.rs
+++ b/oak_functions_containers_app/src/main.rs
@@ -20,10 +20,11 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use oak_containers_orchestrator::launcher_client::LauncherClient;
 use oak_containers_sdk::{InstanceEncryptionKeyHandle, OrchestratorClient};
-use oak_functions_containers_app::serve;
+use oak_functions_containers_app::{native_handler::NativeHandler, serve};
+use oak_functions_service::wasm::wasmtime::WasmtimeHandler;
 use opentelemetry::{global::set_error_handler, metrics::MeterProvider, KeyValue};
 use tokio::{net::TcpListener, runtime::Handle};
 
@@ -32,10 +33,23 @@ const OAK_FUNCTIONS_CONTAINERS_APP_PORT: u16 = 8080;
 #[global_allocator]
 static ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+#[derive(Clone, Debug, strum::Display, ValueEnum)]
+pub enum HandlerType {
+    /// The uploaded bytecode to be a .so file that will be dynamically opened.
+    Native,
+
+    /// The uploaded bytecode is Wasm bytecode, executed in a Wasm sandbox.
+    Wasm,
+}
+
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(default_value = "http://10.0.2.100:8080")]
     launcher_addr: String,
+
+    /// Type of request handler to use
+    #[arg(default_value = "wasm")]
+    handler: HandlerType,
 }
 
 #[tokio::main]
@@ -141,7 +155,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         OAK_FUNCTIONS_CONTAINERS_APP_PORT,
     );
     let listener = TcpListener::bind(addr).await?;
-    let server_handle = tokio::spawn(serve(listener, Arc::new(encryption_key_handle), meter));
+    let server_handle = tokio::spawn(async move {
+        match args.handler {
+            HandlerType::Native => {
+                serve::<_, NativeHandler>(listener, Arc::new(encryption_key_handle), meter).await
+            }
+            HandlerType::Wasm => {
+                serve::<_, WasmtimeHandler>(listener, Arc::new(encryption_key_handle), meter).await
+            }
+        }
+    });
 
     eprintln!("Running Oak Functions on Oak Containers at address: {addr}");
     client

--- a/oak_functions_containers_app/src/native_handler.rs
+++ b/oak_functions_containers_app/src/native_handler.rs
@@ -1,0 +1,50 @@
+//
+// Copyright 2024 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::sync::Arc;
+
+use oak_functions_abi::{Request, Response};
+use oak_functions_service::{lookup::LookupDataManager, Handler, Observer};
+
+pub struct NativeHandler {
+    #[allow(dead_code)]
+    lookup_data_manager: Arc<LookupDataManager>,
+
+    #[allow(dead_code)]
+    observer: Option<Arc<dyn Observer + Send + Sync>>,
+}
+
+impl Handler for NativeHandler {
+    type HandlerType = NativeHandler;
+
+    fn new_handler(
+        _wasm_module_bytes: &[u8],
+        lookup_data_manager: Arc<LookupDataManager>,
+        observer: Option<Arc<dyn Observer + Send + Sync>>,
+    ) -> anyhow::Result<NativeHandler> {
+        Ok(Self {
+            lookup_data_manager,
+            observer,
+        })
+    }
+
+    fn handle_invoke(&self, invoke_request: Request) -> Result<Response, micro_rpc::Status> {
+        let response_bytes = invoke_request.body;
+        let invoke_response =
+            Response::create(oak_functions_abi::StatusCode::Success, response_bytes);
+        Ok(invoke_response)
+    }
+}

--- a/oak_functions_containers_app/tests/integration_test.rs
+++ b/oak_functions_containers_app/tests/integration_test.rs
@@ -31,7 +31,9 @@ use std::{
 
 use oak_crypto::encryption_key::generate_encryption_key_pair;
 use oak_functions_containers_app::serve;
-use oak_functions_service::proto::oak::functions::InitializeRequest;
+use oak_functions_service::{
+    proto::oak::functions::InitializeRequest, wasm::wasmtime::WasmtimeHandler,
+};
 use opentelemetry::metrics::{noop::NoopMeterProvider, MeterProvider};
 use tokio::net::TcpListener;
 use tonic::{codec::CompressionEncoding, transport::Endpoint};
@@ -49,7 +51,7 @@ async fn test_lookup() {
 
     let (encryption_key, _) = generate_encryption_key_pair();
 
-    let server_handle = tokio::spawn(serve(
+    let server_handle = tokio::spawn(serve::<_, WasmtimeHandler>(
         listener,
         Arc::new(encryption_key),
         NoopMeterProvider::new().meter(""),


### PR DESCRIPTION
I thought about creating a separate `oak_functions_containers_app` crate, but there's a ton more going on here -- like all the instrumentation to report metrics back to the launcher -- so decided that it's probably best, for now, to just tack the native handler onto the existing app.

Right now it does nothing; just echoes back the request.

In the future we probably do want some crate features in here to say whether to include wasm and/or native handlers.