### PR TITLE
Add support for listening on vsock to `oak_functions_containers_app`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2676,6 +2677,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
+ "tokio-vsock",
  "tonic",
  "tower",
  "tower-http",
@@ -4754,6 +4756,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.5.0"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "tonic",
+ "vsock",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5053,6 +5067,16 @@ name = "volatile"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
+
+[[package]]
+name = "vsock"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfb6e7a74830912f1f4a7655227c9ded1ea4e9136676311fedf54bedb412f35"
+dependencies = [
+ "libc",
+ "nix 0.27.1",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,3 +139,6 @@ prost-types = "*"
 tokio = "*"
 tonic = "*"
 tonic-build = { version = "*", default-features = false }
+
+[patch.crates-io]
+tokio-vsock = { path = "third_party/tokio-vsock" }

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -43,6 +43,7 @@ tempfile = { version = "*", optional = true }
 tikv-jemallocator = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
 tokio-stream = { version = "*", features = ["net"] }
+tokio-vsock = { version = "*", features = ["tonic-conn"] }
 tonic = { workspace = true, features = ["gzip"] }
 tower = { version = "*", features = ["load-shed"] }
 tower-http = { version = "*", features = ["trace"] }

--- a/proto/oak_functions/application_config.proto
+++ b/proto/oak_functions/application_config.proto
@@ -34,6 +34,11 @@ message TcpCommunicationChannel {
   uint32 port = 1;
 }
 
+message VsockCommunicationChannel {
+  // Port to listen on. If not specified, defaults to 8080.
+  uint32 port = 1;
+}
+
 message ApplicationConfig {
   // How to load the provided module.
   HandlerType handler_type = 1;
@@ -45,5 +50,6 @@ message ApplicationConfig {
   //   - on Oak Containers, if not specified, the default communication channel is TCP.
   oneof communication_channel {
     TcpCommunicationChannel tcp_channel = 2;
+    VsockCommunicationChannel vsock_channel = 3;
   }
 }


### PR DESCRIPTION
Untested as of right now, as I'll need to add support for vsock to the launcher before adding tests.

The code is a bit hacky; I'd really want to assign `stream` to a variable and then call `oak_functions_containers_app::serve` in one location (instead of having an extra `serve` function as I do right now). But I couldn't figure out how to do that; no, you can't have variables with `impl Trait` types, so the obvious answer won't work.