### PR TITLE
Add support for virtio-vsock to Oak Functions on Oak Containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,6 +2419,7 @@ dependencies = [
  "prost-types",
  "tokio",
  "tokio-stream",
+ "tokio-vsock",
  "tonic",
  "which 5.0.0",
 ]
@@ -2719,7 +2720,9 @@ dependencies = [
  "oak_proto_rust",
  "prost",
  "tokio",
+ "tokio-vsock",
  "tonic",
+ "tower",
  "ubyte",
  "xtask",
 ]

--- a/oak_containers_launcher/Cargo.toml
+++ b/oak_containers_launcher/Cargo.toml
@@ -34,5 +34,6 @@ tokio = { version = "*", features = [
   "sync",
 ] }
 tokio-stream = { version = "*", features = ["net"] }
+tokio-vsock = "*"
 tonic = { workspace = true, features = ["codegen"] }
 which = "*"

--- a/oak_containers_launcher/src/lib.rs
+++ b/oak_containers_launcher/src/lib.rs
@@ -54,6 +54,7 @@ use tokio::{
     task::JoinHandle,
     time::{timeout, Duration},
 };
+use tokio_vsock::VsockAddr;
 use tonic::transport::Channel as TonicChannel;
 
 use crate::proto::oak::{
@@ -83,6 +84,9 @@ pub enum ChannelType {
     /// Use virtual networking.
     #[default]
     Network,
+
+    // Use virtio-vsock.
+    VirtioVsock,
 }
 
 #[derive(Parser, Debug)]
@@ -136,11 +140,15 @@ pub enum Channel {
         host_proxy_port: u16,
         trusted_app_address: Option<SocketAddr>,
     },
+    VirtioVsock {
+        trusted_app_address: Option<VsockAddr>,
+    },
 }
 
 /// Interface that is connected to the trusted application.
 pub enum TrustedApplicationAddress {
     Network(SocketAddr),
+    VirtioVsock(VsockAddr),
 }
 
 impl TryFrom<Channel> for TrustedApplicationAddress {
@@ -152,6 +160,9 @@ impl TryFrom<Channel> for TrustedApplicationAddress {
                 host_proxy_port: _,
                 trusted_app_address,
             } => trusted_app_address.map(TrustedApplicationAddress::Network),
+            Channel::VirtioVsock {
+                trusted_app_address,
+            } => trusted_app_address.map(TrustedApplicationAddress::VirtioVsock),
         }
         .ok_or_else(|| anyhow::anyhow!("trusted application address not set"))
     }
@@ -161,6 +172,7 @@ impl Display for TrustedApplicationAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TrustedApplicationAddress::Network(addr) => addr.fmt(f),
+            TrustedApplicationAddress::VirtioVsock(addr) => addr.fmt(f),
         }
     }
 }
@@ -201,11 +213,6 @@ impl Launcher {
             shutdown_receiver,
         ));
 
-        // Also get an open port for that QEMU can use for proxying requests to the server. Since we
-        // don't have a mechanism to pass this port to QEMU we have to unbind it by dropping it.
-        // There is a small window for a race condition, but since the assigned port will be random
-        // the probability of another process grabbing the port before QEMU can should be very low.
-
         let trusted_app_channel = match args.communication_channel {
             ChannelType::Network => {
                 // Also get an open port for that QEMU can use for proxying requests to the server.
@@ -220,7 +227,11 @@ impl Launcher {
                     trusted_app_address: None,
                 }
             }
+            ChannelType::VirtioVsock => Channel::VirtioVsock {
+                trusted_app_address: None,
+            },
         };
+
         let host_orchestrator_proxy_port = {
             TcpListener::bind(orchestrator_sockaddr)
                 .await?
@@ -235,6 +246,9 @@ impl Launcher {
                     host_proxy_port,
                     trusted_app_address: _,
                 } => Some(host_proxy_port),
+                Channel::VirtioVsock {
+                    trusted_app_address: _,
+                } => None,
             },
             host_orchestrator_proxy_port,
         )?;
@@ -277,6 +291,14 @@ impl Launcher {
                 } => {
                     trusted_app_address
                         .replace(SocketAddr::new(IpAddr::V4(PROXY_ADDRESS), *host_proxy_port));
+                }
+                Channel::VirtioVsock {
+                    trusted_app_address,
+                } => {
+                    trusted_app_address.replace(VsockAddr::new(
+                        self.vmm.guest_cid().expect("VMM does not have a guest CID"),
+                        VM_LOCAL_PORT.into(),
+                    ));
                 }
             }
         }

--- a/oak_containers_launcher/src/qemu.rs
+++ b/oak_containers_launcher/src/qemu.rs
@@ -152,28 +152,22 @@ impl Qemu {
         // Set up the networking. `rombar=0` is so that QEMU wouldn't bother with the
         // `efi-virtio.rom` file, as we're not using EFI anyway.
         let vm_address = crate::VM_LOCAL_ADDRESS;
-        let vm_port = crate::VM_LOCAL_PORT;
         let vm_orchestrator_port = crate::VM_ORCHESTRATOR_LOCAL_PORT;
         let host_address = Ipv4Addr::LOCALHOST;
-        let host_proxy_rule = if let Some(host_proxy_port) = host_proxy_port {
-            format!("hostfwd=tcp:{host_address}:{host_proxy_port}-{vm_address}:{vm_port}")
-        } else {
-            String::new()
+
+        let mut netdev_rules = vec![
+            "user".to_string(),
+            "id=netdev".to_string(),
+            format!("guestfwd=tcp:10.0.2.100:8080-cmd:nc {host_address} {launcher_service_port}"),
+            format!("hostfwd=tcp:{host_address}:{host_orchestrator_proxy_port}-{vm_address}:{vm_orchestrator_port}"),
+        ];
+        if let Some(host_proxy_port) = host_proxy_port {
+            let vm_port = crate::VM_LOCAL_PORT;
+            netdev_rules.push(format!(
+                "hostfwd=tcp:{host_address}:{host_proxy_port}-{vm_address}:{vm_port}"
+            ));
         };
-        cmd.args([
-            "-netdev",
-            [
-                "user",
-                "id=netdev",
-                &format!(
-                    "guestfwd=tcp:10.0.2.100:8080-cmd:nc {host_address} {launcher_service_port}"
-                ),
-                &host_proxy_rule,
-                &format!("hostfwd=tcp:{host_address}:{host_orchestrator_proxy_port}-{vm_address}:{vm_orchestrator_port}"),
-            ]
-            .join(",")
-            .as_str(),
-        ]);
+        cmd.args(["-netdev", netdev_rules.join(",").as_str()]);
         cmd.args(["-device", "virtio-net,netdev=netdev,rombar=0"]);
         if let Some(virtio_guest_cid) = params.virtio_guest_cid {
             cmd.args([
@@ -259,7 +253,6 @@ impl Qemu {
         self.instance.wait().await.map_err(anyhow::Error::from)
     }
 
-    #[allow(unused)]
     pub fn guest_cid(&self) -> Option<u32> {
         self.guest_cid
     }

--- a/oak_functions_containers_launcher/Cargo.toml
+++ b/oak_functions_containers_launcher/Cargo.toml
@@ -21,7 +21,9 @@ oak_functions_launcher = { workspace = true }
 oak_proto_rust = { workspace = true }
 prost = "*"
 tokio = { version = "*", features = ["rt-multi-thread", "macros", "sync"] }
+tokio-vsock = "*"
 tonic = { workspace = true }
+tower = "*"
 ubyte = "*"
 
 [dev-dependencies]

--- a/oak_functions_containers_launcher/src/lib.rs
+++ b/oak_functions_containers_launcher/src/lib.rs
@@ -33,7 +33,9 @@ use anyhow::Context;
 use oak_containers_launcher::{Launcher, TrustedApplicationAddress};
 use oak_functions_launcher::LookupDataConfig;
 use tokio::time::Duration;
+use tokio_vsock::VsockStream;
 use tonic::transport::Endpoint;
+use tower::service_fn;
 
 use crate::proto::oak::functions::{
     oak_functions_client::OakFunctionsClient as GrpcOakFunctionsClient, InitializeRequest,
@@ -58,6 +60,24 @@ impl UntrustedApp {
                         .connect()
                         .await
                         .context("couldn't connect to trusted app")?
+                }
+                TrustedApplicationAddress::VirtioVsock(trusted_app_address) => {
+                    // The common URI scheme would be `vsock:cid:port` (see
+                    // https://grpc.github.io/grpc/cpp/md_doc_naming.html), but this is not palatable
+                    // to the URI class in Rust. The URL is ignored anyway as we're going to
+                    // override the connector so it doesn't matter what we pass in there.
+                    Endpoint::from_shared(format!(
+                        "vsock://{}:{}",
+                        trusted_app_address.cid(),
+                        trusted_app_address.port()
+                    ))
+                    .context("couldn't form channel")?
+                    .connect_timeout(Duration::from_secs(120))
+                    .connect_with_connector(service_fn(move |_| {
+                        VsockStream::connect(trusted_app_address)
+                    }))
+                    .await
+                    .context("couldn't connect to trusted app")?
                 }
             };
             GrpcOakFunctionsClient::new(channel)


### PR DESCRIPTION
This plumbs virtio-vsock through the launcher, and even runs the lookup test twice: once with a network connection, and once with a virtio-vsock connection to ensure both work.

Ref b/289334144