### PR TITLE
fall back to v0 for initial data shorter than the header

### DIFF
--- a/oak_restricted_kernel_orchestrator/src/lib.rs
+++ b/oak_restricted_kernel_orchestrator/src/lib.rs
@@ -120,17 +120,14 @@ impl AttestedApp {
 /// and no more is the *default* behavior when the interpretation header doesn't
 /// match any known values.
 pub fn interpret_initial_data(data: &[u8]) -> InitialData {
-    let header: [u8; INITIAL_DATA_HEADER_SIZE] =
-        data[0..INITIAL_DATA_HEADER_SIZE].try_into().expect("Not enough data in initial frame");
-
-    if header == INITIAL_DATA_V1_HEADER {
+    if data.first_chunk::<INITIAL_DATA_HEADER_SIZE>() == Some(&INITIAL_DATA_V1_HEADER) {
         InitialData::decode(&data[INITIAL_DATA_HEADER_SIZE..])
             .expect("Could not interpret V1 payload as proto")
     } else {
         // For backwards compatibility, when the payload starts with anything
-        // else (most likely an ELF header), then we synthesize the initial
-        // configuration data with the application binary and empty
-        // endorsements.
+        // else (most likely an ELF header) or is shorter than the header, then
+        // we synthesize the initial configuration data with the application
+        // binary and empty endorsements.
         InitialData { application_bytes: data.to_vec(), endorsement_bytes: alloc::vec::Vec::new() }
     }
 }


### PR DESCRIPTION
interpret_initial_data reads the four byte interpretation header with data[0..INITIAL_DATA_HEADER_SIZE] before checking the frame is that long. The bytes come from receive_raw on the boot channel, where the host is the sender and picks the length prefix, so it can hand over a frame of zero to three bytes. That range index then panics and brings down the orchestrator inside load_and_attest, before any attestation runs.

Read the header with first_chunk, which is None when the frame is shorter than four bytes, and let that case take the existing v0 path. The function already documents v0 as the default for anything that does not carry the v1 header, and a truncated frame is simply not a v1 frame. Well formed frames decode exactly as before; the only behavioral change is that a short frame now produces a v0 payload that fails later at ELF loading instead of panicking here.