### PR TITLE
Update restricted kernel oak functions to load via orchestrator

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,12 +36,6 @@ oak_restricted_kernel_simple_io_bin:
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
     just _wrap_kernel oak_restricted_kernel_simple_io
 
-oak_restricted_kernel_initrd_bin:
-    env --chdir=oak_restricted_kernel_bin cargo build --release --features=initrd --bin=oak_restricted_kernel_initrd_bin
-
-oak_restricted_kernel_initrd_bin_wrapper: oak_restricted_kernel_initrd_bin
-    just _wrap_kernel oak_restricted_kernel_initrd
-
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin
 

--- a/oak_functions_launcher/benches/integration_benches.rs
+++ b/oak_functions_launcher/benches/integration_benches.rs
@@ -51,11 +51,8 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
         .unwrap();
 
     runtime.block_on(xtask::testing::run_step(xtask::launcher::build_stage0()));
-    runtime.block_on(xtask::testing::run_step(xtask::launcher::build_binary(
-        "build Oak Restricted Kernel binary",
-        xtask::launcher::OAK_RESTRICTED_KERNEL_BIN_DIR
-            .to_str()
-            .unwrap(),
+    runtime.block_on(xtask::testing::run_step(xtask::launcher::just_build(
+        "oak_restricted_kernel_wrapper",
     )));
     let oak_restricted_kernel_orchestrator_app_path =
         oak_functions_test_utils::build_rust_crate_enclave("oak_orchestrator")
@@ -65,14 +62,8 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
             .expect("Failed to build oak_functions_enclave_app");
 
     let params = launcher::Params {
-        enclave_binary: Some(workspace_path(&[
-            "oak_restricted_kernel_bin",
-            "target",
-            "x86_64-unknown-none",
-            "debug",
-            "oak_restricted_kernel_bin",
-        ])),
-        kernel: None,
+        enclave_binary: None,
+        kernel: Some(xtask::launcher::OAK_RESTRICTED_KERNEL_WRAPPER_BIN.clone()),
         vmm_binary: which::which("qemu-system-x86_64").unwrap(),
         app_binary: Some(oak_functions_enclave_app_path.into()),
         bios_binary: workspace_path(&[

--- a/oak_functions_launcher/benches/integration_benches.rs
+++ b/oak_functions_launcher/benches/integration_benches.rs
@@ -57,7 +57,9 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
             .to_str()
             .unwrap(),
     )));
-
+    let oak_restricted_kernel_orchestrator_app_path =
+        oak_functions_test_utils::build_rust_crate_enclave("oak_orchestrator")
+            .expect("Failed to build oak_orchestrator");
     let oak_functions_enclave_app_path =
         oak_functions_test_utils::build_rust_crate_enclave("oak_functions_enclave_app")
             .expect("Failed to build oak_functions_enclave_app");
@@ -81,7 +83,7 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
             "oak_stage0.bin",
         ]),
         gdb: None,
-        initrd: None,
+        initrd: oak_restricted_kernel_orchestrator_app_path.into(),
         memory_size: Some("256M".to_string()),
     };
     log::debug!("launcher params: {:?}", params);

--- a/oak_functions_launcher/benches/integration_benches.rs
+++ b/oak_functions_launcher/benches/integration_benches.rs
@@ -62,8 +62,7 @@ fn run_bench(b: &mut Bencher, config: &OakFunctionsTestConfig) {
             .expect("Failed to build oak_functions_enclave_app");
 
     let params = launcher::Params {
-        enclave_binary: None,
-        kernel: Some(xtask::launcher::OAK_RESTRICTED_KERNEL_WRAPPER_BIN.clone()),
+        kernel: xtask::launcher::OAK_RESTRICTED_KERNEL_WRAPPER_BIN.clone(),
         vmm_binary: which::which("qemu-system-x86_64").unwrap(),
         app_binary: Some(oak_functions_enclave_app_path.into()),
         bios_binary: workspace_path(&[

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -137,6 +137,10 @@ async fn test_load_large_lookup_data() {
     ))
     .await;
 
+    let oak_restricted_kernel_orchestrator_app_path =
+        oak_functions_test_utils::build_rust_crate_enclave("oak_orchestrator")
+            .expect("Failed to build oak_orchestrator");
+
     let oak_functions_enclave_app_path =
         oak_functions_test_utils::build_rust_crate_enclave("oak_functions_enclave_app")
             .expect("Failed to build oak_functions_enclave_app");
@@ -160,7 +164,7 @@ async fn test_load_large_lookup_data() {
             "oak_stage0.bin",
         ]),
         gdb: None,
-        initrd: None,
+        initrd: oak_restricted_kernel_orchestrator_app_path.into(),
         memory_size: Some("256M".to_string()),
     };
     log::debug!("launcher params: {:?}", params);
@@ -234,6 +238,10 @@ async fn test_load_two_gib_lookup_data() {
     ))
     .await;
 
+    let oak_restricted_kernel_orchestrator_app_path =
+        oak_functions_test_utils::build_rust_crate_enclave("oak_orchestrator")
+            .expect("Failed to build oak_orchestrator");
+
     let oak_functions_enclave_app_path =
         oak_functions_test_utils::build_rust_crate_enclave("oak_functions_enclave_app")
             .expect("Failed to build oak_functions_enclave_app");
@@ -257,7 +265,7 @@ async fn test_load_two_gib_lookup_data() {
             "oak_stage0.bin",
         ]),
         gdb: None,
-        initrd: None,
+        initrd: oak_restricted_kernel_orchestrator_app_path.into(),
         memory_size: Some("256M".to_string()),
     };
     log::debug!("launcher params: {:?}", params);

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -129,13 +129,7 @@ async fn test_load_large_lookup_data() {
     }
 
     xtask::testing::run_step(xtask::launcher::build_stage0()).await;
-    xtask::testing::run_step(xtask::launcher::build_binary(
-        "build Oak Restricted Kernel binary",
-        xtask::launcher::OAK_RESTRICTED_KERNEL_BIN_DIR
-            .to_str()
-            .unwrap(),
-    ))
-    .await;
+    xtask::testing::run_step(xtask::launcher::just_build("oak_restricted_kernel_wrapper")).await;
 
     let oak_restricted_kernel_orchestrator_app_path =
         oak_functions_test_utils::build_rust_crate_enclave("oak_orchestrator")
@@ -146,14 +140,8 @@ async fn test_load_large_lookup_data() {
             .expect("Failed to build oak_functions_enclave_app");
 
     let params = launcher::Params {
-        enclave_binary: Some(workspace_path(&[
-            "oak_restricted_kernel_bin",
-            "target",
-            "x86_64-unknown-none",
-            "debug",
-            "oak_restricted_kernel_bin",
-        ])),
-        kernel: None,
+        enclave_binary: None,
+        kernel: Some(xtask::launcher::OAK_RESTRICTED_KERNEL_WRAPPER_BIN.clone()),
         vmm_binary: which::which("qemu-system-x86_64").unwrap(),
         app_binary: Some(oak_functions_enclave_app_path.into()),
         bios_binary: workspace_path(&[
@@ -230,13 +218,7 @@ async fn test_load_two_gib_lookup_data() {
     }
 
     xtask::testing::run_step(xtask::launcher::build_stage0()).await;
-    xtask::testing::run_step(xtask::launcher::build_binary(
-        "build Oak Restricted Kernel binary",
-        xtask::launcher::OAK_RESTRICTED_KERNEL_BIN_DIR
-            .to_str()
-            .unwrap(),
-    ))
-    .await;
+    xtask::testing::run_step(xtask::launcher::just_build("oak_restricted_kernel_wrapper")).await;
 
     let oak_restricted_kernel_orchestrator_app_path =
         oak_functions_test_utils::build_rust_crate_enclave("oak_orchestrator")
@@ -247,14 +229,8 @@ async fn test_load_two_gib_lookup_data() {
             .expect("Failed to build oak_functions_enclave_app");
 
     let params = launcher::Params {
-        enclave_binary: Some(workspace_path(&[
-            "oak_restricted_kernel_bin",
-            "target",
-            "x86_64-unknown-none",
-            "debug",
-            "oak_restricted_kernel_bin",
-        ])),
-        kernel: None,
+        enclave_binary: None,
+        kernel: Some(xtask::launcher::OAK_RESTRICTED_KERNEL_WRAPPER_BIN.clone()),
         vmm_binary: which::which("qemu-system-x86_64").unwrap(),
         app_binary: Some(oak_functions_enclave_app_path.into()),
         bios_binary: workspace_path(&[

--- a/oak_functions_launcher/tests/integration_test.rs
+++ b/oak_functions_launcher/tests/integration_test.rs
@@ -140,8 +140,7 @@ async fn test_load_large_lookup_data() {
             .expect("Failed to build oak_functions_enclave_app");
 
     let params = launcher::Params {
-        enclave_binary: None,
-        kernel: Some(xtask::launcher::OAK_RESTRICTED_KERNEL_WRAPPER_BIN.clone()),
+        kernel: xtask::launcher::OAK_RESTRICTED_KERNEL_WRAPPER_BIN.clone(),
         vmm_binary: which::which("qemu-system-x86_64").unwrap(),
         app_binary: Some(oak_functions_enclave_app_path.into()),
         bios_binary: workspace_path(&[
@@ -229,8 +228,7 @@ async fn test_load_two_gib_lookup_data() {
             .expect("Failed to build oak_functions_enclave_app");
 
     let params = launcher::Params {
-        enclave_binary: None,
-        kernel: Some(xtask::launcher::OAK_RESTRICTED_KERNEL_WRAPPER_BIN.clone()),
+        kernel: xtask::launcher::OAK_RESTRICTED_KERNEL_WRAPPER_BIN.clone(),
         vmm_binary: which::which("qemu-system-x86_64").unwrap(),
         app_binary: Some(oak_functions_enclave_app_path.into()),
         bios_binary: workspace_path(&[

--- a/oak_launcher_utils/src/launcher.rs
+++ b/oak_launcher_utils/src/launcher.rs
@@ -45,12 +45,8 @@ pub struct Params {
     pub vmm_binary: PathBuf,
 
     /// Path to the enclave binary to load into the VM.
-    #[arg(long, value_parser = path_exists, conflicts_with_all = &["kernel", "initrd"])]
-    pub enclave_binary: Option<PathBuf>,
-
-    /// Path to the enclave binary to load into the VM.
-    #[arg(long, value_parser = path_exists, conflicts_with_all = &["enclave_binary"])]
-    pub kernel: Option<PathBuf>,
+    #[arg(long, value_parser = path_exists)]
+    pub kernel: PathBuf,
 
     /// Path to the Oak Functions application binary to be loaded into the enclave.
     #[arg(long, value_parser = path_exists)]
@@ -165,20 +161,16 @@ impl Instance {
                 .unwrap()
                 .as_str(),
         ]);
-        if let Some(enclave_binary) = params.enclave_binary {
-            // Load the kernel ELF via the loader device.
-            cmd.args([
-                "-device",
-                format!("loader,file={}", enclave_binary.display()).as_str(),
-            ]);
-        }
-        if let Some(kernel) = params.kernel {
-            // stage0 accoutrements: kernel that's compatible with the linux boot protocol
-            cmd.args([
-                "-kernel",
-                kernel.into_os_string().into_string().unwrap().as_str(),
-            ]);
-        }
+        // stage0 accoutrements: kernel that's compatible with the linux boot protocol
+        cmd.args([
+            "-kernel",
+            params
+                .kernel
+                .into_os_string()
+                .into_string()
+                .unwrap()
+                .as_str(),
+        ]);
 
         if let Some(gdb_port) = params.gdb {
             // Listen for a gdb connection on the provided port and wait for debugger before booting

--- a/oak_launcher_utils/src/launcher.rs
+++ b/oak_launcher_utils/src/launcher.rs
@@ -71,7 +71,7 @@ pub struct Params {
 
     /// Path to the initrd image to use.
     #[arg(long, value_parser = path_exists, requires_all = &["kernel"])]
-    pub initrd: Option<PathBuf>,
+    pub initrd: PathBuf,
 }
 
 /// Checks if file with a given path exists.
@@ -186,12 +186,15 @@ impl Instance {
             cmd.arg("-S");
         }
 
-        if let Some(initrd) = params.initrd {
-            cmd.args([
-                "-initrd",
-                initrd.into_os_string().into_string().unwrap().as_str(),
-            ]);
-        }
+        cmd.args([
+            "-initrd",
+            params
+                .initrd
+                .into_os_string()
+                .into_string()
+                .unwrap()
+                .as_str(),
+        ]);
 
         info!("executing: {:?}", cmd);
 

--- a/oak_restricted_kernel/Cargo.toml
+++ b/oak_restricted_kernel/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-default = ["vsock_channel"]
+default = ["vsock_channel", "initrd"]
 # Ability to load an application from initrd, the measurement of which was already taken by stage0.
 # In this case, instead of creating a dice layer, the kernel will expose stage0 dice data to the application.
 initrd = []

--- a/oak_restricted_kernel_bin/Cargo.toml
+++ b/oak_restricted_kernel_bin/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-default = ["virtio_console_channel"]
+default = ["virtio_console_channel", "initrd"]
 virtio_console_channel = ["oak_restricted_kernel/virtio_console_channel"]
 vsock_channel = ["oak_restricted_kernel/vsock_channel"]
 simple_io_channel = ["oak_restricted_kernel/simple_io_channel"]

--- a/oak_restricted_kernel_launcher/README.md
+++ b/oak_restricted_kernel_launcher/README.md
@@ -18,7 +18,7 @@ must be built.
 
 ```shell
 # Stage0, the restricted kernel, and an enclave app may be built like so:
-just stage0_bin oak_restricted_kernel_initrd_bin_wrapper oak_orchestrator && \
+just stage0_bin oak_restricted_kernel_wrapper oak_orchestrator && \
 
 # After building dependencies, an enclave app may be run like so:
 RUST_LOG=DEBUG \

--- a/oak_restricted_kernel_launcher/README.md
+++ b/oak_restricted_kernel_launcher/README.md
@@ -23,7 +23,7 @@ just stage0_bin oak_restricted_kernel_wrapper oak_orchestrator && \
 # After building dependencies, an enclave app may be run like so:
 RUST_LOG=DEBUG \
 cargo run --package=oak_restricted_kernel_launcher -- \
---kernel=oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_initrd_wrapper_bin \
+--kernel=oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper_bin \
 --vmm-binary=$(which qemu-system-x86_64) \
 --memory-size=8G \
 --bios-binary=stage0_bin/target/x86_64-unknown-none/release/stage0_bin \

--- a/xtask/src/examples.rs
+++ b/xtask/src/examples.rs
@@ -19,7 +19,7 @@ use crate::{
     launcher,
     launcher::{
         build_binary, build_stage0, run_oak_functions_launcher_example_with_lookup_data,
-        MOCK_LOOKUP_DATA_PATH, OAK_RESTRICTED_KERNEL_BIN_DIR,
+        MOCK_LOOKUP_DATA_PATH,
     },
 };
 
@@ -48,9 +48,10 @@ pub fn run_oak_functions_example(opt: &RunOakExampleOpt) -> Step {
         name: "run Oak Functions example".to_string(),
         steps: vec![
             build_stage0(),
+            crate::launcher::just_build("oak_restricted_kernel_wrapper"),
             build_binary(
-                "build Oak Restricted Kernel binary",
-                OAK_RESTRICTED_KERNEL_BIN_DIR.to_str().unwrap(),
+                "build Oak Restricted Kernel orchestrator",
+                &launcher::App::from_crate_name("oak_orchestrator").enclave_crate_path(),
             ),
             build_binary("build Oak Functions enclave app", &app.enclave_crate_path()),
             build_rust_crate_wasm(&opt.example_name),

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -35,7 +35,7 @@ pub static OAK_RESTRICTED_KERNEL_WRAPPER_BIN: Lazy<PathBuf> = Lazy::new(|| {
         "target",
         "x86_64-unknown-none",
         "release",
-        "oak_restricted_kernel_initrd_wrapper_bin",
+        "oak_restricted_kernel_wrapper_bin",
     ])
 });
 

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -19,8 +19,6 @@
 pub static MOCK_LOOKUP_DATA_PATH: Lazy<PathBuf> =
     Lazy::new(|| workspace_path(&["oak_functions_launcher", "mock_lookup_data"]));
 static STAGE_0_DIR: Lazy<PathBuf> = Lazy::new(|| workspace_path(&["stage0_bin"]));
-pub static OAK_RESTRICTED_KERNEL_BIN_DIR: Lazy<PathBuf> =
-    Lazy::new(|| workspace_path(&["oak_restricted_kernel_bin"]));
 static OAK_FUNCTIONS_LAUNCHER_BIN_DIR: Lazy<PathBuf> =
     Lazy::new(|| workspace_path(&["oak_functions_launcher"]));
 static OAK_FUNCTIONS_LAUNCHER_BIN: Lazy<PathBuf> = Lazy::new(|| {
@@ -29,6 +27,15 @@ static OAK_FUNCTIONS_LAUNCHER_BIN: Lazy<PathBuf> = Lazy::new(|| {
         "x86_64-unknown-linux-gnu",
         "debug",
         "oak_functions_launcher",
+    ])
+});
+pub static OAK_RESTRICTED_KERNEL_WRAPPER_BIN: Lazy<PathBuf> = Lazy::new(|| {
+    workspace_path(&[
+        "oak_restricted_kernel_wrapper",
+        "target",
+        "x86_64-unknown-none",
+        "release",
+        "oak_restricted_kernel_initrd_wrapper_bin",
     ])
 });
 
@@ -82,16 +89,8 @@ impl App {
     pub fn subcommand(&self) -> Vec<String> {
         vec![
             format!(
-                "--enclave-binary={}",
-                workspace_path(&[
-                    "oak_restricted_kernel_bin",
-                    "target",
-                    "x86_64-unknown-none",
-                    "debug",
-                    "oak_restricted_kernel_bin",
-                ])
-                .to_str()
-                .unwrap()
+                "--kernel={}",
+                OAK_RESTRICTED_KERNEL_WRAPPER_BIN.to_str().unwrap()
             ),
             format!(
                 "--vmm-binary={}",
@@ -102,6 +101,10 @@ impl App {
             ),
             "--memory-size=256M".to_string(),
             format!("--app-binary={}", &self.enclave_binary_path()),
+            format!(
+                "--initrd={}",
+                &App::from_crate_name("oak_orchestrator").enclave_binary_path()
+            ),
             format!(
                 "--bios-binary={}",
                 workspace_path(&[
@@ -147,10 +150,31 @@ pub fn build_stage0() -> Step {
     }
 }
 
+pub fn build_orchestrator_binary() -> Step {
+    Step::Single {
+        name: "Build orchestrator binary".to_string(),
+        command: Cmd::new_in_dir(
+            "cargo",
+            vec!["build", "--release"],
+            Path::new(&App::from_crate_name("oak_orchestrator").enclave_crate_path()),
+        ),
+    }
+}
+
 pub fn build_binary(name: &str, directory: &str) -> Step {
     Step::Single {
         name: name.to_string(),
         command: Cmd::new_in_dir("cargo", vec!["build"], Path::new(directory)),
+    }
+}
+
+pub fn just_build(just_command: &str) -> Step {
+    Step::Single {
+        name: format!("just {}", just_command),
+        command: Cmd::new(
+            "just",
+            vec!["oak_functions_containers_container_bundle_tar"],
+        ),
     }
 }
 
@@ -197,13 +221,8 @@ pub async fn run_oak_functions_example_in_background(
     lookup_data_path: &str,
 ) -> (crate::testing::BackgroundStep, u16) {
     crate::testing::run_step(crate::launcher::build_stage0()).await;
-    crate::testing::run_step(crate::launcher::build_binary(
-        "build Oak Restricted Kernel binary",
-        crate::launcher::OAK_RESTRICTED_KERNEL_BIN_DIR
-            .to_str()
-            .unwrap(),
-    ))
-    .await;
+    crate::testing::run_step(crate::launcher::just_build("oak_restricted_kernel_wrapper")).await;
+    crate::testing::run_step(crate::launcher::build_orchestrator_binary()).await;
     crate::testing::run_step(crate::launcher::build_binary(
         "build Oak Functions Launcher binary",
         crate::launcher::OAK_FUNCTIONS_LAUNCHER_BIN_DIR

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -38,6 +38,15 @@ pub static OAK_RESTRICTED_KERNEL_WRAPPER_BIN: Lazy<PathBuf> = Lazy::new(|| {
         "oak_restricted_kernel_wrapper_bin",
     ])
 });
+static OAK_RESTRICTED_KERNEL_ORCHESTRATOR: Lazy<PathBuf> = Lazy::new(|| {
+    workspace_path(&[
+        "enclave_apps",
+        "target",
+        "x86_64-unknown-none",
+        "release",
+        "oak_orchestrator",
+    ])
+});
 
 use std::path::{Path, PathBuf};
 
@@ -103,7 +112,7 @@ impl App {
             format!("--app-binary={}", &self.enclave_binary_path()),
             format!(
                 "--initrd={}",
-                &App::from_crate_name("oak_orchestrator").enclave_binary_path()
+                OAK_RESTRICTED_KERNEL_ORCHESTRATOR.to_str().unwrap()
             ),
             format!(
                 "--bios-binary={}",

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -170,7 +170,7 @@ pub fn build_binary(name: &str, directory: &str) -> Step {
 
 pub fn just_build(just_command: &str) -> Step {
     Step::Single {
-        name: format!("just {}", just_command),
+        name: format!("build {}", just_command),
         command: Cmd::new(
             "just",
             vec!["oak_functions_containers_container_bundle_tar"],

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -171,10 +171,7 @@ pub fn build_binary(name: &str, directory: &str) -> Step {
 pub fn just_build(just_command: &str) -> Step {
     Step::Single {
         name: format!("build {}", just_command),
-        command: Cmd::new(
-            "just",
-            vec!["oak_functions_containers_container_bundle_tar"],
-        ),
+        command: Cmd::new_in_dir("just", vec![just_command], workspace_path(&[]).as_path()),
     }
 }
 

--- a/xtask/src/launcher.rs
+++ b/xtask/src/launcher.rs
@@ -150,17 +150,6 @@ pub fn build_stage0() -> Step {
     }
 }
 
-pub fn build_orchestrator_binary() -> Step {
-    Step::Single {
-        name: "Build orchestrator binary".to_string(),
-        command: Cmd::new_in_dir(
-            "cargo",
-            vec!["build", "--release"],
-            Path::new(&App::from_crate_name("oak_orchestrator").enclave_crate_path()),
-        ),
-    }
-}
-
 pub fn build_binary(name: &str, directory: &str) -> Step {
     Step::Single {
         name: name.to_string(),
@@ -219,7 +208,7 @@ pub async fn run_oak_functions_example_in_background(
 ) -> (crate::testing::BackgroundStep, u16) {
     crate::testing::run_step(crate::launcher::build_stage0()).await;
     crate::testing::run_step(crate::launcher::just_build("oak_restricted_kernel_wrapper")).await;
-    crate::testing::run_step(crate::launcher::build_orchestrator_binary()).await;
+    crate::testing::run_step(crate::launcher::just_build("oak_orchestrator")).await;
     crate::testing::run_step(crate::launcher::build_binary(
         "build Oak Functions Launcher binary",
         crate::launcher::OAK_FUNCTIONS_LAUNCHER_BIN_DIR


### PR DESCRIPTION
- [x] wait until https://github.com/project-oak/oak/pull/4796 is merged, and this branch rebased.


We'll need to keep the `initrd` feature flag around until the internal launcher is updated to load the orchestrator also.