### PR TITLE
require a peer verifier for peer-attested session types

### DIFF
--- a/java/src/test/java/com/google/oak/session/BUILD
+++ b/java/src/test/java/com/google/oak/session/BUILD
@@ -45,9 +45,11 @@ rust_library(
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         "//java/src/main/java/com/google/oak/session/jni:oak_jni_attestation_publisher",
+        "//oak_attestation_verification_types",
         "//oak_proto_rust",
         "//oak_sdk/common:oak_sdk_common",
         "//oak_session",
+        "@oak_crates_index//:anyhow",
         "@oak_crates_index//:jni",
         "@oak_crates_index//:prost",
     ],

--- a/java/src/test/java/com/google/oak/session/attestation_publisher_test_jni.rs
+++ b/java/src/test/java/com/google/oak/session/attestation_publisher_test_jni.rs
@@ -23,10 +23,13 @@ use jni::{
     objects::{JClass, JObject, JValue},
     sys::{jlong, jobject},
 };
+use oak_attestation_verification_types::verifier::AttestationVerifier;
 use oak_jni_attestation_publisher::JNIAttestationPublisher;
 use oak_proto_rust::oak::{
     Variant,
-    attestation::v1::{Assertion, Endorsements, EventLog, Evidence},
+    attestation::v1::{
+        Assertion, AttestationResults, Endorsements, EventLog, Evidence, attestation_results,
+    },
     session::v1::SessionBinding,
 };
 use oak_sdk_common::{StaticAttester, StaticEndorser};
@@ -36,7 +39,7 @@ use oak_session::{
     generator::{BindableAssertion, BindableAssertionGenerator, BindableAssertionGeneratorError},
     handshake::HandshakeType,
     session::AttestationPublisher,
-    session_binding::SessionBinder,
+    session_binding::{SessionBinder, SessionBindingVerifier, SessionBindingVerifierProvider},
 };
 
 pub fn new_java_session_config_builder(
@@ -89,6 +92,44 @@ impl SessionBinder for FakeSessionBinder {
     }
 }
 
+/// Accepts the fake server evidence. The client config needs a peer verifier so
+/// that it requests genuine peer attestation; this test is about the publisher,
+/// not about verification policy.
+struct FakePeerVerifier {}
+
+impl AttestationVerifier for FakePeerVerifier {
+    fn verify(
+        &self,
+        _evidence: &Evidence,
+        _endorsements: &Endorsements,
+    ) -> anyhow::Result<AttestationResults> {
+        Ok(AttestationResults {
+            status: attestation_results::Status::Success.into(),
+            ..Default::default()
+        })
+    }
+}
+
+#[derive(Debug)]
+struct FakeSessionBindingVerifier {}
+
+impl SessionBindingVerifier for FakeSessionBindingVerifier {
+    fn verify_binding(&self, _bound_data: &[u8], _binding: &[u8]) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+struct FakeSessionBindingVerifierProvider {}
+
+impl SessionBindingVerifierProvider for FakeSessionBindingVerifierProvider {
+    fn create_session_binding_verifier(
+        &self,
+        _attestation_results: &AttestationResults,
+    ) -> anyhow::Result<Box<dyn SessionBindingVerifier>> {
+        Ok(Box::new(FakeSessionBindingVerifier {}))
+    }
+}
+
 #[unsafe(no_mangle)]
 extern "system" fn Java_com_google_oak_session_AttestationPublisherTest_nativeCreateServerConfigBuilder(
     mut env: JNIEnv,
@@ -133,6 +174,11 @@ extern "system" fn Java_com_google_oak_session_AttestationPublisherTest_nativeCr
     new_java_session_config_builder(
         &mut env,
         SessionConfig::builder(AttestationType::PeerUnidirectional, HandshakeType::NoiseNN)
+            .add_peer_verifier_with_binding_verifier_provider(
+                "test id".to_string(),
+                Box::new(FakePeerVerifier {}),
+                Box::new(FakeSessionBindingVerifierProvider {}),
+            )
             .add_attestation_publisher(&publisher),
     )
 }

--- a/oak_session/src/aggregators.rs
+++ b/oak_session/src/aggregators.rs
@@ -61,23 +61,31 @@ pub trait LegacyVerifierResultsAggregator: Send {
 /// A default implementation of the `VerifierResultsAggregator` trait.
 ///
 /// This aggregator requires that:
-/// 1. There is at least one attestation result provided.
-/// 2. All provided attestation results indicate success.
+/// 1. If any peer verifier was configured, at least one of them matched
+///    received evidence.
+/// 2. All matched attestation results indicate success.
 ///
 /// It operates on the principle that only evidence matching a configured peer
 /// verifier is considered, effectively performing an inner join between
 /// expected verifiers and received evidence.
+///
+/// An empty result set is accepted, because it also describes a configuration
+/// that verifies the peer through assertions alone and so has no legacy
+/// verifiers to match. A peer-attested type with no verifier of either kind is
+/// rejected when the session is created; this aggregator cannot distinguish the
+/// two cases, because it never sees the configured `AttestationType`.
 pub struct DefaultLegacyVerifierResultsAggregator {}
 
 impl LegacyVerifierResultsAggregator for DefaultLegacyVerifierResultsAggregator {
-    /// Aggregates results based on the default policy: at least one result, and
-    /// all must be successful.
+    /// Aggregates results based on the default policy: if verifiers were
+    /// configured then at least one must have matched, and every matched result
+    /// must be successful.
     ///
-    /// If `results` is empty, it returns `AttestationFailed` with a reason
-    /// indicating no matching results. If any result in the `results` map
-    /// has a `GenericFailure` status, it returns `AttestationFailed` with
-    /// details of the failures. Otherwise, it returns `AttestationPassed`
-    /// with the original results.
+    /// If a verifier was configured but none matched received evidence, it
+    /// returns `NoMatchedLegacyVerifier`. If any matched result has a
+    /// `GenericFailure` status, it returns `LegacyVerificationFailure` with
+    /// details of the failures. Otherwise it succeeds, which includes the case
+    /// of an empty `results` map.
     fn process_assertion_results(
         &self,
         results: &BTreeMap<String, VerifierResult>,

--- a/oak_session/src/config.rs
+++ b/oak_session/src/config.rs
@@ -40,7 +40,7 @@
 
 use alloc::{boxed::Box, collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 
-use anyhow::Error;
+use anyhow::{Error, anyhow};
 use oak_attestation_types::{attester::Attester, endorser::Endorser};
 use oak_attestation_verification_types::verifier::AttestationVerifier;
 use oak_crypto::{
@@ -99,6 +99,38 @@ impl SessionConfig {
         handshake_type: HandshakeType,
     ) -> SessionConfigBuilder {
         SessionConfigBuilder::new(attestation_type, handshake_type)
+    }
+
+    /// Fails if a peer-attested type was selected but nothing is configured to
+    /// verify the peer.
+    ///
+    /// With no peer verifier and no peer assertion verifier, the verification
+    /// results handed to the aggregators are empty, an empty result set
+    /// aggregates to `PeerAttestationVerdict::AttestationPassed`, and the
+    /// session reaches `Open` against a peer that presented no evidence and no
+    /// assertion. Either kind of verifier is enough, because a configuration
+    /// may legitimately use only assertions or only [`AttestationVerifier`]s.
+    ///
+    /// This is checked here rather than in the attestation handlers because
+    /// `attestation_type` is not carried into [`AttestationHandlerConfig`], so
+    /// the handlers cannot tell an intentionally unattested session apart from
+    /// an attested one whose verifiers were never added.
+    pub(crate) fn validate_peer_verification(&self) -> Result<(), Error> {
+        match self.attestation_type {
+            AttestationType::Bidirectional | AttestationType::PeerUnidirectional => {}
+            AttestationType::SelfUnidirectional | AttestationType::Unattested => return Ok(()),
+        }
+        if self.attestation_handler_config.peer_verifiers.is_empty()
+            && self.attestation_handler_config.peer_assertion_verifiers.is_empty()
+        {
+            return Err(anyhow!(
+                "attestation type {:?} verifies the peer, but neither a peer verifier nor a \
+                 peer assertion verifier is configured; add one, or use \
+                 AttestationType::Unattested if the peer is not meant to be verified",
+                self.attestation_type
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/oak_session/src/session.rs
+++ b/oak_session/src/session.rs
@@ -481,6 +481,7 @@ impl ClientSession {
     /// state. The lifetimes of objects within `config` (e.g., keys in
     /// `HandshakeHandlerConfig`) are now managed by the `ClientSession`.
     pub fn create(config: SessionConfig) -> Result<Self, Error> {
+        config.validate_peer_verification()?;
         Ok(Self {
             step: Step::Attestation {
                 attester: ClientAttestationHandler::create(config.attestation_handler_config)?,
@@ -700,6 +701,7 @@ impl ServerSession {
     /// based on `config.attestation_handler_config.attestation_type` for
     /// the `ServerHandshakeHandler`. The configuration is consumed.
     pub fn create(config: SessionConfig) -> Result<Self, Error> {
+        config.validate_peer_verification()?;
         Ok(Self {
             step: Step::Attestation {
                 attester: ServerAttestationHandler::create(config.attestation_handler_config)?,

--- a/oak_session/src/tests/session_tests.rs
+++ b/oak_session/src/tests/session_tests.rs
@@ -1119,3 +1119,86 @@ async fn channel_pair_test(
 
     server_join.await.context("joining server")?.context("server failing")
 }
+
+// A peer-attested type with no configured peer verification must fail closed.
+// Without this, the empty verification result set aggregates to
+// `AttestationPassed` and the session opens against a peer that presented
+// nothing.
+
+#[googletest::test]
+fn peer_unidirectional_client_without_any_verifier_is_rejected() {
+    let config =
+        SessionConfig::builder(AttestationType::PeerUnidirectional, HandshakeType::NoiseNN).build();
+    let error = ClientSession::create(config).err().expect("expected session creation to fail");
+    assert_that!(error.to_string(), contains_substring("peer assertion verifier"));
+}
+
+#[googletest::test]
+fn bidirectional_client_without_any_verifier_is_rejected() {
+    let config = SessionConfig::builder(AttestationType::Bidirectional, HandshakeType::NoiseNN)
+        .add_self_attester(MATCHED_ATTESTER_ID1.to_string(), create_mock_attester())
+        .add_self_endorser(MATCHED_ATTESTER_ID1.to_string(), create_mock_endorser())
+        .add_session_binder(MATCHED_ATTESTER_ID1.to_string(), create_mock_binder())
+        .build();
+    let error = ClientSession::create(config).err().expect("expected session creation to fail");
+    assert_that!(error.to_string(), contains_substring("peer assertion verifier"));
+}
+
+#[googletest::test]
+fn peer_unidirectional_server_without_any_verifier_is_rejected() {
+    let config =
+        SessionConfig::builder(AttestationType::PeerUnidirectional, HandshakeType::NoiseNN).build();
+    let error = ServerSession::create(config).err().expect("expected session creation to fail");
+    assert_that!(error.to_string(), contains_substring("peer assertion verifier"));
+}
+
+#[googletest::test]
+fn peer_unidirectional_with_only_a_legacy_verifier_is_accepted() -> anyhow::Result<()> {
+    let config =
+        SessionConfig::builder(AttestationType::PeerUnidirectional, HandshakeType::NoiseNN)
+            .add_peer_verifier_with_key_extractor(
+                MATCHED_ATTESTER_ID1.to_string(),
+                create_passing_mock_verifier(),
+                create_mock_key_extractor(),
+            )
+            .build();
+    ClientSession::create(config)?;
+    Ok(())
+}
+
+#[googletest::test]
+fn peer_unidirectional_with_only_an_assertion_verifier_is_accepted() -> anyhow::Result<()> {
+    let config =
+        SessionConfig::builder(AttestationType::PeerUnidirectional, HandshakeType::NoiseNN)
+            .add_peer_assertion_verifier(
+                MATCHED_ATTESTER_ID1.to_string(),
+                create_passing_mock_session_key_assertion_verifier(),
+            )
+            .set_assertion_attestation_aggregator(Box::new(PassThrough {}))
+            .build();
+    ClientSession::create(config)?;
+    Ok(())
+}
+
+#[googletest::test]
+fn unattested_without_any_verifier_is_accepted() -> anyhow::Result<()> {
+    let client_config =
+        SessionConfig::builder(AttestationType::Unattested, HandshakeType::NoiseNN).build();
+    let server_config =
+        SessionConfig::builder(AttestationType::Unattested, HandshakeType::NoiseNN).build();
+    ClientSession::create(client_config)?;
+    ServerSession::create(server_config)?;
+    Ok(())
+}
+
+#[googletest::test]
+fn self_unidirectional_without_any_peer_verifier_is_accepted() -> anyhow::Result<()> {
+    let config =
+        SessionConfig::builder(AttestationType::SelfUnidirectional, HandshakeType::NoiseNN)
+            .add_self_attester(MATCHED_ATTESTER_ID1.to_string(), create_mock_attester())
+            .add_self_endorser(MATCHED_ATTESTER_ID1.to_string(), create_mock_endorser())
+            .add_session_binder(MATCHED_ATTESTER_ID1.to_string(), create_mock_binder())
+            .build();
+    ServerSession::create(config)?;
+    Ok(())
+}


### PR DESCRIPTION
## Problem

A `SessionConfig` built for `PeerUnidirectional` or `Bidirectional` with no peer
verifier and no peer assertion verifier does not verify the peer, and does not
say so. `combine_attestation_results` and `combine_assertion_results` produce
empty maps, both default aggregators accept an empty result set, and
`combine_legacy_and_assertion_aggregated_verification` turns the two `Ok`s into
`PeerAttestationVerdict::AttestationPassed`. `needs_session_bindings()` is an
`any()` over those same empty maps, so no peer session binding is expected
either, and both binding checks iterate empty collections. The session reaches
`Open` against a peer that presented no evidence and no assertion.

Both directions are affected — `ClientSession` and `ServerSession` share
`Step::next` and the same aggregation sequence — and it is not limited to a peer
that withholds evidence: against an honest `SelfUnidirectional` peer, a client
with no assertion verifier records the peer's real assertion as `Unverified` and
opens anyway.

This was previously guarded. `d5f22796dbf2` introduced the aggregator with an
explicit empty-results rejection; `450988047c98` replaced it with a
failures-only filter, and `b04af003e085` reintroduced a guard that only fires
when a verifier was configured but did not match. The zero-verifier case has
been accepted since.

Some bindings cannot work around it: `oak_session_json_wasm` and Java's
`OakSessionConfigBuilder` export the attested `AttestationType` values but
expose no method to add a verifier, so their callers cannot supply one. The C
FFI does export `session_config_builder_add_peer_verifier`, and `oak_proxy`
sidesteps the problem entirely by deriving the attestation type from whether
verifiers are configured.

## Fix

`ClientSession::create` and `ServerSession::create` reject a peer-attested
`AttestationType` that has neither a peer verifier nor a peer assertion
verifier.

The check is a method on `SessionConfig` rather than something the attestation
handlers do, because `attestation_type` is not carried into
`AttestationHandlerConfig`; by the time a handler exists, the information needed
to tell an intentionally unattested session apart from an attested one whose
verifiers were never added is gone.

Either kind of verifier satisfies the check, so assertion-only and legacy-only
configurations both keep working. `Unattested` and `SelfUnidirectional` are
unaffected. Returning an error rather than asserting means the WASM and JNI
wrappers surface it through their existing error paths instead of panicking.

`DefaultLegacyVerifierResultsAggregator`'s documentation claimed an empty result
set fails. It does not, and it should not — an assertion-only configuration
produces exactly that — so the documentation is corrected rather than the
behaviour.

## Tests

New tests in `oak_session/src/tests/session_tests.rs` cover the rejected cases
(client and server, `PeerUnidirectional` and `Bidirectional`) and the accepted
ones (legacy-verifier-only, assertion-verifier-only, `Unattested`,
`SelfUnidirectional`).

`attestation_publisher_test_jni.rs` built a `PeerUnidirectional` client with no
verifier, which the new check rejects, so it now configures one. The test is
about the publisher rather than verification policy, and the server side it
talks to already supplies evidence, endorsements and a binder;
`AttestationPublisherTest` passes unchanged otherwise.

Verified locally at `fc26ac4dc7bf0bfa2ebd9802d429f84c77095cde`:
`//oak_session:oak_session_tests`, `//oak_session/endorsed_evidence:...`,
`//oak_session/ffi:tests`, `//oak_session/tls/...`, `//java/...` and
`//oak_functions_standalone:lib_test` all pass. Four targets could not be built
in my environment for reasons unrelated to this change and failing identically
on a clean checkout: the Android targets (no Android SDK), `e10_confidential_space`
(no `faketime`), `oak_proxy/lib` unit tests (`openssl-sys` build script), and
`oak_functions_standalone_integration_test` (`stage1_cpio` genrule).
Formatted with the pinned `nightly-2026-04-11` rustfmt; `buildifier --lint=warn`
clean on the changed BUILD file.
