### PR TITLE
Reduce the number of exported symbols from the native lookup library

### DIFF
--- a/cc/native_sdk/BUILD
+++ b/cc/native_sdk/BUILD
@@ -36,8 +36,10 @@ cc_library(
 cc_binary(
     name = "key_value_lookup",
     srcs = ["key_value_lookup.cc"],
+    linkopts = ["-Wl,--version-script,$(location symbols.map.ld)"],
     linkshared = True,
     deps = [
+        "symbols.map.ld",
         ":native_sdk",
         "@com_google_absl//absl/log:check",
     ],

--- a/cc/native_sdk/native_sdk.h
+++ b/cc/native_sdk/native_sdk.h
@@ -26,7 +26,7 @@
 // We call oak_main without arguments, and oak_main then calls read_request,
 // processes the request, and then calls write_response.  This makes the API
 // compatible with Oak Functions.
-#define OAK_MAIN void oak_main()
+#define OAK_MAIN extern "C" void oak_main()
 
 namespace oak::functions::sdk {
 

--- a/cc/native_sdk/symbols.map.ld
+++ b/cc/native_sdk/symbols.map.ld
@@ -1,0 +1,7 @@
+{
+    global:
+        register_callbacks;
+        oak_main;
+    local:
+        *;
+};


### PR DESCRIPTION
This ensures that the `.so` only has two global symbols that it exports: `oak_main` and `register_globals`, both following the C calling convention. These are the only symbols that we expect external code to call.

Without this change we have 811 exported symbols:
```
$ nm bazel-bin/cc/native_sdk/libkey_value_lookup.so | grep " T " | wc -l
811
```

After that, it's down to the two we'd expect:
```
$ nm bazel-bin/cc/native_sdk/libkey_value_lookup.so | grep " T "
0000000000009f1f T oak_main
000000000000a9e6 T register_callbacks
```