### PR TITLE
Use GetEndorsedEvidence method in Java transport

### DIFF
--- a/java/src/main/java/com/google/oak/client/OakClient.java
+++ b/java/src/main/java/com/google/oak/client/OakClient.java
@@ -60,15 +60,14 @@ public class OakClient<T extends Transport> implements AutoCloseable {
   public static <E extends EvidenceProvider & Transport, V extends AttestationVerifier>
       Result<OakClient<E>, Exception> create(E transport, V verifier, Clock clock) {
     // TODO(#3641): Implement client-side attestation verification.
-    return transport.getEvidence()
+    return transport.getEndorsedEvidence()
         .mapError(Exception::new)
-        .andThen(bundle
-            -> bundle.getEvidence().hasApplicationKeys()
-                ? verifier.verify(clock.instant(), bundle.getEvidence(), bundle.getEndorsements())
-                      .map(b
-                          -> new OakClient<E>(transport, b.getEncryptionPublicKey().toByteArray()))
-                : Result.success(new OakClient<E>(transport,
-                    bundle.getAttestationEvidence().getEncryptionPublicKey().toByteArray())));
+        .andThen(endorsed_evidence
+            -> verifier
+                   .verify(clock.instant(), endorsed_evidence.getEvidence(),
+                       endorsed_evidence.getEndorsements())
+                   .map(
+                       b -> new OakClient<E>(transport, b.getEncryptionPublicKey().toByteArray())));
   }
 
   private OakClient(T transport, byte[] serverEncryptionPublicKey) {

--- a/java/src/main/java/com/google/oak/transport/EvidenceProvider.java
+++ b/java/src/main/java/com/google/oak/transport/EvidenceProvider.java
@@ -16,7 +16,7 @@
 
 package com.google.oak.transport;
 
-import com.google.oak.session.v1.AttestationBundle;
+import com.google.oak.session.v1.EndorsedEvidence;
 import com.google.oak.util.Result;
 
 /** An interface for providing an enclave evidence. */
@@ -24,7 +24,7 @@ public interface EvidenceProvider {
   /**
    * Returns evidence about the trustworthiness of a remote server.
    *
-   * @return {@code AttestationBundle} wrapped in a {@code Result}
+   * @return {@code EndorsedEvidence} wrapped in a {@code Result}
    */
-  abstract Result<AttestationBundle, String> getEvidence();
+  abstract Result<EndorsedEvidence, String> getEndorsedEvidence();
 }

--- a/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
+++ b/java/src/main/java/com/google/oak/transport/GrpcStreamingTransport.java
@@ -18,9 +18,9 @@ package com.google.oak.transport;
 
 import com.google.oak.crypto.v1.EncryptedRequest;
 import com.google.oak.crypto.v1.EncryptedResponse;
-import com.google.oak.session.v1.AttestationBundle;
-import com.google.oak.session.v1.GetPublicKeyRequest;
-import com.google.oak.session.v1.GetPublicKeyResponse;
+import com.google.oak.session.v1.EndorsedEvidence;
+import com.google.oak.session.v1.GetEndorsedEvidenceRequest;
+import com.google.oak.session.v1.GetEndorsedEvidenceResponse;
 import com.google.oak.session.v1.InvokeRequest;
 import com.google.oak.session.v1.InvokeResponse;
 import com.google.oak.session.v1.RequestWrapper;
@@ -61,14 +61,15 @@ public class GrpcStreamingTransport implements EvidenceProvider, Transport {
   /**
    * Returns evidence about the trustworthiness of a remote server.
    *
-   * @return {@code AttestationBundle} wrapped in a {@code Result}
+   * @return {@code EndorsedEvidence} wrapped in a {@code Result}
    */
   @Override
-  public Result<AttestationBundle, String> getEvidence() {
-    RequestWrapper requestWrapper = RequestWrapper.newBuilder()
-                                        .setGetPublicKeyRequest(GetPublicKeyRequest.newBuilder())
-                                        .build();
-    logger.log(Level.INFO, "sending get public key request: " + requestWrapper);
+  public Result<EndorsedEvidence, String> getEndorsedEvidence() {
+    RequestWrapper requestWrapper =
+        RequestWrapper.newBuilder()
+            .setGetEndorsedEvidenceRequest(GetEndorsedEvidenceRequest.newBuilder())
+            .build();
+    logger.log(Level.INFO, "sending get endorsed evidence request: " + requestWrapper);
     this.requestObserver.onNext(requestWrapper);
 
     ResponseWrapper responseWrapper;
@@ -83,10 +84,10 @@ public class GrpcStreamingTransport implements EvidenceProvider, Transport {
       return Result.error("No response message received");
     }
 
-    logger.log(Level.INFO, "received get public key response: " + responseWrapper);
-    GetPublicKeyResponse response = responseWrapper.getGetPublicKeyResponse();
+    logger.log(Level.INFO, "received get endorsed evidence response: " + responseWrapper);
+    GetEndorsedEvidenceResponse response = responseWrapper.getGetEndorsedEvidenceResponse();
 
-    return Result.success(response.getAttestationBundle());
+    return Result.success(response.getEndorsedEvidence());
   }
 
   /**

--- a/java/src/test/java/com/google/oak/client/OakClientTest.java
+++ b/java/src/test/java/com/google/oak/client/OakClientTest.java
@@ -27,9 +27,7 @@ import com.google.oak.crypto.hpke.KeyPair;
 import com.google.oak.crypto.v1.EncryptedRequest;
 import com.google.oak.crypto.v1.EncryptedResponse;
 import com.google.oak.remote_attestation.AttestationVerifier;
-import com.google.oak.session.v1.AttestationBundle;
-import com.google.oak.session.v1.AttestationEndorsement;
-import com.google.oak.session.v1.AttestationEvidence;
+import com.google.oak.session.v1.EndorsedEvidence;
 import com.google.oak.transport.EvidenceProvider;
 import com.google.oak.transport.Transport;
 import com.google.oak.util.Result;
@@ -78,23 +76,13 @@ public class OakClientTest {
     }
 
     @Override
-    public Result<AttestationBundle, String> getEvidence() {
-      AttestationEvidence attestationEvidence =
-          AttestationEvidence.newBuilder()
-              .setEncryptionPublicKey(ByteString.copyFrom(keyPair.publicKey))
-              .build();
-
-      AttestationEndorsement attestationEndorsement = AttestationEndorsement.getDefaultInstance();
+    public Result<EndorsedEvidence, String> getEndorsedEvidence() {
       Evidence evidence = Evidence.getDefaultInstance();
       Endorsements endorsements = Endorsements.getDefaultInstance();
-      AttestationBundle attestationBundle = AttestationBundle.newBuilder()
-                                                .setAttestationEvidence(attestationEvidence)
-                                                .setAttestationEndorsement(attestationEndorsement)
-                                                .setEvidence(evidence)
-                                                .setEndorsements(endorsements)
-                                                .build();
+      EndorsedEvidence endorsedEvidence =
+          EndorsedEvidence.newBuilder().setEvidence(evidence).setEndorsements(endorsements).build();
 
-      return Result.success(attestationBundle);
+      return Result.success(endorsedEvidence);
     }
 
     @Override

--- a/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
+++ b/java/src/test/java/com/google/oak/transport/GrpcStreamingTransportTest.java
@@ -145,8 +145,8 @@ public class GrpcStreamingTransportTest {
   public void testGrpcStreamingTransport() throws Exception {
     GrpcStreamingTransport transport = new GrpcStreamingTransport(client::stream);
 
-    Result<AttestationBundle, String> getEvidenceResult = transport.getEvidence();
-    Assert.assertTrue(getEvidenceResult.isSuccess());
+    Result<EndorsedEvidence, String> getEndorsedEvidenceResult = transport.getEndorsedEvidence();
+    Assert.assertTrue(getEndorsedEvidenceResult.isSuccess());
 
     Result<EncryptedResponse, String> invokeResult =
         transport.invoke(EncryptedRequest.getDefaultInstance());


### PR DESCRIPTION
This PR makes Java transport and client use `GetEndorsedEvidence` method instead of the deprecated `GetPublicKey`

Ref https://github.com/project-oak/oak/issues/3641
Ref https://github.com/project-oak/oak/issues/4074
Ref https://github.com/project-oak/oak/issues/4627