### PR TITLE
clamp setup header length before copying into hdr

### DIFF
--- a/stage0/src/zero_page.rs
+++ b/stage0/src/zero_page.rs
@@ -103,16 +103,19 @@ impl ZeroPage {
         // data.
         let hdr_start = 0x1F1usize;
         // We can determine the end of the setup header information by adding the value
-        // of the byte as offset 0x201 to the value 0x202.
-        let hdr_end = 0x202usize + (buf[0x201] as usize);
+        // of the byte at offset 0x201 to the value 0x202. That byte is supplied by the
+        // untrusted host, and a newer kernel may declare a header larger than the one
+        // we keep, so clamp the range to the size of `hdr` and to the data we read.
+        let dest = self.inner.hdr.as_mut_bytes();
+        let hdr_end =
+            (0x202usize + (buf[0x201] as usize)).min(hdr_start + dest.len()).min(buf.len());
         let src = &buf[hdr_start..hdr_end];
         // If we are loading an older kernel, the setup header might be a bit shorter.
         // New fields for more recent versions of the boot protocol are
         // added to the end of the setup header and there is padding after
         // header, so the resulting data stucture should still be understood
         // correctly by the kernel.
-        let dest = &mut self.inner.hdr.as_mut_bytes()[..src.len()];
-        dest.copy_from_slice(src);
+        dest[..src.len()].copy_from_slice(src);
         Some((buf, measurement))
     }
 


### PR DESCRIPTION
`try_fill_hdr_from_setup_data` copies the kernel setup header out of the fw_cfg "setup" file into the fixed 123-byte `hdr`. The copied length is `0x202 + buf[0x201] - 0x1F1`, and `buf[0x201]` is a byte of the host-supplied setup file, so it can be up to `0xFF`. Before this change any value above `0x6A` makes the length exceed 123 bytes and the `[..src.len()]` slice of the header panics, and a large value on a short setup file also runs the source range past the bytes that were read.

After this change the header range is clamped to the size of `hdr` and to the data actually read before slicing, the same way `read_pci_crs_allowlist` bounds a host file against its destination array. A normal header (length byte up to `0x6A`) still copies the full 123 bytes unchanged; a larger declared header keeps only the fields stage0 models and drops the trailing fields a newer boot protocol appends. Keeping the bound next to the copy means the host-controlled length can't reach past `hdr` or the setup buffer.