### PR TITLE
Use the raw kernel command-line in DICE

### DIFF
--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -472,8 +472,7 @@ fn verify_kernel_layer(
     )
     .context("kernel failed verification")?;
 
-    // TODO: b/325979696 - Validate the kernel command-line using a regular
-    // expression.
+    // TODO: b/325979696 - Validate the kernel command-line using a regex.
 
     verify_measurement_digest(
         values.init_ram_fs.as_ref().context("no initial RAM disk evidence value")?,

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -24,10 +24,9 @@ use ecdsa::{signature::Verifier, Signature};
 use oak_dice::cert::{
     cose_key_to_hpke_public_key, cose_key_to_verifying_key, get_public_key_from_claims_set,
     ACPI_MEASUREMENT_ID, CONTAINER_IMAGE_LAYER_ID, ENCLAVE_APPLICATION_LAYER_ID,
-    FINAL_LAYER_CONFIG_MEASUREMENT_ID, INITRD_MEASUREMENT_ID, KERNEL_COMMANDLINE_MEASUREMENT_ID,
-    KERNEL_LAYER_ID, KERNEL_MEASUREMENT_ID, LAYER_2_CODE_MEASUREMENT_ID,
-    LAYER_3_CODE_MEASUREMENT_ID, MEMORY_MAP_MEASUREMENT_ID, SETUP_DATA_MEASUREMENT_ID, SHA2_256_ID,
-    SYSTEM_IMAGE_LAYER_ID,
+    FINAL_LAYER_CONFIG_MEASUREMENT_ID, INITRD_MEASUREMENT_ID, KERNEL_LAYER_ID,
+    KERNEL_MEASUREMENT_ID, LAYER_2_CODE_MEASUREMENT_ID, LAYER_3_CODE_MEASUREMENT_ID,
+    MEMORY_MAP_MEASUREMENT_ID, SETUP_DATA_MEASUREMENT_ID, SHA2_256_ID, SYSTEM_IMAGE_LAYER_ID,
 };
 use oak_proto_rust::oak::{
     attestation::v1::{
@@ -473,16 +472,8 @@ fn verify_kernel_layer(
     )
     .context("kernel failed verification")?;
 
-    verify_measurement_digest(
-        values.kernel_cmd_line.as_ref().context("no kernel command-line evidence value")?,
-        now_utc_millis,
-        endorsements.and_then(|value| value.kernel_cmd_line.as_ref()),
-        reference_values
-            .kernel_cmd_line
-            .as_ref()
-            .context("no kernel command-line reference value")?,
-    )
-    .context("kernel command-line failed verification")?;
+    // TODO: b/325979696 - Validate the kernel command-line using a regular
+    // expression.
 
     verify_measurement_digest(
         values.init_ram_fs.as_ref().context("no initial RAM disk evidence value")?,
@@ -866,15 +857,15 @@ fn extract_kernel_values(claims: &ClaimsSet) -> anyhow::Result<KernelLayerData> 
     let kernel_image = Some(value_to_raw_digest(extract_value(values, KERNEL_MEASUREMENT_ID)?)?);
     let kernel_setup_data =
         Some(value_to_raw_digest(extract_value(values, SETUP_DATA_MEASUREMENT_ID)?)?);
-    let kernel_cmd_line =
-        Some(value_to_raw_digest(extract_value(values, KERNEL_COMMANDLINE_MEASUREMENT_ID)?)?);
+    // TODO: b/325979696 - Extract raw kernel command-line.
     let init_ram_fs = Some(value_to_raw_digest(extract_value(values, INITRD_MEASUREMENT_ID)?)?);
     let memory_map = Some(value_to_raw_digest(extract_value(values, MEMORY_MAP_MEASUREMENT_ID)?)?);
     let acpi = Some(value_to_raw_digest(extract_value(values, ACPI_MEASUREMENT_ID)?)?);
+    #[allow(deprecated)]
     Ok(KernelLayerData {
         kernel_image,
         kernel_setup_data,
-        kernel_cmd_line,
+        kernel_cmd_line: None,
         init_ram_fs,
         memory_map,
         acpi,

--- a/oak_dice/src/cert.rs
+++ b/oak_dice/src/cert.rs
@@ -50,7 +50,7 @@ pub const CONTAINER_IMAGE_LAYER_ID: i64 = -4670559;
 /// The CWT private claim ID for the kernel measurement.
 pub const KERNEL_MEASUREMENT_ID: i64 = -4670561;
 /// The CWT private claim ID for the kernel command-line measurement.
-pub const KERNEL_COMMANDLINE_MEASUREMENT_ID: i64 = -4670562;
+pub const KERNEL_COMMANDLINE_ID: i64 = -4670562;
 /// The CWT private claim ID for the kernel setup data measurement.
 pub const SETUP_DATA_MEASUREMENT_ID: i64 = -4670563;
 /// The CWT private claim ID for the initial RAM file system measurement.

--- a/proto/attestation/reference_value.proto
+++ b/proto/attestation/reference_value.proto
@@ -128,9 +128,10 @@ message KernelLayerReferenceValues {
   // Verifies the kernel based on endorsement.
   KernelBinaryReferenceValue kernel = 1;
 
-  // Verifies the command line by which the kernel was built. The command
-  // line is treated as a binary blob, as if it were a binary.
-  BinaryReferenceValue kernel_cmd_line = 2;
+  // No longer used. Will be removed.
+  // TODO: b/325979696 - Validate the kernel command-line using a regular
+  // expression.
+  BinaryReferenceValue kernel_cmd_line = 2 [deprecated = true];
 
   // Fields are deprecated and kept only for backwards compatibility.
   // Remove ASAP.

--- a/proto/attestation/reference_value.proto
+++ b/proto/attestation/reference_value.proto
@@ -129,8 +129,7 @@ message KernelLayerReferenceValues {
   KernelBinaryReferenceValue kernel = 1;
 
   // No longer used. Will be removed.
-  // TODO: b/325979696 - Validate the kernel command-line using a regular
-  // expression.
+  // TODO: b/325979696 - Validate the kernel command-line using a regex.
   BinaryReferenceValue kernel_cmd_line = 2 [deprecated = true];
 
   // Fields are deprecated and kept only for backwards compatibility.

--- a/proto/attestation/verification.proto
+++ b/proto/attestation/verification.proto
@@ -146,8 +146,7 @@ message KernelLayerData {
 
   // Measured digests of the command-line that was passed to the kernel
   // during startup.
-  // TODO: b/325979696 - Validate the kernel command-line using a regular
-  // expression.
+  // TODO: b/325979696 - Validate the kernel command-line using a regex.
   RawDigest kernel_cmd_line = 2 [deprecated = true];
 
   // Measured digests of the initial RAM disk.

--- a/proto/attestation/verification.proto
+++ b/proto/attestation/verification.proto
@@ -146,7 +146,9 @@ message KernelLayerData {
 
   // Measured digests of the command-line that was passed to the kernel
   // during startup.
-  RawDigest kernel_cmd_line = 2;
+  // TODO: b/325979696 - Validate the kernel command-line using a regular
+  // expression.
+  RawDigest kernel_cmd_line = 2 [deprecated = true];
 
   // Measured digests of the initial RAM disk.
   RawDigest init_ram_fs = 4;

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -236,7 +236,6 @@ pub fn rust64_start(encrypted: u64) -> ! {
     }
 
     let cmdline = kernel::try_load_cmdline(&mut fwcfg).unwrap_or_default();
-    let cmdline_sha2_256_digest = measure_byte_slice(cmdline.as_bytes());
 
     let kernel_info =
         kernel::try_load_kernel_image(&mut fwcfg, zero_page.e820_table()).unwrap_or_default();
@@ -303,7 +302,7 @@ pub fn rust64_start(encrypted: u64) -> ! {
 
     log::debug!("Kernel image digest: sha2-256:{}", hex::encode(kernel_info.measurement));
     log::debug!("Kernel setup data digest: sha2-256:{}", hex::encode(setup_data_sha2_256_digest));
-    log::debug!("Kernel image digest: sha2-256:{}", hex::encode(cmdline_sha2_256_digest));
+    log::debug!("Kernel command-line: {}", cmdline);
     log::debug!("Initial RAM disk digest: sha2-256:{}", hex::encode(ram_disk_sha2_256_digest));
     log::debug!("ACPI table generation digest: sha2-256:{}", hex::encode(acpi_sha2_256_digest));
     log::debug!("E820 table digest: sha2-256:{}", hex::encode(memory_map_sha2_256_digest));
@@ -311,7 +310,7 @@ pub fn rust64_start(encrypted: u64) -> ! {
     let measurements = oak_stage0_dice::Measurements {
         acpi_sha2_256_digest,
         kernel_sha2_256_digest: kernel_info.measurement,
-        cmdline_sha2_256_digest,
+        cmdline: cmdline.clone(),
         ram_disk_sha2_256_digest,
         setup_data_sha2_256_digest,
         memory_map_sha2_256_digest,


### PR DESCRIPTION
This is the first step towards validating the kernel command-line using a regular expression. Once this is imported and we are able to generate new DICE evidence with the raw kernel command-line we can update the verification code and protos.