### PR TITLE
Add C++ attestation verifier

### DIFF
--- a/cc/attestation/verification/BUILD
+++ b/cc/attestation/verification/BUILD
@@ -1,0 +1,46 @@
+#
+# Copyright 2023 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "attestation_verifier",
+    hdrs = ["attestation_verifier.h"],
+    deps = [
+        "//proto/attestation:endorsement_cc_proto",
+        "//proto/attestation:evidence_cc_proto",
+        "//proto/attestation:verification_cc_proto",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "insecure_attestation_verifier",
+    srcs = ["insecure_attestation_verifier.cc"],
+    hdrs = ["insecure_attestation_verifier.h"],
+    deps = [
+        ":attestation_verifier",
+        "//cc/utils/cose:cwt",
+        "//proto/attestation:endorsement_cc_proto",
+        "//proto/attestation:evidence_cc_proto",
+        "//proto/attestation:verification_cc_proto",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)

--- a/cc/attestation/verification/attestation_verifier.h
+++ b/cc/attestation/verification/attestation_verifier.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CC_ATTESTATION_VERIFICATION_ATTESTATION_VERIFIER_H_
+#define CC_ATTESTATION_VERIFICATION_ATTESTATION_VERIFIER_H_
+
+#include <chrono>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "proto/attestation/endorsement.pb.h"
+#include "proto/attestation/evidence.pb.h"
+#include "proto/attestation/verification.pb.h"
+
+namespace oak::attestation::verification {
+
+// Abstract class implementing the functionality of a verifier that appraises
+// the attestation evidence and produces an attestation result.
+// <https://www.rfc-editor.org/rfc/rfc9334.html#name-verifier>
+class AttestationVerifier {
+ public:
+  virtual ~AttestationVerifier() = default;
+
+  virtual absl::StatusOr<::oak::attestation::v1::AttestationResults> Verify(
+      std::chrono::time_point<std::chrono::system_clock> now,
+      ::oak::attestation::v1::Evidence evidence,
+      ::oak::attestation::v1::Endorsements endorsements) const = 0;
+};
+
+}  // namespace oak::attestation::verification
+
+#endif  // CC_ATTESTATION_VERIFICATION_ATTESTATION_VERIFIER_H_

--- a/cc/attestation/verification/insecure_attestation_verifier.cc
+++ b/cc/attestation/verification/insecure_attestation_verifier.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cc/attestation/verification/insecure_attestation_verifier.h"
+
+#include <chrono>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "cc/utils/cose/cwt.h"
+#include "proto/attestation/endorsement.pb.h"
+#include "proto/attestation/evidence.pb.h"
+#include "proto/attestation/verification.pb.h"
+
+namespace oak::attestation::verification {
+
+namespace {
+using ::oak::attestation::v1::AttestationResults;
+using ::oak::attestation::v1::Endorsements;
+using ::oak::attestation::v1::Evidence;
+using ::oak::utils::cose::Cwt;
+}  // namespace
+
+absl::StatusOr<AttestationResults> InsecureAttestationVerifier::Verify(
+    std::chrono::time_point<std::chrono::system_clock> now, Evidence evidence,
+    Endorsements endorsements) const {
+  absl::StatusOr<std::string> encryption_public_key =
+      ExtractEncryptionPublicKey(evidence.application_keys().encryption_public_key_certificate());
+  if (!encryption_public_key.ok()) {
+    return encryption_public_key.status();
+  }
+
+  AttestationResults attestation_results;
+  *attestation_results.mutable_encryption_public_key() = *encryption_public_key;
+
+  return attestation_results;
+}
+
+absl::StatusOr<std::string> InsecureAttestationVerifier::ExtractEncryptionPublicKey(
+    absl::string_view certificate) const {
+  auto cwt = Cwt::Deserialize(certificate);
+  if (!cwt.ok()) {
+    return cwt.status();
+  }
+  auto public_key = cwt->subject_public_key.GetPublicKey();
+  return std::string(public_key.begin(), public_key.end());
+}
+
+}  // namespace oak::attestation::verification

--- a/cc/attestation/verification/insecure_attestation_verifier.h
+++ b/cc/attestation/verification/insecure_attestation_verifier.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CC_ATTESTATION_VERIFICATION_INSECURE_ATTESTATION_VERIFIER_H_
+#define CC_ATTESTATION_VERIFICATION_INSECURE_ATTESTATION_VERIFIER_H_
+
+#include <chrono>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "cc/attestation/verification/attestation_verifier.h"
+#include "proto/attestation/endorsement.pb.h"
+#include "proto/attestation/evidence.pb.h"
+#include "proto/attestation/verification.pb.h"
+
+namespace oak::attestation::verification {
+
+// Verifier implementation that doesn't verify attestation evidence and is used for testing.
+class InsecureAttestationVerifier : public AttestationVerifier {
+ public:
+  // Doesn't perform attestation verification and just returns a success value.
+  absl::StatusOr<::oak::attestation::v1::AttestationResults> Verify(
+      std::chrono::time_point<std::chrono::system_clock> now,
+      ::oak::attestation::v1::Evidence evidence,
+      ::oak::attestation::v1::Endorsements endorsements) const override;
+
+ private:
+  absl::StatusOr<std::string> ExtractEncryptionPublicKey(absl::string_view certificate) const;
+};
+
+}  // namespace oak::attestation::verification
+
+#endif  // CC_ATTESTATION_VERIFICATION_INSECURE_ATTESTATION_VERIFIER_H_


### PR DESCRIPTION
Add a C++ `AttestationVerifier` that uses DICE protos.

This PR has been split from https://github.com/project-oak/oak/pull/4787 to avoid breaking changes.

Ref https://github.com/project-oak/oak/issues/3641
Ref https://github.com/project-oak/oak/issues/4074
Ref https://github.com/project-oak/oak/issues/4627