### PR TITLE
fix(oak_crypto): only advance OrderedCrypter's receive nonce after decryption succeeds

### DIFF
--- a/oak_crypto/src/noise_handshake/mod.rs
+++ b/oak_crypto/src/noise_handshake/mod.rs
@@ -55,13 +55,27 @@ pub struct Nonce {
 
 impl Nonce {
     pub fn next_nonce(&mut self) -> Result<[u8; NONCE_LEN], Error> {
+        let ret = self.peek_nonce()?;
+        self.advance();
+        Ok(ret)
+    }
+
+    /// Returns the current nonce without advancing the counter.
+    ///
+    /// Used on the receive path so the counter is only advanced once AEAD
+    /// authentication has actually succeeded -- see `OrderedCrypter::decrypt`.
+    pub fn peek_nonce(&self) -> Result<[u8; NONCE_LEN], Error> {
         if self.nonce > MAX_SEQUENCE {
             return Err(Error::DecryptFailed);
         }
         let mut ret = [0u8; NONCE_LEN];
         ret[NONCE_LEN - 4..].copy_from_slice(self.nonce.to_be_bytes().as_slice());
-        self.nonce += 1;
         Ok(ret)
+    }
+
+    /// Advances the counter past the nonce last returned by `peek_nonce`.
+    pub fn advance(&mut self) {
+        self.nonce += 1;
     }
 
     // Nonce must be `NONCE_LEN` bytes with the last 4 bytes holding the nonce value
@@ -188,7 +202,15 @@ impl OrderedCrypter {
     }
 
     pub fn decrypt(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>, Error> {
-        aes_gcm_256_decrypt(&self.read_key, &self.read_nonce.next_nonce()?, ciphertext)
+        // The nonce is only advanced once the message is known to be
+        // authentic. OrderedCrypter has no reordering or replay-window
+        // tolerance, so advancing on an unauthenticated packet would permanently
+        // desync the channel: the genuine message that should have used this
+        // nonce would then be decrypted against the wrong one and fail forever.
+        let nonce = self.read_nonce.peek_nonce()?;
+        let plaintext = aes_gcm_256_decrypt(&self.read_key, &nonce, ciphertext)?;
+        self.read_nonce.advance();
+        Ok(plaintext)
     }
 }
 

--- a/oak_crypto/src/noise_handshake/tests.rs
+++ b/oak_crypto/src/noise_handshake/tests.rs
@@ -18,8 +18,8 @@ use alloc::{boxed::Box, vec};
 use crate::{
     identity_key::{IdentityKey, IdentityKeyHandle},
     noise_handshake::{
-        NONCE_LEN, SYMMETRIC_KEY_LEN, UnorderedCrypter, client::HandshakeInitiator, error::Error,
-        respond_kk, respond_nk, respond_nn,
+        NONCE_LEN, OrderedCrypter, SYMMETRIC_KEY_LEN, UnorderedCrypter,
+        client::HandshakeInitiator, error::Error, respond_kk, respond_nk, respond_nn,
     },
 };
 
@@ -270,4 +270,45 @@ fn unordered_crypter_forged_message_does_not_advance_window() {
             .expect("genuine message dropped after a forged message moved the window");
         assert_eq!(&plaintext, message);
     }
+}
+
+/// Regression test: `OrderedCrypter` must not advance its receive-side nonce
+/// counter from a message it has not authenticated.
+///
+/// `OrderedCrypter` allows no reordering or replay-window tolerance by
+/// design: it expects consecutive nonces with no drop or reordering. Before
+/// the fix, `decrypt` advanced the nonce counter before
+/// `aes_gcm_256_decrypt` ran, so a single forged or corrupted packet reaching
+/// the receiver first consumed the nonce the genuine sender's next message
+/// was going to use. Because the counter never moves backward, every
+/// subsequent genuine message then failed to decrypt too: the channel was
+/// permanently desynced.
+#[test]
+fn ordered_crypter_forged_message_does_not_desync_channel() {
+    let key_1 = &[42u8; SYMMETRIC_KEY_LEN];
+    let key_2 = &[52u8; SYMMETRIC_KEY_LEN];
+    let mut sender = OrderedCrypter::new(key_2, key_1);
+    let mut receiver = OrderedCrypter::new(key_1, key_2);
+
+    // Genuine message encrypted but not yet delivered (e.g. reordered/delayed
+    // in transit behind the attacker's packet).
+    let genuine_ciphertext = sender.encrypt(b"genuine payload").unwrap();
+
+    // A forged packet, with no knowledge of the key, reaches the receiver first.
+    let forged = vec![0u8; genuine_ciphertext.len()];
+    assert!(matches!(receiver.decrypt(&forged), Err(Error::DecryptFailed)));
+
+    // The genuine message, produced by the real sender and untampered, must
+    // still be accepted -- the forged packet must not have consumed its nonce.
+    let plaintext = receiver
+        .decrypt(&genuine_ciphertext)
+        .expect("genuine message rejected after a forged message reused its nonce");
+    assert_eq!(plaintext, b"genuine payload");
+
+    // The channel must also still be usable for subsequent messages.
+    let next_ciphertext = sender.encrypt(b"second genuine payload").unwrap();
+    let next_plaintext = receiver
+        .decrypt(&next_ciphertext)
+        .expect("channel remained desynced after the genuine message was correctly accepted");
+    assert_eq!(next_plaintext, b"second genuine payload");
 }


### PR DESCRIPTION
Fixes GHSA-crrx-8j53-chmq.

`OrderedCrypter::decrypt` advanced the receive-side nonce counter before AES-GCM authentication ran. `OrderedCrypter` allows no packet reordering or replay-window tolerance by design, so a single forged or corrupted packet reaching the receiver before a genuine message permanently desynced the channel -- the counter had already moved past the nonce the genuine sender's next message needed.

Splits `Nonce::next_nonce` into `peek_nonce` (read without advancing) and `advance` (commit the read), and changes `OrderedCrypter::decrypt` to peek, decrypt, and only advance once authentication succeeds. `next_nonce` itself is unchanged for the write/encrypt paths, which aren't attacker-influenced.

Mirrors the fix already applied to the sibling `UnorderedCrypter` in af30ca2, which did not touch `OrderedCrypter`.

Adds a regression test (`ordered_crypter_forged_message_does_not_desync_channel`) mirroring the `UnorderedCrypter` regression tests added in that same commit.