### PR TITLE
Improve dice chain verification logic clarity

### DIFF
--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -433,6 +433,8 @@ fn verify_root_attestation_signature(
             let actual = report.data.report_data;
 
             anyhow::ensure!(
+                // The report data contains 64 bytes by default, but we only use the first 32 bytes
+                // at the
                 expected.len() > actual.len() && expected != &actual[..expected.len()],
                 "The root layer's ECA public key is not bound to the attestation report"
             );

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -434,7 +434,7 @@ fn verify_root_attestation_signature(
 
             anyhow::ensure!(
                 // The report data contains 64 bytes by default, but we only use the first 32 bytes
-                // at the
+                // at the moment.
                 expected.len() > actual.len() && expected != &actual[..expected.len()],
                 "The root layer's ECA public key is not bound to the attestation report"
             );

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -435,7 +435,7 @@ fn verify_root_attestation_signature(
             anyhow::ensure!(
                 // The report data contains 64 bytes by default, but we only use the first 32 bytes
                 // at the moment.
-                expected.len() > actual.len() && expected != &actual[..expected.len()],
+                expected.len() < actual.len() && expected == &actual[..expected.len()],
                 "The root layer's ECA public key is not bound to the attestation report"
             );
 

--- a/proto/attestation/verification.proto
+++ b/proto/attestation/verification.proto
@@ -50,7 +50,7 @@ message AttestationResults {
   bytes signing_public_key = 4;
 }
 
-// Evidence values extracted from attestatoin evidence during verification.
+// Evidence values extracted from attestation evidence during verification.
 message ExtractedEvidence {
   oneof evidence_values {
     OakRestrictedKernelData oak_restricted_kernel = 1;


### PR DESCRIPTION
I was going through this code in preparation for using it using it in the OC3 talk demo, and found it a bit unwieldy to read. 

This is a small refactor that improves clarity and readability by making it more seqential reducing the number of variables in the outermost scope, and reducing mutation / redeclaration of variables.