### PR TITLE
Directly issue kernel provenance for attestation measurements

### DIFF
--- a/buildconfigs/oak_restricted_kernel_simple_io_init_rd_wrapper.toml
+++ b/buildconfigs/oak_restricted_kernel_simple_io_init_rd_wrapper.toml
@@ -6,4 +6,4 @@ command = [
   "just",
   "oak_restricted_kernel_simple_io_init_rd_wrapper",
 ]
-artifact_path = "./oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_init_rd_wrapper_bin"
+artifact_path = "./oak_restricted_kernel_wrapper/target/released_bin_with_components_oak_restricted_kernel_simple_io_init_rd/*"

--- a/justfile
+++ b/justfile
@@ -26,6 +26,15 @@ oak_restricted_kernel_bin:
 _wrap_kernel kernel_bin_prefix:
     env --chdir=oak_restricted_kernel_wrapper OAK_RESTRICTED_KERNEL_FILE_NAME={{kernel_bin_prefix}}_bin cargo build --release
     rust-objcopy --output-target=binary oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_wrapper oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_bin_prefix}}_wrapper_bin
+    rm -rf oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}
+    mkdir -p oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}
+    cp \
+        oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_bin_prefix}}_wrapper_bin \
+        oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/bzimage
+    cargo run --package oak_kernel_measurement -- \
+        --kernel=oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/bzimage \
+        --kernel-setup-data-output=oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/kernel_setup_data \
+        --kernel-image-output=oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/kernel_image
 
 oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
     just _wrap_kernel oak_restricted_kernel

--- a/oak_kernel_measurement/src/main.rs
+++ b/oak_kernel_measurement/src/main.rs
@@ -29,9 +29,9 @@ const DEFAULT_LINUX_KERNEL: &str = "oak_containers_kernel/target/bzImage";
 struct Cli {
     #[arg(long, help = "The location of the kernel bzImage file")]
     kernel: Option<PathBuf>,
-    #[arg(long, help = "The location of to output the extracted kernel setup data file to")]
+    #[arg(long, help = "The location of output the extracted kernel setup data file to")]
     kernel_setup_data_output: Option<PathBuf>,
-    #[arg(long, help = "The location of to output the extracted kernel image file to")]
+    #[arg(long, help = "The location of output the extracted kernel image file to")]
     kernel_image_output: Option<PathBuf>,
 }
 

--- a/oak_kernel_measurement/src/main.rs
+++ b/oak_kernel_measurement/src/main.rs
@@ -29,6 +29,10 @@ const DEFAULT_LINUX_KERNEL: &str = "oak_containers_kernel/target/bzImage";
 struct Cli {
     #[arg(long, help = "The location of the kernel bzImage file")]
     kernel: Option<PathBuf>,
+    #[arg(long, help = "The location of to output the extracted kernel setup data file to")]
+    kernel_setup_data_output: Option<PathBuf>,
+    #[arg(long, help = "The location of to output the extracted kernel image file to")]
+    kernel_image_output: Option<PathBuf>,
 }
 
 impl Cli {
@@ -50,6 +54,14 @@ fn main() -> anyhow::Result<()> {
     let mut setup_hasher = Sha256::new();
     setup_hasher.update(&kernel_info.setup_data);
     println!("Kernel Setup Data Measurement: sha2-256:{}", hex::encode(setup_hasher.finalize()));
+
+    if let Some(path) = cli.kernel_setup_data_output {
+        std::fs::write(path, kernel_info.setup_data).context("couldn't write kernel setup data")?;
+    }
+
+    if let Some(path) = cli.kernel_image_output {
+        std::fs::write(path, kernel_info.kernel_image).context("couldn't write kernel image")?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Previously the provenance created by the SLSA builder was just for the bzImage. Not the artifact that would be measured in the attestation. With this PR the provenance subjects should include binaries measured in the attestation.

Change-Id: I16e3234d0d65e3790319294c416c378cd7611681

http://b/332723461