### PR TITLE
Balance kokoro test times

### DIFF
--- a/justfile
+++ b/justfile
@@ -86,11 +86,11 @@ all_ensure_no_std: (ensure_no_std "micro_rpc") (ensure_no_std "oak_attestation_v
 
 kokoro_build_binaries_rust: all_enclave_apps oak_restricted_kernel_bin oak_restricted_kernel_simple_io_bin oak_restricted_kernel_simple_io_wrapper stage0_bin
 
-kokoro_oak_containers: all_oak_containers_binaries oak_functions_containers_container_bundle_tar
-    RUST_LOG="debug" cargo nextest run --all-targets --hide-progress-bar --package='oak_containers_hello_world_untrusted_app'
+kokoro_oak_containers: all_oak_containers_binaries
+    RUST_LOG="debug" cargo nextest run --all-targets --hide-progress-bar --package='oak_containers_hello_world_untrusted_app' --package='oak_functions_containers_launcher'
 
 kokoro_run_tests: all_ensure_no_std
-    RUST_LOG="debug" cargo nextest run --all-targets --hide-progress-bar --workspace --exclude='oak_containers_hello_world_untrusted_app'
+    RUST_LOG="debug" cargo nextest run --all-targets --hide-progress-bar --workspace --exclude='oak_containers_hello_world_untrusted_app' --exclude='oak_functions_containers_launcher'
 
 clang-tidy:
     bazel build --config=clang-tidy //cc/...

--- a/kokoro/run_tests.sh
+++ b/kokoro/run_tests.sh
@@ -14,7 +14,7 @@ export XDG_RUNTIME_DIR=/var/run
 cd "$(dirname "$0")/.."
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#default --command just kokoro_run_tests
+./scripts/docker_run nix develop .#ci --command just kokoro_run_tests
 
 mkdir -p "${KOKORO_ARTIFACTS_DIR}/test_logs/"
 cp --preserve=timestamps \


### PR DESCRIPTION
At the moment the `run_tests` kokoro job takes a really long time because it also runs the Oak Functions on Oak Containers integration tests, meaning it must also build all the Oak Containers artifacts.

So, to try to balance things out a bit this now runs all Oak Containers tests in the `build_binaries_oak_containers ` job.