### PR TITLE
PVALIDATE and initialize the legacy SMBIOS range

### DIFF
--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -589,7 +589,7 @@ pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
                 && entry.size() == 0x1_0000
                 && entry.entry_type() == Some(E820EntryType::RESERVED)
         })
-        .unwrap();
+        .expect("couldn't find legacy SMBOIS memory range");
 
     // Pvalidate the legacy SMBIOS range since legacy code may scan this range for
     // the SMBIOS entry point table, even if the range is marked as reserved.

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -589,7 +589,7 @@ pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
                 && entry.size() == 0x1_0000
                 && entry.entry_type() == Some(E820EntryType::RESERVED)
         })
-        .expect("couldn't find legacy SMBOIS memory range");
+        .expect("couldn't find legacy SMBIOS memory range");
 
     // Pvalidate the legacy SMBIOS range since legacy code may scan this range for
     // the SMBIOS entry point table, even if the range is marked as reserved.

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -587,7 +587,7 @@ pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
         .find(|entry| {
             entry.addr() == 0xF_0000
                 && entry.size() == 0x1_0000
-                && entry.entry_type() != Some(E820EntryType::RESERVED)
+                && entry.entry_type() == Some(E820EntryType::RESERVED)
         })
         .unwrap();
 

--- a/stage0/src/sev.rs
+++ b/stage0/src/sev.rs
@@ -513,17 +513,8 @@ pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
     // the RMP for the fw_cfg DMA buffer.
     let min_addr = 0xA0000;
 
-    // Locate the legacy SMBIOS range in the E820 table and verify it has the
-    // correct size.
-    let legacy_smbios_range_start_addr = 0xF0000;
-    let mut legacy_smbios_range_size = 0;
-
     for entry in e820_table {
-        if entry.addr() == legacy_smbios_range_start_addr
-            && entry.entry_type() == Some(E820EntryType::RESERVED)
-        {
-            legacy_smbios_range_size = entry.size();
-        } else if entry.entry_type() != Some(E820EntryType::RAM) || entry.addr() < min_addr {
+        if entry.entry_type() != Some(E820EntryType::RAM) || entry.addr() < min_addr {
             continue;
         }
 
@@ -589,17 +580,24 @@ pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
         }
     }
 
-    // Sanity check that we have a valid legacy SMBIOS range entry in the E820
-    // table.
-    assert!(legacy_smbios_range_size == 0x1_0000);
+    // Locate the legacy SMBIOS range [0xF_0000, 0x10_0000) in the E820 table.
+    // Unwrap() will panic if entry not found with expected start, size, and type.
+    let legacy_smbios_range_entry = e820_table
+        .iter()
+        .find(|entry| {
+            entry.addr() == 0xF_0000
+                && entry.size() == 0x1_0000
+                && entry.entry_type() != Some(E820EntryType::RESERVED)
+        })
+        .unwrap();
 
     // Pvalidate the legacy SMBIOS range since legacy code may scan this range for
     // the SMBIOS entry point table, even if the range is marked as reserved.
     let range = PhysFrame::<Size4KiB>::range(
-        PhysFrame::from_start_address(PhysAddr::new(legacy_smbios_range_start_addr as u64))
+        PhysFrame::from_start_address(PhysAddr::new(legacy_smbios_range_entry.addr() as u64))
             .unwrap(),
         PhysFrame::from_start_address(PhysAddr::new(
-            (legacy_smbios_range_start_addr + legacy_smbios_range_size) as u64,
+            (legacy_smbios_range_entry.addr() + legacy_smbios_range_entry.size()) as u64,
         ))
         .unwrap(),
     );
@@ -608,8 +606,8 @@ pub fn validate_memory(e820_table: &[BootE820Entry], encrypted: u64) {
     // Safety: the E820 table indicates that this is the correct memory segment.
     let legacy_smbios_range_bytes = unsafe {
         core::slice::from_raw_parts_mut::<u8>(
-            legacy_smbios_range_start_addr as *mut u8,
-            legacy_smbios_range_size,
+            legacy_smbios_range_entry.addr() as *mut u8,
+            legacy_smbios_range_entry.size(),
         )
     };
     // Zeroize the legacy SMBIOS range bytes to avoid legacy code reading garbage.

--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -149,11 +149,13 @@ impl ZeroPage {
         self.validate_e820_table();
 
         // Carve out a chunk of memory for the ACPI area in the range
-        // [0x80000-0xA0000). We also remove the region [0xA0000,0x100000)
+        // [0x80000-0xA0000). We also remove the region [0xA0000,0xF0000)
         // since historically this contained hardware-related regions such as
-        // the VGA bios rom.
+        // the VGA bios rom. Finally, reserve [0xF0000,0x100000) as Stage0
+        // initializes this memory to handle legacy scans of the SMBIOS range.
         self.insert_e820_entry(BootE820Entry::new(0x8_0000, 0x2_0000, E820EntryType::ACPI));
-        self.ensure_e820_gap(0xA_0000, 0x6_0000);
+        self.ensure_e820_gap(0xA_0000, 0x5_0000);
+        self.insert_e820_entry(BootE820Entry::new(0xF_0000, 0x1_0000, E820EntryType::RESERVED));
 
         for entry in self.inner.e820_table() {
             log::debug!(


### PR DESCRIPTION
Linux commit 0f4a1e80989a ("x86/sev: Skip ROM range scans and validation for SEV-SNP guests") removes Linux's attempt to PVALIDATE the legacy ROM regions, including the legacy SMBIOS range [0xf0000, 0x100000). However, legacy code may still attempt to scan this range when using non-EFI firmware such as Stage0.

To avoid a crash during guest boot, PVALIDATE the range in Stage0.

To avoid legacy code reading garbage from this region, initialize the PVALIDATEd memory to 0.