### PR TITLE
Start a skeleton of a runtime debug interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb11bd1378bf3731b182997b40cefe00aba6a6cc74042c8318c1b271d3badf7"
 dependencies = [
- "nix",
+ "nix 0.27.1",
  "thiserror",
  "tokio",
 ]
@@ -670,6 +670,15 @@ name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
 dependencies = [
  "cfg-if",
 ]
@@ -1219,6 +1228,18 @@ dependencies = [
  "libc",
  "redox_syscall",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1910,7 +1931,7 @@ dependencies = [
  "bytes",
  "clap",
  "oak_proto_rust",
- "prost",
+ "prost 0.11.9",
  "rand",
 ]
 
@@ -1968,6 +1989,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,7 +2012,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "micro_rpc_build",
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -1990,7 +2020,7 @@ name = "micro_rpc_build"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "prost-build",
+ "prost-build 0.11.9",
 ]
 
 [[package]]
@@ -2001,8 +2031,8 @@ dependencies = [
  "maplit",
  "micro_rpc",
  "micro_rpc_build",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "tokio",
 ]
 
@@ -2105,6 +2135,17 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -2194,7 +2235,7 @@ dependencies = [
  "oak_dice",
  "oak_proto_rust",
  "p256",
- "prost",
+ "prost 0.11.9",
  "rand_core",
  "sha2",
  "zeroize",
@@ -2217,7 +2258,7 @@ dependencies = [
  "oak_sev_snp_attestation_report",
  "p256",
  "p384",
- "prost",
+ "prost 0.11.9",
  "rsa",
  "serde",
  "serde_json",
@@ -2250,7 +2291,7 @@ dependencies = [
  "oak_crypto",
  "oak_grpc_utils",
  "oak_proto_rust",
- "prost",
+ "prost 0.11.9",
  "tonic",
 ]
 
@@ -2264,8 +2305,8 @@ dependencies = [
  "oak_containers_sdk",
  "oak_crypto",
  "oak_grpc_utils",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2285,7 +2326,7 @@ dependencies = [
  "oak_crypto",
  "oak_grpc_utils",
  "once_cell",
- "prost",
+ "prost 0.11.9",
  "tokio",
  "tonic",
  "tower",
@@ -2309,8 +2350,8 @@ dependencies = [
  "oak_grpc_utils",
  "oak_proto_rust",
  "opentelemetry-proto",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2327,7 +2368,7 @@ dependencies = [
  "coset",
  "hpke",
  "log",
- "nix",
+ "nix 0.27.1",
  "oak_attestation",
  "oak_attestation_verification",
  "oak_crypto",
@@ -2340,8 +2381,8 @@ dependencies = [
  "opentelemetry_sdk",
  "p256",
  "procfs",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "rand_core",
  "sha2",
  "syslog",
@@ -2365,8 +2406,8 @@ dependencies = [
  "oak_attestation",
  "oak_crypto",
  "oak_grpc_utils",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2382,15 +2423,15 @@ dependencies = [
  "clap",
  "coset",
  "futures-util",
- "nix",
+ "nix 0.27.1",
  "oak_attestation",
  "oak_crypto",
  "oak_dice",
  "oak_grpc_utils",
  "oak_proto_rust",
  "p256",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "rand_core",
  "rtnetlink",
  "sha2",
@@ -2411,7 +2452,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.4.1",
  "clap",
- "nix",
+ "nix 0.27.1",
  "oak_containers_orchestrator",
  "oak_grpc_utils",
  "opentelemetry",
@@ -2444,11 +2485,23 @@ dependencies = [
  "hpke",
  "micro_rpc_build",
  "p256",
- "prost",
+ "prost 0.11.9",
  "rand_core",
  "sha2",
  "tokio",
  "zeroize",
+]
+
+[[package]]
+name = "oak_debug_service"
+version = "0.1.0"
+dependencies = [
+ "oak_grpc_utils",
+ "pprof",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "tokio",
+ "tonic",
 ]
 
 [[package]]
@@ -2475,7 +2528,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "nix",
+ "nix 0.27.1",
  "simple_logger",
  "subprocess",
 ]
@@ -2486,7 +2539,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "nix",
+ "nix 0.27.1",
  "simple_logger",
 ]
 
@@ -2499,7 +2552,7 @@ dependencies = [
  "log",
  "micro_rpc",
  "micro_rpc_build",
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -2536,7 +2589,7 @@ dependencies = [
  "micro_rpc",
  "oak_client",
  "oak_functions_abi",
- "prost",
+ "prost 0.11.9",
  "regex",
  "tokio",
  "tonic",
@@ -2555,6 +2608,7 @@ dependencies = [
  "oak_containers_orchestrator",
  "oak_containers_sdk",
  "oak_crypto",
+ "oak_debug_service",
  "oak_functions_abi",
  "oak_functions_service",
  "oak_functions_test_utils",
@@ -2563,7 +2617,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "ouroboros",
- "prost",
+ "prost 0.11.9",
  "tempfile",
  "tikv-jemallocator",
  "tokio",
@@ -2594,7 +2648,7 @@ dependencies = [
  "oak_functions_test_utils",
  "oak_grpc_utils",
  "oak_proto_rust",
- "prost",
+ "prost 0.11.9",
  "tokio",
  "tonic",
  "ubyte",
@@ -2617,7 +2671,7 @@ dependencies = [
  "oak_functions_test_utils",
  "oak_proto_rust",
  "oak_restricted_kernel_sdk",
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -2645,7 +2699,7 @@ dependencies = [
  "oak_grpc_utils",
  "oak_launcher_utils",
  "oak_proto_rust",
- "prost",
+ "prost 0.11.9",
  "rand",
  "serde",
  "tokio",
@@ -2666,7 +2720,7 @@ dependencies = [
  "oak_functions_abi",
  "oak_functions_service",
  "oak_functions_test_utils",
- "prost",
+ "prost 0.11.9",
  "tokio",
 ]
 
@@ -2707,7 +2761,7 @@ dependencies = [
  "oak_functions_sdk",
  "oak_functions_test_utils",
  "oak_proto_rust",
- "prost",
+ "prost 0.11.9",
  "rand",
  "spinning_top 0.3.0",
  "tokio",
@@ -2723,7 +2777,7 @@ dependencies = [
  "micro_rpc_build",
  "oak_functions_sdk",
  "oak_proto_rust",
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -2736,13 +2790,13 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "nix",
+ "nix 0.27.1",
  "oak_client",
  "oak_functions_abi",
  "oak_functions_client",
  "oak_proto_rust",
  "port_check",
- "prost",
+ "prost 0.11.9",
  "tempfile",
  "tokio",
  "ubyte",
@@ -2752,8 +2806,8 @@ dependencies = [
 name = "oak_grpc_utils"
 version = "0.1.0"
 dependencies = [
- "prost",
- "prost-build",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
  "tempfile",
  "tonic-build",
 ]
@@ -2764,7 +2818,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "nix",
+ "nix 0.27.1",
  "simple_logger",
 ]
 
@@ -2782,7 +2836,7 @@ dependencies = [
  "micro_rpc",
  "micro_rpc_build",
  "oak_channel",
- "prost",
+ "prost 0.11.9",
  "tokio",
 ]
 
@@ -2802,8 +2856,8 @@ version = "0.0.1"
 dependencies = [
  "micro_rpc",
  "micro_rpc_build",
- "prost",
- "prost-build",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
 ]
 
 [[package]]
@@ -3101,7 +3155,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.11.9",
  "thiserror",
  "tokio",
  "tonic",
@@ -3115,7 +3169,7 @@ checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.11.9",
  "tonic",
 ]
 
@@ -3417,6 +3471,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "parking_lot",
+ "prost 0.12.3",
+ "prost-build 0.12.3",
+ "prost-derive 0.12.3",
+ "sha2",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,6 +3508,16 @@ checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3520,7 +3608,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -3536,11 +3634,33 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
+ "tempfile",
+ "which 4.4.2",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.16",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
+ "regex",
+ "syn 2.0.48",
  "tempfile",
  "which 4.4.2",
 ]
@@ -3559,12 +3679,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -3781,7 +3923,7 @@ dependencies = [
  "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix",
+ "nix 0.27.1",
  "thiserror",
  "tokio",
 ]
@@ -4317,6 +4459,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbolic-common"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cccfffbc6bb3bb2d3a26cd2077f4d055f6808d266f9d4d158797a4c60510dfe"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a99812da4020a67e76c4eb41f08c87364c14170495ff780f30dd519c221a68"
+dependencies = [
+ "cpp_demangle 0.4.3",
+ "rustc-demangle",
+ "symbolic-common",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4622,7 +4787,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.11.9",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
@@ -4640,9 +4805,9 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.1.25",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.11.9",
  "quote",
  "syn 1.0.109",
 ]
@@ -5179,7 +5344,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "cfg-if",
- "cpp_demangle",
+ "cpp_demangle 0.3.5",
  "gimli",
  "ittapi",
  "log",
@@ -5620,7 +5785,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "itertools 0.12.0",
- "nix",
+ "nix 0.27.1",
  "oak_functions_test_utils",
  "once_cell",
  "portpicker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "oak_containers_syslogd",
   "oak_core",
   "oak_crypto",
+  "oak_debug_service",
   "oak_dice",
   "oak_docker_linux_init",
   "oak_echo_linux_init",
@@ -98,6 +99,7 @@ oak_containers_launcher = { path = "./oak_containers_launcher" }
 oak_containers_sdk = { path = "./oak_containers_sdk" }
 oak_core = { path = "./oak_core" }
 oak_crypto = { path = "./oak_crypto" }
+oak_debug_service = { path = "./oak_debug_service" }
 oak_dice = { path = "./oak_dice" }
 oak_enclave_runtime_support = { path = "./oak_enclave_runtime_support", default-features = false }
 oak_functions_abi = { path = "./oak_functions_abi" }

--- a/oak_debug_service/Cargo.toml
+++ b/oak_debug_service/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "oak_debug_service"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[build-dependencies]
+oak_grpc_utils = { workspace = true }
+
+[dependencies]
+pprof = { version = "*", features = ["prost-codec"] }
+prost = "*"
+prost-types = "*"
+tokio = { version = "*" }
+tonic = { workspace = true }
+
+[dev-dependencies]
+tokio = { version = "*", features = ["rt-multi-thread"] }

--- a/oak_debug_service/build.rs
+++ b/oak_debug_service/build.rs
@@ -1,0 +1,31 @@
+//
+// Copyright 2024 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use oak_grpc_utils::{generate_grpc_code, CodegenOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Generate gRPC code for exchanging messages with clients.
+    generate_grpc_code(
+        &["../proto/oak_debug/service/oak_debug.proto"],
+        "..",
+        CodegenOptions {
+            build_server: true,
+            ..Default::default()
+        },
+    )?;
+
+    Ok(())
+}

--- a/oak_debug_service/src/lib.rs
+++ b/oak_debug_service/src/lib.rs
@@ -1,0 +1,131 @@
+//
+// Copyright 2024 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+pub mod proto {
+    pub mod oak {
+        pub mod debug {
+            tonic::include_proto!("oak.debug");
+        }
+    }
+    pub mod perftools {
+        pub mod profiles {
+            tonic::include_proto!("perftools.profiles");
+        }
+    }
+}
+use std::time::Duration;
+
+use pprof::protos::Message as _;
+use prost::Message as _;
+use proto::{
+    oak::debug::{debug_service_server::DebugServiceServer, CpuProfileRequest, CpuProfileResponse},
+    perftools::profiles::Profile,
+};
+
+use crate::proto::oak::debug::debug_service_server::DebugService;
+
+// Interrupt frequency, in Hz.
+const SAMPLE_FREQUENCY: i32 = 100;
+
+pub struct Service {}
+
+impl Service {
+    pub fn new_server() -> DebugServiceServer<Self> {
+        DebugServiceServer::new(Self {})
+    }
+}
+
+#[tonic::async_trait]
+impl DebugService for Service {
+    async fn cpu_profile(
+        &self,
+        request: tonic::Request<CpuProfileRequest>,
+    ) -> tonic::Result<tonic::Response<CpuProfileResponse>> {
+        let request = request.into_inner();
+        let duration: Duration =
+            request
+                .duration
+                .unwrap_or_default()
+                .try_into()
+                .map_err(|err| {
+                    tonic::Status::invalid_argument(format!(
+                        "could not parse given duration: {}",
+                        err
+                    ))
+                })?;
+
+        let profile = {
+            let guard = pprof::ProfilerGuardBuilder::default()
+                .frequency(SAMPLE_FREQUENCY)
+                .build()
+                .map_err(|err| {
+                    tonic::Status::internal(format!("failed to initialize profiler: {}", err))
+                })?;
+            tokio::time::sleep(duration).await;
+            let report = guard.report().build().map_err(|err| {
+                tonic::Status::internal(format!("failed to build report: {}", err))
+            })?;
+            report.pprof().map_err(|err| {
+                tonic::Status::internal(format!(
+                    "failed to translate report into pprof format: {}",
+                    err
+                ))
+            })?
+        };
+
+        // This is silly, but becauce of differing versions of Prost we have to serialize and
+        // deserialize the profile protobuf, although they are quite literally the same protobuf
+        // under the hood.
+        let encoded = profile.encode_to_vec();
+        let profile = Profile::decode(&encoded[..]).map_err(|err| {
+            tonic::Status::internal(format!("failed to deserialize profile proto: {}", err))
+        })?;
+
+        Ok(tonic::Response::new(CpuProfileResponse {
+            profile: Some(profile),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn profile_test() {
+        let svc = Service {};
+
+        let (resp, _) = tokio::join!(
+            svc.cpu_profile(tonic::Request::new(CpuProfileRequest {
+                duration: Some(Duration::from_secs(5).try_into().unwrap()),
+            })),
+            async {
+                // Burn some CPU doing something for the profiler to catch by computing some fake
+                // Fibonacci.
+                let mut fib: Vec<u64> = Vec::with_capacity(1_000_000);
+                fib.push(0u64);
+                fib.push(1);
+                for i in 2..fib.capacity() {
+                    fib.push(fib[i - 1].wrapping_add(fib[i - 2]));
+                }
+            }
+        );
+        let resp = resp.unwrap().into_inner();
+
+        // What _exactly_ is in the profile is highly variable, but we should have _something_ in
+        // there.
+        assert!(!resp.profile.unwrap().sample.is_empty());
+    }
+}

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -19,6 +19,7 @@ http = "*"
 oak_attestation = { workspace = true }
 oak_containers_orchestrator = { workspace = true }
 oak_containers_sdk = { workspace = true }
+oak_debug_service = { workspace = true }
 oak_functions_abi = { workspace = true }
 oak_functions_service = { workspace = true, features = ["std"] }
 oak_crypto = { workspace = true }

--- a/oak_functions_containers_app/src/lib.rs
+++ b/oak_functions_containers_app/src/lib.rs
@@ -424,6 +424,7 @@ where
             .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE)
             .accept_compressed(CompressionEncoding::Gzip),
         )
+        .add_service(oak_debug_service::Service::new_server())
         .serve_with_incoming(TcpListenerStream::new(listener))
         .await
         .context("failed to start up the service")

--- a/proto/oak_debug/service/oak_debug.proto
+++ b/proto/oak_debug/service/oak_debug.proto
@@ -1,0 +1,34 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.debug;
+
+import "google/protobuf/duration.proto";
+import "third_party/google/profile.proto";
+
+service DebugService {
+  rpc CpuProfile(CpuProfileRequest) returns (CpuProfileResponse);
+}
+
+message CpuProfileRequest {
+  google.protobuf.Duration duration = 1;
+}
+
+message CpuProfileResponse {
+  .perftools.profiles.Profile profile = 1;
+}

--- a/third_party/google/profile.proto
+++ b/third_party/google/profile.proto
@@ -1,0 +1,213 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Profile is a common stacktrace profile format.
+//
+// Measurements represented with this format should follow the
+// following conventions:
+//
+// - Consumers should treat unset optional fields as if they had been
+//   set with their default value.
+//
+// - When possible, measurements should be stored in "unsampled" form
+//   that is most useful to humans.  There should be enough
+//   information present to determine the original sampled values.
+//
+// - On-disk, the serialized proto must be gzip-compressed.
+//
+// - The profile is represented as a set of samples, where each sample
+//   references a sequence of locations, and where each location belongs
+//   to a mapping.
+// - There is a N->1 relationship from sample.location_id entries to
+//   locations. For every sample.location_id entry there must be a
+//   unique Location with that id.
+// - There is an optional N->1 relationship from locations to
+//   mappings. For every nonzero Location.mapping_id there must be a
+//   unique Mapping with that id.
+
+syntax = "proto3";
+
+package perftools.profiles;
+
+option java_package = "com.google.perftools.profiles";
+option java_outer_classname = "ProfileProto";
+
+message Profile {
+  // A description of the samples associated with each Sample.value.
+  // For a cpu profile this might be:
+  //   [["cpu","nanoseconds"]] or [["wall","seconds"]] or [["syscall","count"]]
+  // For a heap profile, this might be:
+  //   [["allocations","count"], ["space","bytes"]],
+  // If one of the values represents the number of events represented
+  // by the sample, by convention it should be at index 0 and use
+  // sample_type.unit == "count".
+  repeated ValueType sample_type = 1;
+  // The set of samples recorded in this profile.
+  repeated Sample sample = 2;
+  // Mapping from address ranges to the image/binary/library mapped
+  // into that address range.  mapping[0] will be the main binary.
+  repeated Mapping mapping = 3;
+  // Useful program location
+  repeated Location location = 4;
+  // Functions referenced by locations
+  repeated Function function = 5;
+  // A common table for strings referenced by various messages.
+  // string_table[0] must always be "".
+  repeated string string_table = 6;
+  // frames with Function.function_name fully matching the following
+  // regexp will be dropped from the samples, along with their successors.
+  int64 drop_frames = 7;  // Index into string table.
+  // frames with Function.function_name fully matching the following
+  // regexp will be kept, even if it matches drop_functions.
+  int64 keep_frames = 8;  // Index into string table.
+
+  // The following fields are informational, do not affect
+  // interpretation of results.
+
+  // Time of collection (UTC) represented as nanoseconds past the epoch.
+  int64 time_nanos = 9;
+  // Duration of the profile, if a duration makes sense.
+  int64 duration_nanos = 10;
+  // The kind of events between sampled ocurrences.
+  // e.g [ "cpu","cycles" ] or [ "heap","bytes" ]
+  ValueType period_type = 11;
+  // The number of events between sampled occurrences.
+  int64 period = 12;
+  // Freeform text associated to the profile.
+  repeated int64 comment = 13;  // Indices into string table.
+  // Index into the string table of the type of the preferred sample
+  // value. If unset, clients should default to the last sample value.
+  int64 default_sample_type = 14;
+}
+
+// ValueType describes the semantics and measurement units of a value.
+message ValueType {
+  // Rename it from type to ty to avoid using keyword in Rust.
+  int64 ty = 1;    // Index into string table.
+  int64 unit = 2;  // Index into string table.
+}
+
+// Each Sample records values encountered in some program
+// context. The program context is typically a stack trace, perhaps
+// augmented with auxiliary information like the thread-id, some
+// indicator of a higher level request being handled etc.
+message Sample {
+  // The ids recorded here correspond to a Profile.location.id.
+  // The leaf is at location_id[0].
+  repeated uint64 location_id = 1;
+  // The type and unit of each value is defined by the corresponding
+  // entry in Profile.sample_type. All samples must have the same
+  // number of values, the same as the length of Profile.sample_type.
+  // When aggregating multiple samples into a single sample, the
+  // result has a list of values that is the elemntwise sum of the
+  // lists of the originals.
+  repeated int64 value = 2;
+  // label includes additional context for this sample. It can include
+  // things like a thread id, allocation size, etc
+  repeated Label label = 3;
+}
+
+message Label {
+  int64 key = 1;  // Index into string table
+
+  // At most one of the following must be present
+  int64 str = 2;  // Index into string table
+  int64 num = 3;
+
+  // Should only be present when num is present.
+  // Specifies the units of num.
+  // Use arbitrary string (for example, "requests") as a custom count unit.
+  // If no unit is specified, consumer may apply heuristic to deduce the unit.
+  // Consumers may also  interpret units like "bytes" and "kilobytes" as memory
+  // units and units like "seconds" and "nanoseconds" as time units,
+  // and apply appropriate unit conversions to these.
+  int64 num_unit = 4;  // Index into string table
+}
+
+message Mapping {
+  // Unique nonzero id for the mapping.
+  uint64 id = 1;
+  // Address at which the binary (or DLL) is loaded into memory.
+  uint64 memory_start = 2;
+  // The limit of the address range occupied by this mapping.
+  uint64 memory_limit = 3;
+  // Offset in the binary that corresponds to the first mapped address.
+  uint64 file_offset = 4;
+  // The object this entry is loaded from.  This can be a filename on
+  // disk for the main binary and shared libraries, or virtual
+  // abstractions like "[vdso]".
+  int64 filename = 5;  // Index into string table
+  // A string that uniquely identifies a particular program version
+  // with high probability. E.g., for binaries generated by GNU tools,
+  // it could be the contents of the .note.gnu.build-id field.
+  int64 build_id = 6;  // Index into string table
+
+  // The following fields indicate the resolution of symbolic info.
+  bool has_functions = 7;
+  bool has_filenames = 8;
+  bool has_line_numbers = 9;
+  bool has_inline_frames = 10;
+}
+
+// Describes function and line table debug information.
+message Location {
+  // Unique nonzero id for the location.  A profile could use
+  // instruction addresses or any integer sequence as ids.
+  uint64 id = 1;
+  // The id of the corresponding profile.Mapping for this location.
+  // It can be unset if the mapping is unknown or not applicable for
+  // this profile type.
+  uint64 mapping_id = 2;
+  // The instruction address for this location, if available.  It
+  // should be within [Mapping.memory_start...Mapping.memory_limit]
+  // for the corresponding mapping. A non-leaf address may be in the
+  // middle of a call instruction. It is up to display tools to find
+  // the beginning of the instruction if necessary.
+  uint64 address = 3;
+  // Multiple line indicates this location has inlined functions,
+  // where the last entry represents the caller into which the
+  // preceding entries were inlined.
+  //
+  // E.g., if memcpy() is inlined into printf:
+  //    line[0].function_name == "memcpy"
+  //    line[1].function_name == "printf"
+  repeated Line line = 4;
+  // Provides an indication that multiple symbols map to this location's
+  // address, for example due to identical code folding by the linker. In that
+  // case the line information above represents one of the multiple
+  // symbols. This field must be recomputed when the symbolization state of the
+  // profile changes.
+  bool is_folded = 5;
+}
+
+message Line {
+  // The id of the corresponding profile.Function for this line.
+  uint64 function_id = 1;
+  // Line number in source code.
+  int64 line = 2;
+}
+
+message Function {
+  // Unique nonzero id for the function.
+  uint64 id = 1;
+  // Name of the function, in human-readable form if available.
+  int64 name = 2;  // Index into string table
+  // Name of the function, as identified by the system.
+  // For instance, it can be a C++ mangled name.
+  int64 system_name = 3;  // Index into string table
+  // Source file containing the function.
+  int64 filename = 4;  // Index into string table
+  // Line number in source file.
+  int64 start_line = 5;
+}


### PR DESCRIPTION
What we're lacking now, especially during development, is visibility into what our app is doing inside the enclave.

This RPC server currently adds a facility to request a CPU profile (a lot of open source projects call this `profilez`, as the Google style of z-pages is well known by now).

There are other things I want to expose via this interface, like some way how to get a jemalloc heap profile in the future.

There's also the question of how much private information could leak via this interface and whether we want to disable it when running production, but that's something for a different day.
