### PR TITLE
Add support for large sections to the Stage 0 linker script

### DIFF
--- a/stage0_bin/layout.ld
+++ b/stage0_bin/layout.ld
@@ -86,14 +86,14 @@ SECTIONS {
 
     .bss (NOLOAD) : {
         bss_start = .;
-        *(.bss .bss.*)
+        *(.bss .bss.* .lbss.*)
         bss_size = . - bss_start;
     } > ram_low
 
     .data : 
     AT ( ADDR (.text) + SIZEOF (.text) ) {
         data_start = .;
-        *(.data .data.*)
+        *(.data .data.* .ldata.*)
         data_size = . - data_start;
     } > ram_low
 
@@ -118,11 +118,11 @@ SECTIONS {
     . = ORIGIN(bios);
 
     .rodata : {
-        KEEP(*(.rodata .rodata.*))
+        KEEP(*(.rodata .rodata.* .lrodata.*))
     } > bios
 
     .text : {
-        *(.text .text.*)
+        *(.text .text.* .ltext.*)
         text_end = .;
     } > bios
 

--- a/stage0_bin/layout.ld
+++ b/stage0_bin/layout.ld
@@ -86,6 +86,9 @@ SECTIONS {
 
     .bss (NOLOAD) : {
         bss_start = .;
+        /* Include large section (.lbss) to support large code model.
+         * See <https://lld.llvm.org/ELF/large_sections.html>.
+         */
         *(.bss .bss.* .lbss.*)
         bss_size = . - bss_start;
     } > ram_low
@@ -93,6 +96,9 @@ SECTIONS {
     .data : 
     AT ( ADDR (.text) + SIZEOF (.text) ) {
         data_start = .;
+        /* Include large section (.ldata) to support large code model.
+         * See <https://lld.llvm.org/ELF/large_sections.html>.
+         */
         *(.data .data.* .ldata.*)
         data_size = . - data_start;
     } > ram_low
@@ -118,10 +124,16 @@ SECTIONS {
     . = ORIGIN(bios);
 
     .rodata : {
+        /* Include large section (.lrodata) to support large code model. 
+         * See <https://lld.llvm.org/ELF/large_sections.html>.
+         */
         KEEP(*(.rodata .rodata.* .lrodata.*))
     } > bios
 
     .text : {
+        /* Include large section (.ltext) to support large code model.
+         * See <https://lld.llvm.org/ELF/large_sections.html>.
+         */
         *(.text .text.* .ltext.*)
         text_end = .;
     } > bios


### PR DESCRIPTION
The latest version of LLVM uses new sections when compiling with `-C code-model=large` (`.ltext`, `.ldata`, `.lrodata` and `.lbss`). This causes problems when building the Stage 0 binaries: the sections aren't referenced in the linker script so they get placed in locations that violate some of the requirements of the firmware layout. See https://lld.llvm.org/ELF/large_sections.html and b/330173039 for more context.

This version is used by Rust nightly from version 1.78 onwards, so would block us from updating the Rust compiler without support for these.