### PR TITLE
Update CWT representation of the command-line

### DIFF
--- a/stage0_dice/src/lib.rs
+++ b/stage0_dice/src/lib.rs
@@ -82,10 +82,7 @@ fn generate_stage1_certificate(
             ),
             (
                 Value::Integer(KERNEL_COMMANDLINE_ID.into()),
-                Value::Map(alloc::vec![(
-                    Value::Integer(SHA2_256_ID.into()),
-                    Value::Text(measurements.cmdline.clone()),
-                )]),
+                Value::Text(measurements.cmdline.clone()),
             ),
             (
                 Value::Integer(SETUP_DATA_MEASUREMENT_ID.into()),


### PR DESCRIPTION
The command-line is not a hash, so it should not be nested like other digests.

Ref https://github.com/project-oak/oak/pull/4936#issuecomment-2014595255