### PR TITLE
Test SLSA 2.0 builder release.

### DIFF
--- a/.github/workflows/provenance.yaml
+++ b/.github/workflows/provenance.yaml
@@ -16,26 +16,22 @@ on:
 
 jobs:
   build_binary:
-    if: |
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.labels.*.name, 'provenance:force-run')
-
     # We use the same job template to generate provenances for multiple binaries.
     strategy:
       fail-fast: false
       matrix:
         buildconfig:
-          - buildconfigs/key_xor_test_app.toml
-          - buildconfigs/oak_containers_kernel.toml
-          - buildconfigs/oak_containers_stage1.toml
+          # - buildconfigs/key_xor_test_app.toml
+          # - buildconfigs/oak_containers_kernel.toml
+          # - buildconfigs/oak_containers_stage1.toml
           - buildconfigs/oak_containers_system_image.toml
-          - buildconfigs/oak_echo_enclave_app.toml
-          - buildconfigs/oak_echo_raw_enclave_app.toml
-          - buildconfigs/oak_functions_enclave_app.toml
-          - buildconfigs/oak_functions_insecure_enclave_app.toml
-          - buildconfigs/oak_restricted_kernel_simple_io_init_rd_wrapper_bin.toml
-          - buildconfigs/stage0_bin.toml
-          - buildconfigs/oak_orchestrator.toml
+          # - buildconfigs/oak_echo_enclave_app.toml
+          # - buildconfigs/oak_echo_raw_enclave_app.toml
+          # - buildconfigs/oak_functions_enclave_app.toml
+          # - buildconfigs/oak_functions_insecure_enclave_app.toml
+          # - buildconfigs/oak_restricted_kernel_simple_io_init_rd_wrapper_bin.toml
+          # - buildconfigs/stage0_bin.toml
+          # - buildconfigs/oak_orchestrator.toml
 
     permissions:
       actions: read

--- a/.github/workflows/reusable_full_provenance.yaml
+++ b/.github/workflows/reusable_full_provenance.yaml
@@ -48,7 +48,7 @@ jobs:
     # current release does not include fix for the action deadlocking.
     # Ref: https://github.com/slsa-framework/slsa-github-generator/issues/3571
     # TODO: b/335461780 - Switch to using a released tag once there is one that includes the fix.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml@v2.0.0-rc.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml@v2.0.0
     with:
       builder-image: 'europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development'
       builder-digest: ${{ needs.get_inputs.outputs.builder-digest }}

--- a/.github/workflows/reusable_provenance.yaml
+++ b/.github/workflows/reusable_provenance.yaml
@@ -79,7 +79,7 @@ jobs:
     # current release does not include fix for the action deadlocking.
     # Ref: https://github.com/slsa-framework/slsa-github-generator/issues/3571
     # TODO: b/335461780 - Switch to using a released tag once there is one that includes the fix.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml@v2.0.0-rc.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml@v2.0.0
     with:
       builder-image: 'europe-west2-docker.pkg.dev/oak-ci/oak-development/oak-development'
       builder-digest: ${{ needs.get_inputs.outputs.builder-digest }}
@@ -126,13 +126,13 @@ jobs:
           EOF
 
       - name: Download the built artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.generate_provenance.outputs.build-outputs-name }}
           path: downloads
 
       - name: Download the DSSE document
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name:
             ${{ needs.generate_provenance.outputs.attestations-download-name }}
@@ -179,13 +179,13 @@ jobs:
 
     steps:
       - name: Download the built artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.generate_provenance.outputs.build-outputs-name }}
           path: downloads
 
       - name: Download the DSSE document
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name:
             ${{ needs.generate_provenance.outputs.attestations-download-name }}


### PR DESCRIPTION
2.0 release also upgraded the artifact uploader/downloader

See https://github.com/slsa-framework/slsa-github-generator/blob/v2.0.0/CHANGELOG.md#v200-breaking-change-upload-artifact-and-download-artifact

Change-Id: Ia17d1cbf358aebbb0ea7f5e97a24f2220b784431