### PR TITLE
Resolve transparent release binary filename issues

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,11 +40,11 @@ _wrap_kernel kernel_bin_prefix:
     env --chdir="${OAK_WRAPPER_DIR}" OAK_RESTRICTED_KERNEL_FILE_NAME="${KERNEL_BIN_PREFIX}_bin" cargo build --release
 
     # Copy the kernel binary to the designated location.
-    rust-objcopy --output-target=binary "${KERNEL_BIN_PATH}" "${BIN_DIR}/${KERNEL_BIN_PREFIX}_bzimage"
+    rust-objcopy --output-target=binary "${KERNEL_BIN_PATH}" "${BIN_DIR}/${KERNEL_BIN_PREFIX}_wrapper_bin"
 
     # Process the kernel binary using oak_kernel_measurement.
     cargo run --package oak_kernel_measurement -- \
-        --kernel="${BIN_DIR}/${KERNEL_BIN_PREFIX}_bzimage" \
+        --kernel="${BIN_DIR}/${KERNEL_BIN_PREFIX}_wrapper_bin" \
         --kernel-setup-data-output="${BIN_DIR}/${KERNEL_BIN_PREFIX}_setup_data" \
         --kernel-image-output="${BIN_DIR}/${KERNEL_BIN_PREFIX}_image"
 

--- a/justfile
+++ b/justfile
@@ -43,7 +43,6 @@ _wrap_kernel kernel_bin_prefix:
     rust-objcopy --output-target=binary "${KERNEL_BIN_PATH}" "${BIN_DIR}/${KERNEL_BIN_PREFIX}_bzimage"
 
     # Process the kernel binary using oak_kernel_measurement.
-    echo "Processing the kernel binary..."
     cargo run --package oak_kernel_measurement -- \
         --kernel="${BIN_DIR}/${KERNEL_BIN_PREFIX}_bzimage" \
         --kernel-setup-data-output="${BIN_DIR}/${KERNEL_BIN_PREFIX}_setup_data" \

--- a/kokoro/build_binaries_rust.sh
+++ b/kokoro/build_binaries_rust.sh
@@ -30,8 +30,8 @@ touch "${KOKORO_ARTIFACTS_DIR}/binaries/git_commit_${KOKORO_GIT_COMMIT_oak:?}"
 # Copy the generated binaries to Placer. The timestamps are used to convey
 # the creation time.
 readonly generated_binaries=(
-    ./oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_wrapper_bin
-    ./oak_restricted_kernel_wrapper/target/x86_64-unknown-none/release/oak_restricted_kernel_simple_io_init_rd_wrapper_bin
+    ./oak_restricted_kernel_wrapper/bin/oak_restricted_kernel_simple_io/oak_restricted_kernel_simple_io_bzimage
+    ./oak_restricted_kernel_wrapper/bin/oak_restricted_kernel_simple_io_init_rd/oak_restricted_kernel_simple_io_init_rd_bzimage
     ./oak_restricted_kernel_wrapper/cmd_line_regex.txt
     ./stage0_bin/target/x86_64-unknown-none/release/stage0_bin
     ./enclave_apps/target/x86_64-unknown-none/release/key_xor_test_app
@@ -42,8 +42,8 @@ readonly generated_binaries=(
     ./enclave_apps/target/x86_64-unknown-none/release/oak_orchestrator
 )
 readonly binary_names=(
-    oak_restricted_kernel_simple_io_wrapper_bin
-    oak_restricted_kernel_simple_io_init_rd_wrapper_bin
+    oak_restricted_kernel_simple_io_bzimage
+    oak_restricted_kernel_simple_io_init_rd_bzimage
     oak_restricted_kernel_simple_io_wrapper_cmd_line_regex
     stage0_bin
     key_xor_test_app

--- a/kokoro/build_binaries_rust.sh
+++ b/kokoro/build_binaries_rust.sh
@@ -30,8 +30,8 @@ touch "${KOKORO_ARTIFACTS_DIR}/binaries/git_commit_${KOKORO_GIT_COMMIT_oak:?}"
 # Copy the generated binaries to Placer. The timestamps are used to convey
 # the creation time.
 readonly generated_binaries=(
-    ./oak_restricted_kernel_wrapper/bin/oak_restricted_kernel_simple_io/oak_restricted_kernel_simple_io_bzimage
-    ./oak_restricted_kernel_wrapper/bin/oak_restricted_kernel_simple_io_init_rd/oak_restricted_kernel_simple_io_init_rd_bzimage
+    ./oak_restricted_kernel_wrapper/bin/oak_restricted_kernel_simple_io/oak_restricted_kernel_simple_io_init_rd_wrapper_bin
+    ./oak_restricted_kernel_wrapper/bin/oak_restricted_kernel_simple_io_init_rd/oak_restricted_kernel_simple_io_init_rd_wrapper_bin
     ./oak_restricted_kernel_wrapper/cmd_line_regex.txt
     ./stage0_bin/target/x86_64-unknown-none/release/stage0_bin
     ./enclave_apps/target/x86_64-unknown-none/release/key_xor_test_app

--- a/kokoro/build_binaries_rust.sh
+++ b/kokoro/build_binaries_rust.sh
@@ -42,8 +42,8 @@ readonly generated_binaries=(
     ./enclave_apps/target/x86_64-unknown-none/release/oak_orchestrator
 )
 readonly binary_names=(
-    oak_restricted_kernel_simple_io_bzimage
-    oak_restricted_kernel_simple_io_init_rd_bzimage
+    oak_restricted_kernel_simple_io_wrapper_bin
+    oak_restricted_kernel_simple_io_init_rd_wrapper_bin
     oak_restricted_kernel_simple_io_wrapper_cmd_line_regex
     stage0_bin
     key_xor_test_app

--- a/kokoro/build_binaries_rust.sh
+++ b/kokoro/build_binaries_rust.sh
@@ -30,7 +30,7 @@ touch "${KOKORO_ARTIFACTS_DIR}/binaries/git_commit_${KOKORO_GIT_COMMIT_oak:?}"
 # Copy the generated binaries to Placer. The timestamps are used to convey
 # the creation time.
 readonly generated_binaries=(
-    ./oak_restricted_kernel_wrapper/bin/oak_restricted_kernel_simple_io/oak_restricted_kernel_simple_io_init_rd_wrapper_bin
+    ./oak_restricted_kernel_wrapper/bin/oak_restricted_kernel_simple_io/oak_restricted_kernel_simple_io_wrapper_bin
     ./oak_restricted_kernel_wrapper/bin/oak_restricted_kernel_simple_io_init_rd/oak_restricted_kernel_simple_io_init_rd_wrapper_bin
     ./oak_restricted_kernel_wrapper/cmd_line_regex.txt
     ./stage0_bin/target/x86_64-unknown-none/release/stage0_bin


### PR DESCRIPTION
The tag under which provenances are uploaded must match the binary names defined in [kokoro/build_binaries_rust.sh](https://github.com/project-oak/oak/pull/5004/files/8d88839fa06b0241472c499f63c401388a8255bb#diff-0553e8b04e1d708c02e6b5a96ccef81076830d66d7ba747bbb919c01858edf94). Our existing logic derives the tag using the filename of the binary artifact. This creates an implicit, global, and unchangeable namespace for the filename of binary artifacts we import with TR.

Recent prior PRs had renamed a binary artifact of the restricted kernel. 

As @thmsbinder  correctly identified in #5001, this inadvertently led to an invisible collision in this implicit namespace. 

This PR remedies this, by restoring the original filename of the binary artifact.