### PR TITLE
Create application config proto for Oak Functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,7 +2564,6 @@ dependencies = [
  "opentelemetry_sdk",
  "ouroboros",
  "prost",
- "strum 0.25.0",
  "tempfile",
  "tikv-jemallocator",
  "tokio",

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -38,7 +38,6 @@ opentelemetry-otlp = { version = "*", default-features = false, features = [
 ] }
 ouroboros = { version = "*", optional = true }
 prost = "*"
-strum = { version = "*", features = ["derive"] }
 tempfile = { version = "*", optional = true }
 tikv-jemallocator = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }

--- a/oak_functions_service/src/lib.rs
+++ b/oak_functions_service/src/lib.rs
@@ -33,7 +33,9 @@ extern crate std;
 pub mod proto {
     pub mod oak {
         pub mod functions {
-            #![allow(dead_code)]
+            pub mod config {
+                include!(concat!(env!("OUT_DIR"), "/oak.functions.config.rs"));
+            }
             use prost::Message;
             include!(concat!(env!("OUT_DIR"), "/oak.functions.rs"));
         }

--- a/proto/oak_functions/application_config.proto
+++ b/proto/oak_functions/application_config.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The Project Oak Authors
+// Copyright 2024 The Project Oak Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,19 +14,22 @@
 // limitations under the License.
 //
 
-use micro_rpc_build::ReceiverType;
+syntax = "proto3";
 
-fn main() {
-    micro_rpc_build::compile(
-        &[
-            "../proto/oak_functions/application_config.proto",
-            "../proto/oak_functions/service/oak_functions.proto",
-        ],
-        &[".."],
-        micro_rpc_build::CompileOptions {
-            receiver_type: ReceiverType::RefSelf,
-            bytes: vec![".oak.functions.LookupDataEntry".to_string()],
-            ..Default::default()
-        },
-    );
+package oak.functions.config;
+
+enum HandlerType {
+  // Defaults to WASM.
+  HANDLER_UNSPECIFIED = 0;
+
+  // Use a wasm interpreter to load the module.
+  HANDLER_WASM = 1;
+
+  // Interpret the module as a native .so file. Only supported when running on Oak Containers.
+  HANDLER_NATIVE = 2;
+}
+
+message ApplicationConfig {
+  // How to load the provided module.
+  HandlerType handler_type = 1;
 }


### PR DESCRIPTION
More infrastructure for the eventual native modules.

Previously I added a command-line flag to distinguish between native and wasm modules. However, we already have a facility to provide application configuration to the enclave apps (which should properly be put in the attestation chain as well), so it's far better to use that instead of trying to invent a new way how to pass command line flags to the app.