### PR TITLE
Attempt to create a trivial native key-value lookup test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,6 +2586,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "xtask",
 ]
 
 [[package]]

--- a/cc/native_sdk/BUILD
+++ b/cc/native_sdk/BUILD
@@ -32,3 +32,13 @@ cc_library(
         "@com_google_absl//absl/strings",
     ],
 )
+
+cc_binary(
+    name = "key_value_lookup",
+    srcs = ["key_value_lookup.cc"],
+    linkshared = True,
+    deps = [
+        ":native_sdk",
+        "@com_google_absl//absl/log:check",
+    ],
+)

--- a/cc/native_sdk/key_value_lookup.cc
+++ b/cc/native_sdk/key_value_lookup.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "absl/log/check.h"
+#include "cc/native_sdk/native_sdk.h"
+
+OAK_MAIN {
+  auto request = ::oak::functions::sdk::read_request().value();
+  CHECK_OK(::oak::functions::sdk::log("received request"));
+  auto response = ::oak::functions::sdk::storage_get_item(request).value();
+  CHECK_OK(::oak::functions::sdk::write_response(response));
+}

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -50,3 +50,4 @@ tracing = "*"
 
 [dev-dependencies]
 oak_functions_test_utils = { workspace = true }
+xtask = { workspace = true }

--- a/oak_functions_containers_app/tests/native_test.rs
+++ b/oak_functions_containers_app/tests/native_test.rs
@@ -1,0 +1,61 @@
+//
+// Copyright 2024 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::sync::Arc;
+
+use oak_functions_service::{logger::StandaloneLogger, lookup::LookupDataManager};
+use tokio::{fs, process::Command};
+use xtask::workspace_path;
+
+#[tokio::test]
+async fn test_native_handler() {
+    let status = Command::new("bazel")
+        .arg("build")
+        .arg("//cc/native_sdk:key_value_lookup")
+        .current_dir(workspace_path(&[]))
+        .spawn()
+        .expect("failed to spawn bazel")
+        .wait()
+        .await
+        .expect("failed to wait for bazel");
+    eprintln!("bazel status: {:?}", status);
+    assert!(status.success());
+
+    let _library =
+        fs::read(workspace_path(&[]).join("bazel-bin/cc/native_sdk/libkey_value_lookup.so"))
+            .await
+            .expect("failed to read test library");
+
+    let logger = Arc::new(StandaloneLogger);
+    let lookup_data_manager = Arc::new(LookupDataManager::new_empty(logger));
+    lookup_data_manager.extend_next_lookup_data(
+        [("key_0".as_bytes().into(), "value_0".as_bytes().into())].into_iter(),
+    );
+    lookup_data_manager.finish_next_lookup_data();
+
+    // This test fails right now because the library links in too many other libraries.
+    /*
+    let handler = NativeHandler::new_handler(&library, lookup_data_manager, None)
+        .expect("failed to load test library");
+    let response = handler
+        .handle_invoke(Request {
+            body: "key_0".as_bytes().to_vec(),
+        })
+        .expect("failed to issue invoke");
+    assert_eq!(StatusCode::Success, response.status);
+    assert_eq!("value_0".as_bytes(), response.body().unwrap());
+    */
+}


### PR DESCRIPTION
This uses a `cc_binary` instead of `cc_library` as that's recommended by [bazel](https://bazel.build/reference/be/c-cpp#cc_binary):

> The .so files produced by cc_library rules are not linked against the libraries that they depend on. If you're trying to  create a shared library for use outside of the main repository, e.g. for manual use with dlopen() or LD_PRELOAD, it may be better to use a cc_binary rule with the linkshared=True attribute. See cc_binary.linkshared.

That being said, the test, as-is, doesn't work. For whatever reason, it can't find `libstdc++` in my environment:
```
$ ldd bazel-bin/cc/native_sdk/libkey_value_lookup.so
        linux-vdso.so.1 (0x00007ffd51514000)
        libm.so.6 => /nix/store/p3jshbwxiwifm1py0yq544fmdyy98j8a-glibc-2.38-27/lib/libm.so.6 (0x00007f1c7c10a000)
        libstdc++.so.6 => not found
        libgcc_s.so.1 => /nix/store/ayg5rhjhi9ic73hqw33mjqjxwv59ndym-xgcc-13.2.0-libgcc/lib/libgcc_s.so.1 (0x00007f1c7c0e5000)
        libpthread.so.0 => /nix/store/p3jshbwxiwifm1py0yq544fmdyy98j8a-glibc-2.38-27/lib/libpthread.so.0 (0x00007f1c7c0e0000)
        libc.so.6 => /nix/store/p3jshbwxiwifm1py0yq544fmdyy98j8a-glibc-2.38-27/lib/libc.so.6 (0x00007f1c7bef7000)
        /nix/store/p3jshbwxiwifm1py0yq544fmdyy98j8a-glibc-2.38-27/lib64/ld-linux-x86-64.so.2 (0x00007f1c7c3d0000)
```

Then again, I'd argue that the resultant `.so` that we dlopen should:
  - include no external dependencies (everything statically linked)
  - only export the `register_callbacks` and `oak_main` symbols

I haven't figured out the right incantations to do that. The latter may involve building a linker script, for example.

Assistance in figuring out the magic flags would be much appreciated.