### PR TITLE
reject single-frame channel messages shorter than the header

### DIFF
--- a/oak_channel/src/lib.rs
+++ b/oak_channel/src/lib.rs
@@ -99,6 +99,9 @@ impl InvocationChannel {
         }
 
         if first_frame.flags.contains(frame::Flags::END) {
+            if message_buffer.len() < message::BODY_OFFSET {
+                anyhow::bail!("message is smaller than the message header");
+            }
             return Ok((M::decode(&message_buffer[..]), timer));
         }
 

--- a/oak_channel/src/tests.rs
+++ b/oak_channel/src/tests.rs
@@ -150,6 +150,26 @@ fn test_invocation_channel_truncated_first_frame() {
 }
 
 #[test]
+fn test_invocation_channel_undersized_single_frame() {
+    // A single frame carrying the whole message (START and END both set) whose
+    // body is shorter than the message header must be rejected rather than
+    // panicking on the out-of-range header slice in decode.
+    let mut invocation_channel = {
+        let body = vec![0u8; message::BODY_OFFSET - 1];
+        let mut frame_store = frame::Framed::new(Box::new(MessageStore::default()));
+        frame_store
+            .write_frame(frame::Frame {
+                flags: frame::Flags::START | frame::Flags::END,
+                body: &body,
+            })
+            .unwrap();
+        InvocationChannel { inner: frame_store }
+    };
+
+    invocation_channel.read_message::<message::RequestMessage>().unwrap_err();
+}
+
+#[test]
 fn test_invocation_channel_expected_start_frame() {
     let mut invocation_channel = {
         let message = message::RequestMessage { invocation_id: 0, body: mock_payload() }.encode();


### PR DESCRIPTION
read_message treats a first frame that has both START and END set as a complete message and passes its body straight to RequestMessage::decode. decode reads an 8-byte header, slicing [4..8] for the invocation id and [8..] for the body, but the frame layer only requires a body of at least one byte. Before this change a single frame from the peer with a 1 to 7 byte body reaches decode below the header size and panics on the out-of-range slice; after it, that frame is rejected with an error.

The guard sits in the single-frame branch of read_message rather than in decode. The multi-frame branch already bounds its buffer through the declared message length, and decode has no fallible return, so validating the length once where a lone frame becomes a message keeps the check next to the only path that can be short and leaves the decoders unchanged.