### PR TITLE
Specify 'ES256' instead of 'ES256K' in COSE keys generated by cert.rs

### DIFF
--- a/oak_dice/src/cert.rs
+++ b/oak_dice/src/cert.rs
@@ -182,7 +182,7 @@ pub fn cose_key_to_verifying_key(cose_key: &CoseKey) -> Result<VerifyingKey, &'s
     if cose_key.kty != KeyType::Assigned(iana::KeyType::EC2) {
         return Err("invalid key type");
     }
-    if cose_key.alg != Some(Algorithm::Assigned(iana::Algorithm::ES256K)) {
+    if cose_key.alg != Some(Algorithm::Assigned(iana::Algorithm::ES256)) {
         return Err("invalid algorithm");
     }
     if !cose_key
@@ -238,7 +238,7 @@ pub fn verifying_key_to_cose_key(public_key: &VerifyingKey) -> CoseKey {
     CoseKey {
         kty: KeyType::Assigned(iana::KeyType::EC2),
         key_id: Vec::from(derive_verifying_key_id(public_key)),
-        alg: Some(Algorithm::Assigned(iana::Algorithm::ES256K)),
+        alg: Some(Algorithm::Assigned(iana::Algorithm::ES256)),
         key_ops: vec![KeyOperation::Assigned(iana::KeyOperation::Verify)]
             .into_iter()
             .collect(),
@@ -338,7 +338,7 @@ fn generate_certificate(
     }
 
     let protected = coset::HeaderBuilder::new()
-        .algorithm(iana::Algorithm::ES256K)
+        .algorithm(iana::Algorithm::ES256)
         .build();
     let unprotected = coset::HeaderBuilder::new()
         .key_id((*b"AsymmetricECDSA256").into())


### PR DESCRIPTION
The keys being used are all provided by the p256 library, which uses the secp256r1 curve rather than the secp256k1 curve that `cose::iana::Algorithm::ES256K` maps to. Instead, we should be using `cose::iana::Algorithm::ES256`, which maps to the secp256r1 curve (see https://www.rfc-editor.org/rfc/rfc9053.html#section-2.1).