### PR TITLE
Fix validation check on RSDP table size in acpi_tables

### DIFF
--- a/stage0/src/acpi_tables.rs
+++ b/stage0/src/acpi_tables.rs
@@ -146,7 +146,7 @@ impl Rsdp {
         if &self.signature != b"RSD PTR " {
             return Err("Invalid RSDP signature");
         }
-        let len = if self.revision > 2 { self.length } else { 20 } as usize;
+        let len = if self.revision >= 2 { self.length } else { 20 } as usize;
 
         if len > size_of::<Rsdp>() {
             return Err("invalid RSDP size");


### PR DESCRIPTION
I was going through the ACPI table logic for stage0 because I'm adding some internal patches related to acpi tables, and saw that the validation logic seemed to be off.

According to https://uefi.org/specs/ACPI/6.5/05_ACPI_Software_Programming_Model.html#root-system-description-pointer-rsdp-structure, the `Length` field is provided when `Revision` is 2 or above, which implies `revision >= 2` if I'm not mistaken

```
* These fields are only valid when the Revision value is 2 or above.
```

This function seems to work on `main` because the size would always be set to `20`, which the static size of an RSDP will always be larger than based on the number of fields in RSDP (current revision value is 2, so the true branch would likely never get triggered unless we see another revision to the ACPI specification). Maybe this was missed when cleaning up the file in https://github.com/project-oak/oak/commit/2989a4db6942634e2832507f729e5c4eaa05f19b?

# Test plan
Tested on our own internal build of stage0 (q35 machines). CVMs built with this change + were able to start up.

