### PR TITLE
Add `ExtractedEvidence` to the `AttestationResults` proto.

### DIFF
--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -76,10 +76,12 @@ pub fn to_attestation_results(
     verify_result: &anyhow::Result<ExtractedEvidence>,
 ) -> AttestationResults {
     match verify_result {
+        #[allow(deprecated)]
         Ok(extracted_evidence) => AttestationResults {
             status: Status::Success.into(),
             encryption_public_key: extracted_evidence.encryption_public_key.clone(),
             signing_public_key: extracted_evidence.signing_public_key.clone(),
+            extracted_evidence: Some(extracted_evidence.clone()),
             ..Default::default()
         },
         Err(err) => AttestationResults {

--- a/proto/attestation/verification.proto
+++ b/proto/attestation/verification.proto
@@ -42,12 +42,22 @@ message AttestationResults {
 
   // Contains the verified public key for encryption whenever the status
   // indicates success. The key is serialized as an X25519 octet string.
-  bytes encryption_public_key = 3;
+  //
+  // Deprecated: will be replaced by the
+  // `extracted_evidence.encryption_public_key` field. For now both are
+  // populated.
+  bytes encryption_public_key = 3 [deprecated = true];
 
   // Contains the verified public key for signing whenever the status
   // indicates success. The key is serialized using the SEC 1
   // Elliptic-Curve-Point-to-Octet-String conversion.
-  bytes signing_public_key = 4;
+  //
+  // Deprecated: will be replaced by the `extracted_evidence.signing_public_key`
+  // field. For now both are populated.
+  bytes signing_public_key = 4 [deprecated = true];
+
+  // Contains the evidence values whenever the status indicates success.
+  ExtractedEvidence extracted_evidence = 5;
 }
 
 // Evidence values extracted from attestation evidence during verification.


### PR DESCRIPTION
This exposes more of the extracted evidence via the `AttestationResults` proto, rather than just the encryption and signing public keys. Since the `ExtractedEvidence` message  contains those same public keys again, the existing public key fields are marked deprecated, to be removed in a follow-up commit.