### PR TITLE
docs: fix missing proto link in README.md

### DIFF
--- a/testing/oak_echo_service/README.md
+++ b/testing/oak_echo_service/README.md
@@ -3,4 +3,4 @@
 `no_std` compatible implementation of the business logic of the Echo Service.
 
 The interface of the service is defined via microRPC in
-[`oak_echo_service.proto`](/testing/oak_echo_service/proto/oak_echo_service.proto).
+[`oak_echo.proto`](/testing/oak_echo_service/proto/oak_echo.proto).


### PR DESCRIPTION
This PR just fixes a link to proto file oak_echo.proto in testing/oak_echo_service/README.md.