### PR TITLE
Added randomness to lookup_htbl.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,6 +2810,7 @@ dependencies = [
  "pprof",
  "prost 0.11.9",
  "rand",
+ "rand_core",
  "spinning_top 0.3.0",
  "tokio",
  "wasmi",

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "oak_functions_sdk",
  "oak_proto_rust",
  "prost",
+ "rand_core",
  "spinning_top",
  "wasmi",
 ]

--- a/oak_functions_service/Cargo.toml
+++ b/oak_functions_service/Cargo.toml
@@ -28,6 +28,9 @@ oak_dice = { workspace = true }
 oak_functions_abi = { workspace = true }
 oak_functions_sdk = { workspace = true }
 oak_proto_rust = { workspace = true }
+rand_core = { version = "*", default-features = false, features = [
+  "getrandom",
+] }
 spinning_top = "*"
 wasmi = { version = "*", default-features = false }
 wasmtime = { version = "*", optional = true }

--- a/oak_functions_service/src/lib.rs
+++ b/oak_functions_service/src/lib.rs
@@ -27,6 +27,7 @@ use lookup::LookupDataManager;
 use oak_functions_abi::{Request, Response};
 
 extern crate alloc;
+extern crate rand_core;
 
 #[cfg(test)]
 extern crate std;

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -423,7 +423,8 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
     num_bytes
 }
 
-// This hash both defends against DDoS attacks and passes dieharder tests.
+// This hash both defends against DDoS attacks and passes dieharder tests.  It is 2 rounds of
+// hashing in order to pass the dieharder tests.
 #[inline]
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
     let v1 = u64::wrapping_mul((v ^ hash_secret) ^ (v >> 32), 0x9d46_0858_ea81_ac79);

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -70,6 +70,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use core::mem;
 
 use bytes::Bytes;
+use rand_core::{OsRng, RngCore};
 
 // To save memory, we use 5 byte array index values instead of 8 bytes.  This saves 12 bytes per
 // k/v pair.  It is referred to as u40 below.
@@ -97,6 +98,7 @@ pub struct LookupHtbl {
     max_entries: usize, // The number at which we must grow the table.
     used_data: usize,
     used_entries: usize,
+    hash_secret: u64, // For defense against DDoS, and some defense vs cache timing.
 }
 
 // Retured by LookupHtbl::lookup.
@@ -122,6 +124,10 @@ impl LookupHtbl {
         // the first chunk will never be used as a result.
         self.used_data = 1usize;
         self.used_entries = 0usize;
+        self.hash_secret = OsRng.next_u64();
+        if self.hash_secret == 0u64 {
+            panic!("There is something very wrong with OsRng");
+        }
     }
 
     // Lookup the key/value pair.  If found, return LookupResult::Found(table_index, data_index).
@@ -130,7 +136,7 @@ impl LookupHtbl {
         if self.table.is_empty() {
             panic!("Check for emtpy before calling lookup");
         }
-        let key_hash: u64 = hash(key);
+        let key_hash: u64 = hash(key, self.hash_secret);
         // The lower 32-bites are used in reduce to compute the table index, and values next to
         // each other in the table will have their lower-32 bits close to each other.  The next
         // higher byte should have no significant correlation for unequal keys.
@@ -417,40 +423,30 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
     num_bytes
 }
 
-// Multiplication is our best fast mixing primitive, and with XOR, we have a non-linear hash.  We
-// multiply by odd numbers so it is reversible.  The upper 32 bits of the result of a 64x64->64
-// multiplication has a good mix from the lower 32 bits, but the upper 32 bits of the input do not
-// effect the result's lower 32 bits.  Therefore, multiply by v + (v >> 32), so that high and low
-// bits influence the high bits of the result.  Then, mix the upper 32 bits into the lower 32.
-//
-// We don't have to use this, but it does help us gain back some performance lost in all the bit
-// manipulation.  It also reduces dependencies.  Finally, this is something we will need to do
-// ourselves in any case once we start defending against side-channel attacks.  We'll want to
-// include a random value in this hash, with constant-time processing.
+// This hash both defends against DDoS attacks and passes dieharder tests.
 #[inline]
-fn hash_u64(v: u64) -> u64 {
-    let v1 = u64::wrapping_mul(
-        u64::wrapping_add(v ^ 0xae47cb4bcc70f561, v >> 32),
-        0x9d460858ea81ac79,
-    );
-    u64::wrapping_add(v1, v1 >> 32)
+fn hash_u64(v: u64, hash_secret: u64) -> u64 {
+    let v1 = u64::wrapping_mul((v ^ hash_secret) ^ (v >> 32), 0x9d46_0858_ea81_ac79);
+    let v2 = u64::wrapping_add(v1 ^ v, v1 >> 32);
+    let v3 = u64::wrapping_mul((v2 ^ hash_secret) ^ (v2 >> 32), 0x5437_b730_d14a_aa83u64);
+    u64::wrapping_add(v3 ^ v, v3 >> 32)
 }
 
 #[inline]
-fn hash(v: &[u8]) -> u64 {
+fn hash(v: &[u8], hash_secret: u64) -> u64 {
     let mut i = 0usize;
     let mut val = 0u64;
     let mut bytes = [0u8; 8];
     while i + 8 <= v.len() {
         bytes.copy_from_slice(&v[i..i + 8]);
         let digit = u64::from_le_bytes(bytes);
-        val = hash_u64(val ^ digit);
+        val = hash_u64(val ^ digit, hash_secret);
         i += 8;
     }
     if i < v.len() {
         bytes[0..v.len() - i].copy_from_slice(&v[i..v.len()]);
         let digit: u64 = u64::from_le_bytes(bytes);
-        val = hash_u64(val ^ digit);
+        val = hash_u64(val ^ digit, hash_secret);
     }
     val
 }
@@ -487,7 +483,7 @@ mod tests {
         let mut misses = 0;
         let mut total = 0u64;
         for i in 0u64..NUM_LOOKUPS as u64 {
-            let key = hash_u64(i) & mask;
+            let key = hash_u64(i, 0) & mask;
             match table.get(&key.to_le_bytes()) {
                 Some(val) => {
                     hits += 1;
@@ -532,13 +528,12 @@ mod tests {
     // This further tests the hash function.
     struct Rand {
         seed: u64,
+        hash_secret: u64,
     }
 
     impl Rand {
         fn rand64(&mut self) -> u64 {
-            // Mask off the MSB to force this to disrupt the group structure.  Hour "hash" function
-            // is a permutation, and group structure comes into play otherwise.
-            self.seed = hash_u64(self.seed) & (!0u64 >> 1);
+            self.seed = hash_u64(self.seed, self.hash_secret);
             self.seed
         }
 
@@ -550,7 +545,7 @@ mod tests {
             let mut v = vec![];
             for _ in 0..len {
                 v.push(self.seed as u8);
-                self.seed = hash_u64(self.seed);
+                self.seed = hash_u64(self.seed, self.hash_secret);
             }
             v
         }
@@ -566,7 +561,10 @@ mod tests {
 
     #[test]
     fn test_rand_vals() {
-        let mut r = Rand { seed: 0u64 };
+        let mut r = Rand {
+            seed: 0u64,
+            hash_secret: 0u64,
+        };
         let mut kv_pairs: Vec<(Vec<u8>, Vec<u8>)> = vec![];
         let mut table = LookupHtbl::default();
         for _ in 0..2 {
@@ -602,14 +600,21 @@ mod tests {
     // This is a linear-time algorithm for finding the cycle length of an RNG.
     #[test]
     fn test_rng_sequence_len() {
-        let mut r = Rand { seed: 0u64 };
-        for loop_power in 0..28 {
+        let mut r = Rand {
+            seed: 0u64,
+            hash_secret: 1u64,
+        };
+        for loop_power in 0..34 {
             let target = r.rand64();
             for i in 0usize..(1usize << loop_power) {
                 if r.rand64() == target {
-                    panic!("Rand sequence length =  {}", i + 1);
+                    if i < 1 << 28 {
+                        panic!("Sequence too short");
+                    }
+                    return;
                 }
             }
         }
+        panic!("Sequence too long");
     }
 }

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -428,9 +428,7 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
 #[inline]
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
     let v1 = u64::wrapping_mul((v ^ hash_secret) ^ (v >> 32), 0x9d46_0858_ea81_ac79);
-    let v2 = u64::wrapping_add(v1 ^ v, v1 >> 32);
-    let v3 = u64::wrapping_mul((v2 ^ hash_secret) ^ (v2 >> 32), 0x5437_b730_d14a_aa83u64);
-    u64::wrapping_add(v3 ^ v, v3 >> 32)
+    u64::wrapping_add(v1 ^ v, v1 >> 32)
 }
 
 #[inline]

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -637,6 +637,7 @@ mod tests {
         let mut len = 0;
         let mut total_len = 0;
         let mut num_seq = 0;
+        #[allow(clippy::all)]
         for i in 0..table_len {
             if table[i] {
                 len += 1;


### PR DESCRIPTION
This makes it harder to extract a user's location via cache-timing, but not impossible.

The new hash function distributes keys very evenly in tests.  In contrast, the ahash crate produces poor hashes, resulting in more hash collisions.   I've submitted [Issue #210](https://github.com/tkaitchuck/aHash/issues/210) upstream to ahash about this.

The average number of collisions in a 2B entry swiss table with 50% load factor was 3.50 for ahash.  For the custom hasher, it is 2.54, which is identical to what we see using true random numbers as hash values.  The custom hash function is also about 20% faster than ahash on my laptop.