### PR TITLE
Try using the same wildcard as slsa to fix workflow issue

### DIFF
--- a/buildconfigs/oak_restricted_kernel_simple_io_init_rd_wrapper.toml
+++ b/buildconfigs/oak_restricted_kernel_simple_io_init_rd_wrapper.toml
@@ -6,4 +6,4 @@ command = [
   "just",
   "oak_restricted_kernel_simple_io_init_rd_wrapper",
 ]
-artifact_path = "./oak_restricted_kernel_wrapper/target/released_bin_with_components_oak_restricted_kernel_simple_io_init_rd/*"
+artifact_path = "./oak_restricted_kernel_wrapper/target/released_bin_with_components_oak_restricted_kernel_simple_io_init_rd/*.bin"

--- a/justfile
+++ b/justfile
@@ -30,11 +30,11 @@ _wrap_kernel kernel_bin_prefix:
     mkdir -p oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}
     cp \
         oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/{{kernel_bin_prefix}}_wrapper_bin \
-        oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/bzimage
+        oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/bzimage.bin
     cargo run --package oak_kernel_measurement -- \
-        --kernel=oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/bzimage \
-        --kernel-setup-data-output=oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/kernel_setup_data \
-        --kernel-image-output=oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/kernel_image
+        --kernel=oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/bzimage.bin \
+        --kernel-setup-data-output=oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/kernel_setup_data.bin \
+        --kernel-image-output=oak_restricted_kernel_wrapper/target/released_bin_with_components_{{kernel_bin_prefix}}/kernel_image.bin
 
 oak_restricted_kernel_wrapper: oak_restricted_kernel_bin
     just _wrap_kernel oak_restricted_kernel


### PR DESCRIPTION
current workflow breaks: https://github.com/project-oak/oak/actions/runs/8544823048/job/23412049549, while slsa's wildcard workflow succeeds: https://github.com/slsa-framework/example-package/blob/e51524d7e65531856d3028bff6b1ac846ea85913/.github/configs-docker/app-config.toml . Maybe it's that we use more exhaustive wildcard. Worth trying if it fixes it.

There's some other issues to resolve from https://github.com/project-oak/oak/pull/4976 we'll get to them if and once this works

Change-Id: I0b13863f30a7cd6778997f174dfbcdc634ffac8b