### PR TITLE
Check CPUID instruction in Stage0 #VC handler

### DIFF
--- a/stage0_bin/src/asm/boot.s
+++ b/stage0_bin/src/asm/boot.s
@@ -44,7 +44,7 @@ vc_handler:
     pop %ebx              # get the error code
     cmp $0x72, %ebx       # is this about CPUID?
     jne 2f                # if not, skip ahead and crash
-    pop %ebx              # get the instruction pointer
+    mov (%esp), %ebx      # get the instruction pointer
     cmpw $0xa20f, (%ebx)  # was this really a CPUID instruction?
     jne 2f                # if not it might be injected by the hypervisor, skip ahead and crash
     cmp $0x0, %ecx        # are we asked for a CPUID subleaf?

--- a/stage0_bin/src/asm/boot.s
+++ b/stage0_bin/src/asm/boot.s
@@ -43,7 +43,10 @@ gp_handler:
 vc_handler:
     pop %ebx              # get the error code
     cmp $0x72, %ebx       # is this about CPUID?
-    jne 2f                # if not, skip ahead
+    jne 2f                # if not, skip ahead and crash
+    pop %ebx              # get the instruction pointer
+    cmpw $0xa20f, (%ebx)  # was this really a CPUID instruction?
+    jne 2f                # if not it might be injected by the hypervisor, skip ahead and crash
     cmp $0x0, %ecx        # are we asked for a CPUID subleaf?
     jne 2f                # if yes, skip ahead, as we don't support subleaves
     # Use the GHCB MSR protocol to request one page of CPUID information. The protocol itself is


### PR DESCRIPTION
We want to make sure that the instruction pointer in a #VC exception really pointed to a CPUID instruction since it is the only #VC exception type we support.

Ref b/330197837