### PR TITLE
Create Starlark rule for Oak Functions native modules

### DIFF
--- a/cc/oak_functions/native_sdk/BUILD
+++ b/cc/oak_functions/native_sdk/BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("//cc/oak_functions/native_sdk:native_rules.bzl", "oak_functions_native_module")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
@@ -33,14 +35,10 @@ cc_library(
     ],
 )
 
-cc_binary(
+oak_functions_native_module(
     name = "key_value_lookup",
     srcs = ["key_value_lookup.cc"],
-    linkopts = ["-Wl,--version-script,$(location symbols.map.ld)"],
-    linkshared = True,
     deps = [
-        "symbols.map.ld",
-        ":native_sdk",
         "@com_google_absl//absl/log:check",
     ],
 )

--- a/cc/oak_functions/native_sdk/native_rules.bzl
+++ b/cc/oak_functions/native_sdk/native_rules.bzl
@@ -1,0 +1,16 @@
+"""Rules to build native modules for Oak Functions on Oak Containers."""
+
+def oak_functions_native_module(name, deps, **kwargs):
+    native.cc_binary(
+        name = name,
+        linkshared = 1,
+        linkstatic = 1,
+        linkopts = [
+            "-Wl,--version-script,$(location //cc/oak_functions/native_sdk:symbols.map.ld)",
+        ],
+        deps = [
+            "//cc/oak_functions/native_sdk",
+            "symbols.map.ld",
+        ] + deps,
+        **kwargs
+    )


### PR DESCRIPTION
This just moves stuff from the existing `cc_binary` rule to a reusable bzl file.