### PR TITLE
fix(noise_handshake): replace public-key hash with actual DH for ss token in Noise KK

### DIFF
--- a/oak_crypto/src/noise_handshake/client.rs
+++ b/oak_crypto/src/noise_handshake/client.rs
@@ -78,10 +78,14 @@ impl HandshakeInitiator {
             self.noise.mix_key(&es_ecdh_bytes);
         }
         if let Some(self_priv_key) = self.self_identity_priv_key.as_ref() {
-            let self_static_pub_key =
-                self_priv_key.get_public_key().map_err(|_| Error::InvalidPublicKey)?;
             if let Some(peer_identity_pub_key) = self.peer_identity_pub_key {
-                let ss_ecdh_bytes = sha256_two_part(&self_static_pub_key, &peer_identity_pub_key);
+                // ss: DH(s_initiator, s_responder) — requires the initiator's private key.
+                // Previously this incorrectly used sha256(pub_a || pub_b) which is computable
+                // from public information alone and defeats the mutual-authentication guarantee
+                // of the KK pattern.
+                let ss_ecdh_bytes = self_priv_key
+                    .derive_dh_secret(peer_identity_pub_key.as_slice())
+                    .map_err(|_| Error::InvalidHandshake)?;
                 self.noise.mix_key(&ss_ecdh_bytes);
             } else {
                 return Err(Error::MissingPeerPublicKey);

--- a/oak_crypto/src/noise_handshake/mod.rs
+++ b/oak_crypto/src/noise_handshake/mod.rs
@@ -356,8 +356,13 @@ pub fn respond_kk(
     let initiator_static_pub_bytes: [u8; P256_X962_LEN] =
         initiator_static_pub.try_into().map_err(|_| Error::InvalidPublicKey)?;
 
-    let ss_ecdh_bytes =
-        sha256_two_part(&initiator_static_pub_bytes, &identity_priv.get_public_key().unwrap());
+    // ss: DH(s_initiator, s_responder) — requires the responder's private key.
+    // Previously this incorrectly used sha256(pub_a || pub_b) which is computable
+    // from public information alone and defeats the mutual-authentication guarantee
+    // of the KK pattern.
+    let ss_ecdh_bytes = identity_priv
+        .derive_dh_secret(initiator_static_pub_bytes.as_slice())
+        .map_err(|_| Error::InvalidHandshake)?;
     noise.mix_key(&ss_ecdh_bytes);
 
     let se_ecdh_bytes = identity_priv


### PR DESCRIPTION
## Summary

The Noise KK handshake `ss` token was computed as `sha256(initiator_static_pub || responder_static_pub)` instead of the required ECDH operation `DH(s_initiator_priv, s_responder_pub)`.

## The problem

Per the [Noise Protocol Framework spec](https://noiseprotocol.org/noise.html#the-kk-handshake-pattern), the KK pattern requires:

```
→ e, es, ss
← e, ee, se
```

Where `ss = DH(s_initiator, s_responder)` — this **must** use a private key. The purpose of the `ss` token is to prove that both parties hold their respective static private keys. With a hash of two public keys, this proof disappears entirely: any observer who knows both public keys (which are exchanged during attestation) can compute the identical value.

### Vulnerable code (client.rs, initiator side)

```rust
// BEFORE — broken: uses hash of PUBLIC keys, computable by anyone
let ss_ecdh_bytes = sha256_two_part(&self_static_pub_key, &peer_identity_pub_key);
self.noise.mix_key(&ss_ecdh_bytes);
```

### Vulnerable code (mod.rs, responder side — respond_kk)

```rust
// BEFORE — broken: same issue on the responder side
let ss_ecdh_bytes =
    sha256_two_part(&initiator_static_pub_bytes, &identity_priv.get_public_key().unwrap());
noise.mix_key(&ss_ecdh_bytes);
```

Note that `es` and `se` in the same handshake correctly use `derive_dh_secret` / `p256_scalar_mult`. Only `ss` was broken.

## The fix

```rust
// AFTER — correct: uses private key; only the key holder can compute this
let ss_ecdh_bytes = self_priv_key
    .derive_dh_secret(peer_identity_pub_key.as_slice())
    .map_err(|_| Error::InvalidHandshake)?;
self.noise.mix_key(&ss_ecdh_bytes);
```

```rust
// AFTER — respond_kk responder side
let ss_ecdh_bytes = identity_priv
    .derive_dh_secret(initiator_static_pub_bytes.as_slice())
    .map_err(|_| Error::InvalidHandshake)?;
noise.mix_key(&ss_ecdh_bytes);
```

## Impact

- Mutual authentication is weakened: the `ss` token no longer proves private key possession
- Noise KK effectively degrades toward Noise NK for the `ss` contribution
- Used in `oak_session` for TEE session establishment, which is the core security boundary of Oak

This was reported to Google OSS VRP.