### PR TITLE
Make restricted kernel orchestrator return evidence to host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,9 +3030,11 @@ name = "oak_restricted_kernel_orchestrator"
 version = "0.1.0"
 dependencies = [
  "log",
+ "oak_attestation",
  "oak_channel",
  "oak_dice",
  "oak_restricted_kernel_dice",
+ "prost",
 ]
 
 [[package]]

--- a/oak_channel/src/basic_framed.rs
+++ b/oak_channel/src/basic_framed.rs
@@ -20,6 +20,8 @@
 //! This protocol is used once.
 //! 1. To load the application. Here the host is the sender, enclave is the
 //!    recipient.
+//! 2. To return the attestation evidence. Here the host is the recipient,
+//!    enclave is the sender.
 //!
 //! The protocol is very simple:
 //! 1. sender sends the size of the payload, as u32

--- a/oak_channel/src/basic_framed.rs
+++ b/oak_channel/src/basic_framed.rs
@@ -17,7 +17,7 @@
 //! Basic framed format for use before the channel is handed off to the
 //! application.
 //!
-//! This protocol is used once.
+//! This protocol is used twice.
 //! 1. To load the application. Here the host is the sender, enclave is the
 //!    recipient.
 //! 2. To return the attestation evidence. Here the host is the recipient,

--- a/oak_channel/src/basic_framed.rs
+++ b/oak_channel/src/basic_framed.rs
@@ -17,11 +17,11 @@
 //! Basic framed format for use before the channel is handed off to the
 //! application.
 //!
-//! This protocol is used twice.
+//! Depending on configuration, this protocol is used twice.
 //! 1. To load the application. Here the host is the sender, enclave is the
 //!    recipient.
-//! 2. To return the attestation evidence. Here the host is the recipient,
-//!    enclave is the sender.
+//! 2. [Optional]: to return the attestation evidence. Here the host is the
+//!    recipient, enclave is the sender.
 //!
 //! The protocol is very simple:
 //! 1. sender sends the size of the payload, as u32

--- a/oak_channel/src/basic_framed.rs
+++ b/oak_channel/src/basic_framed.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-//! Basic framed format for use before the channel is handed of to the
+//! Basic framed format for use before the channel is handed off to the
 //! application.
 //!
 //! This protocol is used once.

--- a/oak_launcher_utils/Cargo.toml
+++ b/oak_launcher_utils/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Dzmitry Huba <huba@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+exchange_evidence = []
+
 [dependencies]
 anyhow = "*"
 async-trait = "*"

--- a/oak_launcher_utils/src/launcher.rs
+++ b/oak_launcher_utils/src/launcher.rs
@@ -165,6 +165,9 @@ impl Instance {
         if let Some(app_bytes) = app_bytes {
             oak_channel::basic_framed::send_raw(&mut host_socket, &app_bytes)
                 .context("failed to send application")?;
+            #[cfg(feature = "exchange_evidence")]
+            let _evidence = oak_channel::basic_framed::receive_raw(&mut host_socket)
+                .context("failed to receive attestion evidence")?;
         }
 
         Ok(Self { guest_console: guest_console_clone, host_socket, instance })

--- a/oak_restricted_kernel/src/lib.rs
+++ b/oak_restricted_kernel/src/lib.rs
@@ -79,8 +79,6 @@ use oak_linux_boot_params::BootParams;
 use oak_sev_guest::msr::{change_snp_state_for_frame, get_sev_status, PageAssignment, SevStatus};
 use spinning_top::Spinlock;
 use strum::{EnumIter, EnumString, IntoEnumIterator};
-#[cfg(not(feature = "initrd"))]
-use x86_64::structures::paging::{PageSize, Size4KiB};
 use x86_64::{
     structures::paging::{Page, PageTable, Size2MiB},
     PhysAddr, VirtAddr,
@@ -434,11 +432,9 @@ pub fn start_kernel(info: &BootParams) -> ! {
         // We need to load the application binary before we hand the channel over to the
         // syscalls, which expose it to the user space.
         info!("Loading application binary...");
-        oak_channel::basic_framed::load_raw::<dyn Channel, { Size4KiB::SIZE as usize }>(
-            &mut *channel,
-        )
-        .expect("failed to load application binary from channel")
-        .into_boxed_slice()
+        oak_channel::basic_framed::receive_raw::<dyn Channel>(&mut *channel)
+            .expect("failed to load application binary from channel")
+            .into_boxed_slice()
     };
 
     log::info!("Binary loaded, size: {}", application_bytes.len());

--- a/oak_restricted_kernel_orchestrator/Cargo.toml
+++ b/oak_restricted_kernel_orchestrator/Cargo.toml
@@ -5,8 +5,13 @@ authors = ["Juliette Pluto <julsh@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+exchange_evidence = ["oak_attestation", "prost"]
+
 [dependencies]
 oak_channel = { workspace = true }
 oak_dice = { workspace = true }
+oak_attestation = { workspace = true, optional = true }
 oak_restricted_kernel_dice = { workspace = true }
 log = "*"
+prost = { workspace = true, optional = true }

--- a/oak_restricted_kernel_orchestrator/src/lib.rs
+++ b/oak_restricted_kernel_orchestrator/src/lib.rs
@@ -18,7 +18,7 @@
 
 extern crate alloc;
 
-use oak_channel::basic_framed::load_raw;
+use oak_channel::basic_framed::receive_raw;
 use oak_dice::evidence::Stage0DiceData;
 
 pub struct AttestedApp {
@@ -32,7 +32,7 @@ impl AttestedApp {
         mut channel: C,
         stage0_dice_data: Stage0DiceData,
     ) -> Self {
-        let elf_binary = load_raw::<C, 4096>(&mut channel).expect("failed to load");
+        let elf_binary = receive_raw::<C>(&mut channel).expect("failed to load");
         log::info!("Binary loaded, size: {}", elf_binary.len());
         let app_digest = oak_restricted_kernel_dice::measure_app_digest_sha2_256(&elf_binary);
         log::info!(


### PR DESCRIPTION
(guarded behind a feature, as we'll need to update the internal launcher as well)