### PR TITLE
require event log length to match dice layer count

### DIFF
--- a/oak_attestation_verification/src/verifier.rs
+++ b/oak_attestation_verification/src/verifier.rs
@@ -484,6 +484,16 @@ fn validate_that_event_log_is_captured_in_dice_layers(
     dice_layers: &[LayerEvidence],
     event_id_type: EventIdType,
 ) -> anyhow::Result<()> {
+    // `zip` below stops at the shorter of the two sequences, so without this check a
+    // log carrying more events than there are layers (or a chain with more layers
+    // than logged events) would pass with the surplus left unverified. Each layer
+    // commits to exactly one event, so the counts must match.
+    anyhow::ensure!(
+        dice_layers.len() == event_log.encoded_events.len(),
+        "event log has {} events but the DICE chain has {} layers",
+        event_log.encoded_events.len(),
+        dice_layers.len()
+    );
     dice_layers.iter().zip(event_log.encoded_events.iter()).try_for_each(
         |(current_layer, encoded_event)| {
             let event_digest = {

--- a/oak_attestation_verification/src/verifier/tests.rs
+++ b/oak_attestation_verification/src/verifier/tests.rs
@@ -88,6 +88,34 @@ fn test_milan_rk_staging_success() {
     assert!(p.status() == Status::Success);
 }
 
+#[test]
+fn event_log_with_unbound_event_is_rejected() {
+    let d = AttestationData::load_milan_oc_staging();
+    let event_log = d.evidence.event_log.as_ref().expect("no event log");
+
+    // Genuine evidence carries one event per DICE layer, so the binding validates.
+    super::validate_that_event_log_is_captured_in_dice_layers(
+        event_log,
+        &d.evidence.layers,
+        super::EventLogType::OriginalEventLog.into(),
+    )
+    .expect("genuine event log should validate");
+
+    // An event that no DICE layer commits to must be rejected: the surplus event is
+    // not captured anywhere in the chain, yet it would still be decoded as a
+    // measurement downstream.
+    let mut tampered = event_log.clone();
+    tampered.encoded_events.push(b"unbound event".to_vec());
+    assert!(
+        super::validate_that_event_log_is_captured_in_dice_layers(
+            &tampered,
+            &d.evidence.layers,
+            super::EventLogType::OriginalEventLog.into(),
+        )
+        .is_err()
+    );
+}
+
 fn create_endorsement(
     digest: &RawDigest,
     claim_types: Vec<&str>,


### PR DESCRIPTION
Repro: hand `validate_that_event_log_is_captured_in_dice_layers` an event log holding more `encoded_events` than the DICE chain has layers (append one event to otherwise valid evidence).
Cause: the binding is walked with `iter().zip()`, which stops at the shorter side, so a surplus event (or a surplus layer) is never bound or checked.
Fix: require equal counts before the zip, the same guard `compare.rs` and `verifiers.rs` already apply to their own layer/event pairings.

Before: an event log longer than the layer list verifies as captured, even though the trailing events are committed by no layer. Those events are still decoded into measurements in `extract_evidence_values`.
After: any count mismatch is rejected up front.

Each genuine layer commits to exactly one event, so equal length is the real invariant and this rejects nothing that verifies today. The check lives in the callee, so all three call sites are covered. Tradeoff: the failure is now length-based, so a caller passing a sub-slice of layers must pass the slice that lines up one-to-one with the events. All current callers already do (the software-rooted path drops its root layer before calling).