### PR TITLE
Sign group keys as part of Key Provisioning

### DIFF
--- a/oak_attestation/src/dice.rs
+++ b/oak_attestation/src/dice.rs
@@ -139,37 +139,39 @@ impl DiceBuilder {
         .map_err(anyhow::Error::msg)?;
 
         // Generate group keys certificates as part of Key Provisioning.
-        let group_encryption_public_key_certificate = if let Some(group_kem_public_key) = group_kem_public_key {
-            let group_encryption_public_key_certificate = generate_kem_certificate(
-                &self.signing_key,
-                issuer_id.clone(),
-                group_kem_public_key,
-                vec![],
-            )
-            .map_err(anyhow::Error::msg)
-            .context("couldn't generate encryption public key certificate")?
-            .to_vec()
-            .map_err(anyhow::Error::msg)?;
-            Some(group_encryption_public_key_certificate)
-        } else {
-            None
-        };
+        let group_encryption_public_key_certificate =
+            if let Some(group_kem_public_key) = group_kem_public_key {
+                let group_encryption_public_key_certificate = generate_kem_certificate(
+                    &self.signing_key,
+                    issuer_id.clone(),
+                    group_kem_public_key,
+                    vec![],
+                )
+                .map_err(anyhow::Error::msg)
+                .context("couldn't generate encryption public key certificate")?
+                .to_vec()
+                .map_err(anyhow::Error::msg)?;
+                Some(group_encryption_public_key_certificate)
+            } else {
+                None
+            };
 
-        let group_signing_public_key_certificate = if let Some(group_verifying_key) = group_verifying_key {
-            let group_signing_public_key_certificate = generate_signing_certificate(
-                &self.signing_key,
-                issuer_id.clone(),
-                group_verifying_key,
-                vec![],
-            )
-            .map_err(anyhow::Error::msg)
-            .context("couldn't generate signing public key certificate")?
-            .to_vec()
-            .map_err(anyhow::Error::msg)?;
-            Some(group_signing_public_key_certificate)
-        } else {
-            None
-        };
+        let group_signing_public_key_certificate =
+            if let Some(group_verifying_key) = group_verifying_key {
+                let group_signing_public_key_certificate = generate_signing_certificate(
+                    &self.signing_key,
+                    issuer_id.clone(),
+                    group_verifying_key,
+                    vec![],
+                )
+                .map_err(anyhow::Error::msg)
+                .context("couldn't generate signing public key certificate")?
+                .to_vec()
+                .map_err(anyhow::Error::msg)?;
+                Some(group_signing_public_key_certificate)
+            } else {
+                None
+            };
 
         evidence.application_keys = Some(ApplicationKeys {
             encryption_public_key_certificate,
@@ -274,5 +276,10 @@ fn application_keys_to_proto(
     let signing_public_key_certificate =
         oak_dice::utils::cbor_encoded_bytes_to_vec(&value.signing_public_key_certificate[..])
             .map_err(anyhow::Error::msg)?;
-    Ok(ApplicationKeys { encryption_public_key_certificate, signing_public_key_certificate, group_encryption_public_key_certificate: None, group_signing_public_key_certificate: None })
+    Ok(ApplicationKeys {
+        encryption_public_key_certificate,
+        signing_public_key_certificate,
+        group_encryption_public_key_certificate: None,
+        group_signing_public_key_certificate: None,
+    })
 }

--- a/oak_attestation/src/dice.rs
+++ b/oak_attestation/src/dice.rs
@@ -96,6 +96,8 @@ impl DiceBuilder {
         additional_claims: Vec<(ClaimName, ciborium::Value)>,
         kem_public_key: &[u8],
         verifying_key: &VerifyingKey,
+        group_kem_public_key: Option<&[u8]>,
+        group_verifying_key: Option<&VerifyingKey>,
     ) -> anyhow::Result<Evidence> {
         // The last evidence layer contains the certificate for the current signing key.
         // Since the builder contains an existing signing key there must be at
@@ -127,7 +129,7 @@ impl DiceBuilder {
 
         let signing_public_key_certificate = generate_signing_certificate(
             &self.signing_key,
-            issuer_id,
+            issuer_id.clone(),
             verifying_key,
             additional_claims,
         )
@@ -136,9 +138,44 @@ impl DiceBuilder {
         .to_vec()
         .map_err(anyhow::Error::msg)?;
 
+        // Generate group keys certificates as part of Key Provisioning.
+        let group_encryption_public_key_certificate = if let Some(group_kem_public_key) = group_kem_public_key {
+            let group_encryption_public_key_certificate = generate_kem_certificate(
+                &self.signing_key,
+                issuer_id.clone(),
+                group_kem_public_key,
+                vec![],
+            )
+            .map_err(anyhow::Error::msg)
+            .context("couldn't generate encryption public key certificate")?
+            .to_vec()
+            .map_err(anyhow::Error::msg)?;
+            Some(group_encryption_public_key_certificate)
+        } else {
+            None
+        };
+
+        let group_signing_public_key_certificate = if let Some(group_verifying_key) = group_verifying_key {
+            let group_signing_public_key_certificate = generate_signing_certificate(
+                &self.signing_key,
+                issuer_id.clone(),
+                group_verifying_key,
+                vec![],
+            )
+            .map_err(anyhow::Error::msg)
+            .context("couldn't generate signing public key certificate")?
+            .to_vec()
+            .map_err(anyhow::Error::msg)?;
+            Some(group_signing_public_key_certificate)
+        } else {
+            None
+        };
+
         evidence.application_keys = Some(ApplicationKeys {
             encryption_public_key_certificate,
             signing_public_key_certificate,
+            group_encryption_public_key_certificate,
+            group_signing_public_key_certificate,
         });
 
         Ok(evidence)
@@ -237,5 +274,5 @@ fn application_keys_to_proto(
     let signing_public_key_certificate =
         oak_dice::utils::cbor_encoded_bytes_to_vec(&value.signing_public_key_certificate[..])
             .map_err(anyhow::Error::msg)?;
-    Ok(ApplicationKeys { encryption_public_key_certificate, signing_public_key_certificate })
+    Ok(ApplicationKeys { encryption_public_key_certificate, signing_public_key_certificate, group_encryption_public_key_certificate: None, group_signing_public_key_certificate: None })
 }

--- a/oak_attestation/src/dice.rs
+++ b/oak_attestation/src/dice.rs
@@ -141,7 +141,7 @@ impl DiceBuilder {
         // Generate group keys certificates as part of Key Provisioning.
         let group_encryption_public_key_certificate =
             if let Some(group_kem_public_key) = group_kem_public_key {
-                let group_encryption_public_key_certificate = generate_kem_certificate(
+                generate_kem_certificate(
                     &self.signing_key,
                     issuer_id.clone(),
                     group_kem_public_key,
@@ -150,15 +150,14 @@ impl DiceBuilder {
                 .map_err(anyhow::Error::msg)
                 .context("couldn't generate encryption public key certificate")?
                 .to_vec()
-                .map_err(anyhow::Error::msg)?;
-                group_encryption_public_key_certificate
+                .map_err(anyhow::Error::msg)?
             } else {
                 vec![]
             };
 
         let group_signing_public_key_certificate =
             if let Some(group_verifying_key) = group_verifying_key {
-                let group_signing_public_key_certificate = generate_signing_certificate(
+                generate_signing_certificate(
                     &self.signing_key,
                     issuer_id.clone(),
                     group_verifying_key,
@@ -167,8 +166,7 @@ impl DiceBuilder {
                 .map_err(anyhow::Error::msg)
                 .context("couldn't generate signing public key certificate")?
                 .to_vec()
-                .map_err(anyhow::Error::msg)?;
-                group_signing_public_key_certificate
+                .map_err(anyhow::Error::msg)?
             } else {
                 vec![]
             };

--- a/oak_attestation/src/dice.rs
+++ b/oak_attestation/src/dice.rs
@@ -151,9 +151,9 @@ impl DiceBuilder {
                 .context("couldn't generate encryption public key certificate")?
                 .to_vec()
                 .map_err(anyhow::Error::msg)?;
-                Some(group_encryption_public_key_certificate)
+                group_encryption_public_key_certificate
             } else {
-                None
+                vec![]
             };
 
         let group_signing_public_key_certificate =
@@ -168,9 +168,9 @@ impl DiceBuilder {
                 .context("couldn't generate signing public key certificate")?
                 .to_vec()
                 .map_err(anyhow::Error::msg)?;
-                Some(group_signing_public_key_certificate)
+                group_signing_public_key_certificate
             } else {
-                None
+                vec![]
             };
 
         evidence.application_keys = Some(ApplicationKeys {
@@ -279,7 +279,7 @@ fn application_keys_to_proto(
     Ok(ApplicationKeys {
         encryption_public_key_certificate,
         signing_public_key_certificate,
-        group_encryption_public_key_certificate: None,
-        group_signing_public_key_certificate: None,
+        group_encryption_public_key_certificate: vec![],
+        group_signing_public_key_certificate: vec![],
     })
 }

--- a/oak_containers_orchestrator/src/main.rs
+++ b/oak_containers_orchestrator/src/main.rs
@@ -18,8 +18,7 @@ use std::{path::PathBuf, sync::Arc};
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use oak_containers_orchestrator::{
-    crypto::generate_instance_keys, launcher_client::LauncherClient,
-    proto::oak::containers::v1::KeyProvisioningRole,
+    crypto::generate_instance_keys, launcher_client::LauncherClient, proto::oak::containers::v1::KeyProvisioningRole
 };
 use tokio_util::sync::CancellationToken;
 
@@ -56,78 +55,88 @@ async fn main() -> anyhow::Result<()> {
             .map_err(|error| anyhow!("couldn't create client: {:?}", error))?,
     );
 
+    // Get key provisioning role.
+    let key_provisioning_role = launcher_client
+        .get_key_provisioning_role()
+        .await
+        .map_err(|error| anyhow!("couldn't get key provisioning role: {:?}", error))?;
+
+    // Generate application keys.
+    let (instance_keys, instance_public_keys) = generate_instance_keys();
+    let (mut group_keys, group_public_keys) = if key_provisioning_role == KeyProvisioningRole::Leader {
+        let (group_keys, group_public_keys) = instance_keys.generate_group_keys();
+        (Some(Arc::new(group_keys)), Some(group_public_keys))
+    } else {
+        (None, None)
+    };
+
+    // Load application.
     let container_bundle = launcher_client
         .get_container_bundle()
         .await
         .map_err(|error| anyhow!("couldn't get container bundle: {:?}", error))?;
-
     let application_config = launcher_client
         .get_application_config()
         .await
         .map_err(|error| anyhow!("couldn't get application config: {:?}", error))?;
 
+    // Generate attestation evidence and send it to the Hostlib.
     let dice_builder = oak_containers_orchestrator::dice::load_stage1_dice_data()?;
     let additional_claims = oak_containers_orchestrator::dice::measure_container_and_config(
         &container_bundle,
         &application_config,
     );
-    let (instance_keys, instance_public_keys) = generate_instance_keys();
-
     let evidence = dice_builder.add_application_keys(
         additional_claims,
         &instance_public_keys.encryption_public_key,
         &instance_public_keys.signing_public_key,
+        if let Some(ref group_public_keys) = group_public_keys {
+            Some(&group_public_keys.encryption_public_key)
+        } else {
+            None
+        },
+        None,
     )?;
     launcher_client
         .send_attestation_evidence(evidence)
         .await
         .map_err(|error| anyhow!("couldn't send attestation evidence: {:?}", error))?;
+    
+    // Request group keys.
+    if key_provisioning_role == KeyProvisioningRole::Follower {
+        let get_group_keys_response = launcher_client
+                .get_group_keys()
+                .await
+                .map_err(|error| anyhow!("couldn't get group keys: {:?}", error))?;
+        let provisioned_group_keys = instance_keys
+            .provide_group_keys(get_group_keys_response)
+            .context("couldn't provide group keys")?;
+        group_keys =  Some(Arc::new(provisioned_group_keys));
+    }
 
     if let Some(path) = args.ipc_socket_path.parent() {
         tokio::fs::create_dir_all(path).await?;
     }
 
-    let key_provisioning_role = launcher_client
-        .get_key_provisioning_role()
-        .await
-        .map_err(|error| anyhow!("couldn't get key provisioning role: {:?}", error))?;
-    let group_keys = Arc::new(match key_provisioning_role {
-        KeyProvisioningRole::Unspecified => anyhow::bail!("unspecified key provisioning role"),
-        KeyProvisioningRole::Leader => {
-            // TODO(#4442): Sign group public keys in the enclave evidence.
-            let (group_keys, _) = instance_keys.generate_group_keys();
-            group_keys
-        }
-        KeyProvisioningRole::Dependant => {
-            let get_group_keys_response = launcher_client
-                .get_group_keys()
-                .await
-                .map_err(|error| anyhow!("couldn't get group keys: {:?}", error))?;
-            instance_keys
-                .provide_group_keys(get_group_keys_response)
-                .context("couldn't provide group keys")?
-        }
-    });
-
     let _metrics = oak_containers_orchestrator::metrics::run(launcher_client.clone())?;
 
+    // Start application and gRPC servers.
     let user = nix::unistd::User::from_name(&args.runtime_user)
         .context(format!("error resolving user {}", args.runtime_user))?
         .context(format!("user `{}` not found", args.runtime_user))?;
-
     let cancellation_token = CancellationToken::new();
     tokio::try_join!(
         oak_containers_orchestrator::ipc_server::create(
             &args.ipc_socket_path,
             instance_keys,
-            group_keys.clone(),
+            group_keys.clone().context("group keys were not provisioned")?,
             application_config,
             launcher_client,
             cancellation_token.clone(),
         ),
         oak_containers_orchestrator::key_provisioning::create(
             &args.orchestrator_addr,
-            group_keys,
+            group_keys.context("group keys were not provisioned")?,
             cancellation_token.clone(),
         ),
         oak_containers_orchestrator::container_runtime::run(

--- a/proto/attestation/evidence.proto
+++ b/proto/attestation/evidence.proto
@@ -92,7 +92,6 @@ message ApplicationKeys {
   // <https://www.rfc-editor.org/rfc/rfc8392.html>
   optional bytes group_encryption_public_key_certificate = 3;
 
-
   // Certificate signing the group signing public key as part of Key
   // Provisioning.
   //

--- a/proto/attestation/evidence.proto
+++ b/proto/attestation/evidence.proto
@@ -84,6 +84,21 @@ message ApplicationKeys {
   // Represented as a CBOR/COSE/CWT ECA certificate.
   // <https://www.rfc-editor.org/rfc/rfc8392.html>
   bytes signing_public_key_certificate = 2;
+
+  // Certificate signing the group encryption public key as part of Key
+  // Provisioning.
+  //
+  // Represented as a CBOR/COSE/CWT ECA certificate.
+  // <https://www.rfc-editor.org/rfc/rfc8392.html>
+  optional bytes group_encryption_public_key_certificate = 3;
+
+
+  // Certificate signing the group signing public key as part of Key
+  // Provisioning.
+  //
+  // Represented as a CBOR/COSE/CWT ECA certificate.
+  // <https://www.rfc-editor.org/rfc/rfc8392.html>
+  optional bytes group_signing_public_key_certificate = 4;
 }
 
 // Attestation Evidence used by the client to the identity of firmware and

--- a/proto/attestation/evidence.proto
+++ b/proto/attestation/evidence.proto
@@ -90,14 +90,14 @@ message ApplicationKeys {
   //
   // Represented as a CBOR/COSE/CWT ECA certificate.
   // <https://www.rfc-editor.org/rfc/rfc8392.html>
-  optional bytes group_encryption_public_key_certificate = 3;
+  bytes group_encryption_public_key_certificate = 3;
 
   // Certificate signing the group signing public key as part of Key
   // Provisioning.
   //
   // Represented as a CBOR/COSE/CWT ECA certificate.
   // <https://www.rfc-editor.org/rfc/rfc8392.html>
-  optional bytes group_signing_public_key_certificate = 4;
+  bytes group_signing_public_key_certificate = 4;
 }
 
 // Attestation Evidence used by the client to the identity of firmware and

--- a/proto/containers/hostlib_key_provisioning.proto
+++ b/proto/containers/hostlib_key_provisioning.proto
@@ -24,7 +24,7 @@ import "proto/key_provisioning/key_provisioning.proto";
 enum KeyProvisioningRole {
   KEY_PROVISIONING_ROLE_UNSPECIFIED = 0;
   LEADER = 1;
-  DEPENDANT = 2;
+  FOLLOWER = 2;
 }
 
 message GetKeyProvisioningRoleResponse {
@@ -40,11 +40,11 @@ service HostlibKeyProvisioning {
   // Get the enclave role for Key Provisioning.
   // Could be one of the following:
   //   - Leader that generates group keys and distributes them.
-  //   - Dependant that requests group keys from the leader.
+  //   - Follower that requests group keys from the leader.
   rpc GetKeyProvisioningRole(google.protobuf.Empty) returns (GetKeyProvisioningRoleResponse) {}
 
   // Get enclave group keys to the enclave as part of Key Provisioning.
-  // This method is only called by the Dependant Orchestrator.
+  // This method is only called by the Follower Orchestrator.
   //
   // This method must be called after `oak.containers.Launcher.SendAttestationEvidence`, because
   // Hostlib needs to have the Attestation Evidence in order to request group keys from the leader.


### PR DESCRIPTION
This PR adds the ability to sign group keys in the attestation evidence as part of Key Provisioning.

Ref https://github.com/project-oak/oak/issues/4442