### PR TITLE
Flesh out the `NativeHandler` to actually invoke native code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +1860,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2562,7 @@ dependencies = [
  "anyhow",
  "clap",
  "http",
+ "libloading",
  "micro_rpc",
  "oak_attestation",
  "oak_containers_orchestrator",
@@ -2558,8 +2575,10 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "ouroboros",
  "prost",
- "strum 0.24.1",
+ "strum 0.25.0",
+ "tempfile",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
@@ -3166,6 +3185,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ouroboros"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b7be5a8a3462b752f4be3ff2b2bf2f7f1d00834902e46be2a4d68b87b0573c"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
+dependencies = [
+ "heck",
+ "itertools 0.12.0",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,6 +3486,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -4222,9 +4279,6 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
 
 [[package]]
 name = "strum"
@@ -4232,20 +4286,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -5602,7 +5643,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "strum 0.24.1",
- "strum_macros 0.25.3",
+ "strum_macros",
  "tokio",
  "toml 0.8.8",
  "walkdir",
@@ -5617,6 +5658,12 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "zerocopy"

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -4,12 +4,17 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = ["native"]
+native = ["dep:libloading", "dep:tempfile", "dep:ouroboros"]
+
 [build-dependencies]
 oak_grpc_utils = { workspace = true }
 
 [dependencies]
 anyhow = "*"
 clap = { version = "*", features = ["derive"] }
+libloading = { version = "*", optional = true }
 http = "*"
 oak_attestation = { workspace = true }
 oak_containers_orchestrator = { workspace = true }
@@ -31,8 +36,10 @@ opentelemetry-otlp = { version = "*", default-features = false, features = [
   "metrics",
   "trace",
 ] }
+ouroboros = { version = "*", optional = true }
 prost = "*"
 strum = { version = "*", features = ["derive"] }
+tempfile = { version = "*", optional = true }
 tikv-jemallocator = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tokio-stream = { version = "*", features = ["net"] }

--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#![feature(c_size_t)]
+
 use std::{
     future::Future,
     pin::Pin,
@@ -44,6 +46,7 @@ use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 use tonic::codec::CompressionEncoding;
 use tracing::Span;
 
+#[cfg(feature = "native")]
 pub mod native_handler;
 
 use crate::proto::oak::functions::oak_functions_server::{OakFunctions, OakFunctionsServer};

--- a/oak_functions_containers_app/src/main.rs
+++ b/oak_functions_containers_app/src/main.rs
@@ -23,7 +23,9 @@ use anyhow::{anyhow, Context};
 use clap::{Parser, ValueEnum};
 use oak_containers_orchestrator::launcher_client::LauncherClient;
 use oak_containers_sdk::{InstanceEncryptionKeyHandle, OrchestratorClient};
-use oak_functions_containers_app::{native_handler::NativeHandler, serve};
+#[cfg(feature = "native")]
+use oak_functions_containers_app::native_handler::NativeHandler;
+use oak_functions_containers_app::serve;
 use oak_functions_service::wasm::wasmtime::WasmtimeHandler;
 use opentelemetry::{global::set_error_handler, metrics::MeterProvider, KeyValue};
 use tokio::{net::TcpListener, runtime::Handle};
@@ -35,6 +37,7 @@ static ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[derive(Clone, Debug, strum::Display, ValueEnum)]
 pub enum HandlerType {
+    #[cfg(feature = "native")]
     /// The uploaded bytecode to be a .so file that will be dynamically opened.
     Native,
 
@@ -157,6 +160,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(addr).await?;
     let server_handle = tokio::spawn(async move {
         match args.handler {
+            #[cfg(feature = "native")]
             HandlerType::Native => {
                 serve::<_, NativeHandler>(listener, Arc::new(encryption_key_handle), meter).await
             }

--- a/oak_functions_containers_app/src/native_handler.rs
+++ b/oak_functions_containers_app/src/native_handler.rs
@@ -14,37 +14,238 @@
 // limitations under the License.
 //
 
-use std::sync::Arc;
+use core::ffi::c_size_t;
+use std::{cell::RefCell, fs::File, io::Write, sync::Arc};
 
+use anyhow::Context;
+use libloading::{Library, Symbol};
 use oak_functions_abi::{Request, Response};
-use oak_functions_service::{lookup::LookupDataManager, Handler, Observer};
+use oak_functions_service::{
+    lookup::{LookupData, LookupDataManager},
+    Handler, Observer,
+};
+use ouroboros::self_referencing;
+use tempfile::{tempdir, TempDir};
 
+struct RequestContext {
+    request: Vec<u8>,
+    response: Vec<u8>,
+    lookup_data: LookupData,
+}
+
+thread_local! {
+    static CONTEXT: RefCell<Option<RequestContext>> = RefCell::new(None);
+}
+
+// Callbacks for the C side.
+#[allow(dead_code)]
+mod callbacks {
+    use core::ffi::c_size_t;
+    use std::{ptr, slice, str};
+
+    use super::CONTEXT;
+
+    /// Safety: the caller needs to guarantee that the `len` pointer is valid.
+    pub unsafe extern "C" fn read_request(len: *mut c_size_t) -> *const u8 {
+        CONTEXT.with(|ctx| {
+            let bind = ctx.borrow();
+            let ctx = bind.as_ref().expect("no currently active request!");
+            *len = ctx.request.len();
+            ctx.request.as_ptr()
+        })
+    }
+
+    /// Safety: the caller needs to guarantee that `data` and `len` are valid.
+    pub unsafe extern "C" fn write_response(data: *const u8, len: c_size_t) -> bool {
+        CONTEXT.with(|ctx| {
+            let mut bind = ctx.borrow_mut();
+            let ctx = bind.as_mut().expect("no currently active request!");
+
+            // Create a copy of the data.
+            ctx.response = slice::from_raw_parts(data, len).into();
+            true
+        })
+    }
+
+    /// Safety: the caller needs to guarantee that `data` and `len` are valid.
+    pub unsafe extern "C" fn log(data: *const u8, len: c_size_t) -> bool {
+        CONTEXT.with(|ctx| {
+            let bind = ctx.borrow();
+            let ctx = bind.as_ref().expect("no currently active request!");
+            match str::from_utf8(slice::from_raw_parts(data, len)) {
+                Ok(message) => {
+                    ctx.lookup_data.log_debug(message);
+                    true
+                }
+                Err(_) => false,
+            }
+        })
+    }
+
+    /// Safety: the caller needs to guarantee `key`, `len` and `item_len` are valid. The caller is
+    /// not allowed to mutate the data the returned pointer points to.
+    pub unsafe extern "C" fn storage_get_item(
+        key: *const u8,
+        len: c_size_t,
+        item_len: *mut c_size_t,
+    ) -> *const u8 {
+        CONTEXT.with(|ctx| {
+            let bind = ctx.borrow();
+            let ctx = bind.as_ref().expect("no currently active request!");
+            let key = slice::from_raw_parts(key, len);
+            match ctx.lookup_data.get(key) {
+                Some(val) => {
+                    *item_len = val.len();
+                    val.as_ptr()
+                }
+                None => {
+                    *item_len = 0;
+                    ptr::null()
+                }
+            }
+        })
+    }
+
+    /// Safety: the caller must guarantee that `status_code` and `len` are valid.
+    pub unsafe extern "C" fn read_error(status_code: *mut u32, len: *mut c_size_t) -> *const u8 {
+        // not entirely sure what to do here
+        *status_code = micro_rpc::StatusCode::Unknown.into();
+        *len = 0;
+        ptr::null()
+    }
+}
+
+#[self_referencing]
+struct SharedLibrary {
+    lib: Library,
+
+    #[borrows(lib)]
+    #[covariant]
+    oak_main: Symbol<'this, unsafe extern "C" fn()>,
+}
+
+/// Variant of a Handler that dynamically loads a `.so` file and invokes native code to handle
+/// requests from there.
 pub struct NativeHandler {
-    #[allow(dead_code)]
     lookup_data_manager: Arc<LookupDataManager>,
 
     #[allow(dead_code)]
     observer: Option<Arc<dyn Observer + Send + Sync>>,
+
+    /// Temporary directory containing the `.so` file.
+    ///
+    /// This field is never read, but we need to keep it around so that the directory would be
+    /// property disposed of when `NativeHandler` goes out of scope.
+    #[allow(dead_code)]
+    directory: TempDir,
+
+    /// Instance of the actual shared library.
+    library: SharedLibrary,
+}
+
+impl NativeHandler {
+    /// Registers our callback functions with the loaded library.
+    ///
+    /// Safety: the library needs to export a `register_callback`` symbol with the expected
+    /// semantics.
+    unsafe fn register_callbacks(&self) -> anyhow::Result<()> {
+        // These signatures should probably come via bindgen from the C header file in the future.
+        let register_callbacks =
+            self.library.borrow_lib().get::<unsafe extern "C" fn(
+                unsafe extern "C" fn(*mut c_size_t) -> *const u8,
+                unsafe extern "C" fn(*const u8, c_size_t) -> bool,
+                unsafe extern "C" fn(*const u8, c_size_t) -> bool,
+                unsafe extern "C" fn(*const u8, c_size_t, *mut c_size_t) -> *const u8,
+                unsafe extern "C" fn(*mut u32, *mut c_size_t) -> *const u8,
+            )>("register_callbacks".as_bytes())?;
+
+        register_callbacks(
+            callbacks::read_request,
+            callbacks::write_response,
+            callbacks::log,
+            callbacks::storage_get_item,
+            callbacks::read_error,
+        );
+
+        Ok(())
+    }
+
+    /// Call the main `oak_main` function from the shared library.
+    ///
+    /// Safety: the library needs to export a `oak_main` symbol with the expected semantics.
+    unsafe fn oak_main(&self) {
+        self.library.borrow_oak_main()()
+    }
 }
 
 impl Handler for NativeHandler {
     type HandlerType = NativeHandler;
 
+    /// Creates a new native handler.
+    ///
+    /// The module is expected to be a dynamically loadable shared object, which we load using
+    /// `dlopen()`.
+    ///
+    /// Safety: It's up to the caller to guarantee that said shared object adheres to the semantics
+    /// we require. This method should really be marked `unsafe` because of that.
     fn new_handler(
-        _wasm_module_bytes: &[u8],
+        module_bytes: &[u8],
         lookup_data_manager: Arc<LookupDataManager>,
         observer: Option<Arc<dyn Observer + Send + Sync>>,
     ) -> anyhow::Result<NativeHandler> {
-        Ok(Self {
+        let directory = tempdir().context("could not create temporary directory")?;
+        let filename = directory.path().join("module.so");
+        {
+            let mut file =
+                File::create(&filename).context("could not open module file for writing")?;
+            file.write_all(module_bytes)
+                .context("could not write module contents")?;
+        }
+
+        // Safety: this is safe as long as the library adheres to our contracts.
+        let lib = unsafe { Library::new(filename) }.context("failed to load shared library")?;
+
+        let handler = NativeHandler {
             lookup_data_manager,
             observer,
-        })
+            library: SharedLibraryTryBuilder {
+                lib,
+                oak_main_builder: |lib| {
+                    unsafe { lib.get("oak_main".as_bytes()) }
+                        .context("could not find `oak_main` in shared library")
+                },
+            }
+            .try_build()?,
+            directory,
+        };
+
+        // Safety: this is safe as long as the library adheres to our contracts.
+        unsafe { handler.register_callbacks() }?;
+
+        Ok(handler)
     }
 
     fn handle_invoke(&self, invoke_request: Request) -> Result<Response, micro_rpc::Status> {
-        let response_bytes = invoke_request.body;
+        // Populate a new RequestContext. The threadlocal should be empty at this point; if it is
+        // not, we've somehow clashed with another thread.
+        assert!(
+            CONTEXT
+                .replace(Some(RequestContext {
+                    request: invoke_request.body,
+                    response: Vec::new(),
+                    lookup_data: self.lookup_data_manager.create_lookup_data(),
+                }))
+                .is_none(),
+            "request context was not empty"
+        );
+
+        // Safety: this is safe as long as the library adheres to our contracts.
+        unsafe { self.oak_main() };
+
+        // Clean up the request memory.
+        let ctx = CONTEXT.replace(None).expect("request context was empty");
         let invoke_response =
-            Response::create(oak_functions_abi::StatusCode::Success, response_bytes);
+            Response::create(oak_functions_abi::StatusCode::Success, ctx.response);
         Ok(invoke_response)
     }
 }


### PR DESCRIPTION
This is entirely untested as I don't have a `.so` file to play around with; constructing a test for this should be the next priority.

But: this will accept a bunch of bytes (that we'll need to append to the DICE log in the future), and attempts to load it dynamically as a shared object expecting it to adhere to the contract we've been discussion about seprately.
