### PR TITLE
Add generating CWT for tests

### DIFF
--- a/cc/utils/cose/BUILD
+++ b/cc/utils/cose/BUILD
@@ -49,6 +49,16 @@ cc_library(
 # Tests
 
 cc_test(
+    name = "cose_test",
+    size = "small",
+    srcs = ["cose_test.cc"],
+    deps = [
+        ":cose",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "cwt_test",
     size = "small",
     srcs = ["cwt_test.cc"],

--- a/cc/utils/cose/cose.cc
+++ b/cc/utils/cose/cose.cc
@@ -150,8 +150,8 @@ absl::StatusOr<CoseKey> CoseKey::DeserializeHpkePublicKey(std::unique_ptr<cppbor
                  std::move(item));
 }
 
-absl::StatusOr<std::vector<uint8_t>>
-CoseKey::SerializeHpkePublicKey(const std::vector<uint8_t>& public_key) {
+absl::StatusOr<std::vector<uint8_t>> CoseKey::SerializeHpkePublicKey(
+    const std::vector<uint8_t>& public_key) {
   cppbor::Map map;
   map.add(KTY, cppbor::Uint(OKP));
   map.add(ALG, cppbor::Nint(ECDH_ES));

--- a/cc/utils/cose/cose.h
+++ b/cc/utils/cose/cose.h
@@ -44,6 +44,11 @@ class CoseSign1 {
 
   static absl::StatusOr<CoseSign1> Deserialize(absl::string_view data);
 
+  // Puts payload into a COSE_Sign1 and serializes it.
+  // TODO(#4818): This function is currently used for tests only. We need to
+  // refactor COSE classes to support both serialization and deserialization.
+  static absl::StatusOr<std::vector<uint8_t>> Serialize(const std::vector<uint8_t>& payload);
+
  private:
   // Parsed CBOR item containing COSE_Sign1 object.
   std::unique_ptr<cppbor::Item> item_;
@@ -64,8 +69,6 @@ class CoseKey {
  public:
   // Identification of the key type.
   const cppbor::Uint* kty;
-  // Key identification value.
-  const cppbor::Bstr* kid;
   // Key usage restriction to this algorithm.
   const cppbor::Nint* alg;
   // Restrict set of permissible operations.
@@ -81,10 +84,18 @@ class CoseKey {
   static absl::StatusOr<CoseKey> DeserializeHpkePublicKey(absl::string_view data);
   static absl::StatusOr<CoseKey> DeserializeHpkePublicKey(const std::vector<uint8_t>& data);
 
+  // Transforms HPKE public key into a COSE_Key and serializes it.
+  // TODO(#4818): This function is currently used for tests only. We need to
+  // refactor COSE classes to support both serialization and deserialization.
+  static absl::StatusOr<std::vector<uint8_t>>
+  SerializeHpkePublicKey(const std::vector<uint8_t>& public_key);
+
   const std::vector<uint8_t>& GetPublicKey() const { return x->value(); }
 
  private:
-  enum Parameter : int {
+  // COSE Key Common parameters.
+  // <https://datatracker.ietf.org/doc/html/rfc8152#section-7.1>
+  enum CoseKeyCommonParameter : int {
     KTY = 1,
     KID = 2,
     ALG = 3,
@@ -97,46 +108,50 @@ class CoseKey {
     X = -2,    // Public key.
   };
 
+  // Key Object parameters.
+  // <https://datatracker.ietf.org/doc/html/rfc8152#section-13>
+  enum KeyObjectParameter : int {
+    Reserved = 0,  // This value is reserved.
+    OKP = 1,  // Octet Key Pair.
+    EC2 = 2,  // Elliptic Curve Keys with x- and y-coordinate pair.
+    Symmetric = 4,  // Symmetric Keys.
+  };
+
+  // COSE Algorithms.
+  // <https://www.iana.org/assignments/cose/cose.xhtml#algorithms>
+  enum CoseAlgorithm : int {
+    ES256 = -7,  // ECDSA with SHA-256.
+    ECDH_ES = -25,  // ECDH ES with HKDF.
+  };
+
+  // Key Operation Values.
+  // <https://datatracker.ietf.org/doc/html/rfc8152#section-7.1>
+  enum KeyOperationValues : int {
+    SIGN = 1, // The key is used to create signatures.
+    VERIFY = 2,  // The key is used for verification of signatures.
+  };
+
+  // COSE Elliptic Curve parameters.
+  // <https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves>
+  enum CoseEllipticCurveParameter : int {
+    P256 = 1,  // NIST P-256 also known as secp256r1.
+    X25519 = 4,  // X25519 for use with ECDH only.
+  };
+
   // Parsed CBOR item containing COSE_Key object.
   std::unique_ptr<cppbor::Item> item_;
 
-  CoseKey(const cppbor::Uint* kty, const cppbor::Bstr* kid, const cppbor::Nint* alg,
-          const cppbor::Array* key_ops, const cppbor::Uint* crv, const cppbor::Bstr* x,
-          std::unique_ptr<cppbor::Item>&& item)
-      : kty(kty), kid(kid), alg(alg), key_ops(key_ops), crv(crv), x(x), item_(std::move(item)) {}
+  CoseKey(const cppbor::Uint* kty, const cppbor::Nint* alg, const cppbor::Array* key_ops,
+          const cppbor::Uint* crv, const cppbor::Bstr* x, std::unique_ptr<cppbor::Item>&& item)
+      : kty(kty), alg(alg), key_ops(key_ops), crv(crv), x(x), item_(std::move(item)) {}
 
   static absl::StatusOr<CoseKey> DeserializeHpkePublicKey(std::unique_ptr<cppbor::Item>&& item);
 };
 
-std::string CborTypeToString(cppbor::MajorType cbor_type) {
-  switch (cbor_type) {
-    case cppbor::MajorType::UINT:
-      return "UINT";
-    case cppbor::MajorType::NINT:
-      return "NINT";
-    case cppbor::MajorType::BSTR:
-      return "BSTR";
-    case cppbor::MajorType::TSTR:
-      return "TSTR";
-    case cppbor::MajorType::ARRAY:
-      return "ARRAY";
-    case cppbor::MajorType::MAP:
-      return "MAP";
-    case cppbor::MajorType::SEMANTIC:
-      return "SEMANTIC";
-    case cppbor::MajorType::SIMPLE:
-      return "SIMPLE";
-    default:
-      return absl::StrCat("UNKNOWN(", cbor_type, ")");
-  }
-}
+std::string CborTypeToString(cppbor::MajorType cbor_type);
 
 absl::Status UnexpectedCborTypeError(std::string_view name, cppbor::MajorType expected,
-                                     cppbor::MajorType found) {
-  return absl::InvalidArgumentError(absl::StrCat("expected ", name, " to have ",
-                                                 CborTypeToString(expected), " CBOR type, found ",
-                                                 CborTypeToString(found)));
-}
+                                     cppbor::MajorType found);
 
 }  // namespace oak::utils::cose
 

--- a/cc/utils/cose/cose.h
+++ b/cc/utils/cose/cose.h
@@ -87,8 +87,8 @@ class CoseKey {
   // Transforms HPKE public key into a COSE_Key and serializes it.
   // TODO(#4818): This function is currently used for tests only. We need to
   // refactor COSE classes to support both serialization and deserialization.
-  static absl::StatusOr<std::vector<uint8_t>>
-  SerializeHpkePublicKey(const std::vector<uint8_t>& public_key);
+  static absl::StatusOr<std::vector<uint8_t>> SerializeHpkePublicKey(
+      const std::vector<uint8_t>& public_key);
 
   const std::vector<uint8_t>& GetPublicKey() const { return x->value(); }
 
@@ -111,30 +111,30 @@ class CoseKey {
   // Key Object parameters.
   // <https://datatracker.ietf.org/doc/html/rfc8152#section-13>
   enum KeyObjectParameter : int {
-    Reserved = 0,  // This value is reserved.
-    OKP = 1,  // Octet Key Pair.
-    EC2 = 2,  // Elliptic Curve Keys with x- and y-coordinate pair.
+    Reserved = 0,   // This value is reserved.
+    OKP = 1,        // Octet Key Pair.
+    EC2 = 2,        // Elliptic Curve Keys with x- and y-coordinate pair.
     Symmetric = 4,  // Symmetric Keys.
   };
 
   // COSE Algorithms.
   // <https://www.iana.org/assignments/cose/cose.xhtml#algorithms>
   enum CoseAlgorithm : int {
-    ES256 = -7,  // ECDSA with SHA-256.
+    ES256 = -7,     // ECDSA with SHA-256.
     ECDH_ES = -25,  // ECDH ES with HKDF.
   };
 
   // Key Operation Values.
   // <https://datatracker.ietf.org/doc/html/rfc8152#section-7.1>
   enum KeyOperationValues : int {
-    SIGN = 1, // The key is used to create signatures.
+    SIGN = 1,    // The key is used to create signatures.
     VERIFY = 2,  // The key is used for verification of signatures.
   };
 
   // COSE Elliptic Curve parameters.
   // <https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves>
   enum CoseEllipticCurveParameter : int {
-    P256 = 1,  // NIST P-256 also known as secp256r1.
+    P256 = 1,    // NIST P-256 also known as secp256r1.
     X25519 = 4,  // X25519 for use with ECDH only.
   };
 

--- a/cc/utils/cose/cose_test.cc
+++ b/cc/utils/cose/cose_test.cc
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/cc/utils/cose/cose_test.cc
+++ b/cc/utils/cose/cose_test.cc
@@ -32,8 +32,8 @@ TEST(CoseTest, CoseSign1SerializeDeserializeSuccess) {
   std::vector<uint8_t> test_payload = {1, 2, 3, 4};
   auto serialized_cose_sign1 = CoseSign1::Serialize(test_payload);
   EXPECT_TRUE(serialized_cose_sign1.ok()) << serialized_cose_sign1.status();
-  auto serialized_cose_sign1_string = std::string(
-      serialized_cose_sign1->begin(), serialized_cose_sign1->end());
+  auto serialized_cose_sign1_string =
+      std::string(serialized_cose_sign1->begin(), serialized_cose_sign1->end());
 
   auto deserialized_cose_sign1 = CoseSign1::Deserialize(serialized_cose_sign1_string);
   EXPECT_TRUE(deserialized_cose_sign1.ok()) << deserialized_cose_sign1.status();

--- a/cc/utils/cose/cose_test.cc
+++ b/cc/utils/cose/cose_test.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cc/utils/cose/cose.h"
+
+#include <cstdint>
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace oak::utils::cose {
+namespace {
+
+using ::testing::ElementsAreArray;
+
+TEST(CoseTest, CoseSign1SerializeDeserializeSuccess) {
+  std::vector<uint8_t> test_payload = {1, 2, 3, 4};
+  auto serialized_cose_sign1 = CoseSign1::Serialize(test_payload);
+  EXPECT_TRUE(serialized_cose_sign1.ok()) << serialized_cose_sign1.status();
+  auto serialized_cose_sign1_string = std::string(
+      serialized_cose_sign1->begin(), serialized_cose_sign1->end());
+
+  auto deserialized_cose_sign1 = CoseSign1::Deserialize(serialized_cose_sign1_string);
+  EXPECT_TRUE(deserialized_cose_sign1.ok()) << deserialized_cose_sign1.status();
+  EXPECT_THAT(deserialized_cose_sign1->payload->value(), ElementsAreArray(test_payload));
+}
+
+TEST(CoseTest, CoseKeySerializeDeserializeSuccess) {
+  std::vector<uint8_t> test_public_key = {1, 2, 3, 4};
+  auto serialized_cose_key = CoseKey::SerializeHpkePublicKey(test_public_key);
+  EXPECT_TRUE(serialized_cose_key.ok()) << serialized_cose_key.status();
+
+  auto deserialized_cose_key = CoseKey::DeserializeHpkePublicKey(*serialized_cose_key);
+  EXPECT_TRUE(deserialized_cose_key.ok()) << deserialized_cose_key.status();
+  EXPECT_THAT(deserialized_cose_key->GetPublicKey(), ElementsAreArray(test_public_key));
+}
+
+}  // namespace
+}  // namespace oak::utils::cose

--- a/cc/utils/cose/cwt.cc
+++ b/cc/utils/cose/cwt.cc
@@ -84,8 +84,8 @@ absl::StatusOr<Cwt> Cwt::Deserialize(absl::string_view data) {
   return Cwt(iss->asTstr(), sub->asTstr(), std::move(*subject_public_key), std::move(item));
 }
 
-absl::StatusOr<std::vector<uint8_t>>
-Cwt::SerializeHpkePublicKey(const std::vector<uint8_t>& public_key) {
+absl::StatusOr<std::vector<uint8_t>> Cwt::SerializeHpkePublicKey(
+    const std::vector<uint8_t>& public_key) {
   auto serialized_public_key_certificate = CoseKey::SerializeHpkePublicKey(public_key);
   if (!serialized_public_key_certificate.ok()) {
     return serialized_public_key_certificate.status();

--- a/cc/utils/cose/cwt.cc
+++ b/cc/utils/cose/cwt.cc
@@ -18,8 +18,8 @@
 
 #include <cstdint>
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"

--- a/cc/utils/cose/cwt.cc
+++ b/cc/utils/cose/cwt.cc
@@ -16,7 +16,9 @@
 
 #include "cc/utils/cose/cwt.h"
 
+#include <cstdint>
 #include <memory>
+#include <vector>
 #include <utility>
 
 #include "absl/status/status.h"

--- a/cc/utils/cose/cwt.h
+++ b/cc/utils/cose/cwt.h
@@ -41,8 +41,8 @@ class Cwt {
   // Transforms HPKE public key into a CWT and serializes it.
   // TODO(#4818): This function is currently used for tests only. We need to
   // refactor CWT class to support both serialization and deserialization.
-  static absl::StatusOr<std::vector<uint8_t>>
-  SerializeHpkePublicKey(const std::vector<uint8_t>& public_key);
+  static absl::StatusOr<std::vector<uint8_t>> SerializeHpkePublicKey(
+      const std::vector<uint8_t>& public_key);
 
  private:
   // CBOR map keys.

--- a/cc/utils/cose/cwt.h
+++ b/cc/utils/cose/cwt.h
@@ -17,7 +17,8 @@
 #ifndef CC_UTILS_COSE_CWT_H_
 #define CC_UTILS_COSE_CWT_H_
 
-#include <string>
+#include <cstdint>
+#include <vector>
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"

--- a/cc/utils/cose/cwt.h
+++ b/cc/utils/cose/cwt.h
@@ -38,6 +38,12 @@ class Cwt {
 
   static absl::StatusOr<Cwt> Deserialize(absl::string_view data);
 
+  // Transforms HPKE public key into a CWT and serializes it.
+  // TODO(#4818): This function is currently used for tests only. We need to
+  // refactor CWT class to support both serialization and deserialization.
+  static absl::StatusOr<std::vector<uint8_t>>
+  SerializeHpkePublicKey(const std::vector<uint8_t>& public_key);
+
  private:
   // CBOR map keys.
   // <https://datatracker.ietf.org/doc/html/rfc8392#section-4>

--- a/cc/utils/cose/cwt_test.cc
+++ b/cc/utils/cose/cwt_test.cc
@@ -55,7 +55,6 @@ class CertificateTest : public testing::Test {
     ASSERT_TRUE(parse_success);
 
     public_key_certificate_ = test_evidence->application_keys().encryption_public_key_certificate();
-    test_public_key_ = std::vector<uint8_t>
   }
 
   std::string public_key_certificate_;
@@ -71,10 +70,12 @@ TEST_F(CertificateTest, CwtSerializeDeserializeSuccess) {
   std::vector<uint8_t> test_public_key = {1, 2, 3, 4};
   auto serialized_cwt = Cwt::SerializeHpkePublicKey(test_public_key);
   EXPECT_TRUE(serialized_cwt.ok()) << serialized_cwt.status();
+  auto serialized_cwt_string = std::string(serialized_cwt->begin(), serialized_cwt->end());
 
-  auto deserialized_cwt = Cwt::Deserialize(*serialized_cwt);
+  auto deserialized_cwt = Cwt::Deserialize(serialized_cwt_string);
   EXPECT_TRUE(deserialized_cwt.ok()) << deserialized_cwt.status();
-  EXPECT_THAT(deserialized_cwt->subject_public_key.GetPublicKey(), ElementsAreArray(test_public_key));
+  EXPECT_THAT(deserialized_cwt->subject_public_key.GetPublicKey(),
+              ElementsAreArray(test_public_key));
 }
 
 }  // namespace

--- a/cc/utils/cose/cwt_test.cc
+++ b/cc/utils/cose/cwt_test.cc
@@ -61,7 +61,7 @@ class CertificateTest : public testing::Test {
 
 TEST_F(CertificateTest, CwtDeserializeSuccess) {
   auto cwt = Cwt::Deserialize(public_key_certificate_);
-  ASSERT_TRUE(cwt.ok()) << cwt.status();
+  EXPECT_TRUE(cwt.ok()) << cwt.status();
   EXPECT_THAT(cwt->subject_public_key.GetPublicKey(), ElementsAreArray(kTestPublicKey));
 }
 

--- a/cc/utils/cose/cwt_test.cc
+++ b/cc/utils/cose/cwt_test.cc
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
@@ -54,6 +55,7 @@ class CertificateTest : public testing::Test {
     ASSERT_TRUE(parse_success);
 
     public_key_certificate_ = test_evidence->application_keys().encryption_public_key_certificate();
+    test_public_key_ = std::vector<uint8_t>
   }
 
   std::string public_key_certificate_;
@@ -63,6 +65,16 @@ TEST_F(CertificateTest, CwtDeserializeSuccess) {
   auto cwt = Cwt::Deserialize(public_key_certificate_);
   EXPECT_TRUE(cwt.ok()) << cwt.status();
   EXPECT_THAT(cwt->subject_public_key.GetPublicKey(), ElementsAreArray(kTestPublicKey));
+}
+
+TEST_F(CertificateTest, CwtSerializeDeserializeSuccess) {
+  std::vector<uint8_t> test_public_key = {1, 2, 3, 4};
+  auto serialized_cwt = Cwt::SerializeHpkePublicKey(test_public_key);
+  EXPECT_TRUE(serialized_cwt.ok()) << serialized_cwt.status();
+
+  auto deserialized_cwt = Cwt::Deserialize(*serialized_cwt);
+  EXPECT_TRUE(deserialized_cwt.ok()) << deserialized_cwt.status();
+  EXPECT_THAT(deserialized_cwt->subject_public_key.GetPublicKey(), ElementsAreArray(test_public_key));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR adds functions to generate COSE_Sign1, COSE_Key and CWT certificates for testing purposes.

These functions are currently not fully implemented and only provide serializing an HPKE public key.

Ref https://github.com/project-oak/oak/issues/3641
Ref https://github.com/project-oak/oak/issues/4074
Ref https://github.com/project-oak/oak/issues/4627