### PR TITLE
bound e820 entry writes in tdx prefill_e820_table

### DIFF
--- a/stage0_tdx/src/platform.rs
+++ b/stage0_tdx/src/platform.rs
@@ -322,6 +322,9 @@ impl FirmwarePlatform for Tdx {
         serial::debug!("Prefill e820 table from TDHOB");
 
         let hit = hob::get_hit()?;
+        // The number of resource descriptors comes from the host-provided TD HoB and
+        // is otherwise unbounded, so writes must stay within the destination table.
+        let dest_len = dest.as_mut_bytes().len();
         let mut index = 0;
 
         for curr_ptr in hit.into_iter() {
@@ -339,6 +342,10 @@ impl FirmwarePlatform for Tdx {
                 serial::debug!("Resource attribute: ", curr_src.resource_attribute);
                 serial::debug!("Physical start: ", curr_src.physical_start);
                 serial::debug!("Resource length: ", curr_src.resource_length);
+
+                if index + size_of::<BootE820Entry>() > dest_len {
+                    return Err("too many resource descriptors in TD HoB");
+                }
 
                 // Figure out the location of the next E820 entry
                 let new_entry_ptr: *mut BootE820Entry = unsafe {


### PR DESCRIPTION
The TDX e820 prefill writes one entry per resource-descriptor HoB into the
fixed 128-entry `e820_table`, advancing a raw pointer with no upper bound:

    for curr_ptr in hit.into_iter() {
        if curr_hdr.is_resource_descriptor() {
            let new_entry_ptr = dest.as_mut_bytes().as_mut_ptr().byte_add(index);
            *new_entry_ptr = BootE820Entry::new(...);  // index never checked vs dest
            index += size_of::<BootE820Entry>();
        }
    }

The descriptor count comes from the host's TD HoB, which stage0 treats as
untrusted, and `get_hit()` validates only the PHIT header, not how many
descriptors follow.

Before: a HoB carrying more than 128 resource descriptors runs the write past
the end of `e820_table`, placing host-controlled `BootE820Entry` bytes into
the rest of `BootParams`, through a raw pointer with no bounds check.
After: `index` is capped against the destination length and an over-long HoB
is rejected with an error, so the destination buffer is what decides how many
entries fit.

Tradeoff: a malformed or oversized HoB now fails the prefill instead of being
written past the table, so boot stops early rather than continuing on a
corrupted zero page. The SEV and base platforms are unaffected, their
`prefill_e820_table` does not write here.
