### PR TITLE
Reference process page table using the underlying PhysicalFrame 

### DIFF
--- a/enclave_apps/oak_echo_raw_enclave_app/src/main.rs
+++ b/enclave_apps/oak_echo_raw_enclave_app/src/main.rs
@@ -36,7 +36,9 @@ fn start_echo_server() -> ! {
     let mut channel = FileDescriptorChannel::default();
     loop {
         let bytes = {
+            log::info!("about to allocate bytes");
             let mut bytes: Vec<u8> = vec![0; MESSAGE_SIZE];
+            log::info!("allocated bytes");
             channel.read_exact(&mut bytes).expect("couldn't read bytes");
             bytes
         };

--- a/oak_restricted_kernel/src/mm/page_tables.rs
+++ b/oak_restricted_kernel/src/mm/page_tables.rs
@@ -293,6 +293,7 @@ impl CurrentRootPageTable {
     /// Safety: The new page tables must keep the identity mapping at -2GB
     /// (kernel space) intact.
     pub unsafe fn replace(&mut self, pml4_frame: PhysFrame) -> Option<RootPageTable> {
+        log::info!("Writing new pml4 to Cr3: {:?}", pml4_frame);
         // This validates any references that expect boot page tables to be valid!
         // Safety: Caller must ensure that the new page tables are safe.
         unsafe {

--- a/oak_restricted_kernel/src/payload.rs
+++ b/oak_restricted_kernel/src/payload.rs
@@ -25,7 +25,7 @@ use goblin::{
 use oak_restricted_kernel_interface::syscalls::{MmapFlags, MmapProtection};
 use self_cell::self_cell;
 use x86_64::{
-    structures::paging::{PageSize, Size2MiB},
+    structures::paging::{PageSize, PhysFrame, Size2MiB},
     VirtAddr,
 };
 
@@ -160,12 +160,13 @@ pub fn identify_pml4_frame(
 }
 
 pub struct Process {
-    pml4: x86_64::structures::paging::PageTable,
+    pml4_frame: PhysFrame,
     entry: VirtAddr,
 }
 
 impl Process {
-    /// Creates a process from the application, without executing it.
+    /// Creates a process from the application, without executing it. Returns
+    /// the PID of the new process.
     ///
     /// # Safety
     ///
@@ -173,6 +174,7 @@ impl Process {
     /// Restricted Application.
     pub unsafe fn from_application(application: &Application) -> Result<Self, anyhow::Error> {
         let pml4 = crate::BASE_L4_PAGE_TABLE.get().context("base l4 table should be set")?.clone();
+        let pml4_frame: PhysFrame = identify_pml4_frame(&pml4)?;
         // Load the process's page table, so the application can be loaded into its
         // memory. Hold onto the previous PT, so we can revert to it once the
         // application has been mapped into the process pt.
@@ -198,17 +200,14 @@ impl Process {
             // Safety: the new page table maintains the same mappings for kernel space.
             unsafe { crate::PAGE_TABLES.lock().replace(pml4_frame) };
         }
-
-        Ok(Self { pml4, entry })
+        Ok(Self { pml4_frame, entry })
     }
     /// Executes the process.
     pub fn execute(&self) -> ! {
-        let pml4_frame = identify_pml4_frame(&self.pml4).expect("could not get pml4 frame");
         // Safety: the new page table maintains the same mappings for kernel space.
-        unsafe { crate::PAGE_TABLES.lock().replace(pml4_frame) };
+        unsafe { crate::PAGE_TABLES.lock().replace(self.pml4_frame) };
 
         let entry = self.entry;
-        log::info!("Running application");
         // Enter Ring 3 and jump to user code.
         // Safety: by now, if we're here, we've loaded a valid ELF file. It's up to the
         // user to guarantee that the file made sense.


### PR DESCRIPTION
Backports the change outlined in https://github.com/project-oak/oak/pull/4918#discussion_r1538117494 onto main.

In principle it should not change behavior, however it does. When the enclave application starts allocating, it now panics. 