### PR TITLE
Enable orchestrator evidence export

### DIFF
--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -904,9 +904,11 @@ name = "oak_restricted_kernel_orchestrator"
 version = "0.1.0"
 dependencies = [
  "log",
+ "oak_attestation",
  "oak_channel",
  "oak_dice",
  "oak_restricted_kernel_dice",
+ "prost",
 ]
 
 [[package]]

--- a/oak_launcher_utils/Cargo.toml
+++ b/oak_launcher_utils/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
+default = ["exchange_evidence"]
 exchange_evidence = []
 
 [dependencies]

--- a/oak_restricted_kernel_orchestrator/Cargo.toml
+++ b/oak_restricted_kernel_orchestrator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
+default = ["exchange_evidence"]
 exchange_evidence = ["oak_attestation", "prost"]
 
 [dependencies]


### PR DESCRIPTION
Upon reflection after merging #4907, we can already enable it. We can update the internal launcher at the same time as we migrate it to using the orchestrator.