### PR TITLE
Add comment calrifying why attestation/verification integration tests are extracted

### DIFF
--- a/oak_attestation_integration_tests/README.md
+++ b/oak_attestation_integration_tests/README.md
@@ -5,6 +5,6 @@ verifying it.
 
 These tests are kept in a seperate crate as they rely on a set of different
 crates, some which are and some of which are not available in google3. Tests for
-individual aspects of the attestation/verification flow and do not rely on other
-crates should be kept in the relevant crate. This way they can be run in google3
-if the crate is imported.
+individual aspects of the attestation/verification flow that do not rely on
+other crates should be kept in the relevant crate. This way they can be run in
+google3 if the crate is imported.

--- a/oak_attestation_integration_tests/README.md
+++ b/oak_attestation_integration_tests/README.md
@@ -2,3 +2,9 @@
 
 Tests that cover the full workflow of generating an attestation to then
 verifying it.
+
+These tests are kept in a seperate crate as they rely on a set of different
+crates, some which are and some of which are not available in google3. Tests for
+individual aspects of the attestation/verification flow and do not rely on other
+crates should be kept in the relevant crate. This way they can be run in google3
+if the crate is imported.


### PR DESCRIPTION
Overlooked your comment on my previous PR, but I agree such a comment would be helpful. :) 