### PR TITLE
Remove signing key from InsecureAttestationVerifier

### DIFF
--- a/cc/attestation/verification/insecure_attestation_verifier.cc
+++ b/cc/attestation/verification/insecure_attestation_verifier.cc
@@ -48,7 +48,6 @@ absl::StatusOr<AttestationResults> InsecureAttestationVerifier::Verify(
 
   AttestationResults attestation_results;
   *attestation_results.mutable_encryption_public_key() = *encryption_public_key;
-  *attestation_results.mutable_signing_public_key() = *signing_public_key;
 
   return attestation_results;
 }

--- a/cc/attestation/verification/insecure_attestation_verifier.cc
+++ b/cc/attestation/verification/insecure_attestation_verifier.cc
@@ -41,11 +41,6 @@ absl::StatusOr<AttestationResults> InsecureAttestationVerifier::Verify(
     return encryption_public_key.status();
   }
 
-  absl::StatusOr<std::string> signing_public_key = ExtractSigningPublicKey(evidence);
-  if (!signing_public_key.ok()) {
-    return signing_public_key.status();
-  }
-
   AttestationResults attestation_results;
   *attestation_results.mutable_encryption_public_key() = *encryption_public_key;
 


### PR DESCRIPTION
Remove parsing signing key in the `InsecureAttestationVerifier` because not all internal tests are currently generating this key