### PR TITLE
Ensure CPUID triggered the #VC exception

### DIFF
--- a/oak_restricted_kernel/src/interrupts.rs
+++ b/oak_restricted_kernel/src/interrupts.rs
@@ -116,8 +116,7 @@ mutable_interrupt_handler_with_error_code!(
                 let instruction: u16 =
                     unsafe { core::ptr::read_unaligned(stack_frame.rip.as_ptr()) };
                 if instruction != CPUID_INSTRUCTION {
-                    error!("KERNEL PANIC: INSTRUCTION WAS NOT CPUID");
-                    shutdown::shutdown();
+                    panic!("INSTRUCTION WAS NOT CPUID");
                 }
 
                 if let Some(cpuid_page) = CPUID_PAGE.get() {

--- a/oak_restricted_kernel/src/interrupts.rs
+++ b/oak_restricted_kernel/src/interrupts.rs
@@ -108,6 +108,18 @@ mutable_interrupt_handler_with_error_code!(
     ) {
         match error_code {
             0x72 => {
+                // Make sure it was triggered from a CPUID instruction.
+                const CPUID_INSTRUCTION: u16 = 0xa20f;
+                // Safety: we are copying two bytes and interpreting it as a
+                // 16-bit number without making any other assumptions about
+                // the layout.
+                let instruction: u16 =
+                    unsafe { core::ptr::read_unaligned(stack_frame.rip.as_ptr()) };
+                if instruction != CPUID_INSTRUCTION {
+                    error!("KERNEL PANIC: INSTRUCTION WAS NOT CPUID");
+                    shutdown::shutdown();
+                }
+
                 if let Some(cpuid_page) = CPUID_PAGE.get() {
                     let target = stack_frame.into();
                     let count = cpuid_page.count as usize;


### PR DESCRIPTION
We want to make sure that the instruction pointer in a #VC exception really pointed to a CPUID instruction since it is the only #VC exception type we support.

This is the equivalent of #4921 but for the restricted kernel.

Thanks to @benschlueter for highlighting the issue and suggesting a fix.