### PR TITLE
Change `application_config` from a path to a `Vec<u8>`

### DIFF
--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -82,8 +82,8 @@ pub struct Args {
     pub system_image: std::path::PathBuf,
     #[arg(long, required = true, value_parser = path_exists,)]
     pub container_bundle: std::path::PathBuf,
-    #[arg(long, value_parser = path_exists,)]
-    pub application_config: Option<std::path::PathBuf>,
+    #[clap(skip)]
+    pub application_config: Vec<u8>,
     #[command(flatten)]
     pub qemu_params: qemu::Params,
 }
@@ -97,7 +97,7 @@ impl Args {
         Self {
             system_image,
             container_bundle,
-            application_config: None,
+            application_config: Vec::new(),
             qemu_params: qemu::Params::default_for_root(root),
         }
     }

--- a/oak_functions_containers_launcher/build.rs
+++ b/oak_functions_containers_launcher/build.rs
@@ -22,6 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &[
             "../proto/crypto/crypto.proto",
             "../proto/attestation/evidence.proto",
+            "../proto/oak_functions/application_config.proto",
             "../proto/oak_functions/service/oak_functions.proto",
         ],
         "..",

--- a/oak_functions_containers_launcher/src/lib.rs
+++ b/oak_functions_containers_launcher/src/lib.rs
@@ -17,6 +17,9 @@ pub mod proto {
     pub mod oak {
         pub mod functions {
             tonic::include_proto!("oak.functions");
+            pub mod config {
+                tonic::include_proto!("oak.functions.config");
+            }
         }
         pub use oak_crypto::proto::oak::crypto;
         pub use oak_proto_rust::oak::attestation;

--- a/oak_functions_containers_launcher/src/main.rs
+++ b/oak_functions_containers_launcher/src/main.rs
@@ -17,8 +17,11 @@ use std::net::{Ipv6Addr, SocketAddr};
 
 use anyhow::Context;
 use clap::Parser;
-use oak_functions_containers_launcher::proto::oak::functions::InitializeRequest;
+use oak_functions_containers_launcher::proto::oak::functions::{
+    config::ApplicationConfig, InitializeRequest,
+};
 use oak_functions_launcher::LookupDataConfig;
+use prost::Message;
 use ubyte::ByteUnit;
 
 #[derive(Parser, Debug)]
@@ -33,7 +36,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     env_logger::init();
-    let args = Args::parse();
+    let mut args = Args::parse();
 
     let lookup_data_config = LookupDataConfig {
         lookup_data_path: args.functions_args.lookup_data,
@@ -42,6 +45,9 @@ async fn main() -> Result<(), anyhow::Error> {
         // gRPC messages are limited to 4 MiB.
         max_chunk_size: ByteUnit::Mebibyte(4),
     };
+
+    let config = ApplicationConfig::default();
+    args.containers_args.application_config = config.encode_to_vec();
 
     let mut untrusted_app =
         oak_functions_containers_launcher::UntrustedApp::create(args.containers_args)


### PR DESCRIPTION
We're not using that to read a file anywhere, and I want to construct a bespoke `ApplicationConfig` in the `oak_functions_containers_launcher`.

If any launcher indeed wants to read the config from a file in the future, they can do it on their own.