### PR TITLE
docs(stage0): Change "ELF" to "bzImage" and add a link to Alioth VMM 

### DIFF
--- a/stage0_bin/README.md
+++ b/stage0_bin/README.md
@@ -5,7 +5,7 @@
 <!-- Oak Logo End -->
 
 Oak stage0 is a purposefully minimal (trusted) firmware for virtual machines
-that can boot 64-bit Linux(-compatible) ELF kernels.
+that can boot 64-bit Linux(-compatible) kernels (bzImage).
 
 The motivating example for having a minimal firmware is secure virtual machines,
 such as virtual machines running under AMD SEV-SNP or Intel TDX, where it is
@@ -27,7 +27,7 @@ We target the QEMU `microvm` machine (and compatible VMMs), and support:
 - serial port (for logging)
 - AMD SEV, SEV-ES and SEV-SNP (setting encrypted bit in the page tables and
   validating guest physical memory)
-- loading and parsing ELF kernels
+- loading and parsing bzImage kernels
 - [the 64-bit Linux boot protocol](https://www.kernel.org/doc/html/v5.6/x86/boot.html#id1)
   (boot parameters structure)
 

--- a/stage0_bin/README.md
+++ b/stage0_bin/README.md
@@ -153,3 +153,6 @@ interest:
 - [EDK2 / OVMF](https://github.com/tianocore/edk2) is a fully-featured UEFI
   firmware that can be used with QEMU. Written in C; supports everything,
   including SEV, SEV-ES, SEV-SNP, and the kitchen sink.
+- [Alioth](https://github.com/google/alioth) is an experimental lightweight VMM.
+  Written in Rust; supports SEV, SEV-ES, and SEV-SNP with stage0 firmware
+  ([doc](https://github.com/google/alioth/blob/main/docs/coco.md)).


### PR DESCRIPTION
Hi Oak team!

This PR changes "ELF" to "bzImage" in stage0 doc to reflect the changes in https://github.com/project-oak/oak/commit/9b5b3e30b64713df2488e9b7b8fc41797a89ae98.

Also, would you mind giving me an ad placement to add a link to Alioth VMM in stage0 readme? Alioth is an experimental lightweight VMM in Rust that supports SEV, SEV-ES, and SEV-SNP with stage0.

Thank you very much for your time!