### PR TITLE
bounds-check host-supplied ACPI entry pointers and checksum slices Fixes #5124

### DIFF
--- a/stage0/src/acpi/mod.rs
+++ b/stage0/src/acpi/mod.rs
@@ -70,13 +70,6 @@ static HIGH_MEMORY_START: core::sync::atomic::AtomicUsize =
 
 /// Returns `true` iff `[addr, addr + len)` is wholly contained in either the
 /// EBDA region or the high-memory ACPI allocator range.
-///
-/// Stage0 receives ACPI table contents from an untrusted VMM (host) via the
-/// bios-linker-loader protocol. RSDT and XSDT entries are u32/u64 values the
-/// host can set to any address. Before any code dereferences such a pointer or
-/// constructs a slice from `(pointer, length)`, it MUST first verify the
-/// pointer falls inside one of the two regions stage0 actually uses for ACPI
-/// memory. Anything else is attacker-controlled input.
 pub(crate) fn acpi_memory_contains(addr: usize, len: usize) -> bool {
     let Some(end) = addr.checked_add(len) else { return false };
 

--- a/stage0/src/acpi/mod.rs
+++ b/stage0/src/acpi/mod.rs
@@ -62,6 +62,42 @@ type HighMemoryAllocator = linked_list_allocator::LockedHeap;
 /// Allocator for high memory (where the ACPI tables themselves will go).
 static HIGH_MEMORY_ALLOCATOR: HighMemoryAllocator = HighMemoryAllocator::empty();
 
+/// Base address of the high-memory ACPI region, recorded by
+/// `setup_high_allocator()`. Used by `acpi_memory_contains()` to validate
+/// host-supplied table pointers. 0 means "not yet initialized".
+static HIGH_MEMORY_START: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
+/// Returns `true` iff `[addr, addr + len)` is wholly contained in either the
+/// EBDA region or the high-memory ACPI allocator range.
+///
+/// Stage0 receives ACPI table contents from an untrusted VMM (host) via the
+/// bios-linker-loader protocol. RSDT and XSDT entries are u32/u64 values the
+/// host can set to any address. Before any code dereferences such a pointer or
+/// constructs a slice from `(pointer, length)`, it MUST first verify the
+/// pointer falls inside one of the two regions stage0 actually uses for ACPI
+/// memory. Anything else is attacker-controlled input.
+pub(crate) fn acpi_memory_contains(addr: usize, len: usize) -> bool {
+    let Some(end) = addr.checked_add(len) else { return false };
+
+    // EBDA region. EBDA is a static `[MaybeUninit<u8>; 0x2_0000]` linked at
+    // section `.ebda`. We use `&raw const` to avoid creating a reference to
+    // the static (which would require `unsafe` for the static-mut access).
+    let ebda_start = (&raw const EBDA) as *const u8 as usize;
+    let ebda_end = ebda_start + 0x2_0000;
+    if addr >= ebda_start && end <= ebda_end {
+        return true;
+    }
+
+    // High-memory ACPI region. Populated by `setup_high_allocator()`.
+    let hi_start = HIGH_MEMORY_START.load(core::sync::atomic::Ordering::Acquire);
+    if hi_start != 0 && addr >= hi_start && end <= hi_start + HIGH_MEM_SIZE {
+        return true;
+    }
+
+    false
+}
+
 const TABLE_LOADER_FILE_NAME: &CStr = c"etc/table-loader";
 
 #[repr(u8)]
@@ -111,6 +147,9 @@ pub fn setup_high_allocator(zero_page: &mut ZeroPage) -> Result<(), &'static str
     unsafe {
         HIGH_MEMORY_ALLOCATOR.lock().init(mem_start as *mut u8, HIGH_MEM_SIZE);
     }
+    // Record the high-memory base so that `acpi_memory_contains()` can
+    // validate host-supplied table pointers fall inside the high-memory range.
+    HIGH_MEMORY_START.store(mem_start, core::sync::atomic::Ordering::Release);
     Ok(())
 }
 

--- a/stage0/src/acpi/tables/mod.rs
+++ b/stage0/src/acpi/tables/mod.rs
@@ -229,10 +229,22 @@ impl<S> DescriptionHeader<S> {
 
     /// Computes the checksum across all data in this structure.
     fn compute_checksum(&self) -> u8 {
-        // Safety: we've ensured that the table is within EBDA.
-        let data = unsafe {
-            slice::from_raw_parts(self.addr_range().start as *const u8, self.length as usize)
-        };
+        // SECURITY: when `self` was obtained by dereferencing an entry value
+        // from an attacker-controlled RSDT/XSDT (see `rsdt.rs::entry_headers`,
+        // `xsdt.rs::Deref`), `self.length` is also attacker-controlled.
+        // Validate that `[self_addr, self_addr + length)` lies wholly inside
+        // ACPI memory this stage0 owns before constructing a slice over it.
+        // Returning a non-zero sentinel makes the surrounding `validate()`
+        // path fail with "checksum invalid", which is the correct behaviour
+        // for input that escapes our memory regions.
+        let self_addr = self as *const _ as usize;
+        let length = self.length as usize;
+        if !crate::acpi::acpi_memory_contains(self_addr, length) {
+            return 1;
+        }
+        // Safety: we just validated that `[self_addr, self_addr + length)`
+        // lies inside an ACPI memory region.
+        let data = unsafe { slice::from_raw_parts(self_addr as *const u8, length) };
         data.iter().fold(0u8, |lhs, &rhs| lhs.wrapping_add(rhs))
     }
 }

--- a/stage0/src/acpi/tables/mod.rs
+++ b/stage0/src/acpi/tables/mod.rs
@@ -229,14 +229,8 @@ impl<S> DescriptionHeader<S> {
 
     /// Computes the checksum across all data in this structure.
     fn compute_checksum(&self) -> u8 {
-        // SECURITY: when `self` was obtained by dereferencing an entry value
-        // from an attacker-controlled RSDT/XSDT (see `rsdt.rs::entry_headers`,
-        // `xsdt.rs::Deref`), `self.length` is also attacker-controlled.
-        // Validate that `[self_addr, self_addr + length)` lies wholly inside
-        // ACPI memory this stage0 owns before constructing a slice over it.
-        // Returning a non-zero sentinel makes the surrounding `validate()`
-        // path fail with "checksum invalid", which is the correct behaviour
-        // for input that escapes our memory regions.
+        // SECURITY: `self.length` may be untrusted. Validate it falls
+        // within our ACPI memory. Returning non-zero fails the checksum.
         let self_addr = self as *const _ as usize;
         let length = self.length as usize;
         if !crate::acpi::acpi_memory_contains(self_addr, length) {

--- a/stage0/src/acpi/tables/rsdt.rs
+++ b/stage0/src/acpi/tables/rsdt.rs
@@ -22,6 +22,7 @@ use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
 use crate::acpi::tables::{
     AcpiTable, Checksum, DescriptionHeader, Result, check_ptr_aligned, signature,
 };
+use crate::acpi::acpi_memory_contains;
 
 #[allow(dead_code)]
 #[derive(Copy, Clone, Debug, Default, Immutable, IntoBytes, KnownLayout, TryFromBytes)]
@@ -168,10 +169,19 @@ impl Rsdt {
     /// Returns an iterator over the headers pointed at by this RSDT, validated.
     pub fn entry_headers(&self) -> impl Iterator<Item = Result<&DescriptionHeader<[u8; 4]>>> {
         self.entries.iter().map(|&entry| {
+            // SECURITY: `entry` is a u32 the untrusted host wrote into the
+            // RSDT contents via fw_cfg. Before dereferencing, verify that
+            // [entry, entry + size_of::<DescriptionHeader>) lies inside an
+            // ACPI memory region this stage0 controls.
+            let addr = entry as usize;
+            if !acpi_memory_contains(addr, size_of::<DescriptionHeader<[u8; 4]>>()) {
+                return Err("RSDT entry points outside ACPI memory");
+            }
             let ptr: *const DescriptionHeader<[u8; 4]> =
-                entry as usize as *const DescriptionHeader<[u8; 4]>;
+                addr as *const DescriptionHeader<[u8; 4]>;
             check_ptr_aligned(ptr);
-            // Safety: we are validating the header.
+            // Safety: we just validated that the pointer lies within ACPI
+            // memory we own, and `check_ptr_aligned` confirms alignment.
             let header = unsafe { &*ptr };
             header.validate()?;
             Ok(header)
@@ -203,9 +213,15 @@ impl Rsdt {
 
     fn entry_headers_mut(&mut self) -> impl Iterator<Item = Result<RsdtEntryPairMut<'_>>> {
         self.entries.iter_mut().map(|addr| {
-            let header_ptr = *addr as usize as *mut DescriptionHeader<[u8; 4]>;
+            // SECURITY: see `entry_headers` — `*addr` is untrusted host input.
+            let raw = *addr as usize;
+            if !acpi_memory_contains(raw, size_of::<DescriptionHeader<[u8; 4]>>()) {
+                return Err("RSDT entry points outside ACPI memory");
+            }
+            let header_ptr = raw as *mut DescriptionHeader<[u8; 4]>;
             check_ptr_aligned(header_ptr);
-            // # Safety we are validating the header.
+            // # Safety: we just validated that the pointer lies within ACPI
+            // memory and `check_ptr_aligned` confirms alignment.
             let header = unsafe { header_ptr.as_mut().ok_or("Address 0x0 in RSDT")? };
             header.validate()?;
             Ok((addr, header))

--- a/stage0/src/acpi/tables/rsdt.rs
+++ b/stage0/src/acpi/tables/rsdt.rs
@@ -169,10 +169,7 @@ impl Rsdt {
     /// Returns an iterator over the headers pointed at by this RSDT, validated.
     pub fn entry_headers(&self) -> impl Iterator<Item = Result<&DescriptionHeader<[u8; 4]>>> {
         self.entries.iter().map(|&entry| {
-            // SECURITY: `entry` is a u32 the untrusted host wrote into the
-            // RSDT contents via fw_cfg. Before dereferencing, verify that
-            // [entry, entry + size_of::<DescriptionHeader>) lies inside an
-            // ACPI memory region this stage0 controls.
+            // SECURITY: Untrusted host input. Bounds check before deref.
             let addr = entry as usize;
             if !acpi_memory_contains(addr, size_of::<DescriptionHeader<[u8; 4]>>()) {
                 return Err("RSDT entry points outside ACPI memory");
@@ -213,7 +210,7 @@ impl Rsdt {
 
     fn entry_headers_mut(&mut self) -> impl Iterator<Item = Result<RsdtEntryPairMut<'_>>> {
         self.entries.iter_mut().map(|addr| {
-            // SECURITY: see `entry_headers` — `*addr` is untrusted host input.
+            // SECURITY: Untrusted host input. Bounds check before deref.
             let raw = *addr as usize;
             if !acpi_memory_contains(raw, size_of::<DescriptionHeader<[u8; 4]>>()) {
                 return Err("RSDT entry points outside ACPI memory");

--- a/stage0/src/acpi/tables/xsdt.rs
+++ b/stage0/src/acpi/tables/xsdt.rs
@@ -22,6 +22,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 use crate::{
     DescriptionHeader,
     acpi::tables::{AcpiTable, Checksum, Result, check_ptr_aligned, signature},
+    acpi::acpi_memory_contains,
 };
 
 /// A wrapper for entry addresses in XSDT table.
@@ -52,18 +53,34 @@ impl Deref for XsdtEntryPtr {
     type Target = DescriptionHeader<[u8; 4]>;
 
     fn deref(&self) -> &DescriptionHeader<[u8; 4]> {
-        let ptr = self.raw_val() as *const DescriptionHeader<[u8; 4]>;
+        let addr = self.raw_val() as usize;
+        // SECURITY: `addr` is a u64 the untrusted host wrote into the XSDT
+        // contents via fw_cfg / AddPointer. The previous comment claimed
+        // validation happened in `Xsdt::validate()`, but that function does
+        // not validate entry-pointer targets. Fail closed by panicking if
+        // the address does not lie inside an ACPI memory region this stage0
+        // controls; boot failure is the correct outcome for malformed input.
+        if !acpi_memory_contains(addr, size_of::<DescriptionHeader<[u8; 4]>>()) {
+            panic!("XSDT entry points outside ACPI memory: {addr:#x}");
+        }
+        let ptr = addr as *const DescriptionHeader<[u8; 4]>;
         check_ptr_aligned(ptr);
-        // Safety: the address has been validated in Xsdt::validate().
+        // Safety: we just validated that the pointer lies within ACPI memory
+        // we own, and `check_ptr_aligned` confirms alignment.
         unsafe { &*ptr }
     }
 }
 
 impl DerefMut for XsdtEntryPtr {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        let ptr = self.raw_val() as *mut DescriptionHeader<[u8; 4]>;
+        let addr = self.raw_val() as usize;
+        // SECURITY: see `Deref::deref` above.
+        if !acpi_memory_contains(addr, size_of::<DescriptionHeader<[u8; 4]>>()) {
+            panic!("XSDT entry points outside ACPI memory: {addr:#x}");
+        }
+        let ptr = addr as *mut DescriptionHeader<[u8; 4]>;
         check_ptr_aligned(ptr);
-        // Safety: the address has been validated in Xsdt::validate().
+        // Safety: as above.
         unsafe { &mut *ptr }
     }
 }

--- a/stage0/src/acpi/tables/xsdt.rs
+++ b/stage0/src/acpi/tables/xsdt.rs
@@ -54,12 +54,7 @@ impl Deref for XsdtEntryPtr {
 
     fn deref(&self) -> &DescriptionHeader<[u8; 4]> {
         let addr = self.raw_val() as usize;
-        // SECURITY: `addr` is a u64 the untrusted host wrote into the XSDT
-        // contents via fw_cfg / AddPointer. The previous comment claimed
-        // validation happened in `Xsdt::validate()`, but that function does
-        // not validate entry-pointer targets. Fail closed by panicking if
-        // the address does not lie inside an ACPI memory region this stage0
-        // controls; boot failure is the correct outcome for malformed input.
+        // SECURITY: Untrusted host input. Bounds check before deref.
         if !acpi_memory_contains(addr, size_of::<DescriptionHeader<[u8; 4]>>()) {
             panic!("XSDT entry points outside ACPI memory: {addr:#x}");
         }
@@ -74,7 +69,7 @@ impl Deref for XsdtEntryPtr {
 impl DerefMut for XsdtEntryPtr {
     fn deref_mut(&mut self) -> &mut Self::Target {
         let addr = self.raw_val() as usize;
-        // SECURITY: see `Deref::deref` above.
+        // SECURITY: Untrusted host input. Bounds check before deref.
         if !acpi_memory_contains(addr, size_of::<DescriptionHeader<[u8; 4]>>()) {
             panic!("XSDT entry points outside ACPI memory: {addr:#x}");
         }


### PR DESCRIPTION
Fixes #5124

## Summary

Stage0 currently treats host-supplied 32-bit (RSDT) and 64-bit (XSDT) entry values as raw pointers and dereferences them as `&DescriptionHeader<[u8; 4]>` without validating that the pointed-at memory falls inside an ACPI region stage0 actually owns. The downstream `DescriptionHeader::compute_checksum` then constructs a slice with `slice::from_raw_parts(self as *const _, self.length as usize)` — where both `self`'s address and `self.length` come from attacker-controlled bytes.

This PR adds a small `acpi_memory_contains(addr, len)` helper that returns true iff `[addr, addr + len)` is wholly contained in either the EBDA static array or the high-memory ACPI allocator range, and uses it to bounds-check every site that turns an entry value into a `&DescriptionHeader`.

The `// Safety:` comments at the affected sites previously claimed "the address has been validated in `Xsdt::validate()`". That claim was incorrect — `Xsdt::validate()` only checks the XSDT's own checksum and entry-count alignment. With this change the comments now accurately describe what was verified.

This is a stop-gap. The proper long-term fix is the migration already in progress (`unsafe` pointer cast → `zerocopy::TryFromBytes`), specifically reframing entry handling as offsets into a known `&[u8]` slice rather than absolute pointers. This PR keeps the existing API shape so the migration can land incrementally.

## Why this matters

Stage0's threat model takes the VMM (host) as untrusted. ACPI table contents are built from host fw_cfg + bios-linker-loader commands, so host bytes flow directly into RSDT/XSDT entry slots. Without this patch, those host-supplied values are dereferenced as raw pointers on every Oak SEV-SNP boot via `stage0_sev/src/platform/smp.rs::bootstrap_aps` → `Xsdt::get(b"APIC")`. The result is an attacker-controlled-pointer, attacker-controlled-length read primitive: enough to deterministically DoS the boot (page fault on unmapped address), to construct a 1-bit-per-boot page-mapping oracle, and to trigger `slice::from_raw_parts` UB (Miri-confirmed; see linked advisory).

A more detailed write-up with a Miri-validated PoC is attached as a private GitHub Security Advisory.

## What this PR changes

`stage0/src/acpi/mod.rs`:

- Adds `HIGH_MEMORY_START: AtomicUsize` and populates it from `setup_high_allocator()` so the high-memory ACPI range is queryable at runtime.
- Adds `pub(crate) fn acpi_memory_contains(addr: usize, len: usize) -> bool` returning true iff `[addr, addr + len)` is wholly inside EBDA or the high-memory ACPI region.

`stage0/src/acpi/tables/rsdt.rs`:

- `entry_headers()` now calls `acpi_memory_contains(entry, size_of::<DescriptionHeader>())` before `unsafe { &*ptr }`. On miss, returns `Err("RSDT entry points outside ACPI memory")`. The matching change is also applied to `entry_headers_mut()`.

`stage0/src/acpi/tables/xsdt.rs`:

- `Deref for XsdtEntryPtr` and `DerefMut for XsdtEntryPtr` perform the same bounds check. Because `Deref` cannot return `Result`, on miss the code `panic!`s — stage0 boot failure with a diagnostic is the correct outcome for malformed host input.

`stage0/src/acpi/tables/mod.rs`:

- `DescriptionHeader::compute_checksum()` calls `acpi_memory_contains(self_addr, self.length as usize)` before `slice::from_raw_parts`. On miss returns `1` (non-zero) so the surrounding `validate()` path fails through the existing "ACPI table checksum invalid" error message rather than reading attacker-named memory.

The previously-misleading `// Safety:` comments at these sites have been updated to accurately describe what is checked.


## Testing

- `cargo build -p stage0` — the patch compiles clean against current `main`.
- Existing unit tests in `stage0/src/acpi/tables/{rsdt,xsdt}.rs` do not exercise `Deref`/`entry_headers` (they inspect `xsdt.entries` directly), so the new bounds check does not interfere with them.
- A standalone PoC crate (linked in the advisory) reproduces the pre-patch UB and exercises Miri to formally confirm it. The same crate, after applying this patch's bounds check to its local copy of the pattern, no longer triggers Miri UB.



