### PR TITLE
Specify 'ES256' instead of 'ES256K' in COSE keys generated by cert.rs

### DIFF
--- a/oak_attestation_verification/tests/verifier_tests.rs
+++ b/oak_attestation_verification/tests/verifier_tests.rs
@@ -168,6 +168,9 @@ fn create_reference_values() -> ReferenceValues {
     }
 }
 
+// TODO: b/326283532 - Update test data so we can stop ignoring these. Building new testdata
+// requires a commit in main, so we must temporarily merge a change that breaks these tests.
+#[ignore]
 #[test]
 fn verify_succeeds() {
     let evidence = create_evidence();
@@ -259,6 +262,9 @@ fn verify_mock_evidence() {
     assert!(p.status() == Status::Success);
 }
 
+// TODO: b/326283532 - Update test data so we can stop ignoring these. Building new testdata
+// requires a commit in main, so we must temporarily merge a change that breaks these tests.
+#[ignore]
 #[test]
 fn verify_fake_evidence() {
     let evidence = create_fake_evidence();

--- a/oak_dice/src/cert.rs
+++ b/oak_dice/src/cert.rs
@@ -182,7 +182,7 @@ pub fn cose_key_to_verifying_key(cose_key: &CoseKey) -> Result<VerifyingKey, &'s
     if cose_key.kty != KeyType::Assigned(iana::KeyType::EC2) {
         return Err("invalid key type");
     }
-    if cose_key.alg != Some(Algorithm::Assigned(iana::Algorithm::ES256K)) {
+    if cose_key.alg != Some(Algorithm::Assigned(iana::Algorithm::ES256)) {
         return Err("invalid algorithm");
     }
     if !cose_key
@@ -238,7 +238,7 @@ pub fn verifying_key_to_cose_key(public_key: &VerifyingKey) -> CoseKey {
     CoseKey {
         kty: KeyType::Assigned(iana::KeyType::EC2),
         key_id: Vec::from(derive_verifying_key_id(public_key)),
-        alg: Some(Algorithm::Assigned(iana::Algorithm::ES256K)),
+        alg: Some(Algorithm::Assigned(iana::Algorithm::ES256)),
         key_ops: vec![KeyOperation::Assigned(iana::KeyOperation::Verify)]
             .into_iter()
             .collect(),
@@ -338,7 +338,7 @@ fn generate_certificate(
     }
 
     let protected = coset::HeaderBuilder::new()
-        .algorithm(iana::Algorithm::ES256K)
+        .algorithm(iana::Algorithm::ES256)
         .build();
     let unprotected = coset::HeaderBuilder::new()
         .key_id((*b"AsymmetricECDSA256").into())


### PR DESCRIPTION
Reopens #4821, tracks b/326283532

The keys being used are all provided by the p256 library, which uses the secp256r1 curve rather than the secp256k1 curve that cose::iana::Algorithm::ES256K maps to. Instead, we should be using cose::iana::Algorithm::ES256, which maps to the secp256r1 curve (see https://www.rfc-editor.org/rfc/rfc9053.html#section-2.1).

This update breaks tests that run against static testdata generated with the old algorithm. To create new testdata on AMD SEV SNP machines, this change must be merged first. Hence tests are temporarily skipped. They will be re-enabled in a follow up PR.