### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/oak_containers/system_image/base/push-base.sh
+++ b/oak_containers/system_image/base/push-base.sh
@@ -50,5 +50,5 @@ xz --force "${TARGET_DIR}/${source}"
 file="${TARGET_DIR}/${source}.xz"
 hash=$(sha256sum "${file}" | cut -d " " -f 1)
 # TODO: b/399705292 - In WORKSPACE, read from oak-files not from oak-bins.
-gsutil cp "${file}" "gs://oak-bins/${static_dir}/${hash}.tar.xz"
-gsutil cp "${file}" "gs://oak-files/sha2-256:${hash}"
+gcloud storage cp "${file}" "gs://oak-bins/${static_dir}/${hash}.tar.xz"
+gcloud storage cp "${file}" "gs://oak-files/sha2-256:${hash}"

--- a/scripts/publish
+++ b/scripts/publish
@@ -31,7 +31,7 @@ usage_and_exit() {
 }
 
 copy_file() {
-  gsutil cp -n "$1" "$2"
+  gcloud storage cp --no-clobber "$1" "$2"
 }
 
 # Uploads a file and returns its SHA2_256 hash.


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
