### PR TITLE
Update the CB reference value proto

### DIFF
--- a/proto/attestation/reference_value.proto
+++ b/proto/attestation/reference_value.proto
@@ -147,6 +147,13 @@ message SystemLayerReferenceValues {
   BinaryReferenceValue system_image = 1;
 }
 
+message CBSystemLayerReferenceValues {
+  // Verifies the system image binary.
+  BinaryReferenceValue system_image = 1;
+  // Verifies the command line by which the system image was built.
+  StringReferenceValue system_cmd_line = 2;
+}
+
 // Represents an application running under Oak Restricted Kernel.
 message ApplicationLayerReferenceValues {
   // Verifies the application binary based on endorsement.
@@ -154,6 +161,12 @@ message ApplicationLayerReferenceValues {
 
   // Verifies configuration with respect to the application binary.
   BinaryReferenceValue configuration = 2;
+}
+
+// Represents digest of application task config.
+message CBApplicationLayerReferenceValues {
+  // Verifies the application task config.
+  BinaryReferenceValue binary = 1;
 }
 
 message ContainerLayerReferenceValues {
@@ -177,18 +190,11 @@ message OakContainersReferenceValues {
   ContainerLayerReferenceValues container_layer = 4;
 }
 
-message CBLayerReferenceValues {
-  string layer_name = 1;
-  repeated FileReferenceValue files = 2;
-  StringReferenceValue config = 3;
-  StringReferenceValue command_line = 4;
-}
-
 message CBReferenceValues {
   RootLayerReferenceValues root_layer = 1;
-
-  // Generic reference values starting from the second layer.
-  repeated CBLayerReferenceValues layers = 2;
+  KernelLayerReferenceValues kernel_layer = 2;
+  CBSystemLayerReferenceValues system_layer = 3;
+  CBApplicationLayerReferenceValues application_layer = 4;
 }
 
 message ReferenceValues {


### PR DESCRIPTION
Update the CB reference value proto.
- In CB there is cmd_line for system layer so that is additional.
- In application layer, CB does not have any configuration.
- Added the kernel layer for CB.