### PR TITLE
fix u32 overflow in add_checksum bounds check

### DIFF
--- a/stage0/src/acpi/commands/add_checksum.rs
+++ b/stage0/src/acpi/commands/add_checksum.rs
@@ -89,15 +89,13 @@ impl<FW: Firmware, F: Files> Invoke<FW, F> for AddChecksum {
     ) -> Result<(), &'static str> {
         let file = files.get_file_mut(self.file())?;
 
-        if self.start as usize > file.len()
-            || (self.start + self.length) as usize > file.len()
-            || self.offset as usize >= file.len()
-        {
+        let start = self.start as usize;
+        let end = start + self.length as usize;
+        if start > file.len() || end > file.len() || self.offset as usize >= file.len() {
             return Err("COMMAND_ADD_CHECKSUM invalid; read or write would overflow file");
         }
 
-        let checksum =
-            AddChecksum::checksum(&file[self.start as usize..(self.start + self.length) as usize]);
+        let checksum = AddChecksum::checksum(&file[start..end]);
         let val = file.get_mut(self.offset as usize).unwrap();
         *val = val.wrapping_sub(checksum);
         Ok(())

--- a/stage0/src/acpi/mod.rs
+++ b/stage0/src/acpi/mod.rs
@@ -381,6 +381,18 @@ mod tests {
             err(anything())
         );
 
+        // `start + length` overflows u32 but wraps below the file length, so a
+        // naive bounds check would pass and then read out of range.
+        expect_that!(
+            AddChecksum::new("test", 0, 1, u32::MAX).invoke(
+                &mut files,
+                &mut TestFirmware,
+                None,
+                &mut digest
+            ),
+            err(anything())
+        );
+
         // Finally, a basic success test (although we don't check the result)
         expect_that!(
             AddChecksum::new("test", 0, 1, 3).invoke(


### PR DESCRIPTION
COMMAND_ADD_CHECKSUM bounds-checks its range with `(self.start + self.length) as usize > file.len()`, adding two host-controlled u32 fields from the `etc/table-loader` file in u32 space. A loader command with a large length wraps that sum below `file.len()`, so the check passes and the slice built from the same wrapped value then panics (the add itself with overflow checks on, or a start>end slice with them off).

Before, the addition ran in u32 and could wrap; after, `start` and `length` widen to usize first, which on x86_64 cannot overflow, matching what ADD_POINTER already does a few lines over. Keeping the widened math in the handler leaves the file buffer as the only thing that decides whether a range is in bounds, instead of relying on each command to pre-clamp its fields.