### PR TITLE
Add communication channel parameters to the Oak Functions app config

### DIFF
--- a/proto/oak_functions/application_config.proto
+++ b/proto/oak_functions/application_config.proto
@@ -29,7 +29,21 @@ enum HandlerType {
   HANDLER_NATIVE = 2;
 }
 
+message TcpCommunicationChannel {
+  // Port to listen on. If not specified, defaults to 8080.
+  uint32 port = 1;
+}
+
 message ApplicationConfig {
   // How to load the provided module.
   HandlerType handler_type = 1;
+
+  // Communication channel parameters.
+  // The default behaviour depends on the flavour of Oak Functions:
+  //   - when running on Restricted Kernel this setting is ignored completely as the communication
+  //     channel is abstracted away by Restricted Kernel itself.
+  //   - on Oak Containers, if not specified, the default communication channel is TCP.
+  oneof communication_channel {
+    TcpCommunicationChannel tcp_channel = 2;
+  }
 }


### PR DESCRIPTION
This doesn't do much right now, but will give us a configuration setting that can be used to switch Oak Functions on Oak Containers to a different communication channel, if needed.

For now, nobody sets the application config proto anyway, so we default to the existing behaviour of listening for connections on TCP port 8080.

Ref b/289334144