### PR TITLE
Remove some generics from `serve` by using dynamic dispatch

### DIFF
--- a/oak_attestation/src/handler.rs
+++ b/oak_attestation/src/handler.rs
@@ -74,24 +74,25 @@ impl<H: FnOnce(Vec<u8>) -> Vec<u8>> EncryptionHandler<H> {
 /// Wraps a closure to an underlying function with request encryption and response decryption logic,
 /// based on the provided encryption key.
 /// [`AsyncEncryptionHandler`] can be used when an [`AsyncEncryptionKeyHandle`] is needed.
-pub struct AsyncEncryptionHandler<G, H, F>
+pub struct AsyncEncryptionHandler<H, F>
 where
-    G: AsyncEncryptionKeyHandle + Send + Sync,
     H: FnOnce(Vec<u8>) -> F,
     F: Future<Output = Vec<u8>>,
 {
     // TODO(#3442): Use attester to attest to the public key.
-    encryption_key_handle: Arc<G>,
+    encryption_key_handle: Arc<dyn AsyncEncryptionKeyHandle + Send + Sync>,
     request_handler: H,
 }
 
-impl<G, H, F> AsyncEncryptionHandler<G, H, F>
+impl<H, F> AsyncEncryptionHandler<H, F>
 where
-    G: AsyncEncryptionKeyHandle + Send + Sync,
     H: FnOnce(Vec<u8>) -> F,
     F: Future<Output = Vec<u8>>,
 {
-    pub fn create(encryption_key_handle: Arc<G>, request_handler: H) -> Self {
+    pub fn create(
+        encryption_key_handle: Arc<dyn AsyncEncryptionKeyHandle + Send + Sync>,
+        request_handler: H,
+    ) -> Self {
         Self {
             encryption_key_handle,
             request_handler,

--- a/oak_functions_containers_app/tests/integration_test.rs
+++ b/oak_functions_containers_app/tests/integration_test.rs
@@ -25,7 +25,6 @@ pub mod proto {
 use std::{
     fs,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
     time::Duration,
 };
 
@@ -50,14 +49,14 @@ async fn test_lookup() {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let listener = TcpListener::bind(addr).await.unwrap();
         let addr = listener.local_addr().unwrap();
-        (addr, TcpListenerStream::new(listener))
+        (addr, Box::new(TcpListenerStream::new(listener)))
     };
 
     let (encryption_key, _) = generate_encryption_key_pair();
 
-    let server_handle = tokio::spawn(serve::<_, WasmtimeHandler, _, _, _>(
+    let server_handle = tokio::spawn(serve::<WasmtimeHandler>(
         stream,
-        Arc::new(encryption_key),
+        Box::new(encryption_key),
         NoopMeterProvider::new().meter(""),
     ));
 


### PR DESCRIPTION
As pointed out in #4862 the signature of `serve` was getting rather unwieldy.

By boxing more things we can push most of the ugliness into the signature of `serve` itself, and clean up points of use so that there's only one generic (that matters) which you have to specify.