### PR TITLE
Temporarily add back the kernel cmdline digest

### DIFF
--- a/oak_dice/src/cert.rs
+++ b/oak_dice/src/cert.rs
@@ -50,7 +50,9 @@ pub const CONTAINER_IMAGE_LAYER_ID: i64 = -4670559;
 /// The CWT private claim ID for the kernel measurement.
 pub const KERNEL_MEASUREMENT_ID: i64 = -4670561;
 /// The CWT private claim ID for the kernel command-line measurement.
-pub const KERNEL_COMMANDLINE_ID: i64 = -4670562;
+pub const KERNEL_COMMANDLINE_MEASUREMENT_ID: i64 = -4670562;
+/// The CWT private claim ID for the raw kernel command-line.
+pub const KERNEL_COMMANDLINE_ID: i64 = -4670573;
 /// The CWT private claim ID for the kernel setup data measurement.
 pub const SETUP_DATA_MEASUREMENT_ID: i64 = -4670563;
 /// The CWT private claim ID for the initial RAM file system measurement.

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -236,6 +236,7 @@ pub fn rust64_start(encrypted: u64) -> ! {
     }
 
     let cmdline = kernel::try_load_cmdline(&mut fwcfg).unwrap_or_default();
+    let cmdline_sha2_256_digest = measure_byte_slice(cmdline.as_bytes());
 
     let kernel_info =
         kernel::try_load_kernel_image(&mut fwcfg, zero_page.e820_table()).unwrap_or_default();
@@ -310,6 +311,7 @@ pub fn rust64_start(encrypted: u64) -> ! {
     let measurements = oak_stage0_dice::Measurements {
         acpi_sha2_256_digest,
         kernel_sha2_256_digest: kernel_info.measurement,
+        cmdline_sha2_256_digest,
         cmdline: cmdline.clone(),
         ram_disk_sha2_256_digest,
         setup_data_sha2_256_digest,

--- a/stage0_dice/src/lib.rs
+++ b/stage0_dice/src/lib.rs
@@ -32,8 +32,8 @@ use oak_dice::{
     cert::{
         derive_verifying_key_id, generate_ecdsa_key_pair, generate_signing_certificate,
         verifying_key_to_cose_key, ACPI_MEASUREMENT_ID, INITRD_MEASUREMENT_ID,
-        KERNEL_COMMANDLINE_ID, KERNEL_LAYER_ID, KERNEL_MEASUREMENT_ID, MEMORY_MAP_MEASUREMENT_ID,
-        SETUP_DATA_MEASUREMENT_ID, SHA2_256_ID,
+        KERNEL_COMMANDLINE_ID, KERNEL_COMMANDLINE_MEASUREMENT_ID, KERNEL_LAYER_ID,
+        KERNEL_MEASUREMENT_ID, MEMORY_MAP_MEASUREMENT_ID, SETUP_DATA_MEASUREMENT_ID, SHA2_256_ID,
     },
     evidence::{Stage0DiceData, TeePlatform, STAGE0_MAGIC},
 };
@@ -49,6 +49,8 @@ type DerivedKey = [u8; 32];
 pub struct Measurements {
     /// The measurement of the kernel image.
     pub kernel_sha2_256_digest: [u8; 32],
+    /// The measurement of the kernel command-line.
+    pub cmdline_sha2_256_digest: [u8; 32],
     /// The raw kernel command-line.
     pub cmdline: String,
     /// The measurement of the kernel setup data.
@@ -78,6 +80,13 @@ fn generate_stage1_certificate(
                 Value::Map(alloc::vec![(
                     Value::Integer(SHA2_256_ID.into()),
                     Value::Bytes(measurements.kernel_sha2_256_digest.into()),
+                )]),
+            ),
+            (
+                Value::Integer(KERNEL_COMMANDLINE_MEASUREMENT_ID.into()),
+                Value::Map(alloc::vec![(
+                    Value::Integer(SHA2_256_ID.into()),
+                    Value::Bytes(measurements.cmdline_sha2_256_digest.into()),
                 )]),
             ),
             (


### PR DESCRIPTION
Repurposing the same ID for the kernel command-line that was used for the digest is a breaking change since some code still expected the ID to be associated with a digest.

So, for now add back the old ID as a digest and create a new ID for the raw kernel command-line. Once all the code has been migrated we can remove the old ID.