### PR TITLE
Include .snp_hash_table section into layout

### DIFF
--- a/stage0_bin/layout.ld
+++ b/stage0_bin/layout.ld
@@ -121,6 +121,7 @@ SECTIONS {
      * https://github.com/tianocore/edk2/blob/f98662c5e35b6ab60f46ee4350fa0e6eab0497cf/OvmfPkg/Include/Fdf/MemFd.fdf.inc#L89-L93
      */
     .snp_hash_table 0x10c00 (NOLOAD) : {
+       *(.snp_hash_table)
        . += 0x400; /* 1k */
     } > ram_low : snp_hash_table
 


### PR DESCRIPTION
I was getting errors with the kernel hashes merges when I tried rebasing on oak master. This is probably because I must've missed it on my end, but there is a subtle bug that probably manifested itself when stage0 layouts were being interacted with (or maybe this happened explicitly with cloud-hypervisor, who knows).

This static should be included in the section, otherwise there's a chance for garbage to be read. Maybe this started manifesting itself with oak because the layout was being referenced more.

# Testing:
I tested this against the commit `ca2f847e5f87f87a877f2a9e5e7642c9dc3cda3b` of the cloud-hypervisor project, as well as with the `buildigvm` [project](https://gitlab.com/qemu-project/buildigvm) using the patches I included (https://gitlab.com/qemu-project/buildigvm/-/merge_requests/7, https://gitlab.com/qemu-project/buildigvm/-/merge_requests/8, https://gitlab.com/qemu-project/buildigvm/-/merge_requests/9).

Without this change, I get a failed boot:
```
stage0 DEBUG: validating measured boot primitives                                                                                                               
stage0 DEBUG: Kernel check failed, expected: 3ad2064b52aafffb75cfe3011bf192a3e738b612c8a5cb5fed46e720183539b7, 
  got 4886d2d7fb4c97b5f9e416969d4fe8e5d121f46c8fff59a560b56ccce1f5ac9f                                                                                                       
stage0 DEBUG: validated measured boot primitives                                                         
stage0 ERROR: panicked at stage0/src/lib.rs:225:9:  assertion failed: P::validate_measured_boot(kernel_cmdline.as_bytes(),                                                                                                     
      &ram_disk_sha2_256_digest, setup_data.as_bytes(), kernel.as_bytes())                                      
cloud-hypervisor:  11.697337s:        
  <vcpu0> ERROR:hypervisor/src/kvm/mod.rs:2441 -- Guest likely triple-faulted   
```

With this, I actually launch into the CVM properly:
```
Ubuntu 24.04.4 LTS cvm-disk ttyS0

cvm-disk login: root (automatic login)

```