### PR TITLE
Update slsa builder version to see if it fixes the broken workflow

### DIFF
--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -77,7 +77,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml@v1.9.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml@v1.10.0
     with:
       builder-image: 'europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development'
       builder-digest: ${{ needs.get_inputs.outputs.builder-digest }}


### PR DESCRIPTION
current workflow breaks: https://github.com/project-oak/oak/actions/runs/8544823048/job/23412049549, while slsa's wildcard workflow succeeds: https://github.com/slsa-framework/example-package/blob/e51524d7e65531856d3028bff6b1ac846ea85913/.github/configs-docker/app-config.toml . Maybe it's that we use an older version. Worth trying if updating fixes it.

There's some other issues to resolve from https://github.com/project-oak/oak/pull/4976 we'll get to them if and once this works

Change-Id: I82cc4a7194980d71318b12e0eeb8f35d6d1f2711