### PR TITLE
bound host e820 addresses in sev and tdx memory acceptance

### DIFF
--- a/stage0_sev/src/platform/accept_memory.rs
+++ b/stage0_sev/src/platform/accept_memory.rs
@@ -343,21 +343,40 @@ pub fn validate_memory(e820_table: &[BootE820Entry]) {
             continue;
         }
 
+        // addr and size come straight from the hypervisor-supplied E820 table, so
+        // the end of the range can overflow usize and either bound can exceed the
+        // valid physical address width. Reject such an entry here instead of
+        // panicking in the arithmetic below, mirroring the checked_add already used
+        // for the host-supplied length in the TD HOB walk.
+        let Some(end) = entry.addr().checked_add(entry.size()) else {
+            log::error!(
+                "nonsensical entry in E820 table: [{:#x}, +{:#x})",
+                entry.addr(),
+                entry.size()
+            );
+            continue;
+        };
+
         // Defense-in-depth: refuse to accept memory that overlaps the firmware ROM
         // window. The CF=1 panic above is the primary mitigation; this check makes
         // the attack fail before any PSC is even issued.
-        if entry.addr() < ROM_GUARD_END && entry.end() > ROM_GUARD_START {
+        if entry.addr() < ROM_GUARD_END && end > ROM_GUARD_START {
             panic!(
                 "hypervisor-supplied E820 RAM entry [{:#x}, {:#x}) overlaps firmware ROM \
                  window; refusing to PVALIDATE",
                 entry.addr(),
-                entry.end()
+                end
             );
         }
 
-        let start_address = PhysAddr::new(entry.addr() as u64).align_up(Size4KiB::SIZE);
-        let limit_address =
-            PhysAddr::new((entry.addr() + entry.size()) as u64).align_down(Size4KiB::SIZE);
+        let (Ok(start), Ok(limit)) =
+            (PhysAddr::try_new(entry.addr() as u64), PhysAddr::try_new(end as u64))
+        else {
+            log::error!("nonsensical entry in E820 table: [{:#x}, {:#x})", entry.addr(), end);
+            continue;
+        };
+        let start_address = start.align_up(Size4KiB::SIZE);
+        let limit_address = limit.align_down(Size4KiB::SIZE);
 
         if start_address > limit_address {
             log::error!(

--- a/stage0_tdx/src/platform.rs
+++ b/stage0_tdx/src/platform.rs
@@ -160,9 +160,26 @@ fn accept_tdx_memory(e820_table: &[oak_linux_boot_params::BootE820Entry]) {
             continue;
         }
 
-        let start_address = PhysAddr::new(entry.addr() as u64).align_up(Size4KiB::SIZE);
-        let limit_address =
-            PhysAddr::new((entry.addr() + entry.size()) as u64).align_down(Size4KiB::SIZE);
+        // addr and size come straight from the hypervisor-supplied E820 table, so
+        // the end of the range can overflow usize and either bound can exceed the
+        // valid physical address width. Reject such an entry here instead of
+        // panicking in the arithmetic below.
+        let Some(end) = entry.addr().checked_add(entry.size()) else {
+            log::error!(
+                "nonsensical entry in E820 table: [{:#x}, +{:#x})",
+                entry.addr(),
+                entry.size()
+            );
+            continue;
+        };
+        let (Ok(start), Ok(limit)) =
+            (PhysAddr::try_new(entry.addr() as u64), PhysAddr::try_new(end as u64))
+        else {
+            log::error!("nonsensical entry in E820 table: [{:#x}, {:#x})", entry.addr(), end);
+            continue;
+        };
+        let start_address = start.align_up(Size4KiB::SIZE);
+        let limit_address = limit.align_down(Size4KiB::SIZE);
 
         if start_address > limit_address {
             log::error!(


### PR DESCRIPTION
validate_memory (SEV-SNP) and accept_tdx_memory (TDX) walk the VMM-supplied E820 table and, for each RAM entry, form PhysAddr::new(entry.addr()) and PhysAddr::new(entry.addr() + entry.size()) from the host-controlled addr and size. An entry with addr at or above 2^52 aborts the acceptance path in release builds, because PhysAddr::new rejects any address with a bit above bit 51 set; a large size separately overflows the addr + size sum that feeds both the second PhysAddr and the SEV ROM-guard check.

Before, those host values reached PhysAddr::new and the addition unchecked, so a crafted entry panics stage0 mid-acceptance. After, the end is computed with checked_add and both bounds go through PhysAddr::try_new, and an entry that overflows or exceeds the physical address width is skipped the same way the existing start > limit check already drops a nonsensical one; the ROM guard tests the checked end so its refusal is unchanged for real overlaps. The bound stays next to the sole consumer of these values, matching the checked_add the TD HOB walk already uses, and the tradeoff is that a malformed entry is logged and dropped rather than fatal.