### PR TITLE
Add the micro_proc options proto with method_id definition

### DIFF
--- a/proto/micro_rpc/BUILD
+++ b/proto/micro_rpc/BUILD
@@ -26,6 +26,12 @@ proto_library(
     srcs = ["messages.proto"],
 )
 
+proto_library(
+    name = "options_proto",
+    srcs = ["options.proto"],
+    deps = ["@com_google_protobuf//:descriptor_proto"],
+)
+
 java_proto_library(
     name = "messages_java_proto",
     deps = [":messages_proto"],

--- a/proto/micro_rpc/options.proto
+++ b/proto/micro_rpc/options.proto
@@ -1,0 +1,28 @@
+//
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package oak.micro_rpc;
+
+import "google/protobuf/descriptor.proto";
+
+// Custom option extension related to micro_rpc
+extend google.protobuf.MethodOptions {
+  // Service methods that will be used with micro_rpc should provide a
+  // unique-per-service method_id number using this custom option.
+  optional int32 method_id = 425000010;
+}


### PR DESCRIPTION
This will allow other external/third party client repository protos to build
service protos that have added this option.

This option will eventually replace the comment-based approach for method_id
management.

b/326866415
