### PR TITLE
only update UnorderedCrypter replay state after decryption succeeds

### DIFF
--- a/oak_crypto/src/noise_handshake/mod.rs
+++ b/oak_crypto/src/noise_handshake/mod.rs
@@ -256,23 +256,26 @@ impl UnorderedCrypter {
         if nonce_value < lowest_acceptable_nonce {
             return Err(Error::InvalidNonce);
         }
-        // Nonce is within the window, check for replayed nonces.
-        else if nonce_value >= lowest_acceptable_nonce && nonce_value <= self.furthest_read_nonce
-        {
-            if self.buffered_read_nonces.contains(&nonce_value) {
-                return Err(Error::ReplayedNonce);
-            }
-            self.buffered_read_nonces.insert(nonce_value);
+        // Nonce is within the window and was already used, reject it. Nonces
+        // above `furthest_read_nonce` are never buffered, so this covers the
+        // whole window.
+        if self.buffered_read_nonces.contains(&nonce_value) {
+            return Err(Error::ReplayedNonce);
         }
+        // The nonce travels next to the ciphertext and is not covered by the
+        // AEAD tag, so the window is only moved once the message is known to be
+        // authentic. Recording it earlier would let anyone who can put a packet
+        // on the wire mark a nonce as used or ratchet the window forward.
+        let plaintext = aes_gcm_256_decrypt(&self.read_key, nonce, ciphertext)?;
         // Nonce is greater than the furthest seen so far.
-        else {
+        if nonce_value > self.furthest_read_nonce {
             self.furthest_read_nonce = nonce_value;
             // Retain only buffered nonces in the new window span.
             let new_lowest_acceptable_nonce = self.get_lowest_acceptable_read_nonce();
             self.buffered_read_nonces.retain(|&n| n >= new_lowest_acceptable_nonce);
-            self.buffered_read_nonces.insert(nonce_value);
         }
-        aes_gcm_256_decrypt(&self.read_key, nonce, ciphertext)
+        self.buffered_read_nonces.insert(nonce_value);
+        Ok(plaintext)
     }
 }
 

--- a/oak_crypto/src/noise_handshake/tests.rs
+++ b/oak_crypto/src/noise_handshake/tests.rs
@@ -17,7 +17,10 @@ use alloc::{boxed::Box, vec};
 
 use crate::{
     identity_key::{IdentityKey, IdentityKeyHandle},
-    noise_handshake::{client::HandshakeInitiator, respond_kk, respond_nk, respond_nn},
+    noise_handshake::{
+        NONCE_LEN, SYMMETRIC_KEY_LEN, UnorderedCrypter, client::HandshakeInitiator, error::Error,
+        respond_kk, respond_nk, respond_nn,
+    },
 };
 
 #[test]
@@ -208,5 +211,63 @@ fn process_nn_handshake() {
         let ciphertext = enclave_crypter.encrypt(message).unwrap();
         let plaintext = client_crypter.decrypt(&ciphertext).unwrap();
         assert_eq!(message, &plaintext);
+    }
+}
+
+/// Regression test: `UnorderedCrypter` must not update its replay state from
+/// a message it has not authenticated.
+///
+/// The nonce is carried next to the ciphertext and is not covered by the AEAD
+/// tag, so anyone able to put a packet on the wire chooses it. Before the fix
+/// the window was advanced and the nonce recorded as used before
+/// `aes_gcm_256_decrypt` ran, so a forged packet reserved a nonce: the genuine
+/// message that later arrived with that nonce was rejected as a replay.
+#[test]
+fn unordered_crypter_forged_message_does_not_consume_nonce() {
+    let key_1 = &[42u8; SYMMETRIC_KEY_LEN];
+    let key_2 = &[52u8; SYMMETRIC_KEY_LEN];
+    let mut sender = UnorderedCrypter::new(key_2, key_1, 8);
+    let mut receiver = UnorderedCrypter::new(key_1, key_2, 8);
+
+    let (ciphertext, nonce) = sender.encrypt(b"genuine payload").unwrap();
+    let nonce: [u8; NONCE_LEN] = nonce.try_into().expect("unexpected nonce length");
+
+    // Same nonce, ciphertext that does not authenticate.
+    let forged = vec![0u8; ciphertext.len()];
+    assert!(matches!(receiver.decrypt(&nonce, &forged), Err(Error::DecryptFailed)));
+
+    // The genuine message must still be accepted.
+    let plaintext = receiver
+        .decrypt(&nonce, &ciphertext)
+        .expect("genuine message rejected after a forged message reused its nonce");
+    assert_eq!(plaintext, b"genuine payload");
+}
+
+/// Regression test: a forged message with a far-future nonce must not ratchet
+/// the replay window past the messages that are still in flight.
+#[test]
+fn unordered_crypter_forged_message_does_not_advance_window() {
+    let key_1 = &[42u8; SYMMETRIC_KEY_LEN];
+    let key_2 = &[52u8; SYMMETRIC_KEY_LEN];
+    let mut sender = UnorderedCrypter::new(key_2, key_1, 8);
+    let mut receiver = UnorderedCrypter::new(key_1, key_2, 8);
+
+    let mut in_flight = vec![];
+    for message in [b"one".as_slice(), b"two".as_slice(), b"three".as_slice()] {
+        let (ciphertext, nonce) = sender.encrypt(message).unwrap();
+        let nonce: [u8; NONCE_LEN] = nonce.try_into().expect("unexpected nonce length");
+        in_flight.push((message, ciphertext, nonce));
+    }
+
+    // A single unauthenticated packet claiming a nonce far ahead of the sender.
+    let mut far_ahead = [0u8; NONCE_LEN];
+    far_ahead[NONCE_LEN - 4..].copy_from_slice(&1_000_000u32.to_be_bytes());
+    assert!(matches!(receiver.decrypt(&far_ahead, &[0u8; 48]), Err(Error::DecryptFailed)));
+
+    for (message, ciphertext, nonce) in &in_flight {
+        let plaintext = receiver
+            .decrypt(nonce, ciphertext)
+            .expect("genuine message dropped after a forged message moved the window");
+        assert_eq!(&plaintext, message);
     }
 }


### PR DESCRIPTION
`UnorderedCrypter::decrypt` records the nonce in `buffered_read_nonces` and advances `furthest_read_nonce` before `aes_gcm_256_decrypt` runs. The nonce travels beside the ciphertext and is not covered by the AEAD tag (`UnorderedChannelEncryptor::decrypt` reads it straight off `Payload::nonce`), so on the unreliable transports this crypter targets, whoever can put a packet on the wire picks it. Before: a forged packet reusing a nonce the sender has not sent yet makes the genuine message carrying that nonce fail with `ReplayedNonce`, and one packet with a far-ahead nonce ratchets the window past everything still in flight.

After: the window moves only once the tag verifies, so a forged packet costs one failed decryption and nothing more, which is what RFC 4303 3.4.3 and RFC 6347 4.1.2.6 require of an anti-replay window. The check belongs in the crypter because that is the only layer holding the window state and the first point where the nonce is trustworthy. Tradeoff: the replayed-nonce lookup now runs against the whole buffered set rather than only the span at or below `furthest_read_nonce`, costing one extra hash lookup for nonces above the window; accepted traffic, out-of-order tolerance and window sizing are unchanged.