### PR TITLE
fix(oak_session): disable TLS resumption with client auth

### DIFF
--- a/oak_session/tls/README.md
+++ b/oak_session/tls/README.md
@@ -60,6 +60,14 @@ The custom verifier receives the standard verification result (as an error code
 in C++, or a `Result` in Rust) and must return a status indicating whether to
 accept or reject the certificate.
 
+## Session Resumption
+
+The C++ server disables TLS session resumption when client authentication is
+configured. Trust anchors and custom certificate verifiers are resolved for
+each new session and may change during the lifetime of a context. Disabling
+resumption ensures every new connection is checked against the current client
+authentication policy instead of authentication state from an earlier session.
+
 ## Server Name and SAN Verification
 
 By default, the library uses `"oak-session-tls"` as the server identity for both

--- a/oak_session/tls/README.md
+++ b/oak_session/tls/README.md
@@ -63,8 +63,8 @@ accept or reject the certificate.
 ## Session Resumption
 
 The C++ server disables TLS session resumption when client authentication is
-configured. Trust anchors and custom certificate verifiers are resolved for
-each new session and may change during the lifetime of a context. Disabling
+configured. Trust anchors and custom certificate verifiers are resolved for each
+new session and may change during the lifetime of a context. Disabling
 resumption ensures every new connection is checked against the current client
 authentication policy instead of authentication state from an earlier session.
 

--- a/oak_session/tls/oak_session_tls.cc
+++ b/oak_session/tls/oak_session_tls.cc
@@ -452,6 +452,14 @@ OakSessionTlsInitializer::CreateServer(
     return initializer.status();
   }
 
+  // Client authentication policy is installed on each new SSL instance. A
+  // resumed session would reuse authentication state from an earlier policy
+  // generation and skip the current trust anchors and custom verifier.
+  if ((SSL_get_verify_mode((*initializer)->ssl_.get()) & SSL_VERIFY_PEER) !=
+      0) {
+    SSL_set_options((*initializer)->ssl_.get(), SSL_OP_NO_TICKET);
+  }
+
   // Set this SSL instance into server mode.
   SSL_set_accept_state((*initializer)->ssl_.get());
 

--- a/oak_session/tls/oak_session_tls_test.cc
+++ b/oak_session/tls/oak_session_tls_test.cc
@@ -557,6 +557,84 @@ TEST(OakSessionTlsTest, CreateAndUseMtlsSession) {
                               "hello from server");
 }
 
+TEST(OakSessionTlsTest, ClientAuthenticatedServerDoesNotIssueSessionTickets) {
+  auto server_identity_provider =
+      util::CreateFromFiles(kTestServerKeyPath, kTestServerCertPath);
+  ASSERT_THAT(server_identity_provider, IsOk());
+  auto server_identity = (*server_identity_provider)->GetIdentity();
+  ASSERT_THAT(server_identity, IsOk());
+
+  auto client_trust_anchor_provider =
+      util::CreateTrustAnchorFromFile(kTestCaCertPath);
+  ASSERT_THAT(client_trust_anchor_provider, IsOk());
+  auto client_trust_anchors =
+      (*client_trust_anchor_provider)->GetTrustAnchors();
+  ASSERT_THAT(client_trust_anchors, IsOk());
+
+  bssl::UniquePtr<SSL_CTX> server_ssl_ctx(SSL_CTX_new(TLS_server_method()));
+  ASSERT_NE(server_ssl_ctx, nullptr);
+  ASSERT_EQ(SSL_CTX_set_min_proto_version(server_ssl_ctx.get(), TLS1_3_VERSION),
+            1);
+  SSL_CTX_set_verify(server_ssl_ctx.get(),
+                     SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                     nullptr);
+
+  int new_session_ticket_count = 0;
+  SSL_CTX_set_msg_callback(
+      server_ssl_ctx.get(), [](int is_write, int, int content_type,
+                               const void* buf, size_t len, SSL*, void* arg) {
+        if (is_write == 1 && content_type == SSL3_RT_HANDSHAKE && len > 0 &&
+            static_cast<const uint8_t*>(buf)[0] == SSL3_MT_NEW_SESSION_TICKET) {
+          ++*static_cast<int*>(arg);
+        }
+      });
+  SSL_CTX_set_msg_callback_arg(server_ssl_ctx.get(), &new_session_ticket_count);
+
+  auto client_identity_provider =
+      util::CreateFromFiles(kTestClientKeyPath, kTestClientCertPath);
+  ASSERT_THAT(client_identity_provider, IsOk());
+  auto client_identity = (*client_identity_provider)->GetIdentity();
+  ASSERT_THAT(client_identity, IsOk());
+
+  auto server_trust_anchor_provider =
+      util::CreateTrustAnchorFromFile(kTestCaCertPath);
+  ASSERT_THAT(server_trust_anchor_provider, IsOk());
+  auto server_trust_anchors =
+      (*server_trust_anchor_provider)->GetTrustAnchors();
+  ASSERT_THAT(server_trust_anchors, IsOk());
+
+  bssl::UniquePtr<SSL_CTX> client_ssl_ctx(SSL_CTX_new(TLS_client_method()));
+  ASSERT_NE(client_ssl_ctx, nullptr);
+  ASSERT_EQ(SSL_CTX_set_min_proto_version(client_ssl_ctx.get(), TLS1_3_VERSION),
+            1);
+  SSL_CTX_set_verify(client_ssl_ctx.get(), SSL_VERIFY_PEER, nullptr);
+  SSL_CTX_set_session_cache_mode(client_ssl_ctx.get(), SSL_SESS_CACHE_CLIENT);
+
+  auto server_initializer = OakSessionTlsInitializer::CreateServer(
+      server_ssl_ctx.get(), &*server_identity, *client_trust_anchors);
+  ASSERT_THAT(server_initializer, IsOk());
+  auto client_initializer = OakSessionTlsInitializer::CreateClient(
+      client_ssl_ctx.get(), kDefaultServerName, &*client_identity,
+      *server_trust_anchors);
+  ASSERT_THAT(client_initializer, IsOk());
+
+  HandshakeToClientReady(**server_initializer, **client_initializer);
+  auto client_result = (*client_initializer)->GetOpenSession();
+  ASSERT_THAT(client_result, IsOk());
+  CompleteServerHandshakeWithData(**server_initializer, *client_result->session,
+                                  "hello server");
+
+  auto server_result = (*server_initializer)->GetOpenSession();
+  ASSERT_THAT(server_result, IsOk());
+  auto encrypted_response = server_result->session->Encrypt("hello client");
+  ASSERT_THAT(encrypted_response, IsOk());
+
+  // BoringSSL sends two TLS 1.3 NewSessionTicket messages by default.
+  // Client-authenticated sessions must not send one because it could bypass a
+  // refreshed trust-anchor or custom-verifier policy.
+  EXPECT_EQ(new_session_ticket_count, 0);
+}
+
 TEST(OakSessionTlsTest, ClientSetsTlsIdentServerDoesntRequest) {
   // Do not enable a trust anchor so the server does not request a client
   // certificate.


### PR DESCRIPTION
## Summary

- disable TLS session tickets on client-authenticated C++ server connections;
- add an mTLS regression test that counts outgoing session tickets; and
- document why C++ client-authenticated servers do not support session resumption.

Closes #5167

## Problem

`OakSessionTlsContext` retains one server `SSL_CTX`, while `NewSession()` resolves current trust anchors and attaches the custom verifier to each new `SSL`. A TLS 1.3 ticket created under an earlier client-authentication policy can therefore resume without a new client certificate check after the policy changes.

This affects servers that keep a context alive while rotating client trust anchors or changing a stateful verifier decision. The supplied reproduction records that an old-ticket connection succeeds after revocation while the same client without the ticket is rejected. No production C++ consumer has been demonstrated.

## Fix

Set `SSL_OP_NO_TICKET` on each server-side `SSL` when `SSL_VERIFY_PEER` is enabled. Applying the option per connection avoids mutating the shared context and leaves servers without client authentication unchanged.

The README now makes the behavior explicit: C++ servers requiring client authentication perform a fresh authentication exchange for each new connection so current trust anchors and verifier policy are applied.

## Tests

- Added `ClientAuthenticatedServerDoesNotIssueSessionTickets`, which completes an mTLS handshake with a session-cache-capable client and counts outgoing server tickets.
- Negative control: with the fix removed, the new test fails because BoringSSL emits two `NewSessionTicket` messages.
- Fixed control: with the fix restored, the new test observes zero tickets.
- `bazel test //oak_session/tls:oak_session_tls_test --test_output=errors` passes.
- `git diff --check` passes.
- The original standalone policy-rotation PoC was not rerun because its files and logs were unavailable.

## Compatibility

There is no public API or framing change. Servers without client authentication retain their existing behavior. Client-authenticated C++ servers intentionally lose TLS session-resumption performance and require a fresh certificate exchange on reconnect so revocation and policy rotation take effect.