### PR TITLE
Update the SNP predicted measurement tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4174,7 +4174,6 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger",
- "goblin",
  "hex",
  "log",
  "oak_sev_guest",

--- a/snp_measurement/Cargo.toml
+++ b/snp_measurement/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 anyhow = "*"
 clap = { version = "*", features = ["derive"] }
 env_logger = "*"
-goblin = "*"
 hex = "*"
 oak_sev_guest = { workspace = true }
 log = "*"

--- a/snp_measurement/src/page.rs
+++ b/snp_measurement/src/page.rs
@@ -186,7 +186,7 @@ enum ImiPage {
 /// The type of page being measured.
 ///
 /// See table 65 in <https://www.amd.com/system/files/TechDocs/56860.pdf>.
-#[derive(Debug, FromRepr, AsBytes)]
+#[derive(Debug, FromRepr, AsBytes, Clone)]
 #[repr(u8)]
 #[allow(unused)]
 pub enum PageType {

--- a/snp_measurement/src/vmsa.rs
+++ b/snp_measurement/src/vmsa.rs
@@ -21,6 +21,8 @@ use x86_64::{
     PhysAddr,
 };
 
+use crate::stage0::SevEsResetBlock;
+
 /// The CPU family of the vCPU we expect to be running on.
 const CPU_FAMILY: u8 = 6;
 
@@ -52,5 +54,14 @@ pub fn get_boot_vmsa() -> VmsaPage {
     result.vmsa.sev_features = 0x00000001;
 
     trace!("Boot VMSA: {:?}", result);
+    result
+}
+
+/// Gets the initial VMSA for additional vCPUs that are not the boot vCPU.
+pub fn get_ap_vmsa(reset_block: &SevEsResetBlock) -> VmsaPage {
+    let mut result = get_boot_vmsa();
+    result.vmsa.rip = reset_block.rip;
+    result.vmsa.cs.base = reset_block.segment_base;
+    trace!("AP VMSA: {:?}", result);
     result
 }


### PR DESCRIPTION
The SNP measurement prediction tool is outdated, since we no-longer preload the kernel into memory before boot. We also have more unmeasured pages configured and need to support additional vCPUs at startup.

With these updates the tool once again predicts that correct measurement in the AMD SEV-SNP attestation report.

Exmaple hex representation of an attestation report running with 2 vCPUs on AMD SEV-SNP:

```
02000000000000000000030000000000000000000000000000000000000000000000000000000000
0000000000000000000000000100000003000000000014d101000000000000000000000000000000
271f735e9368e74f04c92b3bdab5b468ae1405b2b8ad89c11cf8335378142fba0000000000000000
0000000000000000000000000000000000000000000000005f150e289cc75c525939c89ed242131b
7be08be075a7e658efe39542ca0c12005766e90b133da18d1a1d517253f691a80000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
de7d8afa69717ab323fc7bb32fae625ed6804daf37138246936d8c03c53be229ffffffffffffffff
ffffffffffffffffffffffffffffffffffffffffffffffff03000000000014d10000000000000000
00000000000000000000000000000000bc4e89307cec07b7ce106a2d0a09bf8c3283d068461dafa5
02be0fc0b72efdbb7fad1078f59d3f2ed7c3f09189472701509acd1a5d91c9156212d1c65851bcfa
03000000000014d1103701001037010003000000000014d100000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
000000000000000000000000000000000000000000000000000000000000000049dafb5d387f71be
0c2e7869309cd3e85a58cc6c6c49eaf05857509c9ac0605d7eb25bc3c41901a1b61d0c720e7abd68
000000000000000000000000000000000000000000000000524cb73e9d9ba975bbb43124cea3dd88
57936d70f50602e3671dd6f7424906bd3bd515627d27325096a9760132b0d6310000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000
000000000000000000000000000000000000000000000000
```

The measurement starts with the first non-zero bytes on line 4.

Example output from running `cargo run --package=snp_measurement -- --vcpu-count=2` with the same Stage 0 binary:

```
Attestation Measurement: 5f150e289cc75c525939c89ed242131b7be08be075a7e658efe39542ca0c12005766e90b133da18d1a1d517253f691a8
```