### PR TITLE
Force-enable frame pointers and use them for profiling.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,6 +27,10 @@ rustflags = [
   "link-args=-Xlinker --build-id=none",
   "-C",
   "target-cpu=x86-64-v3",
+  # Force generation of frame pointers so that we can get better profiling information with
+  # `oak_debug_service`.
+  "-C",
+  "force-frame-pointers=true",
   # Enable `tokio_unstable` so that we can access the Tokio runtime metrics.
   "--cfg",
   "tokio_unstable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,8 @@ exclude = [
 # See https://doc.rust-lang.org/cargo/reference/profiles.html for more details.
 [profile.release-lto]
 inherits = "release"
-debug = 0
+# Limited debug info. Note that for this flag, `1` != `true`.
+debug = 1
 lto = true
 panic = "abort"
 codegen-units = 1

--- a/oak_debug_service/Cargo.toml
+++ b/oak_debug_service/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 oak_grpc_utils = { workspace = true }
 
 [dependencies]
-pprof = { version = "*", features = ["prost-codec"] }
+pprof = { version = "*", features = ["frame-pointer", "prost-codec"] }
 prost = "*"
 prost-types = "*"
 tokio = { version = "*" }


### PR DESCRIPTION
Using frame pointers will enable `pprof` to properly unwind the stack and give us a meaningful profile.

This will use up one register and extra data on the stack, but guesstimates on the Internet suggest that the performance impact is ~1%, which I think is acceptable as we get much better profiling data as a return.

Frame pointers have a long and complicated story on x86; they were disabled by everybody on x86 as that architecture was starved for registers and having one more available gave a noticeable impact in performance. In comparison, x86-64 has way more registers, and various Linux distributions have been starting re-enabling frame pointers in the recent past.