### PR TITLE
Enable initrd for the simple_io version of restricted kernel

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
     just _wrap_kernel oak_restricted_kernel
 
 oak_restricted_kernel_simple_io_bin:
-    env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --bin=oak_restricted_kernel_simple_io_bin
+    env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel --features=simple_io_channel,initrd --bin=oak_restricted_kernel_simple_io_bin
 
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
     just _wrap_kernel oak_restricted_kernel_simple_io


### PR DESCRIPTION
This is so we can also use the orchestrator internally. This tricky bit here is that the we'll need to import the new kernel binary in the same CL that also updates the internal launcher code to supply the orchestrator as the initial ramdisk.


The alternative would be to create a seperate kernel binary that we import into google3. Then we update the internal code to use that new binary, and then remove the old one. 