### PR TITLE
Add rust-hypervisor-firmware-virtio to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ members = [
   "stage0",
   "stage0_dice",
   "testing/oak_echo_service",
+  "third_party/rust-hypervisor-firmware-virtio",
   "xtask",
   "oak_restricted_kernel_sdk_proc_macro",
 ]
@@ -74,7 +75,6 @@ exclude = [
   "testing/oak_echo_app",
   "testing/oak_echo_raw_app",
   "testing/sev_snp_hello_world_kernel",
-  "third_party/rust-hypervisor-firmware-virtio",
 ]
 
 # Special version of release that enables more aggressive optimizations.


### PR DESCRIPTION
Without this, trying to do a bazel sync of the whole workspace fails
with:

```
Error: The package 'Name("rust-hypervisor-firmware-virtio") Version {
major: 0, minor: 1, patch: 0 }' has no source info so no annotation can
be made
```
