### PR TITLE
Revert "Specify 'ES256' instead of 'ES256K' in COSE keys generated by cert.rs (#4829)"

### DIFF
--- a/oak_attestation_verification/tests/verifier_tests.rs
+++ b/oak_attestation_verification/tests/verifier_tests.rs
@@ -168,9 +168,6 @@ fn create_reference_values() -> ReferenceValues {
     }
 }
 
-// TODO: b/326283532 - Update test data so we can stop ignoring these. Building new testdata
-// requires a commit in main, so we must temporarily merge a change that breaks these tests.
-#[ignore]
 #[test]
 fn verify_succeeds() {
     let evidence = create_evidence();
@@ -262,9 +259,6 @@ fn verify_mock_evidence() {
     assert!(p.status() == Status::Success);
 }
 
-// TODO: b/326283532 - Update test data so we can stop ignoring these. Building new testdata
-// requires a commit in main, so we must temporarily merge a change that breaks these tests.
-#[ignore]
 #[test]
 fn verify_fake_evidence() {
     let evidence = create_fake_evidence();

--- a/oak_dice/src/cert.rs
+++ b/oak_dice/src/cert.rs
@@ -182,7 +182,7 @@ pub fn cose_key_to_verifying_key(cose_key: &CoseKey) -> Result<VerifyingKey, &'s
     if cose_key.kty != KeyType::Assigned(iana::KeyType::EC2) {
         return Err("invalid key type");
     }
-    if cose_key.alg != Some(Algorithm::Assigned(iana::Algorithm::ES256)) {
+    if cose_key.alg != Some(Algorithm::Assigned(iana::Algorithm::ES256K)) {
         return Err("invalid algorithm");
     }
     if !cose_key
@@ -238,7 +238,7 @@ pub fn verifying_key_to_cose_key(public_key: &VerifyingKey) -> CoseKey {
     CoseKey {
         kty: KeyType::Assigned(iana::KeyType::EC2),
         key_id: Vec::from(derive_verifying_key_id(public_key)),
-        alg: Some(Algorithm::Assigned(iana::Algorithm::ES256)),
+        alg: Some(Algorithm::Assigned(iana::Algorithm::ES256K)),
         key_ops: vec![KeyOperation::Assigned(iana::KeyOperation::Verify)]
             .into_iter()
             .collect(),
@@ -338,7 +338,7 @@ fn generate_certificate(
     }
 
     let protected = coset::HeaderBuilder::new()
-        .algorithm(iana::Algorithm::ES256)
+        .algorithm(iana::Algorithm::ES256K)
         .build();
     let unprotected = coset::HeaderBuilder::new()
         .key_id((*b"AsymmetricECDSA256").into())


### PR DESCRIPTION
This reverts commit eaabab4e6328b821f5bfd1a56e4369731afcbfe2 or #4829. We need commit with the aforementioned change to build new testdata. We now have one, so we can revert that PR since it also disabled the relevant tests.