### PR TITLE
Temporarily limit kernel command line length in Stage0 measurements

### DIFF
--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -518,7 +518,10 @@ fn verify_kernel_layer(
     )
     .context("kernel failed verification")?;
 
-    if let Some(kernel_raw_cmd_line) = values.kernel_raw_cmd_line.as_ref() {
+    // TODO(#4981): Remove temporary workaround for command line length limit.
+    if let Some(kernel_raw_cmd_line) = values.kernel_raw_cmd_line.as_ref()
+        && kernel_raw_cmd_line.len() < 256
+    {
         verify_text(
             now_utc_millis,
             kernel_raw_cmd_line.as_str(),
@@ -530,7 +533,7 @@ fn verify_kernel_layer(
         )
         .context("kernel command line failed verification")?;
     } else {
-        // Support missing kernel_raw_cmd_line but only if the corresponding reference
+        // Support invalid kernel_raw_cmd_line but only if the corresponding reference
         // value is set to skip. This is a temporary workaround until all clients are
         // migrated.
         anyhow::ensure!(
@@ -543,7 +546,7 @@ fn verify_kernel_layer(
                     .as_ref(),
                 Some(text_reference_value::Type::Skip(_))
             ),
-            "No kernel_raw_cmd_line provided"
+            "No valid kernel_raw_cmd_line provided"
         )
     }
 

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -518,8 +518,7 @@ fn verify_kernel_layer(
     )
     .context("kernel failed verification")?;
 
-    // TODO: b/331252282 - Remove temporary workaround for command line length
-    // limit.
+    // TODO: b/331252282 - Remove temporary workaround for cmd line.
     if let Some(kernel_raw_cmd_line) = values.kernel_raw_cmd_line.as_ref()
         && kernel_raw_cmd_line.len() < 256
     {

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -518,7 +518,7 @@ fn verify_kernel_layer(
     )
     .context("kernel failed verification")?;
 
-    // TODO(#4981): Remove temporary workaround for command line length limit.
+    // TODO: b/331252282 - Remove temporary workaround for command line length limit.
     if let Some(kernel_raw_cmd_line) = values.kernel_raw_cmd_line.as_ref()
         && kernel_raw_cmd_line.len() < 256
     {

--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -518,7 +518,8 @@ fn verify_kernel_layer(
     )
     .context("kernel failed verification")?;
 
-    // TODO: b/331252282 - Remove temporary workaround for command line length limit.
+    // TODO: b/331252282 - Remove temporary workaround for command line length
+    // limit.
     if let Some(kernel_raw_cmd_line) = values.kernel_raw_cmd_line.as_ref()
         && kernel_raw_cmd_line.len() < 256
     {

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -308,7 +308,7 @@ pub fn rust64_start(encrypted: u64) -> ! {
     log::debug!("ACPI table generation digest: sha2-256:{}", hex::encode(acpi_sha2_256_digest));
     log::debug!("E820 table digest: sha2-256:{}", hex::encode(memory_map_sha2_256_digest));
 
-    // TODO(#4981): Remove temporary workaround for command line length limit.
+    // TODO: b/331252282 - Remove temporary workaround for command line length limit.
     let cmdline_max_len = 256;
     let measurements = oak_stage0_dice::Measurements {
         acpi_sha2_256_digest,

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -308,8 +308,7 @@ pub fn rust64_start(encrypted: u64) -> ! {
     log::debug!("ACPI table generation digest: sha2-256:{}", hex::encode(acpi_sha2_256_digest));
     log::debug!("E820 table digest: sha2-256:{}", hex::encode(memory_map_sha2_256_digest));
 
-    // TODO: b/331252282 - Remove temporary workaround for command line length
-    // limit.
+    // TODO: b/331252282 - Remove temporary workaround for cmd line length.
     let cmdline_max_len = 256;
     let measurements = oak_stage0_dice::Measurements {
         acpi_sha2_256_digest,

--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -308,7 +308,8 @@ pub fn rust64_start(encrypted: u64) -> ! {
     log::debug!("ACPI table generation digest: sha2-256:{}", hex::encode(acpi_sha2_256_digest));
     log::debug!("E820 table digest: sha2-256:{}", hex::encode(memory_map_sha2_256_digest));
 
-    // TODO: b/331252282 - Remove temporary workaround for command line length limit.
+    // TODO: b/331252282 - Remove temporary workaround for command line length
+    // limit.
     let cmdline_max_len = 256;
     let measurements = oak_stage0_dice::Measurements {
         acpi_sha2_256_digest,


### PR DESCRIPTION
As a temporary workaround for #4981, limit the kernel command line included in the Stage0 DICE measurements to 256 chars.