### PR TITLE
Add micro_rpc method_id option to service protos.

### DIFF
--- a/micro_rpc_tests/build.rs
+++ b/micro_rpc_tests/build.rs
@@ -18,7 +18,10 @@ fn main() {
     println!("cargo:rerun-if-env-changed=WORKSPACE_ROOT");
     micro_rpc_build::compile(
         &[format!("{}micro_rpc_tests/proto/test_schema.proto", env!("WORKSPACE_ROOT"))],
-        &[format!("{}micro_rpc_tests/proto", env!("WORKSPACE_ROOT"))],
+        &[
+            format!("{}micro_rpc_tests/proto", env!("WORKSPACE_ROOT")),
+            env!("WORKSPACE_ROOT").to_string(),
+        ],
         Default::default(),
     );
 }

--- a/micro_rpc_tests/proto/test_schema.proto
+++ b/micro_rpc_tests/proto/test_schema.proto
@@ -22,6 +22,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/any.proto";
+import "proto/micro_rpc/options.proto";
 
 message LookupDataRequest {
   bytes key = 1;
@@ -37,15 +38,27 @@ message LogResponse {}
 
 service TestService {
   // method_id: 15
-  rpc LookupData(LookupDataRequest) returns (LookupDataResponse);
+  rpc LookupData(LookupDataRequest) returns (LookupDataResponse) {
+    option (.oak.micro_rpc.method_id) = 15;
+  }
   // method_id: 16
-  rpc Log(LogRequest) returns (LogResponse);
+  rpc Log(LogRequest) returns (LogResponse) {
+    option (.oak.micro_rpc.method_id) = 16;
+  }
   // method_id: 17
-  rpc Empty(google.protobuf.Empty) returns (google.protobuf.Empty);
+  rpc Empty(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (.oak.micro_rpc.method_id) = 17;
+  }
   // method_id: 18
-  rpc Duration(google.protobuf.Duration) returns (google.protobuf.Duration);
+  rpc Duration(google.protobuf.Duration) returns (google.protobuf.Duration) {
+    option (.oak.micro_rpc.method_id) = 18;
+  }
   // method_id: 19
-  rpc Timestamp(google.protobuf.Timestamp) returns (google.protobuf.Timestamp);
+  rpc Timestamp(google.protobuf.Timestamp) returns (google.protobuf.Timestamp) {
+    option (.oak.micro_rpc.method_id) = 19;
+  }
   // method_id: 20
-  rpc Any(google.protobuf.Any) returns (google.protobuf.Any);
+  rpc Any(google.protobuf.Any) returns (google.protobuf.Any) {
+    option (.oak.micro_rpc.method_id) = 20;
+  }
 }

--- a/proto/oak_functions/BUILD
+++ b/proto/oak_functions/BUILD
@@ -42,6 +42,7 @@ proto_library(
 proto_library(
     name = "testing_proto",
     srcs = ["testing.proto"],
+    deps = ["//proto/micro_rpc:options_proto"],
 )
 
 build_test(

--- a/proto/oak_functions/sdk/oak_functions_wasm.proto
+++ b/proto/oak_functions/sdk/oak_functions_wasm.proto
@@ -19,6 +19,7 @@ syntax = "proto3";
 package oak.functions.wasm.v1;
 
 import "google/protobuf/wrappers.proto";
+import "proto/micro_rpc/options.proto";
 
 // The standard API for Oak Functions, which is exposed to Wasm modules via micro RPC, and wrapped
 // by the Oak Functions SDK.
@@ -30,7 +31,9 @@ service StdWasmApi {
   // This method is idempotent: multiple calls result in the same response.
   //
   // method_id: 0
-  rpc ReadRequest(ReadRequestRequest) returns (ReadRequestResponse) {}
+  rpc ReadRequest(ReadRequestRequest) returns (ReadRequestResponse) {
+    option (.oak.micro_rpc.method_id) = 0;
+  }
 
   // Write a response for the client.
   //
@@ -39,7 +42,9 @@ service StdWasmApi {
   // runtime sends an empty response to the client.
   //
   // method_id: 1
-  rpc WriteResponse(WriteResponseRequest) returns (WriteResponseResponse) {}
+  rpc WriteResponse(WriteResponseRequest) returns (WriteResponseResponse) {
+    option (.oak.micro_rpc.method_id) = 1;
+  }
 
   // Writes a debug log message.
   //
@@ -47,22 +52,30 @@ service StdWasmApi {
   // in debug mode.
   //
   // method_id: 2
-  rpc Log(LogRequest) returns (LogResponse) {}
+  rpc Log(LogRequest) returns (LogResponse) {
+    option (.oak.micro_rpc.method_id) = 2;
+  }
 
   // Looks up an item from the in-memory key/value lookup store.
   //
   // method_id: 3
-  rpc LookupData(LookupDataRequest) returns (LookupDataResponse) {}
+  rpc LookupData(LookupDataRequest) returns (LookupDataResponse) {
+    option (.oak.micro_rpc.method_id) = 3;
+  }
 
   // Looks up multiple items from the in-memory key/value lookup store.
   //
   // method_id: 4
-  rpc LookupDataMulti(LookupDataMultiRequest) returns (LookupDataMultiResponse) {}
+  rpc LookupDataMulti(LookupDataMultiRequest) returns (LookupDataMultiResponse) {
+    option (.oak.micro_rpc.method_id) = 4;
+  }
 
   // Test method only.
   //
   // method_id: 128
-  rpc Test(TestRequest) returns (TestResponse) {}
+  rpc Test(TestRequest) returns (TestResponse) {
+    option (.oak.micro_rpc.method_id) = 128;
+  }
 }
 
 message ReadRequestRequest {}

--- a/proto/oak_functions/service/oak_functions.proto
+++ b/proto/oak_functions/service/oak_functions.proto
@@ -20,17 +20,22 @@ package oak.functions;
 
 import "proto/crypto/crypto.proto";
 import "proto/attestation/evidence.proto";
+import "proto/micro_rpc/options.proto";
 
 service OakFunctions {
   // Initializes the service and remote attestation keys.
   //
   // method_id: 0
-  rpc Initialize(InitializeRequest) returns (InitializeResponse);
+  rpc Initialize(InitializeRequest) returns (InitializeResponse) {
+    option (.oak.micro_rpc.method_id) = 0;
+  }
 
   // Handles an invocation coming from a client.
   //
   // method_id: 1
-  rpc HandleUserRequest(InvokeRequest) returns (InvokeResponse);
+  rpc HandleUserRequest(InvokeRequest) returns (InvokeResponse) {
+    option (.oak.micro_rpc.method_id) = 1;
+  }
 
   // Extends the next lookup data by the given chunk of lookup data. Only
   // after the sender calls finishes building the next lookup data, the receiver replaces the
@@ -38,25 +43,33 @@ service OakFunctions {
   // lookups.
   //
   // method_id: 2
-  rpc ExtendNextLookupData(ExtendNextLookupDataRequest) returns (ExtendNextLookupDataResponse);
+  rpc ExtendNextLookupData(ExtendNextLookupDataRequest) returns (ExtendNextLookupDataResponse) {
+    option (.oak.micro_rpc.method_id) = 2;
+  }
 
   // Finishes building the next lookup data with the given chunk of lookup data. The receiver
   // replaces the current lookup data and the next lookup data will be served in lookups.
   //
   // method_id: 3
-  rpc FinishNextLookupData(FinishNextLookupDataRequest) returns (FinishNextLookupDataResponse);
+  rpc FinishNextLookupData(FinishNextLookupDataRequest) returns (FinishNextLookupDataResponse) {
+    option (.oak.micro_rpc.method_id) = 3;
+  }
 
   // Aborts building the next lookup data.option
   //
   // method_id: 4
-  rpc AbortNextLookupData(Empty) returns (AbortNextLookupDataResponse);
+  rpc AbortNextLookupData(Empty) returns (AbortNextLookupDataResponse) {
+    option (.oak.micro_rpc.method_id) = 4;
+  }
 
   // Streaming version combining `ExtendNextLookupData` and `FinishNextLookupData`.
   //
   // This is mainly for use with gRPC, as microRPC doesn't support streaming.
   //
   // method_id: 5
-  rpc StreamLookupData(stream LookupDataChunk) returns (FinishNextLookupDataResponse);
+  rpc StreamLookupData(stream LookupDataChunk) returns (FinishNextLookupDataResponse) {
+    option (.oak.micro_rpc.method_id) = 5;
+  }
 
   // Reserves additional capacity for entries in the lookup table.
   //
@@ -64,7 +77,9 @@ service OakFunctions {
   // number of memory allocations, but it's not mandatory to call this RPC.
   //
   // method_id: 6
-  rpc Reserve(ReserveRequest) returns (ReserveResponse);
+  rpc Reserve(ReserveRequest) returns (ReserveResponse) {
+    option (.oak.micro_rpc.method_id) = 6;
+  }
 }
 
 message InitializeRequest {

--- a/proto/oak_functions/testing.proto
+++ b/proto/oak_functions/testing.proto
@@ -18,11 +18,17 @@ syntax = "proto3";
 
 package oak.functions.testing;
 
+import "proto/micro_rpc/options.proto";
+
 service TestModule {
   // method_id: 0
-  rpc Lookup(LookupRequest) returns (LookupResponse) {}
+  rpc Lookup(LookupRequest) returns (LookupResponse) {
+    option (.oak.micro_rpc.method_id) = 0;
+  }
   // method_id: 1
-  rpc EchoAndPanic(EchoAndPanicRequest) returns (EchoAndPanicResponse) {}
+  rpc EchoAndPanic(EchoAndPanicRequest) returns (EchoAndPanicResponse) {
+    option (.oak.micro_rpc.method_id) = 1;
+  }
 }
 
 message LookupRequest {

--- a/testing/oak_echo_service/proto/oak_echo.proto
+++ b/testing/oak_echo_service/proto/oak_echo.proto
@@ -20,6 +20,7 @@ package oak.echo;
 
 import "google/protobuf/empty.proto";
 import "proto/attestation/evidence.proto";
+import "proto/micro_rpc/options.proto";
 
 message EchoRequest {
   bytes body = 1;
@@ -35,8 +36,12 @@ message GetEvidenceResponse {
 
 service Echo {
   // method_id: 1988
-  rpc Echo(EchoRequest) returns (EchoResponse);
+  rpc Echo(EchoRequest) returns (EchoResponse) {
+    option (.oak.micro_rpc.method_id) = 1988;
+  }
 
   // method_id: 1771
-  rpc GetEvidence(google.protobuf.Empty) returns (GetEvidenceResponse);
+  rpc GetEvidence(google.protobuf.Empty) returns (GetEvidenceResponse) {
+    option (.oak.micro_rpc.method_id) = 1771;
+  }
 }


### PR DESCRIPTION
Eventually we should be able to switch to using these option values and
getting rid of the comments completely.
