### PR TITLE
Split the verify_kernel_measurement_data into get_expected/compare

### DIFF
--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -16,7 +16,7 @@
 
 //! Provides verification based on evidence, endorsements and reference values.
 
-use alloc::{format, string::String, vec, vec::Vec};
+use alloc::{format, string::String, vec::Vec};
 
 use anyhow::Context;
 use coset::{cbor::Value, cwt::ClaimsSet, CborSerializable, CoseKey, RegisteredLabelWithPrivate};
@@ -38,11 +38,12 @@ use oak_proto_rust::oak::{
         ApplicationLayerExpectedValues, ApplicationLayerReferenceValues, AttestationResults,
         BinaryReferenceValue, CbData, CbEndorsements, CbReferenceValues, ContainerLayerData,
         ContainerLayerEndorsements, ContainerLayerExpectedValues, ContainerLayerReferenceValues,
-        Endorsements, Evidence, ExpectedDigests, ExtractedEvidence, FakeAttestationReport,
-        InsecureReferenceValues, IntelTdxAttestationReport, IntelTdxReferenceValues,
-        KernelAttachment, KernelBinaryReferenceValue, KernelLayerData, KernelLayerEndorsements,
-        KernelLayerReferenceValues, OakContainersData, OakContainersEndorsements,
-        OakContainersReferenceValues, OakRestrictedKernelData, OakRestrictedKernelEndorsements,
+        EndorsementReferenceValue, Endorsements, Evidence, ExpectedDigests, ExtractedEvidence,
+        FakeAttestationReport, InsecureReferenceValues, IntelTdxAttestationReport,
+        IntelTdxReferenceValues, KernelAttachment, KernelBinaryReferenceValue,
+        KernelExpectedValues, KernelLayerData, KernelLayerEndorsements, KernelLayerReferenceValues,
+        OakContainersData, OakContainersEndorsements, OakContainersReferenceValues,
+        OakRestrictedKernelData, OakRestrictedKernelEndorsements,
         OakRestrictedKernelReferenceValues, RawDigests, ReferenceValues, RootLayerData,
         RootLayerEndorsements, RootLayerEvidence, RootLayerReferenceValues, SystemLayerData,
         SystemLayerEndorsements, SystemLayerExpectedValues, SystemLayerReferenceValues, TcbVersion,
@@ -519,14 +520,25 @@ fn verify_kernel_layer(
     endorsements: Option<&KernelLayerEndorsements>,
     reference_values: &KernelLayerReferenceValues,
 ) -> anyhow::Result<()> {
-    verify_kernel_measurement_digest(
-        values.kernel_image.as_ref().context("no kernel evidence value")?,
-        values.kernel_setup_data.as_ref().context("no kernel setup data evidence value")?,
+    let expected = get_kernel_expected_values(
         now_utc_millis,
         endorsements.and_then(|value| value.kernel.as_ref()),
         reference_values.kernel.as_ref().context("no kernel reference value")?,
+    )?;
+    compare_measurement_digest(
+        values.kernel_image.as_ref().context("no kernel evidence value")?,
+        &expected
+            .image
+            .ok_or_else(|| anyhow::anyhow!("expected values contained no image digests"))?,
     )
-    .context("kernel failed verification")?;
+    .context("kernel image failed verification")?;
+    compare_measurement_digest(
+        values.kernel_setup_data.as_ref().context("no kernel setup data evidence value")?,
+        &expected
+            .setup_data
+            .ok_or_else(|| anyhow::anyhow!("expected values contained no setup_data digests"))?,
+    )
+    .context("kernel setup data failed verification")?;
 
     if let Some(kernel_raw_cmd_line) = values.kernel_raw_cmd_line.as_ref() {
         verify_text(
@@ -709,23 +721,22 @@ fn get_expected_measurement_digest(
                 &public_keys.endorser_public_key,
                 &public_keys.rekor_public_key,
             )?;
-            Ok(ExpectedDigests {
-                r#type: Some(expected_digests::Type::Digests(RawDigests {
-                    digests: vec![hex_to_raw_digest(&get_digest(&parse_endorsement_statement(
-                        &endorsement.endorsement,
-                    )?)?)?],
-                })),
-            })
+            Ok(into_expected_digests(&[hex_to_raw_digest(&get_digest(
+                &parse_endorsement_statement(&endorsement.endorsement)?,
+            )?)?]))
         }
-        Some(binary_reference_value::Type::Digests(expected_digests)) => Ok(ExpectedDigests {
-            r#type: Some(expected_digests::Type::Digests(RawDigests {
-                digests: expected_digests.digests.clone(),
-            })),
-        }),
+        Some(binary_reference_value::Type::Digests(expected_digests)) => {
+            Ok(into_expected_digests(&expected_digests.digests))
+        }
         None => Err(anyhow::anyhow!("empty binary reference value")),
     }
 }
 
+fn into_expected_digests(source: &[RawDigest]) -> ExpectedDigests {
+    ExpectedDigests {
+        r#type: Some(expected_digests::Type::Digests(RawDigests { digests: source.to_vec() })),
+    }
+}
 /// Verifies the measurement digest value against a reference value and
 /// the expected digests calculated from endorsements and reference values.
 fn compare_measurement_digest(
@@ -744,77 +755,88 @@ fn compare_measurement_digest(
     }
 }
 
-/// Adapted version of verify_measure_digest() for kernels.
-fn verify_kernel_measurement_digest(
-    image_measurement: &RawDigest,
-    setup_data_measurement: &RawDigest,
+// Extract the KernelAttachment data from the provided Endorsement
+// It will only be returned if the endorsement was verified.
+fn get_verified_kernel_attachment(
+    now_utc_millis: i64,
+    endorsement: Option<&TransparentReleaseEndorsement>,
+    public_keys: &EndorsementReferenceValue,
+) -> anyhow::Result<KernelAttachment> {
+    let endorsement = endorsement.context("matching endorsement not found for reference value")?;
+    verify_binary_endorsement(
+        now_utc_millis,
+        &endorsement.endorsement,
+        &endorsement.endorsement_signature,
+        &endorsement.rekor_log_entry,
+        &public_keys.endorser_public_key,
+        &public_keys.rekor_public_key,
+    )?;
+    // Parse endorsement statement and verify attachment digest.
+    let parsed_statement = parse_endorsement_statement(&endorsement.endorsement)?;
+    if parsed_statement.predicate.usage != "kernel" {
+        anyhow::bail!("unexpected endorsement usage");
+    }
+    let expected_digest = get_digest(&parsed_statement)?;
+    let actual_digest = raw_to_hex_digest(&raw_digest_from_contents(&endorsement.subject));
+    verify_hex_digests(&actual_digest, &expected_digest)?;
+    KernelAttachment::decode(&*endorsement.subject)
+        .map_err(|_| anyhow::anyhow!("couldn't parse kernel attachment"))
+}
+
+// Get the expected values from the provided TransportReleaseEndorsement.
+// The endorsement is expected to contain a subject that can be deserialized as
+// a KernelAttachment.
+// The subject itself will be verified, and then the image and setup_data
+// expected values will be returned.
+// Subsequent callers can provide just the cached image and setup_data digests.
+fn get_kernel_expected_values(
     now_utc_millis: i64,
     endorsement: Option<&TransparentReleaseEndorsement>,
     reference_value: &KernelBinaryReferenceValue,
-) -> anyhow::Result<()> {
-    let actual_image = raw_to_hex_digest(image_measurement);
-    let actual_setup_data = raw_to_hex_digest(setup_data_measurement);
+) -> anyhow::Result<KernelExpectedValues> {
     match reference_value.r#type.as_ref() {
-        Some(kernel_binary_reference_value::Type::Skip(_)) => Ok(()),
+        Some(kernel_binary_reference_value::Type::Skip(_)) => Ok(KernelExpectedValues {
+            image: Some(ExpectedDigests {
+                r#type: Some(expected_digests::Type::Skipped(VerificationSkipped {})),
+            }),
+            setup_data: Some(ExpectedDigests {
+                r#type: Some(expected_digests::Type::Skipped(VerificationSkipped {})),
+            }),
+        }),
         Some(kernel_binary_reference_value::Type::Endorsement(public_keys)) => {
-            let endorsement =
-                endorsement.context("matching endorsement not found for reference value")?;
-            verify_binary_endorsement(
-                now_utc_millis,
-                &endorsement.endorsement,
-                &endorsement.endorsement_signature,
-                &endorsement.rekor_log_entry,
-                &public_keys.endorser_public_key,
-                &public_keys.rekor_public_key,
-            )?;
-            // Parse endorsement statement and verify attachment digest.
-            let parsed_statement = parse_endorsement_statement(&endorsement.endorsement)?;
-            if parsed_statement.predicate.usage != "kernel" {
-                anyhow::bail!("unexpected endorsement usage");
-            }
-            let expected_digest = get_digest(&parsed_statement)?;
-            let actual_digest = raw_to_hex_digest(&raw_digest_from_contents(&endorsement.subject));
-            verify_hex_digests(&actual_digest, &expected_digest)?;
-
-            // Parse attachment and verify kernel components.
-            let kernel_attachment = KernelAttachment::decode(&*endorsement.subject)
-                .map_err(|_error| anyhow::anyhow!("couldn't parse kernel attachment"))?;
+            let kernel_attachment =
+                get_verified_kernel_attachment(now_utc_millis, endorsement, public_keys)?;
             let expected_image = kernel_attachment
                 .image
                 .ok_or_else(|| anyhow::anyhow!("no image digest in kernel attachment"))?;
             let expected_setup_data = kernel_attachment
                 .setup_data
                 .ok_or_else(|| anyhow::anyhow!("no setup data digest in kernel attachment"))?;
-            verify_hex_digests(&actual_image, &expected_image)?;
-            verify_hex_digests(&actual_setup_data, &expected_setup_data)
+
+            Ok(KernelExpectedValues {
+                image: Some(into_expected_digests(&[hex_to_raw_digest(&expected_image)?])),
+                setup_data: Some(into_expected_digests(&[hex_to_raw_digest(
+                    &expected_setup_data,
+                )?])),
+            })
         }
         Some(kernel_binary_reference_value::Type::Digests(expected_digests)) => {
-            if !expected_digests
-                .image
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("no kernel image digests specified"))?
-                .digests
-                .iter()
-                .any(|expected| {
-                    verify_hex_digests(&actual_image, &raw_to_hex_digest(expected)).is_ok()
-                })
-            {
-                anyhow::bail!("measurement digest does not match any reference values")
-            }
-            if !expected_digests
-                .setup_data
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("no kernel setup data digests specified"))?
-                .digests
-                .iter()
-                .any(|expected| {
-                    verify_hex_digests(&actual_setup_data, &raw_to_hex_digest(expected)).is_ok()
-                })
-            {
-                anyhow::bail!("measurement digest does not match any reference values")
-            }
-
-            Ok(())
+            Ok(KernelExpectedValues {
+                image: Some(into_expected_digests(
+                    &expected_digests
+                        .image
+                        .as_ref()
+                        .ok_or_else(|| anyhow::anyhow!("no image digests provided"))?
+                        .digests,
+                )),
+                setup_data: Some(into_expected_digests(
+                    &expected_digests
+                        .setup_data
+                        .as_ref()
+                        .ok_or_else(|| anyhow::anyhow!("no setup_data digests provided"))?
+                        .digests,
+                )),
+            })
         }
         None => Err(anyhow::anyhow!("empty binary reference value")),
     }

--- a/proto/attestation/expected_value.proto
+++ b/proto/attestation/expected_value.proto
@@ -43,6 +43,16 @@ message ExpectedDigests {
   }
 }
 
+// The expected values for kernel image and setup data, computed from previously
+// provided endorsements and reference values.
+message KernelExpectedValues {
+  // Allowable digests for the image.
+  ExpectedDigests image = 1;
+
+  // Allowable digests for the setup data.
+  ExpectedDigests setup_data = 2;
+}
+
 // The expected binary digests for a system layer image.
 message SystemLayerExpectedValues {
   // The allowable digest values for a system layer image.


### PR DESCRIPTION
This change is similar to the verify_measurement_digest split, but the
retrieval of reference values is a bit different, since they come from
the endorsement subject as serialized KernelAttachment data, and the
endorsement subject itself must be verified.

Subsequent verifications can use the cached image and setup_data value,
so the subject endorsement remains totally encapsulated in the
get_verified_kernel_attachment helper function; the expected values from
the endorsement itself does not need to be returned to the client.

Another step for b/324837692
