### PR TITLE
Replace `spinning_top` with `parking_lot` when `std` is available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
  "oak_functions_sdk",
  "oak_functions_test_utils",
  "oak_proto_rust",
+ "parking_lot",
  "pprof",
  "prost",
  "rand",

--- a/oak_functions_service/Cargo.toml
+++ b/oak_functions_service/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 default = ["deny_sensitive_logging"]
 # Disable sensitive logging.
 deny_sensitive_logging = []
-std = ["anyhow/std", "wasmi/std", "wasmtime"]
+std = ["anyhow/std", "wasmi/std", "wasmtime", "dep:parking_lot"]
 
 [[bench]]
 name = "wasm_benchmark"
@@ -28,6 +28,7 @@ oak_dice = { workspace = true }
 oak_functions_abi = { workspace = true }
 oak_functions_sdk = { workspace = true }
 oak_proto_rust = { workspace = true }
+parking_lot = { version = "*", optional = true }
 rand_core = { version = "*", default-features = false, features = [
   "getrandom",
 ] }


### PR DESCRIPTION
Now that we can get profiling information, it looks like the spinlocks we currently use for compatibility with `no_std` were one source of inefficiency.

Replacing them with `parking_lot` significanly reduced mutex overhead, on par with `std::sync::Mutex`. However, `parking_top` is API-compatible with `spinning_top`, unlike `std::sync::Mutex`, so using them will require less changes to our code.