### PR TITLE
Enhanced hash_u64 as 2-rounds.

### DIFF
--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -438,8 +438,8 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
 #[inline]
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
     let v1 = u64::wrapping_mul((v + hash_secret) ^ (v >> 32), 0x9d46_0858_ea81_ac79);
-    let v2 = u64::wrapping_add(v1 ^ v, v1 >> 32);
-    let v3 = u64::wrapping_mul((v2 + hash_secret) ^ (v2 >> 32), 0xe177_d33d_28e7_10c9);
+    let v2 = u64::wrapping_add(v1, v1 >> 32);
+    let v3 = u64::wrapping_mul((v2 + hash_secret) ^ (v2 >> 32), 0xe177_d33d_28e7_10c5);
     u64::wrapping_add(v3 ^ v, v3 >> 32)
 }
 

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -439,8 +439,7 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
     let v1 = (v + hash_secret) ^ v.rotate_left(32);
     let v2 = (v1 as u128).wrapping_mul(0x9d46_0858_ea81_ac79);
-    let v3 = (v2 as u64) ^ ((v2 >> 64) as u64)
-    v ^ v3
+    v ^ (v2 as u64) ^ ((v2 >> 64) as u64)
 }
 
 #[inline]
@@ -613,16 +612,13 @@ mod tests {
     fn test_rng_sequence_len() {
         let mut r = Rand {
             seed: 0u64,
-            hash_secret: 1u64,
+            hash_secret: 0x5b97_8fda_47ab_926d,
         };
         for loop_power in 0..28 {
             let target = r.rand64();
             for i in 0usize..(1usize << loop_power) {
                 if r.rand64() == target {
-                    if i < 1 << 28 {
-                        panic!("Sequence too short");
-                    }
-                    return;
+                    panic!("Sequence too short {:#x}", i);
                 }
             }
         }
@@ -666,7 +662,7 @@ mod tests {
                 }
             }
             let ave_seq_len = total_len as f32 / num_seq as f32;
-            assert!((ave_seq_len - 2.5415f32).abs() < 0.002);
+            assert!((ave_seq_len - 2.5415f32).abs() < 0.01);
         }
     }
 }

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -435,12 +435,12 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
 // This hash both defends against DDoS attacks and passes dieharder tests.  It is 2 rounds of
 // hashing in order to pass the dieharder tests.  It also passes distribution checks when used to
 // produce indexes into swiss hash tables in the way we do here, with reduce.
-#[inline]
+#[inline(always)]
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
-    let v1 = u64::wrapping_mul((v + hash_secret) ^ (v >> 32), 0x9d46_0858_ea81_ac79);
-    let v2 = u64::wrapping_add(v1, v1 >> 32);
-    let v3 = u64::wrapping_mul((v2 + hash_secret) ^ (v2 >> 32), 0xe177_d33d_28e7_10c5);
-    u64::wrapping_add(v3 ^ v, v3 >> 32)
+    let v1 = (v + hash_secret) ^ v.rotate_left(32);
+    let v2 = (v1 as u128).wrapping_mul(0x9d46_0858_ea81_ac79);
+    let v3 = (v2 as u64) ^ ((v2 >> 64) as u64)
+    v ^ v3
 }
 
 #[inline]

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -437,7 +437,7 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
 // produce indexes into swiss hash tables in the way we do here, with reduce.
 #[inline(always)]
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
-    let v1 = (v + hash_secret) ^ v.rotate_left(32);
+    let v1 = v.wrapping_add(hash_secret) ^ v.rotate_left(32);
     let v2 = (v1 as u128).wrapping_mul(0x9d46_0858_ea81_ac79);
     v ^ (v2 as u64) ^ ((v2 >> 64) as u64)
 }


### PR DESCRIPTION
Switch back to the 2-round version of hash_u64.

I kept finding weaknesses in the 1-round version.  Most recently, I found that keys ending in several 0's led to many hash collisions.  I enhanced the test to check for this, and also ran the 2-round version through dieharder tests.  A couple fail, but the important ones like birthday pass, which is good enough.  The new function is:

```rust
fn hash_u64(v: u64, hash_secret: u64) -> u64 {
    let v1 = u64::wrapping_mul((v + hash_secret) ^ (v >> 32), 0x9d46_0858_ea81_ac79);
    let v2 = u64::wrapping_add(v1 ^ v, v1 >> 32);
    let v3 = u64::wrapping_mul((v2 + hash_secret) ^ (v2 >> 32), 0xe177_d33d_28e7_10c9);
    u64::wrapping_add(v3 ^ v, v3 >> 32)
}
```