### PR TITLE
bound add_pci_root acpi command offsets to file length

### DIFF
--- a/stage0/src/acpi/commands/add_pci_root_stage1.rs
+++ b/stage0/src/acpi/commands/add_pci_root_stage1.rs
@@ -62,6 +62,16 @@ impl AddPciRootStage1 {
     pub fn file(&self) -> &CStr {
         CStr::from_bytes_until_nul(&self.file).unwrap()
     }
+
+    /// Builds a command targeting `file` whose 32-bit window start is written at
+    /// `pci32_start_offset`; all other offsets stay zero. Test-only.
+    #[cfg(test)]
+    pub fn new(file: &str, pci32_start_offset: u32) -> Self {
+        let mut cmd = <Self as zerocopy::FromZeros>::new_zeroed();
+        cmd.file[..file.len()].copy_from_slice(file.as_bytes());
+        cmd.pci32_start_offset = pci32_start_offset;
+        cmd
+    }
 }
 
 impl<FW: Firmware, F: Files> Invoke<FW, F> for AddPciRootStage1 {
@@ -77,6 +87,23 @@ impl<FW: Firmware, F: Files> Invoke<FW, F> for AddPciRootStage1 {
 
         if self.bus_index != 0 {
             return Err("AddPciRootStage1: only bus 0 supported for now");
+        }
+
+        let file_len = file.len();
+        let write_fits = |offset: u32, size: usize| offset as usize + size <= file_len;
+        if !write_fits(self.pci32_start_offset, size_of::<u32>())
+            || !write_fits(self.pci32_end_offset, size_of::<u32>())
+            || !write_fits(self.pci64_valid_offset, size_of::<u8>())
+            || !write_fits(self.pci64_start_offset, size_of::<u64>())
+            || !write_fits(self.pci64_end_offset, size_of::<u64>())
+            || !write_fits(self.pci64_length_offset, size_of::<u64>())
+            || !write_fits(self.pci16_io_start_offset, size_of::<u16>())
+            || !write_fits(self.pci16_io_end_offset, size_of::<u16>())
+            || self.allowlist_offsets.iter().any(|o| {
+                !write_fits(o.start, size_of::<u32>()) || !write_fits(o.end, size_of::<u32>())
+            })
+        {
+            return Err("AddPciRootStage1 invalid; offsets would overflow file");
         }
 
         let data = pci_windows.ok_or("no PCI holes for AddPciRootStage1 to add")?;

--- a/stage0/src/acpi/commands/add_pci_root_stage2.rs
+++ b/stage0/src/acpi/commands/add_pci_root_stage2.rs
@@ -49,6 +49,16 @@ impl AddPciRootStage2 {
     pub fn file(&self) -> &CStr {
         CStr::from_bytes_until_nul(&self.file).unwrap()
     }
+
+    /// Builds a command targeting `file` whose first allowlist entry writes its
+    /// start at `allowlist_start_offset`; all other offsets stay zero. Test-only.
+    #[cfg(test)]
+    pub fn new(file: &str, allowlist_start_offset: u32) -> Self {
+        let mut cmd = <Self as zerocopy::FromZeros>::new_zeroed();
+        cmd.file[..file.len()].copy_from_slice(file.as_bytes());
+        cmd.allowlist_offsets[0].start = allowlist_start_offset;
+        cmd
+    }
 }
 
 impl<FW: Firmware, F: Files> Invoke<FW, F> for AddPciRootStage2 {
@@ -65,6 +75,17 @@ impl<FW: Firmware, F: Files> Invoke<FW, F> for AddPciRootStage2 {
         if self.bus_index != 0 {
             return Err("AddPciRootStage2: only bus 0 supported for now");
         }
+
+        let file_len = file.len();
+        let write_fits = |offset: u32, size: usize| offset as usize + size <= file_len;
+        if self
+            .allowlist_offsets
+            .iter()
+            .any(|o| !write_fits(o.start, size_of::<u32>()) || !write_fits(o.end, size_of::<u32>()))
+        {
+            return Err("AddPciRootStage2 invalid; offsets would overflow file");
+        }
+
         let crs_allowlist = read_pci_crs_allowlist(fwcfg)?.unwrap_or_default();
         log::debug!("PCI CRS allowlist: {:?}", crs_allowlist);
 

--- a/stage0/src/acpi/mod.rs
+++ b/stage0/src/acpi/mod.rs
@@ -416,6 +416,42 @@ mod tests {
     }
 
     #[gtest]
+    pub fn test_add_pci_root_stage1_rejects_out_of_range_offset() {
+        let mut files = TestFiles::default();
+        let mut digest = Sha256::default();
+        files.new_file(c"test", &[0u8; 64]);
+
+        // A host-controlled offset past the end of the file must be rejected
+        // instead of panicking on an out-of-range slice write.
+        expect_that!(
+            AddPciRootStage1::new("test", 0xFFFF_FFF0).invoke(
+                &mut files,
+                &mut TestFirmware,
+                None,
+                &mut digest
+            ),
+            err(anything())
+        );
+    }
+
+    #[gtest]
+    pub fn test_add_pci_root_stage2_rejects_out_of_range_offset() {
+        let mut files = TestFiles::default();
+        let mut digest = Sha256::default();
+        files.new_file(c"test", &[0u8; 64]);
+
+        expect_that!(
+            AddPciRootStage2::new("test", 0xFFFF_FFF0).invoke(
+                &mut files,
+                &mut TestFirmware,
+                None,
+                &mut digest
+            ),
+            err(anything())
+        );
+    }
+
+    #[gtest]
     pub fn test_add_pointer() {
         let mut files = TestFiles::default();
         let mut digest = Sha256::default();


### PR DESCRIPTION
AddPciRootStage1 and AddPciRootStage2 patch the destination ACPI file at byte offsets taken straight from the etc/table-loader command, but unlike AddPciHoles and AddPointer they never check those offsets against the file length. The table-loader file comes from the VMM, so a command carrying an offset past the end of the file reaches a slice write like file[off..off+4] and panics in stage0 before the guest is measured.

Before, every write in these two commands trusted the host offset; after, each command validates all of its offsets up front and rejects anything that would land outside the file, matching the existing AddPciHoles guard, with regression tests covering the rejection path. The check is conservative for the 64-bit window offsets in stage1 (it validates them even when the 64-bit window is empty and they go unused), which trades a slightly stricter command for keeping the bound in one place next to the writes.