### PR TITLE
Move CWT public key extraction to utils

### DIFF
--- a/cc/attestation/verification/BUILD
+++ b/cc/attestation/verification/BUILD
@@ -36,10 +36,21 @@ cc_library(
     hdrs = ["insecure_attestation_verifier.h"],
     deps = [
         ":attestation_verifier",
-        "//cc/utils/cose:cwt",
+        ":utils",
         "//proto/attestation:endorsement_cc_proto",
         "//proto/attestation:evidence_cc_proto",
         "//proto/attestation:verification_cc_proto",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "utils",
+    srcs = ["utils.cc"],
+    hdrs = ["utils.h"],
+    deps = [
+        "//cc/utils/cose:cwt",
+        "//proto/attestation:evidence_cc_proto",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ],

--- a/cc/attestation/verification/insecure_attestation_verifier.h
+++ b/cc/attestation/verification/insecure_attestation_verifier.h
@@ -21,7 +21,6 @@
 #include <string>
 
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
 #include "cc/attestation/verification/attestation_verifier.h"
 #include "proto/attestation/endorsement.pb.h"
 #include "proto/attestation/evidence.pb.h"
@@ -37,9 +36,6 @@ class InsecureAttestationVerifier : public AttestationVerifier {
       std::chrono::time_point<std::chrono::system_clock> now,
       const ::oak::attestation::v1::Evidence& evidence,
       const ::oak::attestation::v1::Endorsements& endorsements) const override;
-
- private:
-  absl::StatusOr<std::string> ExtractEncryptionPublicKey(absl::string_view certificate) const;
 };
 
 }  // namespace oak::attestation::verification

--- a/cc/attestation/verification/utils.cc
+++ b/cc/attestation/verification/utils.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cc/attestation/verification/utils.h"
+
+#include <chrono>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "cc/utils/cose/cwt.h"
+#include "proto/attestation/evidence.pb.h"
+
+namespace oak::attestation::verification {
+
+namespace {
+using ::oak::attestation::v1::Evidence;
+using ::oak::utils::cose::Cwt;
+}  // namespace
+
+absl::StatusOr<std::string> ExtractPublicKey(absl::string_view certificate) {
+  auto cwt = Cwt::Deserialize(certificate);
+  if (!cwt.ok()) {
+    return cwt.status();
+  }
+  auto public_key = cwt->subject_public_key.GetPublicKey();
+  return std::string(public_key.begin(), public_key.end());
+}
+
+absl::StatusOr<std::string> ExtractEncryptionPublicKey(
+    const ::oak::attestation::v1::Evidence& evidence) {
+  return ExtractPublicKey(evidence.application_keys().encryption_public_key_certificate());
+}
+
+absl::StatusOr<std::string> ExtractSigningPublicKey(
+    const ::oak::attestation::v1::Evidence& evidence) {
+  return ExtractPublicKey(evidence.application_keys().signing_public_key_certificate());
+}
+
+}  // namespace oak::attestation::verification

--- a/cc/attestation/verification/utils.h
+++ b/cc/attestation/verification/utils.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 The Project Oak Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CC_ATTESTATION_VERIFICATION_UTILS_H_
+#define CC_ATTESTATION_VERIFICATION_UTILS_H_
+
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "proto/attestation/evidence.pb.h"
+
+namespace oak::attestation::verification {
+
+absl::StatusOr<std::string> ExtractEncryptionPublicKey(
+    const ::oak::attestation::v1::Evidence& evidence);
+
+absl::StatusOr<std::string> ExtractSigningPublicKey(
+    const ::oak::attestation::v1::Evidence& evidence);
+
+}  // namespace oak::attestation::verification
+
+#endif  // CC_ATTESTATION_VERIFICATION_ATTESTATION_VERIFIER_H_


### PR DESCRIPTION
This PR adds `ExtractEncryptionPublicKey` and `ExtractSigningPublicKey` as low-level attestation functions that could be used in integration tests