### PR TITLE
Fix kernel hashes build failure

### DIFF
--- a/stage0/src/lib.rs
+++ b/stage0/src/lib.rs
@@ -220,7 +220,7 @@ pub fn rust64_start<P: hal::Platform + hal::FirmwarePlatform>() -> ! {
         // supplied, do a quick check to verify that the launch primitives are
         // valid via measured direct boot
         assert!(P::validate_measured_boot(
-            cmdline.as_bytes(),
+            kernel_cmdline.as_bytes(),
             &ram_disk_sha2_256_digest,
             setup_data.as_bytes(),
             kernel.as_bytes()

--- a/stage0_bin/README.md
+++ b/stage0_bin/README.md
@@ -136,6 +136,17 @@ launching the guest VM.
            0x0 +------------------------------------------------+
 ```
 
+### Kernel hashes and measured boot
+
+It may be desirable to have your launch digest include the initrd, kernel,
+and kernel cmdline into your trusted computing base for measured boot. To this
+end, you can enable the `sev_kernel_hashes` feature when building stage0 so that
+[QEMU](https://www.qemu.org/docs/master/system/i386/amd-memory-encryption.html#calculating-expected-guest-launch-measurement)
+include the hashes of these components into your launch digest.
+
+Stage0 will then verify that the kernel, initrd, and cmdline loaded in from
+`fw_cfg` match the hashes found in the hash table at boot time or panick.
+
 ## Related projects
 
 There are several other projects in similar firmware space that may be of

--- a/stage0_bin/README.md
+++ b/stage0_bin/README.md
@@ -138,9 +138,9 @@ launching the guest VM.
 
 ### Kernel hashes and measured boot
 
-It may be desirable to have your launch digest include the initrd, kernel,
-and kernel cmdline into your trusted computing base for measured boot. To this
-end, you can enable the `sev_kernel_hashes` feature when building stage0 so that
+It may be desirable to have your launch digest include the initrd, kernel, and
+kernel cmdline into your trusted computing base for measured boot. To this end,
+you can enable the `sev_kernel_hashes` feature when building stage0 so that
 [QEMU](https://www.qemu.org/docs/master/system/i386/amd-memory-encryption.html#calculating-expected-guest-launch-measurement)
 include the hashes of these components into your launch digest.
 

--- a/stage0_sev/src/platform/mod.rs
+++ b/stage0_sev/src/platform/mod.rs
@@ -53,7 +53,7 @@ static SEV_CPUID: MaybeUninit<oak_sev_guest::cpuid::CpuidPage> = MaybeUninit::un
 pub static AP_JUMP_TABLE: MaybeUninit<ApJumpTable> = MaybeUninit::uninit();
 #[cfg(feature = "sev_kernel_hashes")]
 #[unsafe(link_section = ".snp_hash_table")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 static mut SEV_HASH_TABLE: MaybeUninit<kernel_hash_tables::PaddedSevHashTable> =
     MaybeUninit::uninit();
 


### PR DESCRIPTION
When I was trying to build stage0 with the new `sev_kernel_hashes` feature introduced in https://github.com/project-oak/oak/commit/6fe1a1138628aae63227d184aca59f91db4099f8, I noticed that I was getting build failures:

```
ERROR: /home/kevinhui/oak/stage0/BUILD:25:13: Compiling Rust rlib stage0 (37 files) failed: (Exit 1): process_wrapper failed: error executing Rustc command (from target //stage0:stage0) bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper/process_wrapper --arg-file ... (remaining 168 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error[E0599]: no method named `as_bytes` found for struct `KernelCmdLine` in the current scope
   --> stage0/src/lib.rs:223:21
    |
223 |             cmdline.as_bytes(),
    |                     ^^^^^^^^ method not found in `KernelCmdLine`
    |
   ::: stage0/src/kernel.rs:120:1
    |
120 | pub struct KernelCmdLine {
    | ------------------------ method `as_bytes` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `as_bytes`, perhaps you need to implement it:
            candidate #1: `IntoBytes`

error: aborting due to 1 previous error
```

This is replicable with the following changes:
```
[kevinhui ~/oak (main)]$ git diff
diff --git a/stage0/BUILD b/stage0/BUILD
index ddf5dd06d1..d08bc2a2e1 100644
--- a/stage0/BUILD
+++ b/stage0/BUILD
@@ -26,7 +26,7 @@ rust_library(
     name = "stage0",
     srcs = glob(["src/**"]),
     # Enable if you want to use kernel hashes
-    # crate_features = ["sev_kernel_hashes"],
+    crate_features = ["sev_kernel_hashes"],
     target_compatible_with = any_platform([
         "//:x86_64-none-setting",
         "//:x86_64-none-no_avx-setting",
diff --git a/stage0_sev/BUILD b/stage0_sev/BUILD
index 169115a6f7..d923906883 100644
--- a/stage0_sev/BUILD
+++ b/stage0_sev/BUILD
@@ -25,7 +25,7 @@ rust_library(
     name = "stage0_sev",
     srcs = glob(["src/**/*.rs"]),
     # Enable if you want to use kernel hashes
-    # crate_features = ["sev_kernel_hashes"],
+    crate_features = ["sev_kernel_hashes"],
     aliases = {"//stage0": "oak_stage0"},
     deps = [
         "//oak_attestation",
```

After this PR, those build failures go away:
```
[kevinhui ~/oak (fix-kernel-hashes-build)]$ bazel build //stage0_bin
INFO: Analyzed target //stage0_bin:stage0_bin (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //stage0_bin:stage0_bin up-to-date:
  bazel-bin/stage0_bin/stage0_bin
INFO: Elapsed time: 8.894s, Critical Path: 8.34s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions
```

I also took the liberty to add a note to `stage0_bin/README` to add a comment about kernel hashes