### PR TITLE
Temporarly change stage0 release size to 2 MiB

### DIFF
--- a/stage0_bin/build.rs
+++ b/stage0_bin/build.rs
@@ -21,9 +21,10 @@ fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rustc-link-arg=--script=layout.ld");
 
+    #[allow(clippy::if_same_then_else)]
     if env::var("PROFILE").unwrap() == "release" {
-        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=256K");
+        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=2M");
     } else {
-        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=2048K");
+        println!("cargo:rustc-link-arg=--defsym=BIOS_SIZE=2M");
     }
 }


### PR DESCRIPTION
This is to ensure there aren't any issues stemming from the BIOS area not being aligned to a 2 MiB boundary (and the EDK2 blob is 2M in size as well.)

Unfortunately I need to actually commit this change as because of various permissions and imports I can't run a locally-built stage0 binary.

I may revert this PR in the future.

Ref b/330345538