### PR TITLE
Update Linux kernel patch for v6.7.6

### DIFF
--- a/oak_containers_kernel/patches/virtio-dma.patch
+++ b/oak_containers_kernel/patches/virtio-dma.patch
@@ -1,6 +1,6 @@
-diff '--color=auto' -u -r linux-6.1.33-orig/drivers/virtio/virtio.c linux-6.1.33/drivers/virtio/virtio.c
---- linux-6.1.33-orig/drivers/virtio/virtio.c	2023-06-09 08:34:30.000000000 +0000
-+++ linux-6.1.33/drivers/virtio/virtio.c	2024-02-01 18:55:31.105888971 +0000
+diff '--color=auto' -u -r linux-6.7.6-orig/drivers/virtio/virtio.c linux-6.7.6/drivers/virtio/virtio.c
+--- linux-6.7.6-orig/drivers/virtio/virtio.c	2024-02-23 08:51:59.000000000 +0000
++++ linux-6.7.6/drivers/virtio/virtio.c	2024-02-28 10:58:04.540767266 +0000
 @@ -177,11 +177,8 @@
  	if (virtio_check_mem_acc_cb(dev)) {
  		if (!virtio_has_feature(dev, VIRTIO_F_VERSION_1)) {
@@ -15,10 +15,10 @@ diff '--color=auto' -u -r linux-6.1.33-orig/drivers/virtio/virtio.c linux-6.1.33
  			dev_warn(&dev->dev,
  				 "device must provide VIRTIO_F_ACCESS_PLATFORM\n");
  			return -ENODEV;
-diff '--color=auto' -u -r linux-6.1.33-orig/include/linux/virtio_config.h linux-6.1.33/include/linux/virtio_config.h
---- linux-6.1.33-orig/include/linux/virtio_config.h	2023-06-09 08:34:30.000000000 +0000
-+++ linux-6.1.33/include/linux/virtio_config.h	2024-02-01 19:02:29.526141223 +0000
-@@ -201,6 +201,9 @@
+diff '--color=auto' -u -r linux-6.7.6-orig/include/linux/virtio_config.h linux-6.7.6/include/linux/virtio_config.h
+--- linux-6.7.6-orig/include/linux/virtio_config.h	2024-02-23 08:51:59.000000000 +0000
++++ linux-6.7.6/include/linux/virtio_config.h	2024-02-28 10:58:04.540767266 +0000
+@@ -203,6 +203,9 @@
  	 * Note the reverse polarity of the quirk feature (compared to most
  	 * other features), this is for compatibility with legacy systems.
  	 */


### PR DESCRIPTION
The content of the patch was outdated after updating the Linux kernel to version 6.7.6