### PR TITLE
Move cc `orchestrator_client.{cc,h}` into a separate sdk package

### DIFF
--- a/cc/containers/hello_world_trusted_app/BUILD
+++ b/cc/containers/hello_world_trusted_app/BUILD
@@ -25,7 +25,7 @@ cc_library(
     srcs = ["app_service.cc"],
     hdrs = ["app_service.h"],
     deps = [
-        ":orchestrator_client",
+        "//cc/containers/sdk:orchestrator_client",
         "//cc/crypto:common",
         "//cc/crypto:server_encryptor",
         "//oak_containers_hello_world_trusted_app/proto:interface_cc_grpc",
@@ -36,32 +36,12 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "orchestrator_client",
-    srcs = ["orchestrator_client.cc"],
-    hdrs = ["orchestrator_client.h"],
-    deps = [
-        "//cc/crypto:encryption_key",
-        "//cc/crypto/hpke:recipient_context",
-        "//oak_containers/proto:interfaces_cc_grpc",
-        "//oak_containers/proto:interfaces_cc_proto",
-        "//proto/containers:orchestrator_crypto_cc_grpc",
-        "//proto/containers:orchestrator_crypto_cc_proto",
-        "//proto/crypto:crypto_cc_proto",
-        "@com_github_grpc_grpc//:grpc++",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
-        "@com_google_protobuf//:protobuf",
-    ],
-)
-
 cc_binary(
     name = "main",
     srcs = ["main.cc"],
     deps = [
         ":app_service",
-        ":orchestrator_client",
+        "//cc/containers/sdk:orchestrator_client",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/log:initialize",

--- a/cc/containers/hello_world_trusted_app/app_service.h
+++ b/cc/containers/hello_world_trusted_app/app_service.h
@@ -20,7 +20,7 @@
 
 #include "absl/log/die_if_null.h"
 #include "absl/strings/string_view.h"
-#include "cc/containers/hello_world_trusted_app/orchestrator_client.h"
+#include "cc/containers/sdk/orchestrator_client.h"
 #include "grpcpp/server_context.h"
 #include "grpcpp/support/status.h"
 #include "oak_containers_hello_world_trusted_app/proto/interface.grpc.pb.h"
@@ -30,7 +30,7 @@ namespace oak::oak_containers_hello_world_trusted_app {
 
 class TrustedApplicationImpl : public containers::example::TrustedApplication::Service {
  public:
-  TrustedApplicationImpl(OrchestratorClient* orchestrator_client,
+  TrustedApplicationImpl(::oak::containers::sdk::OrchestratorClient* orchestrator_client,
                          absl::string_view application_config)
       : orchestrator_client_(*ABSL_DIE_IF_NULL(orchestrator_client)),
         application_config_(application_config) {}
@@ -39,7 +39,7 @@ class TrustedApplicationImpl : public containers::example::TrustedApplication::S
                      containers::example::HelloResponse* response) override;
 
  private:
-  OrchestratorClient& orchestrator_client_;
+  ::oak::containers::sdk::OrchestratorClient& orchestrator_client_;
   const std::string application_config_;
 };
 

--- a/cc/containers/hello_world_trusted_app/main.cc
+++ b/cc/containers/hello_world_trusted_app/main.cc
@@ -20,13 +20,12 @@
 #include "absl/status/statusor.h"
 #include "app_service.h"
 #include "cc/containers/hello_world_trusted_app/app_service.h"
-#include "cc/containers/hello_world_trusted_app/orchestrator_client.h"
+#include "cc/containers/sdk/orchestrator_client.h"
 #include "grpcpp/security/server_credentials.h"
 #include "grpcpp/server.h"
 #include "grpcpp/server_builder.h"
-#include "orchestrator_client.h"
 
-using ::oak::oak_containers_hello_world_trusted_app::OrchestratorClient;
+using ::oak::containers::sdk::OrchestratorClient;
 using ::oak::oak_containers_hello_world_trusted_app::TrustedApplicationImpl;
 
 int main(int argc, char* argv[]) {

--- a/cc/containers/sdk/BUILD
+++ b/cc/containers/sdk/BUILD
@@ -1,0 +1,50 @@
+#
+# Copyright 2024 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "orchestrator_client",
+    srcs = ["orchestrator_client.cc"],
+    hdrs = ["orchestrator_client.h"],
+    deps = [
+        "//cc/crypto:encryption_key",
+        "//cc/crypto/hpke:recipient_context",
+        "//oak_containers/proto:interfaces_cc_grpc",
+        "//oak_containers/proto:interfaces_cc_proto",
+        "//proto/containers:orchestrator_crypto_cc_grpc",
+        "//proto/containers:orchestrator_crypto_cc_proto",
+        "//proto/crypto:crypto_cc_proto",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+#cc_library(
+#    name = "oak_containers_sdk",
+#    srcs = ["oak_containers_sdk.cc"],
+#    hdrs = ["oak_containers_sdk.h"],
+#    deps = [
+#        "//oak/containers/proto:interfaces_cc_grpc",
+#        "@com_github_grpc_grpc//:grpc++",
+#    ],
+#)

--- a/cc/containers/sdk/orchestrator_client.cc
+++ b/cc/containers/sdk/orchestrator_client.cc
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cc/containers/hello_world_trusted_app/orchestrator_client.h"
+#include "cc/containers/sdk/orchestrator_client.h"
 
 #include <memory>
 #include <string>
@@ -33,7 +33,7 @@
 #include "proto/containers/orchestrator_crypto.pb.h"
 #include "proto/crypto/crypto.pb.h"
 
-namespace oak::oak_containers_hello_world_trusted_app {
+namespace oak::containers::sdk {
 
 using ::oak::containers::GetApplicationConfigResponse;
 using ::oak::containers::v1::DeriveSessionKeysRequest;
@@ -79,4 +79,4 @@ absl::StatusOr<std::unique_ptr<RecipientContext>> OrchestratorClient::GenerateRe
   return RecipientContext::Deserialize(response.session_keys());
 }
 
-}  // namespace oak::oak_containers_hello_world_trusted_app
+}  // namespace oak::containers::sdk

--- a/cc/containers/sdk/orchestrator_client.h
+++ b/cc/containers/sdk/orchestrator_client.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef CC_OAK_CONTAINERS_HELLO_WORLD_TRUSTED_APP_ORCHESTRATOR_CLIENT_H_
-#define CC_OAK_CONTAINERS_HELLO_WORLD_TRUSTED_APP_ORCHESTRATOR_CLIENT_H_
+#ifndef CC_OAK_CONTAINERS_SDK_ORCHESTRATOR_CLIENT_H_
+#define CC_OAK_CONTAINERS_SDK_ORCHESTRATOR_CLIENT_H_
 
 #include <memory>
 #include <string>
@@ -29,7 +29,7 @@
 #include "proto/containers/orchestrator_crypto.grpc.pb.h"
 #include "proto/crypto/crypto.pb.h"
 
-namespace oak::oak_containers_hello_world_trusted_app {
+namespace oak::containers::sdk {
 
 class OrchestratorClient : public crypto::EncryptionKeyHandle {
  public:


### PR DESCRIPTION
The functionality mirrors the `oak_containers_sdk` Rust crate, and makes it reusable.