### PR TITLE
fix overflow in PciBar::new for zero-size pci bars

### DIFF
--- a/stage0/src/pci/device.rs
+++ b/stage0/src/pci/device.rs
@@ -311,18 +311,27 @@ impl PciBar {
                     let upper_half =
                         access.read(bdf, Self::BAR_REGISTER_OFFSET + offset + 1)? as u64;
 
-                    Some(PciBar::Memory64 {
-                        bdf,
-                        offset,
-                        prefetchable,
-                        bar_size: !((upper_half << 32) + (value as u64)) + 1,
-                    })
+                    // The size is the two's complement of the masked register value. A
+                    // BAR that reports no size bits would make `!mask + 1` overflow, and
+                    // a resulting size of zero divides by zero in the resource allocator,
+                    // so reject it instead of trusting the value the device read back.
+                    let mask = (upper_half << 32) + (value as u64);
+                    if mask == 0 {
+                        return Err("invalid BAR");
+                    }
+                    Some(PciBar::Memory64 { bdf, offset, prefetchable, bar_size: !mask + 1 })
                 } else {
+                    if value == 0 {
+                        return Err("invalid BAR");
+                    }
                     Some(PciBar::Memory32 { bdf, offset, prefetchable, bar_size: !value + 1 })
                 }
             }
             PciBarKind::Io => {
                 let value = value & !PciBarKind::MASK;
+                if value == 0 {
+                    return Err("invalid BAR");
+                }
                 Some(PciBar::Io { bdf, offset, bar_size: !value + 1 })
             }
         })
@@ -543,6 +552,47 @@ mod tests {
                 bar_size: eq(&4)
             })))
         );
+    }
+
+    #[test]
+    fn test_zero_size_memory32_bar_rejected() {
+        let mut access = MockConfigAccess::new();
+        access.expect_write().return_const(Ok(()));
+        // 32-bit memory BAR that reads back with the prefetchable bit set but no size
+        // bits. Computing `!value + 1` over the zero mask used to overflow.
+        access
+            .expect_read()
+            .with(mockall_eq(Bdf::root()), mockall_eq(PciBar::BAR_REGISTER_OFFSET))
+            .return_const(Ok(0x0000_0008));
+        assert_that!(PciBar::new(Bdf::root(), 0, &mut access), err(anything()));
+    }
+
+    #[test]
+    fn test_zero_size_memory64_bar_rejected() {
+        let mut access = MockConfigAccess::new();
+        access.expect_write().return_const(Ok(()));
+        // 64-bit memory BAR whose lower and upper halves both report a zero size mask.
+        access
+            .expect_read()
+            .with(mockall_eq(Bdf::root()), mockall_eq(PciBar::BAR_REGISTER_OFFSET))
+            .return_const(Ok(0x0000_000C));
+        access
+            .expect_read()
+            .with(mockall_eq(Bdf::root()), mockall_eq(PciBar::BAR_REGISTER_OFFSET + 1))
+            .return_const(Ok(0x0000_0000));
+        assert_that!(PciBar::new(Bdf::root(), 0, &mut access), err(anything()));
+    }
+
+    #[test]
+    fn test_zero_size_io_bar_rejected() {
+        let mut access = MockConfigAccess::new();
+        access.expect_write().return_const(Ok(()));
+        // I/O BAR with the I/O indicator bit set but no size bits.
+        access
+            .expect_read()
+            .with(mockall_eq(Bdf::root()), mockall_eq(PciBar::BAR_REGISTER_OFFSET))
+            .return_const(Ok(0x0000_0001));
+        assert_that!(PciBar::new(Bdf::root(), 0, &mut access), err(anything()));
     }
 
     #[test]


### PR DESCRIPTION
PciBar::new sizes each BAR by writing all-ones to the BAR register and taking the two's complement (`!value + 1`) of the value the device reads back. That value comes from host-emulated PCI config space, and the masked size field is never checked for zero. A VMM can expose a device whose BAR reports the type bits but no size bits (`0x0000_0008` for a prefetchable 32-bit memory BAR, `0x0000_0001` for an I/O BAR), so the masked value is zero.

Before: `!0 + 1` overflows. Debug builds panic in PciBar::new; release builds wrap to a size of 0, which then divides by zero in ResourceAllocator::allocate (`next_multiple_of(0)`) while PciBus::init walks the bus, so a malicious host aborts stage0 during PCI setup. After: a zero size mask is rejected up front in all three BAR kinds with the existing `invalid BAR` error, matching how an unimplemented BAR is already skipped. The tradeoff is that a device claiming to decode its entire address space is now dropped rather than assigned a window, which is the safe reading for a value that cannot represent a real size.