### PR TITLE
Use slices instead of `Bytes` in hashtable lookup data update code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,7 +2822,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
- "bytes",
  "criterion",
  "criterion-macro",
  "hashbrown 0.14.3",

--- a/enclave_apps/Cargo.lock
+++ b/enclave_apps/Cargo.lock
@@ -840,7 +840,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
- "bytes",
  "hashbrown 0.14.2",
  "log",
  "micro_rpc",

--- a/oak_functions_containers_app/tests/native_test.rs
+++ b/oak_functions_containers_app/tests/native_test.rs
@@ -42,9 +42,8 @@ async fn test_native_handler() {
 
     let logger = Arc::new(StandaloneLogger);
     let lookup_data_manager = Arc::new(LookupDataManager::new_empty(logger));
-    lookup_data_manager.extend_next_lookup_data(
-        [("key_0".as_bytes().into(), "value_0".as_bytes().into())].into_iter(),
-    );
+    lookup_data_manager
+        .extend_next_lookup_data([("key_0".as_bytes(), "value_0".as_bytes())].into_iter());
 
     lookup_data_manager.finish_next_lookup_data();
 

--- a/oak_functions_sdk/tests/integration_test.rs
+++ b/oak_functions_sdk/tests/integration_test.rs
@@ -110,8 +110,7 @@ async fn test_write_log() {
 
 #[tokio::test]
 async fn test_storage_get_item() {
-    let entries =
-        Vec::from_iter([(b"StorageGet".to_vec().into(), b"StorageGetResponse".to_vec().into())]);
+    let entries = Vec::from_iter([(b"StorageGet".to_vec(), b"StorageGetResponse".to_vec())]);
 
     let logger = Arc::new(StandaloneLogger);
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(entries, logger.clone()));
@@ -148,7 +147,7 @@ async fn test_storage_get_item_not_found() {
 #[ignore]
 async fn test_storage_get_item_huge_key() {
     let bytes: Vec<u8> = vec![42u8; 1 << 20];
-    let entries = Vec::from_iter([(bytes.clone().into(), bytes.clone().into())]);
+    let entries = Vec::from_iter([(bytes.clone(), bytes.clone())]);
 
     let logger = Arc::new(StandaloneLogger);
     let lookup_data_manager = Arc::new(LookupDataManager::for_test(entries, logger.clone()));

--- a/oak_functions_service/Cargo.toml
+++ b/oak_functions_service/Cargo.toml
@@ -18,7 +18,6 @@ required-features = ["wasmtime"]
 [dependencies]
 anyhow = { version = "*", default-features = false }
 byteorder = { version = "*", default-features = false }
-bytes = { version = "*", default-features = false }
 hashbrown = "*"
 log = "*"
 prost = { workspace = true }

--- a/oak_functions_service/src/instance.rs
+++ b/oak_functions_service/src/instance.rs
@@ -16,7 +16,6 @@
 
 use alloc::{format, sync::Arc};
 
-use bytes::Bytes;
 use micro_rpc::{Status, Vec};
 use oak_functions_abi::Request;
 
@@ -65,7 +64,7 @@ impl<H: Handler> OakFunctionsInstance<H> {
         &self,
         request: ExtendNextLookupDataRequest,
     ) -> Result<ExtendNextLookupDataResponse, micro_rpc::Status> {
-        self.lookup_data_manager.extend_next_lookup_data(to_data(request.chunk.ok_or(
+        self.lookup_data_manager.extend_next_lookup_data(to_data(request.chunk.as_ref().ok_or(
             micro_rpc::Status::new_with_message(
                 micro_rpc::StatusCode::InvalidArgument,
                 "no chunk in extend request",
@@ -78,7 +77,7 @@ impl<H: Handler> OakFunctionsInstance<H> {
         &self,
         chunk: LookupDataChunk,
     ) -> Result<(), micro_rpc::Status> {
-        self.lookup_data_manager.extend_next_lookup_data(to_data(chunk));
+        self.lookup_data_manager.extend_next_lookup_data(to_data(&chunk));
         Ok(())
     }
 
@@ -113,6 +112,6 @@ impl<H: Handler> OakFunctionsInstance<H> {
 }
 
 // Helper function to convert [`LookupDataChunk`] to [`Data`].
-fn to_data(chunk: LookupDataChunk) -> impl Iterator<Item = (Bytes, Bytes)> {
-    chunk.items.into_iter().map(|entry| (entry.key, entry.value))
+fn to_data(chunk: &LookupDataChunk) -> impl Iterator<Item = (&[u8], &[u8])> {
+    chunk.items.iter().map(|entry| (entry.key.as_ref(), entry.value.as_ref()))
 }

--- a/oak_functions_service/src/lookup_htbl.rs
+++ b/oak_functions_service/src/lookup_htbl.rs
@@ -73,7 +73,6 @@
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::mem;
 
-use bytes::Bytes;
 use rand_core::{OsRng, RngCore};
 
 // To save memory, we use 5 byte array index values instead of 8 bytes.  This
@@ -319,9 +318,9 @@ impl LookupHtbl {
     }
 
     /// This is like HashMap::extend.
-    pub fn extend<T: IntoIterator<Item = (Bytes, Bytes)>>(&mut self, new_data: T) {
+    pub fn extend<'a, T: IntoIterator<Item = (&'a [u8], &'a [u8])>>(&mut self, new_data: T) {
         for (key, value) in new_data {
-            self.insert(&key, &value);
+            self.insert(key, value);
         }
     }
 


### PR DESCRIPTION
This is not really about performance, given that `Bytes` is effectively an `Arc` under the hood. In fact, I expect this to be performance neutral.

However, this will give us more flexibility in the future, for example, when experimenting with custom serialization formats.