### PR TITLE
Add new version of the restricted kernel simple_io and initrd

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -33,6 +33,7 @@ jobs:
           - buildconfigs/oak_functions_enclave_app.toml
           - buildconfigs/oak_functions_insecure_enclave_app.toml
           - buildconfigs/oak_restricted_kernel_simple_io_wrapper.toml
+          - buildconfigs/oak_restricted_kernel_simple_io_init_rd_wrapper.toml
           - buildconfigs/stage0_bin.toml
           - buildconfigs/oak_orchestrator.toml
 

--- a/buildconfigs/oak_restricted_kernel_simple_io_init_rd_wrapper.toml
+++ b/buildconfigs/oak_restricted_kernel_simple_io_init_rd_wrapper.toml
@@ -1,0 +1,9 @@
+command = [
+  "nix",
+  "develop",
+  ".#rust",
+  "--command",
+  "just",
+  "oak_restricted_kernel_simple_io_init_rd_wrapper",
+]
+artifact_path = "./oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_init_rd_wrapper_bin"

--- a/justfile
+++ b/justfile
@@ -36,6 +36,13 @@ oak_restricted_kernel_simple_io_bin:
 oak_restricted_kernel_simple_io_wrapper: oak_restricted_kernel_simple_io_bin
     just _wrap_kernel oak_restricted_kernel_simple_io
 
+oak_restricted_kernel_simple_io_init_rd_bin:
+    env --chdir=oak_restricted_kernel_bin cargo build --release --no-default-features --features=simple_io_channel,initrd --bin=oak_restricted_kernel_simple_io_init_rd_bin
+
+oak_restricted_kernel_simple_io_init_rd_wrapper: oak_restricted_kernel_simple_io_init_rd_bin
+    just _wrap_kernel oak_restricted_kernel_simple_io_init_rd
+
+
 stage0_bin:
     env --chdir=stage0_bin cargo objcopy --release -- --output-target=binary target/x86_64-unknown-none/release/stage0_bin
 

--- a/justfile
+++ b/justfile
@@ -91,7 +91,7 @@ all_ensure_no_std: (ensure_no_std "micro_rpc") (ensure_no_std "oak_attestation_v
 
 # Entry points for Kokoro CI.
 
-kokoro_build_binaries_rust: all_enclave_apps oak_restricted_kernel_bin oak_restricted_kernel_simple_io_bin oak_restricted_kernel_simple_io_wrapper stage0_bin
+kokoro_build_binaries_rust: all_enclave_apps oak_restricted_kernel_bin oak_restricted_kernel_simple_io_bin oak_restricted_kernel_simple_io_wrapper oak_restricted_kernel_simple_io_init_rd_wrapper stage0_bin
 
 kokoro_oak_containers: all_oak_containers_binaries oak_functions_containers_container_bundle_tar
     RUST_LOG="debug" cargo nextest run --all-targets --hide-progress-bar --package='oak_containers_hello_world_untrusted_app'

--- a/kokoro/build_binaries_rust.sh
+++ b/kokoro/build_binaries_rust.sh
@@ -31,6 +31,7 @@ touch "${KOKORO_ARTIFACTS_DIR}/binaries/git_commit_${KOKORO_GIT_COMMIT_oak:?}"
 # the creation time.
 readonly generated_binaries=(
     ./oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
+    ./oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_init_rd_wrapper
     ./oak_restricted_kernel_wrapper/cmd_line_regex.txt
     ./stage0_bin/target/x86_64-unknown-none/release/stage0_bin
     ./enclave_apps/target/x86_64-unknown-none/release/key_xor_test_app
@@ -42,6 +43,7 @@ readonly generated_binaries=(
 )
 readonly binary_names=(
     oak_restricted_kernel_simple_io_wrapper_bin
+    oak_restricted_kernel_simple_io_init_rd_wrapper
     oak_restricted_kernel_simple_io_wrapper_cmd_line_regex
     stage0_bin
     key_xor_test_app

--- a/kokoro/build_binaries_rust.sh
+++ b/kokoro/build_binaries_rust.sh
@@ -31,7 +31,7 @@ touch "${KOKORO_ARTIFACTS_DIR}/binaries/git_commit_${KOKORO_GIT_COMMIT_oak:?}"
 # the creation time.
 readonly generated_binaries=(
     ./oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
-    ./oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_init_rd_wrapper
+    ./oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_init_rd_wrapper_bin
     ./oak_restricted_kernel_wrapper/cmd_line_regex.txt
     ./stage0_bin/target/x86_64-unknown-none/release/stage0_bin
     ./enclave_apps/target/x86_64-unknown-none/release/key_xor_test_app
@@ -43,7 +43,7 @@ readonly generated_binaries=(
 )
 readonly binary_names=(
     oak_restricted_kernel_simple_io_wrapper_bin
-    oak_restricted_kernel_simple_io_init_rd_wrapper
+    oak_restricted_kernel_simple_io_init_rd_wrapper_bin
     oak_restricted_kernel_simple_io_wrapper_cmd_line_regex
     stage0_bin
     key_xor_test_app

--- a/oak_restricted_kernel_bin/Cargo.toml
+++ b/oak_restricted_kernel_bin/Cargo.toml
@@ -41,3 +41,10 @@ name = "oak_restricted_kernel_simple_io_bin"
 test = false
 bench = false
 required-features = ["simple_io_channel"]
+
+[[bin]]
+path = "src/main.rs"
+name = "oak_restricted_kernel_simple_io_init_rd_bin"
+test = false
+bench = false
+required-features = ["simple_io_channel", "initrd"]


### PR DESCRIPTION
the new oak_restricted_kernel_simple_io_init_rd_wrapper will exist alongside oak_restricted_kernel_simple_io_wrapper for a while. then internal dependencies will be updated, and the the former will be removed.

this approach is significantly simpler than #4828. For #4828 we would need to attempt to synchronize its merging with the updates to the internal launcher and the transparent release imports of the binary. It'd be too flaky.