### PR TITLE
Add const qualification to clarify verifier is not modified

### DIFF
--- a/cc/client/client.cc
+++ b/cc/client/client.cc
@@ -37,7 +37,6 @@
 
 namespace oak::client {
 
-namespace {
 using ::oak::attestation::v1::AttestationResults;
 using ::oak::attestation::verification::AttestationVerifier;
 using ::oak::crypto::ClientEncryptor;
@@ -46,13 +45,12 @@ using ::oak::crypto::v1::EncryptedRequest;
 using ::oak::crypto::v1::EncryptedResponse;
 using ::oak::session::v1::EndorsedEvidence;
 using ::oak::transport::TransportWrapper;
-}  // namespace
 
 constexpr absl::string_view kEmptyAssociatedData = "";
 
 absl::StatusOr<std::unique_ptr<OakClient>> OakClient::Create(
     std::unique_ptr<TransportWrapper> transport,
-    AttestationVerifier& verifier) {
+    const AttestationVerifier& verifier) {
   absl::StatusOr<EndorsedEvidence> endorsed_evidence =
       transport->GetEndorsedEvidence();
   if (!endorsed_evidence.ok()) {

--- a/cc/client/client.h
+++ b/cc/client/client.h
@@ -39,7 +39,7 @@ class OakClient {
   // and creating an encrypted channel.
   static absl::StatusOr<std::unique_ptr<OakClient>> Create(
       std::unique_ptr<::oak::transport::TransportWrapper> transport,
-      ::oak::attestation::verification::AttestationVerifier& verifier);
+      const ::oak::attestation::verification::AttestationVerifier& verifier);
 
   // Invoke the provided method by fetching and verifying the attested enclave
   // public key, and then using it to encrypt the request body.


### PR DESCRIPTION
Clarify in definition and declaration that the verifier is not modified by the OakClient class.