### PR TITLE
Document Stage0 q35 machine support

### DIFF
--- a/stage0_bin/README.md
+++ b/stage0_bin/README.md
@@ -20,7 +20,7 @@ machine state here, so we've had to resort to some assembly code and some
 
 ## Features
 
-We target the QEMU `microvm` machine (and compatible VMMs), and support:
+We target the QEMU `microvm` and `q35` machines (and compatible VMMs), and support:
 
 - [QEMU `fw_cfg`](https://www.qemu.org/docs/master/specs/fw_cfg.html) device
   (for obtaining memory information, ACPI tables etc)
@@ -57,6 +57,7 @@ qemu-system-x86_64 -cpu host -enable-kvm -machine "microvm,acpi=on" -m 1G \
   -nographic -nodefaults -no-reboot -serial stdio \
   -bios "artifacts/binaries/stage0_bin"
 ```
+The same Stage0 boot flow is also tested with `-machine q35`.
 
 ## Loading a kernel
 


### PR DESCRIPTION
## Summary

Update the Stage0 documentation to reflect that QEMU q35 is supported in addition to microvm.

The README previously only listed microvm as the targeted QEMU machine type, while upstream Stage0 already includes smoke coverage for both microvm and q35. This keeps the upstream documentation aligned with the Stage0 boot path supported by the project.

## Test plan

Verified upstream support by inspection:

- stage0/testing/test_kernel_test.rs includes microvm_smoke_test, which launches Stage0 with -machine microvm.
- stage0/testing/test_kernel_test.rs includes q35_smoke_test, which launches Stage0 with -machine q35.

Note: not run locally.

Attempted to set up a run for:
bazel test //stage0/testing:stage0_kernel_test --test_output=all

My available environments could not run it:
macOS does not provide the Linux KVM environment required by the test.
The Linux devserver had kvm, but was missing both bazel and qemu-system-x86_64.