### PR TITLE
Improve distribution of reduce function.

### DIFF
--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -438,8 +438,8 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
 #[inline]
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
     let v1 = u64::wrapping_mul((v + hash_secret) ^ (v >> 32), 0x9d46_0858_ea81_ac79);
-    let v2 = u64::wrapping_add(v1 ^ v, v1 >> 32);
-    let v3 = u64::wrapping_mul((v2 + hash_secret) ^ (v2 >> 32), 0xe177_d33d_28e7_10c9);
+    let v2 = u64::wrapping_add(v1, v1 >> 32);
+    let v3 = u64::wrapping_mul((v2 + hash_secret) ^ (v2 >> 32), 0xe177_d33d_28e7_10c5);
     u64::wrapping_add(v3 ^ v, v3 >> 32)
 }
 

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -150,7 +150,7 @@ impl LookupHtbl {
         // each other in the table will have their lower-32 bits close to each other.  The next
         // higher byte should have no significant correlation for unequal keys.
         let key_hash_byte = (key_hash >> 32) as u8;
-        let mut table_index = reduce(key_hash, self.table.len() as u64);
+        let mut table_index = reduce(key_hash, self.table.len());
         // To quickly find the correct entry, we skip entries that have hash_byte values that don't
         // match the key's hash.  This avoids 99.6% of cache misses caused comparing the key to the
         // wrong key.  Once we found an entry with a matching hash byte, we then compare the two
@@ -379,7 +379,7 @@ impl<'a> IntoIterator for &'a LookupHtbl {
 // hash table.  This is faster than computing x % N, and avoids the wasted space of requiring the
 // hash table to be a power of 2 in size.
 #[inline]
-fn reduce(hash: u64, table_len: u64) -> usize {
+fn reduce(hash: u64, table_len: usize) -> usize {
     (((hash as u128) * (table_len as u128)) >> 64) as usize
 }
 
@@ -640,7 +640,7 @@ mod tests {
             for i in 0..table_len >> 1 {
                 let mut h = reduce(
                     hash_u64((i as u64) << in_shift, hash_secret).rotate_right(out_shift as u32),
-                    table_len as u64,
+                    table_len,
                 );
                 while table[h] {
                     h += 1;

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -375,11 +375,12 @@ impl<'a> IntoIterator for &'a LookupHtbl {
     }
 }
 
-// Reduce maps a random value in the range [0..2^64] to [0..N], which is used as the index into the
-// hash table.  This is faster than computing x % M, and avoids the wasted space of requiring the
+// Reduce maps a 64-bit hash in the range [0..2^64] to [0..N], which is used as the index into the
+// hash table.  This is faster than computing x % N, and avoids the wasted space of requiring the
 // hash table to be a power of 2 in size.
-fn reduce(x: u64, n: u64) -> usize {
-    (((x as u128) * (n as u128)) >> 64) as usize
+#[inline]
+fn reduce(hash: u64, table_len: u64) -> usize {
+    (((hash as u128) * (table_len as u128)) >> 64) as usize
 }
 
 // Read a u40 index from unaligned memory LE, and return it as a usize.

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -665,6 +665,12 @@ mod tests {
             }
             let ave_seq_len = total_len as f32 / num_seq as f32;
             if (ave_seq_len - 2.5415f32).abs() >= 0.02 {
+                // When SHA256(counter) is used to randomly fill a swiss hash table to 50%, then
+                // average sequence length of used entries in the table is (experimentally) 25415.
+                // A good hash function needs to distribute keys well enough to achieve a similar
+                // behavior to that of a cryptographic strength hash function.  For example, with
+                // the old ahash function, I was seeing sequence lengths of 3.5, and this
+                // significantly slowed down lookups.
                 panic!("tweak {}: ave seq len = {}", tweak, ave_seq_len);
             }
         }

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -439,8 +439,7 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
     let v1 = (v + hash_secret) ^ v.rotate_left(32);
     let v2 = (v1 as u128).wrapping_mul(0x9d46_0858_ea81_ac79);
-    let v3 = (v2 as u64) ^ ((v2 >> 64) as u64)
-    v ^ v3
+    v ^ (v2 as u64) ^ ((v2 >> 64) as u64)
 }
 
 #[inline]
@@ -613,16 +612,13 @@ mod tests {
     fn test_rng_sequence_len() {
         let mut r = Rand {
             seed: 0u64,
-            hash_secret: 1u64,
+            hash_secret: 0x5b97_8fda_47ab_926d,
         };
         for loop_power in 0..28 {
             let target = r.rand64();
             for i in 0usize..(1usize << loop_power) {
                 if r.rand64() == target {
-                    if i < 1 << 28 {
-                        panic!("Sequence too short");
-                    }
-                    return;
+                    panic!("Sequence too short {:#x}", i);
                 }
             }
         }
@@ -666,7 +662,7 @@ mod tests {
                 }
             }
             let ave_seq_len = total_len as f32 / num_seq as f32;
-            assert!((ave_seq_len - 2.5415f32).abs() < 0.002);
+            assert!((ave_seq_len - 2.5415f32).abs() < 0.01);
         }
     }
 }

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -435,12 +435,12 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
 // This hash both defends against DDoS attacks and passes dieharder tests.  It is 2 rounds of
 // hashing in order to pass the dieharder tests.  It also passes distribution checks when used to
 // produce indexes into swiss hash tables in the way we do here, with reduce.
-#[inline]
+#[inline(always)]
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
-    let v1 = u64::wrapping_mul((v + hash_secret) ^ (v >> 32), 0x9d46_0858_ea81_ac79);
-    let v2 = u64::wrapping_add(v1, v1 >> 32);
-    let v3 = u64::wrapping_mul((v2 + hash_secret) ^ (v2 >> 32), 0xe177_d33d_28e7_10c5);
-    u64::wrapping_add(v3 ^ v, v3 >> 32)
+    let v1 = (v + hash_secret) ^ v.rotate_left(32);
+    let v2 = (v1 as u128).wrapping_mul(0x9d46_0858_ea81_ac79);
+    let v3 = (v2 as u64) ^ ((v2 >> 64) as u64)
+    v ^ v3
 }
 
 #[inline]

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -437,7 +437,7 @@ fn write_len(data: &mut [u8], index: usize, mut len: usize) -> usize {
 // produce indexes into swiss hash tables in the way we do here, with reduce.
 #[inline(always)]
 fn hash_u64(v: u64, hash_secret: u64) -> u64 {
-    let v1 = (v + hash_secret) ^ v.rotate_left(32);
+    let v1 = v.wrapping_add(hash_secret) ^ v.rotate_left(32);
     let v2 = (v1 as u128).wrapping_mul(0x9d46_0858_ea81_ac79);
     v ^ (v2 as u64) ^ ((v2 >> 64) as u64)
 }

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -380,7 +380,6 @@ impl<'a> IntoIterator for &'a LookupHtbl {
 // hash table to be a power of 2 in size.
 fn reduce(x: u64, n: u64) -> usize {
     (((x as u128) * (n as u128)) >> 64) as usize
-
 }
 
 // Read a u40 index from unaligned memory LE, and return it as a usize.


### PR DESCRIPTION
The reduce function before this change did not uniformly select a hash table location, slightly increasing the number of collisions when inserting a billion entries into the table.  As the number of keys approaches 2^32, the situation becomes worse.  The problem is that a reduce function that takes only the lower 32 bits of the hash cannot evenly distribute to more than 2^32 buckets.

Since the updated hash function already relies on Intel/AMD/ARM u64 * u64->u128 instruction, there seems to be no harm in using that instruction in reduce, allowing it to take u64 hashes instead of u32.  

The reduce function is used rather than the standard masking operation on the hash to derive a table index because we did not want to waste the space required to round the table size up to the next power of 2 in size.  Reduce works on any table size at the cost of one multiply instruction.  The main table already accounts for 10 of the 12.5 bytes of overhead per entry, and in the worst case, forcing a power of 2 size would double that to 20 bytes.