### PR TITLE
fix message length underflow in oak_channel read_message

### DIFF
--- a/oak_channel/src/lib.rs
+++ b/oak_channel/src/lib.rs
@@ -106,9 +106,11 @@ impl InvocationChannel {
         // The length includes the first frame. Decode it so the buffer needs to
         // be resized/copied at most once.
         let message_length: usize = {
-            let mut buffer = [0u8; message::LENGTH_SIZE];
             let range = message::LENGTH_OFFSET..(message::LENGTH_OFFSET + message::LENGTH_SIZE);
-            buffer.copy_from_slice(&first_frame.body[range]);
+            let length_bytes =
+                first_frame.body.get(range).context("first frame too short for message length")?;
+            let mut buffer = [0u8; message::LENGTH_SIZE];
+            buffer.copy_from_slice(length_bytes);
             usize::try_from(message::Length::from_le_bytes(buffer))
                 .expect("couldn't convert message length to usize")
         };
@@ -116,7 +118,10 @@ impl InvocationChannel {
         // This likely causes a copy of the pre-existing data, but we needed to read the
         // first frame to figure out how much space we need for the entire
         // message. No more resizes are going to happen from here.
-        message_buffer.reserve(message_length - frame::MAX_BODY_SIZE);
+        let additional_capacity = message_length
+            .checked_sub(frame::MAX_BODY_SIZE)
+            .context("message length is smaller than the first frame")?;
+        message_buffer.reserve(additional_capacity);
 
         loop {
             let (frame, _) =

--- a/oak_channel/src/tests.rs
+++ b/oak_channel/src/tests.rs
@@ -120,6 +120,36 @@ fn test_invocation_channel_double_start_frame() {
 }
 
 #[test]
+fn test_invocation_channel_undersized_message_length() {
+    // A peer sends a START frame (without END) whose declared total message
+    // length is smaller than a single frame body. Reassembly must reject it
+    // rather than underflowing the capacity reservation.
+    let mut invocation_channel = {
+        let mut body = vec![0u8; message::BODY_OFFSET];
+        body[message::LENGTH_OFFSET..(message::LENGTH_OFFSET + message::LENGTH_SIZE)]
+            .copy_from_slice(&(message::BODY_OFFSET as u32).to_le_bytes());
+        let mut frame_store = frame::Framed::new(Box::new(MessageStore::default()));
+        frame_store.write_frame(frame::Frame { flags: frame::Flags::START, body: &body }).unwrap();
+        InvocationChannel { inner: frame_store }
+    };
+
+    invocation_channel.read_message::<message::RequestMessage>().unwrap_err();
+}
+
+#[test]
+fn test_invocation_channel_truncated_first_frame() {
+    // The first frame is too short to even contain the message length header.
+    let mut invocation_channel = {
+        let body = vec![0u8; message::LENGTH_SIZE - 1];
+        let mut frame_store = frame::Framed::new(Box::new(MessageStore::default()));
+        frame_store.write_frame(frame::Frame { flags: frame::Flags::START, body: &body }).unwrap();
+        InvocationChannel { inner: frame_store }
+    };
+
+    invocation_channel.read_message::<message::RequestMessage>().unwrap_err();
+}
+
+#[test]
 fn test_invocation_channel_expected_start_frame() {
     let mut invocation_channel = {
         let message = message::RequestMessage { invocation_id: 0, body: mock_payload() }.encode();


### PR DESCRIPTION
read_message assembles a message from the peer's frames before any of it is checked. It takes a 4-byte total length from the first frame body and sizes the receive buffer as `message_length - MAX_BODY_SIZE`, and it reads that length field with a fixed `body[0..4]` slice. Both trust the wire, and on the server path the first frame comes from the untrusted host: a START frame declaring a length under one frame body underflows the subtraction, and a first frame shorter than four bytes (frame bodies can be as small as one byte) indexes past the slice.

Read the length through `body.get` and size the reservation with `checked_sub`, so a malformed first frame returns an error here instead of reaching the arithmetic. The guard lives in the reassembler so the server and client handles both inherit it. Before, a debug build panicked on the subtraction and a release build wrapped to a reserve large enough to abort the allocation; after, the frame is rejected and the channel keeps running.
