### PR TITLE
Use checked BootE820Entry::end() in three remaining unbounded-addition sites

### DIFF
--- a/oak_restricted_kernel/src/memory.rs
+++ b/oak_restricted_kernel/src/memory.rs
@@ -340,7 +340,7 @@ impl SensitiveDiceDataMemory {
         assert!(info.e820_table().iter().any(|entry| {
             let dice_data_fully_contained_in_segment = {
                 let range = PhysAddr::new(entry.addr().try_into().unwrap())
-                    ..=PhysAddr::new((entry.addr() + entry.size()).try_into().unwrap());
+                    ..=PhysAddr::new(entry.end().try_into().unwrap());
                 range.contains(&dice_data_phys_addr)
                     && range.contains(&end)
                     && range.contains(&eventlog_phys_addr)
@@ -362,7 +362,7 @@ impl SensitiveDiceDataMemory {
             if let Some(dice_data_attestation_addr) = dice_data_attestation_addr {
                 assert!(info.e820_table().iter().any(|entry| {
                     let range = PhysAddr::new(entry.addr().try_into().unwrap())
-                        ..=PhysAddr::new((entry.addr() + entry.size()).try_into().unwrap());
+                        ..=PhysAddr::new(entry.end().try_into().unwrap());
                     range.contains(&dice_data_attestation_addr) && range.contains(&end)
                 }));
                 let dice_data_attestation_virt_address =

--- a/oak_restricted_kernel_wrapper/src/elf.rs
+++ b/oak_restricted_kernel_wrapper/src/elf.rs
@@ -110,7 +110,7 @@ pub fn check_memory(
     if !e820_table.iter().any(|entry| {
         entry.entry_type() == Some(E820EntryType::RAM)
             && entry.addr() as u64 <= start.as_u64()
-            && (entry.addr() + entry.size()) as u64 >= end.as_u64()
+            && entry.end() as u64 >= end.as_u64()
     }) {
         return Err("region is not backed by physical memory");
     }

--- a/stage0/src/allocator.rs
+++ b/stage0/src/allocator.rs
@@ -230,7 +230,7 @@ pub fn init_global_allocator(e820_table: &[BootE820Entry]) {
     if !e820_table.iter().any(|entry| {
         entry.entry_type() == Some(E820EntryType::RAM)
             && entry.addr() as u64 <= HEAP_START.as_u64()
-            && (entry.addr() + entry.size()) as u64 >= HEAP_END.as_u64()
+            && entry.end() as u64 >= HEAP_END.as_u64()
     }) {
         panic!("heap is not backed by physical memory");
     }


### PR DESCRIPTION
\`check_memory\` (\`oak_restricted_kernel_wrapper/src/elf.rs\`), the two range constructions in \`SensitiveDiceDataMemory::new\` (\`oak_restricted_kernel/src/memory.rs\`), and \`init_global_allocator\` (\`stage0/src/allocator.rs\`) all computed \`entry.addr() + entry.size()\` directly instead of using the existing \`BootE820Entry::end()\` helper. \`entry\` is a hypervisor-supplied E820 entry, so a crafted entry with a large \`size\` can overflow \`usize\`.

This addition feeds an \`entry.addr() <= X && (sum) >= Y\` coverage check. On overflow, the wrapped sum is always \`< entry.addr()\`, and since the check already requires \`entry.addr() <= X <= Y\`, the wrapped sum can never reach \`Y\` — the check can only spuriously reject a valid entry (surfacing as an \`Err\`/panic), not wrongly accept an unbacked range. So this is not a bypass; it's a robustness/consistency fix, switching these three sites to the same overflow-safe helper (\`BootE820Entry::end()\`, \`saturating_add\`-based) already used for the identical pattern in \`setup_high_allocator\` (\`stage0/src/acpi/mod.rs\`) and \`validate_memory\`/\`accept_tdx_memory\` (\`stage0_sev/...\`, \`stage0_tdx/...\`).

I do not have a working Bazel/nix setup on this machine, so I could not run the crate's test suite locally — please let CI exercise the full build.