### PR TITLE
Fail on non-empty reference values

### DIFF
--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -461,6 +461,8 @@ fn verify_root_layer(
     reference_values: &RootLayerReferenceValues,
 ) -> anyhow::Result<()> {
     match values.report.as_ref() {
+        // TODO: Verify stage0 based on the number of configured vCPUs (WIP). We don't
+        //       have an endorsement to compare against.
         Some(Report::SevSnp(report_values)) => verify_amd_sev_attestation_report(
             report_values,
             reference_values

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -394,8 +394,11 @@ fn verify_amd_sev_attestation_report(
         anyhow::bail!("debug mode not allowed");
     }
 
-    let fw = reference_values.firmware_version.as_ref();
-    if fw.is_some_and(|a| a.values.len() > 0) {
+    if reference_values
+        .firmware_version
+        .as_ref()
+        .is_some_and(|a| a.values.len() > 0)
+    {
         anyhow::bail!("firmware version check needs implementation");
     }
 

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -394,6 +394,11 @@ fn verify_amd_sev_attestation_report(
         anyhow::bail!("debug mode not allowed");
     }
 
+    let fw = reference_values.firmware_version.as_ref();
+    if fw.is_some_and(|a| a.values.len() > 0) {
+        anyhow::bail!("firmware version check needs implementation");
+    }
+
     Ok(())
 }
 

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -462,8 +462,8 @@ fn verify_root_layer(
 ) -> anyhow::Result<()> {
     match values.report.as_ref() {
         Some(Report::SevSnp(report_values)) => {
-            // TODO: b/327069120 - We don't have the correct digest in the endorsement
-            // to compare the stage0 measurement. This will fail UNLESS the stage0
+            // See b/327069120: We don't have the correct digest in the endorsement
+            // to compare the stage0 measurement yet. This will fail UNLESS the stage0
             // reference value is set to `skip {}`.
             let measurement = RawDigest {
                 sha2_384: report_values.initial_measurement.to_vec(),

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -397,7 +397,7 @@ fn verify_amd_sev_attestation_report(
     if reference_values
         .firmware_version
         .as_ref()
-        .is_some_and(|a| a.values.len() > 0)
+        .is_some_and(|a| !a.values.is_empty())
     {
         anyhow::bail!("firmware version check needs implementation");
     }

--- a/oak_attestation_verification/tests/verifier_tests.rs
+++ b/oak_attestation_verification/tests/verifier_tests.rs
@@ -166,7 +166,7 @@ fn create_reference_values() -> ReferenceValues {
 fn verify_succeeds() {
     let evidence = create_evidence();
     let endorsements = create_endorsements();
-    let mut reference_values = create_reference_values();
+    let reference_values = create_reference_values();
 
     let r = verify(NOW_UTC_MILLIS, &evidence, &endorsements, &reference_values);
     let p = to_attestation_results(&r);

--- a/oak_attestation_verification/tests/verifier_tests.rs
+++ b/oak_attestation_verification/tests/verifier_tests.rs
@@ -110,7 +110,7 @@ fn create_reference_values() -> ReferenceValues {
         amd_root_public_key: b"".to_vec(),
         firmware_version: None,
         allow_debug: false,
-        // TODO: b/327069120 - This should not be skipped.
+        // See b/327069120: Do not skip over stage0.
         stage0: Some(skip.clone()),
     };
 
@@ -185,7 +185,7 @@ fn verify_fake_evidence() {
     assert!(p.status() == Status::Success);
 }
 
-// TODO: b/327069120 - This test can go once we properly endorse stage0.
+// See b/327069120: This test can go once we properly endorse stage0.
 #[test]
 fn verify_fails_with_stage0_reference_value_set() {
     let evidence = create_evidence();

--- a/oak_attestation_verification/tests/verifier_tests.rs
+++ b/oak_attestation_verification/tests/verifier_tests.rs
@@ -124,13 +124,13 @@ fn create_reference_values() -> ReferenceValues {
             oak_proto_rust::oak::attestation::v1::binary_reference_value::Type::Endorsement(erv),
         ),
     };
-    let srv = StringReferenceValue {
+    let _srv = StringReferenceValue {
         values: ["whatever".to_owned()].to_vec(),
     };
 
     let amd_sev = AmdSevReferenceValues {
         amd_root_public_key: b"".to_vec(),
-        firmware_version: Some(srv.clone()),
+        firmware_version: None,
         allow_debug: false,
         stage0: Some(brv.clone()),
     };

--- a/oak_attestation_verification/tests/verifier_tests.rs
+++ b/oak_attestation_verification/tests/verifier_tests.rs
@@ -102,34 +102,16 @@ fn create_endorsements() -> Endorsements {
 
 // Creates valid reference values for an Oak Containers chain.
 fn create_reference_values() -> ReferenceValues {
-    let endorser_public_key_pem =
-        fs::read_to_string(ENDORSER_PUBLIC_KEY_PATH).expect("couldn't read endorser public key");
-    let rekor_public_key_pem =
-        fs::read_to_string(REKOR_PUBLIC_KEY_PATH).expect("couldn't read rekor public key");
-
-    let endorser_public_key = convert_pem_to_raw(endorser_public_key_pem.as_str())
-        .expect("failed to convert endorser key");
-    let rekor_public_key =
-        convert_pem_to_raw(&rekor_public_key_pem).expect("failed to convert Rekor key");
-
-    let erv = EndorsementReferenceValue {
-        endorser_public_key,
-        rekor_public_key,
-    };
     let skip = BinaryReferenceValue {
         r#type: Some(binary_reference_value::Type::Skip(SkipVerification {})),
-    };
-    let brv = BinaryReferenceValue {
-        r#type: Some(
-            oak_proto_rust::oak::attestation::v1::binary_reference_value::Type::Endorsement(erv),
-        ),
     };
 
     let amd_sev = AmdSevReferenceValues {
         amd_root_public_key: b"".to_vec(),
         firmware_version: None,
         allow_debug: false,
-        stage0: Some(brv.clone()),
+        // TODO: b/327069120 - This should not be skipped.
+        stage0: Some(skip.clone()),
     };
 
     let root_layer = RootLayerReferenceValues {
@@ -201,6 +183,56 @@ fn verify_fake_evidence() {
     eprintln!("======================================");
     assert!(r.is_ok());
     assert!(p.status() == Status::Success);
+}
+
+// TODO: b/327069120 - This test can go once we properly endorse stage0.
+#[test]
+fn verify_fails_with_stage0_reference_value_set() {
+    let evidence = create_evidence();
+    let endorsements = create_endorsements();
+
+    // Set the stage0 field to something.
+    let mut reference_values = create_reference_values();
+    let endorser_public_key_pem =
+        fs::read_to_string(ENDORSER_PUBLIC_KEY_PATH).expect("couldn't read endorser public key");
+    let rekor_public_key_pem =
+        fs::read_to_string(REKOR_PUBLIC_KEY_PATH).expect("couldn't read rekor public key");
+
+    let endorser_public_key = convert_pem_to_raw(endorser_public_key_pem.as_str())
+        .expect("failed to convert endorser key");
+    let rekor_public_key =
+        convert_pem_to_raw(&rekor_public_key_pem).expect("failed to convert Rekor key");
+    let erv = EndorsementReferenceValue {
+        endorser_public_key,
+        rekor_public_key,
+    };
+    let brv = BinaryReferenceValue {
+        r#type: Some(
+            oak_proto_rust::oak::attestation::v1::binary_reference_value::Type::Endorsement(erv),
+        ),
+    };
+    match reference_values.r#type.as_mut() {
+        Some(reference_values::Type::OakContainers(rfs)) => {
+            rfs.root_layer
+                .as_mut()
+                .unwrap()
+                .amd_sev
+                .as_mut()
+                .unwrap()
+                .stage0 = Some(brv);
+        }
+        Some(_) => {}
+        None => {}
+    };
+
+    let r = verify(NOW_UTC_MILLIS, &evidence, &endorsements, &reference_values);
+    let p = to_attestation_results(&r);
+
+    eprintln!("======================================");
+    eprintln!("code={} reason={}", p.status as i32, p.reason);
+    eprintln!("======================================");
+    assert!(r.is_err());
+    assert!(p.status() == Status::GenericFailure);
 }
 
 #[test]


### PR DESCRIPTION
Two goals achieved here:

(1) Make the verification fail on non-empty firmware version. We don't have a spec for that reference value yet. It would be good to address this in one go for all of AttestationReportValues.

(2) Make the verification fail for non-skip stage0 reference value. This adds code that could already work with the derived endorsements but fails now since we don't have the derived endorsements for stage0. 

See b/327069120