### PR TITLE
Ensure attestation report was generated from VMPL0

### DIFF
--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -340,7 +340,8 @@ fn verify_amd_sev_attestation_report(
     // generated in VMPL0.
     anyhow::ensure!(
         attestation_report_values.vmpl == 0,
-        "attestation report was not generated from VMPL 0"
+        "attestation report was not generated from VMPL {}, not VMPL 0",
+        attestation_report_values.vmpl
     );
 
     if !reference_values.allow_debug && attestation_report_values.debug {

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -336,6 +336,13 @@ fn verify_amd_sev_attestation_report(
     attestation_report_values: &AmdAttestationReport,
     reference_values: &AmdSevReferenceValues,
 ) -> anyhow::Result<()> {
+    // Stage 0 only destroys VMPCK0, so we only trust attestation reports that were
+    // generated in VMPL0.
+    anyhow::ensure!(
+        attestation_report_values.vmpl == 0,
+        "attestation report was not generated from VMPL 0"
+    );
+
     if !reference_values.allow_debug && attestation_report_values.debug {
         anyhow::bail!("debug mode not allowed");
     }
@@ -810,6 +817,7 @@ fn extract_root_values(root_layer: &RootLayerEvidence) -> anyhow::Result<RootLay
             let hardware_id = report.data.chip_id.as_ref().to_vec();
             let initial_measurement = report.data.measurement.as_ref().to_vec();
             let report_data = report.data.report_data.as_ref().to_vec();
+            let vmpl = report.data.vmpl;
 
             Ok(RootLayerData {
                 report: Some(Report::SevSnp(AmdAttestationReport {
@@ -818,6 +826,7 @@ fn extract_root_values(root_layer: &RootLayerEvidence) -> anyhow::Result<RootLay
                     initial_measurement,
                     hardware_id,
                     report_data,
+                    vmpl,
                 })),
             })
         }

--- a/proto/attestation/verification.proto
+++ b/proto/attestation/verification.proto
@@ -108,6 +108,10 @@ message AmdAttestationReport {
   // The hardware ID of the AMD SEV-SNP platform that generated the atttestation
   // report.
   bytes hardware_id = 5;
+
+  // The VM Protection Leve (VMPL) that was active when the attestation report
+  // was generated.
+  uint32 vmpl = 6;
 }
 
 // Values extracted from an Intel TDX attestation report.


### PR DESCRIPTION
Stage0 destroys the VM communication key for VM protection level 0 (VMPCK0) to avoid forged attestation reports. We must ensure that the attstation report was generated from VMPL as part of attestation verification for this to work.

Ref b/328163347