### PR TITLE
Add Kokoro build scripts for the remaining xtask items

### DIFF
--- a/kokoro/check_format.sh
+++ b/kokoro/check_format.sh
@@ -14,4 +14,4 @@ export XDG_RUNTIME_DIR=/var/run
 cd "$(dirname "$0")/.."
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#ci --command ./scripts/xtask run-cargo-clippy
+./scripts/docker_run nix develop .#rust --command ./scripts/xtask check-format

--- a/kokoro/completion.sh
+++ b/kokoro/completion.sh
@@ -14,4 +14,4 @@ export XDG_RUNTIME_DIR=/var/run
 cd "$(dirname "$0")/.."
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#ci --command ./scripts/xtask run-cargo-clippy
+./scripts/docker_run nix develop .#rust --command ./scripts/xtask completion

--- a/kokoro/format.sh
+++ b/kokoro/format.sh
@@ -14,4 +14,4 @@ export XDG_RUNTIME_DIR=/var/run
 cd "$(dirname "$0")/.."
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#ci --command ./scripts/xtask run-cargo-clippy
+./scripts/docker_run nix develop .#rust --command ./scripts/xtask format

--- a/kokoro/run_bazel_tests.sh
+++ b/kokoro/run_bazel_tests.sh
@@ -14,4 +14,4 @@ export XDG_RUNTIME_DIR=/var/run
 cd "$(dirname "$0")/.."
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#ci --command ./scripts/xtask run-cargo-clippy
+./scripts/docker_run nix develop .#rust --command ./scripts/xtask run-bazel-tests

--- a/kokoro/run_cargo_deny.sh
+++ b/kokoro/run_cargo_deny.sh
@@ -14,4 +14,4 @@ export XDG_RUNTIME_DIR=/var/run
 cd "$(dirname "$0")/.."
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#ci --command ./scripts/xtask run-cargo-clippy
+./scripts/docker_run nix develop .#rust --command ./scripts/xtask run-cargo-deny

--- a/kokoro/run_cargo_fuzz.sh
+++ b/kokoro/run_cargo_fuzz.sh
@@ -14,4 +14,4 @@ export XDG_RUNTIME_DIR=/var/run
 cd "$(dirname "$0")/.."
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#ci --command ./scripts/xtask run-cargo-clippy
+./scripts/docker_run nix develop .#ci --command ./scripts/xtask run-cargo-fuzz -- -max_total_time=2

--- a/kokoro/run_cargo_udeps.sh
+++ b/kokoro/run_cargo_udeps.sh
@@ -14,4 +14,4 @@ export XDG_RUNTIME_DIR=/var/run
 cd "$(dirname "$0")/.."
 
 ./scripts/docker_pull
-./scripts/docker_run nix develop .#ci --command ./scripts/xtask run-cargo-clippy
+./scripts/docker_run nix develop .#rust --command ./scripts/xtask run-cargo-udeps


### PR DESCRIPTION
I was originally planning to do one PR per item, but doing them all at
once seems reasonable. (Clippy was done already in #4837)

These aren't wired to Kokoro yet, so the testing for this PR has been to
manually run each script.