### PR TITLE
Don't always immediately clone the lookup table entry

### DIFF
--- a/oak_functions_service/src/lookup.rs
+++ b/oak_functions_service/src/lookup.rs
@@ -18,7 +18,6 @@ use alloc::{
     format,
     string::{String, ToString},
     sync::Arc,
-    vec::Vec,
 };
 
 use bytes::Bytes;
@@ -183,8 +182,8 @@ impl LookupData {
     }
 
     /// Gets an individual entry from the backing data.
-    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.data.get(key).cloned().map(Into::into)
+    pub fn get(&self, key: &[u8]) -> Option<&Bytes> {
+        self.data.get(key)
     }
 
     /// Gets the number of entries in the backing data.

--- a/oak_functions_service/src/wasm/api.rs
+++ b/oak_functions_service/src/wasm/api.rs
@@ -123,7 +123,9 @@ impl StdWasmApi for StdWasmApiImpl {
             },
         );
 
-        Ok(LookupDataResponse { value })
+        Ok(LookupDataResponse {
+            value: value.cloned().map(Into::into),
+        })
     }
 
     fn lookup_data_multi(
@@ -143,7 +145,7 @@ impl StdWasmApi for StdWasmApiImpl {
             .map(|key| match self.lookup_data.get(key) {
                 Some(value) => BytesValue {
                     found: true,
-                    value: value.clone(),
+                    value: value.clone().into(),
                 },
                 None => BytesValue {
                     found: false,


### PR DESCRIPTION
This is to help with the native logic implementation.

Wasm code executes in its own sandbox and we copy the lookup data in there, creating a copy; however, if the logic is run in native mode, we _don't_ want to create a copy for each lookup but rather just pass on the pointer into the hashmap straight to the native code.

(Otherwise, we'd need to keep track of values we've cloned for each request ourselves so that we'd know what copies to deallocate once we've handled the request.)