### PR TITLE
Add linux kernel to bzImage provenance shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -208,6 +208,9 @@
             };
             # Shell for container kernel image provenance workflow.
             bzImageProvenance = with pkgs; mkShell {
+              shellHook = ''
+                export LINUX_KERNEL_UPSTREAM="${linux_kernel_upstream}"
+              '';
               inputsFrom = [
                 rust
               ];


### PR DESCRIPTION
I think this was the actual root cause of b/329124627, but we'll see for sure after the commit is merged.