### PR TITLE
gate event-log verification on policies not prover endorsements

### DIFF
--- a/oak_attestation_verification/src/verifiers.rs
+++ b/oak_attestation_verification/src/verifiers.rs
@@ -169,7 +169,7 @@ impl AttestationVerifier for AmdSevSnpDiceAttestationVerifier {
         let mut event_attestation_results = Vec::new();
         event_attestation_results.push(platform_results);
         event_attestation_results.push(firmware_results);
-        if !endorsements.events.is_empty() {
+        if !self.event_policies.is_empty() {
             let results = verify_event_log(
                 verification_time,
                 event_log,
@@ -242,7 +242,7 @@ impl AttestationVerifier for AmdSevSnpTransparentDiceAttestationVerifier {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("no event log"))?;
         let mut event_attestation_results = vec![platform_results, firmware_results];
-        if !endorsements.events.is_empty() {
+        if !self.event_policies.is_empty() {
             let results = verify_event_log(
                 verification_time,
                 transparent_event_log,
@@ -344,7 +344,7 @@ impl AttestationVerifier for IntelTdxAttestationVerifier {
         let mut event_attestation_results = Vec::new();
         event_attestation_results.push(platform_results);
         event_attestation_results.push(firmware_results);
-        if !endorsements.events.is_empty() {
+        if !self.event_policies.is_empty() {
             let results = verify_event_log(
                 verification_time,
                 event_log,
@@ -409,7 +409,7 @@ impl AttestationVerifier for InsecureAttestationVerifier {
             evidence.event_log.as_ref().ok_or_else(|| anyhow::anyhow!("no event log"))?;
         let mut event_attestation_results = Vec::new();
         event_attestation_results.push(insecure_results);
-        if !endorsements.events.is_empty() {
+        if !self.event_policies.is_empty() {
             let results = verify_event_log(
                 verification_time,
                 event_log,

--- a/oak_attestation_verification/tests/policy_tests.rs
+++ b/oak_attestation_verification/tests/policy_tests.rs
@@ -259,6 +259,20 @@ verify_amd_failure! {
     load_fake
 }
 
+// A prover controls whether it sends event endorsements, so an empty
+// `endorsements.events` must not cause the event policies to be skipped. Here
+// the kernel reference value is manipulated to not match the evidence: with no
+// event endorsements present, verification must still fail rather than succeed.
+#[test]
+fn verify_amd_rejects_bad_measurement_without_event_endorsements() {
+    let mut d = AttestationData::load_milan_rk_release();
+    d.endorsements.events.clear();
+    let mut rvs = make_reference_values(&d.evidence);
+    let rv = get_kernel_rv(&mut rvs);
+    manipulate_kernel_image(rv);
+    assert_failure(verify_amd(d.make_valid_time(), &d.evidence, &d.endorsements, &rvs));
+}
+
 macro_rules! verify_amd_success_explicit_reference_values {
     ($($name:tt)*) => {
         mod verify_amd_success_explicit_reference_values {


### PR DESCRIPTION
The AMD, AMD-transparent, Intel TDX, and insecure verifiers in `verifiers.rs` run the per-event measurement policies only when `endorsements.events` is non-empty, and that list comes from the prover. Evidence with an empty events list still passes the platform, DICE chain, and firmware steps, then skips the kernel/system/container/application checks, so `verify()` returns success. Those policies hold the relying party's reference values, so a workload whose measurement was never meant to be accepted gets through.

Gate the event-log step on the verifier's own `event_policies` instead of the prover-supplied endorsements. `verify_event_log` already pads absent endorsements with empty variants and each policy compares digests against its reference values, so an honest prover that sends no event endorsements still verifies while a prover can no longer turn the checks off by omitting them. Before, verification was skipped whenever `endorsements.events` was empty; after, it runs whenever the verifier has policies, and a verifier configured with no event policies keeps its prior behavior.