### PR TITLE
Differentiate orchestrator logs

### DIFF
--- a/oak_restricted_kernel_sdk/src/utils.rs
+++ b/oak_restricted_kernel_sdk/src/utils.rs
@@ -23,12 +23,12 @@ pub use oak_core::*;
 pub use oak_enclave_runtime_support::heap;
 use oak_restricted_kernel_interface::syscall::{fsync, write};
 
-struct Stderr {}
+pub struct Stderr {}
 
 impl Stderr {
     const STDERR_FD: i32 = 2;
 
-    fn flush() {
+    pub fn flush() {
         fsync(Self::STDERR_FD).unwrap();
     }
 }


### PR DESCRIPTION
Now orchestrator logs will be prefixed, just as stage0 and kernel logs are.