### PR TITLE
Execute app loaded by orchestrator

### DIFF
--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -862,6 +862,7 @@ dependencies = [
  "oak_restricted_kernel_orchestrator",
  "oak_restricted_kernel_sdk",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]

--- a/enclave_apps/oak_orchestrator/Cargo.toml
+++ b/enclave_apps/oak_orchestrator/Cargo.toml
@@ -12,6 +12,7 @@ oak_restricted_kernel_orchestrator = { path = "../../oak_restricted_kernel_orche
 oak_dice = { workspace = true }
 zerocopy = "*"
 log = "*"
+zeroize = "*"
 
 [[bin]]
 name = "oak_orchestrator"

--- a/oak_restricted_kernel/src/mm/page_tables.rs
+++ b/oak_restricted_kernel/src/mm/page_tables.rs
@@ -139,6 +139,9 @@ impl RootPageTable {
             inner: EncryptedPageTable::new(pml4, offset, encryption),
         }
     }
+    pub fn inner(&self) -> &EncryptedPageTable<MappedPageTable<'static, PhysOffset>> {
+        &self.inner
+    }
     /// Checks wheter all the pages in the range are unallocated.
     ///
     /// Even though the pages may be of arbitrary size, we check all 4KiB-aligned addresses in the

--- a/oak_restricted_kernel/src/syscall/mod.rs
+++ b/oak_restricted_kernel/src/syscall/mod.rs
@@ -22,6 +22,9 @@ pub mod mmap;
 mod process;
 mod stdio;
 
+#[cfg(feature = "initrd")]
+mod switch_process;
+
 #[cfg(test)]
 mod tests;
 
@@ -40,6 +43,8 @@ use x86_64::{
     VirtAddr,
 };
 
+#[cfg(feature = "initrd")]
+use self::switch_process::syscall_unstable_switch_proccess;
 use self::{
     fd::{syscall_fsync, syscall_read, syscall_write},
     mmap::syscall_mmap,
@@ -123,6 +128,12 @@ extern "sysv64" fn syscall_handler(
             syscall_mmap(arg1 as *const c_void, arg2, arg3, arg4, arg5 as i32, arg6)
         }
         Some(Syscall::Fsync) => syscall_fsync(arg1 as i32),
+        #[cfg(feature = "initrd")]
+        Some(Syscall::UnstableSwitchProcess) => {
+            syscall_unstable_switch_proccess(arg1 as *mut c_void, arg2)
+        }
+        #[cfg(not(feature = "initrd"))]
+        Some(Syscall::UnstableSwitchProcess) => Errno::ENOSYS as isize,
         None => Errno::ENOSYS as isize,
     }
 }

--- a/oak_restricted_kernel/src/syscall/switch_process.rs
+++ b/oak_restricted_kernel/src/syscall/switch_process.rs
@@ -57,7 +57,7 @@ pub fn syscall_unstable_switch_proccess(buf: *mut c_void, count: c_size_t) -> ! 
                 .expect("failed to translate virtual page table address")
         };
         PhysFrame::from_start_address(phys_addr)
-            .except("couldn't get the physical frame for page table address")
+            .expect("couldn't get the physical frame for page table address")
     };
 
     // Safety: the new page table maintains the same mappings for kernel space.

--- a/oak_restricted_kernel/src/syscall/switch_process.rs
+++ b/oak_restricted_kernel/src/syscall/switch_process.rs
@@ -37,13 +37,13 @@ pub fn syscall_unstable_switch_proccess(buf: *mut c_void, count: c_size_t) -> ! 
         .expect("failed to parse application");
 
     // Ensure the page table is not dropped.
-    let mut pml4 = Box::leak(Box::new(PageTable::new()));
+    let pml4 = Box::leak(Box::new(PageTable::new()));
     let encryption = crate::PAGE_TABLES
         .lock()
         .get()
         .unwrap()
         .inner()
-        .copy_kernel_space(&mut pml4);
+        .copy_kernel_space(pml4);
 
     let pml4_frame = {
         let phys_addr = {

--- a/oak_restricted_kernel/src/syscall/switch_process.rs
+++ b/oak_restricted_kernel/src/syscall/switch_process.rs
@@ -1,0 +1,63 @@
+//
+// Copyright 2024 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use alloc::boxed::Box;
+use core::{
+    ffi::{c_size_t, c_void},
+    slice,
+};
+
+use x86_64::structures::paging::PageTable;
+
+use crate::mm::Translator;
+
+pub fn syscall_unstable_switch_proccess(buf: *mut c_void, count: c_size_t) -> ! {
+    // We should validate that the pointer and count are valid, as these come from userspace and
+    // therefore are not to be trusted, but right now everything is in kernel space so there is
+    // nothing to check.
+    let elf_binary_buffer = unsafe { slice::from_raw_parts(buf as *mut u8, count) };
+
+    // Copy the ELF file into kernel space.
+    let copied_elf_binary = elf_binary_buffer.to_vec();
+
+    let application = crate::payload::Application::new(copied_elf_binary.into_boxed_slice())
+        .expect("failed to parse application");
+
+    // Ensure the page table is not dropped.
+    let mut pml4 = Box::leak(Box::new(PageTable::new()));
+    let encryption = crate::PAGE_TABLES
+        .lock()
+        .get()
+        .unwrap()
+        .inner()
+        .copy_kernel_space(&mut pml4);
+
+    let pml4_frame = {
+        let phys_addr = {
+            let addr = &*pml4 as *const PageTable;
+            let pt_guard = crate::PAGE_TABLES.lock();
+            let pt = pt_guard.get().expect("failed to get page tables");
+            pt.translate_virtual(x86_64::addr::VirtAddr::from_ptr(addr))
+                .expect("failed to translate virtual page table address")
+        };
+        x86_64::structures::paging::frame::PhysFrame::from_start_address(phys_addr).unwrap()
+    };
+
+    unsafe { crate::PAGE_TABLES.lock().replace(pml4_frame, encryption) };
+    // Safety: we've loaded the Restricted Application. Whether that's valid or not is no longer
+    // under the kernel's control.
+    unsafe { application.run() }
+}

--- a/oak_restricted_kernel/src/syscall/switch_process.rs
+++ b/oak_restricted_kernel/src/syscall/switch_process.rs
@@ -44,7 +44,7 @@ pub fn syscall_unstable_switch_proccess(buf: *mut c_void, count: c_size_t) -> ! 
     let encryption = crate::PAGE_TABLES
         .lock()
         .get()
-        .except("page tables must exist to switch applications")
+        .expect("page tables must exist to switch applications")
         .inner()
         .copy_kernel_space(pml4);
 

--- a/oak_restricted_kernel_interface/src/syscall.rs
+++ b/oak_restricted_kernel_interface/src/syscall.rs
@@ -120,6 +120,16 @@ pub fn exit(status: i32) -> ! {
     unreachable!();
 }
 
+#[no_mangle]
+pub extern "C" fn sys_unstable_switch_proccess(buf: *const c_void, count: c_size_t) {
+    unsafe { syscall!(Syscall::UnstableSwitchProcess, buf, count) };
+}
+
+pub fn unstable_switch_proccess(buf: &[u8]) -> ! {
+    sys_unstable_switch_proccess(buf.as_ptr() as *const c_void, buf.len());
+    unreachable!();
+}
+
 // Note that these tests are not being executed against Restricted Kernel, but rather the Linux
 // kernel of the machine cargo is running on!
 #[cfg(test)]

--- a/oak_restricted_kernel_interface/src/syscalls.rs
+++ b/oak_restricted_kernel_interface/src/syscalls.rs
@@ -17,6 +17,9 @@
 use bitflags::bitflags;
 use strum::FromRepr;
 
+/// Syscalls above this are unsafe, their behavior and availability cannot be relied upon.
+pub const UNSTABLE_SYSCALL_SPACE: usize = i32::MAX as usize - (10 ^ 3);
+
 /// System calls implemented by Oak Restricted Kernel.
 ///
 /// In general, the system calls are inpired by and look similar to the Linux/POSIX ABI, but we make
@@ -83,6 +86,15 @@ pub enum Syscall {
     /// Returns:
     ///   a value of <errno::Errno> on failure; 0, otherwise.
     Fsync = 74,
+
+    /// Terminates the calling process and executes the supplied ELF binary instead.
+    ///
+    /// Arguments:
+    ///   - arg0 (*mut c_void): pointer to the a buffer holding an ELF file
+    ///   - arg1 (c_size_t): size of the buffer
+    /// Returns:
+    ///   a value of <errno::Errno> on failure; 0, otherwise.
+    UnstableSwitchProcess = UNSTABLE_SYSCALL_SPACE + 1,
 }
 
 bitflags! {


### PR DESCRIPTION
Successfully executes the loaded application. 

Note: the memory of the orchestrator is leaked in this version and not cleared. Secrets are cleared manually by the orchestrator beforehand. 