### PR TITLE
Always read SEV SNP encryption state from registers

### DIFF
--- a/oak_restricted_kernel/src/mm/page_tables.rs
+++ b/oak_restricted_kernel/src/mm/page_tables.rs
@@ -285,11 +285,7 @@ impl CurrentRootPageTable {
     /// Replaces the current pagetable with the parameter, returning the old
     /// pagetable if there was one. Updates the page table on the CPU level.
     /// Safety: The new page tables must keep the identity mapping at -2GB (kernel space) intact.
-    pub unsafe fn replace(
-        &mut self,
-        pml4_frame: PhysFrame,
-        encrypted: MemoryEncryption,
-    ) -> Option<RootPageTable> {
+    pub unsafe fn replace(&mut self, pml4_frame: PhysFrame) -> Option<RootPageTable> {
         // This validates any references that expect boot page tables to be valid!
         // Safety: Caller must ensure that the new page tables are safe.
         unsafe {
@@ -302,7 +298,7 @@ impl CurrentRootPageTable {
             &mut *(super::DIRECT_MAPPING_OFFSET + pml4_frame.start_address().as_u64()).as_mut_ptr()
         };
 
-        let new_pt = RootPageTable::new(pml4, super::DIRECT_MAPPING_OFFSET, encrypted);
+        let new_pt = RootPageTable::new(pml4, super::DIRECT_MAPPING_OFFSET, super::encryption());
 
         self.inner.replace(new_pt)
     }

--- a/oak_restricted_kernel/src/syscall/switch_process.rs
+++ b/oak_restricted_kernel/src/syscall/switch_process.rs
@@ -39,7 +39,7 @@ pub fn syscall_unstable_switch_proccess(buf: *mut c_void, count: c_size_t) -> ! 
     let application = crate::payload::Application::new(copied_elf_binary.into_boxed_slice())
         .expect("failed to parse application");
 
-    let (base_pml4, encrypted) = crate::BASE_L4_PAGE_TABLE
+    let base_pml4 = crate::BASE_L4_PAGE_TABLE
         .get()
         .expect("base l4 table should be set");
     // Ensure the new page table is not dropped.
@@ -58,7 +58,7 @@ pub fn syscall_unstable_switch_proccess(buf: *mut c_void, count: c_size_t) -> ! 
     };
 
     // Safety: the new page table maintains the same mappings for kernel space.
-    unsafe { crate::PAGE_TABLES.lock().replace(pml4_frame, *encrypted) };
+    unsafe { crate::PAGE_TABLES.lock().replace(pml4_frame) };
     // Safety: we've loaded the Restricted Application. Whether that's valid or not is no longer
     // under the kernel's control.
     unsafe { application.run() }


### PR DESCRIPTION
afaik this value should not change. So it’s easier to read it than to pass it around. 