### PR TITLE
Build the insecure flavour of Oak Functions container

### DIFF
--- a/kokoro/build_binaries_oak_containers.sh
+++ b/kokoro/build_binaries_oak_containers.sh
@@ -36,6 +36,7 @@ readonly generated_binaries=(
     ./oak_containers_system_image/target/image.tar.xz
     ./oak_containers_hello_world_container/target/oak_container_example_oci_filesystem_bundle.tar
     ./oak_functions_containers_container/target/oak_functions_container_oci_filesystem_bundle.tar
+    ./oak_functions_containers_container/target/oak_functions_insecure_container_oci_filesystem_bundle.tar
 
     # We track these binaries so that we can monitor their reproducibility, while b/311651716 is completed.
     # We do not expect to import them in google3, since they are part of the system image, which is
@@ -50,6 +51,7 @@ readonly binary_names=(
     oak_containers_system_image
     oak_containers_hello_world_container
     oak_functions_container
+    oak_functions_insecure_container
 
     oak_containers_orchestrator
     oak_containers_syslogd

--- a/oak_functions_containers_app/Cargo.toml
+++ b/oak_functions_containers_app/Cargo.toml
@@ -5,8 +5,12 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-default = ["native"]
+default = ["native", "deny_sensitive_logging"]
 native = ["dep:libloading", "dep:tempfile", "dep:ouroboros"]
+deny_sensitive_logging = ["oak_functions_service/deny_sensitive_logging"]
+# Feature allow_sensitive_logging is not actually used in the code. It is only used as a
+# required feature to differentiate between the two binaries.
+allow_sensitive_logging = []
 
 [build-dependencies]
 oak_grpc_utils = { workspace = true }
@@ -21,7 +25,9 @@ oak_containers_orchestrator = { workspace = true }
 oak_containers_sdk = { workspace = true }
 oak_debug_service = { workspace = true }
 oak_functions_abi = { workspace = true }
-oak_functions_service = { workspace = true, features = ["std"] }
+oak_functions_service = { workspace = true, default-features = false, features = [
+  "std",
+] }
 oak_crypto = { workspace = true }
 oak_proto_rust = { workspace = true }
 micro_rpc = { workspace = true }
@@ -53,3 +59,16 @@ tracing = "*"
 [dev-dependencies]
 oak_functions_test_utils = { workspace = true }
 xtask = { workspace = true }
+
+[[bin]]
+name = "oak_functions_containers_app"
+test = false
+bench = false
+required-features = ["deny_sensitive_logging"]
+
+[[bin]]
+name = "oak_functions_containers_insecure_app"
+path = "src/main.rs"
+test = false
+bench = false
+required-features = ["allow_sensitive_logging"]

--- a/oak_functions_containers_container/Dockerfile.insecure
+++ b/oak_functions_containers_container/Dockerfile.insecure
@@ -1,0 +1,6 @@
+ARG debian_snapshot=sha256:f0b8edb2e4436c556493dce86b941231eead97baebb484d0d5f6ecfe4f7ed193
+FROM debian@${debian_snapshot}
+
+COPY ./target/oak_functions_containers_insecure_app /usr/bin/
+
+CMD ["/bin/oak_functions_containers_insecure_app"]

--- a/oak_functions_containers_container/build_container_bundle
+++ b/oak_functions_containers_container/build_container_bundle
@@ -10,7 +10,8 @@ set -o xtrace
 set -o pipefail
 
 readonly OCI_IMAGE_FILE="./target/oak_functions_container_oci_image.tar"
-set -e
+readonly OCI_INSECURE_IMAGE_FILE="./target/oak_functions_insecure_container_oci_image.tar"
+
 rm --recursive --force ./target
 mkdir --parents ./target
 
@@ -18,6 +19,16 @@ cargo build \
     --package=oak_functions_containers_app \
     --target=x86_64-unknown-linux-musl \
     --profile=release-lto \
+    --bin=oak_functions_containers_app \
+    -Zunstable-options \
+    --out-dir=./target/
+
+cargo build \
+    --package=oak_functions_containers_app \
+    --target=x86_64-unknown-linux-musl \
+    --profile=release-lto \
+    --bin=oak_functions_containers_insecure_app \
+    --features=allow_sensitive_logging \
     -Zunstable-options \
     --out-dir=./target/
 
@@ -34,3 +45,15 @@ docker buildx \
 ../scripts/export_container_bundle \
     -c "${OCI_IMAGE_FILE}" \
     -o ./target/oak_functions_container_oci_filesystem_bundle.tar
+
+docker buildx \
+    --builder="${BUILDER}" \
+    build \
+    --tag=latest \
+    --file=Dockerfile.insecure \
+    --output="type=oci,dest=${OCI_INSECURE_IMAGE_FILE}" \
+    .
+
+../scripts/export_container_bundle \
+    -c "${OCI_INSECURE_IMAGE_FILE}" \
+    -o ./target/oak_functions_insecure_container_oci_filesystem_bundle.tar


### PR DESCRIPTION
This is similar to what we have with the Restricted Kernel version, except a little bit more complicated as we need a whole second container.

(I considered bundling both binaries into one container, but decided against it as we want the choice be explicit.)

Ref b/331866772