### PR TITLE
Fix build scripts to track WORKSPACE_ROOT

### DIFF
--- a/micro_rpc_tests/build.rs
+++ b/micro_rpc_tests/build.rs
@@ -15,6 +15,7 @@
 //
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=WORKSPACE_ROOT");
     micro_rpc_build::compile(
         &[format!(
             "{}micro_rpc_tests/proto/test_schema.proto",

--- a/oak_restricted_kernel_bin/build.rs
+++ b/oak_restricted_kernel_bin/build.rs
@@ -15,6 +15,7 @@
 //
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=WORKSPACE_ROOT");
     println!(
         "cargo:rerun-if-changed={}/oak_restricted_kernel/layout.ld",
         env!("WORKSPACE_ROOT")

--- a/oak_restricted_kernel_wrapper/build.rs
+++ b/oak_restricted_kernel_wrapper/build.rs
@@ -41,7 +41,7 @@ fn try_source_path() -> Result<PathBuf, &'static str> {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=cargo:rerun-if-env-changed=OAK_RESTRICTED_KERNEL_FILE_NAME");
+    println!("cargo:rerun-if-env-changed=OAK_RESTRICTED_KERNEL_FILE_NAME");
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rustc-link-arg=--script=layout.ld");
     let mut destination_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());

--- a/stage0_bin/build.rs
+++ b/stage0_bin/build.rs
@@ -17,6 +17,7 @@
 use std::env;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=PROFILE");
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rustc-link-arg=--script=layout.ld");
 


### PR DESCRIPTION
This is mostly only an issue when switching between docker and non-docker builds.