### PR TITLE
Generate empty attestation config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ dependencies = [
  "ecdsa",
  "getrandom",
  "hex",
+ "oak_attestation",
  "oak_dice",
  "oak_proto_rust",
  "oak_restricted_kernel_sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "hex",
  "oak_dice",
  "oak_proto_rust",
+ "oak_restricted_kernel_sdk",
  "oak_sev_snp_attestation_report",
  "p256",
  "p384",

--- a/oak_attestation_verification/Cargo.toml
+++ b/oak_attestation_verification/Cargo.toml
@@ -45,3 +45,6 @@ zerocopy = "*"
 
 [dev-dependencies]
 prost = { workspace = true }
+oak_restricted_kernel_sdk = { workspace = true, features = [
+  "mock_attestation"
+] }

--- a/oak_attestation_verification/Cargo.toml
+++ b/oak_attestation_verification/Cargo.toml
@@ -48,3 +48,4 @@ prost = { workspace = true }
 oak_restricted_kernel_sdk = { workspace = true, features = [
   "mock_attestation"
 ] }
+oak_attestation = { workspace = true }

--- a/oak_attestation_verification/tests/verifier_tests.rs
+++ b/oak_attestation_verification/tests/verifier_tests.rs
@@ -195,7 +195,10 @@ fn verify_mock_dice_chain() {
         &evidence_to_proto(mock_evidence.clone()).expect("could not convert evidence to proto"),
     );
 
-    assert!(result.is_ok())
+    assert!(result.is_ok());
+    let evidence_values: oak_proto_rust::oak::attestation::v1::extracted_evidence::EvidenceValues =
+        result.unwrap().evidence_values.unwrap();
+    assert!(matches!(evidence_values, oak_proto_rust::oak::attestation::v1::extracted_evidence::EvidenceValues::OakRestrictedKernel{..}))
 }
 
 #[test]

--- a/oak_attestation_verification/tests/verifier_tests.rs
+++ b/oak_attestation_verification/tests/verifier_tests.rs
@@ -22,13 +22,14 @@ use oak_attestation_verification::{
     verifier::{to_attestation_results, verify, verify_dice_chain},
 };
 use oak_proto_rust::oak::attestation::v1::{
-    attestation_results::Status, binary_reference_value, reference_values, AmdSevReferenceValues,
-    BinaryReferenceValue, ContainerLayerEndorsements, ContainerLayerReferenceValues,
-    EndorsementReferenceValue, Endorsements, Evidence, InsecureReferenceValues,
-    KernelLayerEndorsements, KernelLayerReferenceValues, OakContainersEndorsements,
-    OakContainersReferenceValues, ReferenceValues, RootLayerEndorsements, RootLayerReferenceValues,
-    SkipVerification, StringReferenceValue, SystemLayerEndorsements, SystemLayerReferenceValues,
-    TransparentReleaseEndorsement,
+    attestation_results::Status, binary_reference_value, endorsements, reference_values,
+    AmdSevReferenceValues, ApplicationLayerReferenceValues, BinaryReferenceValue,
+    ContainerLayerEndorsements, ContainerLayerReferenceValues, EndorsementReferenceValue,
+    Endorsements, Evidence, InsecureReferenceValues, KernelLayerEndorsements,
+    KernelLayerReferenceValues, OakContainersEndorsements, OakContainersReferenceValues,
+    OakRestrictedKernelEndorsements, OakRestrictedKernelReferenceValues, ReferenceValues,
+    RootLayerEndorsements, RootLayerReferenceValues, SkipVerification, StringReferenceValue,
+    SystemLayerEndorsements, SystemLayerReferenceValues, TransparentReleaseEndorsement,
 };
 use oak_restricted_kernel_sdk::EvidenceProvider;
 use prost::Message;
@@ -195,6 +196,64 @@ fn verify_mock_dice_chain() {
     );
 
     assert!(result.is_ok())
+}
+
+#[test]
+fn verify_mock_evidence() {
+    let mock_evidence_provider =
+        oak_restricted_kernel_sdk::mock_attestation::MockEvidenceProvider::create()
+            .expect("failed to create mock provider");
+    let evidence = evidence_to_proto(mock_evidence_provider.get_evidence().clone())
+        .expect("failed to convert evidence to proto");
+
+    let endorsements = Endorsements {
+        r#type: Some(endorsements::Type::OakRestrictedKernel(
+            OakRestrictedKernelEndorsements {
+                root_layer: Some(RootLayerEndorsements::default()),
+                ..Default::default()
+            },
+        )),
+    };
+
+    // reference values that skip everything.
+    let reference_values = {
+        let skip = BinaryReferenceValue {
+            r#type: Some(binary_reference_value::Type::Skip(
+                SkipVerification::default(),
+            )),
+        };
+        ReferenceValues {
+            r#type: Some(reference_values::Type::OakRestrictedKernel(
+                OakRestrictedKernelReferenceValues {
+                    root_layer: Some(RootLayerReferenceValues {
+                        insecure: Some(InsecureReferenceValues::default()),
+                        ..Default::default()
+                    }),
+                    kernel_layer: Some(KernelLayerReferenceValues {
+                        kernel_image: Some(skip.clone()),
+                        kernel_cmd_line: Some(skip.clone()),
+                        kernel_setup_data: Some(skip.clone()),
+                        init_ram_fs: Some(skip.clone()),
+                        memory_map: Some(skip.clone()),
+                        acpi: Some(skip.clone()),
+                    }),
+                    application_layer: Some(ApplicationLayerReferenceValues {
+                        binary: Some(skip.clone()),
+                        configuration: Some(skip.clone()),
+                    }),
+                },
+            )),
+        }
+    };
+
+    let r = verify(NOW_UTC_MILLIS, &evidence, &endorsements, &reference_values);
+    let p = to_attestation_results(&r);
+
+    eprintln!("======================================");
+    eprintln!("code={} reason={}", p.status as i32, p.reason);
+    eprintln!("======================================");
+    assert!(r.is_ok());
+    assert!(p.status() == Status::Success);
 }
 
 #[test]


### PR DESCRIPTION
This field is currently not populated by the restricted kernel, as there is no application config. However, the verification library expects it. 

Depending on preference, this field should either be populated with an empty value (this PR) or removed https://github.com/project-oak/oak/pull/4807. 

Those PRs are mutually exclusive. But one should be merged, for restricted kernel evidence to be parsed in the verification library. 